### PR TITLE
[Writing Tools] Two Writing Tools context menu items show up; menu item shows up even in non-text cases; panel appears in wrong location with one of the items; menu item is in wrong location

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h
@@ -31,6 +31,12 @@
 
 #import <AppKit/NSMenu_Private.h>
 
+@interface NSMenuItem (Staging_129192954)
+
++ (NSMenuItem *)standardWritingToolsMenuItem;
+
+@end
+
 #elif USE(APPLE_INTERNAL_SDK)
 
 WTF_EXTERN_C_BEGIN
@@ -64,6 +70,7 @@ enum {
 @interface NSMenuItem ()
 + (QLPreviewMenuItem *)standardQuickLookMenuItem;
 + (NSMenuItem *)standardShareMenuItemForItems:(NSArray *)items;
++ (NSMenuItem *)standardWritingToolsMenuItem;
 @end
 
 #endif

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -130,7 +130,7 @@ class EmptyContextMenuClient final : public ContextMenuClient {
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    void handleWritingTools(IntRect) final { };
+    void handleWritingToolsDeprecated(IntRect) final { };
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebCore/page/ContextMenuClient.h
+++ b/Source/WebCore/page/ContextMenuClient.h
@@ -63,7 +63,7 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    virtual void handleWritingTools(IntRect selectionBoundsInRootView) = 0;
+    virtual void handleWritingToolsDeprecated(IntRect selectionBoundsInRootView) = 0;
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -650,7 +650,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
     case ContextMenuItemTagWritingTools:
 #if ENABLE(WRITING_TOOLS)
         if (RefPtr view = frame->view())
-            m_client->handleWritingTools(view->contentsToRootView(enclosingIntRect(frame->selection().selectionBounds())));
+            m_client->handleWritingToolsDeprecated(view->contentsToRootView(enclosingIntRect(frame->selection().selectionBounds())));
 #endif
         break;
 
@@ -1044,11 +1044,6 @@ void ContextMenuController::populate()
         appendItem(translateItem, m_contextMenu.get());
 #endif
 
-#if ENABLE(WRITING_TOOLS)
-        ContextMenuItem writingToolsItem(ContextMenuItemType::Action, ContextMenuItemTagWritingTools, contextMenuItemTagWritingTools());
-        appendItem(writingToolsItem, m_contextMenu.get());
-#endif
-
 #if !PLATFORM(GTK)
         appendItem(SearchWebItem, m_contextMenu.get());
         appendItem(*separatorItem(), m_contextMenu.get());
@@ -1189,6 +1184,12 @@ void ContextMenuController::populate()
 
                 appendItem(ShareMenuItem, m_contextMenu.get());
                 appendItem(*separatorItem(), m_contextMenu.get());
+
+#if ENABLE(WRITING_TOOLS)
+                appendItem(*separatorItem(), m_contextMenu.get());
+                ContextMenuItem writingToolsItem(ContextMenuItemType::Action, ContextMenuItemTagWritingTools, contextMenuItemTagWritingTools());
+                appendItem(writingToolsItem, m_contextMenu.get());
+#endif
 
                 ContextMenuItem SpeechMenuItem(ContextMenuItemType::Submenu, ContextMenuItemTagSpeechMenu, contextMenuItemTagSpeechMenu());
                 createAndAppendSpeechSubMenu(SpeechMenuItem);
@@ -1341,8 +1342,16 @@ void ContextMenuController::populate()
 #endif
 
         if (!inPasswordField) {
-#if !PLATFORM(GTK)
+#if ENABLE(WRITING_TOOLS)
             appendItem(*separatorItem(), m_contextMenu.get());
+            ContextMenuItem writingToolsItem(ContextMenuItemType::Action, ContextMenuItemTagWritingTools, contextMenuItemTagWritingTools());
+            appendItem(writingToolsItem, m_contextMenu.get());
+#endif
+
+#if !PLATFORM(GTK)
+#if !ENABLE(WRITING_TOOLS)
+            appendItem(*separatorItem(), m_contextMenu.get());
+#endif
             ContextMenuItem SpellingAndGrammarMenuItem(ContextMenuItemType::Submenu, ContextMenuItemTagSpellingMenu,
                 contextMenuItemTagSpellingMenu());
             createAndAppendSpellingAndGrammarSubMenu(SpellingAndGrammarMenuItem);

--- a/Source/WebCore/page/writing-tools/WritingToolsTypes.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsTypes.h
@@ -47,6 +47,10 @@ enum class Action : uint8_t {
     Restart,
 };
 
+enum class RequestedTool : uint16_t {
+    // Opaque type to transitively convert to/from WTRequestedTool.
+};
+
 #pragma mark - Session
 
 enum class SessionType : uint8_t {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2088,18 +2088,7 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 
 - (PlatformWritingToolsBehavior)writingToolsBehavior
 {
-    if ([self _isEditable])
-        return PlatformWritingToolsBehaviorComplete;
-
-    auto& editorState = _page->editorState();
-
-    if ([_configuration writingToolsBehavior] == PlatformWritingToolsBehaviorNone || editorState.selectionIsNone || editorState.isInPasswordField)
-        return PlatformWritingToolsBehaviorNone;
-
-    if ([_configuration writingToolsBehavior] == PlatformWritingToolsBehaviorComplete && editorState.isContentEditable)
-        return PlatformWritingToolsBehaviorComplete;
-
-    return PlatformWritingToolsBehaviorLimited;
+    return WebKit::convertToPlatformWritingToolsBehavior(_page->writingToolsBehavior());
 }
 
 - (void)willBeginWritingToolsSession:(WTSession *)session requestContexts:(void (^)(NSArray<WTContext *> *))completion

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1314,6 +1314,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _impl->endPreviewPanelControl(panel);
 }
 
+#pragma mark - NSTextCheckingClient_WritingTools
+
+- (BOOL)providesWritingToolsContextMenu
+{
+    return YES;
+}
+
 @end
 
 #pragma mark -

--- a/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.h
@@ -33,9 +33,11 @@
 namespace WebCore {
 
 namespace WritingTools {
+enum class Behavior : uint8_t;
 enum class EditAction : uint8_t;
 enum class ReplacementBehavior : uint8_t;
 enum class ReplacementState : uint8_t;
+enum class RequestedTool : uint16_t;
 enum class SessionCompositionType : uint8_t;
 enum class SessionType : uint8_t;
 
@@ -52,6 +54,8 @@ namespace WebKit {
 
 PlatformWritingToolsBehavior convertToPlatformWritingToolsBehavior(WebCore::WritingTools::Behavior);
 
+WTRequestedTool convertToPlatformRequestedTool(WebCore::WritingTools::RequestedTool);
+
 WTTextSuggestionState convertToPlatformTextSuggestionState(WebCore::WritingTools::TextSuggestionState);
 
 RetainPtr<WTContext> convertToPlatformContext(const WebCore::WritingTools::Context&);
@@ -59,6 +63,8 @@ RetainPtr<WTContext> convertToPlatformContext(const WebCore::WritingTools::Conte
 #pragma mark - Conversions from platform types to web types.
 
 WebCore::WritingTools::Behavior convertToWebWritingToolsBehavior(PlatformWritingToolsBehavior);
+
+WebCore::WritingTools::RequestedTool convertToWebRequestedTool(WTRequestedTool);
 
 WebCore::WritingTools::TextSuggestionState convertToWebTextSuggestionState(WTTextSuggestionState);
 

--- a/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm
@@ -51,6 +51,11 @@ PlatformWritingToolsBehavior convertToPlatformWritingToolsBehavior(WebCore::Writ
     }
 }
 
+WTRequestedTool convertToPlatformRequestedTool(WebCore::WritingTools::RequestedTool tool)
+{
+    return static_cast<WTRequestedTool>(tool);
+}
+
 WTTextSuggestionState convertToPlatformTextSuggestionState(WebCore::WritingTools::TextSuggestion::State state)
 {
     switch (state) {
@@ -87,6 +92,11 @@ WebCore::WritingTools::Behavior convertToWebWritingToolsBehavior(PlatformWriting
     case PlatformWritingToolsBehaviorComplete:
         return WebCore::WritingTools::Behavior::Complete;
     }
+}
+
+WebCore::WritingTools::RequestedTool convertToWebRequestedTool(WTRequestedTool tool)
+{
+    return static_cast<WebCore::WritingTools::RequestedTool>(tool);
 }
 
 WebCore::WritingTools::TextSuggestion::State convertToWebTextSuggestionState(WTTextSuggestionState state)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -874,9 +874,9 @@ bool WebPageProxy::canHandleContextMenuWritingTools() const
     return protectedPageClient()->canHandleContextMenuWritingTools();
 }
 
-void WebPageProxy::handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView)
+void WebPageProxy::handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView)
 {
-    protectedPageClient()->handleContextMenuWritingTools(selectionBoundsInRootView);
+    protectedPageClient()->handleContextMenuWritingToolsDeprecated(selectionBoundsInRootView);
 }
 
 #endif // ENABLE(WRITING_TOOLS)
@@ -1163,6 +1163,23 @@ void WebPageProxy::setWritingToolsActive(bool active)
     protectedPageClient()->writingToolsActiveWillChange();
     m_isWritingToolsActive = active;
     protectedPageClient()->writingToolsActiveDidChange();
+}
+
+WebCore::WritingTools::Behavior WebPageProxy::writingToolsBehavior() const
+{
+    if (isEditable())
+        return WebCore::WritingTools::Behavior::Complete;
+
+    auto& editorState = this->editorState();
+    auto& configuration = this->configuration();
+
+    if (configuration.writingToolsBehavior() == WebCore::WritingTools::Behavior::None || editorState.selectionIsNone || editorState.isInPasswordField)
+        return WebCore::WritingTools::Behavior::None;
+
+    if (configuration.writingToolsBehavior() == WebCore::WritingTools::Behavior::Complete && editorState.isContentEditable)
+        return WebCore::WritingTools::Behavior::Complete;
+
+    return WebCore::WritingTools::Behavior::Limited;
 }
 
 void WebPageProxy::willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>& session, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -157,8 +157,10 @@ struct PromisedAttachmentInfo;
 struct TranslationContextMenuInfo;
 #endif
 
+#if ENABLE(WRITING_TOOLS)
 namespace WritingTools {
 enum class Action : uint8_t;
+enum class RequestedTool : uint16_t;
 enum class TextSuggestionState : uint8_t;
 
 struct Context;
@@ -168,6 +170,7 @@ struct Session;
 using TextSuggestionID = WTF::UUID;
 using SessionID = WTF::UUID;
 }
+#endif
 
 }
 
@@ -739,7 +742,8 @@ public:
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
     virtual bool canHandleContextMenuWritingTools() const = 0;
-    virtual void handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView) = 0;
+    virtual void handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView) = 0;
+    virtual void handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool, WebCore::IntRect) { }
 #endif
 
 #if ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -306,6 +306,8 @@ struct Item;
 #if ENABLE(WRITING_TOOLS)
 namespace WritingTools {
 enum class Action : uint8_t;
+enum class Behavior : uint8_t;
+enum class RequestedTool : uint16_t;
 enum class TextSuggestionState : uint8_t;
 
 struct Context;
@@ -2248,7 +2250,8 @@ public:
 #if ENABLE(WRITING_TOOLS)
 #if ENABLE(CONTEXT_MENUS)
     bool canHandleContextMenuWritingTools() const;
-    void handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView);
+    void handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView);
+    void handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool);
 #endif
 #endif
 
