### PR TITLE
When a layer size changes, recompute compositing from its stacking context down

### DIFF
--- a/LayoutTests/compositing/shared-backing/update-backing-sharing-on-geometry-change-expected.html
+++ b/LayoutTests/compositing/shared-backing/update-backing-sharing-on-geometry-change-expected.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {
+            background-color: white;
+            color: black;
+        }
+
+        .transformed-container {
+            transform: translate3d(0px, 0px, 0px);
+            border: 1px solid black;
+            padding: 10px;
+            /* width: 200px; */
+        }
+
+        .fixed {
+            position: fixed;
+            top: 20px;
+            right: 320px;
+            width: 20px;
+            height: 20px;
+            border: 2px solid red;
+            transform: translate3d(300px, 0px, 0px);
+        }
+
+        .above {
+            position: absolute;
+            z-index: 1;
+            height: 50px;
+            width: 50px;
+            top: 20px;
+            left: 20px;
+            background-color: green;
+        }
+
+        .translated {
+            transform: translateX(-100%);
+            width: 100px;
+            height: 100px;
+        }
+
+        .slide-left {
+            position: absolute;
+            height: 100px;
+            width: 100px;
+            transform: translateX(100%);
+            background-color: rgba(255, 255, 128, 0.85);
+        }
+
+        .slide-right {
+            position: absolute;
+            height: 100px;
+            width: 100px;
+            transform: translateX(200%);
+        }
+    </style>
+</head>
+
+<body>
+    <div id="containerShrinking" style="width: 150px">
+        <div class="transformed-container">
+            <div class="fixed"></div>
+            <div class="above"></div>
+            <div class="translated">
+                <div class="slide-left"></div>
+                <div class="slide-right"></div>
+            </div>
+        </div>
+    </div>
+    <br>
+    <div id="containerGrowing" style="width: 200px">
+        <div class="transformed-container">
+            <div class="fixed"></div>
+            <div class="above"></div>
+            <div class="translated">
+                <div class="slide-left"></div>
+                <div class="slide-right"></div>
+            </div>
+        </div>
+    </div>
+</body>
+<p>When the red square overlaps the yellow box, the inside box should be green.</p>
+
+</html>

--- a/LayoutTests/compositing/shared-backing/update-backing-sharing-on-geometry-change.html
+++ b/LayoutTests/compositing/shared-backing/update-backing-sharing-on-geometry-change.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {
+            background-color: white;
+            color: black;
+        }
+
+        .transformed-container {
+            transform: translate3d(0px, 0px, 0px);
+            border: 1px solid black;
+            padding: 10px;
+            /* width: 200px; */
+        }
+
+        .fixed {
+            position: fixed;
+            top: 20px;
+            right: 320px;
+            width: 20px;
+            height: 20px;
+            border: 2px solid red;
+            transform: translate3d(300px, 0px, 0px);
+        }
+
+        .above {
+            position: absolute;
+            z-index: 1;
+            height: 50px;
+            width: 50px;
+            top: 20px;
+            left: 20px;
+            background-color: green;
+        }
+
+        .translated {
+            transform: translateX(-100%);
+            width: 100px;
+            height: 100px;
+        }
+
+        .slide-left {
+            position: absolute;
+            height: 100px;
+            width: 100px;
+            transform: translateX(100%);
+            background-color: rgba(255, 255, 128, 0.85);
+        }
+
+        .slide-right {
+            position: absolute;
+            height: 100px;
+            width: 100px;
+            transform: translateX(200%);
+        }
+    </style>
+</head>
+
+<script>
+    function waitAndResizeContainers() {
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+            containerShrinking.style = "width: 150px";
+            containerGrowing.style = "width: 200px";
+            document.documentElement.classList.remove("reftest-wait");
+        }));
+    }
+</script>
+
+<body onload="waitAndResizeContainers()">
+    <div id="containerShrinking" style="width: 200px">
+        <div class="transformed-container">
+            <div class="fixed"></div>
+            <div class="above"></div>
+            <div class="translated">
+                <div class="slide-left"></div>
+                <div class="slide-right"></div>
+            </div>
+        </div>
+    </div>
+    <br>
+    <div id="containerGrowing" style="width: 150px">
+        <div class="transformed-container">
+            <div class="fixed"></div>
+            <div class="above"></div>
+            <div class="translated">
+                <div class="slide-left"></div>
+                <div class="slide-right"></div>
+            </div>
+        </div>
+    </div>
+</body>
+<p>When the red square overlaps the yellow box, the inside box should be green.</p>
+
+</html>

--- a/LayoutTests/compositing/shared-backing/update-backing-sharing-on-size-change-expected.html
+++ b/LayoutTests/compositing/shared-backing/update-backing-sharing-on-size-change-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ OverlappingBackingStoreProvidersEnabled=false ] -->
+<style>
+* { position: absolute; box-shadow: 0px 1px 64px }
+</style>
+<span style="position:sticky">class3</span>

