### PR TITLE
Resign Now Playing status when WKWebView suspends all media playback

### DIFF
--- a/LayoutTests/media/now-playing-info-media-session-private-browsing-expected.txt
+++ b/LayoutTests/media/now-playing-info-media-session-private-browsing-expected.txt
@@ -1,0 +1,30 @@
+
+Tests that the NowPlaying metadata is empty when in private browsing mode.
+
+* NowPlaying should not be active before playback has started.
+RUN(video.src = findMediaFile("video", "content/test"))
+EVENT(canplaythrough)
+RUN(nowPlayingState = internals.nowPlayingState)
+EXPECTED (nowPlayingState.registeredAsNowPlayingApplication == 'false') OK
+RUN(navigator.mediaSession.metadata = new MediaMetadata({title: "title", artist: "artist", album: "album", artwork: [{src: "content/abe.png"}]}))
+RUN(navigator.mediaSession.playbackState = "paused")
+RUN(navigator.mediaSession.positionState = {duration: video.duration, position: video.currentTime})
+RUN(navigator.mediaSession.setActionHandler("play", playAction))
+RUN(navigator.mediaSession.setActionHandler("pause", pauseAction))
+
+* Start to play, NowPlaying should become active.
+RUN(navigator.mediaSession.callActionHandler({action: "play"}))
+ACTION: play
+EVENT(playing)
+RUN(navigator.mediaSession.callActionHandler({action: "pause"}))
+ACTION: pause
+
+* Metadata should be blank due to private browsing mode.
+RUN(nowPlayingMetadata = internals.nowPlayingMetadata)
+EXPECTED (nowPlayingMetadata.title == 'undefined') OK
+EXPECTED (nowPlayingMetadata.artist == 'undefined') OK
+EXPECTED (nowPlayingMetadata.album == 'undefined') OK
+EXPECTED (nowPlayingMetadata.artwork == 'undefined') OK
+
+END OF TEST
+

--- a/LayoutTests/media/now-playing-info-media-session-private-browsing.html
+++ b/LayoutTests/media/now-playing-info-media-session-private-browsing.html
@@ -1,0 +1,85 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <title>now-playing-info-media-session-private-browsing</title>
+    <script src=video-test.js></script>
+    <script src=media-file.js></script>
+    <script>
+
+        let nowPlayingState;
+
+        async function waitForAttributeToChange(attribute, expected) {
+            let start = new Date().getTime();
+            do {
+
+                if (internals.nowPlayingState[attribute] != expected)
+                    return;
+
+                await new Promise(resolve => setTimeout(resolve, 100));
+            } while (new Date().getTime() - start < 500);
+
+            failTest(`** Timed out waiting for "${attribute}" to change from "${expected}"`);
+        }
+
+        function playAction()
+        {
+            consoleWrite('ACTION: play');
+            runWithKeyDown(() => {
+                video.play();
+            });
+        }
+
+        function pauseAction()
+        {
+            consoleWrite('ACTION: pause');
+            runWithKeyDown(() => {
+                video.pause();
+            });
+        }
+
+        async function runTest()
+        {
+            findMediaElement();
+
+            consoleWrite('<br>* NowPlaying should not be active before playback has started.');
+            run('video.src = findMediaFile("video", "content/test")');
+            await waitFor(video, 'canplaythrough');
+
+            run('nowPlayingState = internals.nowPlayingState');
+            testExpected('nowPlayingState.registeredAsNowPlayingApplication', false);
+
+            run('navigator.mediaSession.metadata = new MediaMetadata({title: "title", artist: "artist", album: "album", artwork: [{src: "content/abe.png"}]})');
+            run('navigator.mediaSession.playbackState = "paused"')
+            run('navigator.mediaSession.positionState = {duration: video.duration, position: video.currentTime}');
+            run('navigator.mediaSession.setActionHandler("play", playAction)');
+            run('navigator.mediaSession.setActionHandler("pause", pauseAction)');
+
+            consoleWrite('<br>* Start to play, NowPlaying should become active.');
+            run('navigator.mediaSession.callActionHandler({action: "play"})');
+
+            await waitFor(video, 'playing');
+            run('navigator.mediaSession.callActionHandler({action: "pause"})');
+            await waitForAttributeToChange('registeredAsNowPlayingApplication', false);
+
+            consoleWrite('<br>* Metadata should be blank due to private browsing mode.');
+            run('nowPlayingMetadata = internals.nowPlayingMetadata');
+            await testExpectedEventually('nowPlayingMetadata.title', undefined, '==', 1000);
+            await testExpectedEventually('nowPlayingMetadata.artist', undefined, '==', 1000);
+            await testExpectedEventually('nowPlayingMetadata.album', undefined, '==', 1000);
+            await testExpectedEventually('nowPlayingMetadata.artwork', undefined, '==', 1000);
+
+            consoleWrite('');
+        }
+
+        window.addEventListener('load', event => {
+            runTest().then(endTest).catch(failTest);
+        });
+    </script>
+</head>
+<body">
+    <video controls></video>
+    <br>
+    Tests that the NowPlaying metadata is empty when in private browsing mode.
+</body>
+</html>

