### PR TITLE
Refactor isGeneric as enum and rename it to isGenericFontFamily

### DIFF
--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -64,7 +64,7 @@ class ScriptExecutionContext;
 class StyleProperties;
 class StyleRuleFontFace;
 
-enum class ExternalResourceDownloadPolicy;
+enum class ExternalResourceDownloadPolicy : bool;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSFontFace);
 class CSSFontFace final : public RefCounted<CSSFontFace> {

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -382,12 +382,12 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     bool resolveGenericFamilyFirst = familyName == m_fontFamilyNames.at(FamilyNamesIndex::StandardFamily);
 
     AtomString familyForLookup = familyName;
-    bool isGeneric = false;
+    auto isGenericFontFamily = IsGenericFontFamily::No;
     const FontDescription* fontDescriptionForLookup = &fontDescription;
     auto resolveAndAssignGenericFamily = [&] {
         if (auto genericFamilyOptional = resolveGenericFamily(fontDescription, familyName)) {
             familyForLookup = *genericFamilyOptional;
-            isGeneric = true;
+            isGenericFontFamily = IsGenericFontFamily::Yes;
         }
     };
 
@@ -401,7 +401,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     if (face) {
         if (document && document->settings().webAPIStatisticsEnabled())
             ResourceLoadObserver::shared().logFontLoad(*document, familyForLookup.string(), true);
-        return { face->fontRanges(*fontDescriptionForLookup, fontPaletteValues, fontFeatureValues), isGeneric };
+        return { face->fontRanges(*fontDescriptionForLookup, fontPaletteValues, fontFeatureValues), isGenericFontFamily };
     }
 
     if (!resolveGenericFamilyFirst)
@@ -410,7 +410,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     auto font = FontCache::forCurrentThread().fontForFamily(*fontDescriptionForLookup, familyForLookup, { { }, { }, fontPaletteValues, fontFeatureValues, 1.0 });
     if (document && document->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logFontLoad(*document, familyForLookup.string(), !!font);
-    return { FontRanges { WTFMove(font) }, isGeneric };
+    return { FontRanges { WTFMove(font) }, isGenericFontFamily };
 }
 
 void CSSFontSelector::clearFonts()

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -179,7 +179,7 @@ static FontRanges realizeNextFallback(const FontCascadeDescription& description,
                 return FontRanges(WTFMove(font));
             return FontRanges();
         }, [&](const FontFamilyPlatformSpecification& fontFamilySpecification) -> FontRanges {
-            return { fontFamilySpecification.fontRanges(description), true };
+            return { fontFamilySpecification.fontRanges(description), IsGenericFontFamily::Yes };
         });
         const auto& currentFamily = description.effectiveFamilyAt(index++);
         auto ranges = std::visit(visitor, currentFamily);

--- a/Source/WebCore/platform/graphics/FontRanges.cpp
+++ b/Source/WebCore/platform/graphics/FontRanges.cpp
@@ -39,9 +39,9 @@ const Font* FontRanges::Range::font(ExternalResourceDownloadPolicy policy) const
     return m_fontAccessor->font(policy);
 }
 
-FontRanges::FontRanges(FontRanges&& other, bool isGeneric)
+FontRanges::FontRanges(FontRanges&& other, IsGenericFontFamily isGenericFontFamily)
 : m_ranges { WTFMove(other.m_ranges) }
-, m_isGeneric { isGeneric }
+, m_isGenericFontFamily { isGenericFontFamily }
 {
 }
 
@@ -82,7 +82,7 @@ FontRanges::~FontRanges() = default;
 GlyphData FontRanges::glyphDataForCharacter(char32_t character, ExternalResourceDownloadPolicy policy) const
 {
     const Font* resultFont = nullptr;
-    if (isGeneric() && isPrivateUseAreaCharacter(character))
+    if (isGenericFontFamily() && isPrivateUseAreaCharacter(character))
         return GlyphData();
 
     for (auto& range : m_ranges) {

--- a/Source/WebCore/platform/graphics/FontRanges.h
+++ b/Source/WebCore/platform/graphics/FontRanges.h
@@ -33,9 +33,14 @@ namespace WebCore {
 
 class FontAccessor;
 
-enum class ExternalResourceDownloadPolicy {
+enum class ExternalResourceDownloadPolicy : bool {
     Forbid,
     Allow
+};
+
+enum class IsGenericFontFamily : bool {
+    No,
+    Yes
 };
 
 class FontRanges {
@@ -75,7 +80,7 @@ public:
     ~FontRanges();
 
     FontRanges(const FontRanges&) = default;
-    FontRanges(FontRanges&& other, bool isGeneric);
+    FontRanges(FontRanges&& other, IsGenericFontFamily);
     FontRanges& operator=(FontRanges&&) = default;
 
     bool isNull() const { return m_ranges.isEmpty(); }
@@ -90,11 +95,11 @@ public:
     WEBCORE_EXPORT const Font* fontForCharacter(char32_t) const;
     WEBCORE_EXPORT const Font& fontForFirstRange() const;
     bool isLoading() const;
-    bool isGeneric() const { return m_isGeneric; }
+    bool isGenericFontFamily() const { return m_isGenericFontFamily == IsGenericFontFamily::Yes; }
 
 private:
     Vector<Range, 1> m_ranges;
-    bool m_isGeneric { false };
+    IsGenericFontFamily m_isGenericFontFamily { IsGenericFontFamily::No };
 };
 
 }

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -422,7 +422,7 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
 
     for (unsigned i = 0; !fallbackRangesAt(i).isNull(); ++i) {
         auto& fontRanges = fallbackRangesAt(i);
-        if (fontRanges.isGeneric() && isPrivateUseAreaCharacter(baseCharacter))
+        if (fontRanges.isGenericFontFamily() && isPrivateUseAreaCharacter(baseCharacter))
             continue;
         const Font* font = fontRanges.fontForCharacter(baseCharacter);
         if (!font)

--- a/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
@@ -138,7 +138,7 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
     bool triedBaseCharacterFont = false;
     for (unsigned i = 0; !fallbackRangesAt(i).isNull(); ++i) {
         auto& fontRanges = fallbackRangesAt(i);
-        if (fontRanges.isGeneric() && isPrivateUseAreaCharacter(baseCharacter))
+        if (fontRanges.isGenericFontFamily() && isPrivateUseAreaCharacter(baseCharacter))
             continue;
 
         const Font* font = fontRanges.fontForCharacter(baseCharacter);


### PR DESCRIPTION
#### 0edd05d59f19a69d21f7c4cff455025e9f33f8ff
<pre>
Refactor isGeneric as enum and rename it to isGenericFontFamily
<a href="https://bugs.webkit.org/show_bug.cgi?id=276199">https://bugs.webkit.org/show_bug.cgi?id=276199</a>
<a href="https://rdar.apple.com/131078219">rdar://131078219</a>

Reviewed by Matthieu Dubet.

We are avoiding passing the information about if
&quot;is it a generic font family&quot; as a bool as it gets
harder to read and it carries less meaning in
comparison to a descriptive enum with appropriate values.

We are also renaming &quot;isGeneric&quot; to &quot;isGenericFontFamily&quot;
for a better description.

* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::fontRangesForFamily):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::realizeNextFallback):
* Source/WebCore/platform/graphics/FontRanges.cpp:
(WebCore::FontRanges::FontRanges):
(WebCore::FontRanges::glyphDataForCharacter const):
* Source/WebCore/platform/graphics/FontRanges.h:
(WebCore::FontRanges::isGenericFontFamily const):
(WebCore::FontRanges::isGeneric const): Deleted.
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::FontCascade::fontForCombiningCharacterSequence const):
* Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp:
(WebCore::FontCascade::fontForCombiningCharacterSequence const):

Canonical link: <a href="https://commits.webkit.org/280652@main">https://commits.webkit.org/280652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d67e8a8773fbe5c768dd7b519e5dd8aa3ca8dbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60836 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7658 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46326 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5394 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59245 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34290 "Found 1 new test failure: compositing/self-painting-layers.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27186 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6663 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62516 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1128 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7082 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53584 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49438 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12649 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/949 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32372 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33457 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34542 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->