### PR TITLE
Web Inspector: Update COMPATIBILITY (macOS X.0, iOS X.0) comments with latest versions

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -216,8 +216,8 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
 
         switch (reason) {
         case WI.ConsoleManager.ClearReason.Frontend:
-            // COMPATIBILITY (iOS X.Y, macOS X.Y): `Console.ClearReason.Frontend` did not exist yet.
-            // COMPATIBILITY (iOS X.Y, macOS X.Y): `Console.setConsoleClearAPIEnabled` did not exist yet.
+            // COMPATIBILITY (iOS 18.0, macOS 15.0): `Console.ClearReason.Frontend` did not exist yet.
+            // COMPATIBILITY (iOS 18.0, macOS 15.0): `Console.setConsoleClearAPIEnabled` did not exist yet.
             console.assert(InspectorBackend.hasCommand("Console.setConsoleClearAPIEnabled"));
             console.assert(WI.settings.consoleClearAPIEnabled.value);
             // fallthrough
@@ -300,7 +300,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
 
     _setConsoleClearAPIEnabled(target)
     {
-        // COMPATIBILITY (iOS X.Y, macOS X.Y): `Console.setConsoleClearAPIEnabled` did not exist yet.
+        // COMPATIBILITY (iOS 18.0, macOS 15.0): `Console.setConsoleClearAPIEnabled` did not exist yet.
         if (target.hasCommand("Console.setConsoleClearAPIEnabled"))
             target.ConsoleAgent.setConsoleClearAPIEnabled(WI.settings.consoleClearAPIEnabled.value);
     }

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -1323,6 +1323,7 @@ WI.DOMNode = class DOMNode extends WI.Object
             this.showLayoutOverlay();
     }
 
+    // COMPATIBILITY (iOS 18.0, macOS 15.0): `DOM.getMediaStats` did not exist yet.
     async getMediaStats()
     {
         let target = WI.assumingMainTarget();

--- a/Source/WebInspectorUI/UserInterface/Views/DOMNodeDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMNodeDetailsSidebarPanel.js
@@ -548,7 +548,7 @@ WI.DOMNodeDetailsSidebarPanel = class DOMNodeDetailsSidebarPanel extends WI.DOMD
                 }
 
                 let switchState = "";
-                // COMPATIBILITY (macOS X.0, iOS X.0): DOM.AccessibilityProperties.switchState did not exist yet.
+                // COMPATIBILITY (macOS 15.0, iOS 18.0): DOM.AccessibilityProperties.switchState did not exist yet.
                 if (InspectorBackend.Enum.DOM.AccessibilityPropertiesSwitchState) {
                     switch (accessibilityProperties.switchState) {
                     case InspectorBackend.Enum.DOM.AccessibilityPropertiesSwitchState.On:

--- a/Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ElementsTabContentView.js
@@ -40,6 +40,7 @@ WI.ElementsTabContentView = class ElementsTabContentView extends WI.ContentBrows
         if (InspectorBackend.hasCommand("CSS.getFontDataForNode"))
             detailsSidebarPanelConstructors.push(WI.FontDetailsSidebarPanel);
 
+        // COMPATIBILITY (iOS 18.0, macOS 15.0): `DOM.getMediaStats` did not exist yet.
         if (InspectorBackend.hasCommand("DOM.getMediaStats"))
             detailsSidebarPanelConstructors.push(WI.MediaDetailsSidebarPanel)
 

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -363,7 +363,7 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         consoleSettingsView.addSetting(WI.UIString("Traces:"), WI.settings.consoleAutoExpandTrace, WI.UIString("Auto-expand"));
         consoleSettingsView.addSetting(WI.UIString("Show:"), WI.settings.showConsoleMessageTimestamps, WI.UIString("Timestamps"));
 
-        // COMPATIBILITY (iOS X.Y, macOS X.Y): `Console.setConsoleClearAPIEnabled` did not exist yet.
+        // COMPATIBILITY (iOS 18.0, macOS 15.0): `Console.setConsoleClearAPIEnabled` did not exist yet.
         if (InspectorBackend.hasCommand("Console.setConsoleClearAPIEnabled"))
             consoleSettingsView.addSetting(WI.UIString("Clear:"), WI.settings.consoleClearAPIEnabled, WI.UIString("Allow page to clear Console"));
 


### PR DESCRIPTION
#### a5621e0c9b61812f4b37be8c0e79dcdbfc96cc3e
<pre>
Web Inspector: Update COMPATIBILITY (macOS X.0, iOS X.0) comments with latest versions
<a href="https://bugs.webkit.org/show_bug.cgi?id=276232">https://bugs.webkit.org/show_bug.cgi?id=276232</a>
<a href="https://rdar.apple.com/129159284">rdar://129159284</a>

Reviewed by Devin Rousso.

* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager.prototype.messagesCleared):
(WI.ConsoleManager.prototype._setConsoleClearAPIEnabled):
* Source/WebInspectorUI/UserInterface/Views/DOMNodeDetailsSidebarPanel.js:
(WI.DOMNodeDetailsSidebarPanel.prototype._refreshAccessibility.accessibilityPropertiesCallback):
(WI.DOMNodeDetailsSidebarPanel.prototype._refreshAccessibility):
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createConsoleSettingsView):

Canonical link: <a href="https://commits.webkit.org/280822@main">https://commits.webkit.org/280822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19b7b291e9b9c9b8cf7a04820983db8f45b39265

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61355 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8178 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8366 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46777 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5798 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49887 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27602 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31527 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7179 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7182 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63037 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53997 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54114 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12771 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1393 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32890 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33976 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35060 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->