@@ -2395,6 +2398,8 @@ public:
 
 #if ENABLE(WRITING_TOOLS)
     void setWritingToolsActive(bool);
+
+    WebCore::WritingTools::Behavior writingToolsBehavior() const;
 
     void willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>&, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -233,7 +233,7 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
-    HandleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView)
+    HandleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView)
 #endif
 
 #if ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -309,7 +309,8 @@ private:
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
     bool canHandleContextMenuWritingTools() const override;
-    void handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView) override;
+    void handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView) override;
+    void handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool, WebCore::IntRect) override;
 #endif
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -37,6 +37,7 @@
 #import "NativeWebMouseEvent.h"
 #import "NativeWebWheelEvent.h"
 #import "NavigationState.h"
+#import "PlatformWritingToolsUtilities.h"
 #import "RemoteLayerTreeNode.h"
 #import "UndoOrRedo.h"
 #import "ViewGestureController.h"
@@ -79,6 +80,7 @@
 #import <WebCore/TextUndoInsertionMarkupMac.h>
 #import <WebCore/ValidationBubble.h>
 #import <WebCore/WebCoreCALayerExtras.h>
+#import <pal/spi/cocoa/WritingToolsSPI.h>
 #import <pal/spi/mac/NSApplicationSPI.h>
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/RetainPtr.h>
@@ -89,6 +91,8 @@
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 #import <WebCore/WebMediaSessionManager.h>
 #endif
