### PR TITLE
[Writing Tools] Smart replies are not inserted into Mail

### DIFF
--- a/Source/WebCore/editing/WritingToolsCompositionCommand.cpp
+++ b/Source/WebCore/editing/WritingToolsCompositionCommand.cpp
@@ -40,9 +40,6 @@ WritingToolsCompositionCommand::WritingToolsCompositionCommand(Ref<Document>&& d
 
 void WritingToolsCompositionCommand::replaceContentsOfRangeWithFragment(RefPtr<DocumentFragment>&& fragment, const SimpleRange& range, MatchStyle matchStyle, State state)
 {
-    if (endingSelection().isNoneOrOrphaned() || !endingSelection().isContentEditable())
-        return;
-
     auto contextRange = m_endingContextRange;
 
     auto contextRangeCount = characterCount(contextRange);

--- a/Source/WebCore/editing/WritingToolsCompositionCommand.h
+++ b/Source/WebCore/editing/WritingToolsCompositionCommand.h
@@ -56,6 +56,8 @@ public:
 
     SimpleRange endingContextRange() const { return m_endingContextRange; }
 
+    void setEndingContextRange(const SimpleRange& range) { m_endingContextRange = range; }
+
 private:
     WritingToolsCompositionCommand(Ref<Document>&&, const SimpleRange&);
 

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -87,6 +87,7 @@ private:
         // These two vectors should never have the same command in both of them.
         Vector<Ref<WritingToolsCompositionCommand>> unappliedCommands;
         Vector<Ref<WritingToolsCompositionCommand>> reappliedCommands;
+        bool hasReceivedText { false };
     };
 
     struct ProofreadingState : CanMakeCheckedPtr<ProofreadingState> {

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -384,6 +384,19 @@ void WritingToolsController::compositionSessionDidReceiveTextWithReplacementRang
         return;
     }
 
+#if PLATFORM(IOS_FAMILY)
+    if (!state->hasReceivedText && session.compositionType == WritingTools::Session::CompositionType::SmartReply) {
+        // UIKit inserts a space prior to `willBegin` and before `didReceiveText`, so the initial session range
+        // becomes invalid and must be re-computed.
+        //
+        // FIXME: (rdar://131197624) Remove this special-case logic if/when UIKit no longer injects a space.
+        if (auto selectedRange = document->selection().selection().firstRange())
+            state->reappliedCommands.last()->setEndingContextRange(*selectedRange);
+    }
+
+    state->hasReceivedText = true;
+#endif
+
     m_page->chrome().client().removeInitialTextAnimation(session.identifier);
 
     document->selection().clear();


### PR DESCRIPTION
#### f86d3400c875519b3f3c368f1ea9a37ed8a1d11b
<pre>
[Writing Tools] Smart replies are not inserted into Mail
<a href="https://bugs.webkit.org/show_bug.cgi?id=276273">https://bugs.webkit.org/show_bug.cgi?id=276273</a>
<a href="https://rdar.apple.com/131083006">rdar://131083006</a>

Reviewed by Aditya Keerthi.

UIKit and AppKit behave different with regards to how they use the Writing Tools delegate methods
for the smart replies use case; with UIKit, UIKit inserts a space into the document prior to the
`willBegin` call, and subsequently removes the space prior to the `didReceiveText` call. As a result,
the initial session range created will now be invalid.

This was not a problem previously as live ranges were being used, which incidentally made this work as-is.
However, with the move to using `SimpleRange`s, this no longer happens.

Fix by re-computing the session range the first time `didReceiveText` is called so that it has the correct
session range. This will just be a temporary fix until UIKit changes behavior to no longer insert the space.

* Source/WebCore/editing/WritingToolsCompositionCommand.cpp:
(WebCore::WritingToolsCompositionCommand::replaceContentsOfRangeWithFragment):
* Source/WebCore/editing/WritingToolsCompositionCommand.h:
(WebCore::WritingToolsCompositionCommand::setEndingContextRange):
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange):
(WebCore::WritingToolsController::writingToolsSessionDidReceiveAction&lt;WritingTools::Session::Type::Proofreading&gt;): Deleted.
(WebCore::WritingToolsController::writingToolsSessionDidReceiveAction&lt;WritingTools::Session::Type::Composition&gt;): Deleted.
(WebCore::WritingToolsController::writingToolsSessionDidReceiveAction): Deleted.
(WebCore::WritingToolsController::didEndWritingToolsSession&lt;WritingTools::Session::Type::Proofreading&gt;): Deleted.
(WebCore::WritingToolsController::didEndWritingToolsSession&lt;WritingTools::Session::Type::Composition&gt;): Deleted.
(WebCore::WritingToolsController::didEndWritingToolsSession): Deleted.
(WebCore::WritingToolsController::updateStateForSelectedSuggestionIfNeeded): Deleted.
(WebCore::appliedCommandIsWritingToolsCommand): Deleted.
(WebCore::WritingToolsController::respondToUnappliedEditing): Deleted.
(WebCore::WritingToolsController::respondToReappliedEditing): Deleted.
(WebCore::WritingToolsController::contextRangeForSessionWithID const): Deleted.
(WebCore::WritingToolsController::stateForSession): Deleted.
(WebCore::WritingToolsController::document const): Deleted.
(WebCore::WritingToolsController::showOriginalCompositionForSession): Deleted.
(WebCore::WritingToolsController::showRewrittenCompositionForSession): Deleted.
(WebCore::WritingToolsController::restartCompositionForSession): Deleted.
(WebCore::WritingToolsController::findTextSuggestionMarkerByID const): Deleted.
(WebCore::WritingToolsController::findTextSuggestionMarkerContainingRange const): Deleted.
(WebCore::WritingToolsController::replaceContentsOfRangeInSession): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, SmartReplyTest)):

Canonical link: <a href="https://commits.webkit.org/280703@main">https://commits.webkit.org/280703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b0353d97ab4593c49e04d5e2f2d84a1189b4d39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61008 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/7831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8019 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/7831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34452 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/49562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/27335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31234 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/6873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6834 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/7144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62687 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1299 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1305 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/49596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1109 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8560 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/33628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/34713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->