### PR TITLE
Digital Credentials: implement visibility and focus requirements

### DIFF
--- a/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html
+++ b/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html
@@ -1,9 +1,24 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>Digital Credential API: get() default behavior checks.</title>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<body></body>
 <script>
+    promise_setup(async () => {
+        if (document.visibilityState === "hidden") {
+            await new Promise((resolve) => {
+                document.onvisibilitychange = resolve;
+                testRunner.setPageVisibility("visible");
+            });
+        }
+        assert_equals(document.visibilityState, "visible", "should be visible");
+    });
+
     promise_test(async (t) => {
+        await test_driver.bless();
         await promise_rejects_dom(
             t,
             "NotSupportedError",
@@ -11,6 +26,7 @@
             "navigator.identity.get() with no argument."
         );
 
+        await test_driver.bless();
         await promise_rejects_dom(
             t,
             "NotSupportedError",
@@ -18,6 +34,7 @@
             "navigator.identity.get() with empty dictionary."
         );
 
+        await test_driver.bless();
         await promise_rejects_js(
             t,
             TypeError,
@@ -25,6 +42,7 @@
             "navigator.identity.get() with bogus digital type"
         );
 
+        await test_driver.bless();
         await promise_rejects_dom(
             t,
             "NotSupportedError",
@@ -32,6 +50,7 @@
             "navigator.identity.get() with unknown key (same as passing empty dictionary)."
         );
 
+        await test_driver.bless();
         await promise_rejects_js(
             t,
             TypeError,
@@ -39,6 +58,7 @@
             "navigator.identity.get() with an empty list of providers"
         );
 
+        await test_driver.bless();
         await promise_rejects_js(
             t,
             TypeError,

--- a/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS navigator.identity.get() can't be used with hidden documents.
+

--- a/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html
+++ b/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>
+    Digital Credential API: get() can't be used with hidden documents.
+</title>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body></body>
+<script>
+    promise_setup(async () => {
+        if (document.visibilityState !== "hidden") {
+            await new Promise((resolve) => {
+                document.onvisibilitychange = resolve;
+                testRunner.setPageVisibility("hidden");
+            });
+        }
+    });
+
+    promise_test(async function (test) {
+        this.add_cleanup(() => {
+            testRunner.setPageVisibility("visible");
+        });
+
+        assert_equals(
+            document.visibilityState,
+            "hidden",
+            "now should be hidden"
+        );
+
+        await test_driver.bless();
+
+        assert_true(
+            navigator.userActivation.isActive,
+            "User activation should be active after test_driver.bless()."
+        );
+
+        await promise_rejects_dom(
+            test,
+            "NotAllowedError",
+            navigator.identity.get({})
+        );
+    }, "navigator.identity.get() can't be used with hidden documents.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-user-activation.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-user-activation.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS navigator.identity.get() calling the API without user activation should reject with NotAllowedError.
+PASS navigator.identity.get() consumes user activation.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-user-activation.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-user-activation.https.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>Digital Credential API: get() consumes user activation.</title>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body></body>
+<script>
+  promise_test(async (t) => {
+    assert_false(
+        navigator.userActivation.isActive,
+        "User activation should not be active"
+    );
+    await promise_rejects_dom(t, "NotAllowedError", navigator.identity.get({}));
+  }, "navigator.identity.get() calling the API without user activation should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    await test_driver.bless();
+    assert_true(
+        navigator.userActivation.isActive,
+        "User activation should be active after test_driver.bless()."
+    );
+    await promise_rejects_dom(
+        t,
+        "NotSupportedError",
+        navigator.identity.get({})
+    );
+    assert_false(
+        navigator.userActivation.isActive,
+        "User activation should be consumed after navigator.identity.get()."
+    );
+  }, "navigator.identity.get() consumes user activation.");
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -351,6 +351,9 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements
 http/tests/cache/disk-cache/disk-cache-media-small.html
 http/tests/media/audio-load-loadeddata.html [ Pass ]
 
+# Digital Credentials
+http/wpt/identity/identitycredentialscontainer-get-hidden.https.html [ Skip ]
+
 # No touch events
 fast/events/touch [ Skip ]
 fast/shadow-dom/touch-event-ios.html [ Skip ]

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
@@ -65,12 +65,12 @@ public:
 
 private:
     ScopeAndCrossOriginParent scopeAndCrossOriginParent() const;
-
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 
 protected:
     template<typename Options>
     bool performCommonChecks(const Options&, CredentialPromise&);
+    const Document* document() const { return m_document.get(); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
+++ b/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
@@ -36,6 +36,8 @@
 #include "ExceptionOr.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSDigitalCredential.h"
+#include "LocalDOMWindow.h"
+#include "VisibilityState.h"
 
 namespace WebCore {
 IdentityCredentialsContainer::IdentityCredentialsContainer(WeakPtr<Document, WeakPtrImplWithEventTargetData>&& document)
@@ -47,6 +49,23 @@ void IdentityCredentialsContainer::get(CredentialRequestOptions&& options, Crede
 {
     if (!performCommonChecks(options, promise))
         return;
+
+    RefPtr document = this->document();
+    if (!document->hasFocus()) {
+        promise.reject(Exception { ExceptionCode::NotAllowedError, "The document is not focused."_s });
+        return;
+    }
+
+    if (document->visibilityState() != VisibilityState::Visible) {
+        promise.reject(Exception { ExceptionCode::NotAllowedError, "The document is not visible."_s });
+        return;
+    }
+
+    RefPtr window = document->domWindow();
+    if (!window || !window->consumeTransientActivation()) {
+        promise.reject(Exception { ExceptionCode::NotAllowedError, "Calling get() needs to be triggered by an activation triggering user event."_s });
+        return;
+    }
 
     if (!options.digital) {
         promise.reject(Exception { ExceptionCode::NotSupportedError, "Only digital member is supported."_s });


### PR DESCRIPTION
#### aadfa72463c7e523faf7ce6c0c9adee99a4d9f04
<pre>
Digital Credentials: implement visibility and focus requirements
<a href="https://bugs.webkit.org/show_bug.cgi?id=275782">https://bugs.webkit.org/show_bug.cgi?id=275782</a>
<a href="https://rdar.apple.com/130821648">rdar://130821648</a>

Reviewed by Andy Estes.

Adds visibility, focus, and user activation checks as per:
See <a href="https://github.com/WICG/digital-credentials/pull/129">https://github.com/WICG/digital-credentials/pull/129</a>

* LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html:
* LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https-expected.txt: Added.
* LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-user-activation.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-user-activation.https.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::scopeAndCrossOriginParent const):
(WebCore::CredentialsContainer::get):
(WebCore::CredentialsContainer::isCreate):
(WebCore::CredentialsContainer::preventSilentAccess const):
(WebCore::CredentialsContainer::performCommonChecks):
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h:
(WebCore::CredentialsContainer::document const):
* Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp:
(WebCore::IdentityCredentialsContainer::get):

Canonical link: <a href="https://commits.webkit.org/281003@main">https://commits.webkit.org/281003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bba3f1aaad5afa57143e6313b9584f2616d19bfa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61926 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47234 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6246 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28075 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7707 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7750 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63631 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54552 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54617 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12890 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1890 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34544 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34289 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->