### PR TITLE
Apply SIMD table lookup to 16bit characters in HTML fast path parser

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -476,42 +476,38 @@ private:
     // `LChar` parser.
     String scanText()
     {
-        auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
-            using UnsignedType = std::make_unsigned_t<CharacterType>;
-            if constexpr (sizeof(UnsignedType) == 1) {
-                // https://lemire.me/blog/2024/06/08/scan-html-faster-with-simd-instructions-chrome-edition/
-                // By looking up the table via lower 4bit, we can identify the category.
-                // '\0' => 0000 0000
-                // '&'  => 0010 0110
-                // '<'  => 0011 1100
-                // '\r' => 0000 1101
-                using VectorType = decltype(input);
-                constexpr VectorType lowNibbleMask { '\0', 0, 0, 0, 0, 0, '&', 0, 0, 0, 0, 0, '<', '\r', 0, 0 };
-                constexpr VectorType v0f = SIMD::splat<UnsignedType>(0x0f);
-                auto lowpart = simde_vqtbl1q_u8(lowNibbleMask, SIMD::bitAnd(input, v0f));
-                return SIMD::findFirstNonZeroIndex(SIMD::equal(lowpart, input));
-            } else {
-                constexpr auto quoteMask = SIMD::splat<UnsignedType>('<');
-                constexpr auto escapeMask = SIMD::splat<UnsignedType>('&');
-                constexpr auto newlineMask = SIMD::splat<UnsignedType>('\r');
-                constexpr auto zeroMask = SIMD::splat<UnsignedType>(0);
-
-                auto quotes = SIMD::equal(input, quoteMask);
-                auto escapes = SIMD::equal(input, escapeMask);
-                auto newlines = SIMD::equal(input, newlineMask);
-                auto zeros = SIMD::equal(input, zeroMask);
-                auto mask = SIMD::bitOr(zeros, quotes, escapes, newlines);
-                return SIMD::findFirstNonZeroIndex(mask);
-            }
-        };
+        auto* start = m_parsingBuffer.position();
+        const auto* end = start + m_parsingBuffer.lengthRemaining();
 
         auto scalarMatch = [&](auto character) ALWAYS_INLINE_LAMBDA {
             return character == '<' || character == '&' || character == '\r' || character == '\0';
         };
 
