### PR TITLE
Update smart pointer expectations to reflect bugfixes

### DIFF
--- a/Source/WebCore/SmartPointerExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SmartPointerExpectations/UncountedCallArgsCheckerExpectations
@@ -333,7 +333,6 @@ JSStorageManager.cpp
 JSStyleMedia.h
 JSStyleSheetList.cpp
 JSSubtleCrypto.cpp
-JSText.cpp
 JSTextTrack.cpp
 JSTextTrackCue.cpp
 JSTextTrackCueList.cpp
@@ -349,7 +348,6 @@ JSVideoConfiguration.cpp
 JSVideoTrack.cpp
 JSViewTimeline.cpp
 JSVisualViewport.cpp
-JSWakeLock.cpp
 JSWakeLockSentinel.cpp
 JSWaveShaperNode.cpp
 JSWebAnimation.cpp
@@ -1521,7 +1519,6 @@ page/PageSerializer.cpp
 page/PartitionedSecurityOrigin.h
 page/Performance.cpp
 page/PerformanceMark.cpp
-page/PerformanceMeasure.cpp
 page/PerformanceMonitor.cpp
 page/PerformanceObserver.cpp
 page/PerformanceUserTiming.cpp
@@ -1708,7 +1705,6 @@ platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm
 platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
 platform/graphics/coreimage/FilterImageCoreImage.mm
 platform/graphics/coretext/FontCascadeCoreText.cpp
-platform/graphics/coretext/FontCoreText.cpp
 platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
 platform/graphics/coretext/FontPlatformDataCoreText.cpp
 platform/graphics/cv/GraphicsContextGLCVCocoa.cpp
@@ -1760,7 +1756,6 @@ platform/mediastream/mac/AVCaptureDeviceManager.mm
 platform/mediastream/mac/AVVideoCaptureSource.mm
 platform/mediastream/mac/CGDisplayStreamCaptureSource.cpp
 platform/mediastream/mac/CGDisplayStreamScreenCaptureSource.mm
-platform/mediastream/mac/CoreAudioCaptureSource.cpp
 platform/mediastream/mac/CoreAudioSharedUnit.cpp
 platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.cpp
 platform/mediastream/mac/MockAudioSharedUnit.mm

--- a/Source/WebCore/SmartPointerExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SmartPointerExpectations/UncountedLocalVarsCheckerExpectations
@@ -294,12 +294,8 @@ JSReadableStreamDefaultController.h
 JSRemotePlayback.cpp
 JSRemotePlaybackAvailabilityCallback.cpp
 JSReportingObserver.cpp
-JSSQLResultSet.cpp
-JSSQLResultSet.h
 JSSQLResultSetRowList.cpp
 JSSQLStatementCallback.cpp
-JSSVGGradientElement.cpp
-JSSVGGraphicsElement.cpp
 JSSVGLengthList.cpp
 JSSVGUseElement.cpp
 JSScreen.cpp
@@ -333,6 +329,7 @@ JSTextTrackCueList.cpp
 JSTextTrackList.cpp
 JSTrustedHTML.h
 JSTrustedScript.h
+JSTrustedTypePolicy.cpp
 JSTrustedTypePolicyFactory.cpp
 JSTypeConversions.cpp
 JSTypeConversions.h
@@ -346,7 +343,6 @@ JSVideoTrackList.cpp
 JSViewTransition.cpp
 JSVisualViewport.cpp
 JSWakeLock.cpp
-JSWakeLock.h
 JSWakeLockSentinel.cpp
 JSWaveShaperNode.cpp
 JSWebAnimation.cpp
@@ -383,7 +379,6 @@ JSWebGLQuery.cpp
 JSWebGLRenderSharedExponent.cpp
 JSWebGLRenderbuffer.cpp
 JSWebGLRenderingContext.cpp
-JSWebGLRenderingContext.h
 JSWebGLSampler.cpp
 JSWebGLShader.cpp
 JSWebGLStencilTexturing.cpp
@@ -1167,14 +1162,11 @@ platform/graphics/filters/FilterImage.cpp
 platform/graphics/filters/FilterOperations.cpp
 platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
 platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
-platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
 platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp
 platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
 platform/graphics/filters/software/FEImageSoftwareApplier.cpp
-platform/graphics/filters/software/FELightingSoftwareApplier.cpp
 platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
 platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
-platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
 platform/graphics/mac/ComplexTextControllerCoreText.mm
 platform/graphics/mac/controls/MeterMac.mm
 platform/graphics/mac/controls/ProgressBarMac.mm

--- a/Source/WebKit/SmartPointerExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebKit/SmartPointerExpectations/NoUncountedMemberCheckerExpectations
@@ -52,7 +52,6 @@ WebProcess/WebCoreSupport/WebScreenOrientationManager.h
 WebProcess/WebPage/FindController.h
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
 WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
-WebProcess/WebPage/ViewGestureGeometryCollector.h
 WebProcess/WebPage/WebURLSchemeHandlerProxy.h
 WebProcess/WebPage/WebURLSchemeTaskProxy.h
 WebProcess/WebStorage/StorageAreaMap.h

--- a/Source/WebKit/SmartPointerExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SmartPointerExpectations/UncountedLocalVarsCheckerExpectations
@@ -135,7 +135,6 @@ WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
 WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
 WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
 WebProcess/GPU/media/WebMediaStrategy.cpp
-WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
 WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
 WebProcess/GPU/webrtc/MediaRecorderProvider.cpp
 WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp


### PR DESCRIPTION
#### 7ac61c795bfb261b908783a611808ccba7acf524
<pre>
Update smart pointer expectations to reflect bugfixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=276134">https://bugs.webkit.org/show_bug.cgi?id=276134</a>
<a href="https://rdar.apple.com/130986705">rdar://130986705</a>

Reviewed by Tim Nguyen.

Removes files that have been fixed from expectations.

* Source/WebCore/SmartPointerExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SmartPointerExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/SmartPointerExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebKit/SmartPointerExpectations/UncountedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/280589@main">https://commits.webkit.org/280589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/671cda120c3a2e086479bfc5f2cf18e03a35b292

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57042 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/36370 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/9517 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/60662 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/7485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/59170 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/43994 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/7675 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/60662 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/7485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/59072 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/43994 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/9517 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/60662 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/43994 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/9517 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/6490 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/43994 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/9517 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/62343 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/955 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/7675 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/62343 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/958 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/9517 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/62343 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8497 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/33284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/34369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/33030 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->