### PR TITLE
[tvOS, visionOS, watchOS] Skip install step for WebKit process extensions

### DIFF
--- a/Source/WebKit/Configurations/BaseExtension.xcconfig
+++ b/Source/WebKit/Configurations/BaseExtension.xcconfig
@@ -29,6 +29,8 @@ CLANG_INSTRUMENT_FOR_OPTIMIZATION_PROFILING = NO;
 INSTALL_PATH = $(INSTALL_PATH_PREFIX)/System/Library/ExtensionKit/Extensions;
 INSTALL_PATH[sdk=*simulator] = $(WK_INSTALL_PATH_PREFIX)/System/Library/ExtensionKit/Extensions;
 INSTALL_PATH[sdk=iphone*17.4*] = $(WK_INSTALL_PATH_PREFIX)/System/Library/ExtensionKit/Extensions;
+SKIP_INSTALL = YES;
+SKIP_INSTALL[sdk=iphone*] = NO;
 SWIFT_OBJC_BRIDGING_HEADER = ;
 SWIFT_OBJC_BRIDGING_HEADER[sdk=iphone*] = Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtensionBridge.h;
 SWIFT_OBJC_BRIDGING_HEADER[sdk=iphone*17.0*] = ;


### PR DESCRIPTION
#### 2a81bcc7ebee1e798932ea49c0aaab2ced22015e
<pre>
[tvOS, visionOS, watchOS] Skip install step for WebKit process extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=276210">https://bugs.webkit.org/show_bug.cgi?id=276210</a>
<a href="https://rdar.apple.com/130775557">rdar://130775557</a>

Reviewed by NOBODY (OOPS!).

Skip install step for WebKit process extensions on platforms where they are not enabled.
We need to explicitly skip the install step for visionOS and watchOS, since they
otherwise will match an iPhone SDK predicate.

* Source/WebKit/Configurations/BaseExtension.xcconfig:
</pre>