### PR TITLE
[WPE] Add support for local inspector when using the WPE Platform API

### DIFF
--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -237,6 +237,8 @@ UIProcess/gstreamer/WebPageProxyGStreamer.cpp
 UIProcess/Inspector/glib/RemoteInspectorClient.cpp
 UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
 
+UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
+
 UIProcess/Launcher/glib/BubblewrapLauncher.cpp
 UIProcess/Launcher/glib/FlatpakLauncher.cpp
 UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
@@ -275,6 +277,8 @@ WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebProcessExtensionManager.cpp @no-unify
 
 WebProcess/InjectedBundle/glib/InjectedBundleGlib.cpp
+
+WebProcess/Inspector/wpe/WebInspectorUIWPE.cpp
 
 WebProcess/MediaCache/WebMediaKeyStorageManager.cpp
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -481,6 +481,9 @@ webkit_web_view_get_display                          (WebKitWebView             
 
 WEBKIT_API WPEView *
 webkit_web_view_get_wpe_view                         (WebKitWebView             *web_view);
+
+WEBKIT_API void
+webkit_web_view_toggle_inspector                     (WebKitWebView             *web_view);
 #endif
 #endif
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
@@ -51,6 +51,7 @@ View::~View()
     if (m_accessible)
         webkitWebViewAccessibleSetWebView(m_accessible.get(), nullptr);
 #endif
+    m_pageProxy->close();
 }
 
 void View::createWebPage(const API::PageConfiguration& configuration)

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
@@ -21,6 +21,7 @@
 #include "WebKitWebView.h"
 
 #include "PageClientImpl.h"
+#include "WebInspectorUIProxy.h"
 #include "WebKitColorPrivate.h"
 #include "WebKitScriptDialogPrivate.h"
 #include "WebKitWebViewPrivate.h"
@@ -292,4 +293,34 @@ guint createShowOptionMenuSignal(WebKitWebViewClass* webViewClass)
         G_TYPE_BOOLEAN, 2,
         WEBKIT_TYPE_OPTION_MENU,
         WEBKIT_TYPE_RECTANGLE | G_SIGNAL_TYPE_STATIC_SCOPE);
+}
+
+/**
+ * webkit_web_view_toggle_inspector:
+ * @web_view: a #WebKitWebView
+ *
+ * Show or hide the web inspector of @web_view
+ * Note that local inspector is only supported by
+ * WPEWebKit when using WPE Platform API.
+ *
+ * Since: 2.46
+ */
+void webkit_web_view_toggle_inspector(WebKitWebView* webView)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
+
+    auto& page = webkitWebViewGetPage(webView);
+    if (!page.wpeView()) {
+        g_warning("Local inspector is only supported by WPEWebKit when using WPE Platform API");
+        return;
+    }
+
+    auto* inspector = page.inspector();
+    if (!inspector)
+        return;
+
+    if (inspector->isVisible())
+        inspector->close();
+    else
+        inspector->show();
 }

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -816,7 +816,7 @@ void WebInspectorUIProxy::evaluateInFrontendForTesting(const String& expression)
 
 // Unsupported configurations can use the stubs provided here.
 