+
+#import <pal/cocoa/WritingToolsUISoftLink.h>
 
 static NSString * const kAXLoadCompleteNotification = @"AXLoadComplete";
 
@@ -1103,9 +1107,15 @@ bool PageClientImpl::canHandleContextMenuWritingTools() const
     return m_impl->canHandleContextMenuWritingTools();
 }
 
-void PageClientImpl::handleContextMenuWritingTools(IntRect selectionBoundsInRootView)
+void PageClientImpl::handleContextMenuWritingToolsDeprecated(IntRect selectionBoundsInRootView)
 {
-    m_impl->handleContextMenuWritingTools(selectionBoundsInRootView);
+    m_impl->handleContextMenuWritingToolsDeprecated(selectionBoundsInRootView);
+}
+
+void PageClientImpl::handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool tool, WebCore::IntRect selectionRect)
+{
+    RetainPtr webView = this->webView();
+    [[PAL::getWTWritingToolsClass() sharedInstance] showTool:WebKit::convertToPlatformRequestedTool(tool) forSelectionRect:selectionRect ofView:m_view forDelegate:webView.get() smartReplyConfiguration:nil];
 }
 
 #endif

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h
@@ -37,6 +37,12 @@ OBJC_CLASS NSView;
 OBJC_CLASS NSWindow;
 OBJC_CLASS WKMenuDelegate;
 
