### PR TITLE
AX: The Node pointer member of the TextMarkerData structure is no longer needed.

### DIFF
--- a/LayoutTests/accessibility/mac/textmarker-routines.html
+++ b/LayoutTests/accessibility/mac/textmarker-routines.html
@@ -13,7 +13,6 @@ text
 <div id="console"></div>
 
 <script>
-
     description("This verifies usage of isTextMarkerValid, indexForTextMarker and textMarkerForIndex.");
 
     if (window.accessibilityController) {
@@ -35,13 +34,9 @@ text
 
         shouldBeTrue("item2.isTextMarkerValid(secondTextMarker)");
         shouldBe("item2.indexForTextMarker(secondTextMarker)", "5");
-        shouldBeTrue("item2.textMarkerForIndex(item2.indexForTextMarker(secondTextMarker)).isEqual(secondTextMarker)");       
+        shouldBeTrue("item2.textMarkerForIndex(item2.indexForTextMarker(secondTextMarker)).isEqual(secondTextMarker)");
     }
-
 </script>
-
 <script src="../../resources/js-test-post.js"></script>
-
 </body>
 </html>
-

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1103,7 +1103,6 @@ void AXObjectCache::remove(Node& node)
 {
     AXTRACE(makeString("AXObjectCache::remove Node& 0x"_s, hex(reinterpret_cast<uintptr_t>(this))));
 
-    removeNodeForUse(node);
     remove(m_nodeObjectMapping.take(&node));
     remove(node.renderer());
 
@@ -2799,14 +2798,14 @@ Ref<Document> AXObjectCache::protectedDocument() const
 
 VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const TextMarkerData& textMarkerData)
 {
-    if (!textMarkerData.node)
+    RefPtr node = nodeForID(textMarkerData.axObjectID());
+    if (!node)
         return { };
 
-    Ref node = *textMarkerData.node;
-    if (!isNodeInUse(node) || node->isPseudoElement())
+    if (node->isPseudoElement())
         return { };
 
-    auto visiblePosition = VisiblePosition({ node.ptr(), textMarkerData.offset, textMarkerData.anchorType }, textMarkerData.affinity);
+    auto visiblePosition = VisiblePosition({ node.get(), textMarkerData.offset, textMarkerData.anchorType }, textMarkerData.affinity);
     auto deepPosition = visiblePosition.deepEquivalent();
     if (deepPosition.isNull())
         return { };
@@ -2816,7 +2815,7 @@ VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const TextMarker
         return { };
 
     auto* cache = renderer->document().axObjectCache();
-    if (cache && !cache->m_idsInUse.contains(textMarkerData.objectID))
+    if (cache && !cache->m_idsInUse.contains(textMarkerData.axObjectID()))
         return { };
 
     return visiblePosition;
@@ -2824,14 +2823,14 @@ VisiblePosition AXObjectCache::visiblePositionForTextMarkerData(const TextMarker
 
 CharacterOffset AXObjectCache::characterOffsetForTextMarkerData(const TextMarkerData& textMarkerData)
 {
-    if (textMarkerData.ignored || !textMarkerData.node)
+    if (textMarkerData.ignored)
         return { };
 
-    RefAllowingPartiallyDestroyed<Node> node = *textMarkerData.node;
-    if (!isNodeInUse(node))
+    RefPtr node = nodeForID(textMarkerData.axObjectID());
+    if (!node)
         return { };
 
-    CharacterOffset result(node.ptr(), textMarkerData.characterStart, textMarkerData.characterOffset);
+    CharacterOffset result(node.get(), textMarkerData.characterStart, textMarkerData.characterOffset);
     // When we are at a line wrap and the VisiblePosition is upstream, it means the text marker is at the end of the previous line.
     // We use the previous CharacterOffset so that it will match the Range.
     if (textMarkerData.affinity == Affinity::Upstream)
@@ -3103,7 +3102,6 @@ TextMarkerData AXObjectCache::textMarkerDataForCharacterOffset(const CharacterOf
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(characterOffset.node.get()); input && input->isSecureField())
         return { *this, { }, true };
 
-    setNodeInUse(Ref { *characterOffset.node });
     return { *this, characterOffset, false };
 }
 
@@ -3363,16 +3361,20 @@ CharacterOffset AXObjectCache::characterOffsetFromVisiblePosition(const VisibleP
     return result;
 }
 
-AccessibilityObject* AXObjectCache::accessibilityObjectForTextMarkerData(const TextMarkerData& textMarkerData)
+AccessibilityObject* AXObjectCache::objectForTextMarkerData(const TextMarkerData& textMarkerData)
 {
     if (textMarkerData.ignored)
         return nullptr;
 
-    RefPtr domNode = textMarkerData.node.get();
-    if (!domNode || !isNodeInUse(*domNode))
+    RefPtr object = m_objects.get(textMarkerData.axObjectID());
+    if (!object)
         return nullptr;
 
-    return getOrCreate(*domNode);
+    Node* node = object->node();
+    if (!node)
+        return nullptr;
+    ASSERT(object.get() == getOrCreate(*node));
+    return getOrCreate(*node);
 }
 
 std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(const VisiblePosition& visiblePosition)
@@ -3398,22 +3400,8 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
     CheckedPtr cache = node->document().axObjectCache();
     if (!cache)
         return std::nullopt;
-    cache->setNodeInUse(*node);
-    return { { *cache, node.get(), visiblePosition,
+    return { { *cache, visiblePosition,
         characterOffset.startIndex, characterOffset.offset, false } };
-}
-
-// This function exists as a performance optimization to avoid a synchronous layout.
-std::optional<TextMarkerData> AXObjectCache::textMarkerDataForFirstPositionInTextControl(HTMLTextFormControlElement& textControl)
-{
-    if (RefPtr input = dynamicDowncast<HTMLInputElement>(textControl); input && input->isSecureField())
-        return std::nullopt;
-
-    CheckedPtr cache = textControl.document().axObjectCache();
-    if (!cache)
-        return std::nullopt;
-    cache->setNodeInUse(textControl);
-    return { { *cache, &textControl, { }, false } };
 }
 
 CharacterOffset AXObjectCache::nextCharacterOffset(const CharacterOffset& characterOffset, bool ignoreNextNodeStart)
@@ -4031,7 +4019,6 @@ static void filterWeakHashMapForRemoval(WeakHashMapType& map, const Document& do
 void AXObjectCache::prepareForDocumentDestruction(const Document& document)
 {
     HashSet<Ref<Node>> nodesToRemove;
-    filterListForRemoval(m_textMarkerNodes, document, nodesToRemove);
     filterWeakListHashSetForRemoval(m_deferredTextChangedList, document, nodesToRemove);
     filterWeakListHashSetForRemoval(m_deferredNodeAddedOrRemovedList, document, nodesToRemove);
     filterWeakHashSetForRemoval(m_deferredRecomputeIsIgnoredList, document, nodesToRemove);

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -74,14 +74,14 @@ struct CharacterOffset {
     int startIndex;
     int offset;
     int remainingOffset;
-    
+
     CharacterOffset(Node* n = nullptr, int startIndex = 0, int offset = 0, int remaining = 0)
         : node(n)
         , startIndex(startIndex)
         , offset(offset)
         , remainingOffset(remaining)
     { }
-    
+
     int remaining() const { return remainingOffset; }
     bool isNull() const { return !node; }
     bool isEqual(const CharacterOffset& other) const
@@ -434,6 +434,7 @@ public:
 
     AccessibilityObject* objectForID(const AXID id) const { return m_objects.get(id); }
     template<typename U> Vector<RefPtr<AXCoreObject>> objectsForIDs(const U&) const;
+    Node* nodeForID(const AXID) const;
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void onPaint(const RenderObject&, IntRect&&) const;
@@ -445,7 +446,6 @@ public:
 
     // Text marker utilities.
     std::optional<TextMarkerData> textMarkerDataForVisiblePosition(const VisiblePosition&);
-    std::optional<TextMarkerData> textMarkerDataForFirstPositionInTextControl(HTMLTextFormControlElement&);
     TextMarkerData textMarkerDataForCharacterOffset(const CharacterOffset&);
     TextMarkerData textMarkerDataForNextCharacterOffset(const CharacterOffset&);
     AXTextMarker nextTextMarker(const AXTextMarker&);
@@ -458,7 +458,7 @@ public:
     CharacterOffset previousCharacterOffset(const CharacterOffset&, bool ignorePreviousNodeEnd = true);
     TextMarkerData startOrEndTextMarkerDataForRange(const SimpleRange&, bool);
     CharacterOffset startOrEndCharacterOffsetForRange(const SimpleRange&, bool, bool enterTextControls = false);
-    AccessibilityObject* accessibilityObjectForTextMarkerData(const TextMarkerData&);
+    AccessibilityObject* objectForTextMarkerData(const TextMarkerData&);
     std::optional<SimpleRange> rangeForUnorderedCharacterOffsets(const CharacterOffset&, const CharacterOffset&);
     static SimpleRange rangeForNodeContents(Node&);
     static unsigned lengthForRange(const SimpleRange&);
@@ -574,8 +574,6 @@ public:
     static bool clientIsInTestMode();
 #endif
 
-    bool isNodeInUse(Node& node) const { return m_textMarkerNodes.contains(node); }
-
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void scheduleObjectRegionsUpdate(bool scheduleImmediately = false) { m_geometryManager->scheduleObjectRegionsUpdate(scheduleImmediately); }
     void willUpdateObjectRegions() { m_geometryManager->willUpdateObjectRegions(); }
@@ -625,10 +623,6 @@ protected:
 
     void frameLoadingEventPlatformNotification(AccessibilityObject*, AXLoadingEvent);
     void handleLabelChanged(AccessibilityObject*);
-
-    // This is a weak reference cache for knowing if Nodes used by TextMarkers are valid.
-    void setNodeInUse(Node& node) { m_textMarkerNodes.add(node); }
-    void removeNodeForUse(Node& node) { m_textMarkerNodes.remove(node); }
 
     // CharacterOffset functions.
     enum TraverseOption { TraverseOptionDefault = 1 << 0, TraverseOptionToNodeEnd = 1 << 1, TraverseOptionIncludeStart = 1 << 2, TraverseOptionValidateOffset = 1 << 3, TraverseOptionDoNotEnterTextControls = 1 << 4 };
@@ -762,8 +756,6 @@ private:
     HashMap<SingleThreadWeakRef<RenderObject>, AXID> m_renderObjectMapping;
     HashMap<SingleThreadWeakRef<Widget>, AXID> m_widgetObjectMapping;
     HashMap<WeakRef<Node, WeakPtrImplWithEventTargetData>, AXID> m_nodeObjectMapping;
-    // The pointers in this HashSet should never be dereferenced.
-    ListHashSet<WeakRef<Node, WeakPtrImplWithEventTargetData>> m_textMarkerNodes;
 
     std::unique_ptr<AXComputedObjectAttributeCache> m_computedObjectAttributeCache;
 
@@ -860,6 +852,15 @@ inline Vector<RefPtr<AXCoreObject>> AXObjectCache::objectsForIDs(const U& axIDs)
             return RefPtr { object };
         return std::nullopt;
     });
+}
+
+inline Node* AXObjectCache::nodeForID(const AXID axID) const
+{
+    if (!axID.isValid())
+        return nullptr;
+
+    auto* object = m_objects.get(axID);
+    return object ? object->node() : nullptr;
 }
 
 inline bool AXObjectCache::accessibilityEnabled()

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -44,33 +44,37 @@ static AXID nodeID(AXObjectCache& cache, Node* node)
     return { };
 }
 
-TextMarkerData::TextMarkerData(AXObjectCache& cache, Node* node, const VisiblePosition& visiblePosition, int charStart, int charOffset, bool ignoredParam)
-    : treeID(cache.treeID())
-    , objectID(nodeID(cache, node))
-    , node(node)
-    , affinity(visiblePosition.affinity())
-    , characterStart(std::max(charStart, 0))
-    , characterOffset(std::max(charOffset, 0))
-    , ignored(ignoredParam)
+TextMarkerData::TextMarkerData(AXObjectCache& cache, const VisiblePosition& visiblePosition, int charStart, int charOffset, bool ignoredParam)
 {
+    ASSERT(isMainThread());
+
+    memset(static_cast<void*>(this), 0, sizeof(*this));
+    treeID = cache.treeID().toUInt64();
     auto position = visiblePosition.deepEquivalent();
+    objectID = nodeID(cache, position.anchorNode()).toUInt64();
     offset = !visiblePosition.isNull() ? std::max(position.deprecatedEditingOffset(), 0) : 0;
     anchorType = position.anchorType();
+    affinity = visiblePosition.affinity();
+    characterStart = std::max(charStart, 0);
+    characterOffset = std::max(charOffset, 0);
+    ignored = ignoredParam;
 }
 
-TextMarkerData::TextMarkerData(AXObjectCache& cache, const CharacterOffset& characterOffset, bool ignoredParam)
-    : treeID(cache.treeID())
-    , objectID(nodeID(cache, characterOffset.node.get()))
-    , node(characterOffset.node.get())
-    , anchorType(Position::PositionIsOffsetInAnchor)
-    , characterStart(std::max(characterOffset.startIndex, 0))
-    , characterOffset(std::max(characterOffset.offset, 0))
-    , ignored(ignoredParam)
+TextMarkerData::TextMarkerData(AXObjectCache& cache, const CharacterOffset& characterOffsetParam, bool ignoredParam)
 {
-    auto visiblePosition = cache.visiblePositionFromCharacterOffset(characterOffset);
+    ASSERT(isMainThread());
+
+    memset(static_cast<void*>(this), 0, sizeof(*this));
+    treeID = cache.treeID().toUInt64();
+    objectID = nodeID(cache, characterOffsetParam.node.get()).toUInt64();
+    auto visiblePosition = cache.visiblePositionFromCharacterOffset(characterOffsetParam);
     auto position = visiblePosition.deepEquivalent();
     offset = !visiblePosition.isNull() ? std::max(position.deprecatedEditingOffset(), 0) : 0;
+    anchorType = Position::PositionIsOffsetInAnchor;
     affinity = visiblePosition.affinity();
+    characterStart = std::max(characterOffsetParam.startIndex, 0);
+    characterOffset = std::max(characterOffsetParam.offset, 0);
+    ignored = ignoredParam;
 }
 
 AXTextMarker::AXTextMarker(const VisiblePosition& visiblePosition)
@@ -104,28 +108,6 @@ AXTextMarker::AXTextMarker(const CharacterOffset& characterOffset)
         m_data = cache->textMarkerDataForCharacterOffset(characterOffset);
 }
 
-void AXTextMarker::setNodeIfNeeded() const
-{
-    ASSERT(isMainThread());
-    if (m_data.node)
-        return;
-
-    WeakPtr cache = std::get<WeakPtr<AXObjectCache>>(axTreeForID(treeID()));
-    if (!cache)
-        return;
-
-    auto* object = cache->objectForID(objectID());
-    if (!object)
-        return;
-
-    RefPtr node = object->node();
-    if (!node)
-        return;
-
-    const_cast<AXTextMarker*>(this)->m_data.node = *node;
-    cache->setNodeInUse(*node);
-}
-
 AXTextMarker::operator VisiblePosition() const
 {
     ASSERT(isMainThread());
@@ -134,7 +116,6 @@ AXTextMarker::operator VisiblePosition() const
     if (!cache)
         return { };
 
-    setNodeIfNeeded();
     return cache->visiblePositionForTextMarkerData(m_data);
 }
 
@@ -145,18 +126,15 @@ AXTextMarker::operator CharacterOffset() const
     if (isIgnored() || isNull())
         return { };
 
-    WeakPtr cache = AXTreeStore<AXObjectCache>::axObjectCacheForID(m_data.treeID);
+    WeakPtr cache = AXTreeStore<AXObjectCache>::axObjectCacheForID(m_data.axTreeID());
     if (!cache)
         return { };
 
-    if (RefPtr node = m_data.node.get()) {
-        // Make sure that this node is still in cache->m_textMarkerNodes. Since this method can be called as a result of a dispatch from the AX thread, the Node may have gone away in a previous main loop cycle.
-        if (!cache->isNodeInUse(*node))
-            return { };
-    } else
-        setNodeIfNeeded();
+    RefPtr object = cache->objectForID(m_data.axObjectID());
+    if (!object)
+        return { };
 
-    CharacterOffset result((RefPtr { m_data.node.get() }).get(), m_data.characterStart, m_data.characterOffset);
+    CharacterOffset result(object->node(), m_data.characterStart, m_data.characterOffset);
     // When we are at a line wrap and the VisiblePosition is upstream, it means the text marker is at the end of the previous line.
     // We use the previous CharacterOffset so that it will match the Range.
     if (m_data.affinity == Affinity::Upstream)
@@ -227,7 +205,6 @@ String AXTextMarker::debugDescription() const
         , separator, "objectID "_s, objectID().loggingString()
         , separator, "role "_s, object ? accessibilityRoleToString(object->roleValue()) : "no object"_str
         , isIgnored() ? makeString(separator, "ignored"_s) : ""_s
-        , isMainThread() && node() ? makeString(separator, node()->debugDescription()) : ""_s
         , separator, "anchor "_s, m_data.anchorType
         , separator, "affinity "_s, m_data.affinity
         , separator, "offset "_s, m_data.offset
@@ -276,8 +253,8 @@ AXTextMarkerRange::AXTextMarkerRange(AXID treeID, AXID objectID, unsigned start,
 {
     if (start > end)
         std::swap(start, end);
-    m_start = AXTextMarker({ treeID, objectID, nullptr, start, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, start });
-    m_end = AXTextMarker({ treeID, objectID, nullptr, end, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, end });
+    m_start = AXTextMarker({ treeID, objectID, start, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, start });
+    m_end = AXTextMarker({ treeID, objectID, end, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, end });
 }
 
 AXTextMarkerRange::operator VisiblePositionRange() const
@@ -318,9 +295,8 @@ std::optional<AXTextMarkerRange> AXTextMarkerRange::intersectionWith(const AXTex
 {
     if (UNLIKELY(m_start.m_data.treeID != m_end.m_data.treeID
         || other.m_start.m_data.treeID != other.m_end.m_data.treeID
-        || m_start.m_data.treeID != other.m_start.m_data.treeID)) {
+        || m_start.m_data.treeID != other.m_start.m_data.treeID))
         return std::nullopt;
-    }
 
     // Fast path: both ranges span one object
     if (m_start.m_data.objectID == m_end.m_data.objectID
@@ -335,8 +311,8 @@ std::optional<AXTextMarkerRange> AXTextMarkerRange::intersectionWith(const AXTex
             return std::nullopt;
 
         return { {
-            AXTextMarker({ m_start.treeID(), m_start.objectID(), nullptr, startOffset, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, startOffset }),
-            AXTextMarker({ m_start.treeID(), m_start.objectID(), nullptr, endOffset, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, endOffset })
+            AXTextMarker({ m_start.treeID(), m_start.objectID(), startOffset, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, startOffset }),
+            AXTextMarker({ m_start.treeID(), m_start.objectID(), endOffset, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, endOffset })
         } };
     }
 
@@ -911,16 +887,5 @@ std::partial_ordering AXTextMarker::partialOrderByTraversal(const AXTextMarker& 
     return std::partial_ordering::unordered;
 }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
-
-TextMarkerData RawTextMarkerData::toTextMarkerData() const
-{
-    ObjectIdentifier<AXIDType> axTreeID(treeID);
-    WeakPtr cache = AXTreeStore<AXObjectCache>::axObjectCacheForID(axTreeID);
-    // Make sure the node is not stale before storing it in a WeakPtr.
-    Node* validNode = nullptr;
-    if (node && cache && cache->isNodeInUse(*node))
-        validNode = node;
-    return { axTreeID, ObjectIdentifier<AXIDType>(objectID), validNode, offset, anchorType, affinity, characterStart, characterOffset, ignored };
-}
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
@@ -46,31 +46,23 @@ AXTextMarker::AXTextMarker(PlatformTextMarkerData platformData)
         return;
     }
 
-    RawTextMarkerData rawTextMarkerData;
-    if (AXTextMarkerGetLength(platformData) != sizeof(rawTextMarkerData)) {
+    if (AXTextMarkerGetLength(platformData) != sizeof(m_data)) {
         ASSERT_NOT_REACHED();
         return;
     }
 
-    memcpy(&rawTextMarkerData, AXTextMarkerGetBytePtr(platformData), sizeof(rawTextMarkerData));
-    m_data = rawTextMarkerData.toTextMarkerData();
+    memcpy(&m_data, AXTextMarkerGetBytePtr(platformData), sizeof(m_data));
 #else // PLATFORM(IOS_FAMILY)
-    RawTextMarkerData rawTextMarkerData;
-    [platformData getBytes:&rawTextMarkerData length:sizeof(rawTextMarkerData)];
-    m_data = rawTextMarkerData.toTextMarkerData();
+    [platformData getBytes:&m_data length:sizeof(m_data)];
 #endif
-
-    if (isMainThread())
-        setNodeIfNeeded();
 }
 
 RetainPtr<PlatformTextMarkerData> AXTextMarker::platformData() const
 {
-    auto rawTextMarkerData = m_data.toRawTextMarkerData();
 #if PLATFORM(MAC)
-    return adoptCF(AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8*)&rawTextMarkerData, sizeof(rawTextMarkerData)));
+    return adoptCF(AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8*)&m_data, sizeof(m_data)));
 #else // PLATFORM(IOS_FAMILY)
