### PR TITLE
Cache results of selector matching (MatchResult)

### DIFF
--- a/LayoutTests/fast/css/style-invalidation-inline-csstext.html
+++ b/LayoutTests/fast/css/style-invalidation-inline-csstext.html
@@ -14,7 +14,7 @@ function testInvalidation(cssText, shouldInvalidate, name)
 
         testDiv.style.cssText = cssText;
 
-        assert_equals(internals.styleChangeType(testDiv), shouldInvalidate ? "InlineStyleChange" : "NoStyleChange");
+        assert_equals(internals.styleChangeType(testDiv), shouldInvalidate ? "InlineStyleInvalid" : "NoStyleChange");
         assert_equals(internals.styleChangeType(testDivChild), "NoStyleChange");
     }, name);
 }

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -740,7 +740,7 @@ protected:
         void clearDescendantsNeedStyleResolution() { m_flags = (flags() - NodeStyleFlag::DescendantNeedsStyleResolution - NodeStyleFlag::DirectChildNeedsStyleResolution).toRaw(); }
 
     private:
-        uint16_t m_styleValidity : 2;
+        uint16_t m_styleValidity : 3;
         uint16_t m_flags : 13;
     };
 

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -158,7 +158,7 @@ void StyledElement::styleAttributeChanged(const AtomString& newStyleString, Attr
 
     elementData()->setStyleAttributeIsDirty(false);
 
-    invalidateStyleInternal();
+    Node::invalidateStyle(Style::Validity::InlineStyleInvalid);
     InspectorInstrumentation::didInvalidateStyleAttr(*this);
 }
 
@@ -184,7 +184,8 @@ void StyledElement::invalidateStyleAttribute()
     }
 
     elementData()->setStyleAttributeIsDirty(true);
-    invalidateStyleInternal();
+
+    Node::invalidateStyle(Style::Validity::InlineStyleInvalid);
 
     // In the rare case of selectors like "[style] ~ div" we need to synchronize immediately to invalidate.
     if (styleResolver().ruleSets().hasComplexSelectorsForStyleAttribute()) {

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -435,6 +435,11 @@ void RenderStyle::copyPseudoElementsFrom(const RenderStyle& other)
         addCachedPseudoStyle(makeUnique<RenderStyle>(cloneIncludingPseudoElements(*pseudoElementStyle)));
 }
 
+void RenderStyle::copyPseudoElementBitsFrom(const RenderStyle& other)
+{
+    m_nonInheritedFlags.pseudoBits = other.m_nonInheritedFlags.pseudoBits;
+}
+
 bool RenderStyle::operator==(const RenderStyle& other) const
 {
     // compare everything except the pseudoStyle pointer
@@ -1417,11 +1422,7 @@ bool RenderStyle::outOfFlowPositionStyleDidChange(const RenderStyle* other) cons
     // https://drafts.csswg.org/css-scroll-anchoring/#suppression-triggers
     // Determine if there is a style change that causes an element to become or stop
     // being absolutely or fixed positioned
-    if (other && m_nonInheritedData.ptr() != other->m_nonInheritedData.ptr()) {
-        if (hasOutOfFlowPosition() != other->hasOutOfFlowPosition())
-            return true;
-    }
-    return false;
+    return other && hasOutOfFlowPosition() != other->hasOutOfFlowPosition();
 }
 
 StyleDifference RenderStyle::diff(const RenderStyle& other, OptionSet<StyleDifferenceContextSensitiveProperty>& changedContextSensitiveProperties) const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -338,6 +338,7 @@ public:
     void copyNonInheritedFrom(const RenderStyle&);
     void copyContentFrom(const RenderStyle&);
     void copyPseudoElementsFrom(const RenderStyle&);
