### PR TITLE
Deprecate WKBundlePageGetPDFDocumentInFrame

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.h
@@ -29,6 +29,7 @@
 
 #include <WebKit/WKBase.h>
 #include <WebKit/WKBundlePage.h>
+#include <WebKit/WKDeprecated.h>
 
 @class PDFDocument;
 
@@ -36,7 +37,7 @@
 extern "C" {
 #endif
 
-WK_EXPORT PDFDocument *WKBundlePageGetPDFDocumentInFrame(WKBundlePageRef page, WKBundleFrameRef frame);
+WK_EXPORT PDFDocument *WKBundlePageGetPDFDocumentInFrame(WKBundlePageRef page, WKBundleFrameRef frame) WK_C_API_DEPRECATED;
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm
@@ -26,18 +26,7 @@
 #import "config.h"
 #import "WKBundlePageMac.h"
 
-#import "PluginView.h"
-#import "WKBundleAPICast.h"
-#import "WKBundleFrame.h"
-#import "WebFrame.h"
-#import "WebPage.h"
-
-WK_EXPORT PDFDocument *WKBundlePageGetPDFDocumentInFrame(WKBundlePageRef, WKBundleFrameRef frame)
+WK_EXPORT PDFDocument *WKBundlePageGetPDFDocumentInFrame(WKBundlePageRef, WKBundleFrameRef)
 {
-#if ENABLE(PDF_PLUGIN)
-    if (auto* pluginView = WebKit::WebPage::pluginViewForFrame(WebKit::toImpl(frame)->coreLocalFrame()))
-        return pluginView->pdfDocumentForPrinting().autorelease();
-#endif
-    UNUSED_PARAM(frame);
     return nil;
 }


### PR DESCRIPTION
#### 384ab1753eb2b5c640a72bcd7b45d64f62dbe852
<pre>
Deprecate WKBundlePageGetPDFDocumentInFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=276144">https://bugs.webkit.org/show_bug.cgi?id=276144</a>
<a href="https://rdar.apple.com/130979489">rdar://130979489</a>

Reviewed by Jeff Miller.

* Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm:
(WKBundlePageGetPDFDocumentInFrame):

Canonical link: <a href="https://commits.webkit.org/280599@main">https://commits.webkit.org/280599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a64f81c436647fb9645f7e29df34ae7f1eb82b34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7499 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46207 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5273 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27067 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30943 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6504 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62357 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53465 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53513 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/819 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8507 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32213 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33298 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34383 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->