### PR TITLE
Add validation to file-backed blob urls from WebContent

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-paste-attachment.html
+++ b/LayoutTests/editing/pasteboard/copy-paste-attachment.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html>
 <body>
 <div contenteditable="true" id="test1">This is a paragraph with an attachment

--- a/LayoutTests/fast/attachment/attachment-dom.html
+++ b/LayoutTests/fast/attachment/attachment-dom.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html>
 <head>
 <meta charset="utf-8">

--- a/LayoutTests/fast/attachment/attachment-folder-icon-expected.html
+++ b/LayoutTests/fast/attachment/attachment-folder-icon-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment title=" "></attachment>

--- a/LayoutTests/fast/attachment/attachment-icon-from-file-extension-expected.html
+++ b/LayoutTests/fast/attachment/attachment-icon-from-file-extension-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment></attachment>

--- a/LayoutTests/fast/attachment/attachment-label-highlight.html
+++ b/LayoutTests/fast/attachment/attachment-label-highlight.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html>
 <body>
 <script>

--- a/LayoutTests/fast/attachment/attachment-progress.html
+++ b/LayoutTests/fast/attachment/attachment-progress.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html>
 <body>
 <attachment progress="-1.5"></attachment>

--- a/LayoutTests/fast/attachment/attachment-select-on-click-inside-user-select-all.html
+++ b/LayoutTests/fast/attachment/attachment-select-on-click-inside-user-select-all.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html>
 <body onload="runTest()">
 <div style="-webkit-user-select: all;">text before <attachment id="attachment"></attachment> text after</div>

--- a/LayoutTests/fast/attachment/attachment-select-on-click.html
+++ b/LayoutTests/fast/attachment/attachment-select-on-click.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html>
 <body onload="runTest()">
 <div id="container">text before <attachment id="attachment"></attachment> text after</div>

--- a/LayoutTests/fast/attachment/attachment-subtitle.html
+++ b/LayoutTests/fast/attachment/attachment-subtitle.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html>
 <body>
 <attachment id="attachment" subtitle="1024 bytes"></attachment>

--- a/LayoutTests/fast/attachment/attachment-title.html
+++ b/LayoutTests/fast/attachment/attachment-title.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html>
 <body>
 <attachment id="attachment" title="overridden title" subtitle="1024 bytes"></attachment>

--- a/LayoutTests/fast/attachment/attachment-type-attribute-expected.html
+++ b/LayoutTests/fast/attachment/attachment-type-attribute-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment id="attachment" title="  "></attachment>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-dom.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-dom.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true allowTestOnlyIPC=true ] -->
 <html>
 <head>
 <meta charset="utf-8">

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-folder-icon-expected.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-folder-icon-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true allowTestOnlyIPC=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment title=" "></attachment>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-icon-from-file-extension-expected.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-icon-from-file-extension-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true allowTestOnlyIPC=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment></attachment>

--- a/LayoutTests/fast/attachment/mac/attachment-keynote-icon-expected.html
+++ b/LayoutTests/fast/attachment/mac/attachment-keynote-icon-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment></attachment>

--- a/LayoutTests/fast/attachment/mac/attachment-numbers-icon-expected.html
+++ b/LayoutTests/fast/attachment/mac/attachment-numbers-icon-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment></attachment>

--- a/LayoutTests/fast/attachment/mac/attachment-pages-icon-expected.html
+++ b/LayoutTests/fast/attachment/mac/attachment-pages-icon-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment></attachment>

--- a/LayoutTests/fast/attachment/mac/wide-attachment-type-attribute-expected.html
+++ b/LayoutTests/fast/attachment/mac/wide-attachment-type-attribute-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true allowTestOnlyIPC=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment id="attachment" title="  "></attachment>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate.html
@@ -1,16 +1,19 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">
 <script src="../../../resources/ui-helper.js"></script>
 <script>
-if (window.testRunner) {
-  testRunner.dumpAsText();
-  testRunner.setShouldLogDownloadCallbacks(true);
-  testRunner.waitUntilDownloadFinished();
-  testRunner.setShouldDownloadUndisplayableMIMETypes(true);
-  if (testRunner.setShouldDecideResponsePolicyAfterDelay)
-    testRunner.setShouldDecideResponsePolicyAfterDelay(true);
+onload = async () => {
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.setShouldLogDownloadCallbacks(true);
+        testRunner.waitUntilDownloadFinished();
+        testRunner.setShouldDownloadUndisplayableMIMETypes(true);
+        if (testRunner.setShouldDecideResponsePolicyAfterDelay)
+            testRunner.setShouldDecideResponsePolicyAfterDelay(true);
+    }
+    await runTest();
 }
 </script>
 </head>
@@ -27,14 +30,13 @@ function click(elmt)
     UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
-    file = internals.createFile("../../../resources/Ahem.otf");
+    file = await internals.asyncCreateFile("../../../resources/Ahem.otf");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
     click(link);
 }
-runTest();
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download.html
@@ -1,14 +1,17 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true  ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">
 <script src="../../../resources/ui-helper.js"></script>
 <script>
-if (window.testRunner) {
-  testRunner.dumpAsText();
-  testRunner.setShouldLogDownloadCallbacks(true);
-  testRunner.waitUntilDownloadFinished();
-  testRunner.setShouldDownloadUndisplayableMIMETypes(true);
+onload = async () => {
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.setShouldLogDownloadCallbacks(true);
+        testRunner.waitUntilDownloadFinished();
+        testRunner.setShouldDownloadUndisplayableMIMETypes(true);
+    }
+    await runTest();
 }
 </script>
 </head>
@@ -25,14 +28,13 @@ function click(elmt)
     UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
-    file = internals.createFile("../../../resources/Ahem.otf");
+    file = await internals.asyncCreateFile("../../../resources/Ahem.otf");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
     click(link);
 }
-runTest();
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-base-target-popup-not-allowed.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-base-target-popup-not-allowed.html
@@ -1,14 +1,17 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">
 <base target="_blank">
 <script src="../../../resources/ui-helper.js"></script>
 <script>
-if (window.testRunner) {
-  testRunner.dumpAsText();
-  testRunner.setShouldLogDownloadCallbacks(true);
-  testRunner.waitUntilDownloadFinished();
+onload = async () => {
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.setShouldLogDownloadCallbacks(true);
+        testRunner.waitUntilDownloadFinished();
+    }
+    await runTest();
 }
 </script>
 </head>
@@ -25,14 +28,13 @@ function click(elmt)
     UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
-    file = internals.createFile("../resources/abe.png");
+    file = await internals.asyncCreateFile("../resources/abe.png");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
     click(link);
 }
-runTest();
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target-popup-not-allowed.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target-popup-not-allowed.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-backslash.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-backslash.html
@@ -1,13 +1,16 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">
 <script src="../../../resources/ui-helper.js"></script>
 <script>
-if (window.testRunner) {
-  testRunner.dumpAsText();
-  testRunner.setShouldLogDownloadCallbacks(true);
-  testRunner.waitUntilDownloadFinished();
+onload = async () => {
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.setShouldLogDownloadCallbacks(true);
+        testRunner.waitUntilDownloadFinished();
+    }
+    await runTest();
 }
 </script>
 </head>
@@ -24,14 +27,13 @@ function click(elmt)
     UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
-    file = internals.createFile("../resources/abe.png");
+    file = await internals.asyncCreateFile("../resources/abe.png");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
     click(link);
 }
-runTest();
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-doublequote.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-doublequote.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-slashes.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-slashes.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-unicode.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-unicode.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-no-extension.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-no-extension.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -804,6 +804,21 @@ BeaconAPIEnabled:
     WebCore:
       default: false
 
+BlobFileAccessEnforcementEnabled:
+  type: bool
+  status: testable
+  category: security
+  humanReadableName: "Enforce blob backed file access valid for web process"
+  humanReadableDescription: "Validate file backed blobs were created by the correct web process"
+  sharedPreferenceForWebProcess: true
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 BlobRegistryTopOriginPartitioningEnabled:
   type: bool
   status: stable

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -827,6 +827,11 @@ String parentPath(const String& path)
     return fromStdFileSystemPath(toStdFileSystemPath(path).parent_path());
 }
 
