### PR TITLE
[GStreamer] Fix typo in X265 encoder options

### DIFF
--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -29,7 +29,6 @@
 #include <wtf/StdMap.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/MakeString.h>
-#include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/StringView.h>
 
@@ -959,16 +958,15 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                 return;
             setBitrateKbitPerSec(object, propertyName, bitrate);
             auto bitrateMode = GPOINTER_TO_INT(g_object_get_qdata(object, x265BitrateQuark));
-            StringBuilder builder;
+            String options;
             switch (bitrateMode) {
             case CONSTANT_BITRATE_MODE:
-                builder.append("vbv-maxrate="_s, bitrate, ":vbv-bufsize="_s, bitrate / 2);
+                options = makeString("vbv-maxrate="_s, bitrate, ":vbv-bufsize="_s, bitrate / 2);
                 break;
             case VARIABLE_BITRATE_MODE:
-                builder.append("vbv-maxrate=0:vbvbufsize=0"_s);
+                options = "vbv-maxrate=0:vbv-bufsize=0"_s;
                 break;
             };
-            auto options = builder.toString();
             g_object_set(object, "option-string", options.ascii().data(), nullptr);
         }, "key-int-max", [](GstElement* encoder, BitrateMode mode) {
             g_object_set_qdata(G_OBJECT(encoder), x265BitrateQuark, GINT_TO_POINTER(mode));


### PR DESCRIPTION
#### bba4f82149e3872da296e534f359c13da39ae1d7
<pre>
[GStreamer] Fix typo in X265 encoder options
<a href="https://bugs.webkit.org/show_bug.cgi?id=276249">https://bugs.webkit.org/show_bug.cgi?id=276249</a>

Reviewed by Xabier Rodriguez-Calvar.

The vbv bufsize option was missing a dash in case variable bitrate mode configuration. Driving by,
removed un-needed StringBuilder usage.

* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(webkit_video_encoder_class_init):

Canonical link: <a href="https://commits.webkit.org/280685@main">https://commits.webkit.org/280685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af26cbf1f99f978b0cad35c6b289ed99a72b7008

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60941 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46413 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5484 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27276 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6811 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6767 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62620 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53675 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1237 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53754 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12668 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1045 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32476 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34646 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->