### PR TITLE
[Navigation] Detect early error in Navigation.navigate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-window-stop-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-window-stop-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL window.stop() signals event.signal assert_true: expected true got false
+PASS window.stop() signals event.signal
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-204-205-download-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-204-205-download-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL navigate() promises to 204s never settle assert_equals: expected 1 but got 2
-FAIL navigate() promises to 205s never settle assert_equals: expected 1 but got 2
-FAIL navigate() promises to Content-Disposition: attachment responses never settle assert_equals: expected 1 but got 2
+FAIL navigate() promises to 204s never settle assert_equals: expected "http://localhost:8800/common/blank.html" but got "http://localhost:8800/common/blank.html?pipe=status(204)"
+FAIL navigate() promises to 205s never settle assert_equals: expected "http://localhost:8800/common/blank.html" but got "http://localhost:8800/common/blank.html?pipe=status(205)"
+PASS navigate() promises to Content-Disposition: attachment responses never settle
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-file-url-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-file-url-expected.txt
@@ -1,6 +1,4 @@
 CONSOLE MESSAGE: Not allowed to load local resource: /
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigate() to a file: URL Test timed out
+PASS navigate() to a file: URL
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-pagehide-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-pagehide-expected.txt
@@ -1,6 +1,11 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_throws_dom: function "() => { throw committedReason; }" threw object "AbortError: Navigation aborted" that is not a DOMException InvalidStateError: property "code" is equal to 20, expect...
 
 
-Harness Error (TIMEOUT), message = null
+Harness Error (FAIL), message = Unhandled rejection: assert_throws_dom: function "() => { throw committedReason; }" threw object "AbortError: Navigation aborted" that is not a DOMException InvalidStateError: property "code" is equal to 20, expected 11
+
+TIMEOUT navigate() inside onpagehide Test timed out
+
+Harness Error (FAIL), message = Unhandled rejection: assert_throws_dom: function "() => { throw committedReason; }" threw object "AbortError: Navigation aborted" that is not a DOMException InvalidStateError: property "code" is equal to 20, expected 11
 
 TIMEOUT navigate() inside onpagehide Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-pagehide-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-pagehide-expected.txt
@@ -1,11 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: expected 1 but got 2
 
 
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: expected 1 but got 2
-
-TIMEOUT navigate() with an invalid URL inside onpagehide throws "SyntaxError", not "InvalidStateError" Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: expected 1 but got 2
-
-TIMEOUT navigate() with an invalid URL inside onpagehide throws "SyntaxError", not "InvalidStateError" Test timed out
+PASS navigate() with an invalid URL inside onpagehide throws "SyntaxError", not "InvalidStateError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-pagehide-unserializablestate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-pagehide-unserializablestate-expected.txt
@@ -1,11 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: expected 1 but got 2
 
 
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: expected 1 but got 2
-
-TIMEOUT navigate() with an unserializable state inside onpagehide throws "DataCloneError", not "InvalidStateError" Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: expected 1 but got 2
-
-TIMEOUT navigate() with an unserializable state inside onpagehide throws "DataCloneError", not "InvalidStateError" Test timed out
+PASS navigate() with an unserializable state inside onpagehide throws "DataCloneError", not "InvalidStateError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-cross-document-double-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-cross-document-double-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL event and promise ordering when navigate() is called to a cross-document destination, interrupting another navigate() to a cross-document destination assert_array_equals: expected property 2 to be "navigateerror" but got "navigate" (expected array ["navigate", "AbortSignal abort", "navigateerror", "navigate", "committed rejected 1", "finished rejected 1", "promise microtask"] got ["navigate", "AbortSignal abort", "navigate", "navigate", "AbortSignal abort", "navigate", "promise microtask"])
+FAIL event and promise ordering when navigate() is called to a cross-document destination, interrupting another navigate() to a cross-document destination assert_array_equals: lengths differ, expected array ["navigate", "AbortSignal abort", "navigateerror", "navigate", "committed rejected 1", "finished rejected 1", "promise microtask"] length 7, got ["navigate", "AbortSignal abort", "navigate", "promise microtask"] length 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-cross-document-event-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-cross-document-event-order-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigate() event ordering for cross-document navigation assert_array_equals: lengths differ, expected array ["onnavigate", "onunload", "readystateinteractive", "domcontentloaded", "readystatecomplete", "onload", "onpageshow"] length 7, got ["onnavigate", "onnavigate", "onunload", "readystateinteractive", "domcontentloaded", "readystatecomplete", "onload", "onpageshow"] length 8
+PASS navigate() event ordering for cross-document navigation
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1784,9 +1784,6 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
 
     if (shouldPerformFragmentNavigation(isFormSubmission, httpMethod, policyChecker().loadType(), newURL)) {
 
-        if (!dispatchNavigateEvent(newURL, type, loader->triggeringAction(), NavigationHistoryBehavior::Auto, true, formState.get()))
-            return;
-
         RefPtr oldDocumentLoader = m_documentLoader;
         NavigationAction action { frame->protectedDocument().releaseNonNull(), loader->request(), InitiatedByMainFrame::Unknown, loader->isRequestFromClientOrUserInput(), policyChecker().loadType(), isFormSubmission };
         action.setNavigationAPIType(determineNavigationType(type, NavigationHistoryBehavior::Auto));
@@ -1801,12 +1798,6 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
             continueFragmentScrollAfterNavigationPolicy(request, requesterOrigin.get(), navigationPolicyDecision == NavigationPolicyDecision::ContinueLoad, NavigationHistoryBehavior::Auto);
         }, PolicyDecisionMode::Synchronous);
         return;