+String lexicallyNormal(const String& path)
+{
+    return fromStdFileSystemPath(toStdFileSystemPath(path).lexically_normal());
+}
+
 String createTemporaryFile(StringView prefix, StringView suffix)
 {
     auto [path, handle] = openTemporaryFile(prefix, suffix);

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -128,6 +128,7 @@ WTF_EXPORT_PRIVATE String lastComponentOfPathIgnoringTrailingSlash(const String&
 WTF_EXPORT_PRIVATE bool makeAllDirectories(const String& path);
 WTF_EXPORT_PRIVATE String pathFileName(const String&);
 WTF_EXPORT_PRIVATE String parentPath(const String&);
+WTF_EXPORT_PRIVATE String lexicallyNormal(const String&);
 WTF_EXPORT_PRIVATE std::optional<uint64_t> volumeFreeSpace(const String&);
 WTF_EXPORT_PRIVATE std::optional<uint64_t> volumeCapacity(const String&);
 WTF_EXPORT_PRIVATE std::optional<uint32_t> volumeFileBlockSize(const String&);

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -396,6 +396,8 @@ public:
     virtual RefPtr<ShapeDetection::FaceDetector> createFaceDetector(const ShapeDetection::FaceDetectorOptions&) const { return nullptr; }
     virtual RefPtr<ShapeDetection::TextDetector> createTextDetector() const { return nullptr; }
 
+    virtual void registerBlobPathForTesting(const String&, CompletionHandler<void()>&&) { }
+
     // Pass nullptr as the GraphicsLayer to detatch the root layer.
     virtual void attachRootGraphicsLayer(LocalFrame&, GraphicsLayer*) = 0;
     virtual void attachViewOverlayGraphicsLayer(GraphicsLayer*) = 0;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -128,6 +128,7 @@
 #include "InternalsMapLike.h"
 #include "InternalsSetLike.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSFile.h"
 #include "JSImageData.h"
 #include "JSInternals.h"
 #include "LegacySchemeRegistry.h"
@@ -5366,8 +5367,38 @@ RefPtr<File> Internals::createFile(const String& path)
     if (!url.protocolIsFile())
         return nullptr;
 
+    if (auto* page = document->page())
+        page->chrome().client().registerBlobPathForTesting(url.fileSystemPath(), [] () { });
+
     return File::create(document, url.fileSystemPath());
 }
+void Internals::asyncCreateFile(const String& path, DOMPromiseDeferred<IDLInterface<File>>&& promise)
+{
+    Document* document = contextDocument();
+    if (!document) {
+        promise.reject(ExceptionCode::InvalidStateError);
+        return;
+    }
+
+    URL url = document->completeURL(path);
+    if (!url.protocolIsFile()) {
+        promise.reject(ExceptionCode::InvalidStateError);
+        return;
+    }
+
+    if (auto* page = document->page()) {
+        auto fileSystemPath = url.fileSystemPath();
+        page->chrome().client().registerBlobPathForTesting(fileSystemPath, [promise = WTFMove(promise), weakDocument = WeakPtr { *document }, url = WTFMove(url)] () mutable {
+            if (!weakDocument) {
+                promise.reject(ExceptionCode::InvalidStateError);
+                return;
+            }
+            promise.resolve(File::create(weakDocument.get(), url.fileSystemPath()));
+        });
+    } else
+        promise.reject(ExceptionCode::InvalidStateError);
+}
+
 
 String Internals::createTemporaryFile(const String& name, const String& contents)
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -868,6 +868,7 @@ public:
     void disableCORSForURL(const String&);
 
     RefPtr<File> createFile(const String&);
+    void asyncCreateFile(const String&, DOMPromiseDeferred<IDLInterface<File>>&&);
     String createTemporaryFile(const String& name, const String& contents);
 
     void queueMicroTask(int);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1045,6 +1045,7 @@ enum RenderingMode {
     undefined disableCORSForURL(DOMString url);
 
     File? createFile(DOMString url);
+    Promise<File> asyncCreateFile(DOMString url);
     DOMString createTemporaryFile(DOMString name, DOMString contents);
 
     undefined queueMicroTask(long testNumber);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -958,6 +958,19 @@ void NetworkConnectionToWebProcess::cookieEnabledStateMayHaveChanged()
     protectedConnection()->send(Messages::NetworkProcessConnection::UpdateCachedCookiesEnabled(), 0);
 }
 
+bool NetworkConnectionToWebProcess::isFilePathAllowed(NetworkSession& session, String path)
+{
+    path = FileSystem::lexicallyNormal(path);
+    auto parentPath = FileSystem::parentPath(path);
+    while (parentPath != path) {
+        if (m_allowedFilePaths.contains(path) || parentPath == session.storageManager().path() || parentPath == session.storageManager().customIDBStoragePath())
+            return true;
+        path = parentPath;
+        parentPath = FileSystem::parentPath(path);
+    }
+    return false;
+}
+
 void NetworkConnectionToWebProcess::registerInternalFileBlobURL(const URL& url, const String& path, const String& replacementPath, SandboxExtension::Handle&& extensionHandle, const String& contentType)
 {
     MESSAGE_CHECK(!url.isEmpty());
@@ -965,6 +978,8 @@ void NetworkConnectionToWebProcess::registerInternalFileBlobURL(const URL& url, 
     auto* session = networkSession();
     if (!session)
         return;
+    if (blobFileAccessEnforcementEnabled())
+        MESSAGE_CHECK(isFilePathAllowed(*session, path));
 
     m_blobURLs.add({ url, std::nullopt });
     session->blobRegistry().registerInternalFileBlobURL(url, BlobDataFileReferenceWithSandboxExtension::create(path, replacementPath, SandboxExtension::create(WTFMove(extensionHandle))), contentType);
@@ -990,13 +1005,14 @@ void NetworkConnectionToWebProcess::registerBlobURL(const URL& url, const URL& s
     session->blobRegistry().registerBlobURL(url, srcURL, WTFMove(policyContainer), topOrigin);
 }
 
-void NetworkConnectionToWebProcess::registerInternalBlobURLOptionallyFileBacked(const URL& url, const URL& srcURL, const String& fileBackedPath, const String& contentType)
+void NetworkConnectionToWebProcess::registerInternalBlobURLOptionallyFileBacked(URL&& url, URL&& srcURL, const String& fileBackedPath, String&& contentType)
 {
     MESSAGE_CHECK(!url.isEmpty() && !srcURL.isEmpty() && !fileBackedPath.isEmpty());
-
     auto* session = networkSession();
     if (!session)
         return;
+    if (blobFileAccessEnforcementEnabled())
+        MESSAGE_CHECK(isFilePathAllowed(*session, fileBackedPath));
 
     m_blobURLs.add({ url, std::nullopt });
     session->blobRegistry().registerInternalBlobURLOptionallyFileBacked(url, srcURL, BlobDataFileReferenceWithSandboxExtension::create(fileBackedPath), contentType, { });
@@ -1076,6 +1092,26 @@ void NetworkConnectionToWebProcess::writeBlobsToTemporaryFilesForIndexedDB(const
 
         completionHandler(WTFMove(filePaths));
     });
+}
+
+void NetworkConnectionToWebProcess::registerBlobPathForTesting(const String& path, CompletionHandler<void()>&& completion)
+{
+    if (!allowTestOnlyIPC())
+        return completion();
+    allowAccessToFile(path);
+    completion();
+}
+
+void NetworkConnectionToWebProcess::allowAccessToFile(const String& path)
+{
+    m_allowedFilePaths.add(FileSystem::lexicallyNormal(path));
+}
+
+
+void NetworkConnectionToWebProcess::allowAccessToFiles(const Vector<String>& filePaths)
+{
+    for (auto& filePath : filePaths)
+        m_allowedFilePaths.add(FileSystem::lexicallyNormal(filePath));
 }
 
 void NetworkConnectionToWebProcess::setCaptureExtraNetworkLoadMetricsEnabled(bool enabled)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -151,6 +151,7 @@ public:
 
     bool isWebTransportEnabled() const { return m_sharedPreferencesForWebProcess.webTransportEnabled; }
     bool usesSingleWebProcess() const { return m_sharedPreferencesForWebProcess.usesSingleWebProcess; }
+    bool blobFileAccessEnforcementEnabled() const { return m_sharedPreferencesForWebProcess.blobFileAccessEnforcementEnabled; }
 
     void didCleanupResourceLoader(NetworkResourceLoader&);
     void transferKeptAliveLoad(NetworkResourceLoader&);
@@ -240,6 +241,8 @@ public:
 
     WebSWServerToContextConnection* swContextConnection() { return m_swContextConnection.get(); }
     void clearFrameLoadRecordsForStorageAccess(WebCore::FrameIdentifier);
+    void allowAccessToFile(const String& path);
+    void allowAccessToFiles(const Vector<String>& filePaths);
 
 private:
     NetworkConnectionToWebProcess(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&, IPC::Connection::Identifier);
@@ -290,12 +293,14 @@ private:
     void registerInternalFileBlobURL(const URL&, const String& path, const String& replacementPath, SandboxExtension::Handle&&, const String& contentType);
     void registerInternalBlobURL(const URL&, Vector<WebCore::BlobPart>&&, const String& contentType);
     void registerBlobURL(const URL&, const URL& srcURL, WebCore::PolicyContainer&&, const std::optional<WebCore::SecurityOriginData>& topOrigin);
-    void registerInternalBlobURLOptionallyFileBacked(const URL&, const URL& srcURL, const String& fileBackedPath, const String& contentType);
+    void registerInternalBlobURLOptionallyFileBacked(URL&&, URL&& srcURL, const String& fileBackedPath, String&& contentType);
     void registerInternalBlobURLForSlice(const URL&, const URL& srcURL, int64_t start, int64_t end, const String& contentType);
     void blobType(const URL&, CompletionHandler<void(String)>&&);
     void blobSize(const URL&, CompletionHandler<void(uint64_t)>&&);
     void unregisterBlobURL(const URL&, const std::optional<WebCore::SecurityOriginData>& topOrigin);
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&&)>&&);
+    void registerBlobPathForTesting(const String& path, CompletionHandler<void()>&&);
+    bool isFilePathAllowed(NetworkSession&, String path);
 
     void registerBlobURLHandle(const URL&, const std::optional<WebCore::SecurityOriginData>& topOrigin);
     void unregisterBlobURLHandle(const URL&, const std::optional<WebCore::SecurityOriginData>& topOrigin);
@@ -490,6 +495,7 @@ private:
     HashSet<BlobURLKey> m_blobURLs;
     HashCountedSet<BlobURLKey> m_blobURLHandles;
     SharedPreferencesForWebProcess m_sharedPreferencesForWebProcess;
+    HashSet<String> m_allowedFilePaths;
 #if ENABLE(IPC_TESTING_API)
     IPCTester m_ipcTester;
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -67,6 +67,7 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
     WriteBlobsToTemporaryFilesForIndexedDB(Vector<String> blobURLs) -> (Vector<String> fileNames)
     RegisterBlobURLHandle(URL url, std::optional<WebCore::SecurityOriginData> topOrigin);
     UnregisterBlobURLHandle(URL url, std::optional<WebCore::SecurityOriginData> topOrigin);
+    RegisterBlobPathForTesting(String path) -> ();
 
     SetCaptureExtraNetworkLoadMetricsEnabled(bool enabled)
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3013,6 +3013,22 @@ void NetworkProcess::countNonDefaultSessionSets(PAL::SessionID sessionID, Comple
     completionHandler(session ? session->countNonDefaultSessionSets() : 0);
 }
 
+void NetworkProcess::allowFilesAccessFromWebProcess(WebCore::ProcessIdentifier processID, const Vector<String>& paths, CompletionHandler<void()>&& completionHandler)
+{
+    if (auto* connection = webProcessConnection(processID)) {
+        for (auto& path : paths)
+            connection->allowAccessToFile(path);
+    }
+    completionHandler();
+}
+
+void NetworkProcess::allowFileAccessFromWebProcess(WebCore::ProcessIdentifier processID, const String& path, CompletionHandler<void()>&& completionHandler)
+{
+    if (auto* connection = webProcessConnection(processID))
+        connection->allowAccessToFile(path);
+    completionHandler();
+}
+
 void NetworkProcess::requestBackgroundFetchPermission(PAL::SessionID sessionID, const ClientOrigin& origin, CompletionHandler<void(bool)>&& callback)
 {
     parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::RequestBackgroundFetchPermission(sessionID, origin), WTFMove(callback));

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -427,6 +427,9 @@ public:
 
     void getAppBadgeForTesting(PAL::SessionID, CompletionHandler<void(std::optional<uint64_t>)>&&);
 
+    void allowFilesAccessFromWebProcess(WebCore::ProcessIdentifier, const Vector<String>&, CompletionHandler<void()>&&);
+    void allowFileAccessFromWebProcess(WebCore::ProcessIdentifier, const String&, CompletionHandler<void()>&&);
+
 private:
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -219,6 +219,9 @@ messages -> NetworkProcess LegacyReceiver {
     RemoveWebPageNetworkParameters(PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier pageID)
     CountNonDefaultSessionSets(PAL::SessionID sessionID) -> (size_t count)
 
+    AllowFileAccessFromWebProcess(WebCore::ProcessIdentifier processIdentifier, String url) -> ()
+    AllowFilesAccessFromWebProcess(WebCore::ProcessIdentifier processIdentifier, Vector<String> urls) -> () ReplyCanDispatchOutOfOrder
+
     TerminateRemoteWorkerContextConnectionWhenPossible(enum:uint8_t WebKit::RemoteWorkerType workerType, PAL::SessionID sessionID,  WebCore::RegistrableDomain registrableDomain, WebCore::ProcessIdentifier processIdentifier);
 
     GetPendingPushMessages(PAL::SessionID sessionID) -> (Vector<WebKit::WebPushMessage> messages)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -180,6 +180,8 @@ NetworkStorageManager::NetworkStorageManager(NetworkProcess& process, PAL::Sessi
                 addResult.iterator->value = *this;
         }
     }
+    m_pathNormalizedMainThread = FileSystem::lexicallyNormal(path);
+    m_customIDBStoragePathNormalizedMainThread = FileSystem::lexicallyNormal(customIDBStoragePath);
 
     m_queue->dispatch([this, weakThis = ThreadSafeWeakPtr { *this }, path = path.isolatedCopy(), customLocalStoragePath = crossThreadCopy(customLocalStoragePath), customIDBStoragePath = crossThreadCopy(customIDBStoragePath), customCacheStoragePath = crossThreadCopy(customCacheStoragePath), customServiceWorkerStoragePath = crossThreadCopy(customServiceWorkerStoragePath), defaultOriginQuota, originQuotaRatio, totalQuotaRatio, standardVolumeCapacity, volumeCapacityOverride, level, storageSiteValidationEnabled]() mutable {
         assertIsCurrent(workQueue());

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -136,6 +136,8 @@ public:
     void clearServiceWorkerRegistrations(CompletionHandler<void()>&&);
     void importServiceWorkerRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>)>&&);
     void updateServiceWorkerRegistrations(Vector<WebCore::ServiceWorkerContextData>&&, Vector<WebCore::ServiceWorkerRegistrationKey>&&, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerScripts>>)>&&);
