### PR TITLE
Support border/margin/padding on mfrac and mspace elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/fractions/frac-1-expected.txt
@@ -3,7 +3,7 @@ PASS Fraction axis is aligned on the math axis
 PASS Vertical positions of numerator and denominator
 PASS Horizontal alignments of numerator and denominator
 PASS Dimension of mfrac elements
-FAIL Preferred width of mfrac elements assert_approx_equals: Should be the maximum preferred width of numerator/denominator. expected 32 +/- 1 but got 30
+PASS Preferred width of mfrac elements
 
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/no-spacing-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Spacing inside <mfrac>. assert_less_than_equal: expected a number less than or equal to 100 but got 225
+FAIL Spacing inside <mfrac>. assert_less_than_equal: expected a number less than or equal to 100 but got 227
 PASS Spacing around <mfrac>.
 FAIL Spacing inside <msub>. assert_less_than_equal: expected a number less than or equal to 100 but got 455
 PASS Spacing around <msub>.

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout-expected.txt
@@ -24,9 +24,9 @@ PASS merror layout is not affected by children with "position: fixed" style
 PASS mfrac preferred width calculation is not affected by children with "display: none" style
 PASS mfrac layout is not affected by children with "display: none" style
 PASS mfrac preferred width calculation is not affected by children with "position: absolute" style
-FAIL mfrac layout is not affected by children with "position: absolute" style assert_approx_equals: block size expected 18.71875 +/- 1 but got 0
+FAIL mfrac layout is not affected by children with "position: absolute" style assert_approx_equals: inline size expected 2 +/- 1 but got 0
 PASS mfrac preferred width calculation is not affected by children with "position: fixed" style
-FAIL mfrac layout is not affected by children with "position: fixed" style assert_approx_equals: block size expected 18.71875 +/- 1 but got 0
+FAIL mfrac layout is not affected by children with "position: fixed" style assert_approx_equals: inline size expected 2 +/- 1 but got 0
 PASS mi preferred width calculation is not affected by children with "display: none" style
 PASS mi layout is not affected by children with "display: none" style
 PASS mi preferred width calculation is not affected by children with "position: absolute" style

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002-expected.txt
@@ -5,8 +5,8 @@ FAIL Border properties on menclose assert_approx_equals: bottom border expected 
 FAIL Border properties on menclose (rtl) assert_approx_equals: bottom border expected 60 +/- 1 but got -3.96875
 PASS Border properties on merror
 PASS Border properties on merror (rtl)
-FAIL Border properties on mfrac assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on mfrac (rtl) assert_approx_equals: left border expected 30 +/- 1 but got 0
+PASS Border properties on mfrac
+PASS Border properties on mfrac (rtl)
 PASS Border properties on mi
 PASS Border properties on mi (rtl)
 FAIL Border properties on mmultiscripts assert_approx_equals: left border expected 30 +/- 1 but got 0
@@ -27,7 +27,7 @@ PASS Border properties on mrow
 PASS Border properties on mrow (rtl)
 PASS Border properties on ms
 PASS Border properties on ms (rtl)
