### PR TITLE
[GTK][WPE] Use a common timer to schedule activity state changes

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -251,9 +251,8 @@ typedef HashMap<uint32_t, GRefPtr<GdkEvent>> TouchEventsMap;
 
 struct _WebKitWebViewBasePrivate {
     _WebKitWebViewBasePrivate()
-        : updateActivityStateTimer(RunLoop::main(), this, &_WebKitWebViewBasePrivate::updateActivityStateTimerFired)
+        : pageScaleFactor(1.0)
 #if GTK_CHECK_VERSION(3, 24, 0)
-        , pageScaleFactor(1.0)
         , releaseEmojiChooserTimer(RunLoop::main(), this, &_WebKitWebViewBasePrivate::releaseEmojiChooserTimerFired)
 #endif
         , nextPresentationUpdateTimer(RunLoop::main(), this, &_WebKitWebViewBasePrivate::nextPresentationUpdateTimerFired)
@@ -262,14 +261,6 @@ struct _WebKitWebViewBasePrivate {
         releaseEmojiChooserTimer.setPriority(RunLoopSourcePriority::ReleaseUnusedResourcesTimer);
 #endif
         nextPresentationUpdateTimer.setPriority(GDK_PRIORITY_REDRAW - 10);
-    }
-
-    void updateActivityStateTimerFired()
-    {
-        if (!pageProxy)
-            return;
-        pageProxy->activityStateDidChange(activityStateFlagsToUpdate);
-        activityStateFlagsToUpdate = { };
     }
 
 #if GTK_CHECK_VERSION(3, 24, 0)
@@ -342,11 +333,7 @@ struct _WebKitWebViewBasePrivate {
 
     ToplevelWindow* toplevelOnScreenWindow { nullptr };
 
-    // View State.
     OptionSet<ActivityState> activityState;
-    OptionSet<ActivityState> activityStateFlagsToUpdate;
-    RunLoop::Timer updateActivityStateTimer;
-
     PlatformDisplayID displayID;
     double pageScaleFactor; // Adjusts all CSS units to match fontDPI
 
@@ -469,16 +456,6 @@ static void webkitWebViewBaseUpdateDisplayID(WebKitWebViewBase* webViewBase, Gdk
         webViewBase->priv->pageProxy->windowScreenDidChange(displayID);
 }
 
-static void webkitWebViewBaseScheduleUpdateActivityState(WebKitWebViewBase* webViewBase, OptionSet<ActivityState> flagsToUpdate)
-{
-    WebKitWebViewBasePrivate* priv = webViewBase->priv;
-    priv->activityStateFlagsToUpdate.add(flagsToUpdate);
-    if (priv->updateActivityStateTimer.isActive())
-        return;
-
-    priv->updateActivityStateTimer.startOneShot(0_s);
-}
-
 void webkitWebViewBaseToplevelWindowIsActiveChanged(WebKitWebViewBase* webViewBase, bool isActive)
 {
     WebKitWebViewBasePrivate* priv = webViewBase->priv;
@@ -499,7 +476,7 @@ void webkitWebViewBaseToplevelWindowIsActiveChanged(WebKitWebViewBase* webViewBa
             priv->inputMethodFilter.notifyFocusedOut();
 #endif
     }
-    webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::WindowIsActive);
+    priv->pageProxy->activityStateDidChange(ActivityState::WindowIsActive);
 }
 
 void webkitWebViewBaseToplevelWindowStateChanged(WebKitWebViewBase* webViewBase, uint32_t changedMask, uint32_t state)
@@ -552,7 +529,7 @@ void webkitWebViewBaseToplevelWindowStateChanged(WebKitWebViewBase* webViewBase,
             return;
         priv->activityState.remove(ActivityState::IsVisible);
     }
-    webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::IsVisible);
+    priv->pageProxy->activityStateDidChange(ActivityState::IsVisible);
 }
 
 void webkitWebViewBaseToplevelWindowMonitorChanged(WebKitWebViewBase* webViewBase, GdkMonitor* monitor)
@@ -561,12 +538,12 @@ void webkitWebViewBaseToplevelWindowMonitorChanged(WebKitWebViewBase* webViewBas
     if (priv->toplevelOnScreenWindow->isInMonitor()) {
         if (!(priv->activityState & ActivityState::IsVisible) && gtk_widget_get_mapped(GTK_WIDGET(webViewBase)) && !priv->toplevelOnScreenWindow->isMinimized()) {
             priv->activityState.add(ActivityState::IsVisible);
-            webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::IsVisible);
+            priv->pageProxy->activityStateDidChange(ActivityState::IsVisible);
         }
     } else {
         if (priv->activityState & ActivityState::IsVisible) {
             priv->activityState.remove(ActivityState::IsVisible);
-            webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::IsVisible);
+            priv->pageProxy->activityStateDidChange(ActivityState::IsVisible);
         }
     }
     webkitWebViewBaseUpdateDisplayID(webViewBase, monitor);
@@ -621,7 +598,7 @@ static void webkitWebViewBaseSetToplevelOnScreenWindow(WebKitWebViewBase* webVie
     }
 
     if (flagsToUpdate)
