### PR TITLE
Text replacement animations do not run in the correct order and fail to animate over the correct ranges when text comes in over time.

### DIFF
--- a/Source/WebCore/editing/CharacterRange.h
+++ b/Source/WebCore/editing/CharacterRange.h
@@ -46,6 +46,8 @@ struct CharacterRange {
     CharacterRange() = default;
     constexpr CharacterRange(uint64_t location, uint64_t length);
 
+    bool operator==(const CharacterRange&) const = default;
+
 #if USE(CF)
     constexpr CharacterRange(CFRange);
     constexpr operator CFRange() const;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -678,9 +678,11 @@ public:
 
     virtual void addInitialTextAnimation(const WritingTools::SessionID&) { }
 
-    virtual void addSourceTextAnimation(const WritingTools::SessionID&, const CharacterRange&) { }
+    virtual void addSourceTextAnimation(const WritingTools::SessionID&, const CharacterRange&, const String, WTF::CompletionHandler<void(void)>&&) { }
 
-    virtual void addDestinationTextAnimation(const WritingTools::SessionID&, const CharacterRange&) { }
+    virtual void addDestinationTextAnimation(const WritingTools::SessionID&, const CharacterRange&, const String) { }
+
+    virtual void clearAnimationsForSessionID(const WritingTools::SessionID&) { };
 #endif
 
     virtual void hasActiveNowPlayingSessionChanged(bool) { }

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -30,6 +30,9 @@
 #import "Range.h"
 #import "WritingToolsCompositionCommand.h"
 #import "WritingToolsTypes.h"
+#import <wtf/CheckedPtr.h>
+#import <wtf/FastMalloc.h>
+#import <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -43,9 +46,10 @@ class Page;
 
 struct SimpleRange;
 
-class WritingToolsController final {
+class WritingToolsController final : public CanMakeWeakPtr<WritingToolsController>, public CanMakeCheckedPtr<WritingToolsController> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(WritingToolsController);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WritingToolsController);
 
 public:
     explicit WritingToolsController(Page&);

--- a/Source/WebKit/Shared/TextAnimationType.serialization.in
+++ b/Source/WebKit/Shared/TextAnimationType.serialization.in
@@ -32,7 +32,7 @@ header: "TextAnimationType.h"
 header: "TextAnimationType.h"
 [CustomHeader] struct WebKit::TextAnimationData {
     WebKit::TextAnimationType style;
-    WTF::UUID remainingRangeUUID;
+    WTF::UUID unanimatedRangeUUID;
 };
 
 #endif

--- a/Source/WebKit/UIProcess/TextAnimationType.h
+++ b/Source/WebKit/UIProcess/TextAnimationType.h
@@ -37,7 +37,8 @@ enum class TextAnimationType : uint8_t {
 
 struct TextAnimationData {
     TextAnimationType style;
-    WTF::UUID remainingRangeUUID { WTF::UUID::emptyValue };
+    WTF::UUID unanimatedRangeUUID { WTF::UUID::emptyValue };
+
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10060,6 +10060,10 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
     setMediaCapability(std::nullopt);
 #endif
 
+#if ENABLE(WRITING_TOOLS)
+    internals().completionHandlerForAnimationID.clear();
+#endif
+
     m_nowPlayingMetadataObservers.clear();
     m_nowPlayingMetadataObserverForTesting = nullptr;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2422,11 +2422,12 @@ public:
 #endif // ENABLE(WRITING_TOOLS)
 
 #if ENABLE(WRITING_TOOLS_UI)
-    void addTextAnimationForAnimationID(IPC::Connection&, const WTF::UUID&, const WebKit::TextAnimationData&, const WebCore::TextIndicatorData&);
+    void addTextAnimationForAnimationID(IPC::Connection&, const WTF::UUID&, const WebKit::TextAnimationData&, const WebCore::TextIndicatorData&, WTF::CompletionHandler<void(void)>&&);
     void removeTextAnimationForAnimationID(IPC::Connection&, const WTF::UUID&);
     void enableSourceTextAnimationAfterElementWithID(const String& elementID, const WTF::UUID&);
     void enableTextAnimationTypeForElementWithID(const String& elementID, const WTF::UUID&);
 
+    void callCompletionHandlerForAnimationID(const WTF::UUID&);
     void getTextIndicatorForID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
     void updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID&, bool, CompletionHandler<void()>&& = [] { });
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -520,7 +520,7 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(WRITING_TOOLS_UI)
-    AddTextAnimationForAnimationID(WTF::UUID uuid, struct WebKit::TextAnimationData styleData, struct WebCore::TextIndicatorData indicatorData)
+    AddTextAnimationForAnimationID(WTF::UUID uuid, struct WebKit::TextAnimationData styleData, struct WebCore::TextIndicatorData indicatorData) -> ()
     RemoveTextAnimationForAnimationID(WTF::UUID uuid)
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -294,7 +294,8 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    HashMap<WTF::UUID, WebCore::TextIndicatorData> textIndicatorDataForChunk;
+    HashMap<WTF::UUID, WebCore::TextIndicatorData> textIndicatorDataForAnimationID;
+    HashMap<WTF::UUID, CompletionHandler<void()>> completionHandlerForAnimationID;
 #endif
 
     MonotonicTime didFinishDocumentLoadForMainFrameTimestamp;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -13171,6 +13171,12 @@ inline static NSString *extendSelectionCommand(UITextLayoutDirection direction)
     return self;
 }
 
+- (void)callCompletionHandlerForAnimationID:(NSUUID *)uuid
+{
+    auto animationUUID = WTF::UUID::fromNSUUID(uuid);
+    _page->callCompletionHandlerForAnimationID(*animationUUID);
+}
+
 #endif
 
 #pragma mark - BETextInteractionDelegate

--- a/Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift
+++ b/Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift
@@ -114,8 +114,19 @@ extension TextAnimationManager: UITextEffectView.ReplacementTextEffect.Delegate 
     
     public func replacementEffectDidComplete(_ effect: UITextEffectView.ReplacementTextEffect) {
         self.effectView.removeEffect(effect.id)
-        
-        // FIXME: remove the effect from the chunkToEffect map rdar://126307144
+
+        guard let (animationID, _) = chunkToEffect.first(where: { (_, value) in value == effect.id }) else {
+            return
+        }
+
+        chunkToEffect[animationID] = nil
+
+        guard let delegate = self.delegate else {
+            Self.logger.debug("Can't obtain Targeted Preview. Missing delegate.")
+            return
+        }
+
+        delegate.callCompletionHandler(forAnimationID: animationID)
     }
 }
 

