### PR TITLE
[JSC] DestructuringAssignmentTarget should be evaluated prior to calling [[Get]] / stepping iterator

### DIFF
--- a/JSTests/stress/destructuring-evaluation-order-array-bracket-accessor-iterator-done.js
+++ b/JSTests/stress/destructuring-evaluation-order-array-bracket-accessor-iterator-done.js
@@ -1,0 +1,59 @@
+var log = [];
+var logExpected = ["source", "iterator", "iterator-step", "iterator-done", "target", "target-key", "default-value", "target-key-tostring", "set"];
+
+function source() {
+    log.push("source");
+    var iterator = {
+        next: function() {
+            log.push("iterator-step");
+            return {
+                get done() {
+                    log.push("iterator-done");
+                    return true;
+                },
+                get value() {
+                    // Note: This getter shouldn't be called.
+                    log.push("iterator-value");
+                },
+            };
+        },
+    };
+    var source = {};
+    source[Symbol.iterator] = function() {
+        log.push("iterator");
+        return iterator;
+    };
+    return source;
+}
+
+function target() {
+    log.push("target");
+    return {
+        set q(v) {
+            log.push("set");
+        },
+    };
+}
+
+function targetKey() {
+    log.push("target-key");
+    return {
+        toString: function() {
+            log.push("target-key-tostring");
+            return "q";
+        },
+    };
+}
+
+function defaultValue() {
+    log.push("default-value");
+}
+
+for (var i = 0; i < 1e5; i++) {
+    log = [];
+
+    ([_, target()[targetKey()] = defaultValue()] = source());
+
+    if (log.toString() !== logExpected.toString())
+        throw new Error(`Bad value: ${log}!`);
+}

--- a/JSTests/stress/destructuring-evaluation-order-array-bracket-accessor.js
+++ b/JSTests/stress/destructuring-evaluation-order-array-bracket-accessor.js
@@ -1,0 +1,61 @@
+var log = [];
+var logExpected = ["source", "iterator", "target", "target-key", "iterator-step", "iterator-done", "default-value", "target-key-tostring", "set"];
+
+function source() {
+    log.push("source");
+    var iterator = {
+        next: function() {
+            log.push("iterator-step");
+            return {
+                get done() {
+                    log.push("iterator-done");
+                    return true;
+                },
+                get value() {
+                    // Note: This getter shouldn't be called.
+                    log.push("iterator-value");
+                },
+            };
+        },
+    };
+    var source = {};
+    source[Symbol.iterator] = function() {
+        log.push("iterator");
+        return iterator;
+    };
+    return source;
+}
+
+function target() {
+    log.push("target");
+    return {
+        set q(v) {
+            log.push("set");
+        },
+    };
+}
+
+function targetKey() {
+    log.push("target-key");
+    return {
+        toString: function() {
+            log.push("target-key-tostring");
+            return "q";
+        },
+    };
+}
+
+function defaultValue() {
+    log.push("default-value");
+}
+
+(function() {
+    for (var i = 0; i < 1e5; i++) {
+        log = [];
+
+        ([target()[targetKey()] = defaultValue()] = source());
+
+        if (log.toString() !== logExpected.toString())
+            throw new Error(`Bad value: ${log}!`);
+    }
+})();

--- a/JSTests/stress/destructuring-evaluation-order-array-dot-accessor-iterator-done.js
+++ b/JSTests/stress/destructuring-evaluation-order-array-dot-accessor-iterator-done.js
@@ -1,0 +1,57 @@
+var log = [];
+var logExpected = ["source", "iterator", "iterator-step", "iterator-done", "target-foo", "default-value", "set"];
+
+function source() {
+    log.push("source");
+    var iterator = {
+        next: function() {
+            log.push("iterator-step");
+            return {
+                get done() {
+                    log.push("iterator-done");
+                    return true;
+                },
+                get value() {
+                    // Note: This getter shouldn't be called.
+                    log.push("iterator-value");
+                },
+            };
+        },
+    };
+    var source = {};
+    source[Symbol.iterator] = function() {
+        log.push("iterator");
+        return iterator;
+    };
+    return source;
+}
+
+var target = {
+    get foo() {
+        log.push("target-foo");
+        return {
+            get bar() {
+                // Note: This getter shouldn't be called.
+                log.push("target-bar");
+            },
+            set bar(v) {
+                log.push("set");
+            },
+        };
+    },
+};
+
+function defaultValue() {
+    log.push("default-value");
+}
+
+(function() {
+    for (var i = 0; i < 1e5; i++) {
+        log = [];
+
+        ([_, target.foo.bar = defaultValue()] = source());
+
+        if (log.toString() !== logExpected.toString())
+            throw new Error(`Bad value: ${log}!`);
+    }
+})();

