### PR TITLE
[WPE] Simplify WKWPE::ViewPlatform constructor

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
@@ -30,10 +30,9 @@
 #include "GRefPtrWPE.h"
 #include "RendererBufferFormat.h"
 #include "WPEWebView.h"
+#include <wpe/wpe-platform.h>
 #include <wtf/HashMap.h>
 #include <wtf/glib/GRefPtr.h>
-
-typedef struct _WPEDisplay WPEDisplay;
 
 namespace WebKit {
 class AcceleratedBackingStoreDMABuf;
@@ -70,10 +69,14 @@ private:
     void setCursor(const WebCore::Cursor&) override;
 
     void updateDisplayID();
+    bool activityStateChanged(WebCore::ActivityState, bool);
+    void toplevelStateChanged(WPEToplevelState previousState, WPEToplevelState);
 
 #if ENABLE(TOUCH_EVENTS)
     Vector<WebKit::WebPlatformTouchPoint> touchPointsForEvent(WPEEvent*);
 #endif
+
+    gboolean handleEvent(WPEEvent*);
 
     GRefPtr<WPEView> m_wpeView;
     std::unique_ptr<WebKit::AcceleratedBackingStoreDMABuf> m_backingStore;


### PR DESCRIPTION
#### 6b394a6a5842367664e883136bf0e448c6e4fb0e
<pre>
[WPE] Simplify WKWPE::ViewPlatform constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=276114">https://bugs.webkit.org/show_bug.cgi?id=276114</a>

Reviewed by Nikolas Zimmermann.

Move signal callback implementations to helper functions to reduce the
size of the constructor and improve readability.

* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::ViewPlatform):
(WKWPE::ViewPlatform::activityStateChanged):
(WKWPE::ViewPlatform::toplevelStateChanged):
(WKWPE::ViewPlatform::handleEvent):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h:

Canonical link: <a href="https://commits.webkit.org/280569@main">https://commits.webkit.org/280569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e01728efade366e1d01a1100fb6e60d8fba76128

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60628 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7451 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7641 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5239 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59038 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49206 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27031 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30905 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6456 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62309 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6912 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53429 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49261 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53470 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/782 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8493 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32165 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33250 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->