-    return [NSData dataWithBytes:&rawTextMarkerData length:sizeof(rawTextMarkerData)];
+    return [NSData dataWithBytes:&m_data length:sizeof(m_data)];
 #endif
 }
 

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -152,12 +152,10 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
 {
     if (!(self = [super init]))
         return nil;
-    
+
     _cache = cache;
-    RawTextMarkerData rawTextMarkerData;
-    [data getBytes:&rawTextMarkerData length:sizeof(rawTextMarkerData)];
-    _textMarkerData = rawTextMarkerData.toTextMarkerData();
-    
+    [data getBytes:&_textMarkerData length:sizeof(_textMarkerData)];
+
     return self;
 }
 
@@ -203,8 +201,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
 
 - (NSData *)dataRepresentation
 {
-    auto rawTextMarkerData = _textMarkerData.toRawTextMarkerData();
-    return [NSData dataWithBytes:&rawTextMarkerData length:sizeof(rawTextMarkerData)];
+    return [NSData dataWithBytes:&_textMarkerData length:sizeof(_textMarkerData)];
 }
 
 - (VisiblePosition)visiblePosition
@@ -224,12 +221,12 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
 
 - (AccessibilityObject*)accessibilityObject
 {
-    return _cache->accessibilityObjectForTextMarkerData(_textMarkerData);
+    return _cache->objectForTextMarkerData(_textMarkerData);
 }
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"[AXTextMarker %p] = node: %p offset: %d", self, _textMarkerData.node.get(), _textMarkerData.offset];
+    return [NSString stringWithFormat:@"[AXTextMarker %p] = objectID: %d offset: %d", self, _textMarkerData.objectID, _textMarkerData.offset];
 }
 
 - (TextMarkerData)textMarkerData

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -230,12 +230,8 @@ RetainPtr<NSAttributedString> AXIsolatedObject::attributedStringForTextMarkerRan
     auto attributedText = propertyValue<RetainPtr<NSAttributedString>>(AXPropertyName::AttributedText);
     if (!isConfined || !attributedText) {
         return Accessibility::retrieveValueFromMainThread<RetainPtr<NSAttributedString>>([markerRange = WTFMove(markerRange), &spellCheck, this] () mutable -> RetainPtr<NSAttributedString> {
-            if (RefPtr axObject = associatedAXObject()) {
-                // Ensure that the TextMarkers have valid Node references, in case the range was created on the AX thread.
-                markerRange.start().setNodeIfNeeded();
-                markerRange.end().setNodeIfNeeded();
+            if (RefPtr axObject = associatedAXObject())
                 return axObject->attributedStringForTextMarkerRange(WTFMove(markerRange), spellCheck);
-            }
             return { };
         });
     }