--- a/Source/WebKit/WebKitSwift/TextAnimation/WKSTextAnimationSourceDelegate.h
+++ b/Source/WebKit/WebKitSwift/TextAnimation/WKSTextAnimationSourceDelegate.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)targetedPreviewForID:(NSUUID *)uuid completionHandler:(void (^)(UITargetedPreview * _Nullable))completionHandler;
 - (void)updateUnderlyingTextVisibilityForTextAnimationID:(NSUUID *)uuid visible:(BOOL)visible completionHandler:(void (^)(void))completionHandler;
 - (UIView *)containingViewForTextAnimationType;
+- (void)callCompletionHandlerForAnimationID:(NSUUID *)uuid;
 
 @end
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1885,14 +1885,19 @@ void WebChromeClient::addInitialTextAnimation(const WritingTools::Session::ID& s
     protectedPage()->addInitialTextAnimation(sessionID);
 }
 
-void WebChromeClient::addSourceTextAnimation(const WritingTools::Session::ID& sessionID, const CharacterRange& range)
+void WebChromeClient::addSourceTextAnimation(const WritingTools::Session::ID& sessionID, const CharacterRange& range, const String string, WTF::CompletionHandler<void(void)>&& completionHandler)
 {
-    protectedPage()->addSourceTextAnimation(sessionID, range);
+    protectedPage()->addSourceTextAnimation(sessionID, range, string, WTFMove(completionHandler));
 }
 
-void WebChromeClient::addDestinationTextAnimation(const WritingTools::Session::ID& sessionID, const CharacterRange& range)
+void WebChromeClient::addDestinationTextAnimation(const WritingTools::Session::ID& sessionID, const CharacterRange& range, const String string)
 {
-    protectedPage()->addDestinationTextAnimation(sessionID, range);
+    protectedPage()->addDestinationTextAnimation(sessionID, range, string);
+}
+
+void WebChromeClient::clearAnimationsForSessionID(const WritingTools::Session::ID& sessionID)
+{
+    protectedPage()->clearAnimationsForSessionID(sessionID);
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -523,9 +523,12 @@ private:
 
     void removeTransparentMarkersForSessionID(const WebCore::WritingTools::SessionID&) final;
 
-    void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&) final;
+    void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String, WTF::CompletionHandler<void(void)>&&) final;
 
-    void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&) final;
+    void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String) final;
+
+    void clearAnimationsForSessionID(const WebCore::WritingTools::SessionID&) final;
+
 #endif
 
     void hasActiveNowPlayingSessionChanged(bool) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9232,9 +9232,9 @@ void WebPage::lastNavigationWasAppInitiated(CompletionHandler<void(bool)>&& comp
 
 #if ENABLE(WRITING_TOOLS_UI)
 
-void WebPage::addTextAnimationForAnimationID(const WTF::UUID& uuid, const WebKit::TextAnimationData& styleData, const WebCore::TextIndicatorData& indicatorData)
+void WebPage::addTextAnimationForAnimationID(const WTF::UUID& uuid, const WebKit::TextAnimationData& styleData, const WebCore::TextIndicatorData& indicatorData, CompletionHandler<void()>&& completionHandler)
 {
-    send(Messages::WebPageProxy::AddTextAnimationForAnimationID(uuid, styleData, indicatorData));
+    sendWithAsyncReply(Messages::WebPageProxy::AddTextAnimationForAnimationID(uuid, styleData, indicatorData), WTFMove(completionHandler));
 }
 
 void WebPage::removeTextAnimationForAnimationID(const WTF::UUID& uuid)
@@ -9258,14 +9258,19 @@ void WebPage::addInitialTextAnimation(const WTF::UUID& uuid)
 }
 
 
