### PR TITLE
Cherry-pick libwebrtc "Allow for reordering around IRAPs."

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/h26x_packet_buffer.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/h26x_packet_buffer.h
@@ -72,6 +72,7 @@ class H26xPacketBuffer {
   };
 
   static constexpr int kBufferSize = 2048;
+  static constexpr int kNumTrackedSequences = 5;
 
   std::unique_ptr<Packet>& GetPacket(int64_t unwrapped_seq_num);
   bool BeginningOfStream(const Packet& packet) const;
@@ -91,7 +92,8 @@ class H26xPacketBuffer {
   // Indicates whether IDR frames without SPS and PPS are allowed.
   const bool h264_idr_only_keyframes_allowed_;
   std::array<std::unique_ptr<Packet>, kBufferSize> buffer_;
-  absl::optional<int64_t> last_continuous_unwrapped_seq_num_;
+  std::array<int64_t, kNumTrackedSequences> last_continuous_in_sequence_;
+  int64_t last_continuous_in_sequence_index_ = 0;
   SeqNumUnwrapper<uint16_t> seq_num_unwrapper_;
 
   // Map from pps_pic_parameter_set_id to the PPS payload associated with this


### PR DESCRIPTION
#### 883f937925d83f349e138abd59ef4d8619ea66f1
<pre>
Cherry-pick libwebrtc &quot;Allow for reordering around IRAPs.&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=276178">https://bugs.webkit.org/show_bug.cgi?id=276178</a>
<a href="https://rdar.apple.com/problem/131059517">rdar://problem/131059517</a>

Reviewed by Jean-Yves Avenard.

We cherry-pick <a href="https://webrtc-review.googlesource.com/c/src/+/355482">https://webrtc-review.googlesource.com/c/src/+/355482</a> to improve H265 packetization support.

* Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/h26x_packet_buffer.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/h26x_packet_buffer.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/h26x_packet_buffer_unittest.cc:

Canonical link: <a href="https://commits.webkit.org/280677@main">https://commits.webkit.org/280677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3163ba1d693b71276935b32b5ac640fa8811914

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60927 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7748 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46401 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5472 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49484 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6796 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6753 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62606 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53661 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49519 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53738 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12664 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1031 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32462 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33547 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34632 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->