### PR TITLE
Fix a bug that a root for an A/B test can be pruned during A/B test creation

### DIFF
--- a/Websites/perf.webkit.org/server-tests/resources/test-server.js
+++ b/Websites/perf.webkit.org/server-tests/resources/test-server.js
@@ -34,8 +34,7 @@ class TestServer {
 
     start()
     {
-        let testConfigContent = this.testConfig();
-        fs.writeFileSync(this._testConfigPath, JSON.stringify(testConfigContent, null, '    '));
+        this.writeTestConfig();
 
         this._ensureTestDatabase();
         this._ensureDataDirectory();
@@ -90,6 +89,18 @@ class TestServer {
             'dashboards': {},
             'summaryPages': []
         }
+    }
+
+    writeTestConfig(testConfigContent = null)
+    {
+        testConfigContent = testConfigContent || this.testConfig();
+        fs.writeFileSync(this._testConfigPath, JSON.stringify(testConfigContent, null, '    '));
+    }
+
+    overwriteTestConfig(override)
+    {
+        const testConfigContent = {...this.testConfig(), ...override};
+        this.writeTestConfig(testConfigContent);
     }
 
     _ensureDataDirectory()
@@ -254,6 +265,7 @@ class TestServer {
             this.timeout(10000);
             self.initDatabase();
             self.cleanDataDirectory();
+            self.writeTestConfig();
             originalRemote = global.RemoteAPI;
             global.RemoteAPI = self._remote;
             self._remote.clearCookies();


### PR DESCRIPTION
#### 7ab89ec17812da9b0187990f789cf32fad6cdff7
<pre>
Fix a bug that a root for an A/B test can be pruned during A/B test creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=276265">https://bugs.webkit.org/show_bug.cgi?id=276265</a>
<a href="https://rdar.apple.com/122118306">rdar://122118306</a>

Reviewed by Ryosuke Niwa.

Fix a bug that a root uploaded during creation of an A/B test can be pruned because of other
root upload for current test or other tests by introducing &apos;uploadFileGracePeriodInHours&apos; config.
Fix a pruning issue that file can be double counted during pruning because a root can be referenced
by multiple commit sets.
Improve a pruning query to use &apos;commitset_requires_build&apos; isntead of &apos;commitset_patch_file IS NOT NULL&apos;
to determine if a root is built for a configuration. This increase the accuracy of the query because
a build request will be built if the other side of build request requires building.
Fix a bug that API response for &apos;/api/upload-root&apos; may contain stale file information if re-upload
happens.
Update file creation time while re-uploading a pruned file so that it will qualify the grace period for
a new uploaded file.

* Websites/perf.webkit.org/public/include/uploaded-file-helpers.php:
Add support for &apos;uploadFileGracePeriodInHours&apos;.
Fix a bug that &apos;/api/upload-root&apos; does not return latest information for a re-uploaded file.
Fix and improve the pruning query.
* Websites/perf.webkit.org/server-tests/privileged-api-upload-file-tests.js: Fix and add unit tests.
* Websites/perf.webkit.org/server-tests/resources/test-server.js: Add support to overwrite test config.
(TestServer.prototype.start):
(TestServer.prototype.writeTestConfig):
(TestServer.prototype.overwriteTestConfig):
(TestServer.prototype.inject):
(TestServer):

Canonical link: <a href="https://commits.webkit.org/280806@main">https://commits.webkit.org/280806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04b174f75837ef16b566d9cf5f74eefa4afb24cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61323 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8146 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46751 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5775 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27576 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31499 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7150 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63004 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53971 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1621 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54084 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12761 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1366 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32858 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33944 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33689 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->