### PR TITLE
[svg] make `d` a presentation attribute

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7542,10 +7542,7 @@ imported/w3c/web-platform-tests/svg/painting/reftests/markers-orient-002.svg [ I
 imported/w3c/web-platform-tests/svg/painting/reftests/paint-context-001.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/paint-context-002.svg [ ImageOnlyFailure ]
 
-# tests added with webkit.org/b/272414
-webkit.org/b/272415 imported/w3c/web-platform-tests/svg/path/property/marker-path.svg [ ImageOnlyFailure ]
 webkit.org/b/272416 imported/w3c/web-platform-tests/svg/path/property/mpath.svg [ ImageOnlyFailure ]
-webkit.org/b/272417 imported/w3c/web-platform-tests/svg/path/property/priority.svg [ ImageOnlyFailure ]
 
 # re-import css/css-align WPT failure
 webkit.org/b/271692 imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-break-overflow-020.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/getComputedStyle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/getComputedStyle-expected.txt
@@ -1,7 +1,7 @@
 
 PASS d property of g0 should be none.
 PASS d property of p1 should be none.
-FAIL d property of p2 should be path("M 10 2 H 20"). assert_equals: expected "path(\"M 10 2 H 20\")" but got "none"
+PASS d property of p2 should be path("M 10 2 H 20").
 PASS d property of p3 should be path("M 10 3 H 30").
 PASS d property of p4 should be path("M 10 4 H 40").
 PASS d property of g5 should be path("M 10 5 H 50").

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/test_style_flush_on_dom_api_with_d_property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/test_style_flush_on_dom_api_with_d_property-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL getTotalLength() with d property assert_equals: the total length expected 10 but got 0
 FAIL getPointAtLength() with d property assert_equals: x-axis position expected 10 but got 0
-FAIL isPointInFill() with d property assert_equals: expected true but got false
-FAIL isPointInStroke() with d property assert_equals: expected true but got false
+PASS isPointInFill() with d property
+PASS isPointInStroke() with d property
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-relevant-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-relevant-expected.txt
@@ -11,7 +11,7 @@ PASS cx presentation attribute supported on a relevant element
 PASS cy presentation attribute supported on a relevant element
 PASS direction presentation attribute supported on a relevant element
 PASS display presentation attribute supported on a relevant element
-FAIL d presentation attribute supported on a relevant element assert_true: Presentation attribute d="M0,0 L1,1" should be supported on path element expected true got false
+PASS d presentation attribute supported on a relevant element
 PASS dominant-baseline presentation attribute supported on a relevant element
 PASS fill presentation attribute supported on a relevant element
 PASS fill-opacity presentation attribute supported on a relevant element

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases-expected.txt
@@ -10,7 +10,7 @@ PASS x, y, width, and height presentation attributes supported on use element
 PASS r presentation attribute supported on circle element
 PASS rx and ry presentation attributes supported on ellipse element
 PASS rx and ry presentation attributes supported on rect element
-FAIL d presentation attribute supported on path element assert_true: Presentation attribute d="M0,0 L1,1" should be supported on path element expected true got false
+PASS d presentation attribute supported on path element
 FAIL cx and cy presentation attributes not supported on other elements assert_false: Presentation attribute cx="1" should not be supported on g element expected false got true
 FAIL x, y, width, and height presentation attributes not supported on other elements assert_false: Presentation attribute x="1" should not be supported on g element expected false got true
 FAIL r presentation attribute not supported on other elements assert_false: Presentation attribute r="1" should not be supported on g element expected false got true

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -382,4 +382,9 @@ void StyledElement::addPropertyToPresentationalHintStyle(MutableStyleProperties&
     style.setProperty(propertyID, value, false, CSSParserContext(document()));
 }
 
+void StyledElement::addPropertyToPresentationalHintStyle(MutableStyleProperties& style, CSSPropertyID propertyID, RefPtr<CSSValue>&& value)
+{
+    style.setProperty(propertyID, WTFMove(value), false);
+}
+
 }

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -84,6 +84,7 @@ protected:
     void addPropertyToPresentationalHintStyle(MutableStyleProperties&, CSSPropertyID, CSSValueID identifier);
     void addPropertyToPresentationalHintStyle(MutableStyleProperties&, CSSPropertyID, double value, CSSUnitType);
     void addPropertyToPresentationalHintStyle(MutableStyleProperties&, CSSPropertyID, const String& value);
