### PR TITLE
[GTK4] Ensure that clipboard read operations work synchronously

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -422,6 +422,7 @@ public:
     void decrementDispatchMessageMarkedDispatchWhenWaitingForSyncReplyCount() { --m_inDispatchMessageMarkedDispatchWhenWaitingForSyncReplyCount; }
 
     bool inSendSync() const { return m_inSendSyncCount; }
+    unsigned inDispatchSyncMessageCount() const { return m_inDispatchSyncMessageCount; }
 
     Identifier identifier() const;
 

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -129,9 +129,9 @@ private:
 
 #if PLATFORM(GTK)
     void getTypes(const String& pasteboardName, CompletionHandler<void(Vector<String>&&)>&&);
-    void readText(const String& pasteboardName, CompletionHandler<void(String&&)>&&);
-    void readFilePaths(const String& pasteboardName, CompletionHandler<void(Vector<String>&&)>&&);
-    void readBuffer(const String& pasteboardName, const String& pasteboardType, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
+    void readText(IPC::Connection&, const String& pasteboardName, CompletionHandler<void(String&&)>&&);
+    void readFilePaths(IPC::Connection&, const String& pasteboardName, CompletionHandler<void(Vector<String>&&)>&&);
+    void readBuffer(IPC::Connection&, const String& pasteboardName, const String& pasteboardType, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
     void writeToClipboard(const String& pasteboardName, WebCore::SelectionData&&);
     void clearClipboard(const String& pasteboardName);
     void getPasteboardChangeCount(IPC::Connection&, const String& pasteboardName, CompletionHandler<void(int64_t)>&&);

--- a/Source/WebKit/UIProcess/gtk/Clipboard.h
+++ b/Source/WebKit/UIProcess/gtk/Clipboard.h
@@ -52,12 +52,14 @@ public:
     explicit Clipboard(Type);
     ~Clipboard();
 
+    enum class ReadMode : uint8_t { Asynchronous, Synchronous };
+
     Type type() const;
     void formats(CompletionHandler<void(Vector<String>&&)>&&);
-    void readText(CompletionHandler<void(String&&)>&&);
-    void readFilePaths(CompletionHandler<void(Vector<String>&&)>&&);
-    void readURL(CompletionHandler<void(String&& url, String&& title)>&&);
-    void readBuffer(const char*, CompletionHandler<void(Ref<WebCore::SharedBuffer>&&)>&&);
+    void readText(CompletionHandler<void(String&&)>&&, ReadMode = ReadMode::Asynchronous);
+    void readFilePaths(CompletionHandler<void(Vector<String>&&)>&&, ReadMode = ReadMode::Asynchronous);
+    void readURL(CompletionHandler<void(String&& url, String&& title)>&&, ReadMode = ReadMode::Asynchronous);
+    void readBuffer(const char*, CompletionHandler<void(Ref<WebCore::SharedBuffer>&&)>&&, ReadMode = ReadMode::Asynchronous);
     void write(WebCore::SelectionData&&, CompletionHandler<void(int64_t)>&&);
     void clear();
 

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
@@ -99,7 +99,7 @@ struct ReadTextAsyncData {
     CompletionHandler<void(String&&)> completionHandler;
 };
 
-void Clipboard::readText(CompletionHandler<void(String&&)>&& completionHandler)
+void Clipboard::readText(CompletionHandler<void(String&&)>&& completionHandler, ReadMode)
 {
     gtk_clipboard_request_text(m_clipboard, [](GtkClipboard*, const char* text, gpointer userData) {
         std::unique_ptr<ReadTextAsyncData> data(static_cast<ReadTextAsyncData*>(userData));
@@ -118,7 +118,7 @@ struct ReadFilePathsAsyncData {
     CompletionHandler<void(Vector<String>&&)> completionHandler;
 };
 
-void Clipboard::readFilePaths(CompletionHandler<void(Vector<String>&&)>&& completionHandler)
+void Clipboard::readFilePaths(CompletionHandler<void(Vector<String>&&)>&& completionHandler, ReadMode)
 {
     gtk_clipboard_request_uris(m_clipboard, [](GtkClipboard*, char** uris, gpointer userData) {
         std::unique_ptr<ReadFilePathsAsyncData> data(static_cast<ReadFilePathsAsyncData*>(userData));
@@ -154,7 +154,7 @@ struct ReadURLAsyncData {
     CompletionHandler<void(String&& url, String&& title)> completionHandler;
 };
 
-void Clipboard::readURL(CompletionHandler<void(String&& url, String&& title)>&& completionHandler)
+void Clipboard::readURL(CompletionHandler<void(String&& url, String&& title)>&& completionHandler, ReadMode)
 {
     gtk_clipboard_request_uris(m_clipboard, [](GtkClipboard*, char** uris, gpointer userData) {
         std::unique_ptr<ReadURLAsyncData> data(static_cast<ReadURLAsyncData*>(userData));
@@ -162,7 +162,7 @@ void Clipboard::readURL(CompletionHandler<void(String&& url, String&& title)>&& 
     }, new ReadURLAsyncData(WTFMove(completionHandler)));
 }
 
-void Clipboard::readBuffer(const char* format, CompletionHandler<void(Ref<WebCore::SharedBuffer>&&)>&& completionHandler)
+void Clipboard::readBuffer(const char* format, CompletionHandler<void(Ref<WebCore::SharedBuffer>&&)>&& completionHandler, ReadMode)
 {
     gtk_clipboard_request_contents(m_clipboard, gdk_atom_intern(format, TRUE), [](GtkClipboard*, GtkSelectionData* selection, gpointer userData) {
         std::unique_ptr<ReadBufferAsyncData> data(static_cast<ReadBufferAsyncData*>(userData));


### PR DESCRIPTION
#### 5db7057e3b2f627f2d8df8f8af1a98ed3a89272e
<pre>
[GTK4] Ensure that clipboard read operations work synchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=265088">https://bugs.webkit.org/show_bug.cgi?id=265088</a>

Reviewed by Alejandro G. Castro.

When running layout tests clipboard operations are usually
triggered by an injected bundle synchronous message from
the web process to the UI process. Pasteboard operations are
also handled using synchronous IPC messages, but GTK4 clipboard
reads are asynchronous, and this can easily cause deadlocks.

This can happen, for example, when the test calls testRunner.execCommand(&quot;Paste&quot;),
which is implemented as a synchronous injected bundle message.
The UI process receives the message that ends up calling WKPageExecuteCommandForTesting,
which sends a synchronous message with reply to the web process. The web
process then handles the paste editing command asking the UI process
pasteboard sending another synchronous API message. In the UI process
a clipboard request is started, but the GdkClipboard GTask can&apos;t finish
because the run loop is blocked by the initial injected bundle message
that is waiting to provide a reply. This works if we can reply to the
pasteboard request synchronously, by running a nested main loop that
allows the GdkClipboard GTask to complete in an idle.

Running nested main loops can be dangerous, but we only need to do that
when a pasteboard read request is done while already dispatching a
synchronous message, which probably only happens in tests.

This fixes many pasteboard tests that are timing out only when running
on GTK4 builds.

Co-authored-by: Claudio Saavedra &lt;csaavedra@igalia.com&gt;

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::inDispatchSyncMessageCount const):
* Source/WebKit/UIProcess/WebPasteboardProxy.h:
* Source/WebKit/UIProcess/gtk/Clipboard.h:
* Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp:
(WebKit::Clipboard::readText):
(WebKit::Clipboard::readFilePaths):
(WebKit::Clipboard::readURL):
(WebKit::Clipboard::readBuffer):
* Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp:
(WebKit::Clipboard::readText):
(WebKit::Clipboard::readFilePaths):
(WebKit::Clipboard::readBuffer):
(WebKit::Clipboard::readURL):
(WebKit::ReadTextAsyncData::ReadTextAsyncData): Deleted.
(WebKit::ReadFilePathsAsyncData::ReadFilePathsAsyncData): Deleted.
(WebKit::ReadBufferAsyncData::ReadBufferAsyncData): Deleted.
(WebKit::ReadURLAsyncData::ReadURLAsyncData): Deleted.
* Source/WebKit/UIProcess/gtk/WebPasteboardProxyGtk.cpp:
(WebKit::WebPasteboardProxy::readText):
(WebKit::WebPasteboardProxy::readFilePaths):
(WebKit::WebPasteboardProxy::readBuffer):
(WebKit::WebPasteboardProxy::typesSafeForDOMToReadAndWrite):
(WebKit::WebPasteboardProxy::readURLFromPasteboard):
(WebKit::WebPasteboardProxy::readBufferFromPasteboard):

Canonical link: <a href="https://commits.webkit.org/280852@main">https://commits.webkit.org/280852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a181026648832549bfa578cbdd951937ed4b9f67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60939 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7760 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46412 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5483 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27275 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31319 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6765 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62618 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53674 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53753 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12793 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1043 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32474 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33559 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34644 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33305 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->