### PR TITLE
[WebXR] Many WPT tests crash in WebXROpaqueFramebuffer dtor

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/xrSession_requestReferenceSpace_features.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/xrSession_requestReferenceSpace_features.https-expected.txt
@@ -1,26 +1,26 @@
 
 PASS Non-immersive session supports viewer space by default - webgl
-FAIL Non-immersive session supports viewer space by default - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Non-immersive session supports viewer space by default - webgl2
 PASS Immersive session supports viewer space by default - webgl
-FAIL Immersive session supports viewer space by default - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Immersive session supports viewer space by default - webgl2
 PASS Immersive session supports local space by default - webgl
-FAIL Immersive session supports local space by default - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Immersive session supports local space by default - webgl2
 PASS Non-immersive session supports local space when required - webgl
-FAIL Non-immersive session supports local space when required - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Non-immersive session supports local space when required - webgl2
 PASS Non-immersive session supports local space when optional - webgl
-FAIL Non-immersive session supports local space when optional - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Non-immersive session supports local space when optional - webgl2
 PASS Non-immersive session supports local-floor space when required - webgl
-FAIL Non-immersive session supports local-floor space when required - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Non-immersive session supports local-floor space when required - webgl2
 PASS Immersive session supports local-floor space when required - webgl
-FAIL Immersive session supports local-floor space when required - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Immersive session supports local-floor space when required - webgl2
 PASS Immersive session supports local-floor space when optional - webgl
-FAIL Immersive session supports local-floor space when optional - webgl2 assert_implements: webgl2 not supported. undefined
-FAIL Non-immersive session rejects bounded-floor space even when requested - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL Non-immersive session rejects bounded-floor space even when requested - webgl2 assert_implements: webgl2 not supported. undefined
-FAIL Non-immersive session rejects unbounded space even when requested - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL Non-immersive session rejects unbounded space even when requested - webgl2 assert_implements: webgl2 not supported. undefined
-FAIL Non-immersive session rejects local space if not requested - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL Non-immersive session rejects local space if not requested - webgl2 assert_implements: webgl2 not supported. undefined
-FAIL Immersive session rejects local-floor space if not requested - webgl promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'sessionObjects.gl.makeXRCompatible')"
-FAIL Immersive session rejects local-floor space if not requested - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Immersive session supports local-floor space when optional - webgl2
+PASS Non-immersive session rejects bounded-floor space even when requested - webgl
+PASS Non-immersive session rejects bounded-floor space even when requested - webgl2
+PASS Non-immersive session rejects unbounded space even when requested - webgl
+PASS Non-immersive session rejects unbounded space even when requested - webgl2
+PASS Non-immersive session rejects local space if not requested - webgl
+PASS Non-immersive session rejects local space if not requested - webgl2
+PASS Immersive session rejects local-floor space if not requested - webgl
+PASS Immersive session rejects local-floor space if not requested - webgl2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_draw.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_draw.https-expected.txt
@@ -1,8 +1,4 @@
-CONSOLE MESSAGE: WebGL: INVALID_FRAMEBUFFER_OPERATION: clear: An opaque framebuffer is considered incomplete outside of a requestAnimationFrame
-CONSOLE MESSAGE: WebGL: INVALID_FRAMEBUFFER_OPERATION: clear: An opaque framebuffer is considered incomplete outside of a requestAnimationFrame
-CONSOLE MESSAGE: WebGL: INVALID_FRAMEBUFFER_OPERATION: drawArrays: An opaque framebuffer is considered incomplete outside of a requestAnimationFrame
-CONSOLE MESSAGE: WebGL: INVALID_FRAMEBUFFER_OPERATION: drawElements: An opaque framebuffer is considered incomplete outside of a requestAnimationFrame
 
 PASS Ensure a WebGL layer's framebuffer can only be drawn to inside a XR frame - webgl
-FAIL Ensure a WebGL layer's framebuffer can only be drawn to inside a XR frame - webgl2 assert_implements: webgl2 not supported. undefined
+PASS Ensure a WebGL layer's framebuffer can only be drawn to inside a XR frame - webgl2
 

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -124,11 +124,9 @@ imported/w3c/web-platform-tests/webxr/light-estimation [ Skip ]
 # rdar://125739629 [ visionOS ] Multiple tests in imported/w3c/web-platform-tests/webxr are consistent failing
 imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.https.html [ Failure ]
 imported/w3c/web-platform-tests/webxr/webxr_feature_policy.https.html [ Failure ]
-imported/w3c/web-platform-tests/webxr/xrSession_requestReferenceSpace_features.https.html [ Failure ]
 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_scale.https.html [ Failure ]
 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https.html [ Failure ]
 imported/w3c/web-platform-tests/webxr/xr_viewport_scale.https.html [ Failure ]
-imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_draw.https.html [ Failure ]
 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer_stencil.https.html [ Failure ]
 
 webkit.org/b/274980 imported/w3c/web-platform-tests/webxr/xrViewport_valid.https.html [ Failure ]

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp
@@ -117,6 +117,7 @@ WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer()
     if (RefPtr gl = m_context.graphicsContextGL()) {
         m_drawAttachments.release(*gl);
         m_resolveAttachments.release(*gl);
+        m_displayFBO.release(*gl);
         m_resolvedFBO.release(*gl);
         m_context.deleteFramebuffer(m_drawFramebuffer.ptr());
     } else {


### PR DESCRIPTION
#### ebf65f9d47ccc59bc21384b4384fc1055535f78c
<pre>
[WebXR] Many WPT tests crash in WebXROpaqueFramebuffer dtor
<a href="https://bugs.webkit.org/show_bug.cgi?id=276159">https://bugs.webkit.org/show_bug.cgi?id=276159</a>
<a href="https://rdar.apple.com/131014002">rdar://131014002</a>

Reviewed by Mike Wyrzykowski.

Many imported WebXR tests from WPT are asserting in
WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer(). We have a GL object leak! The
display framebuffer, `m_displayFBO`, is not being released.

* LayoutTests/imported/w3c/web-platform-tests/webxr/xrSession_requestReferenceSpace_features.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_draw.https-expected.txt:
* LayoutTests/platform/visionos/TestExpectations:
* Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp:
(WebCore::WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer):

Canonical link: <a href="https://commits.webkit.org/280615@main">https://commits.webkit.org/280615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df9576e7d490cdb192c9e99bd7f3d14e36a8803b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7553 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46244 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5311 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59140 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34212 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27105 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30989 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6627 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6558 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52946 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62411 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6996 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53502 "Found 1 new test failure: http/tests/inspector/network/har/har-page.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53557 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/862 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8515 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32267 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33352 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34437 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->