--- a/JSTests/stress/destructuring-evaluation-order-array-dot-accessor.js
+++ b/JSTests/stress/destructuring-evaluation-order-array-dot-accessor.js
@@ -1,0 +1,57 @@
+var log = [];
+var logExpected = ["source", "iterator", "target-foo", "iterator-step", "iterator-done", "default-value", "set"];
+
+function source() {
+    log.push("source");
+    var iterator = {
+        next: function() {
+            log.push("iterator-step");
+            return {
+                get done() {
+                    log.push("iterator-done");
+                    return true;
+                },
+                get value() {
+                    // Note: This getter shouldn't be called.
+                    log.push("iterator-value");
+                },
+            };
+        },
+    };
+    var source = {};
+    source[Symbol.iterator] = function() {
+        log.push("iterator");
+        return iterator;
+    };
+    return source;
+}
+
+var target = {
+    get foo() {
+        log.push("target-foo");
+        return {
+            get bar() {
+                // Note: This getter shouldn't be called.
+                log.push("target-bar");
+            },
+            set bar(v) {
+                log.push("set");
+            },
+        };
+    },
+};
+
+function defaultValue() {
+    log.push("default-value");
+}
+
+(function() {
+    for (var i = 0; i < 1e5; i++) {
+        log = [];
+
+        ([target.foo.bar = defaultValue()] = source());
+
+        if (log.toString() !== logExpected.toString())
+            throw new Error(`Bad value: ${log}!`);
+    }
+})();

--- a/JSTests/stress/destructuring-evaluation-order-array-rest-element-iterator-done.js
+++ b/JSTests/stress/destructuring-evaluation-order-array-rest-element-iterator-done.js
@@ -1,0 +1,55 @@
+var log = [];
+var logExpected = ["source", "iterator", "iterator-step", "iterator-done", "target", "target-key", "target-key-tostring", "set"];
+
+function source() {
+    log.push("source");
+    var iterator = {
+        next: function() {
+            log.push("iterator-step");
+            return {
+                get done() {
+                    log.push("iterator-done");
+                    return true;
+                },
+                get value() {
+                    // Note: This getter shouldn't be called.
+                    log.push("iterator-value");
+                },
+            };
+        },
+    };
+    var source = {};
+    source[Symbol.iterator] = function() {
+        log.push("iterator");
+        return iterator;
+    };
+    return source;
+}
+
+function target() {
+    log.push("target");
+    return {
+        set q(v) {
+            log.push("set");
+        },
+    };
+}
+
+function targetKey() {
+    log.push("target-key");
+    return {
+        toString: function() {
+            log.push("target-key-tostring");
+            return "q";
+        },
+    };
+}
+
+for (var i = 0; i < 1e5; i++) {
+    log = [];
+
+    ([_, ...target()[targetKey()]] = source());
+
+    if (log.toString() !== logExpected.toString())
+        throw new Error(`Bad value: ${log}!`);
+}

