### PR TITLE
[WGSL] built-in functions should only be allowed in appropriate shader stages

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTCallExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTCallExpression.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ASTExpression.h"
+#include <wtf/OptionSet.h>
 
 namespace WGSL {
 class BoundsCheckVisitor;
@@ -54,6 +55,8 @@ public:
 
     bool isConstructor() const { return m_isConstructor; }
 
+    const OptionSet<ShaderStage>& visibility() const { return m_visibility; }
+
 private:
     CallExpression(SourceSpan span, Expression::Ref&& target, Expression::List&& arguments)
         : Expression(span)
@@ -69,6 +72,7 @@ private:
     Expression::List m_arguments;
 
     bool m_isConstructor { false };
+    OptionSet<ShaderStage> m_visibility { ShaderStage::Compute, ShaderStage::Vertex, ShaderStage::Fragment };
 };
 
 } // namespace AST

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1935,9 +1935,10 @@ const Type* TypeChecker::chooseOverload(ASCIILiteral kind, const SourceSpan& spa
             callArguments[i].m_inferredType = overload->parameters[i];
         inferred(overload->result);
 
-        if (expression && it->value.kind == OverloadedDeclaration::Constructor) {
-            if (auto* call = dynamicDowncast<AST::CallExpression>(*expression))
-                call->m_isConstructor = true;
+        if (expression && is<AST::CallExpression>(*expression)) {
+            auto& call = uncheckedDowncast<AST::CallExpression>(*expression);
+            call.m_isConstructor = it->value.kind == OverloadedDeclaration::Constructor;
+            call.m_visibility = it->value.visibility;
         }
 
         unsigned argumentCount = callArguments.size();

--- a/Source/WebGPU/WGSL/VisibilityValidator.cpp
+++ b/Source/WebGPU/WGSL/VisibilityValidator.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "VisibilityValidator.h"
+
+#include "AST.h"
+#include "ASTVisitor.h"
+#include "WGSLEnums.h"
+#include "WGSLShaderModule.h"
+#include <wtf/text/MakeString.h>
+
+namespace WGSL {
+
+class VisibilityValidator : public AST::Visitor {
+public:
+    VisibilityValidator(ShaderModule&);
+
+    std::optional<FailedCheck> validate();
+
+    void visit(AST::Function&) override;
+    void visit(AST::CallExpression&) override;
+
+private:
+    template<typename... Arguments>
+    void error(const SourceSpan&, Arguments&&...);
+
+    ShaderModule& m_shaderModule;
+    Vector<Error> m_errors;
+    ShaderStage m_stage;
+};
+
+VisibilityValidator::VisibilityValidator(ShaderModule& shaderModule)
+    : m_shaderModule(shaderModule)
+{
+}
+
+std::optional<FailedCheck> VisibilityValidator::validate()
+{
+    for (auto& entryPoint : m_shaderModule.callGraph().entrypoints()) {
+        m_stage = entryPoint.stage;
+        visit(entryPoint.function);
+
+    }
+
+    if (m_errors.isEmpty())
+        return std::nullopt;
+    return FailedCheck { WTFMove(m_errors), { } };
+}
+
+void VisibilityValidator::visit(AST::Function& function)
+{
+    AST::Visitor::visit(function);
+
+    for (auto& callee : m_shaderModule.callGraph().callees(function))
+        visit(*callee.target);
+}
+
+void VisibilityValidator::visit(AST::CallExpression& call)
+{
+    AST::Visitor::visit(call);
+    if (!call.visibility().contains(m_stage))
+        error(call.span(), "built-in cannot be used by "_s, toString(m_stage), " pipeline stage"_s);
+}
+
+template<typename... Arguments>
+void VisibilityValidator::error(const SourceSpan& span, Arguments&&... arguments)
+{
+    m_errors.append({ makeString(std::forward<Arguments>(arguments)...), span });
+}
+
+std::optional<FailedCheck> validateVisibility(ShaderModule& shaderModule)
+{
+    return VisibilityValidator(shaderModule).validate();
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/VisibilityValidator.h
+++ b/Source/WebGPU/WGSL/VisibilityValidator.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WGSL.h"
+
+namespace WGSL {
+
+class ShaderModule;
+
+std::optional<FailedCheck> validateVisibility(ShaderModule&);
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -39,6 +39,7 @@
 #include "PhaseTimer.h"
 #include "PointerRewriter.h"
 #include "TypeCheck.h"
+#include "VisibilityValidator.h"
 #include "WGSLShaderModule.h"
 
 namespace WGSL {
@@ -77,6 +78,7 @@ std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const
     CHECK_PASS(validateAttributes, shaderModule);
     RUN_PASS(buildCallGraph, shaderModule);
     CHECK_PASS(validateIO, shaderModule);
+    CHECK_PASS(validateVisibility, shaderModule);
 
     Vector<Warning> warnings { };
     return std::variant<SuccessfulCheck, FailedCheck>(std::in_place_type<SuccessfulCheck>, WTFMove(warnings), WTFMove(shaderModule));

--- a/Source/WebGPU/WGSL/tests/invalid/visibility.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/visibility.wgsl
@@ -1,0 +1,11 @@
+// RUN: %not %wgslc | %check
+
+fn f() {
+    // CHECK-L: built-in cannot be used by fragment pipeline stage
+    storageBarrier();
+}
+
+@fragment
+fn main() {
+    f();
+}

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -4505,7 +4505,7 @@ fn testTextureNumSamples()
 
 // 16.7.8
 // RUN: %metal-compile testTextureSample
-@compute @workgroup_size(1)
+@fragment
 fn testTextureSample()
 {
     // [].(Texture[F32, Texture1d], Sampler, F32) => Vector[F32, 4],
@@ -4557,7 +4557,7 @@ fn testTextureSample()
 
 // 16.7.9
 // RUN: %metal-compile testTextureSampleBias
-@compute @workgroup_size(1)
+@fragment
 fn testTextureSampleBias()
 {
     // [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], F32) => Vector[F32, 4],
@@ -4587,7 +4587,7 @@ fn testTextureSampleBias()
 
 // 16.7.10
 // RUN: %metal-compile testTextureSampleCompare
-@compute @workgroup_size(1)
+@fragment
 fn testTextureSampleCompare()
 {
     // [].(texture_depth_2d, sampler_comparison, vec2[f32], f32) => f32,

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -181,6 +181,8 @@
 		97D398E62B06A85B00D8C4AA /* ASTDiagnosticDirective.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D398E42B06A85B00D8C4AA /* ASTDiagnosticDirective.h */; };
 		97D398E72B06A85B00D8C4AA /* ASTDiagnostic.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D398E52B06A85B00D8C4AA /* ASTDiagnostic.h */; };
 		97D398E92B2387F300D8C4AA /* ASTTypeAlias.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D398E82B2387F300D8C4AA /* ASTTypeAlias.h */; };
+		97DE28472C348D8A00F4DEC3 /* VisibilityValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 97DE28452C348D8A00F4DEC3 /* VisibilityValidator.h */; };
+		97DE28482C348D8A00F4DEC3 /* VisibilityValidator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97DE28462C348D8A00F4DEC3 /* VisibilityValidator.cpp */; };
 		97E21C8B2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */; };
 		97E21C972A2512F7009CEB0E /* ConstantValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97E21C942A2512F7009CEB0E /* ConstantValue.cpp */; };
 		97E21C982A2512F7009CEB0E /* ConstantValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 97E21C952A2512F7009CEB0E /* ConstantValue.h */; };
@@ -479,6 +481,8 @@
 		97D398E42B06A85B00D8C4AA /* ASTDiagnosticDirective.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTDiagnosticDirective.h; sourceTree = "<group>"; };
 		97D398E52B06A85B00D8C4AA /* ASTDiagnostic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTDiagnostic.h; sourceTree = "<group>"; };
 		97D398E82B2387F300D8C4AA /* ASTTypeAlias.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTTypeAlias.h; sourceTree = "<group>"; };
+		97DE28452C348D8A00F4DEC3 /* VisibilityValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VisibilityValidator.h; sourceTree = "<group>"; };
+		97DE28462C348D8A00F4DEC3 /* VisibilityValidator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VisibilityValidator.cpp; sourceTree = "<group>"; };
 		97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASTDecrementIncrementStatement.cpp; sourceTree = "<group>"; };
 		97E21C942A2512F7009CEB0E /* ConstantValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConstantValue.cpp; sourceTree = "<group>"; };
 		97E21C952A2512F7009CEB0E /* ConstantValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConstantValue.h; sourceTree = "<group>"; };
@@ -687,6 +691,8 @@
 				978A9131298BBFD300B37E5E /* Types.h */,
 				978A9136298D40F100B37E5E /* TypeStore.cpp */,
 				978A9135298D40F100B37E5E /* TypeStore.h */,
+				97DE28462C348D8A00F4DEC3 /* VisibilityValidator.cpp */,
+				97DE28452C348D8A00F4DEC3 /* VisibilityValidator.h */,
 				1CEBD8022716BF8200A5254D /* WGSL.cpp */,
 				1CEBD7F72716B34400A5254D /* WGSL.h */,
 				97FA1A8729C085A60052D650 /* wgslc.cpp */,
@@ -957,6 +963,7 @@
 				978A912F298AD3DA00B37E5E /* TypeCheck.h in Headers */,
 				978A9133298BBFD300B37E5E /* Types.h in Headers */,
 				978A9137298D40F100B37E5E /* TypeStore.h in Headers */,
+				97DE28472C348D8A00F4DEC3 /* VisibilityValidator.h in Headers */,
 				1CEBD7F82716B34400A5254D /* WGSL.h in Headers */,
 				97099AC72AC49AAB003B41F8 /* WGSLEnums.h in Headers */,
 				9776BE7629957E12002D6D93 /* WGSLShaderModule.h in Headers */,
@@ -1191,6 +1198,7 @@
 				97296766299C09BC001C8BD4 /* TypeDeclarations.rb in Sources */,
 				978A9134298BBFD300B37E5E /* Types.cpp in Sources */,
 				978A9138298D40F100B37E5E /* TypeStore.cpp in Sources */,
+				97DE28482C348D8A00F4DEC3 /* VisibilityValidator.cpp in Sources */,
 				1CEBD8032716BF8200A5254D /* WGSL.cpp in Sources */,
 				97099AC62AC49AAB003B41F8 /* WGSLEnums.cpp in Sources */,
 			);


