### PR TITLE
Change _WKWebExtension creation methods to be asynchronous.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -80,36 +80,16 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 /*!
  @abstract Returns a web extension initialized with a specified app extension bundle.
  @param appExtensionBundle The bundle to use for the new web extension.
- @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
- @seealso initWithAppExtensionBundle:error:
+ @param completionHandler A block to be called with an initialized web extension, or \c nil if the object could not be initialized due to an error.
  */
-+ (nullable instancetype)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle;
++ (void)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle completionHandler:(void (^)(_WKWebExtension * _Nullable extension, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);
 
 /*!
  @abstract Returns a web extension initialized with a specified resource base URL.
  @param resourceBaseURL The directory URL to use for the new web extension.
- @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
- @seealso initWithResourceBaseURL:error:
+ @param completionHandler A block to be called with an initialized web extension, or \c nil if the object could not be initialized due to an error.
  */
-+ (nullable instancetype)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL;
-
-/*!
- @abstract Returns a web extension initialized with a specified app extension bundle.
- @param appExtensionBundle The bundle to use for the new web extension.
- @param error Set to \c nil or an \c NSError instance if an error occurred.
- @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
- @discussion This is a designated initializer.
- */
-- (nullable instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error NS_DESIGNATED_INITIALIZER;
-
-/*!
- @abstract Returns a web extension initialized with a specified resource base URL.
- @param resourceBaseURL The directory URL to use for the new web extension.
- @param error Set to \c nil or an \c NSError instance if an error occurred.
- @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
- @discussion This is a designated initializer. The URL must be a file URL that points to a directory containing a `manifest.json` file.
- */
-- (nullable instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error NS_DESIGNATED_INITIALIZER;
++ (void)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL completionHandler:(void (^)(_WKWebExtension * _Nullable extension, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);
 
 /*!
  @abstract The active errors for the extension.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -44,35 +44,55 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
 
 WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtension, WebExtension, _webExtension);
 
-+ (instancetype)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle
++ (void)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle completionHandler:(void (^)(_WKWebExtension *extension, NSError *error))completionHandler
 {
     NSParameterAssert([appExtensionBundle isKindOfClass:NSBundle.class]);
 
-    NSError * __autoreleasing internalError;
-    auto result = WebKit::WebExtension::create(appExtensionBundle, &internalError);
+    // FIXME: <https://webkit.org/b/276194> Make the WebExtension class load data on a background thread.
+    // Use an async dispatch in the meantime to prevent clients from expecting synchronous results.
 
-    if (internalError)
-        return nil;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSError * __autoreleasing error;
+        Ref result = WebKit::WebExtension::create(appExtensionBundle, &error);
 
-    return result->wrapper();
+        if (error) {
+            completionHandler(nil, error);
+            return;
+        }
+
+        completionHandler(result->wrapper(), nil);
+    });
 }
 
-+ (instancetype)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL
++ (void)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL completionHandler:(void (^)(_WKWebExtension *extension, NSError *error))completionHandler
 {
     NSParameterAssert([resourceBaseURL isKindOfClass:NSURL.class]);
     NSParameterAssert([resourceBaseURL isFileURL]);
     NSParameterAssert([resourceBaseURL hasDirectoryPath]);
 
-    NSError * __autoreleasing internalError;
-    auto result = WebKit::WebExtension::create(resourceBaseURL, &internalError);
+    // FIXME: <https://webkit.org/b/276194> Make the WebExtension class load data on a background thread.
+    // Use an async dispatch in the meantime to prevent clients from expecting synchronous results.
 
-    if (internalError)
-        return nil;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSError * __autoreleasing error;
+        Ref result = WebKit::WebExtension::create(resourceBaseURL, &error);
 
-    return result->wrapper();
+        if (error) {
+            completionHandler(nil, error);
+            return;
+        }
+
+        completionHandler(result->wrapper(), nil);
+    });
 }
 
+// FIXME: Remove after Safari has adopted new methods.
 - (instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error
+{
+    return [self _initWithAppExtensionBundle:appExtensionBundle error:error];
+}
+
+- (instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error
 {
     NSParameterAssert([appExtensionBundle isKindOfClass:NSBundle.class]);
 
@@ -94,7 +114,13 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtension, WebExtension, _webExtensi
     return self;
 }
 
+// FIXME: Remove after Safari has adopted new methods.
 - (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
+{
+    return [self _initWithResourceBaseURL:resourceBaseURL error:error];
+}
+
+- (instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
 {
     NSParameterAssert([resourceBaseURL isKindOfClass:NSURL.class]);
     NSParameterAssert([resourceBaseURL isFileURL]);
@@ -298,23 +324,37 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtension, WebExtension, _webExtensi
 
 #else // ENABLE(WK_WEB_EXTENSIONS)
 
-+ (instancetype)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle
++ (void)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle completionHandler:(void (^)(_WKWebExtension *extension, NSError *error))completionHandler
 {
-    return nil;
+    completionHandler(nil, [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil]);
 }
 
-+ (instancetype)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL
++ (void)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL completionHandler:(void (^)(_WKWebExtension *extension, NSError *error))completionHandler
 {
-    return nil;
+    completionHandler(nil, [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil]);
 }
 
 - (instancetype)initWithAppExtensionBundle:(NSBundle *)bundle error:(NSError **)error
 {
+    return [self _initWithAppExtensionBundle:bundle error:error];
+}
+
+- (instancetype)_initWithAppExtensionBundle:(NSBundle *)bundle error:(NSError **)error
+{
+    if (error)
+        *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil];
     return nil;
 }
 
 - (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
 {
+    return [self _initWithResourceBaseURL:resourceBaseURL error:error];
+}
+
+- (instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
+{
+    if (error)
+        *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil];
     return nil;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -1103,6 +1103,7 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 
 - (void)loadBackgroundContentWithCompletionHandler:(void (^)(NSError *error))completionHandler
 {
+    completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil]);
 }
 
 - (_WKWebExtensionAction *)actionForTab:(id<_WKWebExtensionTab>)tab NS_SWIFT_NAME(action(for:))

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
@@ -306,11 +306,15 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 
 - (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext error:(NSError **)error
 {
+    if (error)
+        *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil];
     return NO;
 }
 
-- (BOOL)unloadExtensionContext:(_WKWebExtensionContext *)extensionContext error:(NSError **)outError
+- (BOOL)unloadExtensionContext:(_WKWebExtensionContext *)extensionContext error:(NSError **)error
 {
+    if (error)
+        *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil];
     return NO;
 }
 
@@ -341,14 +345,17 @@ static inline NSSet *toAPI(const HashSet<Ref<T>>& inputSet)
 
 - (void)fetchDataRecordsOfTypes:(NSSet<_WKWebExtensionDataType> *)dataTypes completionHandler:(void (^)(NSArray<_WKWebExtensionDataRecord *> *))completionHandler
 {
+    completionHandler(@[ ]);
 }
 
 - (void)fetchDataRecordOfTypes:(NSSet<_WKWebExtensionDataType> *)dataTypes forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(_WKWebExtensionDataRecord *))completionHandler
 {
+    completionHandler(nil);
 }
 
 - (void)removeDataOfTypes:(NSSet<_WKWebExtensionDataType> *)dataTypes forDataRecords:(NSArray<_WKWebExtensionDataRecord *> *)dataRecords completionHandler:(void (^)())completionHandler
 {
+    completionHandler();
 }
 
 - (void)didOpenWindow:(id<_WKWebExtensionWindow>)newWindow

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm
@@ -293,11 +293,15 @@ static OptionSet<WebKit::WebExtensionMatchPattern::Options> toImpl(_WKWebExtensi
 
 - (instancetype)initWithString:(NSString *)string error:(NSError **)error
 {
+    if (error)
+        *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil];
     return nil;
 }
 
 - (instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path error:(NSError **)error
 {
+    if (error)
+        *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil];
     return nil;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm
@@ -112,6 +112,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionMessagePort, WebExtensionMe
 
 - (void)sendMessage:(id)message completionHandler:(void (^)(BOOL success, NSError *))completionHandler
 {
+    completionHandler(NO, [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil]);
 }
 
 - (void)disconnectWithError:(NSError *)error

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h
@@ -29,10 +29,52 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface _WKWebExtension ()
 
-- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest;
-- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(nullable NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
+// FIXME: Remove after Safari has adopted new methods.
+- (nullable instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error;
+- (nullable instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error;
 
-- (instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
+/*!
+ @abstract Returns a web extension initialized with a specified app extension bundle.
+ @param appExtensionBundle The bundle to use for the new web extension.
+ @param error Set to \c nil or an \c NSError instance if an error occurred.
+ @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
+ */
+- (nullable instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+
+/*!
+ @abstract Returns a web extension initialized with a specified resource base URL.
+ @param resourceBaseURL The directory URL to use for the new web extension.
+ @param error Set to \c nil or an \c NSError instance if an error occurred.
+ @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
+ @discussion The URL must be a file URL that points to a directory containing a `manifest.json` file.
+ */
+- (nullable instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+
+/*!
+ @abstract Returns a web extension initialized with a specified manifest dictionary.
+ @param manifest The dictionary containing the manifest data for the web extension.
+ @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
+ */
+- (nullable instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest;
+
+/*!
+ @abstract Returns a web extension initialized with a specified manifest dictionary and resources.
+ @param manifest The dictionary containing the manifest data for the web extension.
+ @param resources A dictionary of file paths to data, string, or JSON-serializable values.
+ @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
+ @discussion The resources dictionary provides additional data required for the web extension. Paths in resources can
+ have subdirectories, such as `_locales/en/messages.json`.
+ */
+- (nullable instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(nullable NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
+
+/*!
+ @abstract Returns a web extension initialized with specified resources.
+ @param resources A dictionary of file paths to data, string, or JSON-serializable values.
+ @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
+ @discussion The resources dictionary must provide at least the `manifest.json` resource.  Paths in resources can
+ have subdirectories, such as `_locales/en/messages.json`.
+ */
+- (nullable instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
 
 /*! @abstract A Boolean value indicating whether the extension background content is a service worker. */
 @property (readonly, nonatomic) BOOL _backgroundContentIsServiceWorker;


### PR DESCRIPTION
#### 8b43053675f985642ddcad0b88f0bcf0219ad7c8
<pre>
Change _WKWebExtension creation methods to be asynchronous.
<a href="https://webkit.org/b/276196">https://webkit.org/b/276196</a>
<a href="https://rdar.apple.com/problem/131076684">rdar://problem/131076684</a>

Reviewed by Jeff Miller and Alex Christensen.

Add asynchronous convenience methods to _WKWebExtension so we can update these
to load the extension data on a background thread in the future (see bug 276194).

Moved the existing init methods to _WKWebExtensionPrivate.h.

Also make sure the watchOS and tvOS stubs always return an unsupported error and
call the completion handlers.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(+[_WKWebExtension extensionWithAppExtensionBundle:completionHandler:]): Added.
(+[_WKWebExtension extensionWithResourceBaseURL:completionHandler:]): Added.
(-[_WKWebExtension initWithAppExtensionBundle:error:]): Call the private method.
(-[_WKWebExtension _initWithAppExtensionBundle:error:]): Added.
(-[_WKWebExtension initWithResourceBaseURL:error:]): Call the private method.
(-[_WKWebExtension _initWithResourceBaseURL:error:]): Added.
(+[_WKWebExtension extensionWithAppExtensionBundle:]): Deleted.
(+[_WKWebExtension extensionWithResourceBaseURL:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext loadBackgroundContentWithCompletionHandler:]): Call completionHandler
with unsupported error.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm:
(-[_WKWebExtensionController loadExtensionContext:error:]): Return unsupported error.
(-[_WKWebExtensionController unloadExtensionContext:error:]): Ditto.
(-[_WKWebExtensionController fetchDataRecordsOfTypes:completionHandler:]): Call completionHandler.
(-[_WKWebExtensionController fetchDataRecordOfTypes:forExtensionContext:completionHandler:]): Ditto.
(-[_WKWebExtensionController removeDataOfTypes:forDataRecords:completionHandler:]): Ditto.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.mm:
(-[_WKWebExtensionMatchPattern initWithString:error:]): Return unsupported error.
(-[_WKWebExtensionMatchPattern initWithScheme:host:path:error:]): Ditto.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm:
(-[_WKWebExtensionMessagePort sendMessage:completionHandler:]): Call completionHandler.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h: Moved init method here.
Added missing documentation comments.

Canonical link: <a href="https://commits.webkit.org/280642@main">https://commits.webkit.org/280642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39ad1041454ee1e4273fbaccba293dfffdccce96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60812 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7634 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7824 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5373 "Passed tests") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59221 "Failed to checkout and rebase branch from PR 30461") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34273 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27169 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/31055 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6639 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/6965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62492 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1104 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7063 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53568 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49418 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/930 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8531 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/33433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/34518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->