--- a/JSTests/stress/destructuring-evaluation-order-array-rest-element.js
+++ b/JSTests/stress/destructuring-evaluation-order-array-rest-element.js
@@ -1,0 +1,55 @@
+var log = [];
+var logExpected = ["source", "iterator", "target", "target-key", "iterator-step", "iterator-done", "target-key-tostring", "set"];
+
+function source() {
+    log.push("source");
+    var iterator = {
+        next: function() {
+            log.push("iterator-step");
+            return {
+                get done() {
+                    log.push("iterator-done");
+                    return true;
+                },
+                get value() {
+                    // Note: This getter shouldn't be called.
+                    log.push("iterator-value");
+                },
+            };
+        },
+    };
+    var source = {};
+    source[Symbol.iterator] = function() {
+        log.push("iterator");
+        return iterator;
+    };
+    return source;
+}
+
+function target() {
+    log.push("target");
+    return {
+        set q(v) {
+            log.push("set");
+        },
+    };
+}
+
+function targetKey() {
+    log.push("target-key");
+    return {
+        toString: function() {
+            log.push("target-key-tostring");
+            return "q";
+        },
+    };
+}
+
+for (var i = 0; i < 1e5; i++) {
+    log = [];
+
+    ([...target()[targetKey()]] = source());
+
+    if (log.toString() !== logExpected.toString())
+        throw new Error(`Bad value: ${log}!`);
+}

--- a/JSTests/stress/destructuring-evaluation-order-object-bracket-accessor.js
+++ b/JSTests/stress/destructuring-evaluation-order-object-bracket-accessor.js
@@ -1,0 +1,53 @@
+var log = [];
+var logExpected = ["source", "source-key", "source-key-tostring", "target", "target-key", "get", "default-value", "target-key-tostring", "set"];
+
+function source() {
+    log.push("source");
+    return {
+        get p() {
+            log.push("get");
+        },
+    };
+}
+
+function target() {
+    log.push("target");
+    return {
+        set q(v) {
+            log.push("set");
+        },
+    };
+}
+
+function sourceKey() {
+    log.push("source-key");
+    return {
+        toString: function() {
+            log.push("source-key-tostring");
+            return "p";
+        },
+    };
+}
+
+function targetKey() {
+    log.push("target-key");
+    return {
+        toString: function() {
+            log.push("target-key-tostring");
+            return "q";
+        },
+    };
+}
+
+function defaultValue() {
+    log.push("default-value");
+}
+
+for (var i = 0; i < 1e5; i++) {
+    log = [];
+
+    ({[sourceKey()]: target()[targetKey()] = defaultValue()} = source());
+
+    if (log.toString() !== logExpected.toString())
+        throw new Error(`Bad value: ${log}!`);
+}

--- a/JSTests/stress/destructuring-evaluation-order-object-dot-accessor.js
+++ b/JSTests/stress/destructuring-evaluation-order-object-dot-accessor.js
@@ -1,0 +1,49 @@
+var log = [];
+var logExpected = ["source", "source-key", "source-key-tostring", "target-foo", "get", "default-value", "set"];
+
+function source() {
+    log.push("source");
+    return {
+        get p() {
+            log.push("get");
+        },
+    };
+}
+
+function sourceKey() {
+    log.push("source-key");
+    return {
+        toString: function() {
+            log.push("source-key-tostring");
+            return "p";
+        },
+    };
+}
+
+var target = {
+    get foo() {
+        log.push("target-foo");
+        return {
+            get bar() {
+                // Note: This getter shouldn't be called.
+                log.push("target-bar");
+            },
+            set bar(v) {
+                log.push("set");
+            },
+        };
+    },
+};
+
+function defaultValue() {
+    log.push("default-value");
+}
+
+for (var i = 0; i < 1e5; i++) {
+    log = [];
+
+    ({[sourceKey()]: target.foo.bar = defaultValue()} = source());
+
+    if (log.toString() !== logExpected.toString())
+        throw new Error(`Bad value: ${log}!`);
+}

--- a/JSTests/stress/destructuring-evaluation-order-object-rest-element.js
+++ b/JSTests/stress/destructuring-evaluation-order-object-rest-element.js
@@ -1,0 +1,41 @@
+var log = [];
+var logExpected = ["source", "target", "target-key", "get", "target-key-tostring", "set"];
+
+function source() {
+    log.push("source");
+    return {
+        get p() {
+            log.push("get");
+        },
+    };
+}
+
+function target() {
+    log.push("target");
+    return {
+        set q(v) {
+            log.push("set");
+        },
+    };
+}
+
+function targetKey() {
+    log.push("target-key");
+    return {
+        toString: function() {
+            log.push("target-key-tostring");
+            return "q";
+        },
+    };
+}
+
+(function() {
+    for (var i = 0; i < 1e5; i++) {
+        log = [];
+
+        ({...target()[targetKey()]} = source());
+
+        if (log.toString() !== logExpected.toString())
+            throw new Error(`Bad value: ${log}!`);
+    }
+})();

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -971,18 +971,12 @@ test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-p
   default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«param», «undefined») to be true'
 test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign.js:
   default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«param», «undefined») to be true'
