### PR TITLE
[GTK] Fix pointer lock on X11

### DIFF
--- a/Source/WebKit/UIProcess/gtk/PointerLockManager.cpp
+++ b/Source/WebKit/UIProcess/gtk/PointerLockManager.cpp
@@ -92,7 +92,7 @@ bool PointerLockManager::unlock()
     return true;
 }
 
-void PointerLockManager::handleMotion(FloatSize&& delta)
+void PointerLockManager::handleMotion(const FloatSize& delta)
 {
     m_webPage.handleMouseEvent(NativeWebMouseEvent(WebEventType::MouseMove, m_button, m_buttons, IntPoint(m_position), IntPoint(m_initialPoint), 0, m_modifiers, delta, mousePointerID, mousePointerEventType(), PlatformMouseEvent::IsTouch::No));
 }

--- a/Source/WebKit/UIProcess/gtk/PointerLockManager.h
+++ b/Source/WebKit/UIProcess/gtk/PointerLockManager.h
@@ -52,7 +52,7 @@ public:
     virtual void didReceiveMotionEvent(const WebCore::FloatPoint&) { };
 
 protected:
-    void handleMotion(WebCore::FloatSize&&);
+    void handleMotion(const WebCore::FloatSize&);
 
     WebPageProxy& m_webPage;
     WebCore::FloatPoint m_position;

--- a/Source/WebKit/UIProcess/gtk/PointerLockManagerX11.h
+++ b/Source/WebKit/UIProcess/gtk/PointerLockManagerX11.h
@@ -43,6 +43,8 @@ private:
     bool lock() override;
     bool unlock() override;
     void didReceiveMotionEvent(const WebCore::FloatPoint&) override;
+
+    WebCore::IntPoint m_x11RootInitialPoint;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 637888b2d2a394b67803afc2340826d0d25db9fc
<pre>
[GTK] Fix pointer lock on X11
<a href="https://bugs.webkit.org/show_bug.cgi?id=273876">https://bugs.webkit.org/show_bug.cgi?id=273876</a>

Reviewed by Carlos Garcia Campos.

The XGrabPointer call was returning AlreadyGrabbed. This is apparently
because there is an active passive grab when the mouse is pressed down,
that comes via X Input Extensions (XI2) and not X Core. The XGrabPointer
implementation returns AlreadyGrabbed when the &quot;grabtype&quot; differs, i.e.
&quot;XI&quot; or &quot;CORE&quot;. The passive grab may have changed into a touch grab at
some point, which goes through XI2.

My solution is to call XUngrabPointer before trying to grab it.

Fixing this uncovered a secondary issue: the coordinates given to
XWarpPointer were incorrect. I get the actual root-relative coordinates
with XQueryPointer during lock() instead of trying to convert from
m_initialPoint. (That would require handling the offset of the widget
inside the window and DPI scaling.)

I then got a continuous stream of MouseEvents even when the mouse was
stationary due to float rounding differences. In didReceiveMotionEvent,
I added a check that the delta coordinates are non-zero when rounded to
integers, so no events are sent with delta 0.

There are slight errors and differences in how movementX/Y values behave
when locked vs unlocked. These should be addressed separately.

Tested manually with -DUSE_GTK4=ON,OFF, GDK_SCALE=1,2.

* Source/WebKit/UIProcess/gtk/PointerLockManager.cpp:
(WebKit::PointerLockManager::handleMotion):
* Source/WebKit/UIProcess/gtk/PointerLockManager.h:
* Source/WebKit/UIProcess/gtk/PointerLockManagerX11.cpp:
(WebKit::PointerLockManagerX11::lock):
(WebKit::PointerLockManagerX11::didReceiveMotionEvent):
* Source/WebKit/UIProcess/gtk/PointerLockManagerX11.h:

Canonical link: <a href="https://commits.webkit.org/280623@main">https://commits.webkit.org/280623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fb7f4fb1687bd8774eaf77839623c29c2e97699

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60748 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7571 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46262 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5330 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34226 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27123 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31006 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6576 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62429 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1041 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7015 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53522 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49367 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53582 "2 api tests failed or timed out") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12631 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/883 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32285 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33370 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34455 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33116 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->