+    const String& path() const { return m_pathNormalizedMainThread; }
+    const String& customIDBStoragePath() const { return m_customIDBStoragePathNormalizedMainThread; }
 
 private:
     NetworkStorageManager(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled);
@@ -262,6 +264,7 @@ private:
     PAL::SessionID m_sessionID;
     Ref<SuspendableWorkQueue> m_queue;
     String m_path;
+    String m_pathNormalizedMainThread;
     FileSystem::Salt m_salt;
     bool m_closed { false };
     HashMap<WebCore::ClientOrigin, std::unique_ptr<OriginStorageManager>> m_originStorageManagers WTF_GUARDED_BY_CAPABILITY(workQueue());
@@ -272,6 +275,7 @@ private:
     std::unique_ptr<CacheStorageRegistry> m_cacheStorageRegistry;
     String m_customLocalStoragePath;
     String m_customIDBStoragePath;
+    String m_customIDBStoragePathNormalizedMainThread;
     String m_customCacheStoragePath;
     String m_customServiceWorkerStoragePath;
     uint64_t m_defaultOriginQuota;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -801,6 +801,7 @@ static Ref<API::PageConfiguration> webkitWebViewCreatePageConfiguration(WebKitWe
     auto pageConfiguration = API::PageConfiguration::create();
     pageConfiguration->setProcessPool(&webkitWebContextGetProcessPool(priv->context.get()));
     pageConfiguration->setPreferences(webkitSettingsGetPreferences(priv->settings.get()));
+    pageConfiguration->preferences().setAllowTestOnlyIPC(pageConfiguration->allowTestOnlyIPC());
     pageConfiguration->setRelatedPage(priv->relatedView ? &webkitWebViewGetPage(priv->relatedView) : nullptr);
     pageConfiguration->setUserContentController(priv->userContentManager ? webkitUserContentManagerGetUserContentControllerProxy(priv->userContentManager.get()) : nullptr);
     pageConfiguration->setControlledByAutomation(priv->isControlledByAutomation);

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -200,17 +200,18 @@ void WebPageProxy::loadRecentSearches(IPC::Connection& connection, const String&
     m_websiteDataStore->loadRecentSearches(name, WTFMove(completionHandler));
 }
 
-void WebPageProxy::grantAccessToCurrentPasteboardData(const String& pasteboardName, std::optional<FrameIdentifier> frameID)
+std::optional<IPC::AsyncReplyID> WebPageProxy::grantAccessToCurrentPasteboardData(const String& pasteboardName, CompletionHandler<void()>&& completionHandler, std::optional<FrameIdentifier> frameID)
 {
-    if (!hasRunningProcess())
-        return;
+    if (!hasRunningProcess()) {
+        completionHandler();
+        return std::nullopt;
+    }
     if (frameID) {
         if (auto* frame = WebFrameProxy::webFrame(*frameID)) {
-            WebPasteboardProxy::singleton().grantAccessToCurrentData(frame->process(), pasteboardName);
-            return;
+            return WebPasteboardProxy::singleton().grantAccessToCurrentData(frame->process(), pasteboardName, WTFMove(completionHandler));
         }
     }
-    WebPasteboardProxy::singleton().grantAccessToCurrentData(m_legacyMainFrameProcess, pasteboardName);
+    return WebPasteboardProxy::singleton().grantAccessToCurrentData(m_legacyMainFrameProcess, pasteboardName, WTFMove(completionHandler));
 }
 
 void WebPageProxy::beginSafeBrowsingCheck(const URL& url, bool forMainFrameNavigation, WebFramePolicyListenerProxy& listener)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1696,21 +1696,21 @@ void WebPageProxy::tryCloseTimedOut()
     closePage();
 }
 
-void WebPageProxy::maybeInitializeSandboxExtensionHandle(WebProcessProxy& process, const URL& url, const URL& resourceDirectoryURL, SandboxExtension::Handle& sandboxExtensionHandle, bool checkAssumedReadAccessToResourceURL)
+void WebPageProxy::maybeInitializeSandboxExtensionHandle(WebProcessProxy& process, const URL& url, const URL& resourceDirectoryURL, bool checkAssumedReadAccessToResourceURL, CompletionHandler<void(std::optional<SandboxExtension::Handle>)>&& completionHandler)
 {
     if (!url.protocolIsFile())
-        return;
+        return completionHandler(std::nullopt);
 
 #if HAVE(AUDIT_TOKEN)
     // If the process is still launching then it does not have a PID yet. We will take care of creating the sandbox extension
     // once the process has finished launching.
     if (process.isLaunching() || process.wasTerminated())
-        return;
+        return completionHandler(std::nullopt);
 #endif
-
+    SandboxExtension::Handle sandboxExtensionHandle;
     if (!resourceDirectoryURL.isEmpty()) {
         if (checkAssumedReadAccessToResourceURL && process.hasAssumedReadAccessToURL(resourceDirectoryURL))
-            return;
+            return completionHandler(std::nullopt);
 
         bool createdExtension = false;
 #if HAVE(AUDIT_TOKEN)
@@ -1730,13 +1730,15 @@ void WebPageProxy::maybeInitializeSandboxExtensionHandle(WebProcessProxy& proces
         }
 
         if (createdExtension) {
-            process.assumeReadAccessToBaseURL(*this, resourceDirectoryURL.string());
+            process.assumeReadAccessToBaseURL(*this, resourceDirectoryURL.string(), [sandboxExtensionHandle = WTFMove(sandboxExtensionHandle), completionHandler = WTFMove(completionHandler)] () mutable {
+                completionHandler(WTFMove(sandboxExtensionHandle));
+            });
             return;
         }
     }
 
     if (process.hasAssumedReadAccessToURL(url))
-        return;
+        return completionHandler(std::nullopt);
 
     // Inspector resources are in a directory with assumed access.
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!WebKit::isInspectorPage(*this));
@@ -1760,6 +1762,11 @@ void WebPageProxy::maybeInitializeSandboxExtensionHandle(WebProcessProxy& proces
 
     if (createdExtension) {
         willAcquireUniversalFileReadSandboxExtension(process);
+        auto baseURL = url.truncatedForUseAsBase();
+        auto basePath = baseURL.fileSystemPath();
+        process.assumeReadAccessToBaseURL(*this, basePath, [sandboxExtensionHandle = WTFMove(sandboxExtensionHandle), completionHandler = WTFMove(completionHandler)] () mutable {
+            completionHandler(WTFMove(sandboxExtensionHandle));
+        });
         return;
     }
 
@@ -1772,7 +1779,7 @@ void WebPageProxy::maybeInitializeSandboxExtensionHandle(WebProcessProxy& proces
     auto baseURL = url.truncatedForUseAsBase();
     auto basePath = baseURL.fileSystemPath();
     if (basePath.isNull())
-        return;
+        return completionHandler(std::nullopt);
 #if HAVE(AUDIT_TOKEN)
     if (process.connection() && process.connection()->getAuditToken()) {
         if (auto handle = SandboxExtension::createHandleForReadByAuditToken(basePath, *(process.connection()->getAuditToken()))) {
@@ -1789,7 +1796,9 @@ void WebPageProxy::maybeInitializeSandboxExtensionHandle(WebProcessProxy& proces
     }
 
     if (createdExtension)
-        process.assumeReadAccessToBaseURL(*this, baseURL.string());
+        process.assumeReadAccessToBaseURL(*this, baseURL.string(), [sandboxExtensionHandle = WTFMove(sandboxExtensionHandle), completionHandler = WTFMove(completionHandler)] mutable {
+            completionHandler(WTFMove(sandboxExtensionHandle));
+        });
 }
 
 void WebPageProxy::prepareToLoadWebPage(WebProcessProxy& process, LoadParameters& parameters)
@@ -1879,21 +1888,25 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     loadParameters.advancedPrivacyProtections = navigation.originatorAdvancedPrivacyProtections();
     loadParameters.isRequestFromClientOrUserInput = navigation.isRequestFromClientOrUserInput();
     loadParameters.isPerformingHTTPFallback = isPerformingHTTPFallback == IsPerformingHTTPFallback::Yes;
-    maybeInitializeSandboxExtensionHandle(process, url, internals().pageLoadState.resourceDirectoryURL(), loadParameters.sandboxExtensionHandle);
 
-    prepareToLoadWebPage(process, loadParameters);
+    maybeInitializeSandboxExtensionHandle(process, url, internals().pageLoadState.resourceDirectoryURL(), true, [weakThis = WeakPtr { *this }, weakProcess = WeakPtr { process }, loadParameters = WTFMove(loadParameters), url, navigation = Ref { navigation }, webPageID, shouldTreatAsContinuingLoad] (std::optional<SandboxExtension::Handle> sandboxExtensionHandle) mutable {
+        if (!weakProcess || !weakThis)
+            return;
+        if (sandboxExtensionHandle)
+            loadParameters.sandboxExtensionHandle = WTFMove(*sandboxExtensionHandle);
+        weakThis->prepareToLoadWebPage(*weakProcess, loadParameters);
 
-    if (shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::No)
-        preconnectTo(ResourceRequest { loadParameters.request });
+        if (shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::No)
+            weakThis->preconnectTo(ResourceRequest { loadParameters.request });
 
-    navigation.setIsLoadedWithNavigationShared(true);
-
-    process->markProcessAsRecentlyUsed();
-    if (!process->isLaunching() || !url.protocolIsFile())
-        process->send(Messages::WebPage::LoadRequest(WTFMove(loadParameters)), webPageID);
-    else
-        process->send(Messages::WebPage::LoadRequestWaitingForProcessLaunch(WTFMove(loadParameters), internals().pageLoadState.resourceDirectoryURL(), internals().identifier, true), webPageID);
-    process->startResponsivenessTimer();
+        navigation->setIsLoadedWithNavigationShared(true);
+        weakProcess->markProcessAsRecentlyUsed();
+        if (!weakProcess->isLaunching() || !url.protocolIsFile())
+            weakProcess->send(Messages::WebPage::LoadRequest(WTFMove(loadParameters)), webPageID);
+        else
+            weakProcess->send(Messages::WebPage::LoadRequestWaitingForProcessLaunch(WTFMove(loadParameters), weakThis->internals().pageLoadState.resourceDirectoryURL(), weakThis->internals().identifier, true), webPageID);
+        weakProcess->startResponsivenessTimer();
+    });
 }
 
 RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, const String& resourceDirectoryURLString, bool isAppInitiated, API::Object* userData)
@@ -1956,17 +1969,23 @@ RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, cons
     loadParameters.userData = UserData(legacyMainFrameProcess().transformObjectsToHandles(userData).get());
     loadParameters.publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(loadParameters.request.url());
     loadParameters.isRequestFromClientOrUserInput = isAppInitiated;
-    const bool checkAssumedReadAccessToResourceURL = false;
     Ref process = m_legacyMainFrameProcess;
-    maybeInitializeSandboxExtensionHandle(process, fileURL, resourceDirectoryURL, loadParameters.sandboxExtensionHandle, checkAssumedReadAccessToResourceURL);
-    prepareToLoadWebPage(process, loadParameters);
+    maybeInitializeSandboxExtensionHandle(process, fileURL, resourceDirectoryURL, true, [weakThis = WeakPtr { *this }, weakProcess = WeakPtr { process }, loadParameters = WTFMove(loadParameters), fileURL, resourceDirectoryURL] (std::optional<SandboxExtension::Handle> sandboxExtension) mutable {
+        const bool checkAssumedReadAccessToResourceURL = false;
+        if (!weakThis || !weakProcess)
+            return;
+        if (sandboxExtension)
+            loadParameters.sandboxExtensionHandle = WTFMove(*sandboxExtension);
 
-    process->markProcessAsRecentlyUsed();
-    if (process->isLaunching())
-        send(Messages::WebPage::LoadRequestWaitingForProcessLaunch(WTFMove(loadParameters), resourceDirectoryURL, internals().identifier, checkAssumedReadAccessToResourceURL));
-    else
-        send(Messages::WebPage::LoadRequest(WTFMove(loadParameters)));
-    process->startResponsivenessTimer();
+        weakThis->prepareToLoadWebPage(*weakProcess, loadParameters);
+
+        weakProcess->markProcessAsRecentlyUsed();
+        if (weakProcess->isLaunching())
+            weakThis->send(Messages::WebPage::LoadRequestWaitingForProcessLaunch(WTFMove(loadParameters), resourceDirectoryURL, weakThis->internals().identifier, checkAssumedReadAccessToResourceURL));
+        else
+            weakThis->send(Messages::WebPage::LoadRequest(WTFMove(loadParameters)));
+        weakProcess->startResponsivenessTimer();
+    });
 
     return navigation;
 }