--- a/LayoutTests/media/now-playing-info-media-session-suspend-playback-expected.txt
+++ b/LayoutTests/media/now-playing-info-media-session-suspend-playback-expected.txt
@@ -1,0 +1,33 @@
+
+Tests that the NowPlaying metadata is empty when in private browsing mode.
+
+* NowPlaying should not be active before playback has started.
+RUN(video.src = findMediaFile("video", "content/test"))
+EVENT(canplaythrough)
+RUN(nowPlayingState = internals.nowPlayingState)
+EXPECTED (nowPlayingState.registeredAsNowPlayingApplication == 'false') OK
+RUN(navigator.mediaSession.metadata = new MediaMetadata({title: "title", artist: "artist", album: "album", artwork: [{src: "content/abe.png"}]}))
+RUN(navigator.mediaSession.playbackState = "paused")
+RUN(navigator.mediaSession.positionState = {duration: video.duration, position: video.currentTime})
+RUN(navigator.mediaSession.setActionHandler("play", playAction))
+RUN(navigator.mediaSession.setActionHandler("pause", pauseAction))
+
+* Start to play, NowPlaying should become active.
+RUN(navigator.mediaSession.callActionHandler({action: "play"}))
+ACTION: play
+EVENT(playing)
+RUN(navigator.mediaSession.callActionHandler({action: "pause"}))
+ACTION: pause
+
+* Metadata should not be blank.
+RUN(nowPlayingMetadata = internals.nowPlayingMetadata)
+EXPECTED (nowPlayingMetadata != 'null') OK
+EXPECTED (nowPlayingMetadata.title != '') OK
+
+* Suspending all media playback NowPlaying to deactivate.
+RUN(internals.suspendAllMediaPlayback())
+EXPECTED (nowPlayingState.registeredAsNowPlayingApplication == 'false') OK
+EXPECTED (internals.nowPlayingMetadata == 'null') OK
+
+END OF TEST
+