-#if !PLATFORM(MAC) && !PLATFORM(GTK) && !PLATFORM(WIN)
+#if !PLATFORM(MAC) && !PLATFORM(GTK) && !PLATFORM(WIN) && !ENABLE(WPE_PLATFORM)
 
 WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
 {

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -61,6 +61,10 @@ OBJC_CLASS WKInspectorViewController;
 #include "WebView.h"
 #elif PLATFORM(GTK)
 #include <wtf/glib/GWeakPtr.h>
+#elif PLATFORM(WPE)
+#include "WPEWebView.h"
+#include <wtf/glib/GRefPtr.h>
+typedef struct _WPEToplevel WPEToplevel;
 #endif
 
 namespace WebCore {
@@ -249,6 +253,8 @@ private:
 
 #if PLATFORM(MAC)
     bool platformCanAttach(bool webProcessCanAttach);
+#elif PLATFORM(WPE)
+    bool platformCanAttach(bool) { return false; }
 #else
     bool platformCanAttach(bool webProcessCanAttach) { return webProcessCanAttach; }
 #endif
@@ -343,6 +349,9 @@ private:
     GWeakPtr<GtkWidget> m_inspectorWindow;
     GtkWidget* m_headerBar { nullptr };
     String m_inspectedURLString;
+#elif PLATFORM(WPE)
+    RefPtr<WKWPE::View> m_inspectorView;
+    GRefPtr<WPEToplevel> m_inspectorWindow;
 #elif PLATFORM(WIN)
     HWND m_inspectedViewWindow { nullptr };
     HWND m_inspectedViewParentWindow { nullptr };

--- a/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
@@ -1,0 +1,299 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebInspectorUIProxy.h"
+
+#if ENABLE(WPE_PLATFORM)
+
+#include "APINavigationAction.h"
+#include "APINavigationClient.h"
+#include "APIPageConfiguration.h"
+#include "WPEWebViewPlatform.h"
+#include "WebFramePolicyListenerProxy.h"
+#include "WebPageGroup.h"
+#include "WebPageProxy.h"
+#include "WebPreferences.h"
+#include "WebProcessPool.h"
+#include "WebsiteDataStore.h"
+#include <WebCore/CertificateInfo.h>
+#include <WebCore/FloatRect.h>
+#include <WebCore/InspectorFrontendClient.h>
+#include <WebCore/NotImplemented.h>
+#include <wpe/wpe-platform.h>
+#include <wtf/FileSystem.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+class InspectorNavigationClient final : public API::NavigationClient {
+public:
+    explicit InspectorNavigationClient(WebInspectorUIProxy& proxy)
+        : m_proxy(proxy)
+    {
+    }
+
+    bool processDidTerminate(WebPageProxy&, ProcessTerminationReason reason) override
+    {
+        if (reason == ProcessTerminationReason::Crash)
+            m_proxy.closeForCrash();
+        return true;
+    }
+
+    void decidePolicyForNavigationAction(WebPageProxy&, Ref<API::NavigationAction>&& navigationAction, Ref<WebFramePolicyListenerProxy>&& listener) override
+    {
+        // Allow non-main frames to navigate anywhere.
+        if (!navigationAction->targetFrame()->isMainFrame()) {
+            listener->use();
+            return;
+        }
+
+        // Allow loading of the main inspector file.
+        if (WebInspectorUIProxy::isMainOrTestInspectorPage(navigationAction->request().url())) {
+            listener->use();
+            return;
+        }
+
+        // Prevent everything else.
+        listener->ignore();
+
+        // Try to load the request in the inspected page.
+        if (RefPtr page = m_proxy.inspectedPage()) {
+            auto request = navigationAction->request();
+            page->loadRequest(WTFMove(request));
+        }
+    }
+
+private:
+    WebInspectorUIProxy& m_proxy;
+};
+
+static Ref<WebsiteDataStore> inspectorWebsiteDataStore()
+{
+    static constexpr auto versionedDirectory = "wpewebkit-" WPE_API_VERSION G_DIR_SEPARATOR_S "WebInspector" G_DIR_SEPARATOR_S ""_s;
+    String baseCacheDirectory = FileSystem::pathByAppendingComponent(FileSystem::userCacheDirectory(), versionedDirectory);
+    String baseDataDirectory = FileSystem::pathByAppendingComponent(FileSystem::userDataDirectory(), versionedDirectory);
+
+    auto configuration = WebsiteDataStoreConfiguration::createWithBaseDirectories(baseCacheDirectory, baseDataDirectory);
+    return WebsiteDataStore::create(WTFMove(configuration), PAL::SessionID::generatePersistentSessionID());
+}
+
+WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
+{
+    auto* inspectedWPEView = inspectedPage()->wpeView();
+    if (!inspectedWPEView)
+        return nullptr;
+
+    RELEASE_ASSERT(inspectedPage());
+    RELEASE_ASSERT(!m_inspectorView);
+
+    auto preferences = WebPreferences::create(String(), "WebKit2."_s, "WebKit2."_s);
+#if ENABLE(DEVELOPER_MODE)
+    // Allow developers to inspect the Web Inspector in debug builds without changing settings.
+    preferences->setDeveloperExtrasEnabled(true);
+    preferences->setLogsPageMessagesToSystemConsoleEnabled(true);
+#endif
+    preferences->setAllowTopNavigationToDataURLs(true);
+    preferences->setJavaScriptRuntimeFlags({ });
+    preferences->setAcceleratedCompositingEnabled(true);
+    preferences->setForceCompositingMode(true);
+    preferences->setThreadedScrollingEnabled(true);
+    if (m_underTest)
+        preferences->setHiddenPageDOMTimerThrottlingEnabled(false);
+
+    auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(inspectedPage().get()));
+    auto websiteDataStore = inspectorWebsiteDataStore();
+    auto& processPool = WebKit::defaultInspectorProcessPool(inspectionLevel());
+
+    auto pageConfiguration = API::PageConfiguration::create();
+    pageConfiguration->setProcessPool(&processPool);
+    pageConfiguration->setPreferences(preferences.ptr());
+    pageConfiguration->setPageGroup(pageGroup.ptr());
+    pageConfiguration->setWebsiteDataStore(websiteDataStore.ptr());
+    m_inspectorView = WKWPE::ViewPlatform::create(wpe_view_get_display(inspectedWPEView), *pageConfiguration.ptr());
+
+    Ref page = m_inspectorView->page();
+    page->setNavigationClient(makeUniqueRef<InspectorNavigationClient>(*this));
+
+    auto* wpeView = m_inspectorView->wpeView();
+    g_signal_connect(wpeView, "closed", G_CALLBACK(+[](WPEView* wpeView, WebInspectorUIProxy* proxy) {
+        proxy->close();
+    }), this);
+    m_inspectorWindow = wpe_view_get_toplevel(wpeView);
+    wpe_view_set_toplevel(wpeView, nullptr);
+    wpe_toplevel_resize(m_inspectorWindow.get(), initialWindowWidth, initialWindowHeight);
+
+    return page.ptr();
+}
+
+void WebInspectorUIProxy::platformCreateFrontendWindow()
+{
+    wpe_toplevel_resize(m_inspectorWindow.get(), initialWindowWidth, initialWindowHeight);
+    wpe_view_set_toplevel(m_inspectorView->wpeView(), m_inspectorWindow.get());
+}
+
+void WebInspectorUIProxy::platformCloseFrontendPageAndWindow()
+{
+    if (m_inspectorView)
+        g_signal_handlers_disconnect_by_data(m_inspectorView->wpeView(), this);
+    m_inspectorView = nullptr;
+    m_inspectorWindow = nullptr;
+}
+
+void WebInspectorUIProxy::platformDidCloseForCrash()
+{
+    notImplemented();
+}
+
+void WebInspectorUIProxy::platformInvalidate()
+{
+    if (m_inspectorView)
+        g_signal_handlers_disconnect_by_data(m_inspectorView->wpeView(), this);
+}
+
+void WebInspectorUIProxy::platformResetState()
+{
+    notImplemented();
+}
+
+void WebInspectorUIProxy::platformBringToFront()
+{
+    notImplemented();
+}
+
+void WebInspectorUIProxy::platformBringInspectedPageToFront()
+{
+    notImplemented();
+}
+
+void WebInspectorUIProxy::platformHide()
+{
+    notImplemented();
+}
+
+bool WebInspectorUIProxy::platformIsFront()
+{
+    notImplemented();
+    return false;
+}
+
+void WebInspectorUIProxy::platformSetForcedAppearance(WebCore::InspectorFrontendClient::Appearance)
+{
+    notImplemented();
+}
+
+void WebInspectorUIProxy::platformRevealFileExternally(const String&)
+{
+    notImplemented();
+}
+
+void WebInspectorUIProxy::platformInspectedURLChanged(const String& url)
+{
+    if (!m_inspectorWindow)
+        return;
+
+    GUniquePtr<char> title(g_strdup_printf("Web Inspector — %s", url.utf8().data()));
+    wpe_toplevel_set_title(m_inspectorWindow.get(), title.get());
+}
+
+void WebInspectorUIProxy::platformShowCertificate(const WebCore::CertificateInfo&)
+{
+    notImplemented();
+}
+
+void WebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::SaveData>&&, bool /* forceSaveAs */)
+{
+    notImplemented();
+}
+
+void WebInspectorUIProxy::platformLoad(const String&, CompletionHandler<void(const String&)>&& completionHandler)
+{
+    notImplemented();
+    completionHandler(nullString());
+}
+
+void WebInspectorUIProxy::platformPickColorFromScreen(CompletionHandler<void(const std::optional<WebCore::Color>&)>&& completionHandler)
+{
+    notImplemented();
+    completionHandler({ });
+}
+
+void WebInspectorUIProxy::platformAttach()
+{
+    notImplemented();
+}
+
+void WebInspectorUIProxy::platformDetach()
+{
+    notImplemented();
+}
+
+void WebInspectorUIProxy::platformSetAttachedWindowHeight(unsigned)
+{
+    notImplemented();
+}
+
+void WebInspectorUIProxy::platformSetSheetRect(const WebCore::FloatRect&)
+{
+    notImplemented();
+}
+
+void WebInspectorUIProxy::platformStartWindowDrag()
+{
+    notImplemented();
+}
+
+String WebInspectorUIProxy::inspectorPageURL()
+{
+    return "resource:///org/webkit/inspector/UserInterface/Main.html"_s;
+}
+
+String WebInspectorUIProxy::inspectorTestPageURL()
+{
+    return "resource:///org/webkit/inspector/UserInterface/Test.html"_s;
+}
+
+DebuggableInfoData WebInspectorUIProxy::infoForLocalDebuggable()
+{
+    auto data = DebuggableInfoData::empty();
+    data.debuggableType = Inspector::DebuggableType::WebPage;
+    return data;
+}
+
+void WebInspectorUIProxy::platformSetAttachedWindowWidth(unsigned)
+{
+    notImplemented();
+}
+
+void WebInspectorUIProxy::platformAttachAvailabilityChanged(bool)
+{
+    notImplemented();
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2706,7 +2706,7 @@ void WebPageProxy::activityStateDidChange(OptionSet<ActivityState> mayHaveChange
         return;
     }
 
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
     bool isNewlyInWindow = !isInWindow() && (mayHaveChanged & ActivityState::IsInWindow) && pageClient->isViewInWindow();
     if (dispatchMode == ActivityStateChangeDispatchMode::Immediate || isNewlyInWindow) {
         dispatchActivityStateChange();

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -80,6 +80,8 @@ void WebInspectorUI::establishConnection(WebPageProxyIdentifier inspectedPageIde
     m_frontendController->setInspectorFrontendClient(this);
 
     updateConnection();
+
+    didEstablishConnection();
 }
 
 void WebInspectorUI::updateConnection()
@@ -463,8 +465,7 @@ WebCore::Page* WebInspectorUI::frontendPage()
     return m_page.corePage();
 }
 
-
-#if !PLATFORM(MAC) && !PLATFORM(GTK) && !PLATFORM(WIN)
+#if !PLATFORM(MAC) && !PLATFORM(GTK) && !PLATFORM(WIN) && !ENABLE(WPE_PLATFORM)
 bool WebInspectorUI::canSave(InspectorFrontendClient::SaveMode)
 {
     notImplemented();
@@ -487,6 +488,11 @@ String WebInspectorUI::localizedStringsURL() const
 {
     notImplemented();
     return emptyString();
+}
+
+void WebInspectorUI::didEstablishConnection()
+{
+    notImplemented();
 }
 #endif // !PLATFORM(MAC) && !PLATFORM(GTK) && !PLATFORM(WIN)
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
@@ -178,6 +178,8 @@ public:
 private:
     explicit WebInspectorUI(WebPage&);
 
+    void didEstablishConnection();
+
     WebPage& m_page;
     Ref<WebCore::InspectorFrontendAPIDispatcher> m_frontendAPIDispatcher;
     RefPtr<WebCore::InspectorFrontendHost> m_frontendHost;

--- a/Source/WebKit/WebProcess/Inspector/gtk/WebInspectorUIGtk.cpp
+++ b/Source/WebKit/WebProcess/Inspector/gtk/WebInspectorUIGtk.cpp
@@ -63,4 +63,8 @@ String WebInspectorUI::localizedStringsURL() const
     return "resource:///org/webkit/inspector/Localizations/en.lproj/localizedStrings.js"_s;
 }
 
+void WebInspectorUI::didEstablishConnection()
+{
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/win/WebInspectorUIWin.cpp
+++ b/Source/WebKit/WebProcess/Inspector/win/WebInspectorUIWin.cpp
@@ -62,4 +62,8 @@ String WebInspectorUI::localizedStringsURL() const
     return "inspector-resource:///localizedStrings.js"_s;
 }
 
+void WebInspectorUI::didEstablishConnection()
+{
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/wpe/WebInspectorUIWPE.cpp
+++ b/Source/WebKit/WebProcess/Inspector/wpe/WebInspectorUIWPE.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,47 +23,58 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "WebInspectorUI.h"
+#include "config.h"
+#include "WebInspectorUI.h"
 
-#import "WKInspectorViewController.h"
+#if ENABLE(WPE_PLATFORM)
 
-#if PLATFORM(MAC)
+#include <wtf/glib/GUniquePtr.h>
 
 namespace WebKit {
-using namespace WebCore;
 
-bool WebInspectorUI::canSave(InspectorFrontendClient::SaveMode saveMode)
+void WebInspectorUI::didEstablishConnection()
 {
-    switch (saveMode) {
-    case InspectorFrontendClient::SaveMode::SingleFile:
-    case InspectorFrontendClient::SaveMode::FileVariants:
-        return true;
-    }
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        const char* libDir = PKGLIBDIR;
+#if ENABLE(DEVELOPER_MODE)
+        // Probably no need for a specific env var here. Assume the inspector resources.so file is
+        // in the same directory as the injected bundle lib, for developer builds.
+        const char* path = g_getenv("WEBKIT_INJECTED_BUNDLE_PATH");
+        if (path && g_file_test(path, G_FILE_TEST_IS_DIR))
+            libDir = path;
+#endif
+        GUniquePtr<char> bundleFilename(g_build_filename(libDir, "libWPEWebInspectorResources.so", nullptr));
+        GModule* resourcesModule = g_module_open(bundleFilename.get(), G_MODULE_BIND_LAZY);
+        if (!resourcesModule) {
+            WTFLogAlways("Error loading libWPEWebInspectorResources.so: %s", g_module_error());
+            return;
+        }
 
-    ASSERT_NOT_REACHED();
+        g_module_make_resident(resourcesModule);
+    });
+}
+
+bool WebInspectorUI::canSave(InspectorFrontendClient::SaveMode)
+{
     return false;
 }
 
 bool WebInspectorUI::canLoad()
 {
-    return true;
+    return false;
 }
 
 bool WebInspectorUI::canPickColorFromScreen()
 {
-    return true;
+    return false;
 }
 
 String WebInspectorUI::localizedStringsURL() const
 {
-    return [WKInspectorViewController URLForInspectorResource:@"localizedStrings.js"].absoluteString;
-}
-
-void WebInspectorUI::didEstablishConnection()
-{
+    return "resource:///org/webkit/inspector/Localizations/en.lproj/localizedStrings.js"_s;
 }
 
 } // namespace WebKit
 