-FAIL Border properties on mspace assert_approx_equals: left/right border expected 70 +/- 1 but got 0
+PASS Border properties on mspace
 FAIL Border properties on msqrt assert_approx_equals: bottom border expected 60 +/- 1 but got -8.21875
 FAIL Border properties on msqrt (rtl) assert_approx_equals: bottom border expected 60 +/- 1 but got -8.21875
 PASS Border properties on mstyle

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-002-expected.txt
@@ -8,9 +8,9 @@ FAIL Margin properties on menclose (no margin-collapsing) assert_approx_equals: 
 FAIL Margin properties on merror assert_approx_equals: top margin expected 50 +/- 1 but got 100
 FAIL Margin properties on merror (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
 FAIL Margin properties on merror (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
-FAIL Margin properties on mfrac assert_approx_equals: left margin expected 30 +/- 1 but got 0
-FAIL Margin properties on mfrac (rtl) assert_approx_equals: left margin expected 30 +/- 1 but got 0
-FAIL Margin properties on mfrac (no margin-collapsing) assert_approx_equals: left margin expected 60 +/- 1 but got 30
+FAIL Margin properties on mfrac assert_approx_equals: top margin expected 50 +/- 1 but got 0
+FAIL Margin properties on mfrac (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 0
+FAIL Margin properties on mfrac (no margin-collapsing) assert_approx_equals: bottom margin expected 120 +/- 1 but got 10
 FAIL Margin properties on mi assert_approx_equals: top margin expected 50 +/- 1 but got 100
 FAIL Margin properties on mi (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
 FAIL Margin properties on mi (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
@@ -41,7 +41,7 @@ FAIL Margin properties on mrow (no margin-collapsing) assert_approx_equals: top 
 FAIL Margin properties on ms assert_approx_equals: top margin expected 50 +/- 1 but got 100
 FAIL Margin properties on ms (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
 FAIL Margin properties on ms (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
-FAIL Margin properties on mspace assert_approx_equals: left/right margin expected 70 +/- 1 but got 0
+FAIL Margin properties on mspace assert_approx_equals: top/bottom margin expected 110 +/- 1 but got 0
 FAIL Margin properties on msqrt assert_approx_equals: top margin expected 50 +/- 1 but got 0
 FAIL Margin properties on msqrt (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 0
 FAIL Margin properties on msqrt (no margin-collapsing) assert_approx_equals: bottom margin expected 120 +/- 1 but got 10

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
@@ -1,15 +1,15 @@
 
-FAIL Margin properties on the children of menclose assert_approx_equals: inline size expected 56.15625 +/- 1 but got 31.15625
-FAIL Margin properties on the children of merror assert_approx_equals: inline size expected 47 +/- 1 but got 22
-FAIL Margin properties on the children of mfrac assert_approx_equals: inline size expected 45 +/- 1 but got 20
+FAIL Margin properties on the children of menclose assert_approx_equals: block size expected 122.96875 +/- 1 but got 77.96875
+FAIL Margin properties on the children of merror assert_approx_equals: block size expected 117 +/- 1 but got 72
+FAIL Margin properties on the children of mfrac assert_approx_equals: preferred width expected 49 +/- 1 but got 24
 FAIL Margin properties on the children of mmultiscripts assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
 FAIL Margin properties on the children of mover assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of mpadded assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of mphantom assert_approx_equals: inline size expected 45 +/- 1 but got 20
+FAIL Margin properties on the children of mpadded assert_approx_equals: block size expected 115 +/- 1 but got 70
+FAIL Margin properties on the children of mphantom assert_approx_equals: block size expected 115 +/- 1 but got 70
 FAIL Margin properties on the children of mroot assert_approx_equals: inline size expected 105.0625 +/- 1 but got 55.0625
-FAIL Margin properties on the children of mrow assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of msqrt assert_approx_equals: inline size expected 64.390625 +/- 1 but got 39.390625
-FAIL Margin properties on the children of mstyle assert_approx_equals: inline size expected 45 +/- 1 but got 20
+FAIL Margin properties on the children of mrow assert_approx_equals: block size expected 115 +/- 1 but got 70
+FAIL Margin properties on the children of msqrt assert_approx_equals: block size expected 118.671875 +/- 1 but got 73.671875
+FAIL Margin properties on the children of mstyle assert_approx_equals: block size expected 115 +/- 1 but got 70
 FAIL Margin properties on the children of msub assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
 FAIL Margin properties on the children of msubsup assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
 FAIL Margin properties on the children of msup assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
@@ -5,8 +5,8 @@ FAIL Padding properties on menclose assert_approx_equals: bottom padding expecte
 FAIL Padding properties on menclose (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -4.1875
 PASS Padding properties on merror
 PASS Padding properties on merror (rtl)
-FAIL Padding properties on mfrac assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mfrac (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on mfrac
+PASS Padding properties on mfrac (rtl)
 FAIL Padding properties on mi assert_approx_equals: right padding expected 40 +/- 1 but got 38.406253814697266
 FAIL Padding properties on mi (rtl) assert_approx_equals: right padding expected 40 +/- 1 but got 38.406253814697266
 FAIL Padding properties on mmultiscripts assert_approx_equals: left padding expected 30 +/- 1 but got 0
@@ -27,7 +27,7 @@ PASS Padding properties on mrow
 PASS Padding properties on mrow (rtl)
 PASS Padding properties on ms
 PASS Padding properties on ms (rtl)
-FAIL Padding properties on mspace assert_approx_equals: left/right padding expected 70 +/- 1 but got 0
+PASS Padding properties on mspace
 FAIL Padding properties on msqrt assert_approx_equals: bottom padding expected 60 +/- 1 but got -10.71875
 FAIL Padding properties on msqrt (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -10.71875
 PASS Padding properties on mstyle

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002-expected.txt
@@ -5,8 +5,8 @@ FAIL Border properties on menclose assert_approx_equals: bottom border expected 
 FAIL Border properties on menclose (rtl) assert_approx_equals: bottom border expected 60 +/- 1 but got -4.96875
 PASS Border properties on merror
 PASS Border properties on merror (rtl)
-FAIL Border properties on mfrac assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on mfrac (rtl) assert_approx_equals: left border expected 30 +/- 1 but got 0
+PASS Border properties on mfrac
+PASS Border properties on mfrac (rtl)
 PASS Border properties on mi
 PASS Border properties on mi (rtl)
 FAIL Border properties on mmultiscripts assert_approx_equals: left border expected 30 +/- 1 but got 0
@@ -27,7 +27,7 @@ PASS Border properties on mrow
 PASS Border properties on mrow (rtl)
 PASS Border properties on ms
 PASS Border properties on ms (rtl)
-FAIL Border properties on mspace assert_approx_equals: left/right border expected 70 +/- 1 but got 0
+PASS Border properties on mspace
 FAIL Border properties on msqrt assert_approx_equals: bottom border expected 60 +/- 1 but got -7.625
 FAIL Border properties on msqrt (rtl) assert_approx_equals: bottom border expected 60 +/- 1 but got -7.625
 PASS Border properties on mstyle

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
@@ -1,15 +1,15 @@
 
-FAIL Margin properties on the children of menclose assert_approx_equals: inline size expected 56.15625 +/- 1 but got 31.15625
-FAIL Margin properties on the children of merror assert_approx_equals: inline size expected 47 +/- 1 but got 22
-FAIL Margin properties on the children of mfrac assert_approx_equals: inline size expected 45 +/- 1 but got 20
+FAIL Margin properties on the children of menclose assert_approx_equals: block size expected 122.96875 +/- 1 but got 77.96875
+FAIL Margin properties on the children of merror assert_approx_equals: block size expected 117 +/- 1 but got 72
+FAIL Margin properties on the children of mfrac assert_approx_equals: preferred width expected 49 +/- 1 but got 24
 FAIL Margin properties on the children of mmultiscripts assert_approx_equals: inline size expected 90.890625 +/- 1 but got 40.890625
 FAIL Margin properties on the children of mover assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of mpadded assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of mphantom assert_approx_equals: inline size expected 45 +/- 1 but got 20
+FAIL Margin properties on the children of mpadded assert_approx_equals: block size expected 115 +/- 1 but got 70
+FAIL Margin properties on the children of mphantom assert_approx_equals: block size expected 115 +/- 1 but got 70
 FAIL Margin properties on the children of mroot assert_approx_equals: inline size expected 102.546875 +/- 1 but got 52.546875
-FAIL Margin properties on the children of mrow assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of msqrt assert_approx_equals: inline size expected 62 +/- 1 but got 37
-FAIL Margin properties on the children of mstyle assert_approx_equals: inline size expected 45 +/- 1 but got 20
+FAIL Margin properties on the children of mrow assert_approx_equals: block size expected 115 +/- 1 but got 70
+FAIL Margin properties on the children of msqrt assert_approx_equals: block size expected 117.046875 +/- 1 but got 72.046875
+FAIL Margin properties on the children of mstyle assert_approx_equals: block size expected 115 +/- 1 but got 70
 FAIL Margin properties on the children of msub assert_approx_equals: inline size expected 90.890625 +/- 1 but got 40.890625
 FAIL Margin properties on the children of msubsup assert_approx_equals: inline size expected 90.890625 +/- 1 but got 40.890625
 FAIL Margin properties on the children of msup assert_approx_equals: inline size expected 90.890625 +/- 1 but got 40.890625

--- a/LayoutTests/platform/glib/mathml/presentation/roots-expected.txt
+++ b/LayoutTests/platform/glib/mathml/presentation/roots-expected.txt
@@ -55,10 +55,10 @@ layer at (0,0) size 800x546
       RenderBlock {p} at (0,105) size 784x32
         RenderText {#text} at (0,6) size 113x17
           text run at (0,6) width 113: "root of a fraction: "
-        RenderMathMLMath {math} at (113,0) size 53x31
-          RenderMathMLRoot {msqrt} at (0,0) size 53x31
-            RenderMathMLFraction {mfrac} at (16,2) size 37x28 [padding: 0 1 0 1]
-              RenderMathMLRow {mrow} at (0,0) size 37x13
+        RenderMathMLMath {math} at (113,0) size 55x31
+          RenderMathMLRoot {msqrt} at (0,0) size 55x31
+            RenderMathMLFraction {mfrac} at (16,2) size 39x28 [padding: 0 1 0 1]
+              RenderMathMLRow {mrow} at (1,0) size 37x13
                 RenderMathMLToken {mi} at (0,3) size 9x9 [padding: 0 2 0 0]
                   RenderBlock (anonymous) at (0,0) size 8x7
                     RenderText {#text} at (0,-50) size 8x106
@@ -71,7 +71,7 @@ layer at (0,0) size 800x546
                   RenderBlock (anonymous) at (0,0) size 8x11
                     RenderText {#text} at (0,-46) size 8x106
                       text run at (0,-46) width 8: "1"
-              RenderMathMLRow {mrow} at (0,14) size 37x14
+              RenderMathMLRow {mrow} at (1,14) size 37x14
                 RenderMathMLToken {mi} at (0,3) size 9x9 [padding: 0 2 0 0]
                   RenderBlock (anonymous) at (0,0) size 8x7
                     RenderText {#text} at (0,-50) size 8x106
@@ -130,10 +130,10 @@ layer at (0,0) size 800x546
       RenderBlock {p} at (0,221) size 784x31
         RenderText {#text} at (0,6) size 185x17
           text run at (0,6) width 185: "long index w/ complex base: "
-        RenderMathMLMath {math} at (185,0) size 83x31
-          RenderMathMLRoot {mroot} at (0,0) size 83x31
-            RenderMathMLFraction {mfrac} at (46,2) size 37x28 [padding: 0 1 0 1]
-              RenderMathMLRow {mrow} at (0,0) size 37x13
+        RenderMathMLMath {math} at (185,0) size 85x31
+          RenderMathMLRoot {mroot} at (0,0) size 85x31
+            RenderMathMLFraction {mfrac} at (46,2) size 39x28 [padding: 0 1 0 1]
+              RenderMathMLRow {mrow} at (1,0) size 37x13
                 RenderMathMLToken {mi} at (0,3) size 9x9 [padding: 0 2 0 0]
                   RenderBlock (anonymous) at (0,0) size 8x7
                     RenderText {#text} at (0,-50) size 8x106
@@ -146,7 +146,7 @@ layer at (0,0) size 800x546
                   RenderBlock (anonymous) at (0,0) size 8x11
                     RenderText {#text} at (0,-46) size 8x106
                       text run at (0,-46) width 8: "1"
-              RenderMathMLRow {mrow} at (0,14) size 37x14
+              RenderMathMLRow {mrow} at (1,14) size 37x14
                 RenderMathMLToken {mi} at (0,3) size 9x9 [padding: 0 2 0 0]
                   RenderBlock (anonymous) at (0,0) size 8x7
                     RenderText {#text} at (0,-50) size 8x106
@@ -183,23 +183,23 @@ layer at (0,0) size 800x546
       RenderBlock {p} at (0,267) size 784x31
         RenderText {#text} at (0,11) size 75x17
           text run at (0,11) width 75: "high index: "
-        RenderMathMLMath {math} at (75,0) size 22x30
-          RenderMathMLRoot {mroot} at (0,0) size 22x30
-            RenderMathMLToken {mn} at (13,14) size 9x12
+        RenderMathMLMath {math} at (75,0) size 26x30
+          RenderMathMLRoot {mroot} at (0,0) size 26x30
+            RenderMathMLToken {mn} at (17,14) size 9x12
               RenderBlock (anonymous) at (0,0) size 8x11
                 RenderText {#text} at (0,-46) size 8x106
                   text run at (0,-46) width 8: "2"
-            RenderMathMLFraction {mfrac} at (4,0) size 6x20 [padding: 0 1 0 1]
-              RenderMathMLFraction {mfrac} at (0,0) size 5x13 [padding: 0 1 0 1]
-                RenderMathMLToken {mi} at (0,0) size 5x5 [padding: 0 1 0 0]
+            RenderMathMLFraction {mfrac} at (4,0) size 10x20 [padding: 0 1 0 1]
+              RenderMathMLFraction {mfrac} at (1,0) size 7x13 [padding: 0 1 0 1]
+                RenderMathMLToken {mi} at (1,0) size 5x5 [padding: 0 1 0 0]
                   RenderBlock (anonymous) at (0,0) size 5x4
                     RenderText {#text} at (0,-28) size 5x60
                       text run at (0,-28) width 5: "x"
-                RenderMathMLToken {mi} at (0,6) size 5x7 [padding: 0 1 0 0]
+                RenderMathMLToken {mi} at (1,6) size 5x7 [padding: 0 1 0 0]
                   RenderBlock (anonymous) at (0,0) size 5x6
                     RenderText {#text} at (0,-28) size 5x60
                       text run at (0,-28) width 5: "y"
-              RenderMathMLToken {mi} at (0,14) size 5x6 [padding: 0 1 0 0]
+              RenderMathMLToken {mi} at (2,14) size 5x6 [padding: 0 1 0 0]
                 RenderBlock (anonymous) at (0,0) size 4x4
                   RenderText {#text} at (0,-28) size 4x60
                     text run at (0,-28) width 4: "z"
@@ -285,9 +285,9 @@ layer at (0,0) size 800x546
       RenderBlock {p} at (0,384) size 784x58
         RenderText {#text} at (0,21) size 110x17
           text run at (0,21) width 110: "Imbricated roots: "
-        RenderMathMLMath {math} at (110,0) size 351x57
-          RenderMathMLRoot {mroot} at (0,0) size 351x57
-            RenderMathMLRow {mrow} at (17,2) size 334x55
+        RenderMathMLMath {math} at (110,0) size 353x57
+          RenderMathMLRoot {mroot} at (0,0) size 353x57
+            RenderMathMLRow {mrow} at (17,2) size 336x55
               RenderMathMLToken {mn} at (0,22) size 8x11
                 RenderBlock (anonymous) at (0,0) size 8x11
                   RenderText {#text} at (0,-46) size 8x106
@@ -296,8 +296,8 @@ layer at (0,0) size 800x546
                 RenderBlock (anonymous) at (3,0) size 13x12
                   RenderText {#text} at (0,-47) size 12x106
                     text run at (0,-47) width 12: "+"
-              RenderMathMLRoot {mroot} at (27,0) size 306x55
-                RenderMathMLRow {mrow} at (17,2) size 289x53
+              RenderMathMLRoot {mroot} at (27,0) size 308x55
+                RenderMathMLRow {mrow} at (17,2) size 291x53
                   RenderMathMLToken {mn} at (0,20) size 8x11
                     RenderBlock (anonymous) at (0,0) size 8x11
                       RenderText {#text} at (0,-46) size 8x106
@@ -306,8 +306,8 @@ layer at (0,0) size 800x546
                     RenderBlock (anonymous) at (3,0) size 13x12
                       RenderText {#text} at (0,-47) size 12x106
                         text run at (0,-47) width 12: "+"
-                  RenderMathMLRoot {mroot} at (27,0) size 261x53
-                    RenderMathMLRow {mrow} at (17,2) size 244x51
+                  RenderMathMLRoot {mroot} at (27,0) size 263x53
+                    RenderMathMLRow {mrow} at (17,2) size 246x51
                       RenderMathMLToken {mn} at (0,18) size 8x12
                         RenderBlock (anonymous) at (0,0) size 8x12
                           RenderText {#text} at (0,-46) size 8x106
@@ -316,8 +316,8 @@ layer at (0,0) size 800x546
                         RenderBlock (anonymous) at (3,0) size 13x12
                           RenderText {#text} at (0,-47) size 12x106
                             text run at (0,-47) width 12: "+"
-                      RenderMathMLRoot {mroot} at (27,0) size 217x51
-                        RenderMathMLRow {mrow} at (17,2) size 200x49
+                      RenderMathMLRoot {mroot} at (27,0) size 219x51
+                        RenderMathMLRow {mrow} at (17,2) size 202x49
                           RenderMathMLToken {mn} at (0,16) size 8x11
                             RenderBlock (anonymous) at (0,0) size 8x11
                               RenderText {#text} at (0,-46) size 8x106
@@ -326,8 +326,8 @@ layer at (0,0) size 800x546
                             RenderBlock (anonymous) at (3,0) size 13x12
                               RenderText {#text} at (0,-47) size 12x106
                                 text run at (0,-47) width 12: "+"
-                          RenderMathMLRoot {mroot} at (27,0) size 172x49
-                            RenderMathMLRow {mrow} at (16,2) size 156x41
+                          RenderMathMLRoot {mroot} at (27,0) size 174x49
+                            RenderMathMLRow {mrow} at (16,2) size 158x41
                               RenderMathMLToken {mn} at (0,14) size 8x12
                                 RenderBlock (anonymous) at (0,0) size 8x12
                                   RenderText {#text} at (0,-46) size 8x106
@@ -336,8 +336,8 @@ layer at (0,0) size 800x546
                                 RenderBlock (anonymous) at (3,0) size 13x12
                                   RenderText {#text} at (0,-47) size 12x106
                                     text run at (0,-47) width 12: "+"
-                              RenderMathMLRoot {mroot} at (27,0) size 128x41
-                                RenderMathMLRow {mrow} at (16,2) size 112x31
+                              RenderMathMLRoot {mroot} at (27,0) size 130x41
+                                RenderMathMLRow {mrow} at (16,2) size 114x31
                                   RenderMathMLToken {mn} at (0,12) size 8x12
                                     RenderBlock (anonymous) at (0,0) size 8x12
                                       RenderText {#text} at (0,-46) size 8x106
@@ -346,8 +346,8 @@ layer at (0,0) size 800x546
                                     RenderBlock (anonymous) at (3,0) size 13x12
                                       RenderText {#text} at (0,-47) size 12x106
                                         text run at (0,-47) width 12: "+"
-                                  RenderMathMLRoot {mroot} at (27,0) size 85x31
-                                    RenderMathMLRow {mrow} at (16,2) size 69x26
+                                  RenderMathMLRoot {mroot} at (27,0) size 87x31
+                                    RenderMathMLRow {mrow} at (16,2) size 71x26
                                       RenderMathMLToken {mn} at (0,10) size 8x12
                                         RenderBlock (anonymous) at (0,0) size 8x12
                                           RenderText {#text} at (0,-46) size 8x106
@@ -356,13 +356,13 @@ layer at (0,0) size 800x546
                                         RenderBlock (anonymous) at (3,0) size 13x12
                                           RenderText {#text} at (0,-47) size 12x106
                                             text run at (0,-47) width 12: "+"
-                                      RenderMathMLRoot {mroot} at (27,0) size 41x26
-                                        RenderMathMLToken {mi} at (28,9) size 13x13 [padding: 0 2 0 0]
+                                      RenderMathMLRoot {mroot} at (27,0) size 43x26
+                                        RenderMathMLToken {mi} at (30,9) size 13x13 [padding: 0 2 0 0]
                                           RenderBlock (anonymous) at (0,0) size 12x12
                                             RenderText {#text} at (0,-45) size 12x106
                                               text run at (0,-45) width 12: "A"
-                                        RenderMathMLFraction {mfrac} at (4,0) size 21x15 [padding: 0 1 0 1]
-                                          RenderMathMLRow {mrow} at (0,0) size 20x8
+                                        RenderMathMLFraction {mfrac} at (4,0) size 23x15 [padding: 0 1 0 1]
+                                          RenderMathMLRow {mrow} at (1,0) size 20x8
                                             RenderMathMLToken {mi} at (0,2) size 5x5 [padding: 0 1 0 0]
                                               RenderBlock (anonymous) at (0,0) size 5x4
                                                 RenderText {#text} at (0,-28) size 5x60
@@ -375,7 +375,7 @@ layer at (0,0) size 800x546
                                               RenderBlock (anonymous) at (0,0) size 5x6
                                                 RenderText {#text} at (0,-28) size 5x60
                                                   text run at (0,-28) width 5: "y"
-                                          RenderMathMLToken {mi} at (8,9) size 4x6 [padding: 0 1 0 0]
+                                          RenderMathMLToken {mi} at (9,9) size 4x6 [padding: 0 1 0 0]
                                             RenderBlock (anonymous) at (0,0) size 4x4
                                               RenderText {#text} at (0,-28) size 4x60
                                                 text run at (0,-28) width 4: "z"
@@ -411,84 +411,84 @@ layer at (0,0) size 800x546
       RenderBlock {p} at (0,457) size 784x58
         RenderText {#text} at (0,21) size 73x17
           text run at (0,21) width 73: "RTL roots: "
-        RenderMathMLMath {math} at (72,0) size 351x57
-          RenderMathMLRoot {mroot} at (0,0) size 351x57
-            RenderMathMLRow {mrow} at (0,2) size 333x55
-              RenderMathMLToken {mn} at (324,22) size 9x11
+        RenderMathMLMath {math} at (72,0) size 353x57
+          RenderMathMLRoot {mroot} at (0,0) size 353x57
+            RenderMathMLRow {mrow} at (0,2) size 335x55
+              RenderMathMLToken {mn} at (326,22) size 9x11
                 RenderBlock (anonymous) at (0,0) size 8x11
                   RenderText {#text} at (0,-46) size 8x106
                     text run at (0,-46) width 8: "1"
-              RenderMathMLOperator {mo} at (305,23) size 20x12
+              RenderMathMLOperator {mo} at (307,23) size 20x12
                 RenderBlock (anonymous) at (3,0) size 13x12
                   RenderText {#text} at (0,-47) size 12x106
                     text run at (0,-47) width 12 RTL: "+"
-              RenderMathMLRoot {mroot} at (0,0) size 306x55
-                RenderMathMLRow {mrow} at (0,2) size 288x53
-                  RenderMathMLToken {mn} at (279,20) size 9x11
+              RenderMathMLRoot {mroot} at (0,0) size 308x55
+                RenderMathMLRow {mrow} at (0,2) size 290x53
+                  RenderMathMLToken {mn} at (281,20) size 9x11
                     RenderBlock (anonymous) at (0,0) size 8x11
                       RenderText {#text} at (0,-46) size 8x106
                         text run at (0,-46) width 8: "2"
-                  RenderMathMLOperator {mo} at (260,21) size 20x12
+                  RenderMathMLOperator {mo} at (262,21) size 20x12
                     RenderBlock (anonymous) at (3,0) size 13x12
                       RenderText {#text} at (0,-47) size 12x106
                         text run at (0,-47) width 12 RTL: "+"
-                  RenderMathMLRoot {mroot} at (0,0) size 261x53
-                    RenderMathMLRow {mrow} at (0,2) size 244x51
-                      RenderMathMLToken {mn} at (235,18) size 9x12
+                  RenderMathMLRoot {mroot} at (0,0) size 263x53
+                    RenderMathMLRow {mrow} at (0,2) size 246x51
+                      RenderMathMLToken {mn} at (237,18) size 9x12
                         RenderBlock (anonymous) at (0,0) size 8x12
                           RenderText {#text} at (0,-46) size 8x106
                             text run at (0,-46) width 8: "3"
-                      RenderMathMLOperator {mo} at (216,19) size 20x12
+                      RenderMathMLOperator {mo} at (218,19) size 20x12
                         RenderBlock (anonymous) at (3,0) size 13x12
                           RenderText {#text} at (0,-47) size 12x106
                             text run at (0,-47) width 12 RTL: "+"
-                      RenderMathMLRoot {mroot} at (0,0) size 217x51
-                        RenderMathMLRow {mrow} at (0,2) size 199x49
-                          RenderMathMLToken {mn} at (190,16) size 9x11
+                      RenderMathMLRoot {mroot} at (0,0) size 219x51
+                        RenderMathMLRow {mrow} at (0,2) size 201x49
+                          RenderMathMLToken {mn} at (192,16) size 9x11
                             RenderBlock (anonymous) at (0,0) size 8x11
                               RenderText {#text} at (0,-46) size 8x106
                                 text run at (0,-46) width 8: "4"
-                          RenderMathMLOperator {mo} at (171,17) size 20x12
+                          RenderMathMLOperator {mo} at (173,17) size 20x12
                             RenderBlock (anonymous) at (3,0) size 13x12
                               RenderText {#text} at (0,-47) size 12x106
                                 text run at (0,-47) width 12 RTL: "+"
-                          RenderMathMLRoot {mroot} at (0,0) size 172x49
-                            RenderMathMLRow {mrow} at (0,2) size 155x41
-                              RenderMathMLToken {mn} at (146,14) size 9x12
+                          RenderMathMLRoot {mroot} at (0,0) size 174x49
+                            RenderMathMLRow {mrow} at (0,2) size 157x41
+                              RenderMathMLToken {mn} at (148,14) size 9x12
                                 RenderBlock (anonymous) at (0,0) size 8x12
                                   RenderText {#text} at (0,-46) size 8x106
                                     text run at (0,-46) width 8: "5"
-                              RenderMathMLOperator {mo} at (127,15) size 20x12
+                              RenderMathMLOperator {mo} at (129,15) size 20x12
                                 RenderBlock (anonymous) at (3,0) size 13x12
                                   RenderText {#text} at (0,-47) size 12x106
                                     text run at (0,-47) width 12 RTL: "+"
-                              RenderMathMLRoot {mroot} at (0,0) size 128x41
-                                RenderMathMLRow {mrow} at (0,2) size 112x31
-                                  RenderMathMLToken {mn} at (103,12) size 9x12
+                              RenderMathMLRoot {mroot} at (0,0) size 130x41
+                                RenderMathMLRow {mrow} at (0,2) size 114x31
+                                  RenderMathMLToken {mn} at (105,12) size 9x12
                                     RenderBlock (anonymous) at (0,0) size 8x12
                                       RenderText {#text} at (0,-46) size 8x106
                                         text run at (0,-46) width 8: "6"
-                                  RenderMathMLOperator {mo} at (84,13) size 20x12
+                                  RenderMathMLOperator {mo} at (86,13) size 20x12
                                     RenderBlock (anonymous) at (3,0) size 13x12
                                       RenderText {#text} at (0,-47) size 12x106
                                         text run at (0,-47) width 12 RTL: "+"
-                                  RenderMathMLRoot {mroot} at (0,0) size 85x31
-                                    RenderMathMLRow {mrow} at (0,2) size 68x26
-                                      RenderMathMLToken {mn} at (59,10) size 9x12
+                                  RenderMathMLRoot {mroot} at (0,0) size 87x31
+                                    RenderMathMLRow {mrow} at (0,2) size 70x26
+                                      RenderMathMLToken {mn} at (61,10) size 9x12
                                         RenderBlock (anonymous) at (0,0) size 8x12
                                           RenderText {#text} at (0,-46) size 8x106
                                             text run at (0,-46) width 8: "7"
-                                      RenderMathMLOperator {mo} at (40,11) size 20x12
+                                      RenderMathMLOperator {mo} at (42,11) size 20x12
                                         RenderBlock (anonymous) at (3,0) size 13x12
                                           RenderText {#text} at (0,-47) size 12x106
                                             text run at (0,-47) width 12 RTL: "+"
-                                      RenderMathMLRoot {mroot} at (0,0) size 41x26
+                                      RenderMathMLRoot {mroot} at (0,0) size 43x26
                                         RenderMathMLToken {mi} at (0,9) size 12x13 [padding: 0 0 0 2]
                                           RenderBlock (anonymous) at (0,0) size 12x12
                                             RenderText {#text} at (0,-45) size 12x106
                                               text run at (0,-45) width 12: "A"
-                                        RenderMathMLFraction {mfrac} at (16,0) size 21x15 [padding: 0 1 0 1]
-                                          RenderMathMLRow {mrow} at (0,0) size 20x8
+                                        RenderMathMLFraction {mfrac} at (16,0) size 23x15 [padding: 0 1 0 1]
+                                          RenderMathMLRow {mrow} at (1,0) size 20x8
                                             RenderMathMLToken {mi} at (15,2) size 5x5 [padding: 0 0 0 1]
                                               RenderBlock (anonymous) at (0,0) size 5x4
                                                 RenderText {#text} at (0,-28) size 5x60
@@ -501,35 +501,35 @@ layer at (0,0) size 800x546
                                               RenderBlock (anonymous) at (0,0) size 5x6
                                                 RenderText {#text} at (0,-28) size 5x60
                                                   text run at (0,-28) width 5: "y"
-                                          RenderMathMLToken {mi} at (8,9) size 4x6 [padding: 0 0 0 1]
+                                          RenderMathMLToken {mi} at (9,9) size 4x6 [padding: 0 0 0 1]
                                             RenderBlock (anonymous) at (0,0) size 4x4
                                               RenderText {#text} at (0,-28) size 4x60
                                                 text run at (0,-28) width 4: "z"
-                                    RenderMathMLToken {mn} at (74,5) size 6x8
+                                    RenderMathMLToken {mn} at (76,5) size 6x8
                                       RenderBlock (anonymous) at (0,0) size 5x7
                                         RenderText {#text} at (0,-26) size 5x60
                                           text run at (0,-26) width 5: "9"
-                                RenderMathMLToken {mn} at (118,9) size 6x8
+                                RenderMathMLToken {mn} at (120,9) size 6x8
                                   RenderBlock (anonymous) at (0,0) size 5x7
                                     RenderText {#text} at (0,-26) size 5x60
                                       text run at (0,-26) width 5: "8"
-                            RenderMathMLToken {mn} at (162,11) size 6x9
+                            RenderMathMLToken {mn} at (164,11) size 6x9
                               RenderBlock (anonymous) at (0,0) size 5x8
                                 RenderText {#text} at (0,-25) size 5x60
                                   text run at (0,-25) width 5: "7"
-                        RenderMathMLToken {mn} at (206,13) size 6x8
+                        RenderMathMLToken {mn} at (208,13) size 6x8
                           RenderBlock (anonymous) at (0,0) size 5x7
                             RenderText {#text} at (0,-26) size 5x60
                               text run at (0,-26) width 5: "6"
-                    RenderMathMLToken {mn} at (251,14) size 6x8
+                    RenderMathMLToken {mn} at (253,14) size 6x8
                       RenderBlock (anonymous) at (0,0) size 5x7
                         RenderText {#text} at (0,-26) size 5x60
                           text run at (0,-26) width 5: "5"
-                RenderMathMLToken {mn} at (295,15) size 6x8
+                RenderMathMLToken {mn} at (297,15) size 6x8
                   RenderBlock (anonymous) at (0,0) size 5x7
                     RenderText {#text} at (0,-25) size 5x60
                       text run at (0,-25) width 5: "4"
-            RenderMathMLToken {mn} at (340,16) size 6x8
+            RenderMathMLToken {mn} at (342,16) size 6x8
               RenderBlock (anonymous) at (0,0) size 5x7
                 RenderText {#text} at (0,-26) size 5x60
                   text run at (0,-26) width 5: "3"

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout-expected.txt
@@ -24,9 +24,9 @@ PASS merror layout is not affected by children with "position: fixed" style
 PASS mfrac preferred width calculation is not affected by children with "display: none" style
 PASS mfrac layout is not affected by children with "display: none" style
 PASS mfrac preferred width calculation is not affected by children with "position: absolute" style
-FAIL mfrac layout is not affected by children with "position: absolute" style assert_approx_equals: block size expected 11.8125 +/- 1 but got 0
+FAIL mfrac layout is not affected by children with "position: absolute" style assert_approx_equals: inline size expected 2 +/- 1 but got 0
 PASS mfrac preferred width calculation is not affected by children with "position: fixed" style
-FAIL mfrac layout is not affected by children with "position: fixed" style assert_approx_equals: block size expected 11.8125 +/- 1 but got 0
+FAIL mfrac layout is not affected by children with "position: fixed" style assert_approx_equals: inline size expected 2 +/- 1 but got 0
 PASS mi preferred width calculation is not affected by children with "display: none" style
 PASS mi layout is not affected by children with "display: none" style
 PASS mi preferred width calculation is not affected by children with "position: absolute" style

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
@@ -5,8 +5,8 @@ FAIL Padding properties on menclose assert_approx_equals: bottom padding expecte
 FAIL Padding properties on menclose (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -4.96875
 PASS Padding properties on merror
 PASS Padding properties on merror (rtl)
-FAIL Padding properties on mfrac assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mfrac (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on mfrac
+PASS Padding properties on mfrac (rtl)
 FAIL Padding properties on mi assert_approx_equals: right padding expected 40 +/- 1 but got 38.40625
 FAIL Padding properties on mi (rtl) assert_approx_equals: right padding expected 40 +/- 1 but got 38.40625
 FAIL Padding properties on mmultiscripts assert_approx_equals: left padding expected 30 +/- 1 but got 0
@@ -27,7 +27,7 @@ PASS Padding properties on mrow
 PASS Padding properties on mrow (rtl)
 PASS Padding properties on ms
 PASS Padding properties on ms (rtl)
-FAIL Padding properties on mspace assert_approx_equals: left/right padding expected 70 +/- 1 but got 0
+PASS Padding properties on mspace
 FAIL Padding properties on msqrt assert_approx_equals: bottom padding expected 60 +/- 1 but got -7.625
 FAIL Padding properties on msqrt (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -7.625
 PASS Padding properties on mstyle

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
@@ -5,8 +5,8 @@ FAIL Padding properties on menclose assert_approx_equals: bottom padding expecte
 FAIL Padding properties on menclose (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -3.96875
 PASS Padding properties on merror
 PASS Padding properties on merror (rtl)
-FAIL Padding properties on mfrac assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mfrac (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on mfrac
+PASS Padding properties on mfrac (rtl)
 FAIL Padding properties on mi assert_approx_equals: right padding expected 40 +/- 1 but got 38.40625
 FAIL Padding properties on mi (rtl) assert_approx_equals: right padding expected 40 +/- 1 but got 38.40625
 FAIL Padding properties on mmultiscripts assert_approx_equals: left padding expected 30 +/- 1 but got 0
@@ -27,7 +27,7 @@ PASS Padding properties on mrow
 PASS Padding properties on mrow (rtl)
 PASS Padding properties on ms
 PASS Padding properties on ms (rtl)
-FAIL Padding properties on mspace assert_approx_equals: left/right padding expected 70 +/- 1 but got 0
+PASS Padding properties on mspace
 FAIL Padding properties on msqrt assert_approx_equals: bottom padding expected 60 +/- 1 but got -8.21875
 FAIL Padding properties on msqrt (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -8.21875
 PASS Padding properties on mstyle

--- a/LayoutTests/platform/ios/mathml/presentation/roots-expected.txt
+++ b/LayoutTests/platform/ios/mathml/presentation/roots-expected.txt
@@ -55,10 +55,10 @@ layer at (0,0) size 800x604
       RenderBlock {p} at (0,111) size 784x40
         RenderText {#text} at (0,9) size 117x19
           text run at (0,9) width 117: "root of a fraction: "
-        RenderMathMLMath {math} at (116,0) size 55x40
-          RenderMathMLRoot {msqrt} at (0,0) size 55x40
-            RenderMathMLFraction {mfrac} at (18,3) size 37x32 [padding: 0 1 0 1]
-              RenderMathMLRow {mrow} at (0,0) size 36x12
+        RenderMathMLMath {math} at (116,0) size 57x40
+          RenderMathMLRoot {msqrt} at (0,0) size 57x40
+            RenderMathMLFraction {mfrac} at (18,3) size 39x32 [padding: 0 1 0 1]
+              RenderMathMLRow {mrow} at (1,0) size 36x12
                 RenderMathMLToken {mi} at (0,3) size 9x8 [padding: 0 2 0 0]
                   RenderBlock (anonymous) at (0,0) size 8x8
                     RenderText {#text} at (0,-5) size 8x17
@@ -71,7 +71,7 @@ layer at (0,0) size 800x604
                   RenderBlock (anonymous) at (0,0) size 8x11
                     RenderText {#text} at (0,-2) size 8x17
                       text run at (0,-2) width 8: "1"
-              RenderMathMLRow {mrow} at (0,18) size 36x13
+              RenderMathMLRow {mrow} at (1,18) size 36x13
                 RenderMathMLToken {mi} at (0,3) size 9x8 [padding: 0 2 0 0]
                   RenderBlock (anonymous) at (0,0) size 8x8
                     RenderText {#text} at (0,-5) size 8x17
@@ -130,10 +130,10 @@ layer at (0,0) size 800x604
       RenderBlock {p} at (0,239) size 784x40
         RenderText {#text} at (0,9) size 188x19
           text run at (0,9) width 188: "long index w/ complex base: "
-        RenderMathMLMath {math} at (187,0) size 86x40
-          RenderMathMLRoot {mroot} at (0,0) size 85x40
-            RenderMathMLFraction {mfrac} at (49,3) size 36x32 [padding: 0 1 0 1]
-              RenderMathMLRow {mrow} at (0,0) size 36x12
+        RenderMathMLMath {math} at (187,0) size 88x40
+          RenderMathMLRoot {mroot} at (0,0) size 87x40
+            RenderMathMLFraction {mfrac} at (49,3) size 38x32 [padding: 0 1 0 1]
+              RenderMathMLRow {mrow} at (1,0) size 36x12
                 RenderMathMLToken {mi} at (0,3) size 9x8 [padding: 0 2 0 0]
                   RenderBlock (anonymous) at (0,0) size 8x8
                     RenderText {#text} at (0,-5) size 8x17
@@ -146,7 +146,7 @@ layer at (0,0) size 800x604
                   RenderBlock (anonymous) at (0,0) size 8x11
                     RenderText {#text} at (0,-2) size 8x17
                       text run at (0,-2) width 8: "1"
-              RenderMathMLRow {mrow} at (0,18) size 36x13
+              RenderMathMLRow {mrow} at (1,18) size 36x13
                 RenderMathMLToken {mi} at (0,3) size 9x8 [padding: 0 2 0 0]
                   RenderBlock (anonymous) at (0,0) size 8x8
                     RenderText {#text} at (0,-5) size 8x17
@@ -183,23 +183,23 @@ layer at (0,0) size 800x604
       RenderBlock {p} at (0,294) size 784x37
         RenderText {#text} at (0,15) size 77x19
           text run at (0,15) width 77: "high index: "
-        RenderMathMLMath {math} at (76,0) size 22x36
-          RenderMathMLRoot {mroot} at (0,0) size 22x36
-            RenderMathMLToken {mn} at (13,19) size 9x12
+        RenderMathMLMath {math} at (76,0) size 26x36
+          RenderMathMLRoot {mroot} at (0,0) size 26x36
+            RenderMathMLToken {mn} at (17,19) size 9x12
               RenderBlock (anonymous) at (0,0) size 8x11
                 RenderText {#text} at (0,-2) size 8x17
                   text run at (0,-2) width 8: "2"
-            RenderMathMLFraction {mfrac} at (1,0) size 6x26 [padding: 0 1 0 1]
-              RenderMathMLFraction {mfrac} at (0,0) size 6x17 [padding: 0 1 0 1]
-                RenderMathMLToken {mi} at (0,0) size 6x5 [padding: 0 1 0 0]
+            RenderMathMLFraction {mfrac} at (1,0) size 10x26 [padding: 0 1 0 1]
+              RenderMathMLFraction {mfrac} at (1,0) size 8x17 [padding: 0 1 0 1]
+                RenderMathMLToken {mi} at (1,0) size 6x5 [padding: 0 1 0 0]
                   RenderBlock (anonymous) at (0,0) size 5x5
                     RenderText {#text} at (0,-2) size 5x10
                       text run at (0,-2) width 5: "x"
-                RenderMathMLToken {mi} at (0,10) size 5x7 [padding: 0 1 0 0]
+                RenderMathMLToken {mi} at (1,10) size 5x7 [padding: 0 1 0 0]
                   RenderBlock (anonymous) at (0,0) size 5x8
                     RenderText {#text} at (0,-2) size 5x10
                       text run at (0,-2) width 5: "y"
-              RenderMathMLToken {mi} at (0,21) size 5x5 [padding: 0 1 0 0]
+              RenderMathMLToken {mi} at (2,21) size 5x5 [padding: 0 1 0 0]
                 RenderBlock (anonymous) at (0,0) size 5x5
                   RenderText {#text} at (0,-2) size 5x10
                     text run at (0,-2) width 5: "z"
@@ -285,9 +285,9 @@ layer at (0,0) size 800x604
       RenderBlock {p} at (0,424) size 784x67
         RenderText {#text} at (0,35) size 114x19
           text run at (0,35) width 114: "Imbricated roots: "
-        RenderMathMLMath {math} at (113,0) size 362x66
-          RenderMathMLRoot {mroot} at (0,0) size 361x66
-            RenderMathMLRow {mrow} at (19,3) size 342x63
+        RenderMathMLMath {math} at (113,0) size 364x66
+          RenderMathMLRoot {mroot} at (0,0) size 363x66
+            RenderMathMLRow {mrow} at (19,3) size 344x63
               RenderMathMLToken {mn} at (0,35) size 8x11
                 RenderBlock (anonymous) at (0,0) size 8x11
                   RenderText {#text} at (0,-2) size 8x17
@@ -296,8 +296,8 @@ layer at (0,0) size 800x604
                 RenderBlock (anonymous) at (3,0) size 13x10
                   RenderText {#text} at (0,-4) size 12x17
                     text run at (0,-4) width 12: "+"
-              RenderMathMLRoot {mroot} at (26,0) size 316x63
-                RenderMathMLRow {mrow} at (19,3) size 296x60
+              RenderMathMLRoot {mroot} at (26,0) size 318x63
+                RenderMathMLRow {mrow} at (19,3) size 298x60
                   RenderMathMLToken {mn} at (0,31) size 8x11
                     RenderBlock (anonymous) at (0,0) size 8x11
                       RenderText {#text} at (0,-2) size 8x17
@@ -306,8 +306,8 @@ layer at (0,0) size 800x604
                     RenderBlock (anonymous) at (3,0) size 13x10
                       RenderText {#text} at (0,-4) size 12x17
                         text run at (0,-4) width 12: "+"
-                  RenderMathMLRoot {mroot} at (26,0) size 270x59
-                    RenderMathMLRow {mrow} at (19,3) size 250x56
+                  RenderMathMLRoot {mroot} at (26,0) size 272x59
+                    RenderMathMLRow {mrow} at (19,3) size 252x56
                       RenderMathMLToken {mn} at (0,27) size 8x12
                         RenderBlock (anonymous) at (0,0) size 8x12
                           RenderText {#text} at (0,-2) size 8x17
@@ -316,8 +316,8 @@ layer at (0,0) size 800x604
                         RenderBlock (anonymous) at (3,0) size 13x10
                           RenderText {#text} at (0,-4) size 12x17
                             text run at (0,-4) width 12: "+"
-                      RenderMathMLRoot {mroot} at (26,0) size 223x55
-                        RenderMathMLRow {mrow} at (19,3) size 204x52
+                      RenderMathMLRoot {mroot} at (26,0) size 225x55
+                        RenderMathMLRow {mrow} at (19,3) size 206x52
                           RenderMathMLToken {mn} at (0,23) size 8x11
                             RenderBlock (anonymous) at (0,0) size 8x11
                               RenderText {#text} at (0,-2) size 8x17
@@ -326,8 +326,8 @@ layer at (0,0) size 800x604
                             RenderBlock (anonymous) at (3,0) size 13x10
                               RenderText {#text} at (0,-4) size 12x17
                                 text run at (0,-4) width 12: "+"
-                          RenderMathMLRoot {mroot} at (26,0) size 177x52
-                            RenderMathMLRow {mrow} at (19,3) size 158x49
+                          RenderMathMLRoot {mroot} at (26,0) size 179x52
+                            RenderMathMLRow {mrow} at (19,3) size 160x49
                               RenderMathMLToken {mn} at (0,19) size 8x12
                                 RenderBlock (anonymous) at (0,0) size 8x12
                                   RenderText {#text} at (0,-2) size 8x17
@@ -336,8 +336,8 @@ layer at (0,0) size 800x604
                                 RenderBlock (anonymous) at (3,0) size 13x10
                                   RenderText {#text} at (0,-4) size 12x17
                                     text run at (0,-4) width 12: "+"
-                              RenderMathMLRoot {mroot} at (26,0) size 131x48
-                                RenderMathMLRow {mrow} at (18,3) size 113x40
+                              RenderMathMLRoot {mroot} at (26,0) size 133x48
+                                RenderMathMLRow {mrow} at (18,3) size 115x40
                                   RenderMathMLToken {mn} at (0,15) size 8x12
                                     RenderBlock (anonymous) at (0,0) size 8x12
                                       RenderText {#text} at (0,-2) size 8x17
@@ -346,8 +346,8 @@ layer at (0,0) size 800x604
                                     RenderBlock (anonymous) at (3,0) size 13x10
                                       RenderText {#text} at (0,-4) size 12x17
                                         text run at (0,-4) width 12: "+"
-                                  RenderMathMLRoot {mroot} at (26,0) size 86x40
-                                    RenderMathMLRow {mrow} at (18,3) size 67x29
+                                  RenderMathMLRoot {mroot} at (26,0) size 88x40
+                                    RenderMathMLRow {mrow} at (18,3) size 69x29
                                       RenderMathMLToken {mn} at (0,11) size 8x12
                                         RenderBlock (anonymous) at (0,0) size 8x12
                                           RenderText {#text} at (0,-2) size 8x17
@@ -356,13 +356,13 @@ layer at (0,0) size 800x604
                                         RenderBlock (anonymous) at (3,0) size 13x10
                                           RenderText {#text} at (0,-4) size 12x17
                                             text run at (0,-4) width 12: "+"
-                                      RenderMathMLRoot {mroot} at (26,0) size 40x28
-                                        RenderMathMLToken {mi} at (28,10) size 12x12 [padding: 0 2 0 0]
+                                      RenderMathMLRoot {mroot} at (26,0) size 42x28
+                                        RenderMathMLToken {mi} at (30,10) size 12x12 [padding: 0 2 0 0]
                                           RenderBlock (anonymous) at (0,0) size 12x11
                                             RenderText {#text} at (0,-2) size 12x17
                                               text run at (0,-2) width 12: "A"
-                                        RenderMathMLFraction {mfrac} at (1,0) size 21x17 [padding: 0 1 0 1]
-                                          RenderMathMLRow {mrow} at (0,0) size 21x9
+                                        RenderMathMLFraction {mfrac} at (1,0) size 23x17 [padding: 0 1 0 1]
+                                          RenderMathMLRow {mrow} at (1,0) size 21x9
                                             RenderMathMLToken {mi} at (0,2) size 6x5 [padding: 0 1 0 0]
                                               RenderBlock (anonymous) at (0,0) size 5x5
                                                 RenderText {#text} at (0,-2) size 5x10
@@ -375,7 +375,7 @@ layer at (0,0) size 800x604
                                               RenderBlock (anonymous) at (0,0) size 5x8
                                                 RenderText {#text} at (0,-2) size 5x10
                                                   text run at (0,-2) width 5: "y"
-                                          RenderMathMLToken {mi} at (7,12) size 6x5 [padding: 0 1 0 0]
+                                          RenderMathMLToken {mi} at (8,12) size 6x5 [padding: 0 1 0 0]
                                             RenderBlock (anonymous) at (0,0) size 5x5
                                               RenderText {#text} at (0,-2) size 5x10
                                                 text run at (0,-2) width 5: "z"
@@ -411,84 +411,84 @@ layer at (0,0) size 800x604
       RenderBlock {p} at (0,506) size 784x66
         RenderText {#text} at (0,35) size 74x19
           text run at (0,35) width 74: "RTL roots: "
-        RenderMathMLMath {math} at (73,0) size 361x66
-          RenderMathMLRoot {mroot} at (0,0) size 361x66
-            RenderMathMLRow {mrow} at (0,3) size 342x63
-              RenderMathMLToken {mn} at (333,35) size 9x11
+        RenderMathMLMath {math} at (73,0) size 363x66
+          RenderMathMLRoot {mroot} at (0,0) size 363x66
+            RenderMathMLRow {mrow} at (0,3) size 344x63
+              RenderMathMLToken {mn} at (335,35) size 9x11
                 RenderBlock (anonymous) at (0,0) size 8x11
                   RenderText {#text} at (0,-2) size 8x17
                     text run at (0,-2) width 8: "1"
-              RenderMathMLOperator {mo} at (314,37) size 20x10
+              RenderMathMLOperator {mo} at (316,37) size 20x10
                 RenderBlock (anonymous) at (3,0) size 13x10
                   RenderText {#text} at (0,-4) size 12x17
                     text run at (0,-4) width 12 RTL: "+"
-              RenderMathMLRoot {mroot} at (0,0) size 315x63
-                RenderMathMLRow {mrow} at (0,3) size 296x60
-                  RenderMathMLToken {mn} at (287,31) size 9x11
+              RenderMathMLRoot {mroot} at (0,0) size 317x63
+                RenderMathMLRow {mrow} at (0,3) size 298x60
+                  RenderMathMLToken {mn} at (289,31) size 9x11
                     RenderBlock (anonymous) at (0,0) size 8x11
                       RenderText {#text} at (0,-2) size 8x17
                         text run at (0,-2) width 8: "2"
-                  RenderMathMLOperator {mo} at (268,33) size 20x10
+                  RenderMathMLOperator {mo} at (270,33) size 20x10
                     RenderBlock (anonymous) at (3,0) size 13x10
                       RenderText {#text} at (0,-4) size 12x17
                         text run at (0,-4) width 12 RTL: "+"
-                  RenderMathMLRoot {mroot} at (0,0) size 269x59
-                    RenderMathMLRow {mrow} at (0,3) size 249x56
-                      RenderMathMLToken {mn} at (241,27) size 8x12
+                  RenderMathMLRoot {mroot} at (0,0) size 271x59
+                    RenderMathMLRow {mrow} at (0,3) size 251x56
+                      RenderMathMLToken {mn} at (243,27) size 8x12
                         RenderBlock (anonymous) at (0,0) size 8x12
                           RenderText {#text} at (0,-2) size 8x17
                             text run at (0,-2) width 8: "3"
-                      RenderMathMLOperator {mo} at (222,29) size 20x10
+                      RenderMathMLOperator {mo} at (224,29) size 20x10
                         RenderBlock (anonymous) at (3,0) size 13x10
                           RenderText {#text} at (0,-4) size 12x17
                             text run at (0,-4) width 12 RTL: "+"
-                      RenderMathMLRoot {mroot} at (0,0) size 223x55
-                        RenderMathMLRow {mrow} at (0,3) size 203x52
-                          RenderMathMLToken {mn} at (194,23) size 9x11
+                      RenderMathMLRoot {mroot} at (0,0) size 225x55
+                        RenderMathMLRow {mrow} at (0,3) size 205x52
+                          RenderMathMLToken {mn} at (196,23) size 9x11
                             RenderBlock (anonymous) at (0,0) size 8x11
                               RenderText {#text} at (0,-2) size 8x17
                                 text run at (0,-2) width 8: "4"
-                          RenderMathMLOperator {mo} at (176,25) size 19x10
+                          RenderMathMLOperator {mo} at (178,25) size 19x10
                             RenderBlock (anonymous) at (3,0) size 13x10
                               RenderText {#text} at (0,-4) size 12x17
                                 text run at (0,-4) width 12 RTL: "+"
-                          RenderMathMLRoot {mroot} at (0,0) size 177x52
-                            RenderMathMLRow {mrow} at (0,3) size 157x49
-                              RenderMathMLToken {mn} at (148,19) size 9x12
+                          RenderMathMLRoot {mroot} at (0,0) size 179x52
+                            RenderMathMLRow {mrow} at (0,3) size 159x49
+                              RenderMathMLToken {mn} at (150,19) size 9x12
                                 RenderBlock (anonymous) at (0,0) size 8x12
                                   RenderText {#text} at (0,-2) size 8x17
                                     text run at (0,-2) width 8: "5"
-                              RenderMathMLOperator {mo} at (130,21) size 19x10
+                              RenderMathMLOperator {mo} at (132,21) size 19x10
                                 RenderBlock (anonymous) at (3,0) size 13x10
                                   RenderText {#text} at (0,-4) size 12x17
                                     text run at (0,-4) width 12 RTL: "+"
-                              RenderMathMLRoot {mroot} at (0,0) size 131x48
-                                RenderMathMLRow {mrow} at (0,3) size 112x40
-                                  RenderMathMLToken {mn} at (103,15) size 9x12
+                              RenderMathMLRoot {mroot} at (0,0) size 133x48
+                                RenderMathMLRow {mrow} at (0,3) size 114x40
+                                  RenderMathMLToken {mn} at (105,15) size 9x12
                                     RenderBlock (anonymous) at (0,0) size 8x12
                                       RenderText {#text} at (0,-2) size 8x17
                                         text run at (0,-2) width 8: "6"
-                                  RenderMathMLOperator {mo} at (84,17) size 20x10
+                                  RenderMathMLOperator {mo} at (86,17) size 20x10
                                     RenderBlock (anonymous) at (3,0) size 13x10
                                       RenderText {#text} at (0,-4) size 12x17
                                         text run at (0,-4) width 12 RTL: "+"
-                                  RenderMathMLRoot {mroot} at (0,0) size 85x40
-                                    RenderMathMLRow {mrow} at (0,3) size 66x29
-                                      RenderMathMLToken {mn} at (57,11) size 9x12
+                                  RenderMathMLRoot {mroot} at (0,0) size 87x40
+                                    RenderMathMLRow {mrow} at (0,3) size 68x29
+                                      RenderMathMLToken {mn} at (59,11) size 9x12
                                         RenderBlock (anonymous) at (0,0) size 8x12
                                           RenderText {#text} at (0,-2) size 8x17
                                             text run at (0,-2) width 8: "7"
-                                      RenderMathMLOperator {mo} at (39,13) size 19x10
+                                      RenderMathMLOperator {mo} at (41,13) size 19x10
                                         RenderBlock (anonymous) at (3,0) size 13x10
                                           RenderText {#text} at (0,-4) size 12x17
                                             text run at (0,-4) width 12 RTL: "+"
-                                      RenderMathMLRoot {mroot} at (0,0) size 40x28
+                                      RenderMathMLRoot {mroot} at (0,0) size 42x28
                                         RenderMathMLToken {mi} at (0,10) size 11x12 [padding: 0 0 0 2]
                                           RenderBlock (anonymous) at (0,0) size 12x11
                                             RenderText {#text} at (0,-2) size 12x17
                                               text run at (0,-2) width 12: "A"
-                                        RenderMathMLFraction {mfrac} at (18,0) size 21x17 [padding: 0 1 0 1]
-                                          RenderMathMLRow {mrow} at (0,0) size 21x9
+                                        RenderMathMLFraction {mfrac} at (18,0) size 23x17 [padding: 0 1 0 1]
+                                          RenderMathMLRow {mrow} at (1,0) size 21x9
                                             RenderMathMLToken {mi} at (15,2) size 6x5 [padding: 0 0 0 1]
                                               RenderBlock (anonymous) at (0,0) size 5x5
                                                 RenderText {#text} at (0,-2) size 5x10
@@ -501,35 +501,35 @@ layer at (0,0) size 800x604
                                               RenderBlock (anonymous) at (0,0) size 5x8
                                                 RenderText {#text} at (0,-2) size 5x10
                                                   text run at (0,-2) width 5: "y"
-                                          RenderMathMLToken {mi} at (7,12) size 6x5 [padding: 0 0 0 1]
+                                          RenderMathMLToken {mi} at (8,12) size 6x5 [padding: 0 0 0 1]
                                             RenderBlock (anonymous) at (0,0) size 5x5
                                               RenderText {#text} at (0,-2) size 5x10
                                                 text run at (0,-2) width 5: "z"
-                                    RenderMathMLToken {mn} at (79,11) size 5x8
+                                    RenderMathMLToken {mn} at (81,11) size 5x8
                                       RenderBlock (anonymous) at (0,0) size 5x7
                                         RenderText {#text} at (0,-1) size 5x10
                                           text run at (0,-1) width 5: "9"
-                                RenderMathMLToken {mn} at (124,15) size 6x8
+                                RenderMathMLToken {mn} at (126,15) size 6x8
                                   RenderBlock (anonymous) at (0,0) size 5x7
                                     RenderText {#text} at (0,-1) size 5x10
                                       text run at (0,-1) width 5: "8"
-                            RenderMathMLToken {mn} at (170,16) size 6x8
+                            RenderMathMLToken {mn} at (172,16) size 6x8
                               RenderBlock (anonymous) at (0,0) size 5x7
                                 RenderText {#text} at (0,-1) size 5x10
                                   text run at (0,-1) width 5: "7"
-                        RenderMathMLToken {mn} at (216,18) size 6x8
+                        RenderMathMLToken {mn} at (218,18) size 6x8
                           RenderBlock (anonymous) at (0,0) size 5x7
                             RenderText {#text} at (0,-1) size 5x10
                               text run at (0,-1) width 5: "6"
-                    RenderMathMLToken {mn} at (263,20) size 5x8
+                    RenderMathMLToken {mn} at (265,20) size 5x8
                       RenderBlock (anonymous) at (0,0) size 5x7
                         RenderText {#text} at (0,-1) size 5x10
                           text run at (0,-1) width 5: "5"
-                RenderMathMLToken {mn} at (309,22) size 5x7
+                RenderMathMLToken {mn} at (311,22) size 5x7
                   RenderBlock (anonymous) at (0,0) size 5x6
                     RenderText {#text} at (0,-1) size 5x10
                       text run at (0,-1) width 5: "4"
-            RenderMathMLToken {mn} at (355,23) size 5x8
+            RenderMathMLToken {mn} at (357,23) size 5x8
               RenderBlock (anonymous) at (0,0) size 5x7
                 RenderText {#text} at (0,-1) size 5x10
                   text run at (0,-1) width 5: "3"

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
@@ -5,8 +5,8 @@ FAIL Padding properties on menclose assert_approx_equals: bottom padding expecte
 FAIL Padding properties on menclose (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -3.96875
 PASS Padding properties on merror
 PASS Padding properties on merror (rtl)
-FAIL Padding properties on mfrac assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mfrac (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on mfrac
+PASS Padding properties on mfrac (rtl)
 FAIL Padding properties on mi assert_approx_equals: right padding expected 40 +/- 1 but got 38.40625
 FAIL Padding properties on mi (rtl) assert_approx_equals: right padding expected 40 +/- 1 but got 38.40625
 FAIL Padding properties on mmultiscripts assert_approx_equals: left padding expected 30 +/- 1 but got 0
@@ -27,7 +27,7 @@ PASS Padding properties on mrow
 PASS Padding properties on mrow (rtl)
 PASS Padding properties on ms
 PASS Padding properties on ms (rtl)
-FAIL Padding properties on mspace assert_approx_equals: left/right padding expected 70 +/- 1 but got 0
+PASS Padding properties on mspace
 FAIL Padding properties on msqrt assert_approx_equals: bottom padding expected 60 +/- 1 but got -8.21875
 FAIL Padding properties on msqrt (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -8.21875
 PASS Padding properties on mstyle

--- a/LayoutTests/platform/mac/mathml/presentation/roots-expected.txt
+++ b/LayoutTests/platform/mac/mathml/presentation/roots-expected.txt
@@ -55,10 +55,10 @@ layer at (0,0) size 800x603
       RenderBlock {p} at (0,110) size 784x40
         RenderText {#text} at (0,10) size 117x18
           text run at (0,10) width 117: "root of a fraction: "
-        RenderMathMLMath {math} at (116,0) size 55x40
-          RenderMathMLRoot {msqrt} at (0,0) size 55x40
-            RenderMathMLFraction {mfrac} at (18,3) size 37x32 [padding: 0 1 0 1]
-              RenderMathMLRow {mrow} at (0,0) size 36x12
+        RenderMathMLMath {math} at (116,0) size 57x40
+          RenderMathMLRoot {msqrt} at (0,0) size 57x40
+            RenderMathMLFraction {mfrac} at (18,3) size 39x32 [padding: 0 1 0 1]
+              RenderMathMLRow {mrow} at (1,0) size 36x12
                 RenderMathMLToken {mi} at (0,3) size 9x8 [padding: 0 2 0 0]
                   RenderBlock (anonymous) at (0,0) size 8x8
                     RenderText {#text} at (0,-4) size 8x16
@@ -71,7 +71,7 @@ layer at (0,0) size 800x603
                   RenderBlock (anonymous) at (0,0) size 8x11
                     RenderText {#text} at (0,-1) size 8x16
                       text run at (0,-1) width 8: "1"
-              RenderMathMLRow {mrow} at (0,18) size 36x13
+              RenderMathMLRow {mrow} at (1,18) size 36x13
                 RenderMathMLToken {mi} at (0,3) size 9x8 [padding: 0 2 0 0]
                   RenderBlock (anonymous) at (0,0) size 8x8
                     RenderText {#text} at (0,-4) size 8x16
@@ -130,10 +130,10 @@ layer at (0,0) size 800x603
       RenderBlock {p} at (0,238) size 784x40
         RenderText {#text} at (0,10) size 188x18
           text run at (0,10) width 188: "long index w/ complex base: "
-        RenderMathMLMath {math} at (187,0) size 86x40
-          RenderMathMLRoot {mroot} at (0,0) size 85x40
-            RenderMathMLFraction {mfrac} at (49,3) size 36x32 [padding: 0 1 0 1]
-              RenderMathMLRow {mrow} at (0,0) size 36x12
+        RenderMathMLMath {math} at (187,0) size 88x40
+          RenderMathMLRoot {mroot} at (0,0) size 87x40
+            RenderMathMLFraction {mfrac} at (49,3) size 38x32 [padding: 0 1 0 1]
+              RenderMathMLRow {mrow} at (1,0) size 36x12
                 RenderMathMLToken {mi} at (0,3) size 9x8 [padding: 0 2 0 0]
                   RenderBlock (anonymous) at (0,0) size 8x8
                     RenderText {#text} at (0,-4) size 8x16
@@ -146,7 +146,7 @@ layer at (0,0) size 800x603
                   RenderBlock (anonymous) at (0,0) size 8x11
                     RenderText {#text} at (0,-1) size 8x16
                       text run at (0,-1) width 8: "1"
-              RenderMathMLRow {mrow} at (0,18) size 36x13
+              RenderMathMLRow {mrow} at (1,18) size 36x13
                 RenderMathMLToken {mi} at (0,3) size 9x8 [padding: 0 2 0 0]
                   RenderBlock (anonymous) at (0,0) size 8x8
                     RenderText {#text} at (0,-4) size 8x16
@@ -183,23 +183,23 @@ layer at (0,0) size 800x603
       RenderBlock {p} at (0,293) size 784x37
         RenderText {#text} at (0,16) size 77x18
           text run at (0,16) width 77: "high index: "
-        RenderMathMLMath {math} at (76,0) size 22x36
-          RenderMathMLRoot {mroot} at (0,0) size 22x36
-            RenderMathMLToken {mn} at (13,19) size 9x12
+        RenderMathMLMath {math} at (76,0) size 26x36
+          RenderMathMLRoot {mroot} at (0,0) size 26x36
+            RenderMathMLToken {mn} at (17,19) size 9x12
               RenderBlock (anonymous) at (0,0) size 8x11
                 RenderText {#text} at (0,-1) size 8x16
                   text run at (0,-1) width 8: "2"
-            RenderMathMLFraction {mfrac} at (1,0) size 6x26 [padding: 0 1 0 1]
-              RenderMathMLFraction {mfrac} at (0,0) size 6x17 [padding: 0 1 0 1]
-                RenderMathMLToken {mi} at (0,0) size 6x5 [padding: 0 1 0 0]
+            RenderMathMLFraction {mfrac} at (1,0) size 10x26 [padding: 0 1 0 1]
+              RenderMathMLFraction {mfrac} at (1,0) size 8x17 [padding: 0 1 0 1]
+                RenderMathMLToken {mi} at (1,0) size 6x5 [padding: 0 1 0 0]
                   RenderBlock (anonymous) at (0,0) size 5x5
                     RenderText {#text} at (0,-2) size 5x9
                       text run at (0,-2) width 5: "x"
-                RenderMathMLToken {mi} at (0,10) size 5x7 [padding: 0 1 0 0]
+                RenderMathMLToken {mi} at (1,10) size 5x7 [padding: 0 1 0 0]
                   RenderBlock (anonymous) at (0,0) size 5x8
                     RenderText {#text} at (0,-2) size 5x9
                       text run at (0,-2) width 5: "y"
-              RenderMathMLToken {mi} at (0,21) size 5x5 [padding: 0 1 0 0]
+              RenderMathMLToken {mi} at (2,21) size 5x5 [padding: 0 1 0 0]
                 RenderBlock (anonymous) at (0,0) size 5x5
                   RenderText {#text} at (0,-2) size 5x9
                     text run at (0,-2) width 5: "z"
@@ -285,9 +285,9 @@ layer at (0,0) size 800x603
       RenderBlock {p} at (0,423) size 784x67
         RenderText {#text} at (0,36) size 114x18
           text run at (0,36) width 114: "Imbricated roots: "
-        RenderMathMLMath {math} at (113,0) size 362x66
-          RenderMathMLRoot {mroot} at (0,0) size 361x66
-            RenderMathMLRow {mrow} at (19,3) size 342x63
+        RenderMathMLMath {math} at (113,0) size 364x66
+          RenderMathMLRoot {mroot} at (0,0) size 363x66
+            RenderMathMLRow {mrow} at (19,3) size 344x63
               RenderMathMLToken {mn} at (0,35) size 8x11
                 RenderBlock (anonymous) at (0,0) size 8x11
                   RenderText {#text} at (0,-1) size 8x16
@@ -296,8 +296,8 @@ layer at (0,0) size 800x603
                 RenderBlock (anonymous) at (3,0) size 13x10
                   RenderText {#text} at (0,-3) size 12x16
                     text run at (0,-3) width 12: "+"
-              RenderMathMLRoot {mroot} at (26,0) size 316x63
-                RenderMathMLRow {mrow} at (19,3) size 296x60
+              RenderMathMLRoot {mroot} at (26,0) size 318x63
+                RenderMathMLRow {mrow} at (19,3) size 298x60
                   RenderMathMLToken {mn} at (0,31) size 8x11
                     RenderBlock (anonymous) at (0,0) size 8x11
                       RenderText {#text} at (0,-1) size 8x16
@@ -306,8 +306,8 @@ layer at (0,0) size 800x603
                     RenderBlock (anonymous) at (3,0) size 13x10
                       RenderText {#text} at (0,-3) size 12x16
                         text run at (0,-3) width 12: "+"
-                  RenderMathMLRoot {mroot} at (26,0) size 270x59
-                    RenderMathMLRow {mrow} at (19,3) size 250x56
+                  RenderMathMLRoot {mroot} at (26,0) size 272x59
+                    RenderMathMLRow {mrow} at (19,3) size 252x56
                       RenderMathMLToken {mn} at (0,27) size 8x12
                         RenderBlock (anonymous) at (0,0) size 8x12
                           RenderText {#text} at (0,-1) size 8x16
@@ -316,8 +316,8 @@ layer at (0,0) size 800x603
                         RenderBlock (anonymous) at (3,0) size 13x10
                           RenderText {#text} at (0,-3) size 12x16
                             text run at (0,-3) width 12: "+"
-                      RenderMathMLRoot {mroot} at (26,0) size 223x55
-                        RenderMathMLRow {mrow} at (19,3) size 204x52
+                      RenderMathMLRoot {mroot} at (26,0) size 225x55
+                        RenderMathMLRow {mrow} at (19,3) size 206x52
                           RenderMathMLToken {mn} at (0,23) size 8x11
                             RenderBlock (anonymous) at (0,0) size 8x11
                               RenderText {#text} at (0,-1) size 8x16
@@ -326,8 +326,8 @@ layer at (0,0) size 800x603
                             RenderBlock (anonymous) at (3,0) size 13x10
                               RenderText {#text} at (0,-3) size 12x16
                                 text run at (0,-3) width 12: "+"
-                          RenderMathMLRoot {mroot} at (26,0) size 177x52
-                            RenderMathMLRow {mrow} at (19,3) size 158x49
+                          RenderMathMLRoot {mroot} at (26,0) size 179x52
+                            RenderMathMLRow {mrow} at (19,3) size 160x49
                               RenderMathMLToken {mn} at (0,19) size 8x12
                                 RenderBlock (anonymous) at (0,0) size 8x12
                                   RenderText {#text} at (0,-1) size 8x16
@@ -336,8 +336,8 @@ layer at (0,0) size 800x603
                                 RenderBlock (anonymous) at (3,0) size 13x10
                                   RenderText {#text} at (0,-3) size 12x16
                                     text run at (0,-3) width 12: "+"
-                              RenderMathMLRoot {mroot} at (26,0) size 131x48
-                                RenderMathMLRow {mrow} at (18,3) size 113x40
+                              RenderMathMLRoot {mroot} at (26,0) size 133x48
+                                RenderMathMLRow {mrow} at (18,3) size 115x40
                                   RenderMathMLToken {mn} at (0,15) size 8x12
                                     RenderBlock (anonymous) at (0,0) size 8x12
                                       RenderText {#text} at (0,-1) size 8x16
@@ -346,8 +346,8 @@ layer at (0,0) size 800x603
                                     RenderBlock (anonymous) at (3,0) size 13x10
                                       RenderText {#text} at (0,-3) size 12x16
                                         text run at (0,-3) width 12: "+"
-                                  RenderMathMLRoot {mroot} at (26,0) size 86x40
-                                    RenderMathMLRow {mrow} at (18,3) size 67x29
+                                  RenderMathMLRoot {mroot} at (26,0) size 88x40
+                                    RenderMathMLRow {mrow} at (18,3) size 69x29
                                       RenderMathMLToken {mn} at (0,11) size 8x12
                                         RenderBlock (anonymous) at (0,0) size 8x12
                                           RenderText {#text} at (0,-1) size 8x16
@@ -356,13 +356,13 @@ layer at (0,0) size 800x603
                                         RenderBlock (anonymous) at (3,0) size 13x10
                                           RenderText {#text} at (0,-3) size 12x16
                                             text run at (0,-3) width 12: "+"
-                                      RenderMathMLRoot {mroot} at (26,0) size 40x28
-                                        RenderMathMLToken {mi} at (28,10) size 12x12 [padding: 0 2 0 0]
+                                      RenderMathMLRoot {mroot} at (26,0) size 42x28
+                                        RenderMathMLToken {mi} at (30,10) size 12x12 [padding: 0 2 0 0]
                                           RenderBlock (anonymous) at (0,0) size 12x11
                                             RenderText {#text} at (0,-1) size 12x16
                                               text run at (0,-1) width 12: "A"
-                                        RenderMathMLFraction {mfrac} at (1,0) size 21x17 [padding: 0 1 0 1]
-                                          RenderMathMLRow {mrow} at (0,0) size 21x9
+                                        RenderMathMLFraction {mfrac} at (1,0) size 23x17 [padding: 0 1 0 1]
+                                          RenderMathMLRow {mrow} at (1,0) size 21x9
                                             RenderMathMLToken {mi} at (0,2) size 6x5 [padding: 0 1 0 0]
                                               RenderBlock (anonymous) at (0,0) size 5x5
                                                 RenderText {#text} at (0,-2) size 5x9
@@ -375,7 +375,7 @@ layer at (0,0) size 800x603
                                               RenderBlock (anonymous) at (0,0) size 5x8
                                                 RenderText {#text} at (0,-2) size 5x9
                                                   text run at (0,-2) width 5: "y"
-                                          RenderMathMLToken {mi} at (7,12) size 6x5 [padding: 0 1 0 0]
+                                          RenderMathMLToken {mi} at (8,12) size 6x5 [padding: 0 1 0 0]
                                             RenderBlock (anonymous) at (0,0) size 5x5
                                               RenderText {#text} at (0,-2) size 5x9
                                                 text run at (0,-2) width 5: "z"
@@ -411,84 +411,84 @@ layer at (0,0) size 800x603
       RenderBlock {p} at (0,505) size 784x66
         RenderText {#text} at (0,36) size 74x18
           text run at (0,36) width 74: "RTL roots: "
-        RenderMathMLMath {math} at (73,0) size 361x66
-          RenderMathMLRoot {mroot} at (0,0) size 361x66
-            RenderMathMLRow {mrow} at (0,3) size 342x63
-              RenderMathMLToken {mn} at (333,35) size 9x11
+        RenderMathMLMath {math} at (73,0) size 363x66
+          RenderMathMLRoot {mroot} at (0,0) size 363x66
+            RenderMathMLRow {mrow} at (0,3) size 344x63
+              RenderMathMLToken {mn} at (335,35) size 9x11
                 RenderBlock (anonymous) at (0,0) size 8x11
                   RenderText {#text} at (0,-1) size 8x16
                     text run at (0,-1) width 8: "1"
-              RenderMathMLOperator {mo} at (314,37) size 20x10
+              RenderMathMLOperator {mo} at (316,37) size 20x10
                 RenderBlock (anonymous) at (3,0) size 13x10
                   RenderText {#text} at (0,-3) size 12x16
                     text run at (0,-3) width 12 RTL: "+"
-              RenderMathMLRoot {mroot} at (0,0) size 315x63
-                RenderMathMLRow {mrow} at (0,3) size 296x60
-                  RenderMathMLToken {mn} at (287,31) size 9x11
+              RenderMathMLRoot {mroot} at (0,0) size 317x63
+                RenderMathMLRow {mrow} at (0,3) size 298x60
+                  RenderMathMLToken {mn} at (289,31) size 9x11
                     RenderBlock (anonymous) at (0,0) size 8x11
                       RenderText {#text} at (0,-1) size 8x16
                         text run at (0,-1) width 8: "2"
-                  RenderMathMLOperator {mo} at (268,33) size 20x10
+                  RenderMathMLOperator {mo} at (270,33) size 20x10
                     RenderBlock (anonymous) at (3,0) size 13x10
                       RenderText {#text} at (0,-3) size 12x16
                         text run at (0,-3) width 12 RTL: "+"
-                  RenderMathMLRoot {mroot} at (0,0) size 269x59
-                    RenderMathMLRow {mrow} at (0,3) size 249x56
-                      RenderMathMLToken {mn} at (241,27) size 8x12
+                  RenderMathMLRoot {mroot} at (0,0) size 271x59
+                    RenderMathMLRow {mrow} at (0,3) size 251x56
+                      RenderMathMLToken {mn} at (243,27) size 8x12
                         RenderBlock (anonymous) at (0,0) size 8x12
                           RenderText {#text} at (0,-1) size 8x16
                             text run at (0,-1) width 8: "3"
-                      RenderMathMLOperator {mo} at (222,29) size 20x10
+                      RenderMathMLOperator {mo} at (224,29) size 20x10
                         RenderBlock (anonymous) at (3,0) size 13x10
                           RenderText {#text} at (0,-3) size 12x16
                             text run at (0,-3) width 12 RTL: "+"
-                      RenderMathMLRoot {mroot} at (0,0) size 223x55
-                        RenderMathMLRow {mrow} at (0,3) size 203x52
-                          RenderMathMLToken {mn} at (194,23) size 9x11
+                      RenderMathMLRoot {mroot} at (0,0) size 225x55
+                        RenderMathMLRow {mrow} at (0,3) size 205x52
+                          RenderMathMLToken {mn} at (196,23) size 9x11
                             RenderBlock (anonymous) at (0,0) size 8x11
                               RenderText {#text} at (0,-1) size 8x16
                                 text run at (0,-1) width 8: "4"
-                          RenderMathMLOperator {mo} at (176,25) size 19x10
+                          RenderMathMLOperator {mo} at (178,25) size 19x10
                             RenderBlock (anonymous) at (3,0) size 13x10
                               RenderText {#text} at (0,-3) size 12x16
                                 text run at (0,-3) width 12 RTL: "+"
-                          RenderMathMLRoot {mroot} at (0,0) size 177x52
-                            RenderMathMLRow {mrow} at (0,3) size 157x49
-                              RenderMathMLToken {mn} at (148,19) size 9x12
+                          RenderMathMLRoot {mroot} at (0,0) size 179x52
+                            RenderMathMLRow {mrow} at (0,3) size 159x49
+                              RenderMathMLToken {mn} at (150,19) size 9x12
                                 RenderBlock (anonymous) at (0,0) size 8x12
                                   RenderText {#text} at (0,-1) size 8x16
                                     text run at (0,-1) width 8: "5"
-                              RenderMathMLOperator {mo} at (130,21) size 19x10
+                              RenderMathMLOperator {mo} at (132,21) size 19x10
                                 RenderBlock (anonymous) at (3,0) size 13x10
                                   RenderText {#text} at (0,-3) size 12x16
                                     text run at (0,-3) width 12 RTL: "+"
-                              RenderMathMLRoot {mroot} at (0,0) size 131x48
-                                RenderMathMLRow {mrow} at (0,3) size 112x40
-                                  RenderMathMLToken {mn} at (103,15) size 9x12
+                              RenderMathMLRoot {mroot} at (0,0) size 133x48
+                                RenderMathMLRow {mrow} at (0,3) size 114x40
+                                  RenderMathMLToken {mn} at (105,15) size 9x12
                                     RenderBlock (anonymous) at (0,0) size 8x12
                                       RenderText {#text} at (0,-1) size 8x16
                                         text run at (0,-1) width 8: "6"
-                                  RenderMathMLOperator {mo} at (84,17) size 20x10
+                                  RenderMathMLOperator {mo} at (86,17) size 20x10
                                     RenderBlock (anonymous) at (3,0) size 13x10
                                       RenderText {#text} at (0,-3) size 12x16
                                         text run at (0,-3) width 12 RTL: "+"
-                                  RenderMathMLRoot {mroot} at (0,0) size 85x40
-                                    RenderMathMLRow {mrow} at (0,3) size 66x29
-                                      RenderMathMLToken {mn} at (57,11) size 9x12
+                                  RenderMathMLRoot {mroot} at (0,0) size 87x40
+                                    RenderMathMLRow {mrow} at (0,3) size 68x29
+                                      RenderMathMLToken {mn} at (59,11) size 9x12
                                         RenderBlock (anonymous) at (0,0) size 8x12
                                           RenderText {#text} at (0,-1) size 8x16
                                             text run at (0,-1) width 8: "7"
-                                      RenderMathMLOperator {mo} at (39,13) size 19x10
+                                      RenderMathMLOperator {mo} at (41,13) size 19x10
                                         RenderBlock (anonymous) at (3,0) size 13x10
                                           RenderText {#text} at (0,-3) size 12x16
                                             text run at (0,-3) width 12 RTL: "+"
-                                      RenderMathMLRoot {mroot} at (0,0) size 40x28
+                                      RenderMathMLRoot {mroot} at (0,0) size 42x28
                                         RenderMathMLToken {mi} at (0,10) size 11x12 [padding: 0 0 0 2]
                                           RenderBlock (anonymous) at (0,0) size 12x11
                                             RenderText {#text} at (0,-1) size 12x16
                                               text run at (0,-1) width 12: "A"
-                                        RenderMathMLFraction {mfrac} at (18,0) size 21x17 [padding: 0 1 0 1]
-                                          RenderMathMLRow {mrow} at (0,0) size 21x9
+                                        RenderMathMLFraction {mfrac} at (18,0) size 23x17 [padding: 0 1 0 1]
+                                          RenderMathMLRow {mrow} at (1,0) size 21x9
                                             RenderMathMLToken {mi} at (15,2) size 6x5 [padding: 0 0 0 1]
                                               RenderBlock (anonymous) at (0,0) size 5x5
                                                 RenderText {#text} at (0,-2) size 5x9
@@ -501,35 +501,35 @@ layer at (0,0) size 800x603
                                               RenderBlock (anonymous) at (0,0) size 5x8
                                                 RenderText {#text} at (0,-2) size 5x9
                                                   text run at (0,-2) width 5: "y"
-                                          RenderMathMLToken {mi} at (7,12) size 6x5 [padding: 0 0 0 1]
+                                          RenderMathMLToken {mi} at (8,12) size 6x5 [padding: 0 0 0 1]
                                             RenderBlock (anonymous) at (0,0) size 5x5
                                               RenderText {#text} at (0,-2) size 5x9
                                                 text run at (0,-2) width 5: "z"
-                                    RenderMathMLToken {mn} at (79,11) size 5x8
+                                    RenderMathMLToken {mn} at (81,11) size 5x8
                                       RenderBlock (anonymous) at (0,0) size 5x7
                                         RenderText {#text} at (0,-1) size 5x9
                                           text run at (0,-1) width 5: "9"
-                                RenderMathMLToken {mn} at (124,15) size 6x8
+                                RenderMathMLToken {mn} at (126,15) size 6x8
                                   RenderBlock (anonymous) at (0,0) size 5x7
                                     RenderText {#text} at (0,-1) size 5x9
                                       text run at (0,-1) width 5: "8"
-                            RenderMathMLToken {mn} at (170,16) size 6x8
+                            RenderMathMLToken {mn} at (172,16) size 6x8
                               RenderBlock (anonymous) at (0,0) size 5x7
                                 RenderText {#text} at (0,-1) size 5x9
                                   text run at (0,-1) width 5: "7"
-                        RenderMathMLToken {mn} at (216,18) size 6x8
+                        RenderMathMLToken {mn} at (218,18) size 6x8
                           RenderBlock (anonymous) at (0,0) size 5x7
                             RenderText {#text} at (0,-1) size 5x9
                               text run at (0,-1) width 5: "6"
-                    RenderMathMLToken {mn} at (263,20) size 5x8
+                    RenderMathMLToken {mn} at (265,20) size 5x8
                       RenderBlock (anonymous) at (0,0) size 5x7
                         RenderText {#text} at (0,-1) size 5x9
                           text run at (0,-1) width 5: "5"
-                RenderMathMLToken {mn} at (309,22) size 5x7
+                RenderMathMLToken {mn} at (311,22) size 5x7
                   RenderBlock (anonymous) at (0,0) size 5x6
                     RenderText {#text} at (0,-1) size 5x9
                       text run at (0,-1) width 5: "4"
-            RenderMathMLToken {mn} at (355,23) size 5x8
+            RenderMathMLToken {mn} at (357,23) size 5x8
               RenderBlock (anonymous) at (0,0) size 5x7
                 RenderText {#text} at (0,-1) size 5x9
                   text run at (0,-1) width 5: "3"

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
@@ -119,9 +119,9 @@ RenderMathMLFraction::FractionParameters RenderMathMLFraction::fractionParameter
     }
 
     // Adjust fraction shifts to satisfy min gaps.
-    LayoutUnit numeratorAscent = ascentForChild(numerator());
-    LayoutUnit numeratorDescent = numerator().logicalHeight() - numeratorAscent;
-    LayoutUnit denominatorAscent = ascentForChild(denominator());
+    LayoutUnit numeratorAscent = ascentForChild(numerator()) + numerator().marginBefore();
+    LayoutUnit numeratorDescent = numerator().logicalHeight() + numerator().marginLogicalHeight() - numeratorAscent;
+    LayoutUnit denominatorAscent = ascentForChild(denominator()) + denominator().marginBefore();
     LayoutUnit thickness = lineThickness();
     parameters.numeratorShiftUp = std::max(numeratorMinShiftUp, mathAxisHeight() + thickness / 2 + numeratorGapMin + numeratorDescent);
     parameters.denominatorShiftDown = std::max(denominatorMinShiftDown, thickness / 2 + denominatorGapMin + denominatorAscent - mathAxisHeight());
@@ -155,9 +155,9 @@ RenderMathMLFraction::FractionParameters RenderMathMLFraction::stackParameters()
     }
 
     // Adjust fraction shifts to satisfy min gaps.
-    LayoutUnit numeratorAscent = ascentForChild(numerator());
-    LayoutUnit numeratorDescent = numerator().logicalHeight() - numeratorAscent;
-    LayoutUnit denominatorAscent = ascentForChild(denominator());
+    LayoutUnit numeratorAscent = ascentForChild(numerator()) + numerator().marginBefore();
+    LayoutUnit numeratorDescent = numerator().logicalHeight() + numerator().marginLogicalHeight() - numeratorAscent;
+    LayoutUnit denominatorAscent = ascentForChild(denominator()) + denominator().marginBefore();
     LayoutUnit gap = parameters.numeratorShiftUp - numeratorDescent + parameters.denominatorShiftDown - denominatorAscent;
     if (gap < gapMin) {
         LayoutUnit delta = (gapMin - gap) / 2;
@@ -185,9 +185,9 @@ void RenderMathMLFraction::computePreferredLogicalWidths()
     m_maxPreferredLogicalWidth = 0;
 
     if (isValid()) {
-        LayoutUnit numeratorWidth = numerator().maxPreferredLogicalWidth();
-        LayoutUnit denominatorWidth = denominator().maxPreferredLogicalWidth();
-        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = std::max(numeratorWidth, denominatorWidth);
+        LayoutUnit numeratorWidth = numerator().maxPreferredLogicalWidth() + numerator().marginLogicalWidth();
+        LayoutUnit denominatorWidth = denominator().maxPreferredLogicalWidth() + denominator().marginLogicalWidth();
+        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = std::max(numeratorWidth, denominatorWidth) + borderAndPaddingLogicalWidth();
     }
 
     setPreferredLogicalWidthsDirty(false);
@@ -195,11 +195,13 @@ void RenderMathMLFraction::computePreferredLogicalWidths()
 
 LayoutUnit RenderMathMLFraction::horizontalOffset(RenderBox& child, MathMLFractionElement::FractionAlignment align) const
 {
+    LayoutUnit contentBoxInlineSize = logicalWidth() - borderAndPaddingLogicalWidth();
+    LayoutUnit childMarginBoxInlineSize = child.marginStart() + child.logicalWidth() + child.marginEnd();
     switch (align) {
     case MathMLFractionElement::FractionAlignmentRight:
-        return LayoutUnit(logicalWidth() - child.logicalWidth());
+        return LayoutUnit(contentBoxInlineSize - childMarginBoxInlineSize);
     case MathMLFractionElement::FractionAlignmentCenter:
-        return LayoutUnit((logicalWidth() - child.logicalWidth()) / 2);
+        return LayoutUnit((contentBoxInlineSize - childMarginBoxInlineSize) / 2);
     case MathMLFractionElement::FractionAlignmentLeft:
         return 0_lu;
     }
@@ -212,11 +214,11 @@ LayoutUnit RenderMathMLFraction::fractionAscent() const
 {
     ASSERT(isValid());
 
-    LayoutUnit numeratorAscent = ascentForChild(numerator());
+    LayoutUnit numeratorAscent = ascentForChild(numerator()) + numerator().marginBefore();
     if (LayoutUnit thickness = lineThickness())
-        return std::max(mathAxisHeight() + thickness / 2, numeratorAscent + fractionParameters().numeratorShiftUp);
+        return borderAndPaddingBefore() + std::max(mathAxisHeight() + thickness / 2, numeratorAscent + fractionParameters().numeratorShiftUp);
 
-    return numeratorAscent + stackParameters().numeratorShiftUp;
+    return borderAndPaddingBefore() + numeratorAscent + stackParameters().numeratorShiftUp;
 }
 
 void RenderMathMLFraction::layoutBlock(bool relayoutChildren, LayoutUnit)
@@ -231,21 +233,31 @@ void RenderMathMLFraction::layoutBlock(bool relayoutChildren, LayoutUnit)
         return;
     }
 
+    recomputeLogicalWidth();
+
     numerator().layoutIfNeeded();
     denominator().layoutIfNeeded();
+    numerator().computeAndSetBlockDirectionMargins(*this);
+    denominator().computeAndSetBlockDirectionMargins(*this);
 
-    setLogicalWidth(std::max(numerator().logicalWidth(), denominator().logicalWidth()));
+    LayoutUnit numeratorMarginBoxInlineSize = numerator().marginStart() + numerator().logicalWidth() + numerator().marginEnd();
+    LayoutUnit denominatorMarginBoxInlineSize = denominator().marginStart() + denominator().logicalWidth() + denominator().marginEnd();
+    setLogicalWidth(std::max(numeratorMarginBoxInlineSize, denominatorMarginBoxInlineSize) + borderAndPaddingLogicalWidth());
 
-    LayoutUnit verticalOffset; // This is the top of the renderer.
-    LayoutPoint numeratorLocation(horizontalOffset(numerator(), element().numeratorAlignment()), verticalOffset);
+    LayoutUnit borderAndPaddingLeft = style().isLeftToRightDirection() ? borderAndPaddingStart() : borderAndPaddingEnd();
+
+    LayoutUnit verticalOffset = borderAndPaddingBefore(); // This is the top of the renderer.
+    verticalOffset += numerator().marginBefore();
+    LayoutPoint numeratorLocation(borderAndPaddingLeft + numerator().marginLeft() + horizontalOffset(numerator(), element().numeratorAlignment()), verticalOffset);
     numerator().setLocation(numeratorLocation);
 
-    LayoutUnit denominatorAscent = ascentForChild(denominator());
+    LayoutUnit denominatorAscent = ascentForChild(denominator()) + denominator().marginBefore();
     verticalOffset = fractionAscent();
     FractionParameters parameters = lineThickness() ? fractionParameters() : stackParameters();
     verticalOffset += parameters.denominatorShiftDown - denominatorAscent;
 
-    LayoutPoint denominatorLocation(horizontalOffset(denominator(), element().denominatorAlignment()), verticalOffset);
+    verticalOffset += denominator().marginBefore();
+    LayoutPoint denominatorLocation(borderAndPaddingLeft + denominator().marginLeft() + horizontalOffset(denominator(), element().denominatorAlignment()), verticalOffset);
     denominator().setLocation(denominatorLocation);
 
     if (numerator().isOutOfFlowPositioned())
@@ -253,7 +265,7 @@ void RenderMathMLFraction::layoutBlock(bool relayoutChildren, LayoutUnit)
     if (denominator().isOutOfFlowPositioned())
         denominator().containingBlock()->insertPositionedObject(denominator());
 
-    verticalOffset += denominator().logicalHeight(); // This is the bottom of our renderer.
+    verticalOffset += denominator().logicalHeight() + denominator().marginAfter() + borderAndPaddingAfter(); // This is the bottom of our renderer.
     setLogicalHeight(verticalOffset);
 
     layoutPositionedObjects(relayoutChildren);
@@ -270,14 +282,15 @@ void RenderMathMLFraction::paint(PaintInfo& info, const LayoutPoint& paintOffset
     if (info.context().paintingDisabled() || info.phase != PaintPhase::Foreground || style().usedVisibility() != Visibility::Visible || !isValid() || !thickness)
         return;
 
-    IntPoint adjustedPaintOffset = roundedIntPoint(paintOffset + location() + LayoutPoint(0_lu, fractionAscent() - mathAxisHeight()));
+    LayoutUnit borderAndPaddingLeft = style().isLeftToRightDirection() ? borderAndPaddingStart() : borderAndPaddingEnd();
+    IntPoint adjustedPaintOffset = roundedIntPoint(paintOffset + location() + LayoutPoint(borderAndPaddingLeft, fractionAscent() - mathAxisHeight()));
 
     GraphicsContextStateSaver stateSaver(info.context());
 
     info.context().setStrokeThickness(thickness);
     info.context().setStrokeStyle(StrokeStyle::SolidStroke);
     info.context().setStrokeColor(style().visitedDependentColorWithColorFilter(CSSPropertyColor));
-    info.context().drawLine(adjustedPaintOffset, roundedIntPoint(LayoutPoint(adjustedPaintOffset.x() + logicalWidth(), LayoutUnit(adjustedPaintOffset.y()))));
+    info.context().drawLine(adjustedPaintOffset, roundedIntPoint(LayoutPoint(adjustedPaintOffset.x() + logicalWidth() - borderAndPaddingLogicalWidth(), LayoutUnit(adjustedPaintOffset.y()))));
 }
 
 std::optional<LayoutUnit> RenderMathMLFraction::firstLineBaseline() const

--- a/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
@@ -49,7 +49,7 @@ void RenderMathMLSpace::computePreferredLogicalWidths()
 {
     ASSERT(preferredLogicalWidthsDirty());
 
-    m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = spaceWidth();
+    m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = spaceWidth() + borderAndPaddingLogicalWidth();
 
     setPreferredLogicalWidthsDirty(false);
 }
@@ -81,10 +81,12 @@ void RenderMathMLSpace::layoutBlock(bool relayoutChildren, LayoutUnit)
     if (!relayoutChildren && simplifiedLayout())
         return;
 
-    setLogicalWidth(spaceWidth());
+    recomputeLogicalWidth();
+
+    setLogicalWidth(spaceWidth() + borderAndPaddingLogicalWidth());
     LayoutUnit height, depth;
     getSpaceHeightAndDepth(height, depth);
-    setLogicalHeight(height + depth);
+    setLogicalHeight(height + depth + borderAndPaddingLogicalHeight());
 
     updateScrollInfoAfterLayout();
 
@@ -95,7 +97,7 @@ std::optional<LayoutUnit> RenderMathMLSpace::firstLineBaseline() const
 {
     LayoutUnit height, depth;
     getSpaceHeightAndDepth(height, depth);
-    return height;
+    return height + borderAndPaddingBefore();
 }
 
 }


### PR DESCRIPTION
#### 500c94501f7f041167e2671087e51df2f2672880
<pre>
Support border/margin/padding on mfrac and mspace elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=276218">https://bugs.webkit.org/show_bug.cgi?id=276218</a>

Reviewed by Rob Buis.

This implements support for border/margin/padding on the mfrac and
mspace elements, following the rules from the MathML Core specification:

- When handling boxes of children during math layout, we consider *margin*
  boxes. Following other renderers, `recomputeLogicalWidth()` is called
  during the layout of children to set the inline margins while
  `computeAndSetBlockDirectionMargins()` is called during the parent
  layout to set the block margins.

- Current math layout is modified so that padding/border are added in
  order to obtain the border box. In the case of mfrac, the fraction
  bar continues to be aligned with the math axis and to cover the
  numerator/denominator&apos;s margin boxes. In the case of mspace, the
  baseline alignment is preserved.

- In bug 262789, a padding start/end of 1px for mfrac was added to the
  UA stylesheet. With the present patch, we take this into account for
  layout, allowing to address the use case mentioned in the spec
  &quot;To avoid visual confusion between the fraction bar and another
   adjacent items (e.g. minus sign or another fraction&apos;s bar) a
   default 1-pixel space is added around the element.&quot;.

Canonical link: <a href="https://commits.webkit.org/280665@main">https://commits.webkit.org/280665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d738c0600fca016f9079cef82f11f80c7cbc3d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60879 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7700 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46355 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5423 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49439 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27218 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6753 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6705 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62558 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53616 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1175 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53690 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12658 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/986 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32414 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33499 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->