### PR TITLE
[Site Isolation] Make permissions policy work when site isolation is enabled

### DIFF
--- a/LayoutTests/http/tests/site-isolation/permissions-policy-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/permissions-policy-expected.txt
@@ -1,0 +1,14 @@
+CONSOLE MESSAGE: Permission policy 'SyncXHR' check failed for document with origin 'http://localhost:8000'.
+Verifies permissions policy is set correctly on cross-site frames
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is 'exception'
+PASS event.origin is 'http://localhost:8000'
+PASS event.data is 'pass'
+PASS event.origin is 'http://localhost:8000'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/permissions-policy-nested-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/permissions-policy-nested-expected.txt
@@ -1,0 +1,15 @@
+CONSOLE MESSAGE: Permission policy 'SyncXHR' check failed for document with origin 'http://127.0.0.1:8000'.
+Verifies permissions policy is set correctly on nested cross-site frames
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is 'exception'
+FAIL event.origin should be http://127.0.0.1. Was http://127.0.0.1:8000.
+PASS event.data is 'pass'
+FAIL event.origin should be http://127.0.0.1. Was http://127.0.0.1:8000.
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/permissions-policy-nested.html
+++ b/LayoutTests/http/tests/site-isolation/permissions-policy-nested.html
@@ -1,0 +1,28 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+
+description("Verifies permissions policy is set correctly on nested cross-site frames");
+jsTestIsAsync = true;
+
+onmessage = (event) => {
+    let iframe = document.getElementById("iframe");
+    let src = iframe.src;
+    if (src.includes("exception")) {
+        shouldBe("event.data", "'exception'");
+        shouldBe("event.origin", "'http://127.0.0.1'");
+
+        iframe.removeAttribute("allow");
+        iframe.src = "http://localhost:8000/site-isolation/resources/permissions-policy-nested-iframe.html?pass"
+    } else if (src.includes("pass")) {
+        shouldBe("event.data", "'pass'");
+        shouldBe("event.origin", "'http://127.0.0.1'");
+
+        finishJSTest();
+    }
+}
+
+</script>
+<body>
+<iframe id="iframe" allow="sync-xhr 'none'" src="http://localhost:8000/site-isolation/resources/permissions-policy-nested-iframe.html?exception"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/permissions-policy.html
+++ b/LayoutTests/http/tests/site-isolation/permissions-policy.html
@@ -1,0 +1,28 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+
+description("Verifies permissions policy is set correctly on cross-site frames");
+jsTestIsAsync = true;
+
+onmessage = (event) => {
+    let iframe = document.getElementById("iframe");
+    let src = iframe.src;
+    if (src.includes("exception")) {
+        shouldBe("event.data", "'exception'");
+        shouldBe("event.origin", "'http://localhost:8000'");
+
+        iframe.removeAttribute("allow");
+        iframe.src = "http://localhost:8000/site-isolation/resources/permissions-policy-iframe.html?allow";
+    } else if (src.includes("allow")) {
+        shouldBe("event.data", "'pass'");
+        shouldBe("event.origin", "'http://localhost:8000'");
+
+        finishJSTest();
+    }
+}
+
+</script>
+<body>
+<iframe id="iframe" allow="sync-xhr 'none'" src="http://localhost:8000/site-isolation/resources/permissions-policy-iframe.html?exception"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/permissions-policy-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/resources/permissions-policy-expected.txt
@@ -1,0 +1,9 @@
+CONSOLE MESSAGE: fail
+FAIL: Timed out waiting for notifyDone to be called
+
+Verifies permissions policy is set correctly
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+

--- a/LayoutTests/http/tests/site-isolation/resources/permissions-policy-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/permissions-policy-iframe.html
@@ -1,0 +1,20 @@
+<script>
+
+try {
+	const xhr = new XMLHttpRequest();
+	xhr.open("GET", "/site-isolation/resources/simple.html", false);
+	xhr.onload = (e) => {
+	  if (xhr.readyState === 4) {
+	    if (xhr.status === 200)
+	    	window.top.postMessage("pass", "*");
+	    else
+	    	window.top.postMessage("error", "*");
+	  }
+	};
+	xhr.onerror = (e) => { window.top.postMessage("onerror:" + xhr.statusText, "*"); };
+	xhr.send(null);
+} catch(e) {
+	window.top.postMessage("exception", "*"); 
+}
+
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/permissions-policy-nested-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/permissions-policy-nested-iframe.html
@@ -1,0 +1,1 @@
+<iframe src="http://127.0.0.1:8000/site-isolation/resources/permissions-policy-iframe.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/simple.html
+++ b/LayoutTests/http/tests/site-isolation/resources/simple.html
@@ -1,0 +1,3 @@
+<html>
+Hello, world!
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6324,6 +6324,14 @@ HTMLFrameOwnerElement* Document::ownerElement() const
     return frame()->ownerElement();
 }
 
+std::optional<OwnerPermissionsPolicyData> Document::ownerPermissionsPolicy() const
+{
+    if (WeakPtr currentFrame = frame())
+        return currentFrame->ownerPermissionsPolicy();
+
+    return std::nullopt;
+}
+
 // https://html.spec.whatwg.org/#cookie-averse-document-object
 bool Document::isCookieAverse() const
 {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -274,6 +274,7 @@ struct CSSParserContext;
 struct ClientOrigin;
 struct FocusOptions;
 struct IntersectionObserverData;
+struct OwnerPermissionsPolicyData;
 struct QuerySelectorAllResults;
 struct SecurityPolicyViolationEventInit;
 
@@ -1100,6 +1101,7 @@ public:
     // Returns the owning element in the parent document.
     // Returns nullptr if this is the top level document.
     WEBCORE_EXPORT HTMLFrameOwnerElement* ownerElement() const;
+    WEBCORE_EXPORT std::optional<OwnerPermissionsPolicyData> ownerPermissionsPolicy() const;
 
     // Used by DOM bindings; no direction known.
     const String& title() const { return m_title.string; }

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -125,7 +125,6 @@ void HTMLIFrameElement::attributeChanged(const QualifiedName& name, const AtomSt
 
         String invalidTokens;
         setSandboxFlags(newValue.isNull() ? SandboxNone : SecurityContext::parseSandboxPolicy(newValue, invalidTokens));
-        m_permissionsPolicyDirective = std::nullopt;
         if (!invalidTokens.isNull())
             document().addConsoleMessage(MessageSource::Other, MessageLevel::Error, makeString("Error while parsing the 'sandbox' attribute: "_s, invalidTokens));
         break;
@@ -133,7 +132,6 @@ void HTMLIFrameElement::attributeChanged(const QualifiedName& name, const AtomSt
     case AttributeNames::allowAttr:
     case AttributeNames::allowfullscreenAttr:
     case AttributeNames::webkitallowfullscreenAttr:
-        m_permissionsPolicyDirective = std::nullopt;
         break;
     case AttributeNames::loadingAttr:
         // Allow loading=eager to load the frame immediately if the lazy load was started, but
@@ -145,7 +143,6 @@ void HTMLIFrameElement::attributeChanged(const QualifiedName& name, const AtomSt
         break;
     case AttributeNames::srcdocAttr:
     case AttributeNames::srcAttr:
-        m_permissionsPolicyDirective = std::nullopt;
         FALLTHROUGH;
     default:
         HTMLFrameElementBase::attributeChanged(name, oldValue, newValue, attributeModificationReason);
@@ -250,14 +247,6 @@ LazyLoadFrameObserver& HTMLIFrameElement::lazyLoadFrameObserver()
     if (!m_lazyLoadFrameObserver)
         m_lazyLoadFrameObserver = makeUnique<LazyLoadFrameObserver>(*this);
     return *m_lazyLoadFrameObserver;
-}
-
-PermissionsPolicy::PolicyDirective HTMLIFrameElement::permissionsPolicyDirective() const
-{
-    if (!m_permissionsPolicyDirective)
-        m_permissionsPolicyDirective = PermissionsPolicy::processPermissionsPolicyAttribute(*this);
-
-    return *m_permissionsPolicyDirective;
 }
 
 }

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -44,7 +44,6 @@ public:
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const final;
 
-    PermissionsPolicy::PolicyDirective permissionsPolicyDirective() const;
     const AtomString& loadingForBindings() const;
     void setLoadingForBindings(const AtomString&);
 
@@ -77,7 +76,6 @@ private:
     bool isLazyLoadObserverActive() const final;
 
     std::unique_ptr<DOMTokenList> m_sandbox;
-    mutable std::optional<PermissionsPolicy::PolicyDirective> m_permissionsPolicyDirective;
 #if ENABLE(FULLSCREEN_API)
     bool m_IFrameFullscreenFlag { false };
 #endif

--- a/Source/WebCore/html/PermissionsPolicy.h
+++ b/Source/WebCore/html/PermissionsPolicy.h
@@ -36,6 +36,7 @@ class Allowlist;
 class Document;
 class HTMLFrameOwnerElement;
 class HTMLIFrameElement;
+struct OwnerPermissionsPolicyData;
 
 class PermissionsPolicy {
     WTF_MAKE_FAST_ALLOCATED;
@@ -86,8 +87,7 @@ public:
     static PolicyDirective processPermissionsPolicyAttribute(const HTMLIFrameElement&);
 
 private:
-    bool computeInheritedPolicyValueInContainer(Feature, const HTMLFrameOwnerElement*, const SecurityOriginData&) const;
-    bool computeInheritedPolicyValueInContainer(Feature, const SecurityOriginData&, const PermissionsPolicy&, const PolicyDirective&, const SecurityOriginData&) const;
+    bool computeInheritedPolicyValueInContainer(Feature, const std::optional<OwnerPermissionsPolicyData>&, const SecurityOriginData&) const;
 
     InheritedPolicy m_inheritedPolicy;
 };

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -27,6 +27,7 @@
 
 #include "FrameIdentifier.h"
 #include "FrameTree.h"
+#include "OwnerPermissionsPolicyData.h"
 #include "PageIdentifier.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
@@ -115,6 +116,9 @@ public:
 
     WEBCORE_EXPORT RenderWidget* ownerRenderer() const; // Renderer for the element that contains this frame.
 
+    WEBCORE_EXPORT void setOwnerPermissionsPolicy(OwnerPermissionsPolicyData&&);
+    WEBCORE_EXPORT std::optional<OwnerPermissionsPolicyData> ownerPermissionsPolicy() const;
+
 protected:
     Frame(Page&, FrameIdentifier, FrameType, HTMLFrameOwnerElement*, Frame* parent, Frame* opener);
     void resetWindowProxy();
@@ -137,6 +141,7 @@ private:
     WeakPtr<Frame> m_opener;
     WeakHashSet<Frame> m_openedFrames;
     mutable UniqueRef<HistoryController> m_history;
+    std::optional<OwnerPermissionsPolicyData> m_ownerPermisssionsPolicyOverride;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -30,7 +30,6 @@
 #include "AdjustViewSizeOrNot.h"
 #include "Document.h"
 #include "Frame.h"
-#include "OwnerPermissionsPolicyData.h"
 #include "ScrollTypes.h"
 #include "UserScriptTypes.h"
 #include <wtf/CheckedRef.h>
@@ -320,9 +319,6 @@ public:
     String customNavigatorPlatform() const final;
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const final;
 
-    void setOwnerPermissionsPolicy(OwnerPermissionsPolicyData&& policy) { m_ownerPermisssionsPolicy = WTFMove(policy); }
-    std::optional<OwnerPermissionsPolicyData> ownerPermissionsPolicy() const { return m_ownerPermisssionsPolicy; }
-
 protected:
     void frameWasDisconnectedFromOwner() const final;
 
@@ -393,7 +389,6 @@ private:
     const WeakRef<const LocalFrame> m_rootFrame;
     UniqueRef<EventHandler> m_eventHandler;
     HashSet<RegistrableDomain> m_storageAccessExceptionDomains;
-    std::optional<OwnerPermissionsPolicyData> m_ownerPermisssionsPolicy;
 };
 
 inline LocalFrameView* LocalFrame::view() const

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -33,6 +33,7 @@
 #include <WebCore/AdvancedPrivacyProtections.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/FrameLoaderTypes.h>
+#include <WebCore/OwnerPermissionsPolicyData.h>
 #include <WebCore/PublicSuffixStore.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ShouldTreatAsContinuingLoad.h>
@@ -78,6 +79,7 @@ struct LoadParameters {
     WebCore::SubstituteData::SessionHistoryVisibility sessionHistoryVisibility { WebCore::SubstituteData::SessionHistoryVisibility::Visible };
     String clientRedirectSourceForHistory;
     WebCore::SandboxFlags effectiveSandboxFlags { 0 };
+    std::optional<WebCore::OwnerPermissionsPolicyData> ownerPermissionsPolicy;
     std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain;
     std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume;
     bool isServiceWorkerLoad { false };

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -46,6 +46,7 @@ enum class WebKit::NavigatingToAppBoundDomain : bool;
     WebCore::SubstituteData::SessionHistoryVisibility sessionHistoryVisibility
     String clientRedirectSourceForHistory;
     WebCore::SandboxFlags effectiveSandboxFlags;
+    std::optional<WebCore::OwnerPermissionsPolicyData> ownerPermissionsPolicy;
     std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain;
     std::optional<WebKit::NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume;
     bool isServiceWorkerLoad;

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -33,6 +33,7 @@
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FrameLoaderTypes.h>
+#include <WebCore/OwnerPermissionsPolicyData.h>
 #include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ResourceResponse.h>
@@ -69,6 +70,7 @@ struct NavigationActionData {
     WebCore::LockBackForwardList lockBackForwardList { WebCore::LockBackForwardList::No };
     WTF::String clientRedirectSourceForHistory;
     WebCore::SandboxFlags effectiveSandboxFlags { 0 };
+    std::optional<WebCore::OwnerPermissionsPolicyData> ownerPermissionsPolicy;
     std::optional<WebCore::PrivateClickMeasurement> privateClickMeasurement;
     OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections;
     OptionSet<WebCore::AdvancedPrivacyProtections> originatorAdvancedPrivacyProtections;

--- a/Source/WebKit/Shared/NavigationActionData.serialization.in
+++ b/Source/WebKit/Shared/NavigationActionData.serialization.in
@@ -48,6 +48,7 @@ struct WebKit::NavigationActionData {
     WebCore::LockBackForwardList lockBackForwardList;
     String clientRedirectSourceForHistory;
     WebCore::SandboxFlags effectiveSandboxFlags;
+    std::optional<WebCore::OwnerPermissionsPolicyData> ownerPermissionsPolicy;
     std::optional<WebCore::PrivateClickMeasurement> privateClickMeasurement;
     OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections;
     OptionSet<WebCore::AdvancedPrivacyProtections> originatorAdvancedPrivacyProtections;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8287,3 +8287,47 @@ enum class WebCore::EventMakesGamepadsVisible : bool
 enum class WebCore::WillInternallyHandleFailure : bool
 enum class WebCore::ApplyTrackingPrevention : bool
 enum class WebCore::ShouldSample : bool
+
+[Nested] struct WebCore::Allowlist::AllowAllOrigins {
+};
+
+class WebCore::Allowlist {
+    std::variant<HashSet<WebCore::SecurityOriginData>, WebCore::Allowlist::AllowAllOrigins> origins()
+};
+
+struct WebCore::OwnerPermissionsPolicyData {
+    WebCore::SecurityOriginData documentOrigin;
+    WebCore::PermissionsPolicy documentPolicy;
+    WebCore::OwnerPermissionsPolicyData::PolicyDirective containerPolicy;
+};
+
+[Nested] enum class WebCore::PermissionsPolicy::Feature : uint8_t {
+    Camera,
+    Microphone,
+    SpeakerSelection,
+    DisplayCapture,
+    Gamepad,
+    Geolocation,
+    Payment,
+    ScreenWakeLock,
+    SyncXHR,
+    Fullscreen,
+    WebShare,
+#if ENABLE(DEVICE_ORIENTATION)
+    Gyroscope,
+    Accelerometer,
+    Magnetometer,
+#endif
+#if ENABLE(WEB_AUTHN)
+    PublickeyCredentialsGetRule,
+#endif
+#if ENABLE(WEBXR)
+    XRSpatialTracking,
+#endif
+    PrivateToken,
+    Invalid
+};
+
+class WebCore::PermissionsPolicy {
+    WebCore::PermissionsPolicy::InheritedPolicy inheritedPolicy()
+};

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -139,6 +139,7 @@ public:
 
     WTF::String clientRedirectSourceForHistory() const { return m_lastNavigationAction.clientRedirectSourceForHistory; }
     WebCore::SandboxFlags effectiveSandboxFlags() const { return m_lastNavigationAction.effectiveSandboxFlags; }
+    std::optional<WebCore::OwnerPermissionsPolicyData> ownerPermissionsPolicy() const { return m_lastNavigationAction.ownerPermissionsPolicy; }
 
     void setLastNavigationAction(const WebKit::NavigationActionData& navigationAction) { m_lastNavigationAction = navigationAction; }
     const WebKit::NavigationActionData& lastNavigationAction() const { return m_lastNavigationAction; }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1866,6 +1866,7 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     loadParameters.lockBackForwardList = navigation.lockBackForwardList();
     loadParameters.clientRedirectSourceForHistory = navigation.clientRedirectSourceForHistory();
     loadParameters.effectiveSandboxFlags = navigation.effectiveSandboxFlags();
+    loadParameters.ownerPermissionsPolicy = navigation.ownerPermissionsPolicy();
     loadParameters.isNavigatingToAppBoundDomain = isNavigatingToAppBoundDomain;
     loadParameters.existingNetworkResourceLoadIdentifierToResume = existingNetworkResourceLoadIdentifierToResume;
     loadParameters.advancedPrivacyProtections = navigation.originatorAdvancedPrivacyProtections();
@@ -4510,6 +4511,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
             loadParameters.frameIdentifier = frame->frameID();
             loadParameters.isRequestFromClientOrUserInput = navigationAction->data().isRequestFromClientOrUserInput;
             loadParameters.navigationID = navigation->navigationID();
+            loadParameters.ownerPermissionsPolicy = navigation->ownerPermissionsPolicy();
             processNavigatingTo->send(Messages::WebPage::LoadRequest(WTFMove(loadParameters)), webPageIDInMainFrameProcess());
         }
 
@@ -4682,7 +4684,6 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
     Site navigationSite { navigation.currentRequest().url() };
 
     if (preferences().siteIsolationEnabled() && (!frame.isMainFrame() || newProcess->coreProcessIdentifier() == frame.process().coreProcessIdentifier())) {
-
         // FIXME: Add more parameters as appropriate. <rdar://116200985>
         LoadParameters loadParameters;
         loadParameters.request = navigation.currentRequest();
@@ -4691,6 +4692,7 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         loadParameters.isRequestFromClientOrUserInput = navigation.isRequestFromClientOrUserInput();
         loadParameters.navigationID = navigation.navigationID();
         loadParameters.lockBackForwardList = frame.hasPendingBackForwardItem() ? LockBackForwardList::Yes : LockBackForwardList::No;
+        loadParameters.ownerPermissionsPolicy = navigation.lastNavigationAction().ownerPermissionsPolicy;
 
         Ref processNavigatingFrom = frame.isMainFrame() && m_provisionalPage ? m_provisionalPage->process() : frame.process();
         frame.setHasPendingBackForwardItem(frame.parentFrame() && frame.parentFrame()->process() == processNavigatingFrom);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -342,6 +342,7 @@ Page* WebChromeClient::createWindow(LocalFrame& frame, const WindowFeatures& win
         WebCore::LockBackForwardList::No,
         { }, /* clientRedirectSourceForHistory */
         0, /* effectiveSandboxFlags */
+        std::nullopt, /* ownerPermissionsPolicy */
         navigationAction.privateClickMeasurement(),
         { }, /* advancedPrivacyProtections */
         { }, /* originatorAdvancedPrivacyProtections */

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -115,6 +115,10 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
     // FIXME: When we receive a redirect after the navigation policy has been decided for the initial request,
     // the provisional load's DocumentLoader needs to receive navigation policy decisions. We need a better model for this state.
 
+    std::optional<WebCore::OwnerPermissionsPolicyData> ownerPermissionsPolicy;
+    if (RefPtr coreFrame = m_frame->coreFrame())
+        ownerPermissionsPolicy = coreFrame->ownerPermissionsPolicy();
+
     auto& mouseEventData = navigationAction.mouseEventData();
     return NavigationActionData {
         navigationAction.type(),
@@ -141,6 +145,7 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
         navigationAction.lockBackForwardList(),
         clientRedirectSourceForHistory,
         sandboxFlags,
+        WTFMove(ownerPermissionsPolicy),
         navigationAction.privateClickMeasurement(),
         requestingFrame ? requestingFrame->advancedPrivacyProtections() : OptionSet<AdvancedPrivacyProtections> { },
         requestingFrame ? requestingFrame->originatorAdvancedPrivacyProtections() : OptionSet<AdvancedPrivacyProtections> { },

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -489,6 +489,7 @@ void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI
         WebCore::LockBackForwardList::No,
         { }, /* clientRedirectSourceForHistory */
         0, /* effectiveSandboxFlags */
+        std::nullopt, /* ownerPermissionsPolicy */
         std::nullopt, /* privateClickMeasurement */
         { }, /* advancedPrivacyProtections */
         { }, /* originatorAdvancedPrivacyProtections */
@@ -965,6 +966,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
         WebCore::LockBackForwardList::No,
         { }, /* clientRedirectSourceForHistory */
         0, /* effectiveSandboxFlags */
+        std::nullopt, /* ownerPermissionsPolicy */
         navigationAction.privateClickMeasurement(),
         { }, /* advancedPrivacyProtections */
         { }, /* originatorAdvancedPrivacyProtections */

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2073,6 +2073,9 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
             localMainFrame->loader().forceSandboxFlags(loadParameters.effectiveSandboxFlags);
     }
 
+    if (auto onwerPermissionsPolicy = std::exchange(loadParameters.ownerPermissionsPolicy, { }))
+        localFrame->setOwnerPermissionsPolicy(WTFMove(*onwerPermissionsPolicy));
+
     localFrame->loader().load(WTFMove(frameLoadRequest));
 
     ASSERT(!m_pendingNavigationID);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -70,6 +70,7 @@
 #include <WebCore/MediaControlsContextMenuItem.h>
 #include <WebCore/MediaKeySystemRequest.h>
 #include <WebCore/NowPlayingMetadataObserver.h>
+#include <WebCore/OwnerPermissionsPolicyData.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/PageOverlay.h>
 #include <WebCore/PlatformLayerIdentifier.h>


### PR DESCRIPTION
#### 1f8bdc8eab5985a9e2a250e26ad9be088a55dafe
<pre>
[Site Isolation] Make permissions policy work when site isolation is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=276203">https://bugs.webkit.org/show_bug.cgi?id=276203</a>
<a href="https://rdar.apple.com/131080252">rdar://131080252</a>

Reviewed by Youenn Fablet.

When site isolation is enabled, subframe can be in a different process than its parent. However, for document of the
subframe to compute permissions policy, it needs policy information of its owner element (parent frame). To make
permissions policy work with site isolation, we include owner&apos;s policy in navigation data, which is sent from web
process to UI process on deciding policy for navigation. UI process can then forward the owner&apos;s policy to correct frame
process by including it in LoadParameters.

Tests: http/tests/site-isolation/permissions-policy.html
       http/tests/site-isolation/permissions-policy-nested.html

* LayoutTests/http/tests/site-isolation/permissions-policy-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/permissions-policy-nested-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/permissions-policy-nested.html: Added.
* LayoutTests/http/tests/site-isolation/permissions-policy.html: Added.
* LayoutTests/http/tests/site-isolation/resources/permissions-policy-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/resources/permissions-policy-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/permissions-policy-nested-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/simple.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::ownerPermissionsPolicy const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::attributeChanged):
(WebCore::HTMLIFrameElement::permissionsPolicyDirective const): Deleted.
* Source/WebCore/html/HTMLIFrameElement.h:
* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::PermissionsPolicy::computeInheritedPolicyValueInContainer const):
(WebCore::PermissionsPolicy::PermissionsPolicy):
* Source/WebCore/html/PermissionsPolicy.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::setOwnerPermissionsPolicy):
(WebCore::Frame::ownerPermissionsPolicy const):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/LocalFrame.h:
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/Shared/LoadParameters.serialization.in:
* Source/WebKit/Shared/NavigationActionData.h:
* Source/WebKit/Shared/NavigationActionData.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::ownerPermissionsPolicy const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWindow):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::navigationActionData const):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadRequest):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/280942@main">https://commits.webkit.org/280942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59ebe77d4f044974ac507862a8c42a2c56640754

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61703 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8523 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47054 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6069 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27888 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31837 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7502 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7527 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63404 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54300 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54427 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12845 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1704 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33235 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34321 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35405 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->