--- a/LayoutTests/media/now-playing-info-media-session-suspend-playback.html
+++ b/LayoutTests/media/now-playing-info-media-session-suspend-playback.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>now-playing-info-media-session-suspend-playback</title>
+    <script src=video-test.js></script>
+    <script src=media-file.js></script>
+    <script>
+
+        let nowPlayingState;
+
+        async function waitForAttributeToChange(attribute, expected) {
+            let start = new Date().getTime();
+            do {
+
+                if (internals.nowPlayingState[attribute] != expected)
+                    return;
+
+                await new Promise(resolve => setTimeout(resolve, 100));
+            } while (new Date().getTime() - start < 500);
+
+            failTest(`** Timed out waiting for "${attribute}" to change from "${expected}"`);
+        }
+
+        function playAction()
+        {
+            consoleWrite('ACTION: play');
+            video.play();
+        }
+
+        function pauseAction()
+        {
+            consoleWrite('ACTION: pause');
+            video.pause();
+        }
+
+        async function runTest()
+        {
+            findMediaElement();
+
+            consoleWrite('<br>* NowPlaying should not be active before playback has started.');
+            run('video.src = findMediaFile("video", "content/test")');
+            await waitFor(video, 'canplaythrough');
+
+            run('nowPlayingState = internals.nowPlayingState');
+            testExpected('nowPlayingState.registeredAsNowPlayingApplication', false);
+
+            run('navigator.mediaSession.metadata = new MediaMetadata({title: "title", artist: "artist", album: "album", artwork: [{src: "content/abe.png"}]})');
+            run('navigator.mediaSession.playbackState = "paused"')
+            run('navigator.mediaSession.positionState = {duration: video.duration, position: video.currentTime}');
+            run('navigator.mediaSession.setActionHandler("play", playAction)');
+            run('navigator.mediaSession.setActionHandler("pause", pauseAction)');
+
+            consoleWrite('<br>* Start to play, NowPlaying should become active.');
+            runWithKeyDown(() => {
+                run('navigator.mediaSession.callActionHandler({action: "play"})');
+            });
+
+            await waitFor(video, 'playing');
+            run('navigator.mediaSession.callActionHandler({action: "pause"})');
+            await waitForAttributeToChange('registeredAsNowPlayingApplication', false);
+
+            consoleWrite('<br>* Metadata should not be blank.');
+            run('nowPlayingMetadata = internals.nowPlayingMetadata');
+            await testExpectedEventually('nowPlayingMetadata', null, '!=', 10000);
+            await testExpectedEventually('nowPlayingMetadata.title', '', '!=', 10000);
+
+            consoleWrite('<br>* Suspending all media playback NowPlaying to deactivate.');
+            run('internals.suspendAllMediaPlayback()');
+            await waitForAttributeToChange('registeredAsNowPlayingApplication', true);
+            testExpected('nowPlayingState.registeredAsNowPlayingApplication', false);
+
+            await testExpectedEventually('internals.nowPlayingMetadata', null, '==', 10000);
+
+            consoleWrite('');
+        }
+
+        window.addEventListener('load', event => {
+            runTest().then(endTest).catch(failTest);
+        });
+    </script>
+</head>
+<body">
+    <video controls></video>
+    <br>
+    Tests that the NowPlaying metadata is empty when in private browsing mode.
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2464,6 +2464,8 @@ fast/events/webkit-media-key-events-constructor.html [ Skip ]
 # NowPlaying is macOS and iOS only.
 http/tests/media/now-playing-info-private-browsing.html [ Skip ]
 http/tests/media/now-playing-info.html [ Skip ]
+media/now-playing-info-media-session-private-browsing.html [ Skip ]
+media/now-playing-info-media-session-suspend-playback.html [ Skip ]
 
 imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content-rendering-rules/canvas-update-with-border-object-fit.html [ Pass ]
 

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -523,6 +523,13 @@ bool AudioContext::isNowPlayingEligible() const
         return false;
 
     RefPtr document = this->document();
+    if (!document)
+        return false;
+
+    RefPtr page = document->page();
+    if (page && page->mediaPlaybackIsSuspended())
+        return false;
+
     return hasPlayBackAudioSession(document.get());
 }
 
@@ -553,6 +560,9 @@ std::optional<NowPlayingInfo> AudioContext::nowPlayingInfo() const
         isPlaying(),
         !page->isVisibleAndActive()
     };
+
+    if (page->usesEphemeralSession())
+        return nowPlayingInfo;
 
 #if ENABLE(MEDIA_SESSION)
     if (RefPtr mediaSession = NavigatorMediaSession::mediaSessionIfExists(window->protectedNavigator()))

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -705,6 +705,15 @@ RefPtr<HTMLMediaElement> HTMLMediaElement::bestMediaElementForRemoteControls(Med
     return selectedSession ? RefPtr { &downcast<MediaElementSession>(selectedSession.get())->element() } : nullptr;
 }
 
