### PR TITLE
[WPE][GTK] Source links in generated API documentation are incorrect

### DIFF
--- a/Source/WebKit/gtk/gtk3-webkitgtk.toml.in
+++ b/Source/WebKit/gtk/gtk3-webkitgtk.toml.in
@@ -35,6 +35,6 @@ show_index_summary = true
 show_class_hierarchy = true
 
 [source-location]
-base_url = "https://github.com/WebKit/WebKit/tree/main"
+base_url = "https://github.com/WebKit/WebKit/tree/main/"
 
 urlmap_file = "gtk@GTK_API_VERSION@-urlmap.js"

--- a/Source/WebKit/gtk/gtk4-webkitgtk.toml.in
+++ b/Source/WebKit/gtk/gtk4-webkitgtk.toml.in
@@ -35,7 +35,7 @@ show_index_summary = true
 show_class_hierarchy = true
 
 [source-location]
-base_url = "https://github.com/WebKit/WebKit/tree/main"
+base_url = "https://github.com/WebKit/WebKit/tree/main/"
 
 [extra]
 content_files = [

--- a/Source/WebKit/gtk/webkitgtk-web-process-extension.toml.in
+++ b/Source/WebKit/gtk/webkitgtk-web-process-extension.toml.in
@@ -30,7 +30,7 @@ show_index_summary = true
 show_class_hierarchy = true
 
 [source-location]
-base_url = "https://github.com/WebKit/WebKit/tree/main"
+base_url = "https://github.com/WebKit/WebKit/tree/main/"
 
 [extra]
 urlmap_file = "gtk@GTK_API_VERSION@-urlmap.js"

--- a/Source/WebKit/wpe/wpe-web-process-extension.toml.in
+++ b/Source/WebKit/wpe/wpe-web-process-extension.toml.in
@@ -30,7 +30,7 @@ show_index_summary = true
 show_class_hierarchy = true
 
 [source-location]
-base_url = "https://github.com/WebKit/WebKit/tree/main"
+base_url = "https://github.com/WebKit/WebKit/tree/main/"
 
 [extra]
 urlmap_file = "wpe@WPE_API_MAJOR_VERSION@-urlmap.js"

--- a/Source/WebKit/wpe/wpewebkit.toml.in
+++ b/Source/WebKit/wpe/wpewebkit.toml.in
@@ -30,7 +30,7 @@ show_index_summary = true
 show_class_hierarchy = true
 
 [source-location]
-base_url = "https://github.com/WebKit/WebKit/tree/main"
+base_url = "https://github.com/WebKit/WebKit/tree/main/"
 
 [extra]
 urlmap_file = "wpe@WPE_API_MAJOR_VERSION@-urlmap.js"


### PR DESCRIPTION
#### 6a465d3ecf859c297677d5e5b5663e99ca6ec54a
<pre>
[WPE][GTK] Source links in generated API documentation are incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=276119">https://bugs.webkit.org/show_bug.cgi?id=276119</a>

Reviewed by Michael Catanzaro.

gi-docgen strips the last URL path component not ending with a slash, apparently. So the source
links were missing the &quot;main&quot; part.

* Source/WebKit/gtk/gtk3-webkitgtk.toml.in:
* Source/WebKit/gtk/gtk4-webkitgtk.toml.in:
* Source/WebKit/gtk/webkitgtk-web-process-extension.toml.in:
* Source/WebKit/wpe/wpe-web-process-extension.toml.in:
* Source/WebKit/wpe/wpewebkit.toml.in:

Canonical link: <a href="https://commits.webkit.org/280572@main">https://commits.webkit.org/280572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01962a9a8f1c81c9d55a4c823d764866ca21245c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60630 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7453 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46173 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5240 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27033 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30903 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6458 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62311 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53431 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53473 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12601 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/783 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32167 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33252 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->