### PR DESCRIPTION
#### f6b375129695f4b25759d9780f4521f482f93335
<pre>
[WGSL] built-in functions should only be allowed in appropriate shader stages
<a href="https://bugs.webkit.org/show_bug.cgi?id=276140">https://bugs.webkit.org/show_bug.cgi?id=276140</a>
<a href="https://rdar.apple.com/130225282">rdar://130225282</a>

Reviewed by Mike Wyrzykowski.

We already had the information about which shader stages the built-ins could be
called from, but we were missing the check. Add a new pass that traverses the
call graph and checks if all the built-ins are called from the appropriate stages.

* Source/WebGPU/WGSL/AST/ASTCallExpression.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::chooseOverload):
* Source/WebGPU/WGSL/VisibilityValidator.cpp: Added.
(WGSL::VisibilityValidator::VisibilityValidator):
(WGSL::VisibilityValidator::validate):
(WGSL::VisibilityValidator::visit):
(WGSL::VisibilityValidator::error):
(WGSL::validateVisibility):
* Source/WebGPU/WGSL/VisibilityValidator.h: Added.
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::staticCheck):
* Source/WebGPU/WGSL/tests/invalid/visibility.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/280662@main">https://commits.webkit.org/280662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/952257cfcf29922bd87c04f1f4c63bdb97d8c26d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60752 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7575 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46271 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5334 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27127 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31009 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6580 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62433 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1045 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7019 "Found 1 new test failure: workers/wasm-hashset-many.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53526 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49371 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53586 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12655 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/885 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32289 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33374 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34459 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33120 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->