### PR TITLE
[cocoa] Improve respecting X-Content-Type-Options: nosniff

### DIFF
--- a/LayoutTests/http/tests/mime/html-with-html-expected.txt
+++ b/LayoutTests/http/tests/mime/html-with-html-expected.txt
@@ -1,0 +1,3 @@
+html-document.html has MIME type text/html
+CONSOLE MESSAGE: Pass
+

--- a/LayoutTests/http/tests/mime/html-with-html.html
+++ b/LayoutTests/http/tests/mime/html-with-html.html
@@ -1,0 +1,24 @@
+<html>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpResourceResponseMIMETypes();
+    testRunner.dumpAsText();
+}
+</script>
+<body>
+<script>
+function runTests() {
+    let iframe = document.createElement("iframe");
+    iframe.src = 'resources/html-document.html';
+    if (window.testRunner) {
+        iframe.onerror = testRunner.notifyDone();
+        iframe.onload = testRunner.notifyDone();
+    }
+    document.body.appendChild(iframe);
+}
+runTests();
+</script>
+</body>
+</html>
+

--- a/LayoutTests/http/tests/mime/html-with-nosniff-html-expected.txt
+++ b/LayoutTests/http/tests/mime/html-with-nosniff-html-expected.txt
@@ -1,0 +1,2 @@
+nosniff-html.html has MIME type application/octet-stream
+

--- a/LayoutTests/http/tests/mime/html-with-nosniff-html.html
+++ b/LayoutTests/http/tests/mime/html-with-nosniff-html.html
@@ -1,0 +1,24 @@
+<html>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpResourceResponseMIMETypes();
+    testRunner.dumpAsText();
+}
+</script>
+<body>
+<script>
+function runTests() {
+    let iframe = document.createElement("iframe");
+    iframe.src = 'resources/nosniff-html.html';
+    if (window.testRunner) {
+        iframe.onerror = testRunner.notifyDone();
+        iframe.onload = testRunner.notifyDone();
+    }
+    document.body.appendChild(iframe);
+}
+runTests();
+</script>
+</body>
+</html>
+

--- a/LayoutTests/http/tests/mime/resources/.htaccess
+++ b/LayoutTests/http/tests/mime/resources/.htaccess
@@ -1,3 +1,7 @@
+<Files nosniff-html.html>
+Header always set X-Content-Type-Options "nosniff"
+Header always set Content-Type ""
+</Files>
 <Files xml-with-html.xml>
 ForceType "text/plain"
 </Files>

--- a/LayoutTests/http/tests/mime/resources/html-document.html
+++ b/LayoutTests/http/tests/mime/resources/html-document.html
@@ -1,0 +1,3 @@
+<html>
+<script>console.log("Pass");</script>
+</html>

--- a/LayoutTests/http/tests/mime/resources/nosniff-html.html
+++ b/LayoutTests/http/tests/mime/resources/nosniff-html.html
@@ -1,0 +1,3 @@
+<html>
+<script>console.log("Fail");</script>
+</html>

--- a/LayoutTests/platform/glib/http/tests/mime/html-with-nosniff-html-expected.txt
+++ b/LayoutTests/platform/glib/http/tests/mime/html-with-nosniff-html-expected.txt
@@ -1,0 +1,2 @@
+nosniff-html.html has MIME type text/plain
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1585,6 +1585,9 @@ fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download.html [ Skip ]
 fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate.html [ Skip ]
 http/tests/download/convert-cached-load-to-download.html [ Skip ]
 
+# Can't load application/octet-stream in WK1
+http/tests/mime/html-with-nosniff-html.html [ Skip ]
+
 # dumpPolicyDelegateCallbacks is not supported in DumpRenderTree
 fast/loader/iframe-src-invalid-url.html [ Skip ]
 

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -770,6 +770,7 @@ http/tests/media [ Skip ]
 
 # need to implement content sniffing
 http/tests/mime/mime-type-sniff.html [ Skip ]
+http/tests/mime/html-with-nosniff-html.html [ Skip ]
 
 http/tests/misc/authentication-redirect-3/authentication-sent-to-redirect-same-origin-with-location-credentials.html [ Failure ]
 http/tests/misc/favicon-loads-with-icon-loading-override.html [ Failure ]

--- a/Source/WebCore/platform/network/ios/WebCoreURLResponseIOS.mm
+++ b/Source/WebCore/platform/network/ios/WebCoreURLResponseIOS.mm
@@ -43,7 +43,7 @@ static inline bool shouldPreferTextPlainMIMEType(const String& mimeType, const S
     return ("text/plain"_s == mimeType) && ((proposedMIMEType == "text/xml"_s) || (proposedMIMEType == "application/xml"_s) || (proposedMIMEType == "image/svg+xml"_s));
 }
 
-void adjustMIMETypeIfNecessary(CFURLResponseRef response, bool isMainResourceLoad)
+void adjustMIMETypeIfNecessary(CFURLResponseRef response, IsMainResourceLoad isMainResourceLoad, IsNoSniffSet isNoSniffSet)
 {
     auto type = CFURLResponseGetMIMEType(response);
     if (!type) {
@@ -58,10 +58,11 @@ void adjustMIMETypeIfNecessary(CFURLResponseRef response, bool isMainResourceLoa
 
 #if !USE(QUICK_LOOK)
     UNUSED_PARAM(isMainResourceLoad);
+    UNUSED_PARAM(isNoSniffSet);
 #else
     // Ensure that the MIME type is correct so that QuickLook's web plug-in is called when needed.
     // The shouldUseQuickLookForMIMEType function filters out the common MIME types so we don't do unnecessary work in those cases.
-    if (isMainResourceLoad && shouldUseQuickLookForMIMEType((__bridge NSString *)type)) {
+    if (isMainResourceLoad == IsMainResourceLoad::Yes && isNoSniffSet == IsNoSniffSet::No && shouldUseQuickLookForMIMEType((__bridge NSString *)type)) {
         RetainPtr<CFStringRef> updatedType;
         auto suggestedFilename = adoptCF(CFURLResponseCopySuggestedFilename(response));
         if (auto quickLookType = adoptNS(PAL::softLink_QuickLook_QLTypeCopyBestMimeTypeForFileNameAndMimeType((__bridge NSString *)suggestedFilename.get(), (__bridge NSString *)type)))

--- a/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
+++ b/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
@@ -256,7 +256,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         int statusCode = [r respondsToSelector:@selector(statusCode)] ? [(id)r statusCode] : 0;
         if (statusCode != 304) {
             bool isMainResourceLoad = m_handle->firstRequest().requester() == ResourceRequestRequester::Main;
-            adjustMIMETypeIfNecessary([r _CFURLResponse], isMainResourceLoad);
+            adjustMIMETypeIfNecessary([r _CFURLResponse], isMainResourceLoad ? IsMainResourceLoad::Yes : IsMainResourceLoad::No, IsNoSniffSet::No);
         }
 
         if ([m_handle->firstRequest().nsURLRequest(HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) _propertyForKey:@"ForceHTMLMIMEType"])

--- a/Source/WebCore/platform/network/mac/WebCoreURLResponse.h
+++ b/Source/WebCore/platform/network/mac/WebCoreURLResponse.h
@@ -36,7 +36,10 @@ namespace WebCore {
 WEBCORE_EXPORT NSURLResponse *synthesizeRedirectResponseIfNecessary(NSURLRequest *currentRequest, NSURLRequest *newRequest, NSURLResponse *redirectResponse);
 #endif
 
-WEBCORE_EXPORT void adjustMIMETypeIfNecessary(CFURLResponseRef, bool isMainResourceLoad);
+enum class IsMainResourceLoad : bool { No, Yes };
+enum class IsNoSniffSet : bool { No, Yes };
+
+WEBCORE_EXPORT void adjustMIMETypeIfNecessary(CFURLResponseRef, IsMainResourceLoad, IsNoSniffSet);
 
 RetainPtr<CFStringRef> filePathExtension(CFURLResponseRef);
 RetainPtr<CFStringRef> preferredMIMETypeForFileExtensionFromUTType(CFStringRef extension);

--- a/Source/WebCore/platform/network/mac/WebCoreURLResponse.mm
+++ b/Source/WebCore/platform/network/mac/WebCoreURLResponse.mm
@@ -41,14 +41,14 @@ namespace WebCore {
 
 #if PLATFORM(MAC)
 
-void adjustMIMETypeIfNecessary(CFURLResponseRef response, bool /*isMainResourceLoad*/)
+void adjustMIMETypeIfNecessary(CFURLResponseRef response, IsMainResourceLoad, IsNoSniffSet isNoSniffSet)
 {
     if (CFURLResponseGetMIMEType(response))
         return;
 
     RetainPtr<CFStringRef> type;
 
-    if (auto extension = filePathExtension(response)) {
+    if (auto extension = filePathExtension(response); extension && isNoSniffSet == IsNoSniffSet::No) {
         // <rdar://problem/7007389> CoreTypes UTI map is missing 100+ file extensions that GateKeeper knew about
         // Once UTType matches one of these mappings on all versions of macOS we support, we can remove that pair.
         // Alternatively, we could remove any pairs that we determine we no longer need.

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1095,10 +1095,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         ALLOW_DEPRECATED_DECLARATIONS_END
 
         // Avoid MIME type sniffing if the response comes back as 304 Not Modified.
-        int statusCode = [response isKindOfClass:NSHTTPURLResponse.class] ? [(NSHTTPURLResponse *)response statusCode] : 0;
+        auto isNSHTTPURLResponseClass = [response isKindOfClass:NSHTTPURLResponse.class];
+        int statusCode = isNSHTTPURLResponseClass ? [(NSHTTPURLResponse *)response statusCode] : 0;
+        NSString *xContentTypeOptions = isNSHTTPURLResponseClass ? [(NSHTTPURLResponse *)response valueForHTTPHeaderField:@"X-Content-Type-Options"] : nil;
+        bool isNoSniff = xContentTypeOptions && [xContentTypeOptions caseInsensitiveCompare:@"nosniff"] == NSOrderedSame;
         if (statusCode != httpStatus304NotModified) {
             bool isMainResourceLoad = networkDataTask->firstRequest().requester() == WebCore::ResourceRequestRequester::Main;
-            WebCore::adjustMIMETypeIfNecessary(response._CFURLResponse, isMainResourceLoad);
+            WebCore::adjustMIMETypeIfNecessary(response._CFURLResponse, isMainResourceLoad ? WebCore::IsMainResourceLoad::Yes : WebCore::IsMainResourceLoad::No, isNoSniff ? WebCore::IsNoSniffSet::Yes : WebCore::IsNoSniffSet::No);
         }
 
         WebCore::ResourceResponse resourceResponse(response);


### PR DESCRIPTION
#### 604669158f651d3e21541270a2b71bd5adf04a7f
<pre>
[cocoa] Improve respecting X-Content-Type-Options: nosniff
<a href="https://bugs.webkit.org/show_bug.cgi?id=276214">https://bugs.webkit.org/show_bug.cgi?id=276214</a>
<a href="https://rdar.apple.com/131092817">rdar://131092817</a>

Reviewed by NOBODY (OOPS!).

Respect the X-Content-Type-Options: nosniff header, instead of trying to guess
the best MIME type for the document based on the file extension.

Also convert isMainResourceLoad into an enum class, so it&apos;s consistent with isNoSniffSet.

* LayoutTests/http/tests/mime/html-with-html-expected.txt: Added.
* LayoutTests/http/tests/mime/html-with-html.html: Added.
* LayoutTests/http/tests/mime/html-with-nosniff-html-expected.txt: Added.
* LayoutTests/http/tests/mime/html-with-nosniff-html.html: Added.
* LayoutTests/http/tests/mime/resources/.htaccess:
* LayoutTests/http/tests/mime/resources/html-document.html: Added.
* LayoutTests/http/tests/mime/resources/nosniff-html.html: Added.
* LayoutTests/platform/glib/http/tests/mime/html-with-nosniff-html-expected.txt: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/platform/network/ios/WebCoreURLResponseIOS.mm:
(WebCore::adjustMIMETypeIfNecessary):
* Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm:
(-[WebCoreResourceHandleAsOperationQueueDelegate connection:didReceiveResponse:]):
* Source/WebCore/platform/network/mac/WebCoreURLResponse.h:
* Source/WebCore/platform/network/mac/WebCoreURLResponse.mm:
(WebCore::adjustMIMETypeIfNecessary):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:dataTask:didReceiveResponse:completionHandler:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/604669158f651d3e21541270a2b71bd5adf04a7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7722 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46376 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5445 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27239 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6773 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6727 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53095 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62580 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53637 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53713 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1008 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32436 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33521 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34606 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->