### PR TITLE
[ApplePay] PaymentRequestValidator::validateTotal() imposes an arbitrary 8 digit limit on the total amount

### DIFF
--- a/LayoutTests/http/tests/ssl/applepay/ApplePaySession-expected.txt
+++ b/LayoutTests/http/tests/ssl/applepay/ApplePaySession-expected.txt
@@ -152,9 +152,6 @@ PASS new ApplePaySession(2, request) threw exception TypeError: "amount" is not 
 SETUP: request = validRequest(); request.total = { label: 'label', amount: '-10.00' };
 PASS new ApplePaySession(2, request) threw exception TypeError: Total amount must not be negative..
 
-SETUP: request = validRequest(); request.total = { label: 'label', amount: '10000000000.00' };
-PASS new ApplePaySession(2, request) threw exception TypeError: Total amount is too big..
-
 SETUP: request = validRequest(); request.total = { label: 'label', amount: '10.00', type: 'invalid' };
 PASS new ApplePaySession(2, request) threw exception TypeError: Type error.
 

--- a/LayoutTests/http/tests/ssl/applepay/ApplePaySession.html
+++ b/LayoutTests/http/tests/ssl/applepay/ApplePaySession.html
@@ -110,7 +110,6 @@ function go() {
     logAndShouldThrow("request = validRequest(); request.total = { label: 'label' };", "new ApplePaySession(2, request)")
     logAndShouldThrow("request = validRequest(); request.total = { label: 'label', amount: 'amount' };", "new ApplePaySession(2, request)")
     logAndShouldThrow("request = validRequest(); request.total = { label: 'label', amount: '-10.00' };", "new ApplePaySession(2, request)")
-    logAndShouldThrow("request = validRequest(); request.total = { label: 'label', amount: '10000000000.00' };", "new ApplePaySession(2, request)")
     logAndShouldThrow("request = validRequest(); request.total = { label: 'label', amount: '10.00', type: 'invalid' };", "new ApplePaySession(2, request)")
     logAndShouldNotThrow("request = validRequest(); request.total = { label: 'label', amount: '10.00', type: 'pending' };", "new ApplePaySession(2, request)")
     

--- a/LayoutTests/http/tests/ssl/applepay/PaymentRequest.https-expected.txt
+++ b/LayoutTests/http/tests/ssl/applepay/PaymentRequest.https-expected.txt
@@ -205,8 +205,6 @@ PASS new PaymentRequest([validPaymentMethod()], paymentDetails) threw exception 
 SETUP: paymentDetails = validPaymentDetails(); paymentDetails.total = { label: 'label', amount: { currency: 'USD', value:'-10.00'} };
 PASS new PaymentRequest([validPaymentMethod()], paymentDetails) threw exception TypeError: Total currency values cannot be negative..
 
-SETUP: paymentDetails = validPaymentDetails(); paymentDetails.total = { label: 'label', amount: { currency: 'USD', value: '10000000000.00' } }; request = new PaymentRequest([validPaymentMethod()], paymentDetails)
-PASS request.show() rejected promise  with TypeError: Total amount is too big..
 
 
 Testing PaymentDetails.displayItems

--- a/LayoutTests/http/tests/ssl/applepay/PaymentRequest.https.html
+++ b/LayoutTests/http/tests/ssl/applepay/PaymentRequest.https.html
@@ -147,7 +147,6 @@ async function go() {
     await logAndShouldThrow("paymentDetails = validPaymentDetails(); paymentDetails.total = { label: 'label', amount: 'amount' };", "new PaymentRequest([validPaymentMethod()], paymentDetails)")
     await logAndShouldThrow("paymentDetails = validPaymentDetails(); paymentDetails.total = { label: 'label', amount: { currency: '', value: '0' } };", "new PaymentRequest([validPaymentMethod()], paymentDetails)")
     await logAndShouldThrow("paymentDetails = validPaymentDetails(); paymentDetails.total = { label: 'label', amount: { currency: 'USD', value:'-10.00'} };", "new PaymentRequest([validPaymentMethod()], paymentDetails)")
-    await logAndShouldReject("paymentDetails = validPaymentDetails(); paymentDetails.total = { label: 'label', amount: { currency: 'USD', value: '10000000000.00' } }; request = new PaymentRequest([validPaymentMethod()], paymentDetails)", "request.show()")
     debug("")
     debug("")
 

--- a/Source/WebCore/Modules/applepay/PaymentRequestValidator.mm
+++ b/Source/WebCore/Modules/applepay/PaymentRequestValidator.mm
@@ -105,8 +105,9 @@ ExceptionOr<void> PaymentRequestValidator::validateTotal(const ApplePayLineItem&
     if (amount < 0)
         return Exception { ExceptionCode::TypeError, "Total amount must not be negative."_s };
 
-    if (amount > 100000000)
-        return Exception { ExceptionCode::TypeError, "Total amount is too big."_s };
+    // We can safely defer a maximum amount check to the underlying payment system, instead.
+    // The downside is we lose an informative error mode and get an opaque payment sheet error for too large total amounts.
+    // FIXME: <https://webkit.org/b/276088> PaymentRequestValidator should adopt per-currency checks for total amounts.
 
     return { };
 }


### PR DESCRIPTION
#### d2ec1f7779ef1a96793eaa8b83a60e4b8782d8b3
<pre>
[ApplePay] PaymentRequestValidator::validateTotal() imposes an arbitrary 8 digit limit on the total amount
<a href="https://bugs.webkit.org/show_bug.cgi?id=276087">https://bugs.webkit.org/show_bug.cgi?id=276087</a>
<a href="https://rdar.apple.com/112078798">rdar://112078798</a>

Reviewed by Megan Gardner.

WebCore performs some sanity checks on Apple Pay line items, and one of
these checks is to make sure the total amount of a payment request is
smaller than (some) large value. This value was made to match PassKit&apos;s
maximum amount in 177329@main.

Unfortunately, now, this is _just_ an arbitrarily large value, and does
not match PassKit&apos;s maximum amount any longer. Moreover, we have found
this simple max amount check to be misleading since said amount is not
static; it is modulated by various factors, such the varying minor
decimal places per currency. To this end, we simply delegate checking
against a maximum total amount to the underlying payment system instead
of trying to resolve all the nuances ourselves, some of which require
system support that is unavailable.

This change means that we unfortunately lose a descriptive error mode
since we no longer surface a &quot;Total amount is too large&quot; type error in
the web console and instead just opaquely fail at the payment sheet. We
want to restore this behavior as part of webkit.org/b/276088 by adopting
per-currency checks for the total amount.

* LayoutTests/http/tests/ssl/applepay/ApplePaySession-expected.txt:
* LayoutTests/http/tests/ssl/applepay/ApplePaySession.html:
* LayoutTests/http/tests/ssl/applepay/PaymentRequest.https-expected.txt:
* LayoutTests/http/tests/ssl/applepay/PaymentRequest.https.html:
* Source/WebCore/Modules/applepay/PaymentRequestValidator.mm:
(WebCore::PaymentRequestValidator::validateTotal):

Canonical link: <a href="https://commits.webkit.org/280584@main">https://commits.webkit.org/280584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04416791335f4818d6685a7e87b76dd6c067ccd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60621 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7444 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7634 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46164 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5232 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27024 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30895 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6530 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6449 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62302 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53421 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53460 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12613 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/775 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32158 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33243 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34328 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->