-test/language/expressions/assignment/destructuring/iterator-destructuring-property-reference-target-evaluation-order.js:
-  default: 'Test262Error: Expected [source, iterator, iterator-step, iterator-done, target, target-key, target-key-tostring, set] and [source, iterator, target, target-key, iterator-step, iterator-done, target-key-tostring, set] to have the same contents. '
-  strict mode: 'Test262Error: Expected [source, iterator, iterator-step, iterator-done, target, target-key, target-key-tostring, set] and [source, iterator, target, target-key, iterator-step, iterator-done, target-key-tostring, set] to have the same contents. '
-test/language/expressions/assignment/destructuring/keyed-destructuring-property-reference-target-evaluation-order.js:
-  default: 'Test262Error: Expected [source, source-key, source-key-tostring, get, target, target-key, target-key-tostring, set] and [source, source-key, source-key-tostring, target, target-key, get, target-key-tostring, set] to have the same contents. '
-  strict mode: 'Test262Error: Expected [source, source-key, source-key-tostring, get, target, target-key, target-key-tostring, set] and [source, source-key, source-key-tostring, target, target-key, get, target-key-tostring, set] to have the same contents. '
 test/language/expressions/assignment/destructuring/obj-prop-__proto__dup.js:
   default: 'SyntaxError: Attempted to redefine __proto__ property.'
   strict mode: 'SyntaxError: Attempted to redefine __proto__ property.'
 test/language/expressions/assignment/dstr/array-elem-iter-rtrn-close-err.js:
-  default: "TypeError: undefined is not a function (near '...[ {}[ yield ] ]...')"
-  strict mode: "TypeError: undefined is not a function (near '...[ {}[ yield ] ]...')"
+  default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
 test/language/expressions/assignment/dstr/array-elem-iter-rtrn-close-null.js:
   default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
@@ -990,11 +984,11 @@ test/language/expressions/assignment/dstr/array-elem-iter-rtrn-close.js:
   default: 'Test262Error: Expected SameValue(«0», «1») to be true'
   strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/expressions/assignment/dstr/array-elem-iter-thrw-close-err.js:
-  default: 'Test262Error: Expected SameValue(«1», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«1», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/expressions/assignment/dstr/array-elem-iter-thrw-close.js:
-  default: 'Test262Error: Expected SameValue(«1», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«1», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/expressions/assignment/dstr/array-elem-trlg-iter-list-rtrn-close-err.js:
   default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
@@ -1005,11 +999,11 @@ test/language/expressions/assignment/dstr/array-elem-trlg-iter-list-rtrn-close.j
   default: 'Test262Error: Expected SameValue(«0», «1») to be true'
   strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/expressions/assignment/dstr/array-elem-trlg-iter-list-thrw-close-err.js:
-  default: 'Test262Error: Expected SameValue(«1», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«1», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/expressions/assignment/dstr/array-elem-trlg-iter-list-thrw-close.js:
-  default: 'Test262Error: Expected SameValue(«1», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«1», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/expressions/assignment/dstr/array-elem-trlg-iter-rest-rtrn-close-err.js:
   default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
@@ -1017,32 +1011,32 @@ test/language/expressions/assignment/dstr/array-elem-trlg-iter-rest-rtrn-close-n
   default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
 test/language/expressions/assignment/dstr/array-elem-trlg-iter-rest-rtrn-close.js:
