### PR TITLE
[Writing Tools] Disable editing while content is being processed

### DIFF
--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1193,6 +1193,13 @@ static void dispatchInputEvents(RefPtr<Element> startRoot, RefPtr<Element> endRo
 
 bool Editor::willApplyEditing(CompositeEditCommand& command, Vector<RefPtr<StaticRange>>&& targetRanges)
 {
+#if ENABLE(WRITING_TOOLS)
+    if (suppressEditingForWritingTools()) {
+        RELEASE_LOG(Editing, "Editor %p suppressed editing for Writing Tools", this);
+        return false;
+    }
+#endif
+
     m_hasHandledAnyEditing = true;
 
     if (!command.shouldDispatchInputEvents())

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -284,6 +284,11 @@ public:
     WEBCORE_EXPORT void applyStyleToSelection(Ref<EditingStyle>&&, EditAction, ColorFilterMode);
     void applyParagraphStyleToSelection(StyleProperties*, EditAction);
 
+#if ENABLE(WRITING_TOOLS)
+    bool suppressEditingForWritingTools() const { return m_suppressEditingForWritingTools; }
+    void setSuppressEditingForWritingTools(bool suppress) { m_suppressEditingForWritingTools = suppress; }
+#endif
+
     // Returns whether or not we should proceed with editing.
     bool willApplyEditing(CompositeEditCommand&, Vector<RefPtr<StaticRange>>&&);
     bool willUnapplyEditing(const EditCommandComposition&) const;
@@ -693,6 +698,10 @@ private:
     const std::unique_ptr<AlternativeTextController> m_alternativeTextController;
     EditorParagraphSeparator m_defaultParagraphSeparator { EditorParagraphSeparator::div };
     bool m_overwriteModeEnabled { false };
+
+#if ENABLE(WRITING_TOOLS)
+    bool m_suppressEditingForWritingTools { false };
+#endif
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     MemoryCompactRobinHoodHashSet<String> m_insertedAttachmentIdentifiers;

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -116,6 +116,17 @@ private:
         using Value = CompositionState;
     };
 
+    class EditingScope {
+        WTF_MAKE_NONCOPYABLE(EditingScope); WTF_MAKE_FAST_ALLOCATED;
+    public:
+        EditingScope(Document&);
+        ~EditingScope();
+
+    private:
+        RefPtr<Document> m_document;
+        bool m_editingWasSuppressed;
+    };
+
     static CharacterRange characterRange(const SimpleRange& scope, const SimpleRange&);
     static SimpleRange resolveCharacterRange(const SimpleRange& scope, CharacterRange);
     static uint64_t characterCount(const SimpleRange&);


### PR DESCRIPTION
#### 3dfc596a48b0a7ac069c6aa6de17d0d453c9f3f2
<pre>
[Writing Tools] Disable editing while content is being processed
<a href="https://bugs.webkit.org/show_bug.cgi?id=276166">https://bugs.webkit.org/show_bug.cgi?id=276166</a>
<a href="https://rdar.apple.com/125812157">rdar://125812157</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

In order to ensure Writing Tools behaves sensibly, editing should be suppressed
while content is being processed.

For proofreading, suppression ends once the last suggestion is received. For
rewriting, suppression ends only once the session is over, meaning the user
has either accepted, rejected, or cancelled.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::willApplyEditing):

Suppression is effectively implemented by returning false in `willApplyEditing`.

* Source/WebCore/editing/Editor.h:

Add hooks for `WritingToolsController` to suppress editing.

* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::EditingScope::EditingScope):
(WebCore::WritingToolsController::EditingScope::~EditingScope):

Use the RAII idiom to temporarily allow editing during the session, so that
replacement can be performed.

(WebCore::WritingToolsController::willBeginWritingToolsSession):

Suppress editing in `willBeginWritingToolsSession`, since the context string is
handed of at this point.

(WebCore::WritingToolsController::proofreadingSessionDidReceiveSuggestions):

Use `WritingToolsController::EditingScope` to enable replacement to occur.

For proofreading, suppression ends once the last suggestion is received.

(WebCore::WritingToolsController::didEndWritingToolsSession):

For rewriting, suppression ends only once the session is over.

(WebCore::WritingToolsController::replaceContentsOfRangeInSession):

Use `WritingToolsController::EditingScope` to enable replacement to occur.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(-[WritingToolsWKWebView attemptEditingForTesting]):
(TEST(WritingTools, ProofreadingWithAttemptedEditing)):
(TEST(WritingTools, CompositionWithAttemptedEditing)):

Canonical link: <a href="https://commits.webkit.org/280667@main">https://commits.webkit.org/280667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/353a94ed2ca19f24bebe4291e168f13760472e63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60761 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46277 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5342 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27136 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31018 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6659 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6588 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62441 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7028 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53536 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53600 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12659 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/892 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32297 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33382 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34467 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33128 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->