### PR TITLE
REGRESSION (280396@main): Web process receives unexpected message WebPageTesting::ClearWheelEventTestMonitor when running tests

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -43,8 +43,7 @@ namespace WebKit {
 using namespace WebCore;
 
 WebPageProxyTesting::WebPageProxyTesting(WebPageProxy& page)
-    : m_webPageIDInMainFrameProcess(page.webPageIDInMainFrameProcess())
-    , m_page(page)
+    : m_page(page)
 {
 }
 
@@ -65,7 +64,7 @@ IPC::Connection* WebPageProxyTesting::messageSenderConnection() const
 
 uint64_t WebPageProxyTesting::messageSenderDestinationID() const
 {
-    return m_webPageIDInMainFrameProcess.toUInt64();
+    return m_page->webPageIDInMainFrameProcess().toUInt64();
 }
 
 void WebPageProxyTesting::setDefersLoading(bool defersLoading)

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -80,7 +80,6 @@ private:
 
     Ref<WebPageProxy> protectedPage() const;
 
-    const WebCore::PageIdentifier m_webPageIDInMainFrameProcess;
     WeakRef<WebPageProxy> m_page;
 };
 


### PR DESCRIPTION
#### 5deb5d7b1324d9891d34e4060c07f0bc27bca915
<pre>
REGRESSION (280396@main): Web process receives unexpected message WebPageTesting::ClearWheelEventTestMonitor when running tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=276269">https://bugs.webkit.org/show_bug.cgi?id=276269</a>
<a href="https://rdar.apple.com/131191681">rdar://131191681</a>

Reviewed by Charlie Wolfe.

WebPageProxy can change its m_legacyMainFrameProcess and internals().webPageID (i.e. webPageIDInMainFrameProcess()) in
WebPageProxy::swapToProvisionalPage. Currently WebPageProxyTesting sends message to the latest web process of
WebPageProxy, but it uses an old page identifier captured at WebPageProxyTesting&apos;s creation time, so the web process may
not recognize the message.

* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::WebPageProxyTesting):
(WebKit::WebPageProxyTesting::messageSenderDestinationID const):
* Source/WebKit/UIProcess/WebPageProxyTesting.h:

Canonical link: <a href="https://commits.webkit.org/280720@main">https://commits.webkit.org/280720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/270e2df6eb7bd9dcc36a241c30f452f9d5b62658

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60996 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7819 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46465 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5536 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27329 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31223 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6822 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62675 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53726 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53813 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12690 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1099 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32531 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33616 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33362 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->