### PR TITLE
[JSC] add support for `Uint8Array.fromHex` and `Uint8Array.prototype.setFromHex`

### DIFF
--- a/JSTests/stress/uint8array-fromHex.js
+++ b/JSTests/stress/uint8array-fromHex.js
@@ -1,0 +1,42 @@
+//@ requireOptions("--useUint8ArrayBase64Methods=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+shouldBeArray(Uint8Array.fromHex(""), []);
+shouldBeArray(Uint8Array.fromHex("00"), [0]);
+shouldBeArray(Uint8Array.fromHex("01"), [1]);
+shouldBeArray(Uint8Array.fromHex("80"), [128]);
+shouldBeArray(Uint8Array.fromHex("fe"), [254]);
+shouldBeArray(Uint8Array.fromHex("FE"), [254]);
+shouldBeArray(Uint8Array.fromHex("ff"), [255]);
+shouldBeArray(Uint8Array.fromHex("FF"), [255]);
+shouldBeArray(Uint8Array.fromHex("0001"), [0, 1]);
+shouldBeArray(Uint8Array.fromHex("feff"), [254, 255]);
+shouldBeArray(Uint8Array.fromHex("FEFF"), [254, 255]);
+shouldBeArray(Uint8Array.fromHex("000180feff"), [0, 1, 128, 254, 255]);
+shouldBeArray(Uint8Array.fromHex("000180FEFF"), [0, 1, 128, 254, 255]);
+
+for (let invalid of [undefined, null, false, true, 42, {}, []]) {
+    try {
+        Uint8Array.fromHex(invalid);
+    } catch (e) {
+        shouldBe(e instanceof TypeError, true);
+    }
+}
+
+for (let invalid of ["0", "012", "0g", "0G", "g0", "G0", "0✅", "✅0"]) {
+    try {
+        Uint8Array.fromHex(invalid);
+    } catch (e) {
+        shouldBe(e instanceof SyntaxError, true);
+    }
+}

--- a/JSTests/stress/uint8array-setFromHex.js
+++ b/JSTests/stress/uint8array-setFromHex.js
@@ -1,0 +1,73 @@
+//@ requireOptions("--useUint8ArrayBase64Methods=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+function shouldBeObject(actual, expected) {
+    for (let key in expected) {
+        shouldBe(key in actual, true);
+        shouldBe(actual[key], expected[key]);
+    }
+
+    for (let key in actual)
+        shouldBe(key in expected, true);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+function test(input, expectedResult, expectedValue) {
+    let uint8array = new Uint8Array([42, 42, 42, 42, 42]);
+
+    let result = uint8array.setFromHex(input);
+
+    shouldBeObject(result, expectedResult);
+    shouldBeArray(uint8array, expectedValue);
+}
+
+test("", {read: 0, written: 0}, [42, 42, 42, 42, 42]);
+test("00", {read: 2, written: 1}, [0, 42, 42, 42, 42]);
+test("01", {read: 2, written: 1}, [1, 42, 42, 42, 42]);
+test("80", {read: 2, written: 1}, [128, 42, 42, 42, 42]);
+test("fe", {read: 2, written: 1}, [254, 42, 42, 42, 42]);
+test("FE", {read: 2, written: 1}, [254, 42, 42, 42, 42]);
+test("ff", {read: 2, written: 1}, [255, 42, 42, 42, 42]);
+test("FF", {read: 2, written: 1}, [255, 42, 42, 42, 42]);
+test("0001", {read: 4, written: 2}, [0, 1, 42, 42, 42]);
+test("feff", {read: 4, written: 2}, [254, 255, 42, 42, 42]);
+test("FEFF", {read: 4, written: 2}, [254, 255, 42, 42, 42]);
+test("000180feff", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+test("000180FEFF", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+test("000180feff33", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+test("000180FEFF33", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+test("000180feff33cc", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+test("000180FEFF33CC", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+
+try {
+    let uint8array = new Uint8Array;
+    $.detachArrayBuffer(uint8array.buffer);
+    uint8array.setFromHex("");
+} catch (e) {
+    shouldBe(e instanceof TypeError, true);
+}
+
+for (let invalid of [undefined, null, false, true, 42, {}, []]) {
+    try {
+        (new Uint8Array).setFromHex(invalid);
+    } catch (e) {
+        shouldBe(e instanceof TypeError, true);
+    }
+}
+
+for (let invalid of ["0", "012", "0g", "g0", "0✅", "✅0"]) {
+    try {
+        (new Uint8Array).setFromHex(invalid);
+    } catch (e) {
+        shouldBe(e instanceof SyntaxError, true);
+    }
+}

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -4725,6 +4725,7 @@
 		918E15BD2447B22600447A56 /* AggregateErrorPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AggregateErrorPrototype.h; sourceTree = "<group>"; };
 		918E15BE2447B22700447A56 /* AggregateErrorPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AggregateErrorPrototype.cpp; sourceTree = "<group>"; };
 		918E15BF2447B22700447A56 /* AggregateErrorConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AggregateErrorConstructor.h; sourceTree = "<group>"; };
+		91C3265B2BFFB2B9009C7E2B /* JSGenericTypedArrayViewConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSGenericTypedArrayViewConstructor.cpp; sourceTree = "<group>"; };
 		91C3265D2BFFB2BF009C7E2B /* JSGenericTypedArrayViewPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSGenericTypedArrayViewPrototype.cpp; sourceTree = "<group>"; };
 		91D1578C24E0BE35001F4CED /* Breakpoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Breakpoint.cpp; sourceTree = "<group>"; };
 		91F548A52A4CF448007292DE /* MapConstructor.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = MapConstructor.js; sourceTree = "<group>"; };
@@ -8337,6 +8338,7 @@
 				70B7918D1C024462002481E2 /* JSGeneratorFunction.h */,
 				276B39092A71D2B400252F4E /* JSGeneratorFunctionInlines.h */,
 				0F2B66C317B6B5AB00A7AE3F /* JSGenericTypedArrayView.h */,
+				91C3265B2BFFB2B9009C7E2B /* JSGenericTypedArrayViewConstructor.cpp */,
 				0F2B66C417B6B5AB00A7AE3F /* JSGenericTypedArrayViewConstructor.h */,
 				0F2B66C517B6B5AB00A7AE3F /* JSGenericTypedArrayViewConstructorInlines.h */,
 				0F2B66C617B6B5AB00A7AE3F /* JSGenericTypedArrayViewInlines.h */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -917,6 +917,7 @@ runtime/JSFinalizationRegistry.cpp
 runtime/JSFunction.cpp
 runtime/JSGenerator.cpp
 runtime/JSGeneratorFunction.cpp
+runtime/JSGenericTypedArrayViewConstructor.cpp
 runtime/JSGenericTypedArrayViewPrototype.cpp
 runtime/JSGlobalLexicalEnvironment.cpp
 runtime/JSGlobalObject.cpp

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -236,6 +236,7 @@
     macro(propertyIsEnumerable) \
     macro(prototype) \
     macro(raw) \
+    macro(read) \
     macro(region) \
     macro(replace) \
     macro(resizable) \
@@ -297,6 +298,7 @@
     macro(weeks) \
     macro(weeksDisplay) \
     macro(writable) \
+    macro(written) \
     macro(year) \
     macro(years) \
     macro(yearsDisplay)

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSGenericTypedArrayViewConstructor.h"
+
+#include "ParseInt.h"
+#include <wtf/text/Base64.h>
+
+namespace JSC {
+
+JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromHex, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSString* jsString = jsDynamicCast<JSString*>(callFrame->argument(0));
+    if (UNLIKELY(!jsString))
+        return throwVMTypeError(globalObject, scope, "Uint8Array.fromHex requires a string"_s);
+    if (UNLIKELY(jsString->length() % 2))
+        return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.fromHex requires a string of even length"_s));
+
+    StringView view = jsString->view(globalObject);
+
+    size_t count = static_cast<size_t>(view.length() / 2);
+    for (size_t i = 0; i < count * 2; ++i) {
+        int digit = parseDigit(view[i], 16);
+        if (UNLIKELY(digit == -1))
+            return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.prototype.setFromHex requires a string containing only \"0123456789abcdefABCDEF\""_s));
+    }
+
+    JSUint8Array* uint8Array = JSUint8Array::create(globalObject, globalObject->typedArrayStructure(TypeUint8, false), count);
+    uint8_t* data = uint8Array->typedVector();
+
+    size_t read = 0;
+    size_t written = 0;
+    for (size_t i = 0; i < count; ++i) {
+        int tens = parseDigit(view[read++], 16);
+        int ones = parseDigit(view[read++], 16);
+        data[written++] = (tens * 16) + ones;
+    }
+    ASSERT(read == count * 2);
+    ASSERT(written == count);
+
+    return JSValue::encode(uint8Array);
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h
@@ -141,4 +141,6 @@ private:
     void finishCreation(VM&, JSGlobalObject*, JSObject* prototype, const String& name);
 };
 
+JSC_DECLARE_HOST_FUNCTION(uint8ArrayConstructorFromHex);
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -35,6 +35,7 @@
 #include "JSDataView.h"
 #include "JSGenericTypedArrayViewConstructor.h"
 #include "JSGlobalObject.h"
+#include "JSTypedArrays.h"
 #include "StructureInlines.h"
 
 namespace JSC {
@@ -46,11 +47,16 @@ JSGenericTypedArrayViewConstructor<ViewClass>::JSGenericTypedArrayViewConstructo
 }
 
 template<typename ViewClass>
-void JSGenericTypedArrayViewConstructor<ViewClass>::finishCreation(VM& vm, JSGlobalObject*, JSObject* prototype, const String& name)
+void JSGenericTypedArrayViewConstructor<ViewClass>::finishCreation(VM& vm, JSGlobalObject* globalObject, JSObject* prototype, const String& name)
 {
     Base::finishCreation(vm, ViewClass::TypedArrayStorageType == TypeDataView ? 1 : 3, name, PropertyAdditionMode::WithoutStructureTransition);
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, prototype, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectWithoutTransition(vm, vm.propertyNames->BYTES_PER_ELEMENT, jsNumber(ViewClass::elementSize), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly | PropertyAttribute::DontDelete);
+
+    if constexpr (std::is_same_v<ViewClass, JSUint8Array>) {
+        if (Options::useUint8ArrayBase64Methods())
+            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("fromHex"_s, uint8ArrayConstructorFromHex, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    }
 }
 
 template<typename ViewClass>

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.h
@@ -56,6 +56,7 @@ private:
     void finishCreation(VM&, JSGlobalObject*);
 };
 
+JSC_DECLARE_HOST_FUNCTION(uint8ArrayPrototypeSetFromHex);
 JSC_DECLARE_HOST_FUNCTION(uint8ArrayPrototypeToBase64);
 JSC_DECLARE_HOST_FUNCTION(uint8ArrayPrototypeToHex);
 

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h
@@ -49,6 +49,7 @@ void JSGenericTypedArrayViewPrototype<ViewClass>::finishCreation(
 
     if constexpr (std::is_same_v<ViewClass, JSUint8Array>) {
         if (Options::useUint8ArrayBase64Methods()) {
+            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("setFromHex"_s, uint8ArrayPrototypeSetFromHex, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
             JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toBase64"_s, uint8ArrayPrototypeToBase64, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
             JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toHex"_s, uint8ArrayPrototypeToHex, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
         }


### PR DESCRIPTION
#### eeedf04c47ffec014748b4d743f31a68f2a3f292
<pre>
[JSC] add support for `Uint8Array.fromHex` and `Uint8Array.prototype.setFromHex`
<a href="https://bugs.webkit.org/show_bug.cgi?id=275593">https://bugs.webkit.org/show_bug.cgi?id=275593</a>

Reviewed by Yusuke Suzuki.

These methods will make it easier for developers to decode typed character/byte data.

Note that there are other methods in the related proposal, but for ease of reviewing they will be implemented separately.

Spec: &lt;<a href="https://tc39.es/proposal-arraybuffer-base64/spec/">https://tc39.es/proposal-arraybuffer-base64/spec/</a>&gt;
Proposal: &lt;<a href="https://github.com/tc39/proposal-arraybuffer-base64">https://github.com/tc39/proposal-arraybuffer-base64</a>&gt;

* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:
(JSC::JSGenericTypedArrayViewConstructor&lt;ViewClass&gt;::finishCreation):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp: Added.
(JSC::uint8ArrayConstructorFromHex):

* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h:
(JSC::JSGenericTypedArrayViewPrototype&lt;ViewClass&gt;::finishCreation):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp:
(JSC::uint8ArrayPrototypeSetFromHex):

* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
Create builtin identifiers for `read` and `written`.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:

* JSTests/stress/uint8array-fromHex.js: Added.
* JSTests/stress/uint8array-setFromHex.js: Added.

Canonical link: <a href="https://commits.webkit.org/280967@main">https://commits.webkit.org/280967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47657272cc06613b6e6367cba2afb7bc6edb684a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61446 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8269 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46853 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5870 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49972 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27681 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7265 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7273 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50916 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53561 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63129 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57066 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54073 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54194 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12867 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1478 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78827 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32981 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13078 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35151 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->