### PR TITLE
[Win][WebKitTestRunner] Use CreateWindowStation to have an isolated clipboard

### DIFF
--- a/Tools/CISupport/kill-old-processes
+++ b/Tools/CISupport/kill-old-processes
@@ -101,32 +101,18 @@ def are_simulators_booted():
 
 def main(user=None):
     tasksToKillWin = [
-        "cl.exe",
-        "devenv.com",
-        "devenv.exe",
-        "DumpRenderTree.exe",
-        "DumpRenderTree_debug.exe",
+        "clang-cl.exe",
         "httpd.exe",
         "imagediff.exe",
-        "imagediff_debug.exe",
         "jsc.exe",
-        "jsc_debug.exe",
-        "LightTPD.exe",
-        "link.exe",
-        "midl.exe",
+        "lld-link.exe",
         "perl.exe",
-        "Safari.exe",
-        "svn.exe",
         "testapi.exe",
-        "testapi_debug.exe",
-        "VcBuildHelper.exe",
-        "wdiff.exe",
+        "WebKitGPUProcess.exe",
         "WebKitNetworkProcess.exe",
-        "WebKitNetworkProcess_debug.exe",
-        "WebKitWebProcess.exe",
-        "WebKitWebProcess_debug.exe",
         "WebKitTestRunner.exe",
-        "WebKitTestRunner_debug.exe",
+        "WebKitTestRunnerWS.exe",
+        "WebKitWebProcess.exe",
     ]
 
     tasksToKillMac = [

--- a/Tools/Scripts/webkitpy/port/win.py
+++ b/Tools/Scripts/webkitpy/port/win.py
@@ -161,6 +161,9 @@ class WinPort(ApplePort):
             self._copy_value_from_environ_if_set(env, variable)
         return env
 
+    def driver_name(self):
+        return "WebKitTestRunnerWS"
+
     def run_minibrowser(self, args):
         miniBrowser = self._build_path('MiniBrowser.exe')
         return self._executive.run_command([miniBrowser] + args, stdout=None, cwd=self.webkit_base(), return_stderr=False, decode_output=False, ignore_errors=True, env=self.setup_environ_for_server())

--- a/Tools/WebKitTestRunner/PlatformWin.cmake
+++ b/Tools/WebKitTestRunner/PlatformWin.cmake
@@ -26,3 +26,5 @@ list(APPEND TestRunnerInjectedBundle_SOURCES
     InjectedBundle/win/InjectedBundleWin.cpp
     InjectedBundle/win/TestRunnerWin.cpp
 )
+
+add_executable(WebKitTestRunnerWS win/WebKitTestRunnerWS.cpp)

--- a/Tools/WebKitTestRunner/win/TestControllerWin.cpp
+++ b/Tools/WebKitTestRunner/win/TestControllerWin.cpp
@@ -53,7 +53,7 @@ static const double maximumWaitForWebProcessToCrash = 60;
 
 static LONG WINAPI exceptionFilter(EXCEPTION_POINTERS*)
 {
-    fputs("#CRASHED\n", stderr);
+    fprintf(stderr, "#CRASHED - WebKitTestRunner (pid %lu)\n", GetCurrentProcessId());
     fflush(stderr);
     return EXCEPTION_CONTINUE_SEARCH;
 }

--- a/Tools/WebKitTestRunner/win/WebKitTestRunnerWS.cpp
+++ b/Tools/WebKitTestRunner/win/WebKitTestRunnerWS.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2024 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include <string>
+#include <windows.h>
+
+#pragma comment(lib, "user32")
+
+#define DESKTOP_NAME L"Default"
+
+bool replace(std::wstring& str, const std::wstring& from, const std::wstring& to)
+{
+    const auto pos = str.find(from);
+    const int len = from.length();
+    if (pos == std::wstring::npos)
+        return false;
+    str.replace(pos, len, to);
+    return true;
+}
+
+bool containsShowWindowOption(std::wstring& cmd)
+{
+    return cmd.find(L"--show-window") != std::wstring::npos;
+}
+
+int wmain()
+{
+    std::wstring cmd = GetCommandLine();
+    if (!replace(cmd, L"WebKitTestRunnerWS", L"WebKitTestRunner")) {
+        std::wcout << L"WebKitTestRunnerWS not found: " << cmd << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::wstring winStaName = L"WebKit_" + std::to_wstring(GetCurrentProcessId());
+    HDESK desktop = nullptr;
+    if (!containsShowWindowOption(cmd)) {
+        HWINSTA windowStation = CreateWindowStation(winStaName.data(), CWF_CREATE_ONLY, GENERIC_ALL, nullptr);
+        if (windowStation) {
+            if (SetProcessWindowStation(windowStation)) {
+                desktop = CreateDesktop(DESKTOP_NAME, nullptr, nullptr, 0, GENERIC_ALL, nullptr);
+                if (!desktop)
+                    std::wcout << L"CreateDesktop failed with error: " << GetLastError() << std::endl;
+            } else
+                std::wcout << L"SetProcessWindowStation failed with error: " << GetLastError() << std::endl;
+        }
+    }
+
+    std::wstring desktopName = winStaName + L'\\' + DESKTOP_NAME;
+    PROCESS_INFORMATION processInformation { };
+    STARTUPINFO startupInfo { };
+    startupInfo.cb = sizeof(startupInfo);
+    startupInfo.lpDesktop = desktop ? desktopName.data() : nullptr;
+    if (!CreateProcess(0, cmd.data(), nullptr, nullptr, true, 0, 0, 0, &startupInfo, &processInformation)) {
+        std::wcout << L"CreateProcess failed: " << GetLastError() << std::endl;
+        return EXIT_FAILURE;
+    }
+    WaitForSingleObject(processInformation.hProcess, INFINITE);
+    DWORD exitCode;
+    GetExitCodeProcess(processInformation.hProcess, &exitCode);
+    return exitCode;
+}


### PR DESCRIPTION
#### 426186a23c4afc5565407d381766d9cfb9620156
<pre>
[Win][WebKitTestRunner] Use CreateWindowStation to have an isolated clipboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=224919">https://bugs.webkit.org/show_bug.cgi?id=224919</a>

Reviewed by Don Olmstead.

Layout tests using a clipboard are flaky because multiple instances of
WebKitTestRunner are simultaneously using a single clipboard.
&lt;<a href="https://commits.webkit.org/184203@main">https://commits.webkit.org/184203@main</a>&gt; changed DumpRenderTree to use
CreateWindowStation to have a isolated clipboard. However, the exactly
same approach can&apos;t be applied to WebKitTestRunner due to the
multi-process architecture.

Added a new program WebKitTestRunnerWS.exe to create a non-interactive
window station and a hidden desktop and execute WebKitTestRunner.exe
in it.

I confirmed the following scenarios:
1. run-webkit-tests collects crash logs of WebKitTestRunner for crash tests
2. run-webkit-tests kills all child processes of WebKitTestRunnerWS for timeout tests
3. run-webkit-tests --show-window shows windows

* Tools/CISupport/kill-old-processes:
(main):
* Tools/Scripts/webkitpy/port/win.py:
(WinPort.driver_name):
* Tools/WebKitTestRunner/PlatformWin.cmake:
* Tools/WebKitTestRunner/win/TestControllerWin.cpp:
(WTR::exceptionFilter):
* Tools/WebKitTestRunner/win/WebKitTestRunnerWS.cpp: Added.
(replace):
(containsShowWindowOption):
(wmain):

Canonical link: <a href="https://commits.webkit.org/280706@main">https://commits.webkit.org/280706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01474f30df344471fa89494371ec47ba42004305

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57288 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60910 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7731 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46385 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5454 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59318 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34360 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27248 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/56814 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6782 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6736 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62589 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53645 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53722 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1017 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8562 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32445 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33530 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33276 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->