+    void copyPseudoElementBitsFrom(const RenderStyle&);
 
     ContentPosition resolvedJustifyContentPosition(const StyleContentAlignmentData& normalValueBehavior) const;
     ContentDistribution resolvedJustifyContentDistribution(const StyleContentAlignmentData& normalValueBehavior) const;

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -163,7 +163,8 @@ Invalidator::CheckDescendants Invalidator::invalidateIfNeeded(Element& element, 
 
     switch (element.styleValidity()) {
     case Validity::Valid:
-    case Validity::AnimationInvalid: {
+    case Validity::AnimationInvalid:
+    case Validity::InlineStyleInvalid: {
         for (auto& ruleSet : m_ruleSets) {
             ElementRuleCollector ruleCollector(element, *ruleSet, selectorMatchingState);
             ruleCollector.setMode(SelectorChecker::Mode::CollectingRulesIgnoringVirtualPseudoElements);

--- a/Source/WebCore/style/StyleRelations.cpp
+++ b/Source/WebCore/style/StyleRelations.cpp
@@ -147,5 +147,17 @@ void commitRelations(std::unique_ptr<Relations> relations, Update& update)
     }
 }
 
+void copyRelations(RenderStyle& to, const RenderStyle& from)
+{
+    if (from.emptyState())
+        to.setEmptyState(true);
+    if (from.firstChildState())
+        to.setFirstChildState();
+    if (from.lastChildState())
+        to.setLastChildState();
+    if (from.unique())
+        to.setUnique();
+}
+
 }
 }

--- a/Source/WebCore/style/StyleRelations.h
+++ b/Source/WebCore/style/StyleRelations.h
@@ -69,6 +69,7 @@ struct Relation {
 using Relations = Vector<Relation, 8>;
 
 std::unique_ptr<Relations> commitRelationsToRenderStyle(RenderStyle&, const Element&, const Relations&);
+void copyRelations(RenderStyle&, const RenderStyle&);
 void commitRelations(std::unique_ptr<Relations>, Update&);
 
 }

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -92,6 +92,7 @@ public:
     ~Resolver();
 
     ResolvedStyle styleForElement(Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
+    ResolvedStyle styleForElementWithCachedMatchResult(Element&, const ResolutionContext&, const MatchResult&, const RenderStyle& existingRenderStyle);
 
     void keyframeStylesForAnimation(Element&, const RenderStyle& elementStyle, const ResolutionContext&, BlendingKeyframes&);
 
@@ -161,6 +162,7 @@ private:
 
     class State;
 
+    State initializeStateAndStyle(const Element&, const ResolutionContext&);
     BuilderContext builderContext(const State&);
 
     void applyMatchedProperties(State&, const MatchResult&);

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -67,6 +67,7 @@ namespace Style {
 class CustomPropertyRegistry;
 class Resolver;
 class RuleSet;
+struct MatchResult;
 
 class Scope final : public CanMakeWeakPtr<Scope>, public CanMakeCheckedPtr<Scope> {
     WTF_MAKE_FAST_ALLOCATED;
@@ -133,6 +134,9 @@ public:
     void releaseMemory();
 
     void clearViewTransitionStyles();
+
+    const MatchResult* cachedMatchResult(const Element&);
+    void updateCachedMatchResult(const Element&, const MatchResult&);
 
     const Document& document() const { return m_document; }
     Document& document() { return m_document; }
@@ -245,6 +249,7 @@ private:
 
     std::optional<MediaQueryViewportState> m_viewportStateOnPreviousMediaQueryEvaluation;
     WeakHashMap<Element, LayoutSize, WeakPtrImplWithEventTargetData> m_queryContainerStates;
+    mutable WeakHashMap<const Element, UniqueRef<MatchResult>, WeakPtrImplWithEventTargetData> m_cachedMatchResults;
 
     UniqueRef<CustomPropertyRegistry> m_customPropertyRegistry;
     UniqueRef<CSSCounterStyleRegistry> m_counterStyleRegistry;

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -63,8 +63,8 @@ public:
     bool hasUnresolvedAnchorPositionedElements() const { return m_hasUnresolvedAnchorPositionedElements; }
 
 private:
-    enum class ResolutionType : uint8_t { RebuildUsingExisting, AnimationOnly, FastPathInherit, Full };
-    ResolvedStyle styleForStyleable(const Styleable&, ResolutionType, const ResolutionContext&);
+    enum class ResolutionType : uint8_t { RebuildUsingExisting, AnimationOnly, FastPathInherit, FullWithMatchResultCache, Full };
+    ResolvedStyle styleForStyleable(const Styleable&, ResolutionType, const ResolutionContext&, const RenderStyle* existingStyle);
 
     void resolveComposedTree();
 

--- a/Source/WebCore/style/StyleValidity.h
+++ b/Source/WebCore/style/StyleValidity.h
@@ -31,6 +31,7 @@ namespace Style {
 enum class Validity : uint8_t {
     Valid,
     AnimationInvalid,
+    InlineStyleInvalid,
     ElementInvalid,
     SubtreeInvalid,
 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -841,6 +841,8 @@ static String styleValidityToToString(Style::Validity validity)
         return "NoStyleChange"_s;
     case Style::Validity::AnimationInvalid:
         return "AnimationInvalid"_s;
+    case Style::Validity::InlineStyleInvalid:
+        return "InlineStyleInvalid"_s;
     case Style::Validity::ElementInvalid:
         return "InlineStyleChange"_s;
     case Style::Validity::SubtreeInvalid:


### PR DESCRIPTION
#### 904f0ad00263d681191e064154cf732f3e6cb6ee
<pre>
Cache results of selector matching (MatchResult)
<a href="https://bugs.webkit.org/show_bug.cgi?id=276123">https://bugs.webkit.org/show_bug.cgi?id=276123</a>
<a href="https://rdar.apple.com/126281259">rdar://126281259</a>

Reviewed by Alan Baradlay.

We can avoid selector matching on inline style change by caching the last results of selector matching.

* LayoutTests/fast/css/style-invalidation-inline-csstext.html:
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::styleAttributeChanged):
(WebCore::StyledElement::invalidateStyleAttribute):

Add a new InlineStyleInvalid style invalidity state.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::copyPseudoElementBitsFrom):
(WebCore::RenderStyle::outOfFlowPositionStyleDidChange const):

Fix this function (position bits are not in m_nonInheritedData). It was causing failures in achor tests with this patch.

* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateIfNeeded):
* Source/WebCore/style/StyleRelations.cpp:
(WebCore::Style::copyRelations):

Copy style relations from the existing style.

* Source/WebCore/style/StyleRelations.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::initializeStateAndStyle):

Factor into a function.

(WebCore::Style::Resolver::builderContext):
(WebCore::Style::Resolver::styleForElement):
(WebCore::Style::Resolver::styleForElementWithCachedMatchResult):

New version for lookups with cached results.

* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::cachedMatchResult):
(WebCore::Style::Scope::updateCachedMatchResult):

Cache in a map in Scope.

* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::styleForStyleable):

Save and restore per-element match result cache entries.

(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::determineResolutionType):

Use new resolution type for inline-only style changes.

(WebCore::Style::TreeResolver::resolveComposedTree):
* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/StyleValidity.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::styleValidityToToString):

Canonical link: <a href="https://commits.webkit.org/280692@main">https://commits.webkit.org/280692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3df834cb3e3d81b09c57625f40d345299b5b0bff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60954 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7775 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46426 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5498 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59362 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34401 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27289 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31183 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6823 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6780 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62633 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7186 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53688 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53778 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/12673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1058 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32489 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33574 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34659 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33320 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->