### PR TITLE
Fix a bug that a pruned file cannot be re-uploaded from UI.

### DIFF
--- a/Websites/perf.webkit.org/public/v3/components/instant-file-uploader.js
+++ b/Websites/perf.webkit.org/public/v3/components/instant-file-uploader.js
@@ -164,7 +164,7 @@ class InstantFileUploader extends ComponentBase {
         const uploadProgress = this._uploadProgress;
         for (let file of files) {
             UploadedFile.fetchUploadedFileWithIdenticalHash(file).then((uploadedFile) => {
-                if (uploadedFile) {
+                if (uploadedFile && !uploadedFile.deletedAt()) {
                     this._didUploadFile(file, uploadedFile);
                     return;
                 }

--- a/Websites/perf.webkit.org/server-tests/privileged-api-upload-file-tests.js
+++ b/Websites/perf.webkit.org/server-tests/privileged-api-upload-file-tests.js
@@ -121,7 +121,7 @@ describe('/privileged-api/upload-file', function () {
         });
     });
 
-    it('should re-upload the file when the previously uploaded file had been deleted', () => {
+    it('should re-upload the file when the previously uploaded file had been deleted and reuse the file id', () => {
         const db = TestServer.database();
         const limitInMB = TestServer.testConfig().uploadFileLimitInMB;
         let uploadedFile1;
@@ -139,26 +139,21 @@ describe('/privileged-api/upload-file', function () {
             uploadedFile2 = response['uploadedFile'];
             return db.selectAll('uploaded_files', 'id');
         }).then((rows) => {
-            assert.notStrictEqual(uploadedFile1.id, uploadedFile2.id);
-            assert.strictEqual(rows.length, 2);
+            assert.strictEqual(uploadedFile1.id, uploadedFile2.id);
+            assert.strictEqual(rows.length, 1);
             assert.strictEqual(rows[0].id, parseInt(uploadedFile1.id));
-            assert.strictEqual(rows[1].id, parseInt(uploadedFile2.id));
 
             assert.strictEqual(rows[0].filename, 'some.dat');
             assert.strictEqual(rows[0].filename, uploadedFile1.filename);
-            assert.strictEqual(rows[1].filename, 'other.dat');
-            assert.strictEqual(rows[1].filename, uploadedFile2.filename);
 
             assert.strictEqual(parseInt(rows[0].size), limitInMB * 1024 * 1024);
             assert.strictEqual(parseInt(rows[0].size), parseInt(uploadedFile1.size));
             assert.strictEqual(parseInt(rows[0].size), parseInt(uploadedFile2.size));
-            assert.strictEqual(rows[0].size, rows[1].size);
+            assert.strictEqual(rows[0].deleted_at, null);
             assert.strictEqual(rows[0].sha256, '5256ec18f11624025905d057d6befb03d77b243511ac5f77ed5e0221ce6d84b5');
             assert.strictEqual(rows[0].sha256, uploadedFile1.sha256);
             assert.strictEqual(rows[0].sha256, uploadedFile2.sha256);
-            assert.strictEqual(rows[0].sha256, rows[1].sha256);
             assert.strictEqual(rows[0].extension, '.dat');
-            assert.strictEqual(rows[1].extension, '.dat');
         });
     });
 


### PR DESCRIPTION
#### 8ff023c1c88865cbaa402745ba2dd97b675878c9
<pre>
Fix a bug that a pruned file cannot be re-uploaded from UI.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276136">https://bugs.webkit.org/show_bug.cgi?id=276136</a>
<a href="https://rdar.apple.com/121951370">rdar://121951370</a>

Reviewed by Ryosuke Niwa.

Fix a bug that a pruned file cannot be re-uploaded from UI.
Change the backend handling for re-uploaded file from creating a new database entry to reuse existing
database entry. This change has the advantage of avoid creating unnecessary database entries as well
as enabling retries for existing tasks that use pruned files.

* Websites/perf.webkit.org/public/include/uploaded-file-helpers.php: Change the logic to reuse database entries
for re-uploaded files instead of creating new ones.
* Websites/perf.webkit.org/public/v3/components/instant-file-uploader.js: Add a check on whether a file is deleted.
If the file is pruned before, it should be re-uploaded.
(InstantFileUploader.prototype._uploadFiles):
* Websites/perf.webkit.org/server-tests/privileged-api-upload-file-tests.js: Fix and update a corresponding unit test.
(then):

Canonical link: <a href="https://commits.webkit.org/280603@main">https://commits.webkit.org/280603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4f5f9b28fa153daecf8d818eadda18683d98b05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60687 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7510 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46216 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5284 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27077 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30953 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62368 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6962 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49310 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53523 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12615 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/834 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32224 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33309 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/34394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33055 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->