@@ -2028,9 +2047,12 @@ void WebPageProxy::loadDataWithNavigationShared(Ref<WebProcessProxy>&& process, 
     prepareToLoadWebPage(process, loadParameters);
 
     process->markProcessAsRecentlyUsed();
-    process->assumeReadAccessToBaseURL(*this, baseURL);
-    process->send(Messages::WebPage::LoadData(WTFMove(loadParameters)), webPageID);
-    process->startResponsivenessTimer();
+    process->assumeReadAccessToBaseURL(*this, baseURL, [weakProcess = WeakPtr { process }, webPageID, loadParameters = WTFMove(loadParameters)] () mutable {
+        if (!weakProcess)
+            return;
+        weakProcess->send(Messages::WebPage::LoadData(WTFMove(loadParameters)), webPageID);
+        weakProcess->startResponsivenessTimer();
+    }, true);
 }
 
 RefPtr<API::Navigation> WebPageProxy::loadSimulatedRequest(WebCore::ResourceRequest&& simulatedRequest, WebCore::ResourceResponse&& simulatedResponse, std::span<const uint8_t> data)
@@ -2088,9 +2110,10 @@ RefPtr<API::Navigation> WebPageProxy::loadSimulatedRequest(WebCore::ResourceRequ
     prepareToLoadWebPage(process, loadParameters);
 
     process->markProcessAsRecentlyUsed();
-    process->assumeReadAccessToBaseURL(*this, baseURL);
-    process->send(Messages::WebPage::LoadSimulatedRequestAndResponse(WTFMove(loadParameters), simulatedResponse), internals().webPageID);
-    process->startResponsivenessTimer();
+    process->assumeReadAccessToBaseURL(*this, baseURL, [weakProcess = WeakPtr { process }, loadParameters = WTFMove(loadParameters), simulatedResponse = WTFMove(simulatedResponse), webPageID = internals().webPageID] () mutable {
+        weakProcess->send(Messages::WebPage::LoadSimulatedRequestAndResponse(WTFMove(loadParameters), simulatedResponse), webPageID);
+        weakProcess->startResponsivenessTimer();
+    });
 
     return navigation;
 }
@@ -2144,14 +2167,16 @@ void WebPageProxy::loadAlternateHTML(Ref<WebCore::DataSegment>&& htmlData, const
     ] () mutable {
         loadParameters.data = htmlData->span();
         process->markProcessAsRecentlyUsed();
-        process->assumeReadAccessToBaseURL(*this, baseURL.string());
-        process->assumeReadAccessToBaseURL(*this, unreachableURL.string());
-        if (baseURL.protocolIsFile())
-            process->addPreviouslyApprovedFileURL(baseURL);
-        if (unreachableURL.protocolIsFile())
-            process->addPreviouslyApprovedFileURL(unreachableURL);
-        send(Messages::WebPage::LoadAlternateHTML(WTFMove(loadParameters)));
-        process->startResponsivenessTimer();
+        process->assumeReadAccessToBaseURLs(*this, { baseURL.string(), unreachableURL.string() }, [weakThis = WeakPtr { *this }, weakProcess = WeakPtr { process }, baseURL, unreachableURL, loadParameters = WTFMove(loadParameters)] () mutable {
+            if (!weakThis || !weakProcess)
+                return;
+            if (baseURL.protocolIsFile())
+                weakProcess->addPreviouslyApprovedFileURL(baseURL);
+            if (unreachableURL.protocolIsFile())
+                weakProcess->addPreviouslyApprovedFileURL(unreachableURL);
+            weakThis->send(Messages::WebPage::LoadAlternateHTML(WTFMove(loadParameters)));
+            weakProcess->startResponsivenessTimer();
+        });
     };
 
     websiteDataStore().protectedNetworkProcess()->addAllowedFirstPartyForCookies(process, RegistrableDomain(baseURL), LoadedWebArchive::No, WTFMove(continueLoad));
@@ -2207,17 +2232,12 @@ RefPtr<API::Navigation> WebPageProxy::reload(OptionSet<WebCore::ReloadOption> op
 
     SandboxExtension::Handle sandboxExtensionHandle;
 
-    String url = currentURL();
-    if (!url.isEmpty()) {
-        // We may not have an extension yet if back/forward list was reinstated after a WebProcess crash or a browser relaunch
-        maybeInitializeSandboxExtensionHandle(protectedLegacyMainFrameProcess(), URL { url }, currentResourceDirectoryURL(), sandboxExtensionHandle);
-    }
-
     if (!hasRunningProcess())
         return launchProcessForReload();
     
     Ref navigation = m_navigationState->createReloadNavigation(legacyMainFrameProcess().coreProcessIdentifier(), m_backForwardList->protectedCurrentItem());
 
+    String url = currentURL();
     if (!url.isEmpty()) {
         auto transaction = internals().pageLoadState.transaction();
         internals().pageLoadState.setPendingAPIRequest(transaction, { navigation->navigationID(), url });
@@ -2230,15 +2250,24 @@ RefPtr<API::Navigation> WebPageProxy::reload(OptionSet<WebCore::ReloadOption> op
 
     Ref process = m_legacyMainFrameProcess;
     process->markProcessAsRecentlyUsed();
-    send(Messages::WebPage::Reload(navigation->navigationID(), options, WTFMove(sandboxExtensionHandle)));
-    process->startResponsivenessTimer();
+    if (!url.isEmpty()) {
+        // We may not have an extension yet if back/forward list was reinstated after a WebProcess crash or a browser relaunch
+        maybeInitializeSandboxExtensionHandle(protectedLegacyMainFrameProcess(), URL { url }, currentResourceDirectoryURL(), true, [weakThis = WeakPtr { *this }, process = WTFMove(process), options = WTFMove(options), sandboxExtensionHandle = WTFMove(sandboxExtensionHandle), navigation](std::optional<SandboxExtension::Handle> sandboxExtension) mutable {
+            if (!weakThis)
+                return;
+            if (sandboxExtension)
+                sandboxExtensionHandle = WTFMove(*sandboxExtension);
+            weakThis->send(Messages::WebPage::Reload(navigation->navigationID(), options, WTFMove(sandboxExtensionHandle)));
+            process->startResponsivenessTimer();
 
-    if (shouldForceForegroundPriorityForClientNavigation())
-        navigation->setClientNavigationActivity(process->throttler().foregroundActivity("Client reload"_s));
+            if (weakThis->shouldForceForegroundPriorityForClientNavigation())
+                navigation->setClientNavigationActivity(process->throttler().foregroundActivity("Client reload"_s));
 
 #if ENABLE(SPEECH_SYNTHESIS)
-    resetSpeechSynthesizer();
+            weakThis->resetSpeechSynthesizer();
 #endif
+        });
+    }
 
     return navigation;
 }
@@ -3177,33 +3206,49 @@ void WebPageProxy::executeEditCommand(const String& commandName, const String& a
         return;
     }
 
-    if (auto pasteAccessCategory = pasteAccessCategoryForCommand(commandName))
-        willPerformPasteCommand(*pasteAccessCategory);
-
     auto targetFrameID = focusedOrMainFrame() ? std::optional(focusedOrMainFrame()->frameID()) : std::nullopt;
-    sendWithAsyncReplyToProcessContainingFrame(targetFrameID, Messages::WebPage::ExecuteEditCommandWithCallback(commandName, argument), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::executeEditCommand"_s)] () mutable {
-        callbackFunction();
-    });
+
+    auto completionHandler = [weakThis = WeakPtr { * this }, callbackFunction = WTFMove(callbackFunction), commandName, argument, targetFrameID] () mutable {
+        if (!weakThis)
+            return callbackFunction();
+
+        weakThis->sendWithAsyncReplyToProcessContainingFrame(targetFrameID, Messages::WebPage::ExecuteEditCommandWithCallback(commandName, argument), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = weakThis->m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::executeEditCommand"_s)] () mutable {
+            callbackFunction();
+        });
+    };
+
+    if (auto pasteAccessCategory = pasteAccessCategoryForCommand(commandName))
+        willPerformPasteCommand(*pasteAccessCategory, WTFMove(completionHandler), targetFrameID);
+    else
+        completionHandler();
 }
 
 void WebPageProxy::executeEditCommand(const String& commandName, const String& argument)
 {
-    static NeverDestroyed<String> ignoreSpellingCommandName(MAKE_STATIC_STRING_IMPL("ignoreSpelling"));
-
     if (!hasRunningProcess())
         return;
 
     RefPtr focusedFrame = focusedOrMainFrame();
     if (!focusedFrame)
         return;
+    auto frameID = focusedFrame->frameID();
 
-    if (auto pasteAccessCategory = pasteAccessCategoryForCommand(commandName))
-        willPerformPasteCommand(*pasteAccessCategory, focusedFrame->frameID());
+    auto completionHandler = [weakThis = WeakPtr { *this }, commandName, argument, frameID] () mutable {
+        static NeverDestroyed<String> ignoreSpellingCommandName(MAKE_STATIC_STRING_IMPL("ignoreSpelling"));
+        if (!weakThis)
+            return;
 
-    if (commandName == ignoreSpellingCommandName)
-        ++m_pendingLearnOrIgnoreWordMessageCount;
+        if (commandName == ignoreSpellingCommandName)
+            ++weakThis->m_pendingLearnOrIgnoreWordMessageCount;
 
-    sendToProcessContainingFrame(focusedFrame->frameID(), Messages::WebPage::ExecuteEditCommand(commandName, argument));
+        weakThis->sendToProcessContainingFrame(frameID, Messages::WebPage::ExecuteEditCommand(commandName, argument));
+    };
+
+    if (auto pasteAccessCategory = pasteAccessCategoryForCommand(commandName)) {
+        if (auto replyID = willPerformPasteCommand(*pasteAccessCategory, WTFMove(completionHandler), frameID))
+            websiteDataStore().protectedNetworkProcess()->connection()->waitForAsyncReplyAndDispatchImmediately<Messages::NetworkProcess::AllowFilesAccessFromWebProcess>(*replyID, 100_ms);
+    } else
+        completionHandler();
 }
 
 void WebPageProxy::requestFontAttributesAtSelectionStart(CompletionHandler<void(const WebCore::FontAttributes&)>&& callback)
