### PR TITLE
[WebXR] imported/w3c/web-platform-tests/webxr/xrWebGLLayer_viewports.https.html  is constant failure

### DIFF
--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -131,11 +131,9 @@ imported/w3c/web-platform-tests/webxr/xr_viewport_scale.https.html [ Failure ]
 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_draw.https.html [ Failure ]
 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https.html [ Failure ]
 
-webkit.org/b/274931 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_viewports.https.html [ Failure ]
-
 webkit.org/b/274980 imported/w3c/web-platform-tests/webxr/xrViewport_valid.https.html [ Failure ]
 
-imported/w3c/web-platform-tests/webxr/getInputPose_pointer.https.html275009 [VisionOS] 3 tests in fast/events/pointer/iOS tests are timing out constantly
+# webkit.org/b/275009 [VisionOS] 3 tests in fast/events/pointer/iOS tests are timing out constantly
 fast/events/pointer/ios/drag-gives-pointerdown-pointermove-pointerup.html [ Timeout ]
 fast/events/pointer/ios/drag-populates-pointer-events-with-movementxy-fields.html [ Timeout ]
 fast/events/pointer/ios/tap-gives-pointerdown-pointerup.html [ Timeout ]

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -260,7 +260,7 @@ struct FrameData {
 
 #if PLATFORM(COCOA)
     struct RateMapDescription {
-        WebCore::IntSize screenSize;
+        WebCore::IntSize screenSize = { 0, 0 };
         Vector<float> horizontalSamplesLeft;
         Vector<float> horizontalSamplesRight;
         // Vertical samples is shared by both horizontalSamples

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -161,7 +161,13 @@ void SimulatedXRDevice::frameTimerFired()
     for (auto& layer : m_layers) {
 #if PLATFORM(COCOA)
         PlatformXR::FrameData::LayerSetupData layerSetupData;
-        layerSetupData.physicalSize[0] = { static_cast<uint16_t>(layer.value.width()), static_cast<uint16_t>(layer.value.height()) };
+        auto width = layer.value.width();
+        auto height = layer.value.height();
+        layerSetupData.physicalSize[0] = { static_cast<uint16_t>(width), static_cast<uint16_t>(height) };
+        layerSetupData.viewports[0] = { 0, 0, width, height };
+        layerSetupData.physicalSize[1] = { 0, 0 };
+        layerSetupData.viewports[1] = { 0, 0, 0, 0 };
+
         auto layerData = makeUniqueRef<PlatformXR::FrameData::LayerData>(PlatformXR::FrameData::LayerData {
             .layerSetup = layerSetupData,
         });


### PR DESCRIPTION
#### ad47dcc5f6e3ff8961b3c1ef71983eedabfc3cda
<pre>
[WebXR] imported/w3c/web-platform-tests/webxr/xrWebGLLayer_viewports.https.html  is constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=274931">https://bugs.webkit.org/show_bug.cgi?id=274931</a>
<a href="https://rdar.apple.com/129031661">rdar://129031661</a>

Reviewed by Mike Wyrzykowski.

WebFakeXRDevice was not setting up any viewports in
PlatformXR::FrameData::layerSetupData which causes the test to conclude that the
viewports overlap and, thus, fail.

Passing sensible values for the left and right viewport fixes the test.

* LayoutTests/platform/visionos/TestExpectations:
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::frameTimerFired):

Canonical link: <a href="https://commits.webkit.org/280605@main">https://commits.webkit.org/280605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83abe349a40c55e83aadd7a155cf3ca03cba9d36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60614 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7437 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46154 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5225 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27014 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6523 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6442 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62295 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53414 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53453 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12621 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/766 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32151 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33236 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34321 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->