### PR TITLE
[run-benchmark] Add motionmark1.3 plan variant that enforces 15fps for low-end devices

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
@@ -55,6 +55,8 @@ class BenchmarkBuilder(object):
                     self._apply_patch(self._plan['signpost_patch'])
                 else:
                     _log.warning('Signposts are enabled but a signpost patch was not found in the test plan. Skipping.')
+            for extra_patch in self._plan.get('extra_patches', []):
+                self._apply_patch(extra_patch)
             return self._web_root
         except Exception:
             self._clean()

--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
@@ -79,6 +79,12 @@ class BenchmarkRunner(object):
             with open(plan_file, 'r') as fp:
                 plan_name = os.path.split(os.path.splitext(plan_file)[0])[1]
                 plan = json.load(fp)
+                if 'import_plan_file' in plan:
+                    imported_plan_file = BenchmarkRunner._find_plan_file(plan.pop('import_plan_file'))
+                    with open(imported_plan_file, 'r') as ifp:
+                        imported_plan = json.load(ifp)
+                    imported_plan.update(plan)
+                    plan = imported_plan
                 return plan_name, plan
         except IOError as error:
             _log.error('Can not open plan file: {plan_file} - Error {error}'.format(plan_file=plan_file, error=error))

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3-15FPS.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3-15FPS.patch
@@ -1,0 +1,46 @@
+diff --git a/resources/runner/motionmark.js b/resources/runner/motionmark.js
+index a2ea114..14a9cba 100644
+--- a/resources/runner/motionmark.js
++++ b/resources/runner/motionmark.js
+@@ -477,8 +477,11 @@ window.benchmarkController = {
+         "warmup-length": 2000,
+         "warmup-frame-count": 30,
+         "first-frame-minimum-length": 0,
+-        "system-frame-rate": 60,
+-        "frame-rate": 60,
++        // Running with a target of 15FPS allows low-end devices (like the RPi)
++        // to get scores around 100-600 instead of 1-6 and that (bigger scores)
++        // is really useful for performance regression tracking.
++        "system-frame-rate": 15,
++        "frame-rate": 15,
+     },
+ 
+     initialize: async function()
+@@ -493,11 +496,12 @@ window.benchmarkController = {
+         this._startButton.disabled = true;
+         this._startButton.textContent = Strings.text.determininingFrameRate;
+ 
+-        let targetFrameRate;
++        let targetFrameRate = this.benchmarkDefaultParameters["frame-rate"];
++        /* Do no autodetect the frame-rate, use the one from benchmarkDefaultParameters.
+         try {
+             targetFrameRate = await benchmarkController.determineFrameRate();
+         } catch (e) {
+-        }
++        }*/
+         this.frameRateDeterminationComplete(targetFrameRate);
+     },
+     
+diff --git a/resources/strings.js b/resources/strings.js
+index c82e047..45d7771 100644
+--- a/resources/strings.js
++++ b/resources/strings.js
+@@ -23,7 +23,7 @@
+  * THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ var Strings = {
+-    version: "1.3",
++    version: "1.3-15fps",
+     text: {
+         testName: "Test Name",
+         score: "Score",

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3-15fps.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3-15fps.plan
@@ -1,0 +1,5 @@
+{
+    "import_plan_file": "motionmark1.3.plan",
+    "output_file": "motionmark1.3-15fps.result",
+    "extra_patches": ["data/patches/extra/MotionMark1.3-15FPS.patch"]
+}


### PR DESCRIPTION
#### 9a083c67ec38fa2f7e72bf42745b083b5b7db207
<pre>
[run-benchmark] Add motionmark1.3 plan variant that enforces 15fps for low-end devices
<a href="https://bugs.webkit.org/show_bug.cgi?id=276127">https://bugs.webkit.org/show_bug.cgi?id=276127</a>

Reviewed by Nikolas Zimmermann.

With the default MotionMark settings on low-end devices like the RPi4 the results
are so low (1-3 pts) that it is impossible to use this benchmark to performance
regression tracking.

This adds a variant of motionmark-1.3 with a target frame-rate of 15FPS, that
way on the RPi4 boards we can get scores around 100-600 which are much more useful
to track performance regressions.
We tested with 30FPS but that is still too much for this boards with MotionMark.

The animations on the screen also look better, you can clear see more complexity
in the animations even when you can see that that it animates with low FPS.

In order to avoid copying-pasting the whole plan itself this patch also introduces
a way of importing another plan inside a run-benchmark .plan file via the key
`import_plan_file` and also allows to apply an extra patch via the key `extra_patch`
that will be applied at the end of the patch process.

That allows to see more clearly what this plan changes on top of the default MotionMark
plan.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py:
(BenchmarkBuilder.__enter__):
* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner._load_plan_data):
* Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3-15FPS.patch: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3-15fps.plan: Added.
* Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py:
(BrowserPerfDashRunner._get_test_version_string): Include the imported plan into the hash-version calculation-

Canonical link: <a href="https://commits.webkit.org/280660@main">https://commits.webkit.org/280660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebd23047545d8fea4833d0317ecaa791ebd91e48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7651 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46317 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5384 "Passed tests") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59238 "Build is in progress. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7; Running apply-patch; Checked out pull request; Passed webkitperl tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34285 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27177 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/56734 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31067 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6707 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6656 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6977 "Found 1 new test failure: media/video-transformed.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62509 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53578 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1126 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53651 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/941 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8537 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32365 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33450 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34535 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33196 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->