### PR TITLE
[JSC] Extend double string cache

### DIFF
--- a/JSTests/microbenchmarks/double-to-string.js
+++ b/JSTests/microbenchmarks/double-to-string.js
@@ -1,0 +1,7 @@
+function test(num) {
+    return num + 'px';
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i)
+    test(i + 30.4);

--- a/JSTests/stress/double-to-string.js
+++ b/JSTests/stress/double-to-string.js
@@ -1,0 +1,12 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(num) {
+    return num + 'px';
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i)
+    shouldBe(test(i + 30.4), (i + 30.4) + 'px');

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3893,6 +3893,8 @@ private:
                 }
                 if (edge->shouldSpeculateInt32())
                     return;
+                if (edge->shouldSpeculateNumber())
+                    return;
                 if (m_graph.canOptimizeStringObjectAccess(node->origin.semantic)) {
                     if (edge->shouldSpeculateStringObject()) {
                         atLeastOneString = true;
@@ -3921,6 +3923,10 @@ private:
                 }
                 if (edge->shouldSpeculateInt32()) {
                     convertStringAddUse<Int32Use>(node, edge);
+                    return;
+                }
+                if (edge->shouldSpeculateNumber()) {
+                    convertStringAddUse<DoubleRepUse>(node, edge);
                     return;
                 }
                 if (edge->op() == ToPrimitive) {

--- a/Source/JavaScriptCore/runtime/NumberPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/NumberPrototype.cpp
@@ -505,6 +505,20 @@ JSString* NumericStrings::addJSString(VM& vm, int i)
     return entry.jsString;
 }
 
+JSString* NumericStrings::addJSString(VM& vm, double value)
+{
+    auto& entry = lookup(value);
+    if (value != entry.key || entry.value.isNull()) {
+        entry.key = value;
+        entry.value = String::number(value);
+    } else {
+        if (entry.jsString)
+            return entry.jsString;
+    }
+    entry.jsString = jsNontrivialString(vm, entry.value);
+    return entry.jsString;
+}
+
 void NumericStrings::initializeSmallIntCache(VM& vm)
 {
     for (int i = 0; i < 10; ++i) {
@@ -543,7 +557,7 @@ static ALWAYS_INLINE JSString* numberToStringInternal(VM& vm, double doubleValue
         return int32ToStringInternal(vm, integerValue, radix);
 
     if (radix == 10)
-        return jsString(vm, vm.numericStrings.add(doubleValue));
+        return vm.numericStrings.addJSString(vm, doubleValue);
 
     if (!std::isfinite(doubleValue))
         return jsNontrivialString(vm, String::number(doubleValue));
@@ -566,6 +580,9 @@ JSString* int52ToString(VM& vm, int64_t value, int32_t radix)
         ASSERT(value >= 0);
         return vm.smallStrings.singleCharacterString(radixDigits[value]);
     }
+
+    if (isInRange<int64_t>(value, INT32_MIN, INT32_MAX))
+        return int32ToString(vm, static_cast<int32_t>(value), radix);
 
     if (radix == 10)
         return jsNontrivialString(vm, vm.numericStrings.add(static_cast<double>(value)));


### PR DESCRIPTION
#### b750a5abaa781f9442aa2f3ad68f404362da7bec
<pre>
[JSC] Extend double string cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=276165">https://bugs.webkit.org/show_bug.cgi?id=276165</a>
<a href="https://rdar.apple.com/131021443">rdar://131021443</a>

Reviewed by Keith Miller and Michael Saboff.

This patch adds optimizations for double string.

1. Handle &quot;string&quot; + double + &quot;string&quot; well in DFG / FTL by converting double via ToString node and use MakeRope for them.
2. Add JSString cache for doubles.

* JSTests/microbenchmarks/double-to-string.js: Added.
(test):
* JSTests/stress/double-to-string.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::attemptToMakeFastStringAdd):
* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::NumericStrings::addJSString):
(JSC::numberToStringInternal):
(JSC::int52ToString):
* Source/JavaScriptCore/runtime/NumericStrings.h:
(JSC::NumericStrings::add):
(JSC::NumericStrings::clearOnGarbageCollection):
(JSC::NumericStrings::visitAggregate):
(JSC::NumericStrings::lookup):

Canonical link: <a href="https://commits.webkit.org/280628@main">https://commits.webkit.org/280628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66d5b99d50bce92799a0cc2a965fe56506fb637c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60759 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7581 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7771 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46274 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5340 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59168 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6654 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6586 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50230 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6924 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62439 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/56380 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7025 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53535 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1056 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53599 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/891 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78140 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8521 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32295 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12946 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33380 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34465 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33126 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->