+bool HTMLMediaElement::isNowPlayingEligible() const
+{
+    RefPtr page = document().page();
+    if (page && page->mediaPlaybackIsSuspended())
+        return false;
+
+    return m_mediaSession->hasNowPlayingInfo();
+}
+
 std::optional<NowPlayingInfo> HTMLMediaElement::nowPlayingInfo() const
 {
     return m_mediaSession->computeNowPlayingInfo();

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1018,7 +1018,7 @@ private:
     bool hasMediaStreamSource() const final;
     void processIsSuspendedChanged() final;
     bool shouldOverridePauseDuringRouteChange() const final;
-    bool isNowPlayingEligible() const final { return m_mediaSession->hasNowPlayingInfo(); }
+    bool isNowPlayingEligible() const final;
     std::optional<NowPlayingInfo> nowPlayingInfo() const final;
     WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlatformMediaSession::PlaybackControlsPurpose) final;
 

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1271,8 +1271,10 @@ std::optional<NowPlayingInfo> MediaElementSession::computeNowPlayingInfo() const
         return { };
 
     RefPtr page = m_element.document().page();
+    if (!page)
+        return { };
 
-    bool allowsNowPlayingControlsVisibility = page && !page->isVisibleAndActive();
+    bool allowsNowPlayingControlsVisibility = !page->isVisibleAndActive();
     bool isPlaying = state() == PlatformMediaSession::State::Playing;
 
     bool supportsSeeking = m_element.supportsSeeking();
@@ -1306,6 +1308,12 @@ std::optional<NowPlayingInfo> MediaElementSession::computeNowPlayingInfo() const
         isPlaying,
         allowsNowPlayingControlsVisibility
     };
+
+    if (page->usesEphemeralSession()) {
+        info.metadata = { };
+        return info;
+    }
+
 #if ENABLE(MEDIA_SESSION)
     if (RefPtr session = mediaSession())
         session->updateNowPlayingInfo(info);

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -506,6 +506,7 @@ void MediaSessionManagerCocoa::updateNowPlayingInfo()
         m_lastUpdatedNowPlayingDuration = NAN;
         m_lastUpdatedNowPlayingElapsedTime = NAN;
         m_lastUpdatedNowPlayingInfoUniqueIdentifier = { };
+        m_nowPlayingInfo = std::nullopt;
 
         updateActiveNowPlayingSession(nullptr);
         return;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -602,6 +602,8 @@ void Internals::resetToConsistentState(Page& page)
     PlatformMediaSessionManager::sharedManager().resetSessionState();
     PlatformMediaSessionManager::sharedManager().setWillIgnoreSystemInterruptions(true);
     PlatformMediaSessionManager::sharedManager().applicationWillEnterForeground(false);
+    if (page.mediaPlaybackIsSuspended())
+        page.resumeAllMediaPlayback();
 #endif
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
     PlatformMediaSessionManager::sharedManager().setIsPlayingToAutomotiveHeadUnit(false);
@@ -4979,6 +4981,32 @@ void Internals::suspendAllMediaBuffering()
     page->suspendAllMediaBuffering();
 }
 
+void Internals::suspendAllMediaPlayback()
+{
+    auto frame = this->frame();
+    if (!frame)
+        return;
+
+    auto page = frame->page();
+    if (!page)
+        return;
+
+    page->suspendAllMediaPlayback();
+}
+
+void Internals::resumeAllMediaPlayback()
+{
+    auto frame = this->frame();
+    if (!frame)
+        return;
+
+    auto page = frame->page();
+    if (!page)
+        return;
+
+    page->resumeAllMediaPlayback();
+}
+
 #endif // ENABLE(VIDEO)
 
 #if ENABLE(WEB_AUDIO)
@@ -5020,6 +5048,13 @@ void Internals::simulateSystemWake() const
 #if ENABLE(VIDEO)
     PlatformMediaSessionManager::sharedManager().processSystemDidWake();
 #endif
+}
+
+std::optional<Internals::NowPlayingMetadata> Internals::nowPlayingMetadata() const
+{
+    if (auto nowPlayingInfo = PlatformMediaSessionManager::sharedManager().nowPlayingInfo())
+        return nowPlayingInfo->metadata;
+    return std::nullopt;
 }
 
 ExceptionOr<Internals::NowPlayingState> Internals::nowPlayingState() const

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -37,6 +37,7 @@
 #include "ExceptionOr.h"
 #include "HEVCUtilities.h"
 #include "IDLTypes.h"
+#include "NowPlayingInfo.h"
 #include "OrientationNotifier.h"
 #include "PageConsoleClient.h"
 #include "RealtimeMediaSource.h"
