### PR TITLE
change event not firing when the window loses focus.

### DIFF
--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -425,6 +425,11 @@ static inline void dispatchEventsOnWindowAndFocusedElement(Document* document, b
             return;
         }
 
+        if (RefPtr formControlElement = dynamicDowncast<HTMLFormControlElement>(*document->focusedElement())) {
+            if (formControlElement->wasChangedSinceLastFormControlChangeEvent())
+                formControlElement->dispatchFormControlChangeEvent();
+        }
+
         document->focusedElement()->dispatchBlurEvent(nullptr);
     }
 

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -404,6 +404,7 @@ Tests/WebKitCocoa/WebSocket.mm @nonARC
 Tests/WebKitCocoa/WebTransport.mm @nonARC
 Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm @nonARC
 Tests/WebKitCocoa/WebsitePolicies.mm @nonARC
+Tests/WebKitCocoa/WindowBlurInputChangeEvent.mm @nonARC 
 Tests/WebKitCocoa/WritingSuggestions.mm @nonARC
 Tests/WebKitCocoa/YoutubeReplacementPlugin.mm @nonARC
 Tests/WebKitCocoa/_WKInputDelegate.mm @nonARC

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WindowBlurInputChangeEvent.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WindowBlurInputChangeEvent.mm
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Alexsander Borges Damaceno <alexbdamac@gmail.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+#import "config.h"
+
+#if PLATFORM(MAC)
+#import "TestWKWebView.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <wtf/RetainPtr.h>
+
+TEST(WKWebView, InputChangeFiresOnWindowBlur)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get() addToWindow:YES]);
+    [webView synchronouslyLoadHTMLString:@R"(
+        <!DOCTYPE html>
+        <html>
+        <body>
+            <input id='input' type='text'>
+            <script>
+                window.changeFired = false;
+                document.getElementById('input').addEventListener('change', () => {
+                    window.changeFired = true;
+                });
+            </script>
+        </body>
+        </html>
+    )"];
+
+    [webView objectByEvaluatingJavaScript:@"document.getElementById('input').focus();"];
+    [webView typeCharacter:'a'];
+
+    [webView setVisibility:NO];
+
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.changeFired"] boolValue]);
+}
+
+#endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKInputDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKInputDelegate.mm
@@ -28,6 +28,7 @@
 #import "DeprecatedGlobalValues.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <WebKit/WKFrameInfo.h>


### PR DESCRIPTION
#### 63d26b2d70edb81acd9873c1a3911412120efc9d
<pre>
change event not firing when the window loses focus.
<a href="https://bugs.webkit.org/show_bug.cgi?id=135552">https://bugs.webkit.org/show_bug.cgi?id=135552</a>

Reviewed by Ryosuke Niwa.

The change event was not firing when switching to another window,
even if the value of an input element had changed. Only the blur event was being dispatched.
This happened because the change event was only dispatched when focus moved to another elements in the window.
When switching windows, the focused node did not change, so the event was not fired.
This was fixed by checking whether the element’s contents had changed whenever the window lost focus.
If so, the change event is dispatched.

This aligns the behavior with Firefox and Chrome.

It was not possible to test this using an HTML test.
Rniwa helped me a lot in creating the correct API test.

* Source/WebCore/page/FocusController.cpp:
(WebCore::dispatchEventsOnWindowAndFocusedElement):
Test: Tools/TestWebKitAPI/SourcesCocoa.txt
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WindowBlurInputChangeEvent.mm
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKInputDelegate.mm

Canonical link: <a href="https://commits.webkit.org/308203@main">https://commits.webkit.org/308203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14d33bc1cc5727e7bea46e9cd7bc91cbb40a2ef1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146757 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155421 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19892 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113077 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93822 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14562 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12330 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2865 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157752 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/892 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121084 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121297 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131482 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75051 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22648 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16905 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8368 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82599 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18582 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18732 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->