### PR TITLE
EmberJS does not render with a dark theme in dark mode.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm
@@ -72,7 +72,7 @@ NSString *WebExtensionAPIDevToolsPanels::themeName()
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/themeName
 
-    switch (m_theme) {
+    switch (extensionContext().inspectorAppearance()) {
     case Inspector::ExtensionAppearance::Light:
         return @"light";
 
@@ -95,9 +95,10 @@ void WebExtensionContextProxy::dispatchDevToolsPanelsThemeChangedEvent(Inspector
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/onThemeChanged
 
+    setInspectorAppearance(appearance);
+
     enumerateNamespaceObjects([&](auto& namespaceObject) {
         auto& panels = namespaceObject.devtools().panels();
-        panels.setTheme(appearance);
         panels.onThemeChanged().invokeListenersWithArgument(panels.themeName());
     });
 }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h
@@ -47,16 +47,12 @@ public:
 
     NSString *themeName();
 
-    Inspector::ExtensionAppearance theme() const { return m_theme; }
-    void setTheme(Inspector::ExtensionAppearance appearance) { m_theme = appearance; }
-
     WebExtensionAPIEvent& onThemeChanged();
 #endif
 
 private:
     RefPtr<WebExtensionAPIEvent> m_onThemeChanged;
     HashMap<Inspector::ExtensionTabID, Ref<WebExtensionAPIDevToolsExtensionPanel>> m_extensionPanels;
-    Inspector::ExtensionAppearance m_theme { Inspector::ExtensionAppearance::Light };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -113,6 +113,9 @@ public:
 
     void addInspectorBackgroundPage(WebPage&, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
     bool isInspectorBackgroundPage(WebPage&) const;
+
+    Inspector::ExtensionAppearance inspectorAppearance() const { return m_inspectorAppearance; }
+    void setInspectorAppearance(Inspector::ExtensionAppearance appearance) { m_inspectorAppearance = appearance; }
 #endif
 
     Vector<Ref<WebPage>> popupPages(std::optional<WebExtensionTabIdentifier> = std::nullopt, std::optional<WebExtensionWindowIdentifier> = std::nullopt) const;
@@ -230,6 +233,7 @@ private:
 #if ENABLE(INSPECTOR_EXTENSIONS)
     WeakPageTabWindowMap m_inspectorPageMap;
     WeakPageTabWindowMap m_inspectorBackgroundPageMap;
+    Inspector::ExtensionAppearance m_inspectorAppearance { Inspector::ExtensionAppearance::Light };
 #endif
     WeakPageTabWindowMap m_popupPageMap;
     WeakPageTabWindowMap m_tabPageMap;


### PR DESCRIPTION
#### 26210158488488cceee205996f24db30c91eee53
<pre>
EmberJS does not render with a dark theme in dark mode.
<a href="https://webkit.org/b/276164">https://webkit.org/b/276164</a>
<a href="https://rdar.apple.com/131001081">rdar://131001081</a>

Reviewed by Jeff Miller.

When the appearance is initially set we might not have any namespace objects yet.
Since the appearance is global, we can just store it on the WebExtensionContextProxy.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsPanelsCocoa.mm:
(WebKit::WebExtensionAPIDevToolsPanels::themeName):
(WebKit::WebExtensionContextProxy::dispatchDevToolsPanelsThemeChangedEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h:
(WebKit::WebExtensionAPIDevToolsPanels::theme const): Deleted.
(WebKit::WebExtensionAPIDevToolsPanels::setTheme): Deleted.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:

Canonical link: <a href="https://commits.webkit.org/280624@main">https://commits.webkit.org/280624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e7579e8e644127ede3dc6af8a752a0dc1e55e94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7550 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46241 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5310 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27102 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30986 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6624 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6555 "Built successfully") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52942 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; 2 api tests failed or timed out; 1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62408 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53501 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53556 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/863 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8518 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32264 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33349 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33095 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->