### PR TITLE
[svg] WPT test `svg/path/property/test_style_flush_on_dom_api_with_d_property.html` has failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/test_style_flush_on_dom_api_with_d_property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/test_style_flush_on_dom_api_with_d_property-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL getTotalLength() with d property assert_equals: the total length expected 10 but got 0
-FAIL getPointAtLength() with d property assert_equals: x-axis position expected 10 but got 0
+PASS getTotalLength() with d property
+PASS getPointAtLength() with d property
 PASS isPointInFill() with d property
 PASS isPointInStroke() with d property
 

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -96,7 +96,7 @@ public:
     Ref<SVGPathSegList>& pathSegList() { return m_pathSegList->baseVal(); }
     RefPtr<SVGPathSegList>& animatedPathSegList() { return m_pathSegList->animVal(); }
 
-    const SVGPathByteStream& pathByteStream() const { return m_pathSegList->currentPathByteStream(); }
+    const SVGPathByteStream& pathByteStream() const;
     Path path() const;
     size_t approximateMemoryCost() const final { return m_pathSegList->approximateMemoryCost(); }
 


### PR DESCRIPTION
#### d4bb9d2c03f31fbe54cd1dc7fc27c6628567fe86
<pre>
[svg] WPT test `svg/path/property/test_style_flush_on_dom_api_with_d_property.html` has failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=272621">https://bugs.webkit.org/show_bug.cgi?id=272621</a>
<a href="https://rdar.apple.com/126400894">rdar://126400894</a>

Reviewed by Nikolas Zimmermann.

Since path data can be set via style now, we must make sure that layout is updated when the various
`SVGGeometryElement` DOM methods are called for path-related computations, including `getTotalLength()`,
`getPointAtLength()` and the `SVGPathElement` method `getPathSegAtLength()`. This was already done
for the other `SVGGeometryElement` DOM APIs `isPointInFill()` and `isPointInStroke()`.

We also ensure that the `SVGPathByteStream` we use to run the necessary computations in those methods
is the one held on the `SVGRenderStyle` by making `SVGPathElement::pathByteStream()` account for it.

* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/test_style_flush_on_dom_api_with_d_property-expected.txt:
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::getTotalLength const):
(WebCore::SVGPathElement::getPointAtLength const):
(WebCore::SVGPathElement::getPathSegAtLength const):
(WebCore::SVGPathElement::pathByteStream const):
* Source/WebCore/svg/SVGPathElement.h:

Canonical link: <a href="https://commits.webkit.org/280675@main">https://commits.webkit.org/280675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/025335372fa98ff388da43e9508c5936a7dba862

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60880 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46356 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5424 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27219 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6752 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6706 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7022 "Found 1 new test failure: media/video-transformed.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62559 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53617 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49475 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53691 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/987 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8543 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32415 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34585 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->