+#if ENABLE(WRITING_TOOLS)
+namespace WebCore::WritingTools {
+enum class RequestedTool : uint16_t;
+}
+#endif
+
 namespace WebKit {
 
 class WebContextMenuItemData;
@@ -50,6 +56,10 @@ public:
     ~WebContextMenuProxyMac();
 
     void contextMenuItemSelected(const WebContextMenuItemData&);
+
+#if ENABLE(WRITING_TOOLS)
+    void handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool);
+#endif
 
 #if ENABLE(SERVICE_CONTROLS)
     void clearServicesMenu();

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -825,6 +825,20 @@ void WebPageProxy::handleContextMenuCopySubject(const String& preferredMIMEType)
 
 #endif // ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 
+#if ENABLE(WRITING_TOOLS)
+
+void WebPageProxy::handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool tool)
+{
+    auto& editorState = this->editorState();
+    if (!editorState.hasPostLayoutData())
+        return;
+
+    auto selectionRect = editorState.postLayoutData->selectionBoundingRect;
+    protectedPageClient()->handleContextMenuWritingTools(tool, selectionRect);
+}
+
+#endif
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -714,7 +714,8 @@ public:
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
     bool canHandleContextMenuWritingTools() const;
-    void handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView);
+    // FIXME: (rdar://127608508) Remove all uses of this method when possible, in favor of the non-deprecated implementation.
+    void handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView);
 #endif
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6457,10 +6457,10 @@ void WebViewImpl::handleContextMenuTranslation(const WebCore::TranslationContext
 
 bool WebViewImpl::canHandleContextMenuWritingTools() const
 {
-    return [PAL::getWTWritingToolsViewControllerClass() isAvailable] && m_page->configuration().writingToolsBehavior() != WebCore::WritingTools::Behavior::None;
+    return [PAL::getWTWritingToolsViewControllerClass() isAvailable] && m_page->writingToolsBehavior() != WebCore::WritingTools::Behavior::None;
 }
 
-void WebViewImpl::handleContextMenuWritingTools(IntRect selectionBoundsInRootView)
+void WebViewImpl::handleContextMenuWritingToolsDeprecated(IntRect selectionBoundsInRootView)
 {
     if (!canHandleContextMenuWritingTools()) {
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
@@ -62,7 +62,7 @@ private:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    void handleWritingTools(WebCore::IntRect selectionBoundsInRootView) final;
+    void handleWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView) final;
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -81,12 +81,12 @@ void WebContextMenuClient::handleTranslation(const WebCore::TranslationContextMe
 
 #if ENABLE(WRITING_TOOLS)
 
-void WebContextMenuClient::handleWritingTools(WebCore::IntRect selectionBoundsInRootView)
+void WebContextMenuClient::handleWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView)
 {
     if (!m_page)
         return;
 
-    m_page->send(Messages::WebPageProxy::HandleContextMenuWritingTools(selectionBoundsInRootView));
+    m_page->send(Messages::WebPageProxy::HandleContextMenuWritingToolsDeprecated(selectionBoundsInRootView));
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9197,9 +9197,9 @@ void WebPage::handleContextMenuTranslation(const TranslationContextMenuInfo& inf
 #endif
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
-void WebPage::handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView)
+void WebPage::handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView)
 {
-    send(Messages::WebPageProxy::HandleContextMenuWritingTools(selectionBoundsInRootView));
+    send(Messages::WebPageProxy::HandleContextMenuWritingToolsDeprecated(selectionBoundsInRootView));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1621,7 +1621,7 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
-    void handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView);
+    void handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView);
 #endif
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h
@@ -77,7 +77,7 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    void handleWritingTools(WebCore::IntRect selectionBoundsInRootView) final;
+    void handleWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView) final;
 #endif
 
 private:

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -148,7 +148,7 @@ void WebContextMenuClient::handleTranslation(const TranslationContextMenuInfo& i
 
 #if ENABLE(WRITING_TOOLS)
 
-void WebContextMenuClient::handleWritingTools(IntRect selectionBoundsInRootView)
+void WebContextMenuClient::handleWritingToolsDeprecated(IntRect selectionBoundsInRootView)
 {
 }
 


### PR DESCRIPTION
#### bf5cf82f2df5bbd2afd6e7cdc56f6da24b2b21fb
<pre>
[Writing Tools] Two Writing Tools context menu items show up; menu item shows up even in non-text cases; panel appears in wrong location with one of the items; menu item is in wrong location
<a href="https://bugs.webkit.org/show_bug.cgi?id=276241">https://bugs.webkit.org/show_bug.cgi?id=276241</a>
<a href="https://rdar.apple.com/127608508">rdar://127608508</a>

Reviewed by Wenson Hsieh, Aditya Keerthi and Tim Horton.

* Implement the `providesWritingToolsContextMenu` property so that AppKit does not inject their own
Writing Tools context menu item.

* Move the Writing Tools context menu item to be just above the &apos;Spelling &amp; Grammar&apos; item.

* Use `standardWritingToolsMenuItem` to implement the new Writing Tools context menu item UX so that
it includes each tool as a sub-menu item.

* Maintain compatibility in cases where these methods are not currently implemented by keeping the
old implementation around temporarily.

* Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::populate):
* Source/WebCore/page/writing-tools/WritingToolsTypes.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView writingToolsBehavior]):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView providesWritingToolsContextMenu]):
* Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.h:
* Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm:
(WebKit::convertToPlatformRequestedTool):
(WebKit::convertToWebRequestedTool):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::writingToolsBehavior const):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::writingToolsContextMenuItemSelected):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::writingToolsContextMenuItemSelected):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.h:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(-[WKMenuTarget showWritingTools:]):
(WebKit::WebContextMenuProxyMac::writingToolsContextMenuItemSelected):
(WebKit::WebContextMenuProxyMac::getContextMenuItem):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::writingToolsContextMenuItemSelected):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::canHandleContextMenuWritingTools const):

Canonical link: <a href="https://commits.webkit.org/280705@main">https://commits.webkit.org/280705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1c775e6c350676cc3a57ba99daf2e3e2f835d0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7834 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8022 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5542 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59419 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27337 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31237 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6874 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6837 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62690 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7238 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49597 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53821 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1111 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8561 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33631 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->