### PR TITLE
Ref count Element in `resolveAnchorValue()` for safety

### DIFF
--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -26,16 +26,19 @@
 #include "AnchorPositionEvaluator.h"
 
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "Element.h"
 #include "StyleScope.h"
 
 namespace WebCore::Style {
 
-Length AnchorPositionEvaluator::resolveAnchorValue(const CSSAnchorValue* anchorValue, const Element& element)
+Length AnchorPositionEvaluator::resolveAnchorValue(const CSSAnchorValue* anchorValue, const Element* element)
 {
-    auto& anchorPositionedStateMap = element.document().styleScope().anchorPositionedStateMap();
+    if (!element)
+        return Length(0, LengthType::Fixed);
 
-    auto* anchorPositionedElementState = anchorPositionedStateMap.ensure(element, [&] {
+    auto& anchorPositionedStateMap = element->protectedDocument()->checkedStyleScope()->anchorPositionedStateMap();
+    auto* anchorPositionedElementState = anchorPositionedStateMap.ensure(*element, [&] {
         return WTF::makeUnique<AnchorPositionedElementState>();
     }).iterator->value.get();
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -49,7 +49,7 @@ using AnchorPositionedStateMap = WeakHashMap<Element, std::unique_ptr<AnchorPosi
 
 class AnchorPositionEvaluator {
 public:
-    static Length resolveAnchorValue(const CSSAnchorValue*, const Element&);
+    static Length resolveAnchorValue(const CSSAnchorValue*, const Element*);
 };
 
 }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -267,8 +267,8 @@ inline Length BuilderConverter::convertLength(const BuilderState& builderState, 
         return Length(primitiveValue.cssCalcValue()->createCalculationValue(conversionData));
 
     if (primitiveValue.isAnchor()) {
-        auto& anchorPositionedElement = *builderState.element();
-        return AnchorPositionEvaluator::resolveAnchorValue(primitiveValue.cssAnchorValue(), anchorPositionedElement);
+        RefPtr anchorPositionedElement = builderState.element();
+        return AnchorPositionEvaluator::resolveAnchorValue(primitiveValue.cssAnchorValue(), anchorPositionedElement.get());
     }
 
     ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 2ce73fd81990e9d078077569b417ac244bba34f0
<pre>
Ref count Element in `resolveAnchorValue()` for safety
<a href="https://bugs.webkit.org/show_bug.cgi?id=276142">https://bugs.webkit.org/show_bug.cgi?id=276142</a>
<a href="https://rdar.apple.com/130992562">rdar://130992562</a>

Reviewed by Tim Nguyen and Ryan Reno.

Adds a RefPtr to an Element used for `resolveAnchorValue()` to ensure
the lifetime of the Element across the function call. Also guards
against a null pointer and uses safer getters.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::resolveAnchorValue):
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertLength):

Canonical link: <a href="https://commits.webkit.org/280610@main">https://commits.webkit.org/280610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3d747398da9590e84f5a0ef4df8f1bf418c865b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60713 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46231 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5297 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6610 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6541 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62394 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6981 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53490 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49333 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53543 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 3 api tests failed or timed out; 3 api tests failed or timed out; Compiled WebKit; 2 api tests failed or timed out; Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12620 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/849 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32250 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33335 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34420 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->