### PR TITLE
[WPE] WPE Platform: add WPEView:has-focus property and remove focus-in/out signals

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -134,6 +134,7 @@ WPE_API guint                   wpe_view_compute_press_count           (WPEView 
                                                                         guint32             time);
 WPE_API void                    wpe_view_focus_in                      (WPEView            *view);
 WPE_API void                    wpe_view_focus_out                     (WPEView            *view);
+WPE_API gboolean                wpe_view_get_has_focus                 (WPEView            *view);
 WPE_API WPEBufferDMABufFormats *wpe_view_get_preferred_dma_buf_formats (WPEView            *view);
 WPE_API void                    wpe_view_set_opaque_rectangles         (WPEView            *view,
                                                                         WPERectangle       *rects,


### PR DESCRIPTION
#### 77eabc325154fa9ca49a2ec3d082106dbe45ba23
<pre>
[WPE] WPE Platform: add WPEView:has-focus property and remove focus-in/out signals
<a href="https://bugs.webkit.org/show_bug.cgi?id=276219">https://bugs.webkit.org/show_bug.cgi?id=276219</a>

Reviewed by Alejandro G. Castro.

We need a way to query if a view has the keyboard focus, so add
has-focus property and use notify signal to monitor focus.

* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::ViewPlatform):
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpeViewGetProperty):
(wpe_view_class_init):
(wpe_view_focus_in):
(wpe_view_focus_out):
(wpe_view_get_has_focus):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:

Canonical link: <a href="https://commits.webkit.org/280681@main">https://commits.webkit.org/280681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffa0623400fbf9afa5f910d7e281f88882f857cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60871 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7692 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46349 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5418 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27212 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31105 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6697 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53069 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7015 "Found 1 new test failure: media/video-transformed.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62550 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53610 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53684 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/980 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8546 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32406 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34576 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->