### PR TITLE
Remove unneeded functions in RenderTreeAsText.cpp

### DIFF
--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -178,43 +178,6 @@ String quoteAndEscapeNonPrintables(StringView s)
     return result.toString();
 }
 
-static inline bool isRenderInlineEmpty(const RenderInline& inlineRenderer)
-{
-    if (isEmptyInline(inlineRenderer))
-        return true;
-
-    for (auto& child : childrenOfType<RenderObject>(inlineRenderer)) {
-        if (child.isFloatingOrOutOfFlowPositioned())
-            continue;
-        auto isChildEmpty = false;
-        if (auto* renderInline = dynamicDowncast<RenderInline>(child))
-            isChildEmpty = isRenderInlineEmpty(*renderInline);
-        else if (auto* text = dynamicDowncast<RenderText>(child))
-            isChildEmpty = !text->linesBoundingBox().height();
-        if (!isChildEmpty)
-            return false;
-    }
-    return true;
-}
-
-static inline bool hasNonEmptySibling(const RenderInline& inlineRenderer)
-{
-    auto* parent = inlineRenderer.parent();
-    if (!parent)
-        return false;
-
-    for (auto& sibling : childrenOfType<RenderObject>(*parent)) {
-        if (&sibling == &inlineRenderer || sibling.isFloatingOrOutOfFlowPositioned())
-            continue;
-        auto* siblingRendererInline = dynamicDowncast<RenderInline>(sibling);
-        if (!siblingRendererInline)
-            return true;
-        if (siblingRendererInline->mayAffectLayout() || !isRenderInlineEmpty(*siblingRendererInline))
-            return true;
-    }
-    return false;
-}
-
 inline bool shouldEnableSubpixelPrecisionForTextDump(const Document& document)
 {
     // If LBSE is activated and the document contains outermost <svg> elements, generate the text


### PR DESCRIPTION
#### adedad6c3074b5cdf0b97cc3db38d488531fbc06
<pre>
Remove unneeded functions in RenderTreeAsText.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=276231">https://bugs.webkit.org/show_bug.cgi?id=276231</a>

Reviewed by Alan Baradlay.

Remove functions in RenderTreeAsText.cpp that are not used
anymore after 275888@main.

* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::isRenderInlineEmpty): Deleted.
(WebCore::hasNonEmptySibling): Deleted.

Canonical link: <a href="https://commits.webkit.org/280671@main">https://commits.webkit.org/280671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a0427c7ef15d5f34c326472ccc1ad438148d148

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60897 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7718 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46372 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5442 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27235 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6769 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6723 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62576 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53633 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53709 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12661 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1004 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32432 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33517 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34602 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->