### PR TITLE
Fix canvas-drawImage-hdr-video.html color failures

### DIFF
--- a/LayoutTests/fast/canvas/canvas-drawImage-hdr-video.html
+++ b/LayoutTests/fast/canvas/canvas-drawImage-hdr-video.html
@@ -22,15 +22,15 @@
 
         let x = 1920;
         let y = 540;
-        let sigma = 5;
 
         let pixel = "pixelColor(" + x + " ," + y + ")";
         let expectedColor = [0, 174, 0, 255];
+        let sigma = [0, 0, 0, 0];
 
-        shouldBeCloseTo(pixel + "[0]", expectedColor[0], sigma);
-        shouldBeCloseTo(pixel + "[1]", expectedColor[1], sigma);
-        shouldBeCloseTo(pixel + "[2]", expectedColor[2], sigma);
-        shouldBeCloseTo(pixel + "[3]", expectedColor[3], sigma);
+        shouldBeCloseTo(pixel + "[0]", expectedColor[0], sigma[0]);
+        shouldBeCloseTo(pixel + "[1]", expectedColor[1], sigma[1]);
+        shouldBeCloseTo(pixel + "[2]", expectedColor[2], sigma[2]);
+        shouldBeCloseTo(pixel + "[3]", expectedColor[3], sigma[3]);
 
         finishJSTest();
     });

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3374,8 +3374,6 @@ imported/w3c/web-platform-tests/html/canvas/element/wide-gamut-canvas/ [ Skip ]
 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/ [ Skip ]
 imported/w3c/web-platform-tests/html/canvas/offscreen/wide-gamut-canvas/ [ Skip ]
 
-webkit.org/b/254415 fast/canvas/canvas-drawImage-hdr-video.html [ Failure ]
-
 storage/indexeddb/structured-clone-image-data-display-p3.html [ Skip ]
 
 # UIScriptController


### PR DESCRIPTION
#### d94d26102f6b3e3f0c787d129129d6a934945b17
<pre>
Fix canvas-drawImage-hdr-video.html color failures
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Draft PR to sniff the actual values on EWS... DO NOT PUBLISH!

* LayoutTests/fast/canvas/canvas-drawImage-hdr-video.html:
* LayoutTests/platform/glib/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d94d26102f6b3e3f0c787d129129d6a934945b17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60617 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7440 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7630 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46160 "Found 1 new test failure: fast/canvas/canvas-drawImage-hdr-video.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5229 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59027 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34114 "Found 1 new test failure: fast/canvas/canvas-drawImage-hdr-video.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27020 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30894 "Exiting early after 10 failures. 10 tests run. 1 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6527 "Found 1 new test failure: fast/canvas/canvas-drawImage-hdr-video.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6445 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52854 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6798 "Found 1 new test failure: fast/canvas/canvas-drawImage-hdr-video.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62298 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/910 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6901 "Found 1 new test failure: fast/canvas/canvas-drawImage-hdr-video.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53418 "Found 1 new test failure: fast/canvas/canvas-drawImage-hdr-video.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/913 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49251 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53457 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/771 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32154 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33239 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->