@@ -831,6 +832,8 @@ public:
     void endAudioSessionInterruption();
     void clearAudioSessionInterruptionFlag();
     void suspendAllMediaBuffering();
+    void suspendAllMediaPlayback();
+    void resumeAllMediaPlayback();
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
@@ -1118,6 +1121,10 @@ public:
 
     bool usingAppleInternalSDK() const;
     bool usingGStreamer() const;
+
+    using NowPlayingInfoArtwork = WebCore::NowPlayingInfoArtwork;
+    using NowPlayingMetadata = WebCore::NowPlayingMetadata;
+    std::optional<NowPlayingMetadata> nowPlayingMetadata() const;
 
     struct NowPlayingState {
         String title;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -159,6 +159,27 @@ enum AutoplayPolicy {
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     Conditional=VIDEO,
     JSGenerateToJSObject,
+] dictionary NowPlayingInfoArtwork {
+    DOMString src;
+    DOMString mimeType;
+};
+
+[
+    ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
+    Conditional=VIDEO,
+    JSGenerateToJSObject,
+] dictionary NowPlayingMetadata {
+    DOMString title;
+    DOMString artist;
+    DOMString album;
+    DOMString sourceApplicationIdentifier;
+    NowPlayingInfoArtwork? artwork;
+};
+
+[
+    ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
+    Conditional=VIDEO,
+    JSGenerateToJSObject,
 ] dictionary MediaUsageState {
     DOMString mediaURL;
     boolean isPlaying;
@@ -964,6 +985,8 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     [Conditional=VIDEO] undefined endAudioSessionInterruption();
     [Conditional=VIDEO] undefined clearAudioSessionInterruptionFlag();
     [Conditional=VIDEO] undefined suspendAllMediaBuffering();
+    [Conditional=VIDEO] undefined suspendAllMediaPlayback();
+    [Conditional=VIDEO] undefined resumeAllMediaPlayback();
 
     [Conditional=WIRELESS_PLAYBACK_TARGET] undefined setMockMediaPlaybackTargetPickerEnabled(boolean enabled);
     [Conditional=WIRELESS_PLAYBACK_TARGET] undefined setMockMediaPlaybackTargetPickerState(DOMString deviceName, DOMString deviceState);
@@ -1185,6 +1208,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     undefined setMaxCanvasArea(unsigned long size);
 
+    [Conditional=VIDEO] readonly attribute NowPlayingMetadata? nowPlayingMetadata;
     [Conditional=VIDEO] readonly attribute NowPlayingState nowPlayingState;
 
     [Conditional=VIDEO] HTMLMediaElement bestMediaElementForRemoteControls(PlaybackControlsPurpose purpose);


### PR DESCRIPTION
#### 07fd7c7499a7c38e9794fe517374f03777bbe3db
<pre>
Resign Now Playing status when WKWebView suspends all media playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=276133">https://bugs.webkit.org/show_bug.cgi?id=276133</a>
<a href="https://rdar.apple.com/129853095">rdar://129853095</a>

Reviewed by Eric Carlson.

When a WKWebView suspensd all media playback, we should resign Now Playing status (because
we can no longer resume playback from Now Playing controls). Additionally, when the page is
ephemeral, we should not report the media metadata information to Now Playing.

* LayoutTests/media/now-playing-info-media-session-private-browsing-expected.txt: Added.
* LayoutTests/media/now-playing-info-media-session-private-browsing.html: Added.
* LayoutTests/media/now-playing-info-media-session-suspend-playback-expected.txt: Added.
* LayoutTests/media/now-playing-info-media-session-suspend-playback.html: Added.
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::isNowPlayingEligible const):
(WebCore::AudioContext::nowPlayingInfo const):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::isNowPlayingEligible const):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::computeNowPlayingInfo const):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateNowPlayingInfo):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::suspendAllMediaPlayback):
(WebCore::Internals::resumeAllMediaPlayback):
(WebCore::Internals::nowPlayingMetadata const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/280914@main">https://commits.webkit.org/280914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4948ce588e0ff49f9daeee911c4321314df7c60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61629 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8449 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8638 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47009 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6019 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27840 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31775 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7433 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7453 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53722 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63317 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7772 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54373 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12832 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1644 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33161 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34247 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->