-  default: 'Test262Error: Expected SameValue(«11», «1») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«11», «1») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/expressions/assignment/dstr/array-elem-trlg-iter-rest-thrw-close-err.js:
-  default: 'Test262Error: Expected SameValue(«11», «1») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«11», «1») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/expressions/assignment/dstr/array-elem-trlg-iter-rest-thrw-close.js:
-  default: 'Test262Error: Expected SameValue(«11», «1») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«11», «1») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/expressions/assignment/dstr/array-rest-iter-rtrn-close-err.js:
-  default: "TypeError: undefined is not a function (near '...[...{}[yield]]...')"
-  strict mode: "TypeError: undefined is not a function (near '...[...{}[yield]]...')"
+  default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
 test/language/expressions/assignment/dstr/array-rest-iter-rtrn-close-null.js:
-  default: "TypeError: undefined is not a function (near '...[...{}[yield]]...')"
-  strict mode: "TypeError: undefined is not a function (near '...[...{}[yield]]...')"
+  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
 test/language/expressions/assignment/dstr/array-rest-iter-rtrn-close.js:
-  default: 'Test262Error: '
-  strict mode: 'Test262Error: '
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/expressions/assignment/dstr/array-rest-iter-thrw-close-err.js:
-  default: 'Test262Error: Expected SameValue(«11», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«11», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/expressions/assignment/dstr/array-rest-iter-thrw-close.js:
-  default: 'Test262Error: Expected SameValue(«11», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«11», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/expressions/assignment/dstr/array-rest-lref-err.js:
-  default: 'Test262Error: Expected SameValue(«1», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«1», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/expressions/assignment/fn-name-lhs-cover.js:
   default: 'Test262Error: descriptor value should be ; object value should be '
   strict mode: 'Test262Error: descriptor value should be ; object value should be '
@@ -1158,9 +1152,6 @@ test/language/statements/class/elements/nested-direct-eval-err-contains-argument
 test/language/statements/class/elements/nested-private-direct-eval-err-contains-arguments.js:
   default: 'Test262Error: Expected a SyntaxError but got a ReferenceError'
   strict mode: 'Test262Error: Expected a SyntaxError but got a ReferenceError'
-test/language/statements/class/elements/privatefieldset-evaluation-order-1.js:
-  default: 'Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all'
 test/language/statements/class/subclass/default-constructor-spread-override.js:
   default: 'Test262Error: @@iterator invoked'
   strict mode: 'Test262Error: @@iterator invoked'
@@ -1172,8 +1163,8 @@ test/language/statements/for-in/head-lhs-let.js:
 test/language/statements/for-in/identifier-let-allowed-as-lefthandside-expression-not-strict.js:
   default: "SyntaxError: Cannot use the keyword 'in' as a lexical variable name."
 test/language/statements/for-of/dstr/array-elem-iter-rtrn-close-err.js:
-  default: "TypeError: undefined is not a function (near '...[ {}[ yield ] ]...')"
-  strict mode: "TypeError: undefined is not a function (near '...[ {}[ yield ] ]...')"
+  default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
 test/language/statements/for-of/dstr/array-elem-iter-rtrn-close-null.js:
   default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
@@ -1181,11 +1172,11 @@ test/language/statements/for-of/dstr/array-elem-iter-rtrn-close.js:
   default: 'Test262Error: Expected SameValue(«0», «1») to be true'
   strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/statements/for-of/dstr/array-elem-iter-thrw-close-err.js:
-  default: 'Test262Error: Expected SameValue(«1», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«1», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/statements/for-of/dstr/array-elem-iter-thrw-close.js:
-  default: 'Test262Error: Expected SameValue(«1», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«1», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/statements/for-of/dstr/array-elem-trlg-iter-list-rtrn-close-err.js:
   default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
@@ -1196,11 +1187,11 @@ test/language/statements/for-of/dstr/array-elem-trlg-iter-list-rtrn-close.js:
   default: 'Test262Error: Expected SameValue(«0», «1») to be true'
   strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/statements/for-of/dstr/array-elem-trlg-iter-list-thrw-close-err.js:
-  default: 'Test262Error: Expected SameValue(«1», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«1», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/statements/for-of/dstr/array-elem-trlg-iter-list-thrw-close.js:
-  default: 'Test262Error: Expected SameValue(«1», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«1», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/statements/for-of/dstr/array-elem-trlg-iter-rest-rtrn-close-err.js:
   default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
