### PR TITLE
Take libaom 52ba0aed29cccb1560d9dad41eefeede0ef28565 commit

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/ratectrl.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/ratectrl.c
@@ -2227,8 +2227,8 @@ void av1_rc_compute_frame_size_bounds(const AV1_COMP *cpi, int frame_target,
     const int tolerance = (int)AOMMAX(
         100, ((int64_t)cpi->sf.hl_sf.recode_tolerance * frame_target) / 100);
     *frame_under_shoot_limit = AOMMAX(frame_target - tolerance, 0);
-    *frame_over_shoot_limit =
-        AOMMIN(frame_target + tolerance, cpi->rc.max_frame_bandwidth);
+    *frame_over_shoot_limit = (int)AOMMIN((int64_t)frame_target + tolerance,
+                                          cpi->rc.max_frame_bandwidth);
   }
 }
 
@@ -2353,9 +2353,9 @@ void av1_rc_postencode_update(AV1_COMP *cpi, uint64_t bytes_used) {
                                                      cm->width, cm->height));
   if (current_frame->frame_type != KEY_FRAME) {
     p_rc->rolling_target_bits = (int)ROUND_POWER_OF_TWO_64(
-        p_rc->rolling_target_bits * 3 + rc->this_frame_target, 2);
+        (int64_t)p_rc->rolling_target_bits * 3 + rc->this_frame_target, 2);
     p_rc->rolling_actual_bits = (int)ROUND_POWER_OF_TWO_64(
-        p_rc->rolling_actual_bits * 3 + rc->projected_frame_size, 2);
+        (int64_t)p_rc->rolling_actual_bits * 3 + rc->projected_frame_size, 2);
   }
 
   // Actual bits spent


### PR DESCRIPTION
#### ca0992a491dc552b03695861b6520b5cb0fbc5e3
<pre>
Take libaom 52ba0aed29cccb1560d9dad41eefeede0ef28565 commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=276116">https://bugs.webkit.org/show_bug.cgi?id=276116</a>

Reviewed by Eric Carlson.

* Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/pass2_strategy.c:
(av1_twopass_postencode_update):
* Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/ratectrl.c:
(av1_rc_compute_frame_size_bounds):
(av1_rc_postencode_update):

Canonical link: <a href="https://commits.webkit.org/280577@main">https://commits.webkit.org/280577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7add62f67ded8d709af3a5c907f25e7cb3d96516

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7450 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46170 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5238 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27030 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30902 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6536 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6455 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52861 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62308 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53428 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/923 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49260 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53469 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12606 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/781 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32164 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33249 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->