### PR TITLE
[view-transitions] Make ViewTransitionUpdateCallback a weak callback

### DIFF
--- a/Source/WebCore/dom/ViewTransitionUpdateCallback.idl
+++ b/Source/WebCore/dom/ViewTransitionUpdateCallback.idl
@@ -24,6 +24,5 @@
  */
 
 [
-    EnabledBySetting=ViewTransitionsEnabled,
-    IsStrongCallback
+    EnabledBySetting=ViewTransitionsEnabled
 ] callback ViewTransitionUpdateCallback = Promise<any> ();


### PR DESCRIPTION
#### 787ea0cde415618449ff82d9aadaa46907b690b6
<pre>
[view-transitions] Make ViewTransitionUpdateCallback a weak callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=276204">https://bugs.webkit.org/show_bug.cgi?id=276204</a>
<a href="https://rdar.apple.com/131080616">rdar://131080616</a>

Reviewed by NOBODY (OOPS!).

There was no particular reason for it to be strong aside from it being the previous default.

* Source/WebCore/dom/ViewTransitionUpdateCallback.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/787ea0cde415618449ff82d9aadaa46907b690b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/57189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36517 "Hash 787ea0cd for PR 30467 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9664 "Hash 787ea0cd for PR 30467 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60810 "Hash 787ea0cd for PR 30467 does not build (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/7632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59317 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44141 "Hash 787ea0cd for PR 30467 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7822 "Hash 787ea0cd for PR 30467 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/60810 "Hash 787ea0cd for PR 30467 does not build (failure)") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/7632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/59219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/44141 "Hash 787ea0cd for PR 30467 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/9664 "Hash 787ea0cd for PR 30467 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/60810 "Hash 787ea0cd for PR 30467 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/44141 "Hash 787ea0cd for PR 30467 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/9664 "Hash 787ea0cd for PR 30467 does not build (failure)") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/6637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/44141 "Hash 787ea0cd for PR 30467 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/9664 "Hash 787ea0cd for PR 30467 does not build (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/62490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1102 "Hash 787ea0cd for PR 30467 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/7822 "Hash 787ea0cd for PR 30467 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/62490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1107 "Hash 787ea0cd for PR 30467 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/9664 "Hash 787ea0cd for PR 30467 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/62490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/33431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/34516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/33177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->