### PR TITLE
[Writing Tools] Rewritten text gets reselected when trying to modify after rewrite

### DIFF
--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -573,12 +573,6 @@ void WritingToolsController::didEndWritingToolsSession(const WritingTools::Sessi
 
     m_page->chrome().client().removeInitialTextAnimation(session.identifier);
 
-    // At this point, the selection will be the replaced text, which is the desired behavior for
-    // Smart Reply sessions. However, for others, the entire session context range should be selected.
-
-    if (session.compositionType != WritingTools::Session::CompositionType::SmartReply)
-        document->selection().setSelection({ *sessionRange });
-
     m_page->chrome().client().removeTransparentMarkersForSessionID(session.identifier);
 
     m_states.remove(session.identifier);


### PR DESCRIPTION
#### 7cf1101f128db00e1ffd52c3b4e796be3e4580ec
<pre>
[Writing Tools] Rewritten text gets reselected when trying to modify after rewrite
<a href="https://bugs.webkit.org/show_bug.cgi?id=276110">https://bugs.webkit.org/show_bug.cgi?id=276110</a>
<a href="https://rdar.apple.com/130782802">rdar://130782802</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

Currently, the selection is set to the session&apos;s context range when Writing Tools
is ended. This is undesirable, as Writing Tools can be ended by clicking elsewhere
in web content, which itself changes the selection. This results in a scenario
where the user modifies the selection, Writing Tools ends, and then changes the
user&apos;s selection again.

Fix by removing the logic which modifies selection when Writing Tools ends. This
was never the intended behavior. Instead, the selection should simply be set when
rewriting has finished (but the panel is still visible), which continues to be the
case.

Adjust tests to reflect the correct behavior.

* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::didEndWritingToolsSession):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, ProofreadingAcceptReject)):
(TEST(WritingTools, ContextRangeFromCaretSelection)):

It does not make sense to rewrite to an empty string. Correct that.

(TEST(WritingTools, ContextRangeFromRangeSelection)):

Augment this test to modify the selection prior to ending Writing Tools,
ensuring test coverage for the change made this patch.

Canonical link: <a href="https://commits.webkit.org/280580@main">https://commits.webkit.org/280580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4c2e81d2e5466fcc787e6fcfd9c6dad9f09c981

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60609 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7432 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46152 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5219 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49187 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27012 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6518 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6437 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62290 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6893 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53409 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53448 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12609 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/763 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32146 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33231 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34316 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->