### PR TITLE
[WebAuthn] Implement required CTAP API layer for setting pin

### DIFF
--- a/Source/WebCore/Modules/webauthn/fido/Pin.h
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.h
@@ -134,7 +134,7 @@ private:
     explicit KeyAgreementResponse(Ref<WebCore::CryptoKeyEC>&&);
 };
 
-struct SetPinRequest {
+class SetPinRequest {
 public:
     WEBCORE_EXPORT const WebCore::CryptoKeyAES& sharedKey() const;
     WEBCORE_EXPORT static std::optional<SetPinRequest> tryCreate(const String& newPin, const WebCore::CryptoKeyEC&);

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
@@ -120,6 +120,11 @@ void AuthenticatorPresenterCoordinator::updatePresenter(WebAuthenticationStatus 
         m_credentialRequestHandler(nil, error.get());
         break;
     }
+    case WebAuthenticationStatus::PinRequired: {
+        auto error = adoptNS([[NSError alloc] initWithDomain:ASCAuthorizationErrorDomain code:ASCAuthorizationErrorPINRequired userInfo:nil]);
+        m_credentialRequestHandler(nil, error.get());
+        break;
+    }
     case WebAuthenticationStatus::MultipleNFCTagsPresent: {
         auto error = adoptNS([[NSError alloc] initWithDomain:ASCAuthorizationErrorDomain code:ASCAuthorizationErrorMultipleNFCTagsPresent userInfo:nil]);
         [m_presenter updateInterfaceForUserVisibleError:error.get()];

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h
@@ -50,6 +50,7 @@ enum class WebAuthenticationStatus : uint8_t {
     LAExcludeCredentialsMatched,
     LANoCredential,
     KeyStoreFull,
+    PinRequired,
 };
 
 enum class LocalAuthenticatorPolicy : bool {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -312,7 +312,8 @@ void CtapAuthenticator::continueGetKeyAgreementAfterGetRetries(Vector<uint8_t>&&
     auto retries = pin::RetriesResponse::parse(data);
     if (!retries) {
         auto error = getResponseCode(data);
-        receiveRespond(ExceptionData { ExceptionCode::UnknownError, makeString("Unknown internal error. Error code: "_s, static_cast<uint8_t>(error)) });
+        //WTFReportBacktrace()
+        receiveRespond(ExceptionData { ExceptionCode::UnknownError, makeString("Unknown internal error. Error code: "_s, static_cast<uint8_t>(error)) }); //look for this w/no pin key on uv required
         return;
     }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -28,10 +28,17 @@
 #if ENABLE(WEB_AUTHN)
 
 #include "FidoAuthenticator.h"
+#include "WebCore/Pin.h"
 #include <WebCore/AuthenticatorGetInfoResponse.h>
 
 namespace fido {
 namespace pin {
+
+enum class PinRequestType : uint8_t {
+    kSetPin = 1,
+    kGetPinToken = 2,
+};
+
 class TokenRequest;
 }
 }
@@ -65,6 +72,8 @@ private:
     void continueRequestPinAfterGetKeyAgreement(Vector<uint8_t>&&, uint64_t retries);
     void continueGetPinTokenAfterRequestPin(const String& pin, const WebCore::CryptoKeyEC&);
     void continueRequestAfterGetPinToken(Vector<uint8_t>&&, const fido::pin::TokenRequest&);
+    void continueSetPinAfterRequestPin(const String& pin, const WebCore::CryptoKeyEC&);
+    void continueRequestAfterSetPin(Vector<uint8_t>&&, const fido::pin::SetPinRequest&);
     bool tryRestartPin(const fido::CtapDeviceResponseCode&);
 
     bool tryDowngrade();
@@ -76,6 +85,7 @@ private:
     fido::AuthenticatorGetInfoResponse m_info;
     bool m_isDowngraded { false };
     bool m_isKeyStoreFull { false };
+    fido::pin::PinRequestType m_requestType = fido::pin::PinRequestType::kGetPinToken; //TODO: probably should change this later
     size_t m_remainingAssertionResponses { 0 };
     Vector<Ref<WebCore::AuthenticatorAssertionResponse>> m_assertionResponses;
     Vector<uint8_t> m_pinAuth;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -1092,6 +1092,24 @@ TEST(WebAuthenticationPanel, MakeCredentialPin)
     [webView waitForMessage:@"Succeeded!"];
 }
 
+//TODO: my silly little test
+//TEST(WebAuthenticationPanel, MakeCredentialPin)
+//{
+//    reset();
+//    RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"web-authentication-make-credential-hid-pin" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
+//
+//    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+//
+//    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+//    auto delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
+//    [webView setUIDelegate:delegate.get()];
+//    [webView focus];
+//
+//    webAuthenticationPanelPin = "1234"_s;
+//    [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
+//    [webView waitForMessage:@"Succeeded!"];
+//}
+
 TEST(WebAuthenticationPanel, MakeCredentialPinAuthBlockedError)
 {
     reset();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/web-authentication-make-credential-hid-pin.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/web-authentication-make-credential-hid-pin.html
@@ -49,6 +49,13 @@
     navigator.credentials.create(options).then(credential => {
         // console.log("Succeeded!");
         window.webkit.messageHandlers.testHandler.postMessage("Succeeded!");
+        
+        
+	//first create then error
+	//mostly same file
+	//diff fake responses
+	//same pin entry delegate
+	//testwebkitapi
     }, error => {
         // console.log(error.message);
         window.webkit.messageHandlers.testHandler.postMessage(error.message);


### PR DESCRIPTION
#### dce39770aac7fab2c3d2c6fa5b1c15ebe28f0a6a
<pre>
[WebAuthn] Implement required CTAP API layer for setting pin
<a href="https://bugs.webkit.org/show_bug.cgi?id=269083">https://bugs.webkit.org/show_bug.cgi?id=269083</a>
<a href="https://rdar.apple.com/122660610">rdar://122660610</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/Modules/webauthn/fido/Pin.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm:
(WebKit::AuthenticatorPresenterCoordinator::updatePresenter):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::continueRequestPinAfterGetKeyAgreement):
(WebKit::CtapAuthenticator::continueSetPinAfterRequestPin):
(WebKit::CtapAuthenticator::continueRequestAfterSetPin):
(WebKit::CtapAuthenticator::continueRequestAfterGetPinToken):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1b774e0740a97920cba3fcfce83083b2d64e472

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57202 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60823 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7645 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46315 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5382 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59232 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27175 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6701 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6650 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62503 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53580 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49424 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53647 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/937 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32359 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33444 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34529 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->