### PR TITLE
[css-nesting] New behavior for interleaved declarations and rules

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8067,10 +8067,6 @@ imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-js-expose.
 
 fast/canvas/image-buffer-resource-limits.html [ Slow ]
 
-# CSS Nesting interleaved declarations and rules
-# https://bugs.webkit.org/show_bug.cgi?id=275365
-imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html [ ImageOnlyFailure ]
-
 # Standardized CSS zoom tests.
 imported/w3c/web-platform-tests/css/css-viewport/width.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/border-spacing.html [ ImageOnlyFailure ]
@@ -8089,6 +8085,9 @@ imported/w3c/web-platform-tests/css/css-viewport/zoom/word-spacing.html [ ImageO
 
 # WebRTC Encoded Transform - Test Expectation - Crashes on 'mac-wk2' debug and gtk-wk2 / wpe-wk2
 webkit.org/b/275663 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame-simulcast.https.html [ Skip ]
+
+# https://bugs.webkit.org/show_bug.cgi?id=276663
+inspector/css/getMatchedStylesForNodeNestingStyleGrouping.html [ Failure ]
 
 # https://bugs.webkit.org/show_bug.cgi?id=266843 flakey tests with racey promise console.logs
 imported/w3c/web-platform-tests/dom/observable/tentative/observable-from.any.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
@@ -16,4 +16,5 @@ PASS Simple CSSOM manipulation of subrules 8
 PASS Simple CSSOM manipulation of subrules 9
 PASS Simple CSSOM manipulation of subrules 10
 PASS Mutating the selectorText of outer rule invalidates inner rules
+PASS Manipulation of nested declarations through CSSOM
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom.html
@@ -185,4 +185,41 @@
     assert_equals(getComputedStyle(inner1).zIndex, '1');
     assert_equals(getComputedStyle(inner2).zIndex, '1');
   }, 'Mutating the selectorText of outer rule invalidates inner rules');
+
+  // CSSNestedDeclarations
+  test((t) => {
+    const main = document.createElement('main');
+    main.innerHTML = `
+      <style id="main_ss">
+        div {
+          z-index: 1;
+          &.test { foo:bar; }
+        }
+      </style>
+      <div id="outer" class="test">
+      </div>
+    `;
+    document.documentElement.append(main);
+    t.add_cleanup(() => main.remove());
+    assert_equals(getComputedStyle(outer).zIndex, '1');
+    const main_ss = document.getElementById("main_ss").sheet;
+    const rule = main_ss.cssRules[0];
+    assert_equals(rule.cssRules.length, 1);
+    rule.insertRule('z-index: 3;');
+    assert_equals(rule.cssRules.length, 2);
+    assert_equals(getComputedStyle(outer).zIndex, '3');
+
+    // Throw only when no valid declaration  https://github.com/w3c/csswg-drafts/issues/10520
+    assert_throws_dom('SyntaxError', () => { rule.insertRule('nothing-to-insert-because-invalid-property-should-throw: 2;'); });
+    assert_equals(rule.cssRules.length, 2);
+
+    // Test the insertion of nested declarations inside grouping rule
+    rule.insertRule('@media screen { a { color: blue; }}',2);
+    assert_equals(rule.cssRules.length, 3);
+    const mediaRule = rule.cssRules[2];
+    mediaRule.insertRule('z-index: 3;');
+    assert_equals(mediaRule.cssRules.length, 2);
+    assert_throws_dom('SyntaxError', () => { mediaRule.insertRule('nothing-to-insert-because-invalid-property-should-throw: 2;'); });
+  }, 'Manipulation of nested declarations through CSSOM');
+
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/mixed-declarations-rules-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/mixed-declarations-rules-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Conditional rules with nesting</title>
+<link rel="help" href="https://drafts.csswg.org/css-nesting-1/">
+<style>
+  .test {
+    background-color: green;
+    width: 100px;
+    height: 100px;
+  }
+
+  body * + * {
+    margin-top: 8px;
+  }
+</style>
+<body>
+  <p>Tests pass if <strong>block is green</strong></p>
+  <div class="test"><div></div></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/mixed-declarations-rules.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/mixed-declarations-rules.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Mixed declarations and rules</title>
+<link rel="help" href="https://drafts.csswg.org/css-nesting/#nested-declarations-rule">
+
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  background-color: blue;
+  @media all {
+    background-color: red;
+  }
+  background-color: green;
+}
+</style>
+
+<body>
+  <p>Tests pass if <strong>block is green</strong></p>
+  <div class="test"></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL Trailing declarations assert_equals: expected 2 but got 1
-FAIL Mixed declarations assert_equals: expected 6 but got 3
-FAIL CSSNestedDeclarations.style assert_equals: expected 2 but got 1
-FAIL Nested group rule assert_equals: expected 2 but got 1
-FAIL Nested @scope rule assert_equals: expected 2 but got 1
-FAIL Inner rule starting with an ident assert_equals: expected 4 but got 2
-FAIL Inserting a CSSNestedDeclaration rule into style rule The string did not match the expected pattern.
-FAIL Inserting a CSSNestedDeclaration rule into nested group rule The string did not match the expected pattern.
+PASS Trailing declarations
+PASS Mixed declarations
+PASS CSSNestedDeclarations.style
+PASS Nested group rule
+PASS Nested @scope rule
+PASS Inner rule starting with an ident
+PASS Inserting a CSSNestedDeclaration rule into style rule
+PASS Inserting a CSSNestedDeclaration rule into nested group rule
 PASS Attempting to insert a CSSNestedDeclaration rule into top-level @media rule
 PASS Attempting to insert a CSSNestedDeclaration rule into a stylesheet
 PASS Attempting to insert a CSSNestedDeclaration rule, empty block

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching-expected.txt
@@ -1,14 +1,14 @@
 A1
 A2
 
-FAIL Trailing declarations apply after any preceding rules assert_equals: expected "PASS" but got "FAIL"
-FAIL Trailing declarations apply after any preceding rules (no leading) assert_equals: expected "PASS" but got "FAIL"
-FAIL Trailing declarations apply after any preceding rules (multiple) assert_equals: expected "PASS" but got "FAIL"
+PASS Trailing declarations apply after any preceding rules
+PASS Trailing declarations apply after any preceding rules (no leading)
+PASS Trailing declarations apply after any preceding rules (multiple)
 PASS Nested declarations rule has same specificity as outer selector
 PASS Nested declarations rule has top-level specificity behavior
-FAIL Nested declarations rule has top-level specificity behavior (max matching) assert_equals: expected "PASS" but got "FAIL"
-FAIL Bare declartaion in nested grouping rule can match pseudo-element assert_equals: expected "PASS" but got "FAIL"
-FAIL Nested group rules have top-level specificity behavior assert_equals: expected "PASS" but got "FAIL"
+PASS Nested declarations rule has top-level specificity behavior (max matching)
+PASS Bare declartaion in nested grouping rule can match pseudo-element
+PASS Nested group rules have top-level specificity behavior
 FAIL Nested @scope rules behave like :where(:scope) assert_equals: expected "PASS" but got "FAIL"
 FAIL Nested @scope rules behave like :where(:scope) (trailing) assert_equals: expected "PASS" but got "FAIL"
 FAIL Nested declarations rule responds to parent selector text change assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls-expected.txt
@@ -1,13 +1,13 @@
 
 PASS Declarations are serialized on one line, rules on two.
-FAIL Mixed declarations/rules are on two lines. assert_equals: Mixed declarations/rules are on two lines. expected "div {\n  @media screen {\n  color: red; background-color: green;\n}\n}" but got "div {\n  @media screen {\n  & { color: red; background-color: green; }\n}\n}"
-FAIL Implicit rule is serialized assert_equals: Implicit rule is serialized expected "div {\n  @supports selector(&) {\n  color: red; background-color: green;\n}\n  &:hover { color: navy; }\n}" but got "div {\n  @supports selector(&) {\n  & { color: red; background-color: green; }\n}\n  &:hover { color: navy; }\n}"
+PASS Mixed declarations/rules are on two lines.
+PASS Implicit rule is serialized
 PASS Implicit rule not removed
 PASS Implicit + empty hover rule
 PASS Implicit like rule not in first position
 PASS Two implicit-like rules
-FAIL Implicit like rule after decls assert_equals: Implicit like rule after decls expected "div {\n  @media screen {\n  color: red;\n  & { color: red; }\n}\n}" but got "div {\n  @media screen {\n  & { color: red; }\n  & { color: red; }\n}\n}"
-FAIL Implicit like rule after decls, missing closing braces assert_equals: Implicit like rule after decls, missing closing braces expected "div {\n  @media screen {\n  color: red;\n  & { color: blue; }\n}\n}" but got "div {\n  @media screen {\n  & { color: red; }\n  & { color: blue; }\n}\n}"
+PASS Implicit like rule after decls
+PASS Implicit like rule after decls, missing closing braces
 PASS Implicit like rule with other selectors
 PASS Implicit-like rule in style rule
 PASS Empty conditional rule

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity.html
@@ -46,11 +46,12 @@
     assert_equals(rules.length, 1);
     assert_equals(rules[0].selectorText, 'div');
     let div = rules[0];
-    let x = div.style.getPropertyValue('--x');
-    assert_equals(x.trim(), 'hover { }\n    .b { }');
     let childRules = div.cssRules;
-    assert_equals(childRules.length, 1);
+    assert_equals(childRules.length, 2);
     assert_equals(childRules[0].selectorText, '& .a');
+    assert_true(childRules[1] instanceof CSSNestedDeclarations)
+    let x = childRules[1].style.getPropertyValue('--x');
+    assert_equals(x.trim(), 'hover { }\n    .b { }');
   }, 'Nested rule that looks like a custom property declaration');
 </script>
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -929,6 +929,7 @@ set(WebCore_NON_SVG_IDL_FILES
     css/CSSLayerStatementRule.idl
     css/CSSMediaRule.idl
     css/CSSNamespaceRule.idl
+    css/CSSNestedDeclarations.idl
     css/CSSPaintCallback.idl
     css/CSSPaintSize.idl
     css/CSSPageRule.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1243,6 +1243,7 @@ $(PROJECT_DIR)/css/CSSLayerBlockRule.idl
 $(PROJECT_DIR)/css/CSSLayerStatementRule.idl
 $(PROJECT_DIR)/css/CSSMediaRule.idl
 $(PROJECT_DIR)/css/CSSNamespaceRule.idl
+$(PROJECT_DIR)/css/CSSNestedDeclarations.idl
 $(PROJECT_DIR)/css/CSSPageRule.idl
 $(PROJECT_DIR)/css/CSSPaintCallback.idl
 $(PROJECT_DIR)/css/CSSPaintSize.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -433,6 +433,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSMediaRule.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSMediaRule.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSNamespaceRule.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSNamespaceRule.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSNestedDeclarations.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSNestedDeclarations.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSNumericArray.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSNumericArray.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSNumericBaseType.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -964,6 +964,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/css/CSSKeyframesRule.idl \
     $(WebCore)/css/CSSMediaRule.idl \
     $(WebCore)/css/CSSNamespaceRule.idl \
+    $(WebCore)/css/CSSNestedDeclarations.idl \
     $(WebCore)/css/CSSPageRule.idl \
     $(WebCore)/css/CSSPaintCallback.idl \
     $(WebCore)/css/CSSPaintSize.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -897,6 +897,7 @@ css/CSSMarkup.cpp
 css/CSSMediaRule.cpp
 css/CSSNamedImageValue.cpp
 css/CSSNamespaceRule.cpp
+css/CSSNestedDeclarations.cpp
 css/CSSOffsetRotateValue.cpp
 css/CSSPageRule.cpp
 css/CSSPaintImageValue.cpp
@@ -3417,6 +3418,7 @@ JSCSSLayerBlockRule.cpp
 JSCSSLayerStatementRule.cpp
 JSCSSMediaRule.cpp
 JSCSSNamespaceRule.cpp
+JSCSSNestedDeclarations.cpp
 JSCSSPageRule.cpp
 JSCSSPaintCallback.cpp
 JSCSSPaintSize.cpp

--- a/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
@@ -38,6 +38,7 @@
 #include "CSSLayerStatementRule.h"
 #include "CSSMediaRule.h"
 #include "CSSNamespaceRule.h"
+#include "CSSNestedDeclarations.h"
 #include "CSSPageRule.h"
 #include "CSSPropertyRule.h"
 #include "CSSScopeRule.h"
@@ -57,6 +58,7 @@
 #include "JSCSSLayerStatementRule.h"
 #include "JSCSSMediaRule.h"
 #include "JSCSSNamespaceRule.h"
+#include "JSCSSNestedDeclarations.h"
 #include "JSCSSPageRule.h"
 #include "JSCSSPropertyRule.h"
 #include "JSCSSScopeRule.h"
@@ -87,6 +89,8 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<C
         return createWrapper<CSSStyleRule>(globalObject, WTFMove(rule));
     case StyleRuleType::StyleWithNesting:
         return createWrapper<CSSStyleRule>(globalObject, WTFMove(rule));
+    case StyleRuleType::NestedDeclarations:
+        return createWrapper<CSSNestedDeclarations>(globalObject, WTFMove(rule));
     case StyleRuleType::Media:
         return createWrapper<CSSMediaRule>(globalObject, WTFMove(rule));
     case StyleRuleType::FontFace:

--- a/Source/WebCore/css/CSSGradientValue.h
+++ b/Source/WebCore/css/CSSGradientValue.h
@@ -31,10 +31,9 @@
 #include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
 #include "ColorInterpolationMethod.h"
 #include "Gradient.h"
+#include "StyleImage.h"
 
 namespace WebCore {
-
-class StyleImage;
 
 namespace Style {
 class BuilderState;

--- a/Source/WebCore/css/CSSNestedDeclarations.cpp
+++ b/Source/WebCore/css/CSSNestedDeclarations.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "CSSNestedDeclarations.h"
+
+#include "DeclaredStylePropertyMap.h"
+#include "MutableStyleProperties.h"
+#include "PropertySetCSSStyleDeclaration.h"
+#include "StyleProperties.h"
+#include "StyleRule.h"
+
+#include <wtf/text/StringBuilder.h>
+
+namespace WebCore {
+
+CSSNestedDeclarations::CSSNestedDeclarations(StyleRuleNestedDeclarations& rule, CSSStyleSheet* parent)
+    : CSSRule(parent)
+    , m_styleRule(rule)
+{
+}
+
+CSSNestedDeclarations::~CSSNestedDeclarations() = default;
+
+CSSStyleDeclaration& CSSNestedDeclarations::style()
+{
+    if (!m_propertiesCSSOMWrapper)
+        m_propertiesCSSOMWrapper = StyleRuleCSSStyleDeclaration::create(m_styleRule->mutableProperties(), *this);
+    return *m_propertiesCSSOMWrapper;
+}
+
+String CSSNestedDeclarations::cssText() const
+{
+    return m_styleRule->properties().asText();
+}
+
+void CSSNestedDeclarations::reattach(StyleRuleBase& rule)
+{
+    m_styleRule = downcast<StyleRuleNestedDeclarations>(rule);
+
+    if (m_propertiesCSSOMWrapper)
+        m_propertiesCSSOMWrapper->reattach(m_styleRule->mutableProperties());
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSNestedDeclarations.h
+++ b/Source/WebCore/css/CSSNestedDeclarations.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "CSSRule.h"
+
+namespace WebCore {
+
+class CSSRuleList;
+class CSSStyleDeclaration;
+class DeclaredStylePropertyMap;
+class StylePropertyMap;
+class StyleRuleCSSStyleDeclaration;
+class StyleRuleNestedDeclarations;
+
+class CSSNestedDeclarations final : public CSSRule, public CanMakeWeakPtr<CSSNestedDeclarations> {
+public:
+    static Ref<CSSNestedDeclarations> create(StyleRuleNestedDeclarations& rule, CSSStyleSheet* sheet) { return adoptRef(* new CSSNestedDeclarations(rule, sheet)); };
+
+    virtual ~CSSNestedDeclarations();
+
+    WEBCORE_EXPORT CSSStyleDeclaration& style();
+
+private:
+    CSSNestedDeclarations(StyleRuleNestedDeclarations&, CSSStyleSheet*);
+
+    String cssText() const final;
+    String cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const;
+
+    void reattach(StyleRuleBase&) final;
+    StyleRuleType styleRuleType() const final { return StyleRuleType::NestedDeclarations; }
+
+    Ref<StyleRuleNestedDeclarations> m_styleRule;
+    RefPtr<StyleRuleCSSStyleDeclaration> m_propertiesCSSOMWrapper;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_RULE(CSSNestedDeclarations, StyleRuleType::NestedDeclarations)

--- a/Source/WebCore/css/CSSNestedDeclarations.idl
+++ b/Source/WebCore/css/CSSNestedDeclarations.idl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+// https://drafts.csswg.org/css-nesting/#the-cssnestrule
+
+typedef USVString CSSOMString;
+
+[
+    Exposed=Window
+] interface CSSNestedDeclarations: CSSRule {
+    [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
+};

--- a/Source/WebCore/css/CSSShapeSegmentValue.cpp
+++ b/Source/WebCore/css/CSSShapeSegmentValue.cpp
@@ -28,6 +28,7 @@
 #include "CSSShapeSegmentValue.h"
 
 #include "BasicShapes.h"
+#include "CSSPrimitiveValue.h"
 #include "CSSPrimitiveValueMappings.h"
 #include "CSSValuePair.h"
 #include "CalculationValue.h"

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -33,6 +33,7 @@ class StylePropertyMap;
 class StyleRuleCSSStyleDeclaration;
 class StyleRule;
 class StyleRuleWithNesting;
+class StyleRuleCSSStyleDeclaration;
 
 class CSSStyleRule final : public CSSRule, public CanMakeWeakPtr<CSSStyleRule> {
 public:

--- a/Source/WebCore/css/CSSTimingFunctionValue.h
+++ b/Source/WebCore/css/CSSTimingFunctionValue.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveValue.h"
 #include "CSSValue.h"
 #include "TimingFunction.h"
 

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -35,6 +35,7 @@
 #include "CSSLayerStatementRule.h"
 #include "CSSMediaRule.h"
 #include "CSSNamespaceRule.h"
+#include "CSSNestedDeclarations.h"
 #include "CSSPageRule.h"
 #include "CSSPropertyRule.h"
 #include "CSSScopeRule.h"
@@ -88,6 +89,8 @@ template<typename Visitor> constexpr decltype(auto) StyleRuleBase::visitDerived(
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRule>(*this));
     case StyleRuleType::StyleWithNesting:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleWithNesting>(*this));
+    case StyleRuleType::NestedDeclarations:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleNestedDeclarations>(*this));
     case StyleRuleType::Page:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRulePage>(*this));
     case StyleRuleType::FontFace:
@@ -169,6 +172,9 @@ Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet* parentSheet, CSSRu
         },
         [&](StyleRuleWithNesting& rule) -> Ref<CSSRule> {
             return CSSStyleRule::create(rule, parentSheet);
+        },
+        [&](StyleRuleNestedDeclarations& rule) -> Ref<CSSRule> {
+            return CSSNestedDeclarations::create(rule, parentSheet);
         },
         [&](StyleRulePage& rule) -> Ref<CSSRule> {
             return CSSPageRule::create(rule, parentSheet);
@@ -398,6 +404,19 @@ StyleRulePage::StyleRulePage(const StyleRulePage& o)
     , m_properties(o.m_properties->mutableCopy())
     , m_selectorList(o.m_selectorList)
 {
+}
+
+StyleRuleNestedDeclarations::StyleRuleNestedDeclarations(Ref<StyleProperties>&& properties)
+    : StyleRule(WTFMove(properties), false, { })
+{
+    setType(StyleRuleType::NestedDeclarations);
+}
+
+String StyleRuleNestedDeclarations::debugDescription() const
+{
+    StringBuilder builder;
+    builder.append("StyleRuleNestedDeclarations ["_s, properties().asText(), ']');
+    return builder.toString();
 }
 
 StyleRulePage::~StyleRulePage() = default;

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -70,6 +70,7 @@ public:
     bool isPageRule() const { return type() == StyleRuleType::Page; }
     bool isStyleRule() const { return type() == StyleRuleType::Style || type() == StyleRuleType::StyleWithNesting; }
     bool isStyleRuleWithNesting() const { return type() == StyleRuleType::StyleWithNesting; }
+    bool isNestedDeclarationsRule() const { return type() == StyleRuleType::NestedDeclarations; }
     bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container || type() == StyleRuleType::Scope || type() == StyleRuleType::StartingStyle; }
     bool isSupportsRule() const { return type() == StyleRuleType::Supports; }
     bool isImportRule() const { return type() == StyleRuleType::Import; }
@@ -186,6 +187,18 @@ private:
 
     Vector<Ref<StyleRuleBase>> m_nestedRules;
     CSSSelectorList m_originalSelectorList;
+};
+
+class StyleRuleNestedDeclarations final : public StyleRule {
+public:
+    static Ref<StyleRuleNestedDeclarations> create(Ref<StyleProperties>&& properties) { return adoptRef(*new StyleRuleNestedDeclarations(WTFMove(properties))); }
+    ~StyleRuleNestedDeclarations() = default;
+    Ref<StyleRuleNestedDeclarations> copy() const { return adoptRef(*new StyleRuleNestedDeclarations(*this)); }
+
+    String debugDescription() const;
+private:
+    explicit StyleRuleNestedDeclarations(Ref<StyleProperties>&&);
+    StyleRuleNestedDeclarations(const StyleRuleNestedDeclarations&) = default;
 };
 
 class StyleRuleFontFace final : public StyleRuleBase {
@@ -514,6 +527,10 @@ SPECIALIZE_TYPE_TRAITS_END()
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleWithNesting)
     static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isStyleRuleWithNesting(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleNestedDeclarations)
+    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isNestedDeclarationsRule(); }
 SPECIALIZE_TYPE_TRAITS_END()
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleGroup)

--- a/Source/WebCore/css/StyleRuleType.h
+++ b/Source/WebCore/css/StyleRuleType.h
@@ -55,6 +55,7 @@ enum class StyleRuleType : uint8_t {
     StyleWithNesting,
     Scope,
     StartingStyle,
+    NestedDeclarations
 };
 
 static constexpr auto firstUnexposedStyleRuleType = StyleRuleType::ViewTransition;

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -526,7 +526,7 @@ bool StyleSheetContents::traverseRules(const Function<bool(const StyleRuleBase&)
     for (auto& importRule : m_importRules) {
         if (handler(importRule))
             return true;
-        auto* importedStyleSheet = importRule->styleSheet();
+        RefPtr importedStyleSheet = importRule->styleSheet();
         if (importedStyleSheet && importedStyleSheet->traverseRules(handler))
             return true;
     }
@@ -555,6 +555,8 @@ bool StyleSheetContents::traverseSubresources(const Function<bool(const CachedRe
             return uncheckedDowncast<StyleRule>(rule).properties().traverseSubresources(handler);
         case StyleRuleType::StyleWithNesting:
             return uncheckedDowncast<StyleRuleWithNesting>(rule).properties().traverseSubresources(handler);
+        case StyleRuleType::NestedDeclarations:
+            return uncheckedDowncast<StyleRuleNestedDeclarations>(rule).properties().traverseSubresources(handler);
         case StyleRuleType::FontFace:
             return uncheckedDowncast<StyleRuleFontFace>(rule).properties().traverseSubresources(handler);
         case StyleRuleType::Import:
@@ -632,6 +634,8 @@ bool StyleSheetContents::mayDependOnBaseURL() const
             return uncheckedDowncast<StyleRule>(rule).properties().mayDependOnBaseURL();
         case StyleRuleType::StyleWithNesting:
             return uncheckedDowncast<StyleRuleWithNesting>(rule).properties().mayDependOnBaseURL();
+        case StyleRuleType::NestedDeclarations:
+            return uncheckedDowncast<StyleRule>(rule).properties().mayDependOnBaseURL();
         case StyleRuleType::FontFace:
             return uncheckedDowncast<StyleRuleFontFace>(rule).properties().mayDependOnBaseURL();
         case StyleRuleType::Import:

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -32,6 +32,7 @@
 #include "CSSPrimitiveValue.h"
 #include "CalculationCategory.h"
 #include "CalculationExecutor.h"
+#include "RenderStyle.h"
 #include "RenderStyleInlines.h"
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -40,6 +40,7 @@ class Element;
 class ImmutableStyleProperties;
 class MutableStyleProperties;
 class StyleRuleBase;
+class StyleRuleNestedDeclarations;
 class StyleRuleKeyframe;
 class StyleSheetContents;
 

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -1,5 +1,5 @@
 // Copyright 2014 The Chromium Authors. All rights reserved.
-// Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+// Copyright (C) 2016-2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -114,6 +114,8 @@ public:
 
     static IsImportant consumeTrailingImportantAndWhitespace(CSSParserTokenRange&);
 
+    static RefPtr<StyleRuleNestedDeclarations> parseNestedDeclarations(const CSSParserContext&, const String&);
+
     CSSTokenizer* tokenizer() const { return m_tokenizer.get(); }
 
 private:
@@ -184,7 +186,7 @@ private:
 
     RefPtr<StyleSheetContents> protectedStyleSheet() const;
 
-    Ref<StyleRuleBase> createNestingParentRule();
+    Ref<StyleRuleBase> createNestedDeclarationsRule();
     void runInNewNestingContext(auto&& run);
     NestingContext& topContext()
     {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -48,6 +48,7 @@
 #include "CSSPropertyParserConsumer+Length.h"
 #include "CSSPropertyParserConsumer+LengthDefinitions.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
+#include "CSSPropertyParserConsumer+MetaResolver.h"
 #include "CSSPropertyParserConsumer+Number.h"
 #include "CSSPropertyParserConsumer+NumberDefinitions.h"
 #include "CSSPropertyParserConsumer+Percent.h"
@@ -59,6 +60,7 @@
 #include "CSSPropertyParserConsumer+String.h"
 #include "CSSPropertyParserConsumer+URL.h"
 #include "CSSPropertyParserConsumer+UnevaluatedCalc.h"
+#include "CSSValue.h"
 #include "CSSValueList.h"
 #include "StyleImage.h"
 #include <wtf/SortedArrayMap.h>
@@ -1025,7 +1027,7 @@ static RefPtr<CSSPrimitiveValue> consumeImageSetResolutionOrTypeFunction(CSSPars
             return CSSPrimitiveValue::create(typeFunction.value);
         },
         [&](const auto& resolution) -> RefPtr<CSSPrimitiveValue> {
-            return CSSPrimitiveValueResolverBase::resolve(resolution, { }, options);
+            return CSSPrimitiveValueResolverBase::resolve(resolution, CSSCalcSymbolTable { }, options);
         }
     );
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.h
@@ -32,6 +32,7 @@ namespace WebCore {
 class CSSParserTokenRange;
 class CSSValue;
 struct CSSParserContext;
+class CSSValue;
 
 namespace CSSPropertyParserHelpers {
 

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -120,6 +120,7 @@ static RuleFlatteningStrategy flatteningStrategyForStyleRuleType(StyleRuleType s
     case StyleRuleType::FontPaletteValues:
     case StyleRuleType::Property:
     case StyleRuleType::ViewTransition:
+    case StyleRuleType::NestedDeclarations:
         // These rule types do not contain rules that apply directly to an element (i.e. these rules should not appear
         // in the Styles details sidebar of the Elements tab in Web Inspector).
         return RuleFlatteningStrategy::Ignore;

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -119,6 +119,11 @@ void RuleSetBuilder::addChildRule(Ref<StyleRuleBase> rule)
             addStyleRule(uncheckedDowncast<StyleRule>(rule));
         return;
 
+    case StyleRuleType::NestedDeclarations:
+        if (m_ruleSet)
+            addStyleRule(uncheckedDowncast<StyleRuleNestedDeclarations>(rule));
+        return;
+
     case StyleRuleType::Scope: {
         auto scopeRule = uncheckedDowncast<StyleRuleScope>(WTFMove(rule));
         auto previousScopeIdentifier = m_currentScopeIdentifier;
@@ -310,6 +315,14 @@ void RuleSetBuilder::addStyleRule(StyleRuleWithNesting& rule)
 
 void RuleSetBuilder::addStyleRule(const StyleRule& rule)
 {
+    addStyleRuleWithSelectorList(rule.selectorList(), rule);
+}
+
+void RuleSetBuilder::addStyleRule(StyleRuleNestedDeclarations& rule)
+{
+    ASSERT(m_selectorListStack.size());
+    auto selectorList =  *m_selectorListStack.last();
+    rule.wrapperAdoptSelectorList(WTFMove(selectorList));
     addStyleRuleWithSelectorList(rule.selectorList(), rule);
 }
 

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -41,6 +41,7 @@ private:
     RuleSetBuilder(const MQ::MediaQueryEvaluator&);
 
     void addStyleRule(StyleRuleWithNesting&);
+    void addStyleRule(StyleRuleNestedDeclarations&);
     void addRulesFromSheetContents(const StyleSheetContents&);
     void addChildRules(const Vector<Ref<StyleRuleBase>>&);
     void addChildRule(Ref<StyleRuleBase>);


### PR DESCRIPTION
#### f0fd3ce9cf0c9319184d3f49ce6752864dece7ca
<pre>
[css-nesting] New behavior for interleaved declarations and rules
<a href="https://bugs.webkit.org/show_bug.cgi?id=275365">https://bugs.webkit.org/show_bug.cgi?id=275365</a>
<a href="https://rdar.apple.com/130094168">rdar://130094168</a>

Reviewed by Tim Nguyen.

<a href="https://github.com/w3c/csswg-drafts/issues/10234">https://github.com/w3c/csswg-drafts/issues/10234</a>

Before this CSSWG resolution, any declaration inside a style rule
(whatever its position relative to other rules),
would be shifted up at the top of the rule
to be able to represent a style rule with a single leading block of declarations.
This patch implements the new resolved behavior so the order of interleaved declarations is respected
during cascade.

<a href="https://drafts.csswg.org/css-nesting/#the-cssnestrule">https://drafts.csswg.org/css-nesting/#the-cssnestrule</a>

This patch introduces a new StyleRuleNestedDeclarations class
to be able to store a block of declarations in-between rules and fit with the already existing
RuleData/RuleSet mechanism.
Its CSSOM representation (CSSNestedDeclarations) is purposedly not serialized
as a rule in the CSSOM but like a list of declarations.

The CSSOM insertRule() functions (on CSSStyleRule/CSSGroupingRule)
are modified to allow inserting block of declarations.
<a href="https://github.com/w3c/csswg-drafts/issues/10520">https://github.com/w3c/csswg-drafts/issues/10520</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/mixed-declarations-rules-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/mixed-declarations-rules.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-declarations-matching-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity.html:  Manual sync from WPT
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSCSSRuleCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/css/CSSGradientValue.h:
* Source/WebCore/css/CSSNestedDeclarations.cpp: Added.
(WebCore::CSSNestedDeclarations::CSSNestedDeclarations):
(WebCore::CSSNestedDeclarations::style):
(WebCore::CSSNestedDeclarations::cssText const):
(WebCore::CSSNestedDeclarations::reattach):
* Source/WebCore/css/CSSNestedDeclarations.h: Added.
* Source/WebCore/css/CSSNestedDeclarations.idl: Added.
* Source/WebCore/css/CSSShapeSegmentValue.cpp:
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::insertRule):
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::visitDerived):
(WebCore::StyleRuleBase::createCSSOMWrapper const):
(WebCore::StyleRuleNestedDeclarations::StyleRuleNestedDeclarations):
(WebCore::StyleRuleNestedDeclarations::debugDescription const):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::isStyleRuleNestedDeclarations const):
(isType):
* Source/WebCore/css/StyleRuleType.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::traverseRules const):
(WebCore::StyleSheetContents::traverseSubresources const):
(WebCore::StyleSheetContents::mayDependOnBaseURL const):
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.h:
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::parseNestedDeclarations):
(WebCore::CSSParserImpl::createNestedDeclarationsRule):
(WebCore::CSSParserImpl::consumeNestedGroupRules):
(WebCore::CSSParserImpl::consumeBlockContent):
(WebCore::CSSParserImpl::createNestingParentRule): Deleted.
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
(WebCore::CSSPropertyParserHelpers::consumeImageSetResolutionOrTypeFunction):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::flatteningStrategyForStyleRuleType):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):
(WebCore::Style::RuleSetBuilder::addStyleRule):
* Source/WebCore/style/RuleSetBuilder.h:

Canonical link: <a href="https://commits.webkit.org/283188@main">https://commits.webkit.org/283188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b985a211906e59fce3f5799b1428c13d8e54bd99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69535 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16118 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16398 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52607 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11176 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68576 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/56697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33232 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38134 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14075 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14994 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/14417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71240 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13868 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56762 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60193 "Found 1 new API test failure: /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14438 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7818 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1468 "Passed tests") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/40690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41766 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41510 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->