-        auto* start = m_parsingBuffer.position();
-        const auto* end = start + m_parsingBuffer.lengthRemaining();
-        auto* cursor = SIMD::find(std::span { start, end }, vectorMatch, scalarMatch);
+        auto vectorEquals8Bit = [&](auto input) ALWAYS_INLINE_LAMBDA {
+            // https://lemire.me/blog/2024/06/08/scan-html-faster-with-simd-instructions-chrome-edition/
+            // By looking up the table via lower 4bit, we can identify the category.
+            // '\0' => 0000 0000
+            // '&'  => 0010 0110
+            // '<'  => 0011 1100
+            // '\r' => 0000 1101
+            constexpr simde_uint8x16_t lowNibbleMask { '\0', 0, 0, 0, 0, 0, '&', 0, 0, 0, 0, 0, '<', '\r', 0, 0 };
+            constexpr simde_uint8x16_t v0f = SIMD::splat<uint8_t>(0x0f);
+            return SIMD::equal(simde_vqtbl1q_u8(lowNibbleMask, SIMD::bitAnd(input, v0f)), input);
+        };
+
+        const CharacterType* cursor = nullptr;
+        if constexpr (sizeof(CharacterType) == 1) {
+            auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
+                return SIMD::findFirstNonZeroIndex(vectorEquals8Bit(input));
+            };
+            cursor = SIMD::find(std::span { start, end }, vectorMatch, scalarMatch);
+        } else {
+            auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
+                constexpr simde_uint8x16_t zeros = SIMD::splat<uint8_t>(0);
+                return SIMD::findFirstNonZeroIndex(SIMD::bitAnd(vectorEquals8Bit(input.val[0]), SIMD::equal(input.val[1], zeros)));
+            };
+            cursor = SIMD::findInterleaved(std::span { start, end }, vectorMatch, scalarMatch);
+        }
         m_parsingBuffer.setPosition(cursor);
 
         if (cursor != end) {
@@ -633,47 +629,41 @@ private:
             auto quoteChar = m_parsingBuffer.consume();
 
             auto find = [&]<CharacterType quoteChar>(std::span<const CharacterType> span) ALWAYS_INLINE_LAMBDA {
-                auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
-                    using UnsignedType = std::make_unsigned_t<CharacterType>;
-                    if constexpr (sizeof(UnsignedType) == 1) {
-                        // https://lemire.me/blog/2024/06/08/scan-html-faster-with-simd-instructions-chrome-edition/
-                        // By looking up the table via lower 4bit, we can identify the category.
-                        // '\0' => 0000 0000
-                        // '&'  => 0010 0110
-                        // '\'' => 0010 0111
-                        // '\r' => 0000 1101
-                        //
-                        // OR
-                        //
-                        // '\0' => 0000 0000
-                        // '"'  => 0010 0010
-                        // '&'  => 0010 0110
-                        // '\r' => 0000 1101
-                        using VectorType = decltype(input);
-                        constexpr auto lowNibbleMask  = quoteChar == '\'' ? VectorType { '\0', 0, 0, 0, 0, 0, '&', '\'', 0, 0, 0, 0, 0, '\r', 0, 0 } : VectorType { '\0', 0, '"', 0, 0, 0, '&', 0, 0, 0, 0, 0, 0, '\r', 0, 0 };
-                        constexpr auto v0f = SIMD::splat<UnsignedType>(0x0f);
-                        auto lowpart = simde_vqtbl1q_u8(lowNibbleMask, SIMD::bitAnd(input, v0f));
-                        return SIMD::findFirstNonZeroIndex(SIMD::equal(lowpart, input));
-                    } else {
-                        constexpr auto quoteMask = SIMD::splat<UnsignedType>(quoteChar);
-                        constexpr auto escapeMask = SIMD::splat<UnsignedType>('&');
-                        constexpr auto newlineMask = SIMD::splat<UnsignedType>('\r');
-                        constexpr auto zeroMask = SIMD::splat<UnsignedType>(0);
-
-                        auto quotes = SIMD::equal(input, quoteMask);
-                        auto escapes = SIMD::equal(input, escapeMask);
-                        auto newlines = SIMD::equal(input, newlineMask);
-                        auto zeros = SIMD::equal(input, zeroMask);
-                        auto mask = SIMD::bitOr(zeros, quotes, escapes, newlines);
-                        return SIMD::findFirstNonZeroIndex(mask);
-                    }
-                };
-
                 auto scalarMatch = [&](auto character) ALWAYS_INLINE_LAMBDA {
                     return character == quoteChar || character == '&' || character == '\r' || character == '\0';
                 };
 
-                return SIMD::find(span, vectorMatch, scalarMatch);
+                auto vectorEquals8Bit = [&](auto input) ALWAYS_INLINE_LAMBDA {
+                    // https://lemire.me/blog/2024/06/08/scan-html-faster-with-simd-instructions-chrome-edition/
+                    // By looking up the table via lower 4bit, we can identify the category.
+                    // '\0' => 0000 0000
+                    // '&'  => 0010 0110
+                    // '\'' => 0010 0111
+                    // '\r' => 0000 1101
+                    //
+                    // OR
+                    //
+                    // '\0' => 0000 0000
+                    // '"'  => 0010 0010
+                    // '&'  => 0010 0110
+                    // '\r' => 0000 1101
+                    constexpr auto lowNibbleMask  = quoteChar == '\'' ? simde_uint8x16_t { '\0', 0, 0, 0, 0, 0, '&', '\'', 0, 0, 0, 0, 0, '\r', 0, 0 } : simde_uint8x16_t { '\0', 0, '"', 0, 0, 0, '&', 0, 0, 0, 0, 0, 0, '\r', 0, 0 };
+                    constexpr auto v0f = SIMD::splat<uint8_t>(0x0f);
+                    return SIMD::equal(simde_vqtbl1q_u8(lowNibbleMask, SIMD::bitAnd(input, v0f)), input);
+                };
+
+                if constexpr (sizeof(CharacterType) == 1) {
+                    auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
+                        return SIMD::findFirstNonZeroIndex(vectorEquals8Bit(input));
+                    };
+                    return SIMD::find(span, vectorMatch, scalarMatch);
+                } else {
+                    auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
+                        constexpr simde_uint8x16_t zeros = SIMD::splat<uint8_t>(0);
+                        return SIMD::findFirstNonZeroIndex(SIMD::bitAnd(vectorEquals8Bit(input.val[0]), SIMD::equal(input.val[1], zeros)));
+                    };
+                    return SIMD::findInterleaved(span, vectorMatch, scalarMatch);
+                }
             };
 
             start = m_parsingBuffer.position();


### PR DESCRIPTION
#### 4084cae3554fdd89eff4bd49cb60b0f4944142a2
<pre>
Apply SIMD table lookup to 16bit characters in HTML fast path parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=276244">https://bugs.webkit.org/show_bug.cgi?id=276244</a>
<a href="https://rdar.apple.com/131153910">rdar://131153910</a>

Reviewed by Justin Michaud.

280670@main applied SIMD table lookup to 8bit characters. But since searching characters are all ASCII,
this method can be easily applied to 16bit characters too: Use NEON SIMD to load 16bit characters in interleaved manner (lowers and uppers),
and checking uppers are zero and lowers are searching characters via table lookup.

* Source/WTF/wtf/SIMDHelpers.h:
(WTF::SIMD::findInterleaved):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanText):
(WebCore::HTMLFastPathParser::scanAttributeValue):

Canonical link: <a href="https://commits.webkit.org/280741@main">https://commits.webkit.org/280741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/845fada63cdbbdd3dd55a53fb8d835497e8512e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7743 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46398 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5468 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27261 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6795 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6748 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50392 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53115 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62601 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/56542 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53660 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53737 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1030 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78302 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8578 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32457 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12971 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33542 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34627 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->