@@ -1208,31 +1199,31 @@ test/language/statements/for-of/dstr/array-elem-trlg-iter-rest-rtrn-close-null.j
   default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
 test/language/statements/for-of/dstr/array-elem-trlg-iter-rest-rtrn-close.js:
-  default: 'Test262Error: Expected SameValue(«11», «1») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«11», «1») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/statements/for-of/dstr/array-elem-trlg-iter-rest-thrw-close-err.js:
-  default: 'Test262Error: Expected SameValue(«11», «1») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«11», «1») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/statements/for-of/dstr/array-elem-trlg-iter-rest-thrw-close.js:
-  default: 'Test262Error: Expected SameValue(«11», «1») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«11», «1») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/statements/for-of/dstr/array-rest-iter-rtrn-close-err.js:
-  default: "TypeError: undefined is not a function (near '...[...{}[yield]]...')"
-  strict mode: "TypeError: undefined is not a function (near '...[...{}[yield]]...')"
+  default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
 test/language/statements/for-of/dstr/array-rest-iter-rtrn-close-null.js:
-  default: "TypeError: undefined is not a function (near '...[...{}[yield]]...')"
-  strict mode: "TypeError: undefined is not a function (near '...[...{}[yield]]...')"
+  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
 test/language/statements/for-of/dstr/array-rest-iter-rtrn-close.js:
-  default: 'Test262Error: '
-  strict mode: 'Test262Error: '
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/statements/for-of/dstr/array-rest-iter-thrw-close-err.js:
-  default: 'Test262Error: Expected SameValue(«11», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«11», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/statements/for-of/dstr/array-rest-iter-thrw-close.js:
-  default: 'Test262Error: Expected SameValue(«11», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«11», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/statements/for-of/dstr/array-rest-lref-err.js:
-  default: 'Test262Error: Expected SameValue(«1», «0») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«1», «0») to be true'
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «1») to be true'
 test/language/statements/for/head-lhs-let.js:
   default: "SyntaxError: Unexpected token ';'. Expected a parameter pattern or a ')' in parameter list."

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -2467,6 +2467,8 @@ namespace JSC {
 
     class DestructuringPatternNode : public ParserArenaFreeable {
     public:
+        using BaseAndPropertyName = std::pair<RefPtr<RegisterID>, RefPtr<RegisterID>>;
+
         virtual ~DestructuringPatternNode() { }
         virtual void collectBoundIdentifiers(Vector<Identifier>&) const = 0;
         virtual void bindValue(BytecodeGenerator&, RegisterID* source) const = 0;
@@ -2607,6 +2609,9 @@ namespace JSC {
 
         RegisterID* writableDirectBindingIfPossible(BytecodeGenerator&) const final;
         void finishDirectBindingAssignment(BytecodeGenerator&) const;
+
+        std::optional<BaseAndPropertyName> emitNodesForDestructuring(BytecodeGenerator&, RefPtr<RegisterID> base = nullptr, RefPtr<RegisterID> propertyName = nullptr) const;
+        void bindValueWithEmittedNodes(BytecodeGenerator&, BaseAndPropertyName, RegisterID*) const;
 
     private:
         void collectBoundIdentifiers(Vector<Identifier>&) const final;


### PR DESCRIPTION
#### e14851d085d342b16e9b2ed95abaf77957d21f06
<pre>
[JSC] DestructuringAssignmentTarget should be evaluated prior to calling [[Get]] / stepping iterator
<a href="https://bugs.webkit.org/show_bug.cgi?id=268272">https://bugs.webkit.org/show_bug.cgi?id=268272</a>
&lt;<a href="https://rdar.apple.com/problem/121960976">rdar://problem/121960976</a>&gt;

Reviewed by Keith Miller and Yusuke Suzuki.

ECMA-262 specifies left-to-right evaluation order of expressions, which is maintained by evaluating
a DestructuringAssignmentTarget (unless it is a destructuring pattern) prior to calling [[Get]] [1] or
stepping the iterator [2] or evaluating the Initializer. The same applies [3][4] to a ...rest parameter.

This patch makes a copy of AssignmentElementNode::bindValue() for cases except ResolveNode and
divides it into emitNodesForDestructuring() / bindValueWithEmittedNodes().
A few implementation notes:
  a) AssignmentElementNode is guaranteed not to be a destructuring pattern;
  b) when binding to a ResolveNode, all errors occur in PutValue [5] rather then during evaluation
     of DestructuringAssignmentTarget;
  c) in order to prevent register clash when emitting an op_call to @copyDataProperties(),
     emitNodesForDestructuring() accepts temporary registers created before CallArguments.

