### PR TITLE
[GStreamer] gstStructureGet<T> may return optionals with unitialized values on Clang 18

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -279,19 +279,19 @@ inline std::optional<T> gstStructureGet(const GstStructure* structure, ASCIILite
 
     T value;
     if constexpr(std::is_same_v<T, int>) {
-        if (gst_structure_get_int(structure, key.characters(), &value))
+        if (UNLIKELY(gst_structure_get_int(structure, key.characters(), &value)))
             return value;
     } else if constexpr(std::is_same_v<T, int64_t>) {
-        if (gst_structure_get_int64(structure, key.characters(), &value))
+        if (UNLIKELY(gst_structure_get_int64(structure, key.characters(), &value)))
             return value;
     } else if constexpr(std::is_same_v<T, unsigned>) {
-        if (gst_structure_get_uint(structure, key.characters(), &value))
+        if (UNLIKELY(gst_structure_get_uint(structure, key.characters(), &value)))
             return value;
     } else if constexpr(std::is_same_v<T, uint64_t>) {
-        if (gst_structure_get_uint64(structure, key.characters(), &value))
+        if (UNLIKELY(gst_structure_get_uint64(structure, key.characters(), &value)))
             return value;
     } else if constexpr(std::is_same_v<T, double>) {
-        if (gst_structure_get_double(structure, key.characters(), &value))
+        if (UNLIKELY(gst_structure_get_double(structure, key.characters(), &value)))
             return value;
     }
     return std::nullopt;

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
@@ -63,6 +63,11 @@ TEST_F(GStreamerTest, gstStructureGetters)
     ASSERT_TRUE(!gstStructureGet<uint64_t>(structure.get(), "uint64-val-noexist"_s).has_value());
     ASSERT_EQ(gstStructureGet<double>(structure.get(), "double-val"_s), 1.0);
     ASSERT_TRUE(!gstStructureGet<double>(structure.get(), "double-val-noexist"_s).has_value());
+
+    // webkit.org/b/276224
+    auto emptyIntOpt = gstStructureGet<int>(structure.get(), "int-val-noexist2"_s);
+    if (emptyIntOpt && *emptyIntOpt > 0)
+        FAIL() << "emptyIntOpt should be empty, but has value " << *emptyIntOpt;
 }
 
 TEST_F(GStreamerTest, gstStructureJSONSerializing)


### PR DESCRIPTION
#### 98b041523464c50009ef773d070146db9f6084c0
<pre>
[GStreamer] gstStructureGet&lt;T&gt; may return optionals with unitialized values on Clang 18
<a href="https://bugs.webkit.org/show_bug.cgi?id=276224">https://bugs.webkit.org/show_bug.cgi?id=276224</a>

Reviewed by Philippe Normand.

We found an issue that is triggered by a compiler bug. The bug has been
reproduced with Clang 18 and libstdc++ 13.2 so far, and has been reduced
outside of WebKit at <a href="https://github.com/cadubentzen/std-optional-bug-clang.">https://github.com/cadubentzen/std-optional-bug-clang.</a>

In the context of WebKit + GStreamer, it&apos;s triggered as below, where
we hit the assertion:

auto structure = gst_structure_from_string(&quot;a-structure, width=10&quot;, NULL);
auto height = gstStructureGet&lt;int&gt;(structure, &quot;height&quot;_s);
if (height &amp;&amp; *height &gt; 0) {
    useHeightValue(*height);
    ASSERT_NOT_REACHED();
}

The bug is fixed by using UNLIKELY in the branches of gstStructureGet&lt;T&gt;.

A test has also been added to avoid regressing this.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::gstStructureGet):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/280669@main">https://commits.webkit.org/280669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31990e1d5361027286ae32e69a7701ff89e0dc93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60894 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46370 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5438 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27233 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6766 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6720 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62573 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53630 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49489 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53707 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12660 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1001 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32429 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33514 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34599 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->