### PR DESCRIPTION
#### 3341c5cc298816c00e808c6b971a6537104a02e1
<pre>
AX: The Node pointer member of the TextMarkerData structure is no longer needed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276131">https://bugs.webkit.org/show_bug.cgi?id=276131</a>
&lt;<a href="https://rdar.apple.com/problem/130985322">rdar://problem/130985322</a>&gt;

Reviewed by Tyler Wilcock.

This change removes the Node pointer from the TextMarkerData structure since it is no longer needed. The treeID and objectID uniquely identify the AX object, and the Node can be obtained from the ax object when needed. This removes a great deal of complexity from the code since there is no need to keep track of Nodes referenced from a TextMarker any longer. It also eliminates the need for the RawTextMarkerData in addition to the TextMarkerData structure.

* LayoutTests/accessibility/mac/textmarker-routines.html:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::remove):
(WebCore::AXObjectCache::visiblePositionForTextMarkerData):
(WebCore::AXObjectCache::characterOffsetForTextMarkerData):
(WebCore::AXObjectCache::textMarkerDataForCharacterOffset):
(WebCore::AXObjectCache::objectForTextMarkerData):
(WebCore::AXObjectCache::textMarkerDataForVisiblePosition):
(WebCore::AXObjectCache::prepareForDocumentDestruction):
(WebCore::AXObjectCache::accessibilityObjectForTextMarkerData): Deleted.
(WebCore::AXObjectCache::textMarkerDataForFirstPositionInTextControl): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::AXObjectCache::nodeForID const):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::TextMarkerData::TextMarkerData):
(WebCore::AXTextMarker::operator VisiblePosition const):
(WebCore::AXTextMarker::operator CharacterOffset const):
(WebCore::AXTextMarker::debugDescription const):
(WebCore::AXTextMarkerRange::AXTextMarkerRange):
(WebCore::AXTextMarkerRange::intersectionWith const):
(WebCore::AXTextMarker::setNodeIfNeeded const): Deleted.
(WebCore::RawTextMarkerData::toTextMarkerData const): Deleted.
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::TextMarkerData::TextMarkerData):
(WebCore::TextMarkerData::axTreeID const):
(WebCore::TextMarkerData::axObjectID const):
(WebCore::AXTextMarker::AXTextMarker):
(WebCore::AXTextMarker::treeID const):
(WebCore::AXTextMarker::objectID const):
(WebCore::RawTextMarkerData::RawTextMarkerData): Deleted.
(): Deleted.
(WebCore::TextMarkerData::toRawTextMarkerData const): Deleted.
(WebCore::AXTextMarker::node const): Deleted.
* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarker::AXTextMarker):
(WebCore::AXTextMarker::platformData const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityTextMarker initWithData:cache:]):
(-[WebAccessibilityTextMarker dataRepresentation]):
(-[WebAccessibilityTextMarker accessibilityObject]):
(-[WebAccessibilityTextMarker description]):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::attributedStringForTextMarkerRange const):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::addFirstTextMarker):
(WebCore::getBytesFromAXTextMarker):
(WebCore::accessibilityObjectForTextMarker):
(WebCore::textMarkerForVisiblePosition):
(WebCore::textMarkerForCharacterOffset):
(WebCore::startOrEndTextMarkerForRange):

Canonical link: <a href="https://commits.webkit.org/280689@main">https://commits.webkit.org/280689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edbe9eb3e7e1a27ce15eeedccac73c5cd05daed9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60792 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59299 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46297 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5360 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27157 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31045 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6681 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6619 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62472 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53558 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1089 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53627 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12671 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/918 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32328 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33413 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34498 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->