-void WebPage::addSourceTextAnimation(const WTF::UUID& uuid, const CharacterRange& range)
+void WebPage::addSourceTextAnimation(const WTF::UUID& uuid, const CharacterRange& range, const String string, WTF::CompletionHandler<void(void)>&& completionHandler)
 {
-    m_textAnimationController->addSourceTextAnimation(uuid, range);
+    m_textAnimationController->addSourceTextAnimation(uuid, range, string, WTFMove(completionHandler));
 }
 
-void WebPage::addDestinationTextAnimation(const WTF::UUID& uuid, const CharacterRange& range)
+void WebPage::addDestinationTextAnimation(const WTF::UUID& uuid, const CharacterRange& range, const String string)
 {
-    m_textAnimationController->addDestinationTextAnimation(uuid, range);
+    m_textAnimationController->addDestinationTextAnimation(uuid, range, string);
+}
+
+void WebPage::clearAnimationsForSessionID(const WTF::UUID& uuid)
+{
+    m_textAnimationController->clearAnimationsForSessionID(uuid);
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1771,17 +1771,18 @@ public:
     void enableSourceTextAnimationAfterElementWithID(const String&, const WTF::UUID&);
     void enableTextAnimationTypeForElementWithID(const String&, const WTF::UUID&);
 
-    void addTextAnimationForAnimationID(const WTF::UUID&, const WebKit::TextAnimationData&, const WebCore::TextIndicatorData&);
+    void addTextAnimationForAnimationID(const WTF::UUID&, const WebKit::TextAnimationData&, const WebCore::TextIndicatorData&, CompletionHandler<void()>&& = nil);
 
     void removeTextAnimationForAnimationID(const WTF::UUID&);
     void removeTransparentMarkersForSessionID(const WebCore::WritingTools::SessionID&);
 
     void removeInitialTextAnimation(const WebCore::WritingTools::SessionID&);
     void addInitialTextAnimation(const WebCore::WritingTools::SessionID&);
-    void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&);
-    void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&);
+    void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String, WTF::CompletionHandler<void(void)>&&);
+    void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&, const String);
+    void clearAnimationsForSessionID(const WebCore::WritingTools::SessionID&);
 
-    void createTextIndicatorForRange(const WebCore::SimpleRange&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
+    std::optional<WebCore::TextIndicatorData> createTextIndicatorForRange(const WebCore::SimpleRange&);
     void createTextIndicatorForTextAnimationID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
 #endif
 


### PR DESCRIPTION
#### 5c25cad683ccc1832ce4f12f283a032a2be9f4ac
<pre>
Text replacement animations do not run in the correct order and fail to animate over the correct ranges when text comes in over time.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276113">https://bugs.webkit.org/show_bug.cgi?id=276113</a>
<a href="https://rdar.apple.com/128292335">rdar://128292335</a>

Reviewed by Aditya Keerthi and Wenson Hsieh.

I was not using the full async animation infrastructure
and the tracking of the different ranges as the different
chunks came in was not correct. These changes should
streamline the animations and correct some not-as-good names
for some of the variables. There are still some frames that
need a bit of polish, but this is a much better working version
than we have had up to this point.

* Source/WebCore/editing/CharacterRange.h:
(WebCore::CharacterRange::operator== const):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::addSourceTextAnimation):
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange):
* Source/WebKit/Shared/TextAnimationType.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::addTextAnimationForAnimationID):
(WebKit::WebPageProxy::callCompletionHandlerForAnimationID):
(WebKit::WebPageProxy::getTextIndicatorForID):
* Source/WebKit/UIProcess/TextAnimationType.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm:
(-[WKTextAnimationManager addTextAnimationForAnimationID:withData:]):
(-[WKTextAnimationManager textPreviewsForChunk:completion:]):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::addSourceTextAnimation):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::TextAnimationController::unreplacedRangeForSessionWithID const):
(WebKit::TextAnimationController::contextRangeForTextAnimationID const):
(WebKit::TextAnimationController::removeTransparentMarkersForSessionID):
(WebKit::remainingCharacterRange):
(WebKit::TextAnimationController::addInitialTextAnimation):
(WebKit::TextAnimationController::addSourceTextAnimation):
(WebKit::TextAnimationController::addDestinationTextAnimation):
(WebKit::TextAnimationController::updateUnderlyingTextVisibilityForTextAnimationID):
(WebKit::newlyReplacedCharacterRange): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::addTextAnimationForAnimationID):
(WebKit::WebPage::addSourceTextAnimation):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/280763@main">https://commits.webkit.org/280763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf31a3bfdb680bdcd10668242db17db0d6465895

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61136 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7959 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46574 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5640 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49682 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27438 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6985 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6962 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53320 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62815 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53832 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53951 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12725 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1218 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32671 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33756 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34841 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->