-        webkitWebViewBaseScheduleUpdateActivityState(webViewBase, flagsToUpdate);
+        priv->pageProxy->activityStateDidChange(flagsToUpdate);
 }
 
 static void webkitWebViewBaseRealize(GtkWidget* widget)
@@ -1113,7 +1090,7 @@ static void webkitWebViewBaseMap(GtkWidget* widget)
         return;
 
     priv->activityState.add(ActivityState::IsVisible);
-    webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::IsVisible);
+    priv->pageProxy->activityStateDidChange(ActivityState::IsVisible);
 }
 
 static void webkitWebViewBaseUnmap(GtkWidget* widget)
@@ -1126,7 +1103,7 @@ static void webkitWebViewBaseUnmap(GtkWidget* widget)
         return;
 
     priv->activityState.remove(ActivityState::IsVisible);
-    webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::IsVisible);
+    priv->pageProxy->activityStateDidChange(ActivityState::IsVisible);
 }
 
 static bool shouldForwardWheelEvent(WebKitWebViewBase* webViewBase, GdkEvent* event)
@@ -2841,7 +2818,7 @@ void webkitWebViewBaseSetFocus(WebKitWebViewBase* webViewBase, bool focused)
     } else
         priv->activityState.remove(ActivityState::IsFocused);
 
-    webkitWebViewBaseScheduleUpdateActivityState(webViewBase, flagsToUpdate);
+    priv->pageProxy->activityStateDidChange(flagsToUpdate);
 }
 
 void webkitWebViewBaseSetEditable(WebKitWebViewBase* webViewBase, bool editable)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1157,9 +1157,12 @@ public:
     bool scrollPerformanceDataCollectionEnabled() const { return m_scrollPerformanceDataCollectionEnabled; }
     RemoteLayerTreeScrollingPerformanceData* scrollingPerformanceData() { return m_scrollingPerformanceData.get(); }
 
-    void scheduleActivityStateUpdate();
     void addActivityStateUpdateCompletionHandler(CompletionHandler<void()>&&);
 #endif // PLATFORM(COCOA)
+
+#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
+    void scheduleActivityStateUpdate();
+#endif
 
     void changeFontAttributes(WebCore::FontAttributeChanges&&);
     void changeFont(WebCore::FontChanges&&);

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -327,6 +327,10 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     HashMap<WebCore::RegistrableDomain, OptionSet<WebCore::WindowProxyProperty>> windowOpenerAccessedProperties;
 #endif
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    RunLoop::Timer activityStateChangeTimer;
+#endif
+
     bool allowsLayoutViewportHeightExpansion { true };
 
     explicit Internals(WebPageProxy&);

--- a/Source/WebKit/UIProcess/glib/WebPageProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebPageProxyGLib.cpp
@@ -29,6 +29,7 @@
 
 #include "PageClient.h"
 #include "WebKitWebResourceLoadManager.h"
+#include "WebPageProxyInternals.h"
 #include "WebPreferences.h"
 #include <WebCore/NotImplemented.h>
 #include <WebCore/SearchPopupMenu.h>
@@ -83,6 +84,14 @@ void WebPageProxy::didFinishLoadForResource(WebCore::ResourceLoaderIdentifier re
 {
     if (auto* manager = pageClient().webResourceLoadManager())
         manager->didFinishLoad(resourceID, frameID, WTFMove(error));
+}
+
+void WebPageProxy::scheduleActivityStateUpdate()
+{
+    if (internals().activityStateChangeTimer.isActive())
+        return;
+
+    internals().activityStateChangeTimer.startOneShot(0_s);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### de96df2a7c26160bb5664d582cb72986ea9e827f
<pre>
[GTK][WPE] Use a common timer to schedule activity state changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=276118">https://bugs.webkit.org/show_bug.cgi?id=276118</a>

Reviewed by Michael Catanzaro.

GTK is already using a timer, but we can use existing code in
WebPageProxy to schedule activity state changes, and use it also for
WPE.

* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(_WebKitWebViewBasePrivate::_WebKitWebViewBasePrivate):
(webkitWebViewBaseToplevelWindowIsActiveChanged):
(webkitWebViewBaseToplevelWindowStateChanged):
(webkitWebViewBaseToplevelWindowMonitorChanged):
(webkitWebViewBaseSetToplevelOnScreenWindow):
(webkitWebViewBaseMap):
(webkitWebViewBaseUnmap):
(webkitWebViewBaseSetFocus):
(_WebKitWebViewBasePrivate::updateActivityStateTimerFired): Deleted.
(webkitWebViewBaseScheduleUpdateActivityState): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::activityStateChangeTimer):
(WebKit::WebPageProxy::setSuppressVisibilityUpdates):
(WebKit::WebPageProxy::activityStateDidChange):
(WebKit::WebPageProxy::dispatchActivityStateChange):
(WebKit::fullscreenVideoTextRecognitionTimer): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/glib/WebPageProxyGLib.cpp:
(WebKit::WebPageProxy::scheduleActivityStateUpdate):

Canonical link: <a href="https://commits.webkit.org/280614@main">https://commits.webkit.org/280614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3f0df0794094e497607c9402055a982b23acc6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60637 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7460 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46179 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5247 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49214 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27039 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30911 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6465 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52872 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62318 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53437 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49269 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53482 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/790 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8513 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32174 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33259 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34344 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->