To achieve complete spec compatibility, emitToPropertyKeyOrNumber() is called for computed property
names before evaluating DestructuringAssignmentTarget [6] regardless of ...rest parameter presence,
and is skipped only for commonly known types (string, number) to preserve performance.

Aligns JSC with the spec, V8, and SpiderMonkey. Proven to be perf-neutral on JS2 and SP3.

[1]: <a href="https://tc39.es/ecma262/#sec-runtime-semantics-keyeddestructuringassignmentevaluation">https://tc39.es/ecma262/#sec-runtime-semantics-keyeddestructuringassignmentevaluation</a> (step 1)
[2]: <a href="https://tc39.es/ecma262/#sec-runtime-semantics-iteratordestructuringassignmentevaluation">https://tc39.es/ecma262/#sec-runtime-semantics-iteratordestructuringassignmentevaluation</a> (production before last, step 1)
[3]: <a href="https://tc39.es/ecma262/#sec-runtime-semantics-restdestructuringassignmentevaluation">https://tc39.es/ecma262/#sec-runtime-semantics-restdestructuringassignmentevaluation</a> (step 1)
[4]: <a href="https://tc39.es/ecma262/#sec-runtime-semantics-iteratordestructuringassignmentevaluation">https://tc39.es/ecma262/#sec-runtime-semantics-iteratordestructuringassignmentevaluation</a> (last production, step 1)
[5]: <a href="https://tc39.es/ecma262/#sec-putvalue">https://tc39.es/ecma262/#sec-putvalue</a>
[6]: <a href="https://tc39.es/ecma262/#sec-runtime-semantics-propertydestructuringassignmentevaluation">https://tc39.es/ecma262/#sec-runtime-semantics-propertydestructuringassignmentevaluation</a> (last production, step 1)

* JSTests/stress/destructuring-evaluation-order-array-bracket-accessor-iterator-done.js: Added.
* JSTests/stress/destructuring-evaluation-order-array-bracket-accessor.js: Added.
* JSTests/stress/destructuring-evaluation-order-array-dot-accessor-iterator-done.js: Added.
* JSTests/stress/destructuring-evaluation-order-array-dot-accessor.js: Added.
* JSTests/stress/destructuring-evaluation-order-array-rest-element-iterator-done.js: Added.
* JSTests/stress/destructuring-evaluation-order-array-rest-element.js: Added.
* JSTests/stress/destructuring-evaluation-order-object-bracket-accessor.js: Added.
* JSTests/stress/destructuring-evaluation-order-object-dot-accessor.js: Added.
* JSTests/stress/destructuring-evaluation-order-object-rest-element.js: Added.
* JSTests/test262/expectations.yaml: Mark 5 tests as passing, progress 56 tests.
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ArrayPatternNode::bindValue const):
(JSC::ObjectPatternNode::bindValue const):
(JSC::AssignmentElementNode::emitNodesForDestructuring const):
(JSC::AssignmentElementNode::bindValueWithEmittedNodes const):
* Source/JavaScriptCore/parser/Nodes.h:

Canonical link: <a href="https://commits.webkit.org/281013@main">https://commits.webkit.org/281013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31219f3bdf1478ffec81885805c143c867b7d02f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62052 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/8871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9068 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/8871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60458 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/50518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/28165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/32118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/7817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7875 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/51518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/8087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63756 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57669 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2340 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2348 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/50540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/54708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/1980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79429 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8702 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/13214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/34669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/34414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->