### PR TITLE
ref.null accepts invalid type indices

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -366,20 +366,20 @@ inline bool isSubtype(StorageType sub, StorageType parent)
     return isSubtype(sub.as<Type>(), parent.as<Type>());
 }
 
-inline bool isValidHeapTypeKind(TypeKind kind)
+inline bool isValidHeapTypeKind(intptr_t kind)
 {
     switch (kind) {
-    case TypeKind::Funcref:
-    case TypeKind::Externref:
+    case static_cast<intptr_t>(TypeKind::Funcref):
+    case static_cast<intptr_t>(TypeKind::Externref):
         return true;
-    case TypeKind::I31ref:
-    case TypeKind::Arrayref:
-    case TypeKind::Structref:
-    case TypeKind::Eqref:
-    case TypeKind::Anyref:
-    case TypeKind::Nullref:
-    case TypeKind::Nullfuncref:
-    case TypeKind::Nullexternref:
+    case static_cast<intptr_t>(TypeKind::I31ref):
+    case static_cast<intptr_t>(TypeKind::Arrayref):
+    case static_cast<intptr_t>(TypeKind::Structref):
+    case static_cast<intptr_t>(TypeKind::Eqref):
+    case static_cast<intptr_t>(TypeKind::Anyref):
+    case static_cast<intptr_t>(TypeKind::Nullref):
+    case static_cast<intptr_t>(TypeKind::Nullfuncref):
+    case static_cast<intptr_t>(TypeKind::Nullexternref):
         return Options::useWebAssemblyGC();
     default:
         break;
@@ -390,7 +390,7 @@ inline bool isValidHeapTypeKind(TypeKind kind)
 // FIXME: separating out heap types in wasm.json could be cleaner in the long term.
 inline const char* heapTypeKindAsString(TypeKind kind)
 {
-    ASSERT(isValidHeapTypeKind(kind));
+    ASSERT(isValidHeapTypeKind(static_cast<intptr_t>(kind)));
     switch (kind) {
     case TypeKind::Funcref:
         return "func";

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -295,7 +295,7 @@ ALWAYS_INLINE typename ParserBase::PartialResult ParserBase::parseBlockSignature
         TypeKind typeKind = static_cast<TypeKind>(kindByte);
 
         if (UNLIKELY(Options::useWebAssemblyTypedFunctionReferences())) {
-            if ((isValidHeapTypeKind(typeKind) || typeKind == TypeKind::Ref || typeKind == TypeKind::RefNull))
+            if ((isValidHeapTypeKind(kindByte) || typeKind == TypeKind::Ref || typeKind == TypeKind::RefNull))
                 return parseReftypeSignature(info, result);
         }
 
@@ -339,7 +339,7 @@ ALWAYS_INLINE bool ParserBase::parseHeapType(const ModuleInformation& info, int3
         return false;
 
     if (heapType < 0) {
-        if (isValidHeapTypeKind(static_cast<TypeKind>(heapType))) {
+        if (isValidHeapTypeKind(heapType)) {
             result = heapType;
             return true;
         }
@@ -363,7 +363,7 @@ ALWAYS_INLINE bool ParserBase::parseValueType(const ModuleInformation& info, Typ
 
     TypeKind typeKind = static_cast<TypeKind>(kind);
     TypeIndex typeIndex = 0;
-    if (Options::useWebAssemblyTypedFunctionReferences() && isValidHeapTypeKind(typeKind)) {
+    if (Options::useWebAssemblyTypedFunctionReferences() && isValidHeapTypeKind(kind)) {
         typeIndex = static_cast<TypeIndex>(typeKind);
         typeKind = TypeKind::RefNull;
     } else if (typeKind == TypeKind::Ref || typeKind == TypeKind::RefNull) {


### PR DESCRIPTION
#### f6a59631fa7d079af7134f69134d66238eaee15d
<pre>
ref.null accepts invalid type indices
<a href="https://bugs.webkit.org/show_bug.cgi?id=276268">https://bugs.webkit.org/show_bug.cgi?id=276268</a>
<a href="https://rdar.apple.com/130746860">rdar://130746860</a>

Reviewed by Mark Lam.

ref.null only checks the low byte due to casting, meaning that invalid indices could be incorrectly treated as valid reference types.

* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::isValidHeapTypeKind):
(JSC::Wasm::heapTypeKindAsString):
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::ParserBase::parseBlockSignature):
(JSC::Wasm::ParserBase::parseHeapType):
(JSC::Wasm::ParserBase::parseValueType):

Canonical link: <a href="https://commits.webkit.org/280743@main">https://commits.webkit.org/280743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20dd5e17cd3d7617439fefd9eb72b405ef44350d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60995 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7818 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46463 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5533 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27327 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6859 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6821 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50465 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62674 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/56615 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7225 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53724 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53811 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12714 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1098 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78375 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32530 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12984 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33615 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34700 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33361 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->