### PR TITLE
[WebGPU] https://compute.toys/view/1203 fails to load (works in Chrome)

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -366,8 +366,7 @@ void RewriteGlobalVariables::visit(AST::CompoundStatement& statement)
 
 void RewriteGlobalVariables::visit(AST::CompoundAssignmentStatement& statement)
 {
-    Packing lhsPacking = pack(Packing::Either, statement.leftExpression());
-    ASSERT(lhsPacking != Packing::Either);
+    Packing lhsPacking = pack(Packing::Unpacked, statement.leftExpression());
     pack(lhsPacking, statement.rightExpression());
 }
 

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -447,6 +447,12 @@ fn testRuntimeArray()
     s.y[0] = 0;
 }
 
+@group(0) @binding(11) var<storage,read_write> D: array<vec3f>;
+fn testPackedVec3CompoundAssignment()
+{
+    D[0] += vec3f(1);
+}
+
 @compute @workgroup_size(1)
 fn main()
 {
@@ -458,4 +464,5 @@ fn main()
     _ = testUnaryOperations();
     _ = testCall();
     testRuntimeArray();
+    testPackedVec3CompoundAssignment();
 }


### PR DESCRIPTION
#### 2f1f2aab9d91e6a1875d5d43fbc94e8e076dbe71
<pre>
[WebGPU] <a href="https://compute.toys/view/1203">https://compute.toys/view/1203</a> fails to load (works in Chrome)
<a href="https://bugs.webkit.org/show_bug.cgi?id=276229">https://bugs.webkit.org/show_bug.cgi?id=276229</a>
<a href="https://rdar.apple.com/131126958">rdar://131126958</a>

Reviewed by Mike Wyrzykowski.

Originally, we had a problem with the left-hand side of compound assignments getting
unpacked, so we changed it so that the packing of the right-hand had to match the
packing of the left (instead of always unpacking it). That works for some cases,
but not for arrays of vec3, since that uses PackedVec3, which can&apos;t be used in
operations with packed_vec3. e.g. `array[0] += vec3f(0)` would have type PackedVec3
on the lhs and a packed_vec3 in the rhs, which are incompatible. In order to fix
that, both the lhs and rhs should always be unpacked. The unfortunate part about
that is that during code generation the expression gets rewritten into `lhs = lhs + rhs`,
which should become `lhs = pack(unpack(lhs) + unpack(rhs))`, but it is not trivial
to rewrite that with our current API. We work around that by generating
`unpack(lhs) += unpack(rhs)`, then during code generation we skip the `unpack`
call on the lhs, resulting in the final code `lhs += unpack(lhs) + unpack(rhs)`.
Notice that this is missing the `pack` call on the rhs, that works since the packed
type can be implicitly constructed from the unpacked type.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visit):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/280731@main">https://commits.webkit.org/280731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81ba3e97900c928b2affac7660804fc4d8dc1590

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61083 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7906 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46531 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5597 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59491 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34518 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27395 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31299 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6909 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62762 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53791 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1380 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53885 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12704 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1173 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32618 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33703 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34788 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->