### PR TITLE
Add document leak tests for Geolocation callbacks

### DIFF
--- a/LayoutTests/http/tests/geolocation/geolocation-get-current-position-does-not-leak.https-expected.txt
+++ b/LayoutTests/http/tests/geolocation/geolocation-get-current-position-does-not-leak.https-expected.txt
@@ -1,0 +1,10 @@
+Tests that navigator.geolocation.getCurrentPosition() does not leak the document object.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html
+++ b/LayoutTests/http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Tests that navigator.geolocation.getCurrentPosition() does not leak the document object.");
+jsTestIsAsync = true;
+
+var framesToCreate = 20;
+var allFrames = new Array(framesToCreate);
+
+for (let i = 0; i < framesToCreate; ++i) {
+    let iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    allFrames[i] = iframe;
+}
+
+function iframeForMessage(message)
+{
+    return allFrames.find(frame => frame.contentWindow === message.source);
+}
+
+var failCount = 0;
+function iFrameLeaked()
+{
+    if (++failCount >= framesToCreate) {
+        testFailed("All iframe documents leaked.");
+        finishJSTest();
+    }
+}
+
+function iframeLoaded(iframe)
+{
+    let frameDocumentID = internals.documentIdentifier(iframe.contentWindow.document);
+    let checkCount = 0;
+    iframe.addEventListener("load", () => {
+        let handle = setInterval(() => {
+            gc();
+            if (!internals.isDocumentAlive(frameDocumentID)) {
+                clearInterval(handle);
+                testPassed("The iframe document didn't leak.");
+                finishJSTest();
+            }
+            if (++checkCount > 5) {
+                clearInterval(handle);
+                iframeLeaked();
+            }
+        }, 10);
+    });
+
+    iframe.src = "about:blank";
+}
+
+onload = () => {
+    if (!(window.internals && window.testRunner)) {
+        testFailed("Test requires internals and testRunner.");
+        finishJSTest();
+    }
+
+    window.addEventListener("message", message => iframeLoaded(iframeForMessage(message)));
+    allFrames.forEach(frame => frame.src = "https://127.0.0.1:8443/geolocation/resources/geolocation-get-position-callback.html");
+};
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/geolocation/geolocation-watch-position-does-not-leak.https-expected.txt
+++ b/LayoutTests/http/tests/geolocation/geolocation-watch-position-does-not-leak.https-expected.txt
@@ -1,0 +1,10 @@
+Tests that navigator.geolocation.watchPosition() does not leak the document object.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/geolocation/geolocation-watch-position-does-not-leak.https.html
+++ b/LayoutTests/http/tests/geolocation/geolocation-watch-position-does-not-leak.https.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Tests that navigator.geolocation.watchPosition() does not leak the document object.");
+jsTestIsAsync = true;
+
+var framesToCreate = 20;
+var allFrames = new Array(framesToCreate);
+
+for (let i = 0; i < framesToCreate; ++i) {
+    let iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    allFrames[i] = iframe;
+}
+
+function iframeForMessage(message)
+{
+    return allFrames.find(frame => frame.contentWindow === message.source);
+}
+
+var failCount = 0;
+function iFrameLeaked()
+{
+    if (++failCount >= framesToCreate) {
+        testFailed("All iframe documents leaked.");
+        finishJSTest();
+    }
+}
+
+function iframeLoaded(iframe)
+{
+    let frameDocumentID = internals.documentIdentifier(iframe.contentWindow.document);
+    let checkCount = 0;
+    iframe.addEventListener("load", () => {
+        let handle = setInterval(() => {
+            gc();
+            if (!internals.isDocumentAlive(frameDocumentID)) {
+                clearInterval(handle);
+                testPassed("The iframe document didn't leak.");
+                finishJSTest();
+            }
+            if (++checkCount > 5) {
+                clearInterval(handle);
+                iframeLeaked();
+            }
+        }, 10);
+    });
+
+    iframe.src = "about:blank";
+}
+
+onload = () => {
+    if (!(window.internals && window.testRunner)) {
+        testFailed("Test requires internals and testRunner.");
+        finishJSTest();
+    }
+
+    window.addEventListener("message", message => iframeLoaded(iframeForMessage(message)));
+    allFrames.forEach(frame => frame.src = "https://127.0.0.1:8443/geolocation/resources/geolocation-watch-position-callback.html");
+};
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/geolocation/resources/geolocation-get-position-callback.html
+++ b/LayoutTests/http/tests/geolocation/resources/geolocation-get-position-callback.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+function error(e)
+{
+    let d = document;
+    let p = d.createElement("p");
+    p.innerText = `Error. Failed to get position: ${e.code}: ${e.message}`;
+    d.body.appendChild(p);
+}
+
+function success(position)
+{
+    let d = document;
+    let p = d.createElement("p");
+    p.innerText = `Success! Latitude: ${position.latitude}, Longitude: ${position.longitude}, Accuracy: ${position.accuracy}.`;
+    d.body.appendChild(p);
+}
+
+onload = () => {
+    navigator.geolocation.getCurrentPosition(success, error, { enableHighAccuracy: true, timeout: 1000 });
+    parent.postMessage("iframeLoaded");
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/geolocation/resources/geolocation-watch-position-callback.html
+++ b/LayoutTests/http/tests/geolocation/resources/geolocation-watch-position-callback.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+function error(e)
+{
+    let d = document;
+    let p = d.createElement("p");
+    p.innerText = `Error. Failed to get position: ${e.code}: ${e.message}`;
+    d.body.appendChild(p);
+}
+
+function success(position)
+{
+    let d = document;
+    let p = d.createElement("p");
+    p.innerText = `Success! Latitude: ${position.latitude}, Longitude: ${position.longitude}, Accuracy: ${position.accuracy}.`;
+    d.body.appendChild(p);
+}
+
+onload = () => {
+    navigator.geolocation.watchPosition(success, error, { enableHighAccuracy: true, timeout: 1000 });
+    parent.postMessage("iframeLoaded");
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 968a81c0077cca90309f9aee9bab959597bd4f90
<pre>
Add document leak tests for Geolocation callbacks
<a href="https://bugs.webkit.org/show_bug.cgi?id=276191">https://bugs.webkit.org/show_bug.cgi?id=276191</a>
<a href="https://rdar.apple.com/131057488">rdar://131057488</a>

Reviewed by Ben Nham.

Add tests for navigator.geolocation callbacks to ensure they do not leak
Documents when capturing the document object.

Since the GC is conservative the test robustness is improved by creating
20 iframes and checking that at least one of them does not cause leaks.
It&apos;s possible that the GC sees something pointer-like to the Document
object and therefore keeps it alive. By spamming iframes we should be
able to convince it to collect at least one document, assuming it isn&apos;t
leaked via a reference cycle.

* LayoutTests/http/tests/geolocation/geolocation-get-current-position-does-not-leak.https-expected.txt: Added.
* LayoutTests/http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html: Added.
* LayoutTests/http/tests/geolocation/geolocation-watch-position-does-not-leak.https-expected.txt: Added.
* LayoutTests/http/tests/geolocation/geolocation-watch-position-does-not-leak.https.html: Added.
* LayoutTests/http/tests/geolocation/resources/geolocation-get-position-callback.html: Added.
* LayoutTests/http/tests/geolocation/resources/geolocation-watch-position-callback.html: Added.

Canonical link: <a href="https://commits.webkit.org/280650@main">https://commits.webkit.org/280650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e547e71cc3daba6f2e97ba2e3937eaf80e9606a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7655 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7845 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46321 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5387 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27181 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6717 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6660 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/6987 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62513 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1125 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7078 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49440 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12643 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/946 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33454 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/34539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->