### PR TITLE
[macOS] Avoid extraneous respondsToSelector call for sharing feature shipping since before macOS 11

### DIFF
--- a/Source/WebKit/UIProcess/mac/ServicesController.mm
+++ b/Source/WebKit/UIProcess/mac/ServicesController.mm
@@ -68,16 +68,11 @@ static void hasCompatibleServicesForItems(dispatch_group_t group, NSArray *items
 {
     NSSharingServiceMask servicesMask = NSSharingServiceMaskViewer | NSSharingServiceMaskEditor;
 
-    if ([NSSharingService respondsToSelector:@selector(getSharingServicesForItems:mask:completion:)]) {
-        dispatch_group_enter(group);
-        [NSSharingService getSharingServicesForItems:items mask:servicesMask completion:makeBlockPtr([completionHandler = WTFMove(completionHandler), group](NSArray *services) {
-            completionHandler(services.count);
-            dispatch_group_leave(group);
-        }).get()];
-        return;
-    }
-    
-    completionHandler([NSSharingService sharingServicesForItems:items mask:servicesMask].count);
+    dispatch_group_enter(group);
+    [NSSharingService getSharingServicesForItems:items mask:servicesMask completion:makeBlockPtr([completionHandler = WTFMove(completionHandler), group](NSArray *services) {
+        completionHandler(services.count);
+        dispatch_group_leave(group);
+    }).get()];
 }
 
 void ServicesController::refreshExistingServices(bool refreshImmediately)


### PR DESCRIPTION
#### ccf89c99d98bc6dfb9fc540469e7a475e9d7c0d1
<pre>
[macOS] Avoid extraneous respondsToSelector call for sharing feature shipping since before macOS 11
<a href="https://bugs.webkit.org/show_bug.cgi?id=276211">https://bugs.webkit.org/show_bug.cgi?id=276211</a>
&lt;<a href="https://rdar.apple.com/problem/131085950">rdar://problem/131085950</a>&gt;

Reviewed by Aditya Keerthi.

We perform a selector check on every call to NSSharingService for
`getSharingServicesForItems:mask:completion:`, even though this method has been part of
NSSharingService since before macOS 11 (two releases before our lowest target OS).

We should avoid this unnecessary call.

* Source/WebKit/UIProcess/mac/ServicesController.mm:
(WebKit::hasCompatibleServicesForItems):

Canonical link: <a href="https://commits.webkit.org/280756@main">https://commits.webkit.org/280756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1a2e33d86e0d490de6faeb13dbdd6e63cd37f0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60838 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7660 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46324 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5391 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27184 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31326 "Found 14 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/abspos/position-absolute-012.html imported/w3c/web-platform-tests/css/css-flexbox/abspos/position-absolute-013.html imported/w3c/web-platform-tests/css/css-flexbox/flex-item-compressible-001.html imported/w3c/web-platform-tests/css/css-flexbox/flex-item-compressible-002.html imported/w3c/web-platform-tests/css/css-inline/text-box-trim/inheritance.html imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-1.html imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing.html imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002.html imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-001.html ... (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6665 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62518 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7083 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53587 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53659 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12720 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/950 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32374 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33459 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->