+    void addPropertyToPresentationalHintStyle(MutableStyleProperties&, CSSPropertyID, RefPtr<CSSValue>&&);
 
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const override;
     Attribute replaceURLsInAttributeValue(const Attribute&, const HashMap<String, String>&) const override;

--- a/Source/WebCore/rendering/style/BasicShapes.h
+++ b/Source/WebCore/rendering/style/BasicShapes.h
@@ -314,6 +314,8 @@ public:
     const SVGPathByteStream* pathData() const { return m_byteStream.get(); }
     const std::unique_ptr<SVGPathByteStream>& byteStream() const { return m_byteStream; }
 
+    const Path& path(const FloatRect&) final;
+
     bool canBlend(const BasicShape&) const final;
     Ref<BasicShape> blend(const BasicShape& from, const BlendingContext&) const final;
 
@@ -322,8 +324,6 @@ private:
     BasicShapePath(std::unique_ptr<SVGPathByteStream>&&, float zoom, WindRule);
 
     Type type() const final { return Type::Path; }
-
-    const Path& path(const FloatRect&) final;
 
     bool operator==(const BasicShape&) const final;
 

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -302,6 +302,8 @@ void SVGRenderStyle::conservativelyCollectChangedAnimatableProperties(const SVGR
             changingProperties.m_properties.set(CSSPropertyX);
         if (first.y != second.y)
             changingProperties.m_properties.set(CSSPropertyY);
+        if (first.d != second.d)
+            changingProperties.m_properties.set(CSSPropertyD);
     };
 
     auto conservativelyCollectChangedAnimatablePropertiesViaInheritedResourceData = [&](auto& first, auto& second) {

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -757,10 +757,10 @@ inline RefPtr<PathOperation> BuilderConverter::convertRayPathOperation(BuilderSt
     return RayPathOperation::create(rayValue.angle()->computeDegrees(), size, rayValue.isContaining());
 }
 
-inline RefPtr<BasicShapePath> BuilderConverter::convertSVGPath(BuilderState& builderState, const CSSValue& value)
+inline RefPtr<BasicShapePath> BuilderConverter::convertSVGPath(BuilderState&, const CSSValue& value)
 {
     if (auto* pathValue = dynamicDowncast<CSSPathValue>(value))
-        return basicShapePathForValue(*pathValue, builderState.style().usedZoom());
+        return basicShapePathForValue(*pathValue);
 
     ASSERT(is<CSSPrimitiveValue>(value));
     ASSERT(downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNone);

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -841,7 +841,7 @@ bool SVGElement::rendererIsNeeded(const RenderStyle& style)
     return false;
 }
 
-CSSPropertyID SVGElement::cssPropertyIdForSVGAttributeName(const QualifiedName& attrName)
+CSSPropertyID SVGElement::cssPropertyIdForSVGAttributeName(const QualifiedName& attrName, const Settings& settings)
 {
     if (!attrName.namespaceURI().isNull())
         return CSSPropertyInvalid;
@@ -871,6 +871,10 @@ CSSPropertyID SVGElement::cssPropertyIdForSVGAttributeName(const QualifiedName& 
         return CSSPropertyCx;
     case AttributeNames::cyAttr:
         return CSSPropertyCy;
+    case AttributeNames::dAttr:
+        if (settings.cssDPropertyEnabled())
+            return CSSPropertyD;
+        break;
     case AttributeNames::directionAttr:
         return CSSPropertyDirection;
     case AttributeNames::displayAttr:
@@ -996,14 +1000,14 @@ CSSPropertyID SVGElement::cssPropertyIdForSVGAttributeName(const QualifiedName& 
 
 bool SVGElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
-    if (cssPropertyIdForSVGAttributeName(name) > 0)
+    if (cssPropertyIdForSVGAttributeName(name, document().settings()) > 0)
         return true;
     return StyledElement::hasPresentationalHintsForAttribute(name);
 }
 
 void SVGElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    CSSPropertyID propertyID = cssPropertyIdForSVGAttributeName(name);
+    CSSPropertyID propertyID = cssPropertyIdForSVGAttributeName(name, document().settings());
     if (propertyID > 0)
         addPropertyToPresentationalHintStyle(style, propertyID, value);
 }
@@ -1016,7 +1020,7 @@ void SVGElement::updateSVGRendererForElementChange()
 
 void SVGElement::svgAttributeChanged(const QualifiedName& attrName)
 {
-    CSSPropertyID propId = cssPropertyIdForSVGAttributeName(attrName);
+    CSSPropertyID propId = cssPropertyIdForSVGAttributeName(attrName, document().settings());
     if (propId > 0) {
         invalidateInstances();
         return;

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -45,6 +45,7 @@ class SVGPropertyAnimatorFactory;
 class SVGResourceElementClient;
 class SVGSVGElement;
 class SVGUseElement;
+class Settings;
 class Timer;
 
 class SVGElement : public StyledElement, public SVGPropertyOwner {
@@ -181,7 +182,7 @@ protected:
     SVGElementRareData& ensureSVGRareData();
 
     void reportAttributeParsingError(SVGParsingError, const QualifiedName&, const AtomString&);
-    static CSSPropertyID cssPropertyIdForSVGAttributeName(const QualifiedName&);
+    static CSSPropertyID cssPropertyIdForSVGAttributeName(const QualifiedName&, const Settings&);
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -80,7 +80,7 @@ Ref<StyleRuleFontFace> SVGFontFaceElement::protectedFontFaceRule() const
 
 void SVGFontFaceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    CSSPropertyID propertyId = cssPropertyIdForSVGAttributeName(name);
+    CSSPropertyID propertyId = cssPropertyIdForSVGAttributeName(name, document().settings());
     if (propertyId > 0) {
         // FIXME: Parse using the @font-face descriptor grammars, not the property grammars.
         Ref fontFaceRule = m_fontFaceRule;

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "SVGPathElement.h"
 
+#include "CSSBasicShapes.h"
 #include "LegacyRenderSVGPath.h"
 #include "LegacyRenderSVGResource.h"
 #include "RenderSVGPath.h"
@@ -31,6 +32,7 @@
 #include "SVGNames.h"
 #include "SVGPathUtilities.h"
 #include "SVGPoint.h"
+#include "SVGRenderStyle.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -143,6 +145,8 @@ void SVGPathElement::svgAttributeChanged(const QualifiedName& attrName)
             path->setNeedsShapeUpdate();
 
         updateSVGRendererForElementChange();
+        if (document().settings().cssDPropertyEnabled())
+            setPresentationalHintStyleIsDirty();
         invalidateResourceImageBuffersIfNeeded();
         return;
     }
@@ -215,6 +219,29 @@ RenderPtr<RenderElement> SVGPathElement::createElementRenderer(RenderStyle&& sty
     if (document().settings().layerBasedSVGEngineEnabled())
         return createRenderer<RenderSVGPath>(*this, WTFMove(style));
     return createRenderer<LegacyRenderSVGPath>(*this, WTFMove(style));
+}
+
+Path SVGPathElement::path() const
+{
+    if (auto* renderer = this->renderer()) {
+        if (auto* basicShapePath = renderer->style().d())
+            return basicShapePath->path({ });
+    }
+
+    return m_pathSegList->currentPath();
+}
+
+void SVGPathElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
+{
+    if (name == SVGNames::dAttr && document().settings().cssDPropertyEnabled()) {
+        // In the case of the `d` property, we want to avoid providing a string value since it will require
+        // the path data to be parsed again and path data can be unwieldy.
+        auto property = cssPropertyIdForSVGAttributeName(name, document().settings());
+        // The WindRule value passed here is not relevant for the `d` property.
+        auto cssPathValue = CSSPathValue::create(m_pathSegList->currentPathByteStream(), WindRule::NonZero);
+        addPropertyToPresentationalHintStyle(style, property, WTFMove(cssPathValue));
+    } else
+        SVGGeometryElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 
 }

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -97,7 +97,7 @@ public:
     RefPtr<SVGPathSegList>& animatedPathSegList() { return m_pathSegList->animVal(); }
 
     const SVGPathByteStream& pathByteStream() const { return m_pathSegList->currentPathByteStream(); }
-    Path path() const { return m_pathSegList->currentPath(); }
+    Path path() const;
     size_t approximateMemoryCost() const final { return m_pathSegList->approximateMemoryCost(); }
 
     static void clearCache();
@@ -119,6 +119,8 @@ private:
     void removedFromAncestor(RemovalType, ContainerNode&) final;
 
     void invalidateMPathDependencies();
+
+    void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 
 private:
     Ref<SVGAnimatedPathSegList> m_pathSegList { SVGAnimatedPathSegList::create(this) };


### PR DESCRIPTION
#### 9c6d47b82456c12d8c6a7bc9473f0f6e2de29b42
<pre>
[svg] make `d` a presentation attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=272509">https://bugs.webkit.org/show_bug.cgi?id=272509</a>
<a href="https://rdar.apple.com/126393877">rdar://126393877</a>

Reviewed by Said Abou-Hallawa.

(This is the same patch as 277451@main which was reverted due to a Speedometer 3 performance regression.
A flag has since been introduced to conditionally enable the `d` CSS property and this patch re-introduces
277451@main but gates the functionality behind that flag, which is still disabled by default. Fixing
the performance regression and enabling the flag is tracked by bug 276172.)

We now make the `d` SVG attribute map to the `d` CSS property as part of the presentation
attribute system by adding the required mapping under `SVGElement::cssPropertyIdForSVGAttributeName()`
and accounting for the path data set on the `SVGRenderStyle` in `pathFromPathElement()`.

We must also call `setPresentationalHintStyleIsDirty()` under `SVGPathElement::svgAttributeChanged()`,
matching the behavior of other SVG elements with presentation attributes.

The SVG presentation attribute system forwards the string value set on the SVG attribute to the
`MutableStyleProperties` object collecting the various matching CSS properties. But in the case
of the `d` property, path data can be large and unwieldy, so we override `collectPresentationalHintsForAttribute()`
on `SVGPathElement` and create a `CSSPathValue` with a copy of the (potentially animated)
`SVGPathByteStream` and call into a new variant of `StyledElement::addPropertyToPresentationalHintStyle()`
that takes in a `RefPtr&lt;CSSValue&gt;&amp;&amp;`.

Finally, adding support for `d` as a presentation attribute revealed a mistake in 277297@main
where we accounted for the CSS `zoom` value when converting the `CSSPathValue`, but the `zoom`
property has no bearing in SVG. This broke the following tests:

    * svg/zoom/page/zoom-coords-viewattr-01-b.svg
    * svg/zoom/page/zoom-img-preserveAspectRatio-support-1.html
    * svg/zoom/page/zoom-replaced-intrinsic-ratio-001.htm

So we modified `BuilderConverter::convertSVGPath()` accordingly.
* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/getComputedStyle-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/test_style_flush_on_dom_api_with_d_property-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-relevant-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases-expected.txt:
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::addPropertyToPresentationalHintStyle):
* Source/WebCore/dom/StyledElement.h:
* Source/WebCore/rendering/style/BasicShapes.h:
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
(WebCore::SVGRenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertSVGPath):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::cssPropertyIdForSVGAttributeName):
(WebCore::SVGElement::hasPresentationalHintsForAttribute const):
(WebCore::SVGElement::collectPresentationalHintsForAttribute):
(WebCore::SVGElement::svgAttributeChanged):
* Source/WebCore/svg/SVGElement.h:
* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::attributeChanged):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::svgAttributeChanged):
(WebCore::SVGPathElement::path const):
(WebCore::SVGPathElement::collectPresentationalHintsForAttribute):
* Source/WebCore/svg/SVGPathElement.h:

Canonical link: <a href="https://commits.webkit.org/280621@main">https://commits.webkit.org/280621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4f672a29285aa24e5915551394c9ccd6ff26203

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9597 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60742 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59250 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46257 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5325 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49315 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27118 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31001 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6637 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6570 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62423 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7011 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53517 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53576 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/878 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8517 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32279 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33364 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->