### PR TITLE
Parallelize Root Building in Performance Dashboard.

### DIFF
--- a/Websites/perf.webkit.org/public/api/build-requests.php
+++ b/Websites/perf.webkit.org/public/api/build-requests.php
@@ -76,8 +76,7 @@ function update_builds($db, $updates) {
             $is_build = $request_row['request_order'] < 0;
             if ($is_build) {
                 $db->query_and_fetch_all('UPDATE build_requests SET request_status = \'failed\'
-                    WHERE request_group = $1 AND request_order > $2',
-                    array($request_row['request_group'], $request_row['request_order']));
+                    WHERE request_group = $1 AND request_order >= 0', array($request_row['request_group']));
             }
             $fields_to_update['status'] = 'failed';
             $db->update_row('build_requests', 'request', array('id' => $id), $fields_to_update);

--- a/Websites/perf.webkit.org/public/api/test-groups.php
+++ b/Websites/perf.webkit.org/public/api/test-groups.php
@@ -35,7 +35,7 @@ function main($path) {
     } elseif ($path[0] == 'ready-for-notification') {
         $test_groups = $db->query_and_fetch_all("SELECT * FROM analysis_test_groups
             WHERE EXISTS(SELECT 1 FROM build_requests
-                WHERE request_group = testgroup_id
+                WHERE request_group = testgroup_id AND request_order >= 0
                     AND request_status IN ('pending', 'scheduled', 'running', 'canceled')) IS FALSE
                     AND testgroup_needs_notification IS TRUE AND testgroup_hidden IS FALSE");
 

--- a/Websites/perf.webkit.org/public/v3/models/build-request.js
+++ b/Websites/perf.webkit.org/public/v3/models/build-request.js
@@ -91,7 +91,7 @@ class BuildRequest extends DataModelObject {
 
     buildId() { return this._buildId; }
     createdAt() { return this._createdAt; }
-    async findBuildRequestWithSameRoots()
+    async findBuildRequestWithSameRoots(scheduledRequestIdList = [])
     {
         if (!this.isBuild())
             return null;
@@ -121,7 +121,7 @@ class BuildRequest extends DataModelObject {
                     continue;
                 if (buildRequest.hasCompleted())
                     return buildRequest;
-                if (buildRequest.isScheduled()
+                if ((buildRequest.isScheduled() || scheduledRequestIdList.includes(+buildRequest.id()))
                     && (!scheduledBuildRequest || buildRequest.createdAt() < scheduledBuildRequest.createdAt())) {
                     scheduledBuildRequest = buildRequest;
                 }


### PR DESCRIPTION
#### 6f6791dcd7c496b1ac4e517d1633b5cee9e9ab70
<pre>
Parallelize Root Building in Performance Dashboard.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276102">https://bugs.webkit.org/show_bug.cgi?id=276102</a>
<a href="https://rdar.apple.com/100645242">rdar://100645242</a>

Reviewed by Ryosuke Niwa.

Reduce root building time by running root building tasks in parallel. As part of this change, a build syncer
is no longer 1-to-1 mapping to a test group, thus the &apos;buildSyncer&apos; variable is removed.
Since root building tasks from one test group can run in parallel, failure from any of them will fail all
test type requests. Whereas previously, any requests after a failed one including build type requests will be
marked as failed.
To avoid delaying the time a build failure notification is sent, &apos;/api/test-groups/ready-for-notification&apos;
now ignores the state of build type requests and only checks if all test type requests are in either &apos;failed&apos;
or &apos;completed&apos;.

Fix a bug that all build type requests with the same build configuration can unnecessarily be scheduled
in one syncing iteration. This is because all of them are pending at the beginning of the sync iteration
and are not eligible for root reuse. This change fixes this issue and ensures only one of them is
scheduled, and the rest will wait for reusing the build product.

* Websites/perf.webkit.org/public/api/build-requests.php: Make one root building failure only cause
test type requests to fail as now build type requests can run in parallel.
* Websites/perf.webkit.org/public/api/test-groups.php: Modify &apos;/api/test-groups/ready-for-notification&apos;
to only check test type requests.
* Websites/perf.webkit.org/public/v3/models/build-request.js:
(BuildRequest.prototype.async findBuildRequestWithSameRoots): Add an optional argument to contain request
id that is scheduled but is not updated yet.
* Websites/perf.webkit.org/server-tests/api-test-groups.js: Add a new unit test for
&apos;/api/test-groups/ready-for-notification&apos; behavior change.
* Websites/perf.webkit.org/server-tests/tools-buildbot-triggerable-tests.js: Fix existing unit tests
and add new tests.
* Websites/perf.webkit.org/server-tests/tools-sync-buildbot-integration-tests.js: Fix existing unit tests
and add new tests.
(configWithOneTesterTwoBuilders):
* Websites/perf.webkit.org/tools/js/buildbot-syncer.js:
(BuildbotSyncer.prototype.scheduleRequestInGroupIfAvailable): Add an optional arugment to specify if request
needs to be scheduled on idle worker (a worker without running or pending tasks) and make the build type
request no longer block the worker from being used by other test groups.
* Websites/perf.webkit.org/tools/js/buildbot-triggerable.js: Make build type requests can be scheduled in
parallel by removing the assumption that a test group only have one build syncer.
Add the logic to always prefer idle worker while scheduling.

Canonical link: <a href="https://commits.webkit.org/280656@main">https://commits.webkit.org/280656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c4d1191739d42722e1a0ba931116d8b3077b2e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60853 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7674 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46333 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5403 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27196 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31084 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6728 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6679 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62532 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53593 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49451 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12647 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/962 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33473 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/34558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33219 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->