### PR TITLE
[iOS] Add a _WKFullscreenDelegate method for the client to provide a presenting view controller

### DIFF
--- a/Source/WebKit/UIProcess/API/APIFullscreenClient.h
+++ b/Source/WebKit/UIProcess/API/APIFullscreenClient.h
@@ -25,6 +25,11 @@
 
 #pragma once
 
+#include <wtf/Forward.h>
+
+OBJC_CLASS NSError;
+OBJC_CLASS UIViewController;
+
 namespace WebKit {
 class WebPageProxy;
 }
@@ -47,6 +52,10 @@ public:
     virtual void didEnterFullscreen(WebKit::WebPageProxy*) { }
     virtual void willExitFullscreen(WebKit::WebPageProxy*) { }
     virtual void didExitFullscreen(WebKit::WebPageProxy*) { }
+
+#if PLATFORM(IOS_FAMILY)
+    virtual void requestPresentingViewController(CompletionHandler<void(UIViewController *, NSError *)>&&) { }
+#endif
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFullscreenDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFullscreenDelegate.h
@@ -25,6 +25,11 @@
 
 #import <WebKit/WKFoundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
+@class NSError;
+@class UIViewController;
+
 WK_API_AVAILABLE(macos(10.13), ios(11.3))
 @protocol _WKFullscreenDelegate <NSObject>
 
@@ -37,6 +42,7 @@ WK_API_AVAILABLE(macos(10.13), ios(11.3))
 - (void)_webViewDidExitElementFullscreen:(WKWebView *)webView;
 
 - (void)_webView:(WKWebView *)webView didFullscreenImageWithQuickLook:(CGSize)imageDimensions;
+- (void)_webView:(WKWebView *)webView requestPresentingViewControllerWithCompletionHandler:(void (^)(UIViewController * _Nullable, NSError * _Nullable))completionHandler;
 #else
 - (void)_webViewWillEnterFullscreen:(NSView *)webView;
 - (void)_webViewDidEnterFullscreen:(NSView *)webView;
@@ -45,3 +51,5 @@ WK_API_AVAILABLE(macos(10.13), ios(11.3))
 #endif
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.h
@@ -36,20 +36,24 @@
 
 namespace WebKit {
 
-class FullscreenClient : public API::FullscreenClient {
+class FullscreenClient final : public API::FullscreenClient {
 public:
     explicit FullscreenClient(WKWebView *);
     ~FullscreenClient() { };
 
-    bool isType(API::FullscreenClient::Type target) const override { return target == API::FullscreenClient::WebKitType; };
+    bool isType(API::FullscreenClient::Type target) const final { return target == API::FullscreenClient::WebKitType; };
 
     RetainPtr<id<_WKFullscreenDelegate>> delegate();
     void setDelegate(id<_WKFullscreenDelegate>);
 
-    void willEnterFullscreen(WebPageProxy*) override;
-    void didEnterFullscreen(WebPageProxy*) override;
-    void willExitFullscreen(WebPageProxy*) override;
-    void didExitFullscreen(WebPageProxy*) override;
+    void willEnterFullscreen(WebPageProxy*) final;
+    void didEnterFullscreen(WebPageProxy*) final;
+    void willExitFullscreen(WebPageProxy*) final;
+    void didExitFullscreen(WebPageProxy*) final;
+
+#if PLATFORM(IOS_FAMILY)
+    void requestPresentingViewController(CompletionHandler<void(UIViewController *, NSError *)>&&) final;
+#endif
 
 private:
     WKWebView *m_webView;
@@ -69,6 +73,9 @@ private:
 #endif
 #if ENABLE(QUICKLOOK_FULLSCREEN)
         bool webViewDidFullscreenImageWithQuickLook : 1;
+#endif
+#if PLATFORM(IOS_FAMILY)
+        bool webViewRequestPresentingViewController : 1;
 #endif
     } m_delegateMethods;
 };

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
@@ -55,6 +55,7 @@ void FullscreenClient::setDelegate(id <_WKFullscreenDelegate> delegate)
     m_delegateMethods.webViewDidEnterElementFullscreen = [delegate respondsToSelector:@selector(_webViewDidEnterElementFullscreen:)];
     m_delegateMethods.webViewWillExitElementFullscreen = [delegate respondsToSelector:@selector(_webViewWillExitElementFullscreen:)];
     m_delegateMethods.webViewDidExitElementFullscreen = [delegate respondsToSelector:@selector(_webViewDidExitElementFullscreen:)];
+    m_delegateMethods.webViewRequestPresentingViewController = [delegate respondsToSelector:@selector(_webView:requestPresentingViewControllerWithCompletionHandler:)];
 #endif
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     m_delegateMethods.webViewDidFullscreenImageWithQuickLook = [delegate respondsToSelector:@selector(_webView:didFullscreenImageWithQuickLook:)];
@@ -120,5 +121,15 @@ void FullscreenClient::didExitFullscreen(WebPageProxy*)
         [m_delegate.get() _webViewDidExitElementFullscreen:m_webView];
 #endif
 }
+
+#if PLATFORM(IOS_FAMILY)
+void FullscreenClient::requestPresentingViewController(CompletionHandler<void(UIViewController *, NSError *)>&& completionHandler)
+{
+    if (!m_delegateMethods.webViewRequestPresentingViewController)
+        return completionHandler(nil, nil);
+
+    [m_delegate _webView:m_webView requestPresentingViewControllerWithCompletionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
+}
+#endif
 
 } // namespace WebKit


### PR DESCRIPTION
#### e2b9154b8477825124b39e22df82f4677bb6eac9
<pre>
[iOS] Add a _WKFullscreenDelegate method for the client to provide a presenting view controller
<a href="https://bugs.webkit.org/show_bug.cgi?id=276274">https://bugs.webkit.org/show_bug.cgi?id=276274</a>
<a href="https://rdar.apple.com/131200749">rdar://131200749</a>

Reviewed by Eric Carlson.

Added -_webView:requestPresentingViewControllerWithCompletionHandler: to _WKFullscreenDelegate on
iOS. If the delegate responds to this method, WKFullScreenWindowController uses the view controller
prodivded in its completion handler to determine the UIWindowScene in which to create its UIWindow.

* Source/WebKit/UIProcess/API/APIFullscreenClient.h:
(API::FullscreenClient::requestPresentingViewController):
* Source/WebKit/UIProcess/API/Cocoa/_WKFullscreenDelegate.h:
* Source/WebKit/UIProcess/Cocoa/FullscreenClient.h:
(WebKit::FullscreenClient::~FullscreenClient): Deleted.
* Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm:
(WebKit::FullscreenClient::setDelegate):
(WebKit::FullscreenClient::requestPresentingViewController):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController _enterFullScreen:windowScene:]):

Canonical link: <a href="https://commits.webkit.org/280711@main">https://commits.webkit.org/280711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7cd6064c8d349521312bef803363a4bf515207d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7835 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46475 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5543 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49566 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27339 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31241 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6838 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62691 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53734 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53822 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12686 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1115 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32547 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33632 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->