### PR TITLE
Interaction Regions consolidation should consider all containers without visual borders

### DIFF
--- a/LayoutTests/interaction-region/loose-container-removal-expected.txt
+++ b/LayoutTests/interaction-region/loose-container-removal-expected.txt
@@ -1,0 +1,20 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction (8,8) width=38 height=38)
+        (cornerRadius 19.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/loose-container-removal.html
+++ b/LayoutTests/interaction-region/loose-container-removal.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+   <div onclick="null" style="width: 35px; height: 35px; cursor: pointer;" role="button">
+      <div onclick="null" style="background-color: gray; border-radius: 9999px; cursor: pointer; height: 38px; width: 38px;">
+      </div>
+   </div>
+
+   <pre id="results"></pre>
+   <script>
+   if (window.testRunner)
+      testRunner.dumpAsText();
+
+   window.onload = function () {
+      if (window.internals)
+         results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+   };
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 19b49cde3364c1ea0b9e572d32164d84e700f4eb
<pre>
Interaction Regions consolidation should consider all containers without visual borders
<a href="https://bugs.webkit.org/show_bug.cgi?id=276272">https://bugs.webkit.org/show_bug.cgi?id=276272</a>
&lt;<a href="https://rdar.apple.com/116705567">rdar://116705567</a>&gt;

Reviewed by Megan Gardner and Tim Horton.

Ensure all candidates are properly considered for removal, and relax
the strictness of the containment check for consolidation.

* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::uniteInteractionRegions):
Move logic here to keep track of all potential candidates for removal.
(WebCore::EventRegionContext::shouldConsolidateInteractionRegion):
Temporarily expand ancestor element&apos;s bounds by 3px on all sides before
checking for element&apos;s containment, and remove old logic to keep track
of candidates for removal.
* LayoutTests/interaction-region/loose-container-removal-expected.txt: Added.
* LayoutTests/interaction-region/loose-container-removal.html: Added.
Add new test case to cover this change.

Canonical link: <a href="https://commits.webkit.org/281044@main">https://commits.webkit.org/281044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18525b1334767403071456bc3a6d7f642b6719b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62020 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8840 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47297 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6304 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28140 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32100 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7834 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7844 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8055 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63725 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8102 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54615 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54681 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12910 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1956 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33552 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34638 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->