### PR TITLE
Support border/padding/margin on RenderMathMLRow and subclasses

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Border properties on maction
 PASS Border properties on maction (rtl)
-FAIL Border properties on menclose assert_approx_equals: bottom border expected 60 +/- 1 but got -3.96875
-FAIL Border properties on menclose (rtl) assert_approx_equals: bottom border expected 60 +/- 1 but got -3.96875
+PASS Border properties on menclose
+PASS Border properties on menclose (rtl)
 PASS Border properties on merror
 PASS Border properties on merror (rtl)
 PASS Border properties on mfrac
@@ -17,19 +17,19 @@ PASS Border properties on mo
 PASS Border properties on mo (rtl)
 FAIL Border properties on mover assert_approx_equals: left border expected 30 +/- 1 but got 0
 FAIL Border properties on mover (rtl) assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on mpadded assert_approx_equals: bottom border expected 60 +/- 1 but got 0
-FAIL Border properties on mpadded (rtl) assert_approx_equals: bottom border expected 60 +/- 1 but got 0
+PASS Border properties on mpadded
+PASS Border properties on mpadded (rtl)
 PASS Border properties on mphantom
 PASS Border properties on mphantom (rtl)
-FAIL Border properties on mroot assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on mroot (rtl) assert_approx_equals: left border expected 30 +/- 1 but got 0
+PASS Border properties on mroot
+PASS Border properties on mroot (rtl)
 PASS Border properties on mrow
 PASS Border properties on mrow (rtl)
 PASS Border properties on ms
 PASS Border properties on ms (rtl)
 PASS Border properties on mspace
-FAIL Border properties on msqrt assert_approx_equals: bottom border expected 60 +/- 1 but got -8.21875
-FAIL Border properties on msqrt (rtl) assert_approx_equals: bottom border expected 60 +/- 1 but got -8.21875
+PASS Border properties on msqrt
+PASS Border properties on msqrt (rtl)
 PASS Border properties on mstyle
 PASS Border properties on mstyle (rtl)
 FAIL Border properties on msub assert_approx_equals: left border expected 30 +/- 1 but got 0

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-001-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL Margin properties on mrow assert_approx_equals: top margin expected 40 +/- 1 but got 80
-FAIL Margin properties on mrow (rtl) assert_approx_equals: top margin expected 40 +/- 1 but got 80
-FAIL Margin properties on mrow (shorthand) assert_approx_equals: top margin expected 20 +/- 1 but got 40
-FAIL Margin properties on mrow (logical) assert_approx_equals: top margin expected 40 +/- 1 but got 80
-FAIL Margin properties on mrow (logical, rtl) assert_approx_equals: top margin expected 40 +/- 1 but got 80
-FAIL Margin properties on mrow (logical, shorthand) assert_approx_equals: top margin expected 30 +/- 1 but got 60
+PASS Margin properties on mrow
+PASS Margin properties on mrow (rtl)
+PASS Margin properties on mrow (shorthand)
+PASS Margin properties on mrow (logical)
+PASS Margin properties on mrow (logical, rtl)
+PASS Margin properties on mrow (logical, shorthand)
 
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-002-expected.txt
@@ -1,75 +1,75 @@
 
-FAIL Margin properties on maction assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on maction (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on maction (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
-FAIL Margin properties on menclose assert_approx_equals: left margin expected 30 +/- 1 but got 0
-FAIL Margin properties on menclose (rtl) assert_approx_equals: left margin expected 30 +/- 1 but got 0
-FAIL Margin properties on menclose (no margin-collapsing) assert_approx_equals: left margin expected 60 +/- 1 but got 30
-FAIL Margin properties on merror assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on merror (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on merror (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
-FAIL Margin properties on mfrac assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on mfrac (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on mfrac (no margin-collapsing) assert_approx_equals: bottom margin expected 120 +/- 1 but got 10
-FAIL Margin properties on mi assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mi (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mi (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
-FAIL Margin properties on mmultiscripts assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on mmultiscripts (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on mmultiscripts (no margin-collapsing) assert_approx_equals: bottom margin expected 120 +/- 1 but got 10
-FAIL Margin properties on mn assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mn (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mn (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
-FAIL Margin properties on mo assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mo (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mo (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
-FAIL Margin properties on mover assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on mover (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on mover (no margin-collapsing) assert_approx_equals: bottom margin expected 120 +/- 1 but got 10
-FAIL Margin properties on mpadded assert_approx_equals: left margin expected 30 +/- 1 but got 0
-FAIL Margin properties on mpadded (rtl) assert_approx_equals: left margin expected 30 +/- 1 but got 0
-FAIL Margin properties on mpadded (no margin-collapsing) assert_approx_equals: left margin expected 60 +/- 1 but got 30
-FAIL Margin properties on mphantom assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mphantom (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mphantom (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
-FAIL Margin properties on mroot assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on mroot (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on mroot (no margin-collapsing) assert_approx_equals: bottom margin expected 120 +/- 1 but got 10
-FAIL Margin properties on mrow assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mrow (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mrow (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
-FAIL Margin properties on ms assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on ms (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on ms (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
-FAIL Margin properties on mspace assert_approx_equals: top/bottom margin expected 110 +/- 1 but got 0
-FAIL Margin properties on msqrt assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on msqrt (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on msqrt (no margin-collapsing) assert_approx_equals: bottom margin expected 120 +/- 1 but got 10
-FAIL Margin properties on mstyle assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mstyle (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mstyle (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
-FAIL Margin properties on msub assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on msub (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on msub (no margin-collapsing) assert_approx_equals: bottom margin expected 120 +/- 1 but got 10
-FAIL Margin properties on msubsup assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on msubsup (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on msubsup (no margin-collapsing) assert_approx_equals: bottom margin expected 120 +/- 1 but got 10
-FAIL Margin properties on msup assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on msup (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on msup (no margin-collapsing) assert_approx_equals: bottom margin expected 120 +/- 1 but got 10
+FAIL Margin properties on maction assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on maction (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on maction (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on menclose assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on menclose (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on menclose (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on merror assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on merror (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on merror (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on mfrac assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mfrac (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mfrac (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on mi assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mi (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mi (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on mmultiscripts assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mmultiscripts (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mmultiscripts (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on mn assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mn (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mn (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on mo assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mo (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mo (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on mover assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mover (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mover (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on mpadded assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mpadded (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mpadded (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on mphantom assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mphantom (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mphantom (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on mroot assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mroot (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mroot (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on mrow assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mrow (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mrow (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on ms assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on ms (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on ms (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on mspace assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on msqrt assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on msqrt (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on msqrt (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on mstyle assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mstyle (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mstyle (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on msub assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on msub (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on msub (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on msubsup assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on msubsup (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on msubsup (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on msup assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on msup (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on msup (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
 PASS Margin properties on mtable
 PASS Margin properties on mtable (rtl)
-FAIL Margin properties on mtable (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 150
-FAIL Margin properties on mtext assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mtext (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on mtext (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
-FAIL Margin properties on munder assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on munder (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on munder (no margin-collapsing) assert_approx_equals: bottom margin expected 120 +/- 1 but got 10
-FAIL Margin properties on munderover assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on munderover (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 0
-FAIL Margin properties on munderover (no margin-collapsing) assert_approx_equals: bottom margin expected 120 +/- 1 but got 10
-FAIL Margin properties on semantics assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on semantics (rtl) assert_approx_equals: top margin expected 50 +/- 1 but got 100
-FAIL Margin properties on semantics (no margin-collapsing) assert_approx_equals: top margin expected 100 +/- 1 but got 200
+FAIL Margin properties on mtable (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 70
+FAIL Margin properties on mtext assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mtext (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on mtext (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on munder assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on munder (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on munder (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on munderover assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on munderover (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on munderover (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
+FAIL Margin properties on semantics assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on semantics (rtl) assert_approx_equals: preferred width expected 70 +/- 1 but got 0
+FAIL Margin properties on semantics (no margin-collapsing) assert_approx_equals: preferred width expected 140 +/- 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
@@ -1,15 +1,15 @@
 
-FAIL Margin properties on the children of menclose assert_approx_equals: block size expected 122.96875 +/- 1 but got 77.96875
-FAIL Margin properties on the children of merror assert_approx_equals: block size expected 117 +/- 1 but got 72
+FAIL Margin properties on the children of menclose assert_approx_equals: preferred width expected 58 +/- 1 but got 33
+FAIL Margin properties on the children of merror assert_approx_equals: preferred width expected 49 +/- 1 but got 24
 FAIL Margin properties on the children of mfrac assert_approx_equals: preferred width expected 49 +/- 1 but got 24
 FAIL Margin properties on the children of mmultiscripts assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
 FAIL Margin properties on the children of mover assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of mpadded assert_approx_equals: block size expected 115 +/- 1 but got 70
-FAIL Margin properties on the children of mphantom assert_approx_equals: block size expected 115 +/- 1 but got 70
-FAIL Margin properties on the children of mroot assert_approx_equals: inline size expected 105.0625 +/- 1 but got 55.0625
-FAIL Margin properties on the children of mrow assert_approx_equals: block size expected 115 +/- 1 but got 70
-FAIL Margin properties on the children of msqrt assert_approx_equals: block size expected 118.671875 +/- 1 but got 73.671875
-FAIL Margin properties on the children of mstyle assert_approx_equals: block size expected 115 +/- 1 but got 70
+FAIL Margin properties on the children of mpadded assert_approx_equals: preferred width expected 47 +/- 1 but got 22
+FAIL Margin properties on the children of mphantom assert_approx_equals: preferred width expected 47 +/- 1 but got 22
+FAIL Margin properties on the children of mroot assert_approx_equals: inline size expected 105.0625 +/- 1 but got 80.0625
+FAIL Margin properties on the children of mrow assert_approx_equals: preferred width expected 47 +/- 1 but got 22
+FAIL Margin properties on the children of msqrt assert_approx_equals: preferred width expected 66 +/- 1 but got 41
+FAIL Margin properties on the children of mstyle assert_approx_equals: preferred width expected 47 +/- 1 but got 22
 FAIL Margin properties on the children of msub assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
 FAIL Margin properties on the children of msubsup assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
 FAIL Margin properties on the children of msup assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Padding properties on maction
 PASS Padding properties on maction (rtl)
-FAIL Padding properties on menclose assert_approx_equals: bottom padding expected 60 +/- 1 but got -4.1875
-FAIL Padding properties on menclose (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -4.1875
+PASS Padding properties on menclose
+PASS Padding properties on menclose (rtl)
 PASS Padding properties on merror
 PASS Padding properties on merror (rtl)
 PASS Padding properties on mfrac
@@ -17,19 +17,19 @@ PASS Padding properties on mo
 PASS Padding properties on mo (rtl)
 FAIL Padding properties on mover assert_approx_equals: left padding expected 30 +/- 1 but got 0
 FAIL Padding properties on mover (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mpadded assert_approx_equals: bottom padding expected 60 +/- 1 but got -0.21875
-FAIL Padding properties on mpadded (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -0.21875
+PASS Padding properties on mpadded
+PASS Padding properties on mpadded (rtl)
 PASS Padding properties on mphantom
 PASS Padding properties on mphantom (rtl)
-FAIL Padding properties on mroot assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mroot (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on mroot
+PASS Padding properties on mroot (rtl)
 PASS Padding properties on mrow
 PASS Padding properties on mrow (rtl)
 PASS Padding properties on ms
 PASS Padding properties on ms (rtl)
 PASS Padding properties on mspace
-FAIL Padding properties on msqrt assert_approx_equals: bottom padding expected 60 +/- 1 but got -10.71875
-FAIL Padding properties on msqrt (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -10.71875
+PASS Padding properties on msqrt
+PASS Padding properties on msqrt (rtl)
 PASS Padding properties on mstyle
 PASS Padding properties on mstyle (rtl)
 FAIL Padding properties on msub assert_approx_equals: left padding expected 30 +/- 1 but got 0

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Border properties on maction
 PASS Border properties on maction (rtl)
-FAIL Border properties on menclose assert_approx_equals: bottom border expected 60 +/- 1 but got -4.96875
-FAIL Border properties on menclose (rtl) assert_approx_equals: bottom border expected 60 +/- 1 but got -4.96875
+PASS Border properties on menclose
+PASS Border properties on menclose (rtl)
 PASS Border properties on merror
 PASS Border properties on merror (rtl)
 PASS Border properties on mfrac
@@ -17,19 +17,19 @@ PASS Border properties on mo
 PASS Border properties on mo (rtl)
 FAIL Border properties on mover assert_approx_equals: left border expected 30 +/- 1 but got 0
 FAIL Border properties on mover (rtl) assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on mpadded assert_approx_equals: bottom border expected 60 +/- 1 but got -1
-FAIL Border properties on mpadded (rtl) assert_approx_equals: bottom border expected 60 +/- 1 but got -1
+PASS Border properties on mpadded
+PASS Border properties on mpadded (rtl)
 PASS Border properties on mphantom
 PASS Border properties on mphantom (rtl)
-FAIL Border properties on mroot assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on mroot (rtl) assert_approx_equals: left border expected 30 +/- 1 but got 0
+PASS Border properties on mroot
+PASS Border properties on mroot (rtl)
 PASS Border properties on mrow
 PASS Border properties on mrow (rtl)
 PASS Border properties on ms
 PASS Border properties on ms (rtl)
 PASS Border properties on mspace
-FAIL Border properties on msqrt assert_approx_equals: bottom border expected 60 +/- 1 but got -7.625
-FAIL Border properties on msqrt (rtl) assert_approx_equals: bottom border expected 60 +/- 1 but got -7.625
+PASS Border properties on msqrt
+PASS Border properties on msqrt (rtl)
 PASS Border properties on mstyle
 PASS Border properties on mstyle (rtl)
 FAIL Border properties on msub assert_approx_equals: left border expected 30 +/- 1 but got 0

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
@@ -1,15 +1,15 @@
 
-FAIL Margin properties on the children of menclose assert_approx_equals: block size expected 122.96875 +/- 1 but got 77.96875
-FAIL Margin properties on the children of merror assert_approx_equals: block size expected 117 +/- 1 but got 72
+FAIL Margin properties on the children of menclose assert_approx_equals: preferred width expected 58 +/- 1 but got 33
+FAIL Margin properties on the children of merror assert_approx_equals: preferred width expected 49 +/- 1 but got 24
 FAIL Margin properties on the children of mfrac assert_approx_equals: preferred width expected 49 +/- 1 but got 24
 FAIL Margin properties on the children of mmultiscripts assert_approx_equals: inline size expected 90.890625 +/- 1 but got 40.890625
 FAIL Margin properties on the children of mover assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of mpadded assert_approx_equals: block size expected 115 +/- 1 but got 70
-FAIL Margin properties on the children of mphantom assert_approx_equals: block size expected 115 +/- 1 but got 70
-FAIL Margin properties on the children of mroot assert_approx_equals: inline size expected 102.546875 +/- 1 but got 52.546875
-FAIL Margin properties on the children of mrow assert_approx_equals: block size expected 115 +/- 1 but got 70
-FAIL Margin properties on the children of msqrt assert_approx_equals: block size expected 117.046875 +/- 1 but got 72.046875
-FAIL Margin properties on the children of mstyle assert_approx_equals: block size expected 115 +/- 1 but got 70
+FAIL Margin properties on the children of mpadded assert_approx_equals: preferred width expected 47 +/- 1 but got 22
+FAIL Margin properties on the children of mphantom assert_approx_equals: preferred width expected 47 +/- 1 but got 22
+FAIL Margin properties on the children of mroot assert_approx_equals: inline size expected 102.546875 +/- 1 but got 77.546875
+FAIL Margin properties on the children of mrow assert_approx_equals: preferred width expected 47 +/- 1 but got 22
+FAIL Margin properties on the children of msqrt assert_approx_equals: preferred width expected 64 +/- 1 but got 39
+FAIL Margin properties on the children of mstyle assert_approx_equals: preferred width expected 47 +/- 1 but got 22
 FAIL Margin properties on the children of msub assert_approx_equals: inline size expected 90.890625 +/- 1 but got 40.890625
 FAIL Margin properties on the children of msubsup assert_approx_equals: inline size expected 90.890625 +/- 1 but got 40.890625
 FAIL Margin properties on the children of msup assert_approx_equals: inline size expected 90.890625 +/- 1 but got 40.890625

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Padding properties on maction
 PASS Padding properties on maction (rtl)
-FAIL Padding properties on menclose assert_approx_equals: bottom padding expected 60 +/- 1 but got -4.96875
-FAIL Padding properties on menclose (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -4.96875
+PASS Padding properties on menclose
+PASS Padding properties on menclose (rtl)
 PASS Padding properties on merror
 PASS Padding properties on merror (rtl)
 PASS Padding properties on mfrac
@@ -17,19 +17,19 @@ PASS Padding properties on mo
 PASS Padding properties on mo (rtl)
 FAIL Padding properties on mover assert_approx_equals: left padding expected 30 +/- 1 but got 0
 FAIL Padding properties on mover (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mpadded assert_approx_equals: bottom padding expected 60 +/- 1 but got -1
-FAIL Padding properties on mpadded (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -1
+PASS Padding properties on mpadded
+PASS Padding properties on mpadded (rtl)
 PASS Padding properties on mphantom
 PASS Padding properties on mphantom (rtl)
-FAIL Padding properties on mroot assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mroot (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on mroot
+PASS Padding properties on mroot (rtl)
 PASS Padding properties on mrow
 PASS Padding properties on mrow (rtl)
 PASS Padding properties on ms
 PASS Padding properties on ms (rtl)
 PASS Padding properties on mspace
-FAIL Padding properties on msqrt assert_approx_equals: bottom padding expected 60 +/- 1 but got -7.625
-FAIL Padding properties on msqrt (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -7.625
+PASS Padding properties on msqrt
+PASS Padding properties on msqrt (rtl)
 PASS Padding properties on mstyle
 PASS Padding properties on mstyle (rtl)
 FAIL Padding properties on msub assert_approx_equals: left padding expected 30 +/- 1 but got 0

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Padding properties on maction
 PASS Padding properties on maction (rtl)
-FAIL Padding properties on menclose assert_approx_equals: bottom padding expected 60 +/- 1 but got -3.96875
-FAIL Padding properties on menclose (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -3.96875
+PASS Padding properties on menclose
+PASS Padding properties on menclose (rtl)
 PASS Padding properties on merror
 PASS Padding properties on merror (rtl)
 PASS Padding properties on mfrac
@@ -17,19 +17,19 @@ PASS Padding properties on mo
 PASS Padding properties on mo (rtl)
 FAIL Padding properties on mover assert_approx_equals: left padding expected 30 +/- 1 but got 0
 FAIL Padding properties on mover (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mpadded assert_approx_equals: bottom padding expected 60 +/- 1 but got 0
-FAIL Padding properties on mpadded (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got 0
+PASS Padding properties on mpadded
+PASS Padding properties on mpadded (rtl)
 PASS Padding properties on mphantom
 PASS Padding properties on mphantom (rtl)
-FAIL Padding properties on mroot assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mroot (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on mroot
+PASS Padding properties on mroot (rtl)
 PASS Padding properties on mrow
 PASS Padding properties on mrow (rtl)
 PASS Padding properties on ms
 PASS Padding properties on ms (rtl)
 PASS Padding properties on mspace
-FAIL Padding properties on msqrt assert_approx_equals: bottom padding expected 60 +/- 1 but got -8.21875
-FAIL Padding properties on msqrt (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -8.21875
+PASS Padding properties on msqrt
+PASS Padding properties on msqrt (rtl)
 PASS Padding properties on mstyle
 PASS Padding properties on mstyle (rtl)
 FAIL Padding properties on msub assert_approx_equals: left padding expected 30 +/- 1 but got 0

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Padding properties on maction
 PASS Padding properties on maction (rtl)
-FAIL Padding properties on menclose assert_approx_equals: bottom padding expected 60 +/- 1 but got -3.96875
-FAIL Padding properties on menclose (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -3.96875
+PASS Padding properties on menclose
+PASS Padding properties on menclose (rtl)
 PASS Padding properties on merror
 PASS Padding properties on merror (rtl)
 PASS Padding properties on mfrac
@@ -17,19 +17,19 @@ PASS Padding properties on mo
 PASS Padding properties on mo (rtl)
 FAIL Padding properties on mover assert_approx_equals: left padding expected 30 +/- 1 but got 0
 FAIL Padding properties on mover (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mpadded assert_approx_equals: bottom padding expected 60 +/- 1 but got 0
-FAIL Padding properties on mpadded (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got 0
+PASS Padding properties on mpadded
+PASS Padding properties on mpadded (rtl)
 PASS Padding properties on mphantom
 PASS Padding properties on mphantom (rtl)
-FAIL Padding properties on mroot assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mroot (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on mroot
+PASS Padding properties on mroot (rtl)
 PASS Padding properties on mrow
 PASS Padding properties on mrow (rtl)
 PASS Padding properties on ms
 PASS Padding properties on ms (rtl)
 PASS Padding properties on mspace
-FAIL Padding properties on msqrt assert_approx_equals: bottom padding expected 60 +/- 1 but got -8.21875
-FAIL Padding properties on msqrt (rtl) assert_approx_equals: bottom padding expected 60 +/- 1 but got -8.21875
+PASS Padding properties on msqrt
+PASS Padding properties on msqrt (rtl)
 PASS Padding properties on mstyle
 PASS Padding properties on mstyle (rtl)
 FAIL Padding properties on msub assert_approx_equals: left padding expected 30 +/- 1 but got 0

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -279,6 +279,12 @@ void RenderMathMLBlock::layoutInvalidMarkup(bool relayoutChildren)
     clearNeedsLayout();
 }
 
+void RenderMathMLBlock::computeAndSetBlockDirectionMarginsOfChildren()
+{
+    for (auto* child = firstChildBox(); child; child = child->nextSiblingBox())
+        child->computeAndSetBlockDirectionMargins(*this);
+}
+
 void RenderMathMLBlock::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     RenderBlock::styleDidChange(diff, oldStyle);

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.h
@@ -78,6 +78,7 @@ protected:
 
     void layoutBlock(bool relayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) override;
     void layoutInvalidMarkup(bool relayoutChildren);
+    void computeAndSetBlockDirectionMarginsOfChildren();
 
 private:
     bool isRenderMathMLBlock() const final { return true; }

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
@@ -237,8 +237,7 @@ void RenderMathMLFraction::layoutBlock(bool relayoutChildren, LayoutUnit)
 
     numerator().layoutIfNeeded();
     denominator().layoutIfNeeded();
-    numerator().computeAndSetBlockDirectionMargins(*this);
-    denominator().computeAndSetBlockDirectionMargins(*this);
+    computeAndSetBlockDirectionMarginsOfChildren();
 
     LayoutUnit numeratorMarginBoxInlineSize = numerator().marginStart() + numerator().logicalWidth() + numerator().marginEnd();
     LayoutUnit denominatorMarginBoxInlineSize = denominator().marginStart() + denominator().logicalWidth() + denominator().marginEnd();

--- a/Source/WebCore/rendering/mathml/RenderMathMLMath.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMath.cpp
@@ -82,6 +82,7 @@ void RenderMathMLMath::layoutBlock(bool relayoutChildren, LayoutUnit pageLogical
         return;
 
     recomputeLogicalWidth();
+    computeAndSetBlockDirectionMarginsOfChildren();
 
     setLogicalHeight(borderAndPaddingLogicalHeight() + scrollbarLogicalHeight());
 
@@ -96,8 +97,9 @@ void RenderMathMLMath::layoutBlock(bool relayoutChildren, LayoutUnit pageLogical
         centerChildren(width);
     else
         setLogicalWidth(width);
+    shiftRowItems(0_lu, borderAndPaddingBefore());
 
-    setLogicalHeight(borderTop() + paddingTop() + ascent + descent + borderBottom() + paddingBottom() + horizontalScrollbarHeight());
+    setLogicalHeight(ascent + descent + borderAndPaddingLogicalHeight() + horizontalScrollbarHeight());
     updateLogicalHeight();
 
     layoutPositionedObjects(relayoutChildren);

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.h
@@ -49,6 +49,8 @@ protected:
     void stretchVerticalOperatorsAndLayoutChildren();
     void getContentBoundingBox(LayoutUnit& width, LayoutUnit& ascent, LayoutUnit& descent) const;
     void layoutRowItems(LayoutUnit width, LayoutUnit ascent);
+    void shiftRowItems(LayoutUnit left, LayoutUnit top);
+    LayoutUnit preferredLogicalWidthOfRowItems();
     void computePreferredLogicalWidths() override;
 
 private:


### PR DESCRIPTION
#### 12803196d5e76b29a63777ce78612ba4e8ec15c1
<pre>
Support border/padding/margin on RenderMathMLRow and subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=276227">https://bugs.webkit.org/show_bug.cgi?id=276227</a>

Reviewed by Rob Buis.

This implements support for border/margin/padding on the mrow, math,
mpadded, mroot, msqrt, menclose, merror, mphantom, mstyle elements
according to the rules described in MathML Core:

- When handling boxes of children during math layout, we consider *margin*
  boxes. Following other renderers, `recomputeLogicalWidth()` is called
  during the layout of children to set the inline margins (this does not
  seem enough for preferred width calculations though, but will be
  considered in follow-up patches) while during the parent we call
  `computeAndSetBlockDirectionMargins()` on each child in order to set
  set the block margins. To make the latter easier, the helper method
  RenderMathMLBlock::computeAndSetBlockDirectionMarginsOfChildren() is
  introduced.

- Current math layout is modified so that padding/border are added in
  order to obtain the border box. RenderMathMLRow already does that but
  then this can become wrong for derived classes (which add extra space
  or painting). Consequently, we modify RenderMathMLRow so the helpers
  getContentBoundingBox(), layoutRowItems() and
  stretchVerticalOperatorsAndLayoutChildren() do not actually consider
  the padding/border and it is up to the callers to add it around their
  own layout. Similarly, a new helper preferredLogicalWidthOfRowItems()
  is introduced to calculate the preferred logical width of a row of
  items without adding the border/padding. Finally we add a helper
  shiftRowItems() to shift children by an offset, something that
  was already used by some subclasses and can be used to shift by the
  top-left border/padding too.

Canonical link: <a href="https://commits.webkit.org/280733@main">https://commits.webkit.org/280733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/007f170f8c1d686110abb8c50fcbf0f6206cda23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61087 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46536 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5603 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27400 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6942 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6913 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62766 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53795 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53889 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12700 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1178 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32622 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33707 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34792 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->