-    }
-
-    auto& action = loader->triggeringAction();
-    if (m_frame->document() && action.requester() && m_frame->document()->securityOrigin().isSameOriginDomain(action.requester()->securityOrigin)) {
-        if (!dispatchNavigateEvent(newURL, type, action, NavigationHistoryBehavior::Auto, false, formState.get()))
-            return;
     }
 
     if (RefPtr parent = dynamicDowncast<LocalFrame>(frame->tree().parent()))

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -310,7 +310,7 @@ Navigation::Result Navigation::navigate(const String& url, NavigateOptions&& opt
     // If the load() call never made it to the point that NavigateEvent was emitted, thus promoteUpcomingAPIMethodTracker() called, this will be true.
     if (m_upcomingNonTraverseMethodTracker == apiMethodTracker) {
         m_upcomingNonTraverseMethodTracker = nullptr;
-        // FIXME: This should return an early error.
+        return createErrorResult(WTFMove(apiMethodTracker->committedPromise), WTFMove(apiMethodTracker->finishedPromise), ExceptionCode::AbortError, "Navigation aborted"_s);
     }
 
     return apiMethodTrackerDerivedResult(*apiMethodTracker);


### PR DESCRIPTION
#### e08a72c3d292c1ef4fd66f9c2efb96581ec7ca87
<pre>
[Navigation] Detect early error in Navigation.navigate
<a href="https://bugs.webkit.org/show_bug.cgi?id=276129">https://bugs.webkit.org/show_bug.cgi?id=276129</a>

Reviewed by Alex Christensen.

Detect early error in Navigation.navigate for the case the navigate event was not dispatched [1].

This PR also removes the code for dispatching navigate events in FrameLoader::loadWithDocumentLoader, because
since r280526 this is handled by FrameLoader::loadURL, and in fact we could end up with multiple navigate
events being dispatched.

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate</a> (Step 12.2)

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-window-stop-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-204-205-download-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-file-url-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-pagehide-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-invalidurl-pagehide-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-rejection-order-pagehide-unserializablestate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-cross-document-double-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-cross-document-event-order-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadWithDocumentLoader):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::navigate):

Canonical link: <a href="https://commits.webkit.org/280616@main">https://commits.webkit.org/280616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9478184ce86b8c8d2bc38eb84b150d020e04e50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60659 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7482 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46196 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5264 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27056 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30929 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6564 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6487 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52894 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62340 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6937 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53454 "Found 1 new test failure: imported/w3c/web-platform-tests/server-timing/server_timing_header-parsing.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53501 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12626 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/806 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32196 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33281 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33027 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->