### PR TITLE
RE-BASELINE: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/mime-types/canPlayType.html

### DIFF
--- a/LayoutTests/platform/mac-ventura-wk1/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/mime-types/canPlayType-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk1/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/mime-types/canPlayType-expected.txt
@@ -1,0 +1,62 @@
+
+
+PASS utility code
+PASS application/octet-stream not supported
+PASS fictional formats and codecs not supported
+PASS audio/mp4 (optional)
+PASS audio/mp4; codecs="mp4a.40.2" (optional)
+PASS audio/mp4 with bogus codec
+PASS audio/mp4 with and without codecs
+FAIL audio/ogg (optional) assert_equals: audio/ogg expected "maybe" but got ""
+FAIL audio/ogg; codecs="opus" (optional) assert_equals: audio/ogg; codecs="opus" expected "probably" but got ""
+FAIL audio/ogg; codecs="vorbis" (optional) assert_equals: audio/ogg; codecs="vorbis" expected "probably" but got ""
+PASS audio/ogg with bogus codec
+PASS audio/ogg with and without codecs
+PASS audio/wav (optional)
+FAIL audio/wav; codecs="1" (optional) assert_equals: audio/wav; codecs="1" expected "probably" but got ""
+PASS audio/wav with bogus codec
+FAIL audio/wav with and without codecs assert_equals: expected false but got true
+FAIL audio/webm (optional) assert_equals: audio/webm expected "maybe" but got ""
+FAIL audio/webm; codecs="opus" (optional) assert_equals: audio/webm; codecs="opus" expected "probably" but got ""
+FAIL audio/webm; codecs="vorbis" (optional) assert_equals: audio/webm; codecs="vorbis" expected "probably" but got ""
+PASS audio/webm with bogus codec
+PASS audio/webm with and without codecs
+PASS video/3gpp (optional)
+PASS video/3gpp; codecs="samr" (optional)
+PASS video/3gpp; codecs="mp4v.20.8" (optional)
+PASS video/3gpp codecs subset
+PASS video/3gpp codecs order
+PASS video/3gpp with bogus codec
+PASS video/3gpp with and without codecs
+PASS video/mp4 (optional)
+PASS video/mp4; codecs="mp4a.40.2" (optional)
+PASS video/mp4; codecs="avc1.42E01E" (optional)
+PASS video/mp4; codecs="avc1.4D401E" (optional)
+PASS video/mp4; codecs="avc1.58A01E" (optional)
+PASS video/mp4; codecs="avc1.64001E" (optional)
+PASS video/mp4; codecs="mp4v.20.8" (optional)
+PASS video/mp4; codecs="mp4v.20.240" (optional)
+PASS video/mp4 codecs subset
+PASS video/mp4 codecs order
+PASS video/mp4 with bogus codec
+PASS video/mp4 with and without codecs
+FAIL video/ogg (optional) assert_equals: video/ogg expected "maybe" but got ""
+FAIL video/ogg; codecs="opus" (optional) assert_equals: video/ogg; codecs="opus" expected "probably" but got ""
+FAIL video/ogg; codecs="vorbis" (optional) assert_equals: video/ogg; codecs="vorbis" expected "probably" but got ""
+FAIL video/ogg; codecs="theora" (optional) assert_equals: video/ogg; codecs="theora" expected "probably" but got ""
+PASS video/ogg codecs subset
+PASS video/ogg codecs order
+PASS video/ogg with bogus codec
+PASS video/ogg with and without codecs
+FAIL video/webm (optional) assert_equals: video/webm expected "maybe" but got ""
+FAIL video/webm; codecs="opus" (optional) assert_equals: video/webm; codecs="opus" expected "probably" but got ""
+FAIL video/webm; codecs="vorbis" (optional) assert_equals: video/webm; codecs="vorbis" expected "probably" but got ""
+FAIL video/webm; codecs="vp8" (optional) assert_equals: video/webm; codecs="vp8" expected "probably" but got ""
+FAIL video/webm; codecs="vp8.0" (optional) assert_equals: video/webm; codecs="vp8.0" expected "probably" but got ""
+FAIL video/webm; codecs="vp9" (optional) assert_equals: video/webm; codecs="vp9" expected "probably" but got ""
+FAIL video/webm; codecs="vp9.0" (optional) assert_equals: video/webm; codecs="vp9.0" expected "probably" but got ""
+PASS video/webm codecs subset
+PASS video/webm codecs order
+PASS video/webm with bogus codec
+PASS video/webm with and without codecs
+

--- a/LayoutTests/platform/mac-ventura/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/mime-types/canPlayType-expected.txt
+++ b/LayoutTests/platform/mac-ventura/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/mime-types/canPlayType-expected.txt
@@ -1,0 +1,62 @@
+
+
+PASS utility code
+PASS application/octet-stream not supported
+PASS fictional formats and codecs not supported
+PASS audio/mp4 (optional)
+PASS audio/mp4; codecs="mp4a.40.2" (optional)
+PASS audio/mp4 with bogus codec
+PASS audio/mp4 with and without codecs
+FAIL audio/ogg (optional) assert_equals: audio/ogg expected "maybe" but got ""
+FAIL audio/ogg; codecs="opus" (optional) assert_equals: audio/ogg; codecs="opus" expected "probably" but got ""
+FAIL audio/ogg; codecs="vorbis" (optional) assert_equals: audio/ogg; codecs="vorbis" expected "probably" but got ""
+PASS audio/ogg with bogus codec
+PASS audio/ogg with and without codecs
+PASS audio/wav (optional)
+FAIL audio/wav; codecs="1" (optional) assert_equals: audio/wav; codecs="1" expected "probably" but got ""
+PASS audio/wav with bogus codec
+FAIL audio/wav with and without codecs assert_equals: expected false but got true
+PASS audio/webm (optional)
+PASS audio/webm; codecs="opus" (optional)
+PASS audio/webm; codecs="vorbis" (optional)
+PASS audio/webm with bogus codec
+PASS audio/webm with and without codecs
+PASS video/3gpp (optional)
+PASS video/3gpp; codecs="samr" (optional)
+PASS video/3gpp; codecs="mp4v.20.8" (optional)
+PASS video/3gpp codecs subset
+PASS video/3gpp codecs order
+PASS video/3gpp with bogus codec
+PASS video/3gpp with and without codecs
+PASS video/mp4 (optional)
+PASS video/mp4; codecs="mp4a.40.2" (optional)
+PASS video/mp4; codecs="avc1.42E01E" (optional)
+PASS video/mp4; codecs="avc1.4D401E" (optional)
+PASS video/mp4; codecs="avc1.58A01E" (optional)
+PASS video/mp4; codecs="avc1.64001E" (optional)
+PASS video/mp4; codecs="mp4v.20.8" (optional)
+PASS video/mp4; codecs="mp4v.20.240" (optional)
+PASS video/mp4 codecs subset
+PASS video/mp4 codecs order
+PASS video/mp4 with bogus codec
+PASS video/mp4 with and without codecs
+FAIL video/ogg (optional) assert_equals: video/ogg expected "maybe" but got ""
+FAIL video/ogg; codecs="opus" (optional) assert_equals: video/ogg; codecs="opus" expected "probably" but got ""
+FAIL video/ogg; codecs="vorbis" (optional) assert_equals: video/ogg; codecs="vorbis" expected "probably" but got ""
+FAIL video/ogg; codecs="theora" (optional) assert_equals: video/ogg; codecs="theora" expected "probably" but got ""
+PASS video/ogg codecs subset
+PASS video/ogg codecs order
+PASS video/ogg with bogus codec
+PASS video/ogg with and without codecs
+PASS video/webm (optional)
+PASS video/webm; codecs="opus" (optional)
+PASS video/webm; codecs="vorbis" (optional)
+PASS video/webm; codecs="vp8" (optional)
+PASS video/webm; codecs="vp8.0" (optional)
+PASS video/webm; codecs="vp9" (optional)
+PASS video/webm; codecs="vp9.0" (optional)
+PASS video/webm codecs subset
+PASS video/webm codecs order
+PASS video/webm with bogus codec
+PASS video/webm with and without codecs
+

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2276,9 +2276,6 @@ webkit.org/b/261911 media/media-source/media-managedmse-seek.html [ Pass ImageOn
 
 webkit.org/b/261958 [ Release ] inspector/console/timestamp.html [ Pass Failure ]
 
-# Results changed with Sonoma
-[ Ventura ] imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/mime-types/canPlayType.html [ Failure ]
-
 # webkit.org/b/262595 (REGRESSION(Sonoma): 2X lookup menu-related tests are constant text failures.)
 editing/mac/dictionary-lookup/dictionary-lookup.html [ Pass Failure ]
 editing/selection/context-menu-text-selection-lookup.html [ Pass Failure ]


### PR DESCRIPTION
#### baa181eea560075d8dfebeae6244aadf3afe7663
<pre>
RE-BASELINE: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/mime-types/canPlayType.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=276255">https://bugs.webkit.org/show_bug.cgi?id=276255</a>
<a href="https://rdar.apple.com/131172336">rdar://131172336</a>

Unreviewed test re-baseline.

This test is constantly failing on macOS Ventura. This is because the test baseline expects a feature
that was added in Sonoma. We previously suppressed the failure, but this PR correctly baselines the
test for Ventura to reflect the expected result on that version of macOS.

* LayoutTests/platform/mac-ventura-wk1/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/mime-types/canPlayType-expected.txt: Added.
* LayoutTests/platform/mac-ventura/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/mime-types/canPlayType-expected.txt: Added.
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/280688@main">https://commits.webkit.org/280688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/873bb563a3718f4c5d097a1258245dac9620750f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/57340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60962 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/7783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7973 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/7783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/59370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/49518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/27295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/31191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/6830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6788 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/7101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62641 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1253 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1258 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/49553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/1066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8552 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32497 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33582 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34667 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33328 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->