### PR TITLE
Re-enable 3 API tests after 280501@main

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
@@ -1402,12 +1402,7 @@ TEST(WKAttachmentTests, InvalidateAttachmentsAfterMainFrameNavigation)
     [htmlAttachment expectRequestedDataToBe:nil];
 }
 
-// FIXME: <rdar://130762747> Investigate why 280261@main seems to have made this time out on open source iOS.
-#if PLATFORM(IOS_FAMILY) && !USE(APPLE_INTERNAL_SDK)
-TEST(WKAttachmentTests, DISABLED_InvalidateAttachmentsAfterWebProcessTermination)
-#else
 TEST(WKAttachmentTests, InvalidateAttachmentsAfterWebProcessTermination)
-#endif
 {
     auto webView = webViewForTestingAttachments();
     RetainPtr<_WKAttachment> pdfAttachment;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm
@@ -180,12 +180,7 @@ TEST(WKNavigation, FailureToStartWebProcessAfterCrashRecovery)
     EXPECT_TRUE(receivedScriptMessage);
 }
 
-// FIXME: <rdar://130762747> Investigate why 280261@main seems to have made this time out on open source iOS.
-#if PLATFORM(IOS_FAMILY) && !USE(APPLE_INTERNAL_SDK)
-TEST(WKNavigation, DISABLED_AutomaticVisibleViewReloadAfterWebProcessCrash)
-#else
 TEST(WKNavigation, AutomaticVisibleViewReloadAfterWebProcessCrash)
-#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
@@ -220,12 +215,7 @@ TEST(WKNavigation, AutomaticVisibleViewReloadAfterWebProcessCrash)
     EXPECT_FALSE(startedLoad);
 }
 
-// FIXME: <rdar://130762747> Investigate why 280261@main seems to have made this time out on open source iOS.
-#if PLATFORM(IOS_FAMILY) && !USE(APPLE_INTERNAL_SDK)
-TEST(WKNavigation, DISABLEDAutomaticHiddenViewDelayedReloadAfterWebProcessCrash)
-#else
 TEST(WKNavigation, AutomaticHiddenViewDelayedReloadAfterWebProcessCrash)
-#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);


### PR DESCRIPTION
#### 68e1e3db3a52177b435dd0b96b0ae98efd34cd48
<pre>
Re-enable 3 API tests after 280501@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=276128">https://bugs.webkit.org/show_bug.cgi?id=276128</a>
<a href="https://rdar.apple.com/130974139">rdar://130974139</a>

Reviewed by Per Arne Vollan.

280501@main seems to have done the work to fix the tests on iOS 17, which I mistakenly thought
was because of the internal vs public SDK.  This unskips the tests.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm:
(TestWebKitAPI::TEST(WKAttachmentTests, InvalidateAttachmentsAfterWebProcessTermination)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm:
(TEST(WKNavigation, AutomaticVisibleViewReloadAfterWebProcessCrash)):
(TEST(WKNavigation, AutomaticHiddenViewDelayedReloadAfterWebProcessCrash)):

Canonical link: <a href="https://commits.webkit.org/280601@main">https://commits.webkit.org/280601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1158fb2d5e0945f942154fbd61ce758c563168a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57028 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36356 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7471 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46188 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5256 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59058 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34140 "Found 2 new test failures: fast/forms/datalist/datalist-option-labels.html fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27048 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30920 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6557 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6476 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52882 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62329 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53446 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53492 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/799 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8506 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32185 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33270 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33016 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->