### PR TITLE
[WGSL] Offset parameter to texture functions should be a const-expression

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1393,16 +1393,47 @@ void TypeChecker::visit(AST::CallExpression& call)
                 m_shaderModule.setUsesDot4U8Packed();
             else if (targetName == "extractBits"_s)
                 m_shaderModule.setUsesExtractBits();
-            else if (targetName == "textureGather"_s) {
-                auto& component = call.arguments()[0];
-                if (satisfies(component.inferredType(), Constraints::ConcreteInteger)) {
-                    auto& constant = component.constantValue();
-                    if (!constant)
-                        typeError(InferBottom::No, component.span(), "the component argument must be a const-expression"_s);
-                    else {
-                        auto componentValue = constant->integerValue();
-                        if (componentValue < 0 || componentValue > 3)
-                            typeError(InferBottom::No, component.span(), "the component argument must be at least 0 and at most 3. component is "_s, String::number(componentValue));
+            else if (
+                targetName == "textureGather"_s
+                || targetName == "textureGatherCompare"_s
+                || targetName == "textureSample"_s
+                || targetName == "textureSampleBias"_s
+                || targetName == "textureSampleCompare"_s
+                || targetName == "textureSampleCompareLevel"_s
+                || targetName == "textureSampleGrad"_s
+                || targetName == "textureSampleLevel"_s
+            ) {
+                if (targetName == "textureGather"_s) {
+                    auto& component = call.arguments()[0];
+                    if (satisfies(component.inferredType(), Constraints::ConcreteInteger)) {
+                        auto& constant = component.constantValue();
+                        if (!constant)
+                            typeError(InferBottom::No, component.span(), "the component argument must be a const-expression"_s);
+                        else {
+                            auto componentValue = constant->integerValue();
+                            if (componentValue < 0 || componentValue > 3)
+                                typeError(InferBottom::No, component.span(), "the component argument must be at least 0 and at most 3. component is "_s, String::number(componentValue));
+                        }
+                    }
+                }
+
+                auto& lastArg = call.arguments().last();
+                auto* vectorType = std::get_if<Types::Vector>(lastArg.inferredType());
+                if (!vectorType || vectorType->size != 2 || vectorType->element != m_types.i32Type())
+                    return;
+
+                auto& maybeConstant = lastArg.constantValue();
+                if (!maybeConstant.has_value()) {
+                    typeError(InferBottom::No, lastArg.span(), "the offset argument must be a const-expression"_s);
+                    return;
+                }
+
+                auto& vector = std::get<ConstantVector>(*maybeConstant);
+                for (unsigned i = 0; i < 2; ++i) {
+                    auto& i32 = std::get<int32_t>(vector.elements[i]);
+                    if (i32 < -8 || i32 > 7) {
+                        typeError(InferBottom::No, lastArg.span(), "each component of the offset argument must be at least -8 and at most 7. offset component "_s, String::number(i), " is "_s, String::number(i32));
+                        break;
                     }
                 }
             }

--- a/Source/WebGPU/WGSL/tests/invalid/texture-offset.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/texture-offset.wgsl
@@ -1,0 +1,18 @@
+// RUN: %not %wgslc | %check
+
+@group(0) @binding(0) var s: sampler;
+@group(0) @binding(23) var td2d: texture_depth_2d;
+
+@fragment
+fn main() {
+    var offset = vec2i(0);
+
+    // CHECK-L: the offset argument must be a const-expression
+    _ = textureGather(td2d, s, vec2f(0), offset);
+
+    // CHECK-L: each component of the offset argument must be at least -8 and at most 7. offset component 0 is -9
+    _ = textureGather(td2d, s, vec2f(0), vec2i(-9));
+
+    // CHECK-L: each component of the offset argument must be at least -8 and at most 7. offset component 0 is 8
+    _ = textureGather(td2d, s, vec2f(0), vec2i(8));
+}


### PR DESCRIPTION
#### 3b1cf88ddf2b118045096099a656ced989c7546d
<pre>
[WGSL] Offset parameter to texture functions should be a const-expression
<a href="https://bugs.webkit.org/show_bug.cgi?id=276226">https://bugs.webkit.org/show_bug.cgi?id=276226</a>
<a href="https://rdar.apple.com/130227871">rdar://130227871</a>

Reviewed by Mike Wyrzykowski.

According to the spec, the `offset` argument to texture functions must be a
const-expression, and the values must be between -8 and 7.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/texture-offset.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/280726@main">https://commits.webkit.org/280726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd5d7091178074bb7106a3f9e27ddb354795713b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57331 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60953 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7774 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46425 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5496 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27288 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31182 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6779 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62632 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53687 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53766 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12696 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1057 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32488 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33573 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34658 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33319 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->