### PR TITLE
[WPE] WPE Platform: make it possible to use headless platform with GPU buffers

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
@@ -31,11 +31,14 @@
 #include "WPEToplevelHeadless.h"
 #include "WPEViewHeadless.h"
 #include <gio/gio.h>
+#include <optional>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
+#include <wtf/text/CString.h>
 
 #if USE(LIBDRM)
 #include <drm_fourcc.h>
+#include <xf86drm.h>
 #endif
 
 /**
@@ -43,7 +46,10 @@
  *
  */
 struct _WPEDisplayHeadlessPrivate {
-
+#if USE(LIBDRM)
+    std::optional<CString> drmDevice;
+    std::optional<CString> drmRenderNode;
+#endif
 };
 WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(WPEDisplayHeadless, wpe_display_headless, WPE_TYPE_DISPLAY, WPEDisplay,
     wpeEnsureExtensionPointsRegistered();
@@ -71,6 +77,50 @@ static WPEBufferDMABufFormats* wpeDisplayHeadlessGetPreferredDMABufFormats(WPEDi
     wpe_buffer_dma_buf_formats_builder_append_format(builder, DRM_FORMAT_ARGB8888, DRM_FORMAT_MOD_LINEAR);
     return wpe_buffer_dma_buf_formats_builder_end(builder);
 }
+
+static void wpeDisplayHeadlessInitializeDRMDevices(WPEDisplayHeadless* display)
+{
+    auto* priv = display->priv;
+    priv->drmDevice = CString();
+    priv->drmRenderNode = CString();
+
+    drmDevicePtr devices[64];
+    memset(devices, 0, sizeof(devices));
+
+    int numDevices = drmGetDevices2(0, devices, std::size(devices));
+    if (numDevices <= 0)
+        return;
+
+    for (int i = 0; i < numDevices && priv->drmDevice->isNull(); ++i) {
+        drmDevice* device = devices[i];
+        if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY | 1 << DRM_NODE_RENDER)))
+            continue;
+
+        if (device->available_nodes & (1 << DRM_NODE_RENDER))
+            priv->drmRenderNode = CString(device->nodes[DRM_NODE_RENDER]);
+        if (device->available_nodes & (1 << DRM_NODE_PRIMARY))
+            priv->drmDevice = CString(device->nodes[DRM_NODE_PRIMARY]);
+    }
+    drmFreeDevices(devices, numDevices);
+}
+
+static const char* wpeDisplayHeadlessGetDRMDevice(WPEDisplay* display)
+{
+    auto* displayHeadless = WPE_DISPLAY_HEADLESS(display);
+    auto* priv = displayHeadless->priv;
+    if (!priv->drmDevice.has_value())
+        wpeDisplayHeadlessInitializeDRMDevices(displayHeadless);
+    return priv->drmDevice->data();
+}
+
+static const char* wpeDisplayHeadlessGetDRMRenderNode(WPEDisplay* display)
+{
+    auto* displayHeadless = WPE_DISPLAY_HEADLESS(display);
+    auto* priv = displayHeadless->priv;
+    if (!priv->drmRenderNode.has_value())
+        wpeDisplayHeadlessInitializeDRMDevices(displayHeadless);
+    return !priv->drmRenderNode->isNull() ? priv->drmRenderNode->data() : priv->drmDevice->data();
+}
 #endif
 
 static void wpe_display_headless_class_init(WPEDisplayHeadlessClass* displayHeadlessClass)
@@ -80,6 +130,8 @@ static void wpe_display_headless_class_init(WPEDisplayHeadlessClass* displayHead
     displayClass->create_view = wpeDisplayHeadlessCreateView;
 #if USE(LIBDRM)
     displayClass->get_preferred_dma_buf_formats = wpeDisplayHeadlessGetPreferredDMABufFormats;
+    displayClass->get_drm_device = wpeDisplayHeadlessGetDRMDevice;
+    displayClass->get_drm_render_node = wpeDisplayHeadlessGetDRMRenderNode;
 #endif
 }
 


### PR DESCRIPTION
#### 379c25a61e635ee1eb9505f9415ca6dccaec52c2
<pre>
[WPE] WPE Platform: make it possible to use headless platform with GPU buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=276221">https://bugs.webkit.org/show_bug.cgi?id=276221</a>

Reviewed by Alejandro G. Castro.

We need to implement the WPEDisplay methods to get the DRM devices.

* Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp:
(wpeDisplayHeadlessInitializeDRMDevices):
(wpeDisplayHeadlessGetDRMDevice):
(wpeDisplayHeadlessGetDRMRenderNode):
(wpe_display_headless_class_init):

Canonical link: <a href="https://commits.webkit.org/280679@main">https://commits.webkit.org/280679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebca4a49ff97e55e0c7b35054b7557d2254c16d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60876 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7697 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44206 "Hash ebca4a49 for PR 30488 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7887 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46352 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5420 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59284 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/44206 "Hash ebca4a49 for PR 30488 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27215 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/44206 "Hash ebca4a49 for PR 30488 does not build (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6702 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/44206 "Hash ebca4a49 for PR 30488 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62555 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53613 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53687 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/983 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8548 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32411 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33496 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34581 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->