### PR TITLE
Restrict performance entries from no-cors cross-origin media requests

### DIFF
--- a/LayoutTests/http/tests/media/resources/hls/.htaccess
+++ b/LayoutTests/http/tests/media/resources/hls/.htaccess
@@ -1,0 +1,3 @@
+<Files playlist-with-cookie.m3u8>
+Header always set Access-Control-Allow-Origin "http://127.0.0.1:8000"
+</Files>

--- a/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-expected.txt
+++ b/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-expected.txt
@@ -1,0 +1,3 @@
+http://127.0.0.1:8000/resources/js-test-pre.js
+http://localhost:8000/media/resources/hls/playlist-with-cookie.m3u8
+

--- a/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-with-cors-expected.txt
+++ b/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-with-cors-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
+CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
+CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
+CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
+http://127.0.0.1:8000/resources/js-test-pre.js
+http://localhost:8000/media/resources/hls/playlist-with-cookie.m3u8
+http://localhost:8000/media/resources/hls/sub-playlist-with-cookie.py
+

--- a/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-with-cors.html
+++ b/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-with-cors.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText()
+        testRunner.waitUntilDone();
+    }
+</script>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<video src="http://localhost:8000/media/resources/hls/playlist-with-cookie.m3u8" crossorigin>
+<script>
+    var entries = new Set();
+    let gotMetadata = false;
+    const expectedEntries = 3;
+    let runTest = function() {
+        for (let entry of performance.getEntriesByType('resource')) {
+            if (entries.has(entry.name))
+                continue;
+            entries.add(entry.name);
+            if (entries.size <= expectedEntries)
+                debug(entry.name);
+        }
+
+        if (gotMetadata && entries.size >= expectedEntries)
+            testRunner.notifyDone();
+    };
+    let video = document.querySelector("video");
+    setInterval(runTest, 100);
+
+    video.addEventListener("loadedmetadata", (e) => {
+        gotMetadata = true;
+        if (gotMetadata && entries.size >= expectedEntries)
+            testRunner.notifyDone();
+    });
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media.html
+++ b/LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText()
+        testRunner.waitUntilDone();
+    }
+</script>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<video src="http://localhost:8000/media/resources/hls/playlist-with-cookie.m3u8">
+<script>
+    var entries = new Set();
+    let gotMetadata = false;
+
+    let video = document.querySelector("video");
+
+    let runTest = function() {
+        for (let entry of performance.getEntriesByType('resource')) {
+            if (entries.has(entry.name))
+                continue;
+            entries.add(entry.name);
+            if (entry.initiatorType == "video" && entry.name != video.src)
+                testFailed("Unexpected entry: " + entry.name);
+            else
+                debug(entry.name);
+        }
+
+        if (gotMetadata && entries.size)
+            testRunner.notifyDone();
+    };
+    setInterval(runTest, 100);
+
+    video.addEventListener("loadedmetadata", (e) => {
+        gotMetadata = true;
+        if (gotMetadata && entries.size)
+            testRunner.notifyDone();
+    });
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2907,6 +2907,8 @@ http/tests/media/modern-media-controls/time-control/1-to-10-hours.html [ Skip ]
 http/tests/media/modern-media-controls/time-control/10-hours-or-more.html [ Skip ]
 http/tests/media/modern-media-controls/time-control/less-than-10-minutes.html [ Skip ]
 http/tests/media/modern-media-controls/time-control/10-minutes-to-1-hour.html [ Skip ]
+http/tests/performance/performance-resource-timing-cross-origin-media.html [ Skip ]
+http/tests/performance/performance-resource-timing-cross-origin-media-with-cors.html [ Skip ]
 
 # DASH media playback support is disabled in the GStreamer ports.
 platform/glib/media/media-can-play-dash.html [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -859,6 +859,9 @@ webkit.org/b/255747 http/tests/security/canvas-remote-read-remote-video-redirect
 
 http/tests/security/canvas-remote-read-remote-video-hls.html [ Skip ] # Timeout
 
+http/tests/performance/performance-resource-timing-cross-origin-media.html [ Skip ] # Timeout
+http/tests/performance/performance-resource-timing-cross-origin-media-with-cors.html [ Skip ] # Timeout
+
 http/tests/security/clipboard/copy-paste-html-across-origin-sanitizes-html.html [ Skip ] # Failure
 http/tests/security/clipboard/copy-paste-html-across-origin-strips-mso-list.html [ Skip ] # Failure
 http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html [ Skip ] # Failure

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -123,6 +123,10 @@ RefPtr<PlatformMediaResource> MediaResourceLoader::requestResource(ResourceReque
         cachingPolicy };
     loaderOptions.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
     loaderOptions.destination = m_destination;
+    if (!m_document->securityOrigin().isSameOriginAs(SecurityOrigin::create(request.url())) && m_crossOriginMode.isNull() && m_wasMainResourceLoaded)
+        loaderOptions.loadedFromOpaqueSource = LoadedFromOpaqueSource::Yes;
+    else if (!m_wasMainResourceLoaded)
+        m_wasMainResourceLoaded = true;
     auto cachedRequest = createPotentialAccessControlRequest(WTFMove(request), WTFMove(loaderOptions), *m_document, m_crossOriginMode);
     if (RefPtr element = m_element.get())
         cachedRequest.setInitiator(*element);

--- a/Source/WebCore/loader/MediaResourceLoader.h
+++ b/Source/WebCore/loader/MediaResourceLoader.h
@@ -67,6 +67,7 @@ public:
 private:
     void contextDestroyed() override;
 
+    bool m_wasMainResourceLoaded { false };
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document WTF_GUARDED_BY_CAPABILITY(mainThread);
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element WTF_GUARDED_BY_CAPABILITY(mainThread);
     String m_crossOriginMode WTF_GUARDED_BY_CAPABILITY(mainThread);


### PR DESCRIPTION
#### 0473037b55025aebdf5a4e9297518b832ab3aaac
<pre>
Restrict performance entries from no-cors cross-origin media requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=276208">https://bugs.webkit.org/show_bug.cgi?id=276208</a>
<a href="https://rdar.apple.com/124946839">rdar://124946839</a>

Reviewed by Ryosuke Niwa.

This patch now sets a media request as coming from an opaque source if it is
  1. cross-origin
  2. no-cors
  3. a nested resource (e.g., from an index file)

* LayoutTests/http/tests/media/resources/hls/.htaccess: Added.
* LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-expected.txt: Added.
* LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-with-cors-expected.txt: Added.
* LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media-with-cors.html: Added.
* LayoutTests/http/tests/performance/performance-resource-timing-cross-origin-media.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResourceLoader::requestResource):
* Source/WebCore/loader/MediaResourceLoader.h:

Canonical link: <a href="https://commits.webkit.org/280985@main">https://commits.webkit.org/280985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/965daadca97d10b16b2b1155cbf865336aa3225a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61855 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8675 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47187 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6200 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50347 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28021 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7644 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7679 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53927 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63560 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7975 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54505 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54564 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1837 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8686 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33387 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34473 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35557 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34218 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->