-#endif // PLATFORM(MAC)
+#endif // ENABLE(WPE_PLATFORM)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -183,6 +183,8 @@ else ()
 endif ()
 endif ()
 
+EXPOSE_STRING_VARIABLE_TO_BUILD(WPE_API_VERSION)
+
 if (ENABLE_2022_GLIB_API)
     set(GLIB_MINIMUM_VERSION 2.70.0)
 else ()

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -186,6 +186,11 @@ static gboolean wpeViewEventCallback(WPEView* view, WPEEvent* event, WebKitWebVi
             webkit_web_view_reload(webView);
             return TRUE;
         }
+
+        if ((modifiers & WPE_MODIFIER_KEYBOARD_SHIFT) && keyval == WPE_KEY_I) {
+            webkit_web_view_toggle_inspector(webView);
+            return TRUE;
+        }
     }
 
     if (modifiers & WPE_MODIFIER_KEYBOARD_ALT) {


### PR DESCRIPTION
#### 438011bd9f98e1fbb7df3ae9bb7362e494ec02ac
<pre>
[WPE] Add support for local inspector when using the WPE Platform API
<a href="https://bugs.webkit.org/show_bug.cgi?id=276173">https://bugs.webkit.org/show_bug.cgi?id=276173</a>

Reviewed by Alejandro G. Castro.

* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::View::~View):
* Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp:
(webkit_web_view_toggle_inspector):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
(WebKit::WebInspectorUIProxy::platformCanAttach):
* Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp: Added.
(WebKit::inspectorWebsiteDataStore):
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
(WebKit::WebInspectorUIProxy::platformCreateFrontendWindow):
(WebKit::WebInspectorUIProxy::platformCloseFrontendPageAndWindow):
(WebKit::WebInspectorUIProxy::platformDidCloseForCrash):
(WebKit::WebInspectorUIProxy::platformInvalidate):
(WebKit::WebInspectorUIProxy::platformResetState):
(WebKit::WebInspectorUIProxy::platformBringToFront):
(WebKit::WebInspectorUIProxy::platformBringInspectedPageToFront):
(WebKit::WebInspectorUIProxy::platformHide):
(WebKit::WebInspectorUIProxy::platformIsFront):
(WebKit::WebInspectorUIProxy::platformSetForcedAppearance):
(WebKit::WebInspectorUIProxy::platformRevealFileExternally):
(WebKit::WebInspectorUIProxy::platformInspectedURLChanged):
(WebKit::WebInspectorUIProxy::platformShowCertificate):
(WebKit::WebInspectorUIProxy::platformSave):
(WebKit::WebInspectorUIProxy::platformLoad):
(WebKit::WebInspectorUIProxy::platformPickColorFromScreen):
(WebKit::WebInspectorUIProxy::platformAttach):
(WebKit::WebInspectorUIProxy::platformDetach):
(WebKit::WebInspectorUIProxy::platformSetAttachedWindowHeight):
(WebKit::WebInspectorUIProxy::platformSetSheetRect):
(WebKit::WebInspectorUIProxy::platformStartWindowDrag):
(WebKit::WebInspectorUIProxy::inspectorPageURL):
(WebKit::WebInspectorUIProxy::inspectorTestPageURL):
(WebKit::WebInspectorUIProxy::infoForLocalDebuggable):
(WebKit::WebInspectorUIProxy::platformSetAttachedWindowWidth):
(WebKit::WebInspectorUIProxy::platformAttachAvailabilityChanged):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::establishConnection):
(WebKit::WebInspectorUI::didEstablishConnection):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.h:
* Source/WebKit/WebProcess/Inspector/gtk/WebInspectorUIGtk.cpp:
(WebKit::WebInspectorUI::didEstablishConnection):
* Source/WebKit/WebProcess/Inspector/mac/WebInspectorUIMac.mm:
(WebKit::WebInspectorUI::didEstablishConnection):
* Source/WebKit/WebProcess/Inspector/win/WebInspectorUIWin.cpp:
(WebKit::WebInspectorUI::didEstablishConnection):
* Source/WebKit/WebProcess/Inspector/wpe/WebInspectorUIWPE.cpp: Added.
(WebKit::WebInspectorUI::didEstablishConnection):
(WebKit::WebInspectorUI::canSave):
(WebKit::WebInspectorUI::canLoad):
(WebKit::WebInspectorUI::canPickColorFromScreen):
(WebKit::WebInspectorUI::localizedStringsURL const):
* Source/cmake/OptionsWPE.cmake:
* Tools/MiniBrowser/wpe/main.cpp:

Canonical link: <a href="https://commits.webkit.org/280678@main">https://commits.webkit.org/280678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d3f4d8293ba52a0b87e5e61ca8c46b8ca1d2d72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60746 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7569 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46260 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5328 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27121 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6643 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6574 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50218 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52964 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62427 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/56368 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7013 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53520 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49366 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53579 "2 api tests failed or timed out") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/880 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78128 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8545 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32283 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12944 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33368 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34453 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->