@@ -3393,18 +3438,17 @@ void WebPageProxy::dragExited(DragData& dragData)
 
 void WebPageProxy::performDragOperation(DragData& dragData, const String& dragStorageName, SandboxExtension::Handle&& sandboxExtensionHandle, Vector<SandboxExtension::Handle>&& sandboxExtensionsForUpload)
 {
-#if PLATFORM(COCOA)
-    grantAccessToCurrentPasteboardData(dragStorageName);
-#endif
 
 #if PLATFORM(GTK)
     performDragControllerAction(DragControllerAction::PerformDragOperation, dragData);
-#else
+#endif
+#if PLATFORM(COCOA)
     if (!hasRunningProcess())
         return;
-
-    sendWithAsyncReply(Messages::WebPage::PerformDragOperation(dragData, WTFMove(sandboxExtensionHandle), WTFMove(sandboxExtensionsForUpload)), [this, protectedThis = Ref { *this }] (bool handled) {
-        protectedPageClient()->didPerformDragOperation(handled);
+    grantAccessToCurrentPasteboardData(dragStorageName, [this, protectedThis = Ref { *this }, dragStorageName, dragData = WTFMove(dragData), sandboxExtensionHandle = WTFMove(sandboxExtensionHandle), sandboxExtensionsForUpload = WTFMove(sandboxExtensionsForUpload)] () mutable {
+        sendWithAsyncReply(Messages::WebPage::PerformDragOperation(dragData, WTFMove(sandboxExtensionHandle), WTFMove(sandboxExtensionsForUpload)), [this, protectedThis = Ref { *this }] (bool handled) {
+            protectedPageClient()->didPerformDragOperation(handled);
+        });
     });
 #endif
 }
@@ -3422,18 +3466,37 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
         dragData.setClientPosition(remoteUserInputEventData->transformedPoint);
         performDragControllerAction(action, dragData, remoteUserInputEventData->targetFrameID);
     };
+    auto filenames = dragData.fileNames();
 
+    auto afterAllowed = [weakThis = WeakPtr { *this }, frameID, action, dragData = WTFMove(dragData), completionHandler = WTFMove(completionHandler)] () mutable {
 #if PLATFORM(GTK)
-    UNUSED_PARAM(frameID);
-    String url = dragData.asURL();
-    if (!url.isEmpty())
-        protectedLegacyMainFrameProcess()->assumeReadAccessToBaseURL(*this, url);
+        UNUSED_PARAM(frameID);
+        String url = dragData.asURL();
+        if (!url.isEmpty()) {
+            weakThis->protectedLegacyMainFrameProcess()->assumeReadAccessToBaseURL(*weakThis, url, [weakThis = WTFMove(weakThis), frameID, action, dragData = WTFMove(dragData), completionHandler = WTFMove(completionHandler)] () mutable {
+                ASSERT(dragData.platformData());
+                weakThis->sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::PerformDragControllerAction(action, dragData.clientPosition(), dragData.globalPosition(), dragData.draggingSourceOperationMask(), *dragData.platformData(), dragData.flags()), WTFMove(completionHandler));
+            });
+            return;
+        }
 
-    ASSERT(dragData.platformData());
-    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::PerformDragControllerAction(action, dragData.clientPosition(), dragData.globalPosition(), dragData.draggingSourceOperationMask(), *dragData.platformData(), dragData.flags()), WTFMove(completionHandler));
+        ASSERT(dragData.platformData());
+        weakThis->sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::PerformDragControllerAction(action, dragData.clientPosition(), dragData.globalPosition(), dragData.draggingSourceOperationMask(), *dragData.platformData(), dragData.flags()), WTFMove(completionHandler));
 #else
-    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::PerformDragControllerAction(frameID, action, dragData), WTFMove(completionHandler));
+        weakThis->sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::PerformDragControllerAction(frameID, action, dragData), WTFMove(completionHandler));
 #endif
+    };
+
+    auto processID = siteIsolatedProcess().coreProcessIdentifier();
+    if (frameID) {
+        if (RefPtr frame = WebFrameProxy::webFrame(*frameID))
+            processID = frame->process().coreProcessIdentifier();
+    }
+
+    if (!filenames.size())
+        return afterAllowed();
+
+    websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(processID, filenames), WTFMove(afterAllowed));
 }
 
 void WebPageProxy::didPerformDragControllerAction(std::optional<WebCore::DragOperation> dragOperation, WebCore::DragHandlingMethod dragHandlingMethod, bool mouseIsOverFileInput, unsigned numberOfItemsToBeAccepted, const IntRect& insertionRect, const IntRect& editableElementRect)
@@ -4543,9 +4606,12 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
         if (policyAction == PolicyAction::Use && item) {
             URL fullURL { item->url() };
             if (fullURL.protocolIsFile()) {
-                SandboxExtension::Handle sandboxExtensionHandle;
-                maybeInitializeSandboxExtensionHandle(processNavigatingTo.get(), fullURL, item->resourceDirectoryURL(), sandboxExtensionHandle);
-                optionalHandle = WTFMove(sandboxExtensionHandle);
+                maybeInitializeSandboxExtensionHandle(processNavigatingTo.get(), fullURL, item->resourceDirectoryURL(), true, [weakThis = WeakPtr { *this }, navigation = WTFMove(navigation), navigationAction = WTFMove(navigationAction), message = WTFMove(message), completionHandler = WTFMove(completionHandler), policyAction] (std::optional<SandboxExtension::Handle>&& sandboxExtension) mutable {
+                    if (!weakThis)
+                        return;
+                    weakThis->receivedPolicyDecision(policyAction, navigation.ptr(), navigation->websitePolicies(), WTFMove(navigationAction), WillContinueLoadInNewProcess::No, WTFMove(sandboxExtension), WTFMove(message), WTFMove(completionHandler));
+                });
+                return;
             }
         }
 
@@ -9208,11 +9274,12 @@ void WebPageProxy::contextMenuItemSelected(const WebContextMenuItemData& item)
             m_navigationClient->contextMenuDidCreateDownload(*this, *download);
         });
     }
-
-    platformDidSelectItemFromActiveContextMenu(item);
-
     auto targetFrameID = focusedOrMainFrame() ? std::optional(focusedOrMainFrame()->frameID()) : std::nullopt;
-    sendToProcessContainingFrame(targetFrameID, Messages::WebPage::DidSelectItemFromActiveContextMenu(item));
+    platformDidSelectItemFromActiveContextMenu(item, [weakThis = WeakPtr { *this }, item, targetFrameID] () mutable {
+        if (!weakThis)
+            return;
+        weakThis->sendToProcessContainingFrame(targetFrameID, Messages::WebPage::DidSelectItemFromActiveContextMenu(item));
+    });
 }
 
 void WebPageProxy::handleContextMenuKeyEvent()
@@ -9250,15 +9317,21 @@ void WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon(const Vect
     if (!hasRunningProcess())
         return;
 
+    auto completionHandler = [weakThis = WeakPtr { *this }, fileURLs, displayString, iconData = RefPtr { iconData }] () mutable {
+        if (!weakThis)
+            return;
+        RefPtr openPanelResultListener = std::exchange(weakThis->m_openPanelResultListener, nullptr);
+        if (RefPtr process = openPanelResultListener->process()) {
 #if ENABLE(SANDBOX_EXTENSIONS)
-    auto sandboxExtensionHandles = SandboxExtension::createReadOnlyHandlesForFiles("WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon"_s, fileURLs);
-    send(Messages::WebPage::ExtendSandboxForFilesFromOpenPanel(WTFMove(sandboxExtensionHandles)));
+            auto sandboxExtensionHandles = SandboxExtension::createReadOnlyHandlesForFiles("WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon"_s, fileURLs);
+            process->send(Messages::WebPage::ExtendSandboxForFilesFromOpenPanel(WTFMove(sandboxExtensionHandles)), weakThis->webPageIDInMainFrameProcess());
 #endif
+            process->send(Messages::WebPage::DidChooseFilesForOpenPanelWithDisplayStringAndIcon(fileURLs, displayString, iconData ? iconData->span() : std::span<const uint8_t>()), weakThis->webPageIDInMainFrameProcess());
+        }
 
-    send(Messages::WebPage::DidChooseFilesForOpenPanelWithDisplayStringAndIcon(fileURLs, displayString, iconData ? iconData->span() : std::span<const uint8_t>()));
-
-    RefPtr openPanelResultListener = std::exchange(m_openPanelResultListener, nullptr);
-    openPanelResultListener->invalidate();
+        openPanelResultListener->invalidate();
+    };
+    websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(m_legacyMainFrameProcess->coreProcessIdentifier(), fileURLs), WTFMove(completionHandler));
 }
 #endif
 
@@ -9307,18 +9380,23 @@ void WebPageProxy::didChooseFilesForOpenPanel(const Vector<String>& fileURLs, co
     if (!hasRunningProcess())
         return;
 
-    RefPtr openPanelResultListener = std::exchange(m_openPanelResultListener, nullptr);
-    if (RefPtr process = openPanelResultListener->process()) {
-        if (!didChooseFilesForOpenPanelWithImageTranscoding(fileURLs, allowedMIMETypes)) {
+    auto completionHandler = [weakThis = WeakPtr { *this }, fileURLs, allowedMIMETypes] () mutable {
+        if (!weakThis)
+            return;
+        RefPtr openPanelResultListener = std::exchange(weakThis->m_openPanelResultListener, nullptr);
+        if (RefPtr process = openPanelResultListener->process()) {
+            if (!weakThis->didChooseFilesForOpenPanelWithImageTranscoding(fileURLs, allowedMIMETypes)) {
 #if ENABLE(SANDBOX_EXTENSIONS)
-            auto sandboxExtensionHandles = SandboxExtension::createReadOnlyHandlesForFiles("WebPageProxy::didChooseFilesForOpenPanel"_s, fileURLs);
-            process->send(Messages::WebPage::ExtendSandboxForFilesFromOpenPanel(WTFMove(sandboxExtensionHandles)), webPageIDInProcess(*process));
+                auto sandboxExtensionHandles = SandboxExtension::createReadOnlyHandlesForFiles("WebPageProxy::didChooseFilesForOpenPanel"_s, fileURLs);
+                process->send(Messages::WebPage::ExtendSandboxForFilesFromOpenPanel(WTFMove(sandboxExtensionHandles)), weakThis->webPageIDInMainFrameProcess());
 #endif
-            process->send(Messages::WebPage::DidChooseFilesForOpenPanel(fileURLs, { }), webPageIDInProcess(*process));
+                process->send(Messages::WebPage::DidChooseFilesForOpenPanel(fileURLs, { }), weakThis->webPageIDInMainFrameProcess());
+            }
         }
-    }
 
-    openPanelResultListener->invalidate();
+        openPanelResultListener->invalidate();
+    };
+    websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(m_legacyMainFrameProcess->coreProcessIdentifier(), fileURLs), WTFMove(completionHandler));
 }
 
 void WebPageProxy::didCancelForOpenPanel()
@@ -13509,7 +13587,7 @@ void WebPageProxy::modelProcessExited(ProcessTerminationReason)
 
 #if ENABLE(CONTEXT_MENUS) && !PLATFORM(MAC)
 
-void WebPageProxy::platformDidSelectItemFromActiveContextMenu(const WebContextMenuItemData&)
+void WebPageProxy::platformDidSelectItemFromActiveContextMenu(const WebContextMenuItemData&, CompletionHandler<void()>&&)
 {
 }
 
@@ -13517,8 +13595,10 @@ void WebPageProxy::platformDidSelectItemFromActiveContextMenu(const WebContextMe
 
 #if !PLATFORM(COCOA)
 
-void WebPageProxy::willPerformPasteCommand(DOMPasteAccessCategory, std::optional<FrameIdentifier>)
+std::optional<IPC::AsyncReplyID> WebPageProxy::willPerformPasteCommand(DOMPasteAccessCategory, CompletionHandler<void()>&& completionHandler, std::optional<FrameIdentifier>)
 {
+    completionHandler();
+    return std::nullopt;
 }
 
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2082,7 +2082,7 @@ public:
     void willStartCapture(const UserMediaPermissionRequestProxy&, CompletionHandler<void()>&&);
 #endif
 
-    void maybeInitializeSandboxExtensionHandle(WebProcessProxy&, const URL&, const URL& resourceDirectoryURL, SandboxExtensionHandle&, bool checkAssumedReadAccessToResourceURL = true);
+    void maybeInitializeSandboxExtensionHandle(WebProcessProxy&, const URL&, const URL& resourceDirectoryURL, bool checkAssumedReadAccessToResourceURL, CompletionHandler<void(std::optional<SandboxExtensionHandle>)>&&);
 
 #if ENABLE(WEB_AUTHN)
     void setMockWebAuthenticationConfiguration(WebCore::MockWebAuthenticationConfiguration&&);
@@ -2140,7 +2140,7 @@ public:
     void clearServiceWorkerEntitlementOverride(CompletionHandler<void()>&&);
         
 #if PLATFORM(COCOA)
-    void grantAccessToCurrentPasteboardData(const String& pasteboardName, std::optional<WebCore::FrameIdentifier> = std::nullopt);
+    std::optional<IPC::AsyncReplyID> grantAccessToCurrentPasteboardData(const String& pasteboardName, CompletionHandler<void()>&&, std::optional<WebCore::FrameIdentifier> = std::nullopt);
 #endif
 
 #if PLATFORM(MAC)
@@ -2149,7 +2149,7 @@ public:
 #endif
 
 #if ENABLE(CONTEXT_MENUS)
-    void platformDidSelectItemFromActiveContextMenu(const WebContextMenuItemData&);
+    void platformDidSelectItemFromActiveContextMenu(const WebContextMenuItemData&, CompletionHandler<void()>&&);
 #endif
 
 #if ENABLE(MEDIA_USAGE)
@@ -2706,7 +2706,7 @@ private:
 #endif
 
     void requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebCore::FrameIdentifier, const WebCore::IntRect&, const String&, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&&);
-    void willPerformPasteCommand(WebCore::DOMPasteAccessCategory, std::optional<WebCore::FrameIdentifier> = std::nullopt);
+    std::optional<IPC::AsyncReplyID> willPerformPasteCommand(WebCore::DOMPasteAccessCategory, CompletionHandler<void()>&&, std::optional<WebCore::FrameIdentifier> = std::nullopt);
 
     // Back/Forward list management
     void backForwardAddItem(WebCore::FrameIdentifier, BackForwardListItemState&&);

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -33,6 +33,8 @@
 #include <wtf/WeakHashSet.h>
 
 namespace IPC {
+struct AsyncReplyIDType;
+using AsyncReplyID = AtomicObjectIdentifier<AsyncReplyIDType>;
 class SharedBufferReference;
 }
 
@@ -66,7 +68,7 @@ public:
 
 #if PLATFORM(COCOA)
     void revokeAccess(WebProcessProxy&);
-    void grantAccessToCurrentData(WebProcessProxy&, const String& pasteboardName);
+    std::optional<IPC::AsyncReplyID> grantAccessToCurrentData(WebProcessProxy&, const String& pasteboardName, CompletionHandler<void()>&&);
     void grantAccessToCurrentTypes(WebProcessProxy&, const String& pasteboardName);
 #endif
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -581,10 +581,17 @@ bool WebProcessProxy::shouldSendPendingMessage(const PendingMessage& message)
         auto resourceDirectoryURL = decoder->decode<URL>();
         auto pageID = decoder->decode<WebPageProxyIdentifier>();
         auto checkAssumedReadAccessToResourceURL = decoder->decode<bool>();
+        auto destinationID = decoder->destinationID();
         if (loadParameters && resourceDirectoryURL && pageID && checkAssumedReadAccessToResourceURL) {
             if (RefPtr page = WebProcessProxy::webPage(*pageID)) {
-                page->maybeInitializeSandboxExtensionHandle(static_cast<WebProcessProxy&>(*this), loadParameters->request.url(), *resourceDirectoryURL, loadParameters->sandboxExtensionHandle, *checkAssumedReadAccessToResourceURL);
-                send(Messages::WebPage::LoadRequest(WTFMove(*loadParameters)), decoder->destinationID());
+                auto url = loadParameters->request.url();
+                page->maybeInitializeSandboxExtensionHandle(static_cast<WebProcessProxy&>(*this), url, *resourceDirectoryURL,  *checkAssumedReadAccessToResourceURL, [weakThis = WeakPtr { *this }, destinationID, loadParameters = WTFMove(loadParameters)] (std::optional<SandboxExtension::Handle> sandboxExtension) mutable {
+                    if (!weakThis)
+                        return;
+                    if (sandboxExtension)
+                        loadParameters->sandboxExtensionHandle = WTFMove(*sandboxExtension);
+                    weakThis->send(Messages::WebPage::LoadRequest(WTFMove(*loadParameters)), destinationID);
+                });
             }
         } else
             ASSERT_NOT_REACHED();
@@ -601,12 +608,19 @@ bool WebProcessProxy::shouldSendPendingMessage(const PendingMessage& message)
         auto pageID = decoder->decode<WebPageProxyIdentifier>();
         if (!pageID)
             return false;
-
+        auto destinationID = decoder->destinationID();
+        auto completionHandler = [weakThis = WeakPtr { *this }, parameters = WTFMove(parameters), destinationID] (std::optional<SandboxExtension::Handle> sandboxExtension) mutable {
+            if (!weakThis)
+                return;
+            if (sandboxExtension)
+                parameters->sandboxExtensionHandle = WTFMove(*sandboxExtension);
+            weakThis->send(Messages::WebPage::GoToBackForwardItem(WTFMove(*parameters)), destinationID);
+        };
         if (RefPtr page = WebProcessProxy::webPage(*pageID)) {
             if (RefPtr item = WebBackForwardListItem::itemForID(parameters->backForwardItemID))
-                page->maybeInitializeSandboxExtensionHandle(static_cast<WebProcessProxy&>(*this), URL { item->url() }, item->resourceDirectoryURL(), parameters->sandboxExtensionHandle);
-        }
-        send(Messages::WebPage::GoToBackForwardItem(WTFMove(*parameters)), decoder->destinationID());
+                page->maybeInitializeSandboxExtensionHandle(static_cast<WebProcessProxy&>(*this), URL { item->url() }, item->resourceDirectoryURL(), true, WTFMove(completionHandler));
+        } else
+            completionHandler(std::nullopt);
         return false;
     }
     return true;
@@ -907,22 +921,70 @@ void WebProcessProxy::didDestroyWebUserContentControllerProxy(WebUserContentCont
     m_webUserContentControllerProxies.remove(proxy);
 }
 
-void WebProcessProxy::assumeReadAccessToBaseURL(WebPageProxy& page, const String& urlString)
+void WebProcessProxy::assumeReadAccessToBaseURL(WebPageProxy& page, const String& urlString, CompletionHandler<void()>&& completionHandler, bool directoryOnly)
 {
     URL url { urlString };
     if (!url.protocolIsFile())
-        return;
+        return completionHandler();
 
     // There's a chance that urlString does not point to a directory.
     // Get url's base URL to add to m_localPathsWithAssumedReadAccess.
     auto path = url.truncatedForUseAsBase().fileSystemPath();
     if (path.isNull())
-        return;
+        return completionHandler();
 
-    // Client loads an alternate string. This doesn't grant universal file read, but the web process is assumed
-    // to have read access to this directory already.
-    m_localPathsWithAssumedReadAccess.add(path);
-    page.addPreviouslyVisitedPath(path);
+    RefPtr dataStore = websiteDataStore();
+    if (!dataStore)
+        return completionHandler();
+    auto afterAllowAccess = [weakThis = WeakPtr { *this }, weakPage = WeakPtr { page }, path, completionHandler = WTFMove(completionHandler)] mutable {
+        if (!weakThis || !weakPage)
+            return completionHandler();
+
+        // Client loads an alternate string. This doesn't grant universal file read, but the web process is assumed
+        // to have read access to this directory already.
+        weakThis->m_localPathsWithAssumedReadAccess.add(path);
+        weakPage->addPreviouslyVisitedPath(path);
+        completionHandler();
+    };
+    if (directoryOnly)
+        afterAllowAccess();
+    else
+        dataStore->networkProcess().sendWithAsyncReply(Messages::NetworkProcess::AllowFileAccessFromWebProcess(coreProcessIdentifier(), path), WTFMove(afterAllowAccess));
+}
+
+void WebProcessProxy::assumeReadAccessToBaseURLs(WebPageProxy& page, const Vector<String>& urls, CompletionHandler<void()>&& completionHandler)
+{
+    RefPtr dataStore = websiteDataStore();
+    if (!dataStore)
+        return completionHandler();
+    Vector<String> paths;
+    for (auto& urlString : urls) {
+        URL url { urlString };
+        if (!url.protocolIsFile())
+            continue;
+
+        // There's a chance that urlString does not point to a directory.
+        // Get url's base URL to add to m_localPathsWithAssumedReadAccess.
+        auto path = url.truncatedForUseAsBase().fileSystemPath();
+        if (path.isNull())
+            return completionHandler();
+        paths.append(path);
+    }
+    if (!paths.size())
+        return completionHandler();
+
+    dataStore->networkProcess().sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(coreProcessIdentifier(), WTFMove(paths)), [weakThis = WeakPtr { *this }, weakPage = WeakPtr { page }, paths, completionHandler = WTFMove(completionHandler)] mutable {
+        if (!weakThis || !weakPage)
+            return completionHandler();
+
+        // Client loads an alternate string. This doesn't grant universal file read, but the web process is assumed
+        // to have read access to this directory already.
+        for (auto& path : paths) {
+            weakThis->m_localPathsWithAssumedReadAccess.add(path);
+            weakPage->addPreviouslyVisitedPath(path);
+        }
+        completionHandler();
+    });
 }
 
 bool WebProcessProxy::hasAssumedReadAccessToURL(const URL& url) const

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -278,7 +278,8 @@ public:
     void updateTextCheckerState();
 
     void willAcquireUniversalFileReadSandboxExtension() { m_mayHaveUniversalFileReadSandboxExtension = true; }
-    void assumeReadAccessToBaseURL(WebPageProxy&, const String&);
+    void assumeReadAccessToBaseURL(WebPageProxy&, const String&, CompletionHandler<void()>&&, bool directoryOnly = false);
+    void assumeReadAccessToBaseURLs(WebPageProxy&, const Vector<String>&, CompletionHandler<void()>&&);
     bool hasAssumedReadAccessToURL(const URL&) const;
 
     bool checkURLReceivedFromWebProcess(const String&, CheckBackForwardList = CheckBackForwardList::Yes);

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -37,6 +37,7 @@
 #import "Logging.h"
 #import "NativeWebKeyboardEvent.h"
 #import "NativeWebTouchEvent.h"
+#import "NetworkProcessMessages.h"
 #import "PageClient.h"
 #import "PickerDismissalReason.h"
 #import "PlatformWritingToolsUtilities.h"
@@ -4849,8 +4850,10 @@ static UIPasteboard *pasteboardForAccessCategory(WebCore::DOMPasteAccessCategory
 - (BOOL)_handleDOMPasteRequestWithResult:(WebCore::DOMPasteAccessResponse)response
 {
     if (auto pasteAccessCategory = std::exchange(_domPasteRequestCategory, std::nullopt)) {
-        if (response == WebCore::DOMPasteAccessResponse::GrantedForCommand || response == WebCore::DOMPasteAccessResponse::GrantedForGesture)
-            _page->grantAccessToCurrentPasteboardData(pasteboardNameForAccessCategory(*pasteAccessCategory));
+        if (response == WebCore::DOMPasteAccessResponse::GrantedForCommand || response == WebCore::DOMPasteAccessResponse::GrantedForGesture) {
+            if (auto replyID = _page->grantAccessToCurrentPasteboardData(pasteboardNameForAccessCategory(*pasteAccessCategory), [] () { }))
+                _page->websiteDataStore().protectedNetworkProcess()->connection()->waitForAsyncReplyAndDispatchImmediately<Messages::NetworkProcess::AllowFilesAccessFromWebProcess>(*replyID, 100_ms);
+        }
     }
 
     if (auto pasteHandler = WTFMove(_domPasteRequestHandler)) {

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1553,13 +1553,12 @@ void WebPageProxy::Internals::isUserFacingChanged(bool isUserFacing)
 
 #endif
 
-void WebPageProxy::willPerformPasteCommand(DOMPasteAccessCategory pasteAccessCategory, std::optional<FrameIdentifier> frameID)
+std::optional<IPC::AsyncReplyID> WebPageProxy::willPerformPasteCommand(DOMPasteAccessCategory pasteAccessCategory, CompletionHandler<void()>&& completionHandler, std::optional<FrameIdentifier> frameID)
 {
     switch (pasteAccessCategory) {
     case DOMPasteAccessCategory::General:
     case DOMPasteAccessCategory::Fonts:
-        grantAccessToCurrentPasteboardData(UIPasteboardNameGeneral, frameID);
-        return;
+        return grantAccessToCurrentPasteboardData(UIPasteboardNameGeneral, WTFMove(completionHandler), frameID);
     }
 }
 

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -37,6 +37,7 @@
 #import "MenuUtilities.h"
 #import "MessageSenderInlines.h"
 #import "NativeWebKeyboardEvent.h"
+#import "NetworkProcessMessages.h"
 #import "PDFContextMenu.h"
 #import "PageClient.h"
 #import "PageClientImplMac.h"
@@ -237,7 +238,8 @@ bool WebPageProxy::readSelectionFromPasteboard(const String& pasteboardName)
     if (!hasRunningProcess())
         return false;
 
-    grantAccessToCurrentPasteboardData(pasteboardName);
+    if (auto replyID = grantAccessToCurrentPasteboardData(pasteboardName, [] () { }))
+        websiteDataStore().protectedNetworkProcess()->connection()->waitForAsyncReplyAndDispatchImmediately<Messages::NetworkProcess::AllowFilesAccessFromWebProcess>(*replyID, 100_ms);
 
     const Seconds messageTimeout(20);
     auto sendResult = legacyMainFrameProcess().sendSync(Messages::WebPage::ReadSelectionFromPasteboard(pasteboardName), webPageIDInMainFrameProcess(), messageTimeout);
@@ -615,23 +617,23 @@ RetainPtr<NSEvent> WebPageProxy::createSyntheticEventForContextMenu(FloatPoint l
     return [NSEvent mouseEventWithType:NSEventTypeRightMouseUp location:location modifierFlags:0 timestamp:0 windowNumber:protectedPageClient()->platformWindow().windowNumber context:nil eventNumber:0 clickCount:0 pressure:0];
 }
 
-void WebPageProxy::platformDidSelectItemFromActiveContextMenu(const WebContextMenuItemData& item)
+void WebPageProxy::platformDidSelectItemFromActiveContextMenu(const WebContextMenuItemData& item, CompletionHandler<void()>&& completionHandler)
 {
     if (item.action() == ContextMenuItemTagPaste)
-        grantAccessToCurrentPasteboardData(NSPasteboardNameGeneral);
+        grantAccessToCurrentPasteboardData(NSPasteboardNameGeneral, WTFMove(completionHandler));
+    else
+        completionHandler();
 }
 
 #endif
 
-void WebPageProxy::willPerformPasteCommand(DOMPasteAccessCategory pasteAccessCategory, std::optional<FrameIdentifier> frameID)
+std::optional<IPC::AsyncReplyID> WebPageProxy::willPerformPasteCommand(DOMPasteAccessCategory pasteAccessCategory, CompletionHandler<void()>&& completionHandler, std::optional<FrameIdentifier> frameID)
 {
     switch (pasteAccessCategory) {
     case DOMPasteAccessCategory::General:
-        grantAccessToCurrentPasteboardData(NSPasteboardNameGeneral, frameID);
-        return;
+        return grantAccessToCurrentPasteboardData(NSPasteboardNameGeneral, WTFMove(completionHandler), frameID);
     case DOMPasteAccessCategory::Fonts:
-        grantAccessToCurrentPasteboardData(NSPasteboardNameFont, frameID);
-        return;
+        return grantAccessToCurrentPasteboardData(NSPasteboardNameFont, WTFMove(completionHandler), frameID);
     }
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -41,6 +41,7 @@
 #import "NativeWebKeyboardEvent.h"
 #import "NativeWebMouseEvent.h"
 #import "NativeWebWheelEvent.h"
+#import "NetworkProcessMessages.h"
 #import "PageClient.h"
 #import "PageClientImplMac.h"
 #import "PasteboardTypes.h"
@@ -4079,6 +4080,60 @@ bool WebViewImpl::prepareForDragOperation(id <NSDraggingInfo>)
     return true;
 }
 
+static void performDragWithLegacyFiles(RefPtr<WebPageProxy> page, Box<Vector<String>>&& fileNames, Box<WebCore::DragData>&& dragData, const String& pasteboardName)
+{
+    auto* networkProcess = page->websiteDataStore().networkProcessIfExists();
+    if (!networkProcess)
+        return;
+    networkProcess->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(page->protectedLegacyMainFrameProcess()->coreProcessIdentifier(), *fileNames), [page = WTFMove(page), fileNames, dragData, pasteboardName]() mutable {
+        if (!page)
+            return;
+        SandboxExtension::Handle sandboxExtensionHandle;
+        Vector<SandboxExtension::Handle> sandboxExtensionForUpload;
+
+        page->createSandboxExtensionsIfNeeded(*fileNames, sandboxExtensionHandle, sandboxExtensionForUpload);
+        dragData->setFileNames(*fileNames);
+        page->performDragOperation(*dragData, pasteboardName, WTFMove(sandboxExtensionHandle), WTFMove(sandboxExtensionForUpload));
+    });
+}
+
+static bool handleLegacyFilesPasteboard(id<NSDraggingInfo> draggingInfo, Box<WebCore::DragData>&& dragData, RefPtr<WebPageProxy> page, RetainPtr<NSView<WebViewImplDelegate>> view)
+{
+    // FIXME: legacyFilesPromisePasteboardType() contains UTIs, not path names. Also, it's not
+    // guaranteed that the count of UTIs equals the count of files, since some clients only write
+    // unique UTIs.
+    NSArray *files = [draggingInfo.draggingPasteboard propertyListForType:WebCore::legacyFilesPromisePasteboardType()];
+    if (![files isKindOfClass:[NSArray class]])
+        return false;
+
+    NSString *dropDestinationPath = FileSystem::createTemporaryDirectory(@"WebKitDropDestination");
+    if (!dropDestinationPath)
+        return false;
+
+    size_t fileCount = files.count;
+    auto fileNames = Box<Vector<String>>::create();
+    NSURL *dropDestination = [NSURL fileURLWithPath:dropDestinationPath isDirectory:YES];
+    String pasteboardName = draggingInfo.draggingPasteboard.name;
+    [draggingInfo enumerateDraggingItemsWithOptions:0 forView:view.autorelease() classes:@[NSFilePromiseReceiver.class] searchOptions:@{ } usingBlock:[&](NSDraggingItem *draggingItem, NSInteger idx, BOOL *stop) {
+        auto queue = adoptNS([NSOperationQueue new]);
+        [draggingItem.item receivePromisedFilesAtDestination:dropDestination options:@{ } operationQueue:queue.get() reader:[page = WTFMove(page), fileNames, fileCount, dragData, pasteboardName](NSURL *fileURL, NSError *errorOrNil) {
+            if (errorOrNil)
+                return;
+
+            RunLoop::main().dispatch([page = WTFMove(page), path = RetainPtr { fileURL.path }, fileNames, fileCount, dragData, pasteboardName] () mutable {
+                if (!page)
+                    return;
+                fileNames->append(path.get());
+                if (fileNames->size() != fileCount)
+                    return;
+                performDragWithLegacyFiles(page, WTFMove(fileNames), WTFMove(dragData), pasteboardName);
+            });
+        }];
+    }];
+
+    return true;
+}
+
 bool WebViewImpl::performDragOperation(id <NSDraggingInfo> draggingInfo)
 {
     WebCore::IntPoint client([m_view convertPoint:draggingInfo.draggingLocation fromView:nil]);
@@ -4089,45 +4144,8 @@ bool WebViewImpl::performDragOperation(id <NSDraggingInfo> draggingInfo)
     SandboxExtension::Handle sandboxExtensionHandle;
     Vector<SandboxExtension::Handle> sandboxExtensionForUpload;
 
-    if (![types containsObject:PasteboardTypes::WebArchivePboardType] && [types containsObject:WebCore::legacyFilesPromisePasteboardType()]) {
-
-        // FIXME: legacyFilesPromisePasteboardType() contains UTIs, not path names. Also, it's not
-        // guaranteed that the count of UTIs equals the count of files, since some clients only write
-        // unique UTIs.
-        NSArray *files = [draggingInfo.draggingPasteboard propertyListForType:WebCore::legacyFilesPromisePasteboardType()];
-        if (![files isKindOfClass:[NSArray class]])
-            return false;
-
-        NSString *dropDestinationPath = FileSystem::createTemporaryDirectory(@"WebKitDropDestination");
-        if (!dropDestinationPath)
-            return false;
-
-        size_t fileCount = files.count;
-        auto fileNames = Box<Vector<String>>::create();
-        NSURL *dropDestination = [NSURL fileURLWithPath:dropDestinationPath isDirectory:YES];
-        String pasteboardName = draggingInfo.draggingPasteboard.name;
-        [draggingInfo enumerateDraggingItemsWithOptions:0 forView:m_view.getAutoreleased() classes:@[ NSFilePromiseReceiver.class ] searchOptions:@{ } usingBlock:[&](NSDraggingItem *draggingItem, NSInteger idx, BOOL *stop) {
-            auto queue = adoptNS([NSOperationQueue new]);
-            [draggingItem.item receivePromisedFilesAtDestination:dropDestination options:@{ } operationQueue:queue.get() reader:[this, fileNames, fileCount, dragData, pasteboardName](NSURL *fileURL, NSError *errorOrNil) {
-                if (errorOrNil)
-                    return;
-
-                RunLoop::main().dispatch([this, path = RetainPtr { fileURL.path }, fileNames, fileCount, dragData, pasteboardName] {
-                    fileNames->append(path.get());
-                    if (fileNames->size() == fileCount) {
-                        SandboxExtension::Handle sandboxExtensionHandle;
-                        Vector<SandboxExtension::Handle> sandboxExtensionForUpload;
-
-                        m_page->createSandboxExtensionsIfNeeded(*fileNames, sandboxExtensionHandle, sandboxExtensionForUpload);
-                        dragData->setFileNames(*fileNames);
-                        m_page->performDragOperation(*dragData, pasteboardName, WTFMove(sandboxExtensionHandle), WTFMove(sandboxExtensionForUpload));
-                    }
-                });
-            }];
-        }];
-
-        return true;
-    }
+    if (![types containsObject:PasteboardTypes::WebArchivePboardType] && [types containsObject:WebCore::legacyFilesPromisePasteboardType()])
+        return handleLegacyFilesPasteboard(draggingInfo, WTFMove(dragData), protectedPage(), m_view.get());
 
     if ([types containsObject:WebCore::legacyFilenamesPasteboardType()]) {
         NSArray *files = [draggingInfo.draggingPasteboard propertyListForType:WebCore::legacyFilenamesPasteboardType()];
@@ -4465,8 +4483,9 @@ void WebViewImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory pasteAcc
     NSData *data = [pasteboardForAccessCategory(pasteAccessCategory) dataForType:@(WebCore::PasteboardCustomData::cocoaType().characters())];
     auto buffer = WebCore::SharedBuffer::create(data);
     if (requiresInteraction == WebCore::DOMPasteRequiresInteraction::No && WebCore::PasteboardCustomData::fromSharedBuffer(buffer.get()).origin() == originIdentifier) {
-        m_page->grantAccessToCurrentPasteboardData(pasteboardNameForAccessCategory(pasteAccessCategory));
-        completion(WebCore::DOMPasteAccessResponse::GrantedForGesture);
+        m_page->grantAccessToCurrentPasteboardData(pasteboardNameForAccessCategory(pasteAccessCategory), [completion = WTFMove(completion)] () mutable {
+            completion(WebCore::DOMPasteAccessResponse::GrantedForGesture);
+        });
         return;
     }
 
@@ -4488,7 +4507,7 @@ void WebViewImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory pasteAcc
 void WebViewImpl::handleDOMPasteRequestForCategoryWithResult(WebCore::DOMPasteAccessCategory pasteAccessCategory, WebCore::DOMPasteAccessResponse response)
 {
     if (response == WebCore::DOMPasteAccessResponse::GrantedForCommand || response == WebCore::DOMPasteAccessResponse::GrantedForGesture)
-        m_page->grantAccessToCurrentPasteboardData(pasteboardNameForAccessCategory(pasteAccessCategory));
+        m_page->grantAccessToCurrentPasteboardData(pasteboardNameForAccessCategory(pasteAccessCategory), [] () { });
 
     hideDOMPasteMenuWithResult(response);
 }

--- a/Source/WebKit/UIProcess/win/WebView.cpp
+++ b/Source/WebKit/UIProcess/win/WebView.cpp
@@ -234,6 +234,7 @@ WebView::WebView(RECT rect, const API::PageConfiguration& configuration, HWND pa
     ASSERT(m_isVisible == static_cast<bool>(::GetWindowLong(m_window, GWL_STYLE) & WS_VISIBLE));
 
     auto pageConfiguration = configuration.copy();
+    pageConfiguration->preferences().setAllowTestOnlyIPC(pageConfiguration->allowTestOnlyIPC());
     WebProcessPool& processPool = pageConfiguration->processPool();
     m_page = processPool.createWebPage(*m_pageClient, WTFMove(pageConfiguration));
     m_page->initializeWebPage();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1151,6 +1151,12 @@ unsigned WebChromeClient::remoteImagesCountForTesting() const
     return protectedPage()->remoteImagesCountForTesting();
 }
 
+void WebChromeClient::registerBlobPathForTesting(const String& path, CompletionHandler<void()>&& completionHandler)
+{
+    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::RegisterBlobPathForTesting(path), WTFMove(completionHandler));
+}
+
+
 void WebChromeClient::contentRuleListNotification(const URL& url, const ContentRuleListResults& results)
 {
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -237,7 +237,8 @@ private:
     void triggerRenderingUpdate() final;
     bool scheduleRenderingUpdate() final;
     void renderingUpdateFramesPerSecondChanged() final;
-    unsigned remoteImagesCountForTesting() const final; 
+    unsigned remoteImagesCountForTesting() const final;
+    void registerBlobPathForTesting(const String& path, CompletionHandler<void()>&&) final;
 
     void contentRuleListNotification(const URL&, const WebCore::ContentRuleListResults&) final;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5733,6 +5733,8 @@ void WebPage::didChooseFilesForOpenPanelWithDisplayStringAndIcon(const Vector<St
         RetainPtr<CFDataRef> dataRef = adoptCF(CFDataCreate(nullptr, iconData.data(), iconData.size()));
         RetainPtr<CGDataProviderRef> imageProviderRef = adoptCF(CGDataProviderCreateWithCFData(dataRef.get()));
         RetainPtr<CGImageRef> imageRef = adoptCF(CGImageCreateWithPNGDataProvider(imageProviderRef.get(), nullptr, true, kCGRenderingIntentDefault));
+        if (!imageRef)
+            imageRef = adoptCF(CGImageCreateWithJPEGDataProvider(imageProviderRef.get(), nullptr, true, kCGRenderingIntentDefault));
         icon = Icon::create(WTFMove(imageRef));
     }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -252,6 +252,8 @@ private:
     RefPtr<WebCore::ShapeDetection::FaceDetector> createFaceDetector(const WebCore::ShapeDetection::FaceDetectorOptions&) const final;
     RefPtr<WebCore::ShapeDetection::TextDetector> createTextDetector() const final;
 
+    void registerBlobPathForTesting(const String&, CompletionHandler<void()>&&) final;
+
     void requestCookieConsent(CompletionHandler<void(WebCore::CookieConsentDecisionResult)>&&) final;
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -1169,6 +1169,11 @@ RefPtr<WebCore::ShapeDetection::TextDetector> WebChromeClient::createTextDetecto
 #endif
 }
 
+void WebChromeClient::registerBlobPathForTesting(const String&, CompletionHandler<void()>&& completion)
+{
+    completion();
+}
+
 void WebChromeClient::requestCookieConsent(CompletionHandler<void(CookieConsentDecisionResult)>&& completion)
 {
     completion(CookieConsentDecisionResult::NotSupported);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RunOpenPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RunOpenPanel.mm
@@ -84,6 +84,7 @@ TEST(WebKit, RunOpenPanelNonLatin1)
     [webView mouseDown:[NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:clickPoint modifierFlags:0 timestamp:0 windowNumber:windowNumber context:nil eventNumber:0 clickCount:1 pressure:1]];
     [webView mouseUp:[NSEvent mouseEventWithType:NSEventTypeLeftMouseUp location:clickPoint modifierFlags:0 timestamp:0 windowNumber:windowNumber context:nil eventNumber:0 clickCount:1 pressure:1]];
     Util::run(&fileSelected);
+    Util::runFor(50_ms);
     
     __block bool testFinished = false;
     [webView evaluateJavaScript:@"document.getElementsByTagName('input')[0].files[0].name" completionHandler:^(id result, NSError *error) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UploadDirectory.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UploadDirectory.mm
@@ -112,6 +112,7 @@ TEST(WebKit, UploadDirectory)
         [webView sendClickAtPoint:chooseFileButtonLocation];
         while (![delegate sentDirectory])
             TestWebKitAPI::Util::spinRunLoop();
+        Util::runFor(50_ms);
         [webView evaluateJavaScript:@"document.getElementById('form').submit()" completionHandler:nil];
         [webView _test_waitForDidFinishNavigation];
     }


### PR DESCRIPTION
#### 9febfdbe1756b5f4924f13105a2a9a6da9d1915a
<pre>
Add validation to file-backed blob urls from WebContent
<a href="https://bugs.webkit.org/show_bug.cgi?id=276193">https://bugs.webkit.org/show_bug.cgi?id=276193</a>
<a href="https://rdar.apple.com/80200949">rdar://80200949</a>

Reviewed by Alex Christensen.

This validates that file paths are valid for a given WebContent process when registering the blob

* LayoutTests/editing/pasteboard/copy-paste-attachment.html:
* LayoutTests/fast/attachment/attachment-dom.html:
* LayoutTests/fast/attachment/attachment-folder-icon-expected.html:
* LayoutTests/fast/attachment/attachment-icon-from-file-extension-expected.html:
* LayoutTests/fast/attachment/attachment-label-highlight.html:
* LayoutTests/fast/attachment/attachment-progress.html:
* LayoutTests/fast/attachment/attachment-select-on-click-inside-user-select-all.html:
* LayoutTests/fast/attachment/attachment-select-on-click.html:
* LayoutTests/fast/attachment/attachment-subtitle.html:
* LayoutTests/fast/attachment/attachment-title.html:
* LayoutTests/fast/attachment/attachment-type-attribute-expected.html:
* LayoutTests/fast/attachment/cocoa/wide-attachment-dom.html:
* LayoutTests/fast/attachment/cocoa/wide-attachment-folder-icon-expected.html:
* LayoutTests/fast/attachment/cocoa/wide-attachment-icon-from-file-extension-expected.html:
* LayoutTests/fast/attachment/mac/attachment-keynote-icon-expected.html:
* LayoutTests/fast/attachment/mac/attachment-numbers-icon-expected.html:
* LayoutTests/fast/attachment/mac/attachment-pages-icon-expected.html:
* LayoutTests/fast/attachment/mac/wide-attachment-type-attribute-expected.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-base-target-popup-not-allowed.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target-popup-not-allowed.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-backslash.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-doublequote.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-slashes.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-unicode.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-no-extension.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::registerBlobPathForTesting):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::createFile):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::isFilePathAllowed):
(WebKit::NetworkConnectionToWebProcess::registerInternalFileBlobURL):
(WebKit::NetworkConnectionToWebProcess::registerInternalBlobURLOptionallyFileBacked):
(WebKit::NetworkConnectionToWebProcess::registerBlobPathForTesting):
(WebKit::NetworkConnectionToWebProcess::allowAccessToFile):
(WebKit::NetworkConnectionToWebProcess::allowAccessToFiles):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
(WebKit::NetworkConnectionToWebProcess::blobFileAccessEnforcementEnabled const):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::allowFilesAccessFromWebProcess):
(WebKit::NetworkProcess::allowFileAccessFromWebProcess):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::grantAccessToCurrentPasteboardData):
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::grantAccessToCurrentData):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::goToBackForwardItem):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::maybeInitializeSandboxExtensionHandle):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::loadDataWithNavigationShared):
(WebKit::WebPageProxy::loadSimulatedRequest):
(WebKit::WebPageProxy::loadAlternateHTML):
(WebKit::WebPageProxy::reload):
(WebKit::WebPageProxy::executeEditCommand):
(WebKit::WebPageProxy::performDragOperation):
(WebKit::WebPageProxy::performDragControllerAction):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::contextMenuItemSelected):
(WebKit::WebPageProxy::didChooseFilesForOpenPanel):
(WebKit::WebPageProxy::platformDidSelectItemFromActiveContextMenu):
(WebKit::WebPageProxy::willPerformPasteCommand):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPasteboardProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shouldSendPendingMessage):
(WebKit::WebProcessProxy::assumeReadAccessToBaseURL):
(WebKit::WebProcessProxy::assumeReadAccessToBaseURLs):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _handleDOMPasteRequestWithResult:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::willPerformPasteCommand):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::readSelectionFromPasteboard):
(WebKit::WebPageProxy::platformDidSelectItemFromActiveContextMenu):
(WebKit::WebPageProxy::willPerformPasteCommand):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::performDragWithLegacyFiles):
(WebKit::handleLegacyFilesPasteboard):
(WebKit::WebViewImpl::performDragOperation):
(WebKit::WebViewImpl::requestDOMPasteAccess):
(WebKit::WebViewImpl::handleDOMPasteRequestForCategoryWithResult):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::registerBlobPathForTesting):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::registerBlobPathForTesting):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RunOpenPanel.mm:
(TestWebKitAPI::TEST(WebKit, RunOpenPanelNonLatin1)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UploadDirectory.mm:
(TEST(WebKit, UploadDirectory)):

Canonical link: <a href="https://commits.webkit.org/281966@main">https://commits.webkit.org/281966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d8f4496e663199f465d869c3fb33309ec60bbea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14168 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12399 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/65587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/8438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53338 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10570 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11057 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54678 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10869 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/67316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60824 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10633 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/67316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53293 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/67316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13719 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4545 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82587 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36737 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14435 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37822 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->