### PR TITLE
Fix build issues with latest Clang

### DIFF
--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -23174,8 +23174,10 @@ IGNORE_CLANG_WARNINGS_END
         return m_out.shl(m_out.zeroExtPtr(structureID), m_out.constIntPtr(StructureID::encodeShiftAmount));
 #else
         LValue maskedStructureID = structureID;
-        if constexpr (structureHeapAddressSize < 4 * GB)
-            maskedStructureID = m_out.bitAnd(structureID, m_out.constInt32(StructureID::structureIDMask));
+        if constexpr (structureHeapAddressSize < 4 * GB) {
+            static_assert(static_cast<uint32_t>(StructureID::structureIDMask) == StructureID::structureIDMask);
+            maskedStructureID = m_out.bitAnd(structureID, m_out.constInt32(static_cast<uint32_t>(StructureID::structureIDMask)));
+        }
         return m_out.bitOr(m_out.constIntPtr(startOfStructureHeap()), m_out.zeroExtPtr(maskedStructureID));
 #endif
     }

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -770,8 +770,10 @@ void AssemblyHelpers::emitNonNullDecodeZeroExtendedStructureID(RegisterID source
     if constexpr (structureHeapAddressSize >= 4 * GB) {
         ASSERT(structureHeapAddressSize == 4 * GB);
         move(source, dest);
-    } else
-        and32(TrustedImm32(StructureID::structureIDMask), source, dest);
+    } else {
+        static_assert(static_cast<uint32_t>(StructureID::structureIDMask) == StructureID::structureIDMask);
+        and32(TrustedImm32(static_cast<uint32_t>(StructureID::structureIDMask)), source, dest);
+    }
     or64(TrustedImm64(startOfStructureHeap()), dest);
 #else // not CPU(ADDRESS64)
     move(source, dest);

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -43,8 +43,8 @@ namespace JSC { namespace IPInt {
 do { \
     void* base = reinterpret_cast<void*>(ipint_unreachable_validate); \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
     RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
 } while (false);
 
@@ -52,8 +52,8 @@ do { \
 do { \
     void* base = reinterpret_cast<void*>(ipint_i32_trunc_sat_f32_s_validate); \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
     RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
 } while (false);
 
@@ -61,8 +61,8 @@ do { \
 do { \
     void* base = reinterpret_cast<void*>(ipint_simd_v128_load_mem_validate); \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
     RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
 } while (false);
 
@@ -70,8 +70,8 @@ do { \
 do { \
     void* base = reinterpret_cast<void*>(ipint_memory_atomic_notify_validate); \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
     RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
 } while (false);
 
@@ -79,8 +79,8 @@ do { \
 do { \
     void* base = reinterpret_cast<void*>(ipint_argumINT_a0_validate); \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
     RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
 } while (false);
 
@@ -88,8 +88,8 @@ do { \
 do { \
     void* base = reinterpret_cast<void*>(ipint_local_get_slow_path_validate); \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
     RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
 } while (false);
 
@@ -97,8 +97,8 @@ do { \
 do { \
     void* base = reinterpret_cast<void*>(ipint_mint_a0_validate); \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
     RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
 } while (false);
 
@@ -106,8 +106,8 @@ do { \
 do { \
     void* base = reinterpret_cast<void*>(ipint_mint_r0_validate); \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
     RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
 } while (false);
 
@@ -115,8 +115,8 @@ do { \
 do { \
     void* base = reinterpret_cast<void*>(ipint_uint_r0_validate); \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
     RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
 } while (false);
 
@@ -125,8 +125,8 @@ do { \
 do { \
     void* base = reinterpret_cast<void*>(js_to_wasm_wrapper_entry_interp_LoadI32_validate); \
     void* ptr = reinterpret_cast<void*>(js_to_wasm_wrapper_entry_interp_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
     RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == ((opcode) * 8 * 4), (#name)); \
 } while (false);
 #else

--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -208,7 +208,7 @@ ALWAYS_INLINE MacroAssemblerCodeRef<tag> getWide32CodeRef(OpcodeID opcodeID)
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getCodeFunctionPtr(OpcodeID opcodeID)
 {
-    return reinterpret_cast<LLIntCode>(getCodePtr<tag>(opcodeID).template taggedPtr());
+    return reinterpret_cast<LLIntCode>(getCodePtr<tag>(opcodeID).template taggedPtr<>());
 }
 
 #if ENABLE(JIT)
@@ -216,13 +216,13 @@ ALWAYS_INLINE LLIntCode getCodeFunctionPtr(OpcodeID opcodeID)
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getWide16CodeFunctionPtr(OpcodeID opcodeID)
 {
-    return reinterpret_cast<LLIntCode>(getWide16CodePtr<tag>(opcodeID).template taggedPtr());
+    return reinterpret_cast<LLIntCode>(getWide16CodePtr<tag>(opcodeID).template taggedPtr<>());
 }
 
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getWide32CodeFunctionPtr(OpcodeID opcodeID)
 {
-    return reinterpret_cast<LLIntCode>(getWide32CodePtr<tag>(opcodeID).template taggedPtr());
+    return reinterpret_cast<LLIntCode>(getWide32CodePtr<tag>(opcodeID).template taggedPtr<>());
 }
 #else // not ENABLE(JIT)
 ALWAYS_INLINE void* getCodePtr(OpcodeID id)
@@ -341,7 +341,7 @@ ALWAYS_INLINE MacroAssemblerCodeRef<tag> getWide32CodeRef(WasmOpcodeID opcodeID)
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getCodeFunctionPtr(WasmOpcodeID opcodeID)
 {
-    return reinterpret_cast<LLIntCode>(getCodePtr<tag>(opcodeID).template taggedPtr());
+    return reinterpret_cast<LLIntCode>(getCodePtr<tag>(opcodeID).template taggedPtr<>());
 }
 
 #if ENABLE(JIT)
@@ -349,13 +349,13 @@ ALWAYS_INLINE LLIntCode getCodeFunctionPtr(WasmOpcodeID opcodeID)
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getWide16CodeFunctionPtr(WasmOpcodeID opcodeID)
 {
-    return reinterpret_cast<LLIntCode>(getWide16CodePtr<tag>(opcodeID).template taggedPtr());
+    return reinterpret_cast<LLIntCode>(getWide16CodePtr<tag>(opcodeID).template taggedPtr<>());
 }
 
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getWide32CodeFunctionPtr(WasmOpcodeID opcodeID)
 {
-    return reinterpret_cast<LLIntCode>(getWide32CodePtr<tag>(opcodeID).template taggedPtr());
+    return reinterpret_cast<LLIntCode>(getWide32CodePtr<tag>(opcodeID).template taggedPtr<>());
 }
 #else // not ENABLE(JIT)
 ALWAYS_INLINE void* getCodePtr(WasmOpcodeID id)

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
- *  Copyright (C) 2003-2019 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  *  Copyright (C) 2007 Cameron Zwarich (cwzwarich@uwaterloo.ca)
  *  Copyright (C) 2007 Maks Orlovich
  *  Copyright (C) 2007 Eric Seidel <eric@webkit.org>
@@ -29,6 +29,7 @@
 #include "ImplementationVisibility.h"
 #include "JITCode.h"
 #include "Label.h"
+#include "ModuleScopeData.h"
 #include "ParserArena.h"
 #include "ParserModes.h"
 #include "ParserTokens.h"
@@ -49,7 +50,6 @@ namespace JSC {
     class FunctionMetadataNode;
     class FunctionParameters;
     class ModuleAnalyzer;
-    class ModuleScopeData;
     class PropertyListNode;
     class ReadModifyResolveNode;
     class RegisterID;

--- a/Source/JavaScriptCore/runtime/JSCast.h
+++ b/Source/JavaScriptCore/runtime/JSCast.h
@@ -241,7 +241,7 @@ template<typename Target, typename From>
 bool inherits(From* from)
 {
     using Dispatcher = InheritsTraits<Target>;
-    return Dispatcher::template inherits(from);
+    return Dispatcher::template inherits<>(from);
 }
 
 } // namespace JSCastingHelpers
@@ -250,7 +250,7 @@ template<typename To, typename From>
 To jsDynamicCast(From* from)
 {
     using Dispatcher = JSCastingHelpers::InheritsTraits<typename std::remove_cv<typename std::remove_pointer<To>::type>::type>;
-    if (LIKELY(Dispatcher::template inherits(from)))
+    if (LIKELY(Dispatcher::template inherits<>(from)))
         return static_cast<To>(from);
     return nullptr;
 }

--- a/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/bio/connect.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/bio/connect.c
@@ -487,7 +487,10 @@ static long conn_callback_ctrl(BIO *bio, int cmd, bio_info_cb fp) {
       // convention.
       OPENSSL_MSVC_PRAGMA(warning(push))
       OPENSSL_MSVC_PRAGMA(warning(disable : 4191))
+      OPENSSL_CLANG_PRAGMA("clang diagnostic push")
+      OPENSSL_CLANG_PRAGMA("clang diagnostic ignored \"-Wcast-function-type-mismatch\"")
       data->info_callback = (int (*)(const struct bio_st *, int, int))fp;
+      OPENSSL_CLANG_PRAGMA("clang diagnostic pop")
       OPENSSL_MSVC_PRAGMA(warning(pop))
       break;
     default:

--- a/Source/WTF/wtf/cf/TypeCastsCF.h
+++ b/Source/WTF/wtf/cf/TypeCastsCF.h
@@ -36,33 +36,6 @@ namespace WTF {
 
 template <typename> struct CFTypeTrait;
 
-#define WTF_DECLARE_CF_TYPE_TRAIT(ClassName) \
-template <> \
-struct WTF::CFTypeTrait<ClassName##Ref> { \
-    static inline CFTypeID typeID(void) { return ClassName##GetTypeID(); } \
-};
-
-WTF_DECLARE_CF_TYPE_TRAIT(CFArray);
-WTF_DECLARE_CF_TYPE_TRAIT(CFBoolean);
-WTF_DECLARE_CF_TYPE_TRAIT(CFData);
-WTF_DECLARE_CF_TYPE_TRAIT(CFDictionary);
-WTF_DECLARE_CF_TYPE_TRAIT(CFNumber);
-WTF_DECLARE_CF_TYPE_TRAIT(CFString);
-WTF_DECLARE_CF_TYPE_TRAIT(CFURL);
-
-#define WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(ClassName, MutableClassName) \
-template <> \
-struct WTF::CFTypeTrait<MutableClassName##Ref> { \
-    static inline CFTypeID typeID(void) { return ClassName##GetTypeID(); } \
-};
-
-WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFArray, CFMutableArray);
-WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFData, CFMutableData);
-WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFDictionary, CFMutableDictionary);
-WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFString, CFMutableString);
-
-#undef WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT
-
 // Use dynamic_cf_cast<> instead of checked_cf_cast<> when actively checking CF types,
 // similar to dynamic_cast<> in C++. Be sure to include a nullptr check.
 
@@ -101,6 +74,33 @@ template<typename T> T checked_cf_cast(CFTypeRef object)
 }
 
 } // namespace WTF
+
+#define WTF_DECLARE_CF_TYPE_TRAIT(ClassName) \
+template <> \
+struct WTF::CFTypeTrait<ClassName##Ref> { \
+    static inline CFTypeID typeID(void) { return ClassName##GetTypeID(); } \
+};
+
+WTF_DECLARE_CF_TYPE_TRAIT(CFArray);
+WTF_DECLARE_CF_TYPE_TRAIT(CFBoolean);
+WTF_DECLARE_CF_TYPE_TRAIT(CFData);
+WTF_DECLARE_CF_TYPE_TRAIT(CFDictionary);
+WTF_DECLARE_CF_TYPE_TRAIT(CFNumber);
+WTF_DECLARE_CF_TYPE_TRAIT(CFString);
+WTF_DECLARE_CF_TYPE_TRAIT(CFURL);
+
+#define WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(ClassName, MutableClassName) \
+template <> \
+struct WTF::CFTypeTrait<MutableClassName##Ref> { \
+    static inline CFTypeID typeID(void) { return ClassName##GetTypeID(); } \
+};
+
+WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFArray, CFMutableArray);
+WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFData, CFMutableData);
+WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFDictionary, CFMutableDictionary);
+WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFString, CFMutableString);
+
+#undef WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT
 
 using WTF::checked_cf_cast;
 using WTF::dynamic_cf_cast;

--- a/Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/decode.c
+++ b/Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/decode.c
@@ -2067,7 +2067,7 @@ static int decode_b(Dav1dTaskContext *const t,
             f->frame_hdr->loopfilter.level_y[1])
         {
             const int is_globalmv =
-                b->inter_mode == (is_comp ? GLOBALMV_GLOBALMV : GLOBALMV);
+                is_comp ? (b->inter_mode == GLOBALMV_GLOBALMV) : (b->inter_mode == GLOBALMV);
             const uint8_t (*const lf_lvls)[8][2] = (const uint8_t (*)[8][2])
                 &ts->lflvl[b->seg_id][0][b->ref[0] + 1][!is_globalmv];
             const uint16_t tx_split[2] = { b->tx_split0, b->tx_split1 };


### PR DESCRIPTION
#### 62b6e2db547e1876be1a5e5e51676839fd58e46e
<pre>
Fix build issues with latest Clang
<a href="https://bugs.webkit.org/show_bug.cgi?id=276198">https://bugs.webkit.org/show_bug.cgi?id=276198</a>
<a href="https://rdar.apple.com/130933637">rdar://130933637</a>

Reviewed by Yusuke Suzuki.

The use of the template keyword to reference template members without a template argument list was deprecated in the C++ standard.
e.g. `foo.template bar()` nows needs to be `foo.template bar&lt;&gt;()`. I ran into a different issue with `std::reference_wrapper` that
blocked me from going any further, which AFAICT is a bug on the Clang side.

This also fixes a few other warnings that popped up while building with the new Clang denoted inline

* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq): Clang didn&apos;t like the implicit static_cast&lt;int32_t&gt;(UINT32_MAX) so make it explicit with a static_assert no data was lost.
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::emitNonNullDecodeZeroExtendedStructureID): Clang didn&apos;t like the implicit static_cast&lt;int32_t&gt;(UINT32_MAX) so make it explicit with a static_assert no data was lost.
* Source/JavaScriptCore/llint/InPlaceInterpreter.cpp:
* Source/JavaScriptCore/llint/LLIntData.h:
(JSC::LLInt::getCodeFunctionPtr):
(JSC::LLInt::getWide16CodeFunctionPtr):
(JSC::LLInt::getWide32CodeFunctionPtr):
* Source/JavaScriptCore/parser/Nodes.h: Missing definition of ModuleScopeData added include.
* Source/JavaScriptCore/runtime/JSCast.h:
(JSC::JSCastingHelpers::inherits):
(JSC::jsDynamicCast):
* Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/bio/connect.c:
(conn_callback_ctrl): Had a warning about an incompatible function type. Seems like this is intentional suppressed the warning.
* Source/WTF/wtf/cf/TypeCastsCF.h: Had a warning about extra namespace qualification. I just moved it out of the namespace. That said, it feels like this warning shouldn&apos;t apply to macro expansions...
* Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/decode.c:
(decode_b): Had a warning about different types on the middle/right of a ternary expression. I just pushed the comparison inside the ternary.

Canonical link: <a href="https://commits.webkit.org/280700@main">https://commits.webkit.org/280700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8605b9867440bcf555a01d121b11612417ffcd0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60973 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7795 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7984 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46447 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5516 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49531 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27310 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6842 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6799 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50443 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62652 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/56593 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53707 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49565 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1077 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78353 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8557 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32508 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12980 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33593 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->