### PR TITLE
[browserperfdash-benchmark][run-benchmark] Add a method for getting the browser version and implement it for Chrome/Linux

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
@@ -41,6 +41,10 @@ class BrowserDriver(object):
         pass
 
     @abstractmethod
+    def browser_version(self):
+        return None
+
+    @abstractmethod
     def restore_env(self):
         pass
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_chrome_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_chrome_driver.py
@@ -25,6 +25,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import re
+from subprocess import check_output
 
 from webkitpy.benchmark_runner.browser_driver.linux_browser_driver import LinuxBrowserDriver
 
@@ -54,3 +56,12 @@ class LinuxChromeDriver(LinuxBrowserDriver):
         driver = webdriver.Chrome(chrome_options=options, executable_path=driver_executable)
         super().launch_webdriver(url, driver)
         return driver
+
+    def browser_version(self):
+        version_cmd = [self.process_name, '--version']
+        version_output = check_output(version_cmd, timeout=3).decode('utf-8', errors='ignore').strip()
+        m = re.match(r'([a-zA-Z ]*)(Chrome|Chromium)([a-zA-Z ]+)([0-9.]+)', version_output)
+        if m:
+            return m.groups()[-1]
+        version_cmd = ' '.join(version_cmd)
+        raise ValueError(f'Unable to parse browser version. Command "{version_cmd}" returned "{version_output}"')


### PR DESCRIPTION
#### 60378803adb761a768bdaa90c2a138174a9129db
<pre>
[browserperfdash-benchmark][run-benchmark] Add a method for getting the browser version and implement it for Chrome/Linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=276125">https://bugs.webkit.org/show_bug.cgi?id=276125</a>

Reviewed by Nikolas Zimmermann.

The script browserperfdash-benchmark needs to know the browser version
used for the tests, because that information is very relevant when
uploading the data to the dashboard. For tests with WPE that is easy as
we simply pass the revision number from the buildbot master.
But for other browsers we don&apos;t know the revision number when executing
the step. So this adds a new switch to browserperfdash-benchmark named
`--query-browser-version` that basically calls the browser driver method
`browser_version()` to obtain the version. It also implements this method
for the Chrome browser.
This doesn&apos;t change anything on the CLI of run-benchmark script.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py:
(BrowserDriver):
(BrowserDriver.browser_version):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_chrome_driver.py:
(LinuxChromeDriver.launch_driver):
(LinuxChromeDriver):
(LinuxChromeDriver.browser_version):
* Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py:
(parse_args):
(BrowserPerfDashRunner.run):

Canonical link: <a href="https://commits.webkit.org/280585@main">https://commits.webkit.org/280585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/023f86bf06d63fc7e2a3b34e19daf1721b70c9cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60642 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7465 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7655 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46184 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5252 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49219 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27044 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/56548 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6550 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6470 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52878 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62323 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53442 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53491 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/795 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8496 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32179 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34349 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33010 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->