### PR TITLE
Use smart pointers in WebPageTesting/WebPageProxyTesting

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -50,12 +50,12 @@ WebPageProxyTesting::WebPageProxyTesting(WebPageProxy& page)
 
 bool WebPageProxyTesting::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions)
 {
-    return m_page->protectedLegacyMainFrameProcess()->sendMessage(WTFMove(encoder), sendOptions);
+    return protectedPage()->protectedLegacyMainFrameProcess()->sendMessage(WTFMove(encoder), sendOptions);
 }
 
 bool WebPageProxyTesting::sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&& encoder, AsyncReplyHandler handler, OptionSet<IPC::SendOption> sendOptions)
 {
-    return m_page->protectedLegacyMainFrameProcess()->sendMessage(WTFMove(encoder), sendOptions, WTFMove(handler));
+    return protectedPage()->protectedLegacyMainFrameProcess()->sendMessage(WTFMove(encoder), sendOptions, WTFMove(handler));
 }
 
 IPC::Connection* WebPageProxyTesting::messageSenderConnection() const
@@ -88,21 +88,21 @@ void WebPageProxyTesting::isLayerTreeFrozen(CompletionHandler<void(bool)>&& comp
 
 void WebPageProxyTesting::setCrossSiteLoadWithLinkDecorationForTesting(const URL& fromURL, const URL& toURL, bool wasFiltered, CompletionHandler<void()>&& completionHandler)
 {
-    m_page->websiteDataStore().protectedNetworkProcess()->setCrossSiteLoadWithLinkDecorationForTesting(m_page->sessionID(), WebCore::RegistrableDomain { fromURL }, WebCore::RegistrableDomain { toURL }, wasFiltered, WTFMove(completionHandler));
+    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->setCrossSiteLoadWithLinkDecorationForTesting(m_page->sessionID(), WebCore::RegistrableDomain { fromURL }, WebCore::RegistrableDomain { toURL }, wasFiltered, WTFMove(completionHandler));
 }
 
 void WebPageProxyTesting::setPermissionLevel(const String& origin, bool allowed)
 {
-    m_page->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+    protectedPage()->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         webProcess.send(Messages::WebPageTesting::SetPermissionLevel(origin, allowed), pageID);
     });
 }
 
 bool WebPageProxyTesting::isEditingCommandEnabled(const String& commandName)
 {
-    auto* focusedOrMainFrame = m_page->focusedOrMainFrame();
+    RefPtr focusedOrMainFrame = m_page->focusedOrMainFrame();
     auto targetFrameID = focusedOrMainFrame ? std::optional(focusedOrMainFrame->frameID()) : std::nullopt;
-    auto sendResult = m_page->sendSyncToProcessContainingFrame(targetFrameID, Messages::WebPageTesting::IsEditingCommandEnabled(commandName), Seconds::infinity());
+    auto sendResult = protectedPage()->sendSyncToProcessContainingFrame(targetFrameID, Messages::WebPageTesting::IsEditingCommandEnabled(commandName), Seconds::infinity());
     if (!sendResult.succeeded())
         return false;
     auto [result] = sendResult.takeReply();
@@ -111,62 +111,62 @@ bool WebPageProxyTesting::isEditingCommandEnabled(const String& commandName)
 
 void WebPageProxyTesting::dumpPrivateClickMeasurement(CompletionHandler<void(const String&)>&& completionHandler)
 {
-    m_page->websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::DumpPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTFMove(completionHandler));
+    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::DumpPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTFMove(completionHandler));
 }
 
 void WebPageProxyTesting::clearPrivateClickMeasurement(CompletionHandler<void()>&& completionHandler)
 {
-    m_page->websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::ClearPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTFMove(completionHandler));
+    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::ClearPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTFMove(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementOverrideTimer(bool value, CompletionHandler<void()>&& completionHandler)
 {
-    m_page->websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementOverrideTimerForTesting(m_page->websiteDataStore().sessionID(), value), WTFMove(completionHandler));
+    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementOverrideTimerForTesting(m_page->websiteDataStore().sessionID(), value), WTFMove(completionHandler));
 }
 
 void WebPageProxyTesting::markAttributedPrivateClickMeasurementsAsExpired(CompletionHandler<void()>&& completionHandler)
 {
-    m_page->websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkAttributedPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTFMove(completionHandler));
+    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkAttributedPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTFMove(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementEphemeralMeasurement(bool value, CompletionHandler<void()>&& completionHandler)
 {
-    m_page->websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementEphemeralMeasurementForTesting(m_page->websiteDataStore().sessionID(), value), WTFMove(completionHandler));
+    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementEphemeralMeasurementForTesting(m_page->websiteDataStore().sessionID(), value), WTFMove(completionHandler));
 }
 
 void WebPageProxyTesting::simulatePrivateClickMeasurementSessionRestart(CompletionHandler<void()>&& completionHandler)
 {
-    m_page->websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SimulatePrivateClickMeasurementSessionRestart(m_page->websiteDataStore().sessionID()), WTFMove(completionHandler));
+    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SimulatePrivateClickMeasurementSessionRestart(m_page->websiteDataStore().sessionID()), WTFMove(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementTokenPublicKeyURL(const URL& url, CompletionHandler<void()>&& completionHandler)
 {
-    m_page->websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenPublicKeyURLForTesting(m_page->websiteDataStore().sessionID(), url), WTFMove(completionHandler));
+    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenPublicKeyURLForTesting(m_page->websiteDataStore().sessionID(), url), WTFMove(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementTokenSignatureURL(const URL& url, CompletionHandler<void()>&& completionHandler)
 {
-    m_page->websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenSignatureURLForTesting(m_page->websiteDataStore().sessionID(), url), WTFMove(completionHandler));
+    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenSignatureURLForTesting(m_page->websiteDataStore().sessionID(), url), WTFMove(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementAttributionReportURLs(const URL& sourceURL, const URL& destinationURL, CompletionHandler<void()>&& completionHandler)
 {
-    m_page->websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAttributionReportURLsForTesting(m_page->websiteDataStore().sessionID(), sourceURL, destinationURL), WTFMove(completionHandler));
+    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAttributionReportURLsForTesting(m_page->websiteDataStore().sessionID(), sourceURL, destinationURL), WTFMove(completionHandler));
 }
 
 void WebPageProxyTesting::markPrivateClickMeasurementsAsExpired(CompletionHandler<void()>&& completionHandler)
 {
-    m_page->websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTFMove(completionHandler));
+    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTFMove(completionHandler));
 }
 
 void WebPageProxyTesting::setPCMFraudPreventionValues(const String& unlinkableToken, const String& secretToken, const String& signature, const String& keyID, CompletionHandler<void()>&& completionHandler)
 {
-    m_page->websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPCMFraudPreventionValuesForTesting(m_page->websiteDataStore().sessionID(), unlinkableToken, secretToken, signature, keyID), WTFMove(completionHandler));
+    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPCMFraudPreventionValuesForTesting(m_page->websiteDataStore().sessionID(), unlinkableToken, secretToken, signature, keyID), WTFMove(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementAppBundleID(const String& appBundleIDForTesting, CompletionHandler<void()>&& completionHandler)
 {
-    m_page->websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAppBundleIDForTesting(m_page->websiteDataStore().sessionID(), appBundleIDForTesting), WTFMove(completionHandler));
+    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAppBundleIDForTesting(m_page->websiteDataStore().sessionID(), appBundleIDForTesting), WTFMove(completionHandler));
 }
 
 #if ENABLE(NOTIFICATIONS)
@@ -194,5 +194,10 @@ void WebPageProxyTesting::setSystemCanPromptForGetDisplayMediaForTesting(bool ca
     DisplayCaptureSessionManager::singleton().setSystemCanPromptForTesting(canPrompt);
 }
 #endif
+
+Ref<WebPageProxy> WebPageProxyTesting::protectedPage() const
+{
+    return m_page.get();
+}
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -78,6 +78,8 @@ private:
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
 
+    Ref<WebPageProxy> protectedPage() const;
+
     const WebCore::PageIdentifier m_webPageIDInMainFrameProcess;
     WeakRef<WebPageProxy> m_page;
 };

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -54,7 +54,8 @@ WebPageTesting::~WebPageTesting()
 
 void WebPageTesting::setDefersLoading(bool defersLoading)
 {
-    m_page->corePage()->setDefersLoading(defersLoading);
+    if (RefPtr page = m_page->corePage())
+        page->setDefersLoading(defersLoading);
 }
 
 void WebPageTesting::isLayerTreeFrozen(CompletionHandler<void(bool)>&& completionHandler)
@@ -65,7 +66,8 @@ void WebPageTesting::isLayerTreeFrozen(CompletionHandler<void(bool)>&& completio
 void WebPageTesting::setPermissionLevel(const String& origin, bool allowed)
 {
 #if ENABLE(NOTIFICATIONS)
-    m_page->notificationPermissionRequestManager()->setPermissionLevelForTesting(origin, allowed);
+    if (RefPtr notificationPermissionRequestManager = protectedPage()->notificationPermissionRequestManager())
+        notificationPermissionRequestManager->setPermissionLevelForTesting(origin, allowed);
 #else
     UNUSED_PARAM(origin);
     UNUSED_PARAM(allowed);
@@ -74,23 +76,26 @@ void WebPageTesting::setPermissionLevel(const String& origin, bool allowed)
 
 void WebPageTesting::isEditingCommandEnabled(const String& commandName, CompletionHandler<void(bool)>&& completionHandler)
 {
-    RefPtr frame = m_page->corePage()->checkedFocusController()->focusedOrMainFrame();
+    RefPtr page = m_page->corePage();
+    RefPtr frame = page->checkedFocusController()->focusedOrMainFrame();
     if (!frame)
         return completionHandler(false);
 
 #if ENABLE(PDF_PLUGIN)
-    if (auto* pluginView = m_page->focusedPluginViewForFrame(*frame))
+    if (RefPtr pluginView = protectedPage()->focusedPluginViewForFrame(*frame))
         return completionHandler(pluginView->isEditingCommandEnabled(commandName));
 #endif
 
-    auto command = frame->editor().command(commandName);
+    auto command = frame->checkedEditor()->command(commandName);
     completionHandler(command.isSupported() && command.isEnabled());
 }
 
 #if ENABLE(NOTIFICATIONS)
 void WebPageTesting::clearNotificationPermissionState()
 {
-    static_cast<WebNotificationClient&>(WebCore::NotificationController::from(m_page->corePage())->client()).clearNotificationPermissionState();
+    RefPtr page = m_page->corePage();
+    auto& client = static_cast<WebNotificationClient&>(WebCore::NotificationController::from(page.get())->client());
+    client.clearNotificationPermissionState();
 }
 #endif
 
@@ -101,6 +106,11 @@ void WebPageTesting::clearWheelEventTestMonitor()
         return;
 
     page->clearWheelEventTestMonitor();
+}
+
+Ref<WebPage> WebPageTesting::protectedPage() const
+{
+    return m_page.get();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -59,6 +59,8 @@ private:
 
     void clearWheelEventTestMonitor();
 
+    Ref<WebPage> protectedPage() const;
+
     const WebCore::PageIdentifier m_identifier;
     WeakRef<WebPage> m_page;
 };


### PR DESCRIPTION
#### d838f8da1127752de331427ed5e1da77cc20aedc
<pre>
Use smart pointers in WebPageTesting/WebPageProxyTesting
<a href="https://bugs.webkit.org/show_bug.cgi?id=276200">https://bugs.webkit.org/show_bug.cgi?id=276200</a>
<a href="https://rdar.apple.com/131078260">rdar://131078260</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::sendMessage):
(WebKit::WebPageProxyTesting::sendMessageWithAsyncReply):
(WebKit::WebPageProxyTesting::setCrossSiteLoadWithLinkDecorationForTesting):
(WebKit::WebPageProxyTesting::setPermissionLevel):
(WebKit::WebPageProxyTesting::isEditingCommandEnabled):
(WebKit::WebPageProxyTesting::dumpPrivateClickMeasurement):
(WebKit::WebPageProxyTesting::clearPrivateClickMeasurement):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementOverrideTimer):
(WebKit::WebPageProxyTesting::markAttributedPrivateClickMeasurementsAsExpired):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementEphemeralMeasurement):
(WebKit::WebPageProxyTesting::simulatePrivateClickMeasurementSessionRestart):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementTokenPublicKeyURL):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementTokenSignatureURL):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementAttributionReportURLs):
(WebKit::WebPageProxyTesting::markPrivateClickMeasurementsAsExpired):
(WebKit::WebPageProxyTesting::setPCMFraudPreventionValues):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementAppBundleID):
* Source/WebKit/UIProcess/WebPageProxyTesting.h:
(WebKit::WebPageProxyTesting::protectedPage const):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::setDefersLoading):
(WebKit::WebPageTesting::setPermissionLevel):
(WebKit::WebPageTesting::isEditingCommandEnabled):
(WebKit::WebPageTesting::clearNotificationPermissionState):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
(WebKit::WebPageTesting::protectedPage const):

Canonical link: <a href="https://commits.webkit.org/280649@main">https://commits.webkit.org/280649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc5cff9c3ba7bc07ed35cbe69afbc0f48b019e3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60822 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7644 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46314 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5380 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27174 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31063 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6649 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62502 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53573 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53646 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/938 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8533 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32358 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->