### PR TITLE
Support border/margin/padding on MathML elements

### DIFF
--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
@@ -119,9 +119,9 @@ RenderMathMLFraction::FractionParameters RenderMathMLFraction::fractionParameter
     }
 
     // Adjust fraction shifts to satisfy min gaps.
-    LayoutUnit numeratorAscent = ascentForChild(numerator());
-    LayoutUnit numeratorDescent = numerator().logicalHeight() - numeratorAscent;
-    LayoutUnit denominatorAscent = ascentForChild(denominator());
+    LayoutUnit numeratorAscent = ascentForChild(numerator()) + numerator().marginBefore();
+    LayoutUnit numeratorDescent = numerator().logicalHeight() + numerator().marginLogicalHeight() - numeratorAscent;
+    LayoutUnit denominatorAscent = ascentForChild(denominator()) + denominator().marginBefore();
     LayoutUnit thickness = lineThickness();
     parameters.numeratorShiftUp = std::max(numeratorMinShiftUp, mathAxisHeight() + thickness / 2 + numeratorGapMin + numeratorDescent);
     parameters.denominatorShiftDown = std::max(denominatorMinShiftDown, thickness / 2 + denominatorGapMin + denominatorAscent - mathAxisHeight());
@@ -155,9 +155,9 @@ RenderMathMLFraction::FractionParameters RenderMathMLFraction::stackParameters()
     }
 
     // Adjust fraction shifts to satisfy min gaps.
-    LayoutUnit numeratorAscent = ascentForChild(numerator());
-    LayoutUnit numeratorDescent = numerator().logicalHeight() - numeratorAscent;
-    LayoutUnit denominatorAscent = ascentForChild(denominator());
+    LayoutUnit numeratorAscent = ascentForChild(numerator()) + numerator().marginBefore();
+    LayoutUnit numeratorDescent = numerator().logicalHeight() + numerator().marginLogicalHeight() - numeratorAscent;
+    LayoutUnit denominatorAscent = ascentForChild(denominator()) + denominator().marginBefore();
     LayoutUnit gap = parameters.numeratorShiftUp - numeratorDescent + parameters.denominatorShiftDown - denominatorAscent;
     if (gap < gapMin) {
         LayoutUnit delta = (gapMin - gap) / 2;
@@ -185,9 +185,9 @@ void RenderMathMLFraction::computePreferredLogicalWidths()
     m_maxPreferredLogicalWidth = 0;
 
     if (isValid()) {
-        LayoutUnit numeratorWidth = numerator().maxPreferredLogicalWidth();
-        LayoutUnit denominatorWidth = denominator().maxPreferredLogicalWidth();
-        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = std::max(numeratorWidth, denominatorWidth);
+        LayoutUnit numeratorWidth = numerator().maxPreferredLogicalWidth() + numerator().marginLogicalWidth();
+        LayoutUnit denominatorWidth = denominator().maxPreferredLogicalWidth()  + denominator().marginLogicalWidth();
+        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = std::max(numeratorWidth, denominatorWidth) + borderAndPaddingLogicalWidth();
     }
 
     setPreferredLogicalWidthsDirty(false);
@@ -195,11 +195,13 @@ void RenderMathMLFraction::computePreferredLogicalWidths()
 
 LayoutUnit RenderMathMLFraction::horizontalOffset(RenderBox& child, MathMLFractionElement::FractionAlignment align) const
 {
+    LayoutUnit contentBoxInlineSize = logicalWidth() - borderAndPaddingLogicalWidth();
+    LayoutUnit childMarginBoxInlineSize = child.marginStart() + child.logicalWidth() + child.marginEnd();
     switch (align) {
     case MathMLFractionElement::FractionAlignmentRight:
-        return LayoutUnit(logicalWidth() - child.logicalWidth());
+        return LayoutUnit(contentBoxInlineSize - childMarginBoxInlineSize);
     case MathMLFractionElement::FractionAlignmentCenter:
-        return LayoutUnit((logicalWidth() - child.logicalWidth()) / 2);
+        return LayoutUnit((contentBoxInlineSize - childMarginBoxInlineSize) / 2);
     case MathMLFractionElement::FractionAlignmentLeft:
         return 0_lu;
     }
@@ -212,11 +214,11 @@ LayoutUnit RenderMathMLFraction::fractionAscent() const
 {
     ASSERT(isValid());
 
-    LayoutUnit numeratorAscent = ascentForChild(numerator());
+    LayoutUnit numeratorAscent = ascentForChild(numerator()) + numerator().marginBefore();
     if (LayoutUnit thickness = lineThickness())
-        return std::max(mathAxisHeight() + thickness / 2, numeratorAscent + fractionParameters().numeratorShiftUp);
+        return borderAndPaddingBefore() + std::max(mathAxisHeight() + thickness / 2, numeratorAscent + fractionParameters().numeratorShiftUp);
 
-    return numeratorAscent + stackParameters().numeratorShiftUp;
+    return borderAndPaddingBefore() + numeratorAscent + stackParameters().numeratorShiftUp;
 }
 
 void RenderMathMLFraction::layoutBlock(bool relayoutChildren, LayoutUnit)
@@ -231,21 +233,29 @@ void RenderMathMLFraction::layoutBlock(bool relayoutChildren, LayoutUnit)
         return;
     }
 
+    recomputeLogicalWidth();
+
     numerator().layoutIfNeeded();
     denominator().layoutIfNeeded();
+    numerator().computeAndSetBlockDirectionMargins(*this);
+    denominator().computeAndSetBlockDirectionMargins(*this);
 
-    setLogicalWidth(std::max(numerator().logicalWidth(), denominator().logicalWidth()));
+    LayoutUnit numeratorMarginBoxInlineSize = numerator().marginStart() + numerator().logicalWidth() + numerator().marginEnd();
+    LayoutUnit denominatorMarginBoxInlineSize = denominator().marginStart() + denominator().logicalWidth() + denominator().marginEnd();
+    setLogicalWidth(std::max(numeratorMarginBoxInlineSize, denominatorMarginBoxInlineSize) + borderAndPaddingLogicalWidth());
 
-    LayoutUnit verticalOffset; // This is the top of the renderer.
-    LayoutPoint numeratorLocation(horizontalOffset(numerator(), element().numeratorAlignment()), verticalOffset);
+    LayoutUnit verticalOffset = borderAndPaddingBefore(); // This is the top of the renderer.
+    verticalOffset += numerator().marginBefore();
+    LayoutPoint numeratorLocation(borderAndPaddingStart() + numerator().marginStart() + horizontalOffset(numerator(), element().numeratorAlignment()), verticalOffset);
     numerator().setLocation(numeratorLocation);
 
-    LayoutUnit denominatorAscent = ascentForChild(denominator());
+    LayoutUnit denominatorAscent = ascentForChild(denominator()) + denominator().marginBefore();
     verticalOffset = fractionAscent();
     FractionParameters parameters = lineThickness() ? fractionParameters() : stackParameters();
     verticalOffset += parameters.denominatorShiftDown - denominatorAscent;
 
-    LayoutPoint denominatorLocation(horizontalOffset(denominator(), element().denominatorAlignment()), verticalOffset);
+    verticalOffset += denominator().marginBefore();
+    LayoutPoint denominatorLocation(borderAndPaddingStart() + denominator().marginStart() + horizontalOffset(denominator(), element().denominatorAlignment()), verticalOffset);
     denominator().setLocation(denominatorLocation);
 
     if (numerator().isOutOfFlowPositioned())
@@ -253,7 +263,7 @@ void RenderMathMLFraction::layoutBlock(bool relayoutChildren, LayoutUnit)
     if (denominator().isOutOfFlowPositioned())
         denominator().containingBlock()->insertPositionedObject(denominator());
 
-    verticalOffset += denominator().logicalHeight(); // This is the bottom of our renderer.
+    verticalOffset += denominator().logicalHeight() + denominator().marginAfter() + borderAndPaddingAfter(); // This is the bottom of our renderer.
     setLogicalHeight(verticalOffset);
 
     layoutPositionedObjects(relayoutChildren);

--- a/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
@@ -49,7 +49,7 @@ void RenderMathMLSpace::computePreferredLogicalWidths()
 {
     ASSERT(preferredLogicalWidthsDirty());
 
-    m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = spaceWidth();
+    m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = spaceWidth() + borderAndPaddingLogicalWidth();
 
     setPreferredLogicalWidthsDirty(false);
 }
@@ -81,10 +81,12 @@ void RenderMathMLSpace::layoutBlock(bool relayoutChildren, LayoutUnit)
     if (!relayoutChildren && simplifiedLayout())
         return;
 
-    setLogicalWidth(spaceWidth());
+    recomputeLogicalWidth();
+
+    setLogicalWidth(spaceWidth() + borderAndPaddingLogicalWidth());
     LayoutUnit height, depth;
     getSpaceHeightAndDepth(height, depth);
-    setLogicalHeight(height + depth);
+    setLogicalHeight(height + depth + borderAndPaddingLogicalHeight());
 
     updateScrollInfoAfterLayout();
 
@@ -95,7 +97,7 @@ std::optional<LayoutUnit> RenderMathMLSpace::firstLineBaseline() const
 {
     LayoutUnit height, depth;
     getSpaceHeightAndDepth(height, depth);
-    return height;
+    return height + borderAndPaddingBefore();
 }
 
 }


### PR DESCRIPTION
#### 21c7ab77fe69c89c0c4a5e8588970022f3f21eea
<pre>
Support border/margin/padding on MathML elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=276169">https://bugs.webkit.org/show_bug.cgi?id=276169</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp:
(WebCore::RenderMathMLFraction::fractionParameters const):
(WebCore::RenderMathMLFraction::stackParameters const):
(WebCore::RenderMathMLFraction::computePreferredLogicalWidths):
(WebCore::RenderMathMLFraction::horizontalOffset const):
(WebCore::RenderMathMLFraction::fractionAscent const):
(WebCore::RenderMathMLFraction::layoutBlock):
* Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp:
(WebCore::RenderMathMLSpace::computePreferredLogicalWidths):
(WebCore::RenderMathMLSpace::layoutBlock):
(WebCore::RenderMathMLSpace::firstLineBaseline const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21c7ab77fe69c89c0c4a5e8588970022f3f21eea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60736 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7559 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7749 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46250 "Found 6 new test failures: imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-1.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-002.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003.html mathml/presentation/roots.xhtml (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5318 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59146 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34214 "Found 1 new test failure: mathml/presentation/roots.xhtml (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27111 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30994 "Found 7 new test failures: imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-1.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-002.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6633 "Found 8 new test failures: imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-1.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-002.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002.html mathml/presentation/roots.xhtml (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6564 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52954 "1 api test failed or timed out") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6903 "Found 8 new test failures: imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-1.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-002.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002.html mathml/presentation/roots.xhtml (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62417 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1029 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7004 "Found 8 new test failures: imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-1.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-002.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002.html mathml/presentation/roots.xhtml (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53510 "Found 8 new test failures: imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-1.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-002.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002.html mathml/presentation/roots.xhtml (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53568 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/871 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32273 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33358 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34443 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33104 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->