### PR TITLE
Revert 280405@main

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3297,12 +3297,6 @@ void WKPageSetPermissionLevelForTesting(WKPageRef pageRef, WKStringRef origin, b
         pageForTesting->setPermissionLevel(toImpl(origin)->string(), allowed);
 }
 
-void WKPageFlushDeferredDidReceiveMouseEventForTesting(WKPageRef pageRef)
-{
-    if (auto* pageForTesting = toImpl(pageRef)->pageForTesting())
-        pageForTesting->flushDeferredDidReceiveMouseEvent();
-}
-
 void WKPageClearOpenerForTesting(WKPageRef pageRef)
 {
     if (auto* pageForTesting = toImpl(pageRef)->pageForTesting())

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -216,8 +216,6 @@ WK_EXPORT void WKPageExecuteCommandForTesting(WKPageRef pageRef, WKStringRef com
 WK_EXPORT bool WKPageIsEditingCommandEnabledForTesting(WKPageRef page, WKStringRef command);
 WK_EXPORT void WKPageSetPermissionLevelForTesting(WKPageRef page, WKStringRef origin, bool allowed);
 
-WK_EXPORT void WKPageFlushDeferredDidReceiveMouseEventForTesting(WKPageRef page);
-
 WK_EXPORT void WKPageClearOpenerForTesting(WKPageRef page);
 
 #ifdef __cplusplus

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -195,13 +195,6 @@ void WebPageProxyTesting::setSystemCanPromptForGetDisplayMediaForTesting(bool ca
 }
 #endif
 
-void WebPageProxyTesting::flushDeferredDidReceiveMouseEvent()
-{
-    m_page->forEachWebContentProcess([](auto& webProcess, auto pageID) {
-        webProcess.sendSync(Messages::WebPageTesting::FlushDeferredDidReceiveMouseEvent(), pageID, Seconds::infinity());
-    });
-}
-
 void WebPageProxyTesting::clearOpener()
 {
     m_page->forEachWebContentProcess([](auto& webProcess, auto pageID) {

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -71,8 +71,6 @@ public:
     void setSystemCanPromptForGetDisplayMediaForTesting(bool);
 #endif
 
-    void flushDeferredDidReceiveMouseEvent();
-
     void clearOpener();
 
 private:

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -776,6 +776,11 @@ void WKBundlePageCallAfterTasksAndTimers(WKBundlePageRef pageRef, WKBundlePageTe
     });
 }
 
+void WKBundlePageFlushDeferredDidReceiveMouseEventForTesting(WKBundlePageRef page)
+{
+    WebKit::toImpl(page)->flushDeferredDidReceiveMouseEvent();
+}
+
 void WKBundlePagePostMessage(WKBundlePageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
     WebKit::toImpl(pageRef)->postMessage(WebKit::toWTFString(messageNameRef), WebKit::toImpl(messageBodyRef));

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h
@@ -142,6 +142,8 @@ WK_EXPORT void WKBundlePagePostSynchronousMessageForTesting(WKBundlePageRef page
 // Same as WKBundlePagePostMessage() but the message cannot become synchronous, even if the connection is in fully synchronous mode.
 WK_EXPORT void WKBundlePagePostMessageIgnoringFullySynchronousMode(WKBundlePageRef page, WKStringRef messageName, WKTypeRef messageBody);
 
+WK_EXPORT void WKBundlePageFlushDeferredDidReceiveMouseEventForTesting(WKBundlePageRef page);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -103,12 +103,6 @@ void WebPageTesting::clearWheelEventTestMonitor()
     page->clearWheelEventTestMonitor();
 }
 
-void WebPageTesting::flushDeferredDidReceiveMouseEvent(CompletionHandler<void()>&& completionHandler)
-{
-    m_page->flushDeferredDidReceiveMouseEvent();
-    completionHandler();
-}
-
 void WebPageTesting::clearOpener()
 {
     if (RefPtr mainFrame = m_page->mainFrame())

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -59,8 +59,6 @@ private:
 
     void clearWheelEventTestMonitor();
 
-    void flushDeferredDidReceiveMouseEvent(CompletionHandler<void()>&&);
-
     void clearOpener();
 
     const WebCore::PageIdentifier m_identifier;

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
@@ -32,7 +32,5 @@ messages -> WebPageTesting NotRefCounted {
 
     ClearWheelEventTestMonitor()
 
-    FlushDeferredDidReceiveMouseEvent() -> () Synchronous
-
     ClearOpener()
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -235,6 +235,7 @@ void EventSendingController::mouseMoveTo(int x, int y, JSStringRef pointerType)
     m_position = WKPointMake(x, y);
     postSynchronousPageMessage("EventSender", body);
 
+    WKBundlePageFlushDeferredDidReceiveMouseEventForTesting(InjectedBundle::singleton().pageRef());
     auto waitForDidReceiveEventBody = adoptWK(WKMutableDictionaryCreate());
     setValue(waitForDidReceiveEventBody, "SubMessage", "WaitForDeferredMouseEvents");
     postSynchronousPageMessage("EventSender", waitForDidReceiveEventBody);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2196,10 +2196,8 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
             return completionHandler(nullptr);
         }
 
-        if (WKStringIsEqualToUTF8CString(subMessageName, "WaitForDeferredMouseEvents")) {
-            WKPageFlushDeferredDidReceiveMouseEventForTesting(mainWebView()->page());
+        if (WKStringIsEqualToUTF8CString(subMessageName, "WaitForDeferredMouseEvents"))
             return completionHandler(nullptr);
-        }
 
 #if PLATFORM(MAC)
         if (WKStringIsEqualToUTF8CString(subMessageName, "MouseForceClick")) {


### PR DESCRIPTION
#### 46ec369cc87cbbfdd6f5ac8efd956bcac0735f94
<pre>
Revert 280405@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=276095">https://bugs.webkit.org/show_bug.cgi?id=276095</a>
<a href="https://rdar.apple.com/130922657">rdar://130922657</a>

Unreviewed.

Caused flaky test failures.

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageFlushDeferredDidReceiveMouseEventForTesting): Deleted.
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::flushDeferredDidReceiveMouseEvent): Deleted.
* Source/WebKit/UIProcess/WebPageProxyTesting.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageFlushDeferredDidReceiveMouseEventForTesting):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::flushDeferredDidReceiveMouseEvent): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in:
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:
(WTR::EventSendingController::mouseMoveTo):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/280559@main">https://commits.webkit.org/280559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/226a17d751c5d00dfc04aa3c626236b4e88aebcc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60596 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7419 "Failed to checkout and rebase branch from PR 30367") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7609 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/7419 "Failed to checkout and rebase branch from PR 30367") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59006 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/49177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27001 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/30871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/6508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6424 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/6779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62277 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/889 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/6881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53399 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/892 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/49232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/752 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8485 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/33218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/34303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/32964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->