--- a/LayoutTests/compositing/shared-backing/update-backing-sharing-on-size-change.html
+++ b/LayoutTests/compositing/shared-backing/update-backing-sharing-on-size-change.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+* { position: absolute; box-shadow: 0px 1px 64px }
+.class9 { position: relative; backdrop-filter: hue-rotate(-1deg); top: -1cm; }
+</style>
+<script>
+function jsfuzzer() {
+mo.firstChild.remove();
+div.contentEditable = "plaintext-only";
+}
+</script>
+<body onload=jsfuzzer()>
+<span style="position:sticky">class3</span>
+<math display="block">
+<mspace class="class9"/>
+<mo id="mo">*</mo>
+<div id="div">
+<embed>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1732,7 +1732,9 @@ bool RenderLayer::updateLayerPosition(OptionSet<UpdateLayerPositionsFlag>* flags
     auto layerRect = computeLayerPositionAndIntegralSize(renderer());
     auto localPoint = layerRect.location();
 
+    bool geometryChanged = false;
     if (IntSize newSize(layerRect.width().toInt(), layerRect.height().toInt()); newSize != size()) {
+        geometryChanged = true;
         setSize(newSize);
 
         if (flags && renderer().hasNonVisibleOverflow())
@@ -1793,29 +1795,30 @@ bool RenderLayer::updateLayerPosition(OptionSet<UpdateLayerPositionsFlag>* flags
     } else if (!m_contentsScrollingScope || m_contentsScrollingScope != m_boxScrollingScope)
         m_contentsScrollingScope = m_boxScrollingScope;
 
-    bool positionOrOffsetChanged = false;
     if (renderer().isInFlowPositioned()) {
         if (auto* boxModelObject = dynamicDowncast<RenderBoxModelObject>(renderer())) {
             auto newOffset = boxModelObject->offsetForInFlowPosition();
-            positionOrOffsetChanged = newOffset != m_offsetForPosition;
+            geometryChanged |= newOffset != m_offsetForPosition;
             m_offsetForPosition = newOffset;
             localPoint.move(m_offsetForPosition);
         }
     }
 
-    positionOrOffsetChanged |= location() != localPoint;
+    geometryChanged |= location() != localPoint;
     setLocation(localPoint);
     
-    if (positionOrOffsetChanged && compositor().hasContentCompositingLayers()) {
+    if (geometryChanged && compositor().hasContentCompositingLayers()) {
         if (isComposited())
             setNeedsCompositingGeometryUpdate();
-        // This layer's position can affect the location of a composited descendant (which may be a sibling in z-order),
-        // so trigger a descendant walk from the paint-order parent.
-        if (auto* paintParent = paintOrderParent())
-            paintParent->setDescendantsNeedUpdateBackingAndHierarchyTraversal();
+        // This layer's footprint can affect the location of a composited descendant (which may be a sibling in z-order),
+        // so trigger a descendant walk from the enclosing stacking context.
+        if (auto* sc = stackingContext()) {
+            sc->setDescendantsNeedCompositingRequirementsTraversal();
+            sc->setDescendantsNeedUpdateBackingAndHierarchyTraversal();
+        }
     }
 
-    return positionOrOffsetChanged;
+    return geometryChanged;
 }
 
 TransformationMatrix RenderLayer::perspectiveTransform() const


### PR DESCRIPTION
#### 7b1e2f8cef2e6be5d52dd160ff14025bf8e592ae
<pre>
When a layer size changes, recompute compositing from its stacking context down
<a href="https://bugs.webkit.org/show_bug.cgi?id=276216">https://bugs.webkit.org/show_bug.cgi?id=276216</a>
<a href="https://rdar.apple.com/130615925">rdar://130615925</a>

Reviewed by Matt Woodrow.

In some cases, changing the size of an element could change how layers overlap,
so the compositing around it should be appropriately recomputed.

* LayoutTests/compositing/shared-backing/update-backing-sharing-on-geometry-change-expected.html: Added.
* LayoutTests/compositing/shared-backing/update-backing-sharing-on-geometry-change.html: Added.
Before this patch, the changing geometry of the container, which moves the red
square into/out of the yellow box, would not correctly update the green box.

* LayoutTests/compositing/shared-backing/update-backing-sharing-on-size-change-expected.html: Added.
* LayoutTests/compositing/shared-backing/update-backing-sharing-on-size-change.html: Added.
Before this patch, this reduced test case was triggering `ASSERT(provider)` in
RenderLayerCompositor::traverseUnchangedSubtree.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateLayerPosition):

Canonical link: <a href="https://commits.webkit.org/280673@main">https://commits.webkit.org/280673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d4f5c735a008bec81a453785c91497c9623688e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60909 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7730 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46384 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5452 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31141 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6781 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6735 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62588 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7144 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53644 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53721 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12662 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1016 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32444 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33529 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34614 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->