### PR TITLE
HTMLVideoElement.requestVideoFrameCallback can leak its captures if cancelVideoFrameCallback is not called.

### DIFF
--- a/LayoutTests/fast/html/request-video-frame-callback-does-not-leak-expected.txt
+++ b/LayoutTests/fast/html/request-video-frame-callback-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that HTMLVideoElement.requestVideoFrameCallback does not leak the document object.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/html/request-video-frame-callback-does-not-leak.html
+++ b/LayoutTests/fast/html/request-video-frame-callback-does-not-leak.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/document-leak-test.js"></script>
+</head>
+<body>
+<script>
+    description("Tests that HTMLVideoElement.requestVideoFrameCallback does not leak the document object.");
+    onload = () => runDocumentLeakTest({ frameURL: "resources/request-video-frame-callback.html", framesToCreate: 20 });
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/html/resources/request-video-frame-callback.html
+++ b/LayoutTests/fast/html/resources/request-video-frame-callback.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<body>
+<video id="vid" src="images/blue.png"></video>
+<script>
+vid.requestVideoFrameCallback((now, _) => {
+    let d = document;
+    let p = d.createElement("p");
+    p.innerText = `[${now}]: This shouldn't cause leaks.`;
+    d.body.appendChild(p);
+});
+
+onload = () => parent.postMessage("iframeLoaded");
+</script>
+</body>
+</html>

--- a/LayoutTests/resources/document-leak-test.js
+++ b/LayoutTests/resources/document-leak-test.js
@@ -1,0 +1,79 @@
+jsTestIsAsync = true;
+
+if (!window.testRunner || !window.internals) {
+    testFailed("Test requires both testRunner and internals");
+    finishJSTest();
+}
+
+var allFrames;
+var maxFailCount = 0;
+
+// Generally for these kinds of tests we want to create more than one frame.
+// Since the GC is conservative and stack-scanning it could find on the stack something
+// pointer-like to the document object we are testing and so through no fault of the code
+// under test the document object won't be collected. By creating multiple iframes and
+// testing those we can improve the robsutness of the test against flaky false-positive leaks.
+// On my M1 Pro MBP I've seen the test pass with as few as 6 frames tested. Something like
+// 10-20 frames under test seems to be a good amount to balance test robustness with test
+// running time in the event of a test failure. Too many frames might mean the test doesn't
+// complete before the test runner times out.
+function createFrames(framesToCreate)
+{
+    if (typeof framesToCreate !== "number")
+        throw TypeError("framesToCreate must be a number.");
+
+    allFrames = new Array(framesToCreate);
+    maxFailCount = framesToCreate;
+
+    for (let i = 0; i < allFrames.length; ++i) {
+        let frame = document.createElement("iframe");
+        document.body.appendChild(frame);
+        allFrames[i] = frame;
+    }
+}
+
+function iframeForMessage(message)
+{
+    return allFrames.find(frame => frame.contentWindow === message.source);
+}
+
+var failCount = 0;
+function iframeLeaked()
+{
+    if (++failCount >= maxFailCount) {
+        testFailed("All iframe documents leaked.");
+        finishJSTest();
+    }
+}
+
+function iframeSentMessage(message)
+{
+    let iframe = iframeForMessage(message);
+    let frameDocumentID = internals.documentIdentifier(iframe.contentWindow.document);
+    let checkCount = 0;
+
+    iframe.addEventListener("load", () => {
+        let handle = setInterval(() => {
+            gc();
+            if (!internals.isDocumentAlive(frameDocumentID)) {
+                clearInterval(handle);
+                testPassed("The iframe document didn't leak.");
+                finishJSTest();
+            }
+
+            if (++checkCount > 5) {
+                clearInterval(handle);
+                iframeLeaked();
+            }
+        }, 10);
+    }, { once: true });
+
+    iframe.src = "about:blank";
+}
+
+function runDocumentLeakTest(options)
+{
+    createFrames(options.framesToCreate);
+    window.addEventListener("message", message => iframeSentMessage(message));
+    allFrames.forEach(iframe => iframe.src = options.frameURL);
+}

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -755,6 +755,10 @@ protected:
     bool videoFullscreenStandby() const { return m_videoFullscreenStandby; }
     void setVideoFullscreenStandbyInternal(bool videoFullscreenStandby) { m_videoFullscreenStandby = videoFullscreenStandby; }
 
+protected:
+    // ActiveDOMObject
+    void stop() override;
+
 private:
     friend class Internals;
 
@@ -777,7 +781,6 @@ private:
     // ActiveDOMObject.
     void suspend(ReasonForSuspension) override;
     void resume() override;
-    void stop() override;
     bool virtualHasPendingActivity() const override;
 
     void stopWithoutDestroyingMediaPlayer();

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -686,6 +686,13 @@ void HTMLVideoElement::cancelVideoFrameCallback(unsigned identifier)
     }
 }
 
+void HTMLVideoElement::stop()
+{
+    m_videoFrameRequests.clear();
+    m_servicedVideoFrameRequests.clear();
+    HTMLMediaElement::stop();
+}
+
 static void processVideoFrameMetadataTimestamps(VideoFrameMetadata& metadata, Performance& performance)
 {
     metadata.presentationTime = performance.relativeTimeFromTimeOriginInReducedResolution(MonotonicTime::fromRawSeconds(metadata.presentationTime));

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -129,6 +129,9 @@ public:
     bool isGStreamerHolePunchingEnabled() const final { return m_enableGStreamerHolePunching; }
 #endif
 
+    // ActiveDOMObject
+    void stop() final;
+
 private:
     HTMLVideoElement(const QualifiedName&, Document&, bool createdByParser);
 


### PR DESCRIPTION
#### 5eb1d50bc03d3ec080f64562e5d5af4d1ef51b2a
<pre>
HTMLVideoElement.requestVideoFrameCallback can leak its captures if cancelVideoFrameCallback is not called.
<a href="https://rdar.apple.com/131184636">rdar://131184636</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=276267">https://bugs.webkit.org/show_bug.cgi?id=276267</a>

Reviewed by Youenn Fablet.

If HTMLVideoElement.requestVideoFrameCallback captures the document
object it will likely leak if cancelVideoFrameCallback is not called by
the web author. This change will clear pending and serviced video frame
callback lists in the HTMLVideoElement when ActiveDOMObject::stop is
called.

Additionally, I&apos;ve factored out some common code which I&apos;ve been using
in writing the Layout Tests for leak regression testing into a helper
file in LayoutTests/resources.

* LayoutTests/fast/html/request-video-frame-callback-does-not-leak-expected.txt: Added.
* LayoutTests/fast/html/request-video-frame-callback-does-not-leak.html: Added.
* LayoutTests/fast/html/resources/request-video-frame-callback.html: Added.
* LayoutTests/resources/document-leak-test.js: Added.
(createFrames):
(iframeForMessage):
(iframeLeaked):
(iframeSentMessage):
(runDocumentLeakTest):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::stop):
* Source/WebCore/html/HTMLVideoElement.h:

Canonical link: <a href="https://commits.webkit.org/280754@main">https://commits.webkit.org/280754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/302231f53fb1b10c385e8fc82d1fa63f1ff335d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61114 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7937 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8125 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46559 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5624 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27422 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31337 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6964 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6940 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62793 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7329 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49686 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12718 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1201 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32649 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33734 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34819 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33480 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->