### PR TITLE
Remove webpushd debug mode logging

### DIFF
--- a/Source/WebKit/Shared/WebPushDaemonConstants.h
+++ b/Source/WebKit/Shared/WebPushDaemonConstants.h
@@ -37,7 +37,6 @@ constexpr unsigned maxSilentPushCount = 3;
 constexpr auto protocolVersionKey = "protocol version"_s;
 constexpr uint64_t protocolVersionValue = 3;
 constexpr auto protocolEncodedMessageKey = "encoded message"_s;
-constexpr auto protocolDebugMessageKey = "debug message"_s;
 
 // FIXME: ConnectionToMachService traits requires we have a message type, so keep this placeholder here
 // until we can remove that requirement.

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -81,15 +81,9 @@ public:
     const String& pushPartitionString() const { return m_pushPartitionString; }
     std::optional<WTF::UUID> dataStoreIdentifier() const { return m_dataStoreIdentifier; }
 
-    bool debugModeIsEnabled() const { return m_debugModeEnabled; }
-    void setDebugModeIsEnabled(bool);
-
     bool useMockBundlesForTesting() const { return m_useMockBundlesForTesting; }
 
     void connectionClosed();
-
-    void broadcastDebugMessage(const String&);
-    void sendDebugMessage(const String&);
 
     void didReceiveMessageWithReplyHandler(IPC::Decoder&, Function<void(UniqueRef<IPC::Encoder>&&)>&&) override;
 

--- a/Source/WebKit/webpushd/PushClientConnection.messages.in
+++ b/Source/WebKit/webpushd/PushClientConnection.messages.in
@@ -25,7 +25,6 @@
 messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     SetPushAndNotificationsEnabledForOrigin(String originString, bool enabled) -> ()
     GetPendingPushMessages() -> (Vector<WebKit::WebPushMessage> messages)
-    SetDebugModeIsEnabled(bool enabled)
     UpdateConnectionConfiguration(WebKit::WebPushD::WebPushDaemonConnectionConfiguration configuration)
     InjectPushMessageForTesting(WebKit::WebPushD::PushMessageForTesting message) -> (String error)
     InjectEncryptedPushMessageForTesting(String encryptedMessage) -> (bool injected)

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -88,12 +88,11 @@ void PushClientConnection::setHostAppAuditTokenData(const Vector<uint8_t>& token
     }
 
     m_hostAppAuditToken = WTFMove(token);
-    WebPushDaemon::singleton().broadcastAllConnectionIdentities();
 }
 
 void PushClientConnection::getPushTopicsForTesting(CompletionHandler<void(Vector<String>, Vector<String>)>&& completionHandler)
 {
-    WebPushDaemon::singleton().getPushTopicsForTesting(WTFMove(completionHandler));
+    WebPushDaemon::singleton().getPushTopicsForTesting(*this, WTFMove(completionHandler));
 }
 
 WebCore::PushSubscriptionSetIdentifier PushClientConnection::subscriptionSetIdentifier()
@@ -165,37 +164,8 @@ bool PushClientConnection::hostHasEntitlement(ASCIILiteral entitlement)
 #endif
 }
 
-void PushClientConnection::setDebugModeIsEnabled(bool enabled)
-{
-    if (enabled == m_debugModeEnabled)
-        return;
-
-    m_debugModeEnabled = enabled;
-    broadcastDebugMessage(makeString("Turned Debug Mode "_s, m_debugModeEnabled ? "on"_s : "off"_s));
-}
-
-void PushClientConnection::broadcastDebugMessage(const String& message)
-{
-    String messageIdentifier;
-    auto signingIdentifier = hostAppCodeSigningIdentifier();
-    if (signingIdentifier.isEmpty())
-        messageIdentifier = makeString("[(0x"_s, hex(reinterpret_cast<uint64_t>(m_xpcConnection.get()), WTF::HexConversionMode::Lowercase), ") ("_s, identifier().toUInt64(), " )] "_s);
-    else
-        messageIdentifier = makeString('[', signingIdentifier, " ("_s, identifier().toUInt64(), ")] "_s);
-
-    WebPushDaemon::singleton().broadcastDebugMessage(makeString(messageIdentifier, message));
-}
-
-void PushClientConnection::sendDebugMessage(const String& message)
-{
-    auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
-    xpc_dictionary_set_string(dictionary.get(), WebKit::WebPushD::protocolDebugMessageKey, message.utf8().data());
-    xpc_connection_send_message(m_xpcConnection.get(), dictionary.get());
-}
-
 void PushClientConnection::connectionClosed()
 {
-    broadcastDebugMessage("Connection closed"_s);
 
     RELEASE_ASSERT(m_xpcConnection);
     m_xpcConnection = nullptr;
@@ -253,7 +223,7 @@ void PushClientConnection::removePushSubscriptionsForOrigin(WebCore::SecurityOri
 
 void PushClientConnection::setPublicTokenForTesting(const String& publicToken, CompletionHandler<void()>&& replySender)
 {
-    WebPushDaemon::singleton().setPublicTokenForTesting(publicToken, WTFMove(replySender));
+    WebPushDaemon::singleton().setPublicTokenForTesting(*this, publicToken, WTFMove(replySender));
 }
 
 void PushClientConnection::getPushPermissionState(URL&&, CompletionHandler<void(const Expected<uint8_t, WebCore::ExceptionData>&)>&& replySender)

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -79,17 +79,14 @@ public:
     void injectPushMessageForTesting(PushClientConnection&, PushMessageForTesting&&, CompletionHandler<void(const String&)>&&);
     void injectEncryptedPushMessageForTesting(PushClientConnection&, const String&, CompletionHandler<void(bool)>&&);
     void getPendingPushMessages(PushClientConnection&, CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender);
-    void getPushTopicsForTesting(CompletionHandler<void(Vector<String>, Vector<String>)>&&);
+    void getPushTopicsForTesting(PushClientConnection&, CompletionHandler<void(Vector<String>, Vector<String>)>&&);
     void subscribeToPushService(PushClientConnection&, const URL& scopeURL, const Vector<uint8_t>& applicationServerKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&& replySender);
     void unsubscribeFromPushService(PushClientConnection&, const URL& scopeURL, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&& replySender);
     void getPushSubscription(PushClientConnection&, const URL& scopeURL, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&& replySender);
     void incrementSilentPushCount(PushClientConnection&, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
     void removeAllPushSubscriptions(PushClientConnection&, CompletionHandler<void(unsigned)>&&);
     void removePushSubscriptionsForOrigin(PushClientConnection&, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
-    void setPublicTokenForTesting(const String& publicToken, CompletionHandler<void()>&&);
-
-    void broadcastDebugMessage(const String&);
-    void broadcastAllConnectionIdentities();
+    void setPublicTokenForTesting(PushClientConnection&, const String& publicToken, CompletionHandler<void()>&&);
 
 private:
     WebPushDaemon();

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -154,8 +154,8 @@ void Connection::sendPushMessage()
 
 void Connection::startDebugStreamAction()
 {
-    sendWithoutUsingIPCConnection(Messages::PushClientConnection::SetDebugModeIsEnabled(true));
-    printf("Now streaming debug messages\n");
+    printf("Now streaming debug messages via: log stream --debug --info --process webpushd");
+    system("log stream --debug --info --process webpushd");
 }
 
 void Connection::sendAuditToken()


### PR DESCRIPTION
#### 6830b0ce039785115a687f151004ec19c9cc6ad3
<pre>
Remove webpushd debug mode logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=276189">https://bugs.webkit.org/show_bug.cgi?id=276189</a>
<a href="https://rdar.apple.com/131070043">rdar://131070043</a>

Reviewed by Sihui Liu.

Remove broadcastDebugMessage and related IPCs from webpushd. They aren&apos;t really used. Log to the
regular system log instead.

* Source/WebKit/Shared/WebPushDaemonConstants.h:
* Source/WebKit/webpushd/PushClientConnection.h:
(WebPushD::PushClientConnection::debugModeIsEnabled const): Deleted.
* Source/WebKit/webpushd/PushClientConnection.messages.in:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::setHostAppAuditTokenData):
(WebPushD::PushClientConnection::getPushTopicsForTesting):
(WebPushD::PushClientConnection::connectionClosed):
(WebPushD::PushClientConnection::setPublicTokenForTesting):
(WebPushD::PushClientConnection::setDebugModeIsEnabled): Deleted.
(WebPushD::PushClientConnection::broadcastDebugMessage): Deleted.
(WebPushD::PushClientConnection::sendDebugMessage): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::connectionAdded):
(WebPushD::WebPushDaemon::injectPushMessageForTesting):
(WebPushD::WebPushDaemon::injectEncryptedPushMessageForTesting):
(WebPushD::WebPushDaemon::notifyClientPushMessageIsAvailable):
(WebPushD::WebPushDaemon::getPendingPushMessages):
(WebPushD::WebPushDaemon::getPushTopicsForTesting):
(WebPushD::WebPushDaemon::setPublicTokenForTesting):
(WebPushD::WebPushDaemon::broadcastDebugMessage): Deleted.
(WebPushD::WebPushDaemon::broadcastAllConnectionIdentities): Deleted.
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::startDebugStreamAction):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::TEST(WebPushD, BasicCommunication)):

Canonical link: <a href="https://commits.webkit.org/280694@main">https://commits.webkit.org/280694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/186056228106cd28e77128c38a2de0e11cc9332d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60787 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7609 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46293 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5357 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27153 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31038 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6676 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6614 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52999 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62467 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53554 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53623 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12675 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/912 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32323 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33408 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34493 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->