### PR TITLE
[macOS] fast/canvas/canvas-drawImage-hdr-video.html is constantly failing on Sequoia

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4976,6 +4976,7 @@ http/tests/media/video-canplaythrough-webm.html [ Skip ]
 media/media-session/mock-coordinator.html [ Skip ]
 media/track/track-description-cue.html [ Skip ]
 media/track/track-extended-descriptions.html [ Skip ]
+fast/canvas/canvas-drawImage-hdr-video.html [ Skip ]
 
 # Soon Cocoa-only (currently only macOS)
 fast/forms/switch/ [ Skip ]

--- a/LayoutTests/fast/canvas/canvas-drawImage-hdr-video-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-drawImage-hdr-video-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS pixelColor(1920 ,540)[0] is within 5 of 0
-PASS pixelColor(1920 ,540)[1] is within 5 of 174
+PASS pixelColor(1920 ,540)[1] is within 5 of 206
 PASS pixelColor(1920 ,540)[2] is within 5 of 0
 PASS pixelColor(1920 ,540)[3] is within 5 of 255
 PASS successfullyParsed is true

--- a/LayoutTests/fast/canvas/canvas-drawImage-hdr-video.html
+++ b/LayoutTests/fast/canvas/canvas-drawImage-hdr-video.html
@@ -25,7 +25,7 @@
         let sigma = 5;
 
         let pixel = "pixelColor(" + x + " ," + y + ")";
-        let expectedColor = [0, 174, 0, 255];
+        let expectedColor = [0, 206, 0, 255];
 
         shouldBeCloseTo(pixel + "[0]", expectedColor[0], sigma);
         shouldBeCloseTo(pixel + "[1]", expectedColor[1], sigma);

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3374,8 +3374,6 @@ imported/w3c/web-platform-tests/html/canvas/element/wide-gamut-canvas/ [ Skip ]
 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/ [ Skip ]
 imported/w3c/web-platform-tests/html/canvas/offscreen/wide-gamut-canvas/ [ Skip ]
 
-webkit.org/b/254415 fast/canvas/canvas-drawImage-hdr-video.html [ Failure ]
-
 storage/indexeddb/structured-clone-image-data-display-p3.html [ Skip ]
 
 # UIScriptController

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -773,6 +773,9 @@ platform/mac/fast/loader/file-url-mimetypes.html [ Failure ]
 # This test rarely times out with color being (0, 0, 0, 0), so far only on macOS Ventura.
 http/tests/media/hls/hls-hdr-switch.html [ Pass Timeout ]
 
+# This test works correctly only on Cocoa platforms.
+[ Sequoia+ ] fast/canvas/canvas-drawImage-hdr-video.html [ Pass ]
+ 
 # rdar://94184618 (REGRESSION): [ Mac Ventura Debug ] 5* editing/secure-input/* (layout-tests) are constant failures)
 editing/secure-input/password-input-changed-type.html [ Pass Failure ]
 editing/secure-input/password-input-focusing-to-different-frame.html [ Pass Failure ]

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -173,7 +173,6 @@ compositing/self-painting-layers2.html [ Skip ] # Timeout
 compositing/shared-backing/clipping-and-shared-backing.html [ Skip ] # Timeout
 compositing/video-page-visibility.html [ Skip ] # Timeout
 compositing/visibility/visibility-simple-video-layer.html [ Skip ] # Timeout
-fast/canvas/canvas-drawImage-hdr-video.html [ Skip ] # Timeout
 fast/events/media-focus-in-standalone-media-document.html [ Skip ]
 http/tests/canvas/webgl/origin-clean-conformance.html [ Skip ] # Timeout
 http/tests/navigation/page-cache-video.html [ Skip ] # Timeout


### PR DESCRIPTION
#### dd2e59c746607f827c842a6f0353d2fd4f09ed30
<pre>
[macOS] fast/canvas/canvas-drawImage-hdr-video.html is constantly failing on Sequoia
<a href="https://bugs.webkit.org/show_bug.cgi?id=276212">https://bugs.webkit.org/show_bug.cgi?id=276212</a>
<a href="https://rdar.apple.com/130628077">rdar://130628077</a>

[Images] Unreviewed test gardening.

In macOS Sequoia, the math for converting the HDR frame to SDR frame has been
fixed. The behavior on macOS Sequoia is a progression for this test. So mark
it as [ Skip ] on all ports but mark it as [ Pass ] for [ Sequoia+ ].

* LayoutTests/TestExpectations:
* LayoutTests/fast/canvas/canvas-drawImage-hdr-video-expected.txt:
* LayoutTests/fast/canvas/canvas-drawImage-hdr-video.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/wincairo/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/280659@main">https://commits.webkit.org/280659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/092b6f9c599be81c66c7e2362362d897c4f8cae6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60841 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7663 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46328 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5396 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27188 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6719 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6668 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62521 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1133 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7084 "Found 1 new test failure: media/video-transformed.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53589 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49442 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53662 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12652 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/953 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32377 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33462 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->