### PR TITLE
WebCodecs VideoDecoder callbacks leak the Document object

### DIFF
--- a/LayoutTests/http/tests/resources/document-leak-test.js
+++ b/LayoutTests/http/tests/resources/document-leak-test.js
@@ -1,0 +1,70 @@
+jsTestIsAsync = true;
+
+if (!(window.testRunner && window.internals)) {
+    testFailed("Test requires both testRunner and internals");
+    finishJSTest();
+}
+
+var allFrames;
+var maxFailCount = 0;
+
+function createFrames(framesToCreate)
+{
+    if (typeof framesToCreate !== "number")
+        throw TypeError("framesToCreate must be a number.");
+
+    allFrames = new Array(framesToCreate);
+    maxFailCount = framesToCreate;
+
+    for (let i = 0; i < allFrames.length; ++i) {
+        let frame = document.createElement("iframe");
+        document.body.appendChild(frame);
+        allFrames[i] = frame;
+    }
+}
+
+function iframeForMessage(message)
+{
+    return allFrames.find(frame => frame.contentWindow === message.source);
+}
+
+var failCount = 0;
+function iframeLeaked()
+{
+    if (++failCount >= maxFailCount) {
+        testFailed("All iframe documents leaked.");
+        finishJSTest();
+    }
+}
+
+function iframeSentMessage(message)
+{
+    let iframe = iframeForMessage(message);
+    let frameDocumentID = internals.documentIdentifier(iframe.contentWindow.document);
+    let checkCount = 0;
+
+    iframe.addEventListener("load", () => {
+        let handle = setInterval(() => {
+            gc();
+            if (!internals.isDocumentAlive(frameDocumentID)) {
+                clearInterval(handle);
+                testPassed("The iframe document didn't leak.");
+                finishJSTest();
+            }
+
+            if (++checkCount > 5) {
+                clearInterval(handle);
+                iframeLeaked();
+            }
+        }, 10);
+    }, { once: true });
+
+    iframe.src = "about:blank";
+}
+
+function runDocumentLeakTest(options)
+{
+    createFrames(options.framesToCreate);
+    window.addEventListener("message", message => iframeSentMessage(message));
+    allFrames.forEach(iframe => iframe.src = options.frameURL);
+}

--- a/LayoutTests/http/tests/webcodecs/resources/video-decoder-callbacks-frame.html
+++ b/LayoutTests/http/tests/webcodecs/resources/video-decoder-callbacks-frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+const videoDecoder = new VideoDecoder({
+    output: _ => {},
+    error: _ => {},
+});
+
+onload = () => parent.postMessage("iframeLoaded");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webcodecs/video-decoder-callbacks-do-not-leak-expected.txt
+++ b/LayoutTests/http/tests/webcodecs/video-decoder-callbacks-do-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that VideoDecoder error callback does not leak the document object.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webcodecs/video-decoder-callbacks-do-not-leak.html
+++ b/LayoutTests/http/tests/webcodecs/video-decoder-callbacks-do-not-leak.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/document-leak-test.js"></script>
+</head>
+<body>
+<script>
+    description("Tests that VideoDecoder error callback does not leak the document object.");
+    onload = () => runDocumentLeakTest({ frameURL: "./resources/video-decoder-callbacks-frame.html", framesToCreate: 20 });
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.h
@@ -41,6 +41,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(DOMException&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.idl
@@ -23,7 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_CODECS,
-    IsStrongCallback
-] callback WebCodecsErrorCallback = undefined(DOMException error);
+[ Conditional=WEB_CODECS ] callback WebCodecsErrorCallback = undefined(DOMException error);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -61,6 +61,9 @@ public:
     WebCodecsCodecState state() const { return m_state; }
     size_t decodeQueueSize() const { return m_decodeQueueSize; }
 
+    WebCodecsVideoFrameOutputCallback& outputCallbackConcurrently() { return m_output.get(); }
+    WebCodecsErrorCallback& errorCallbackConcurrently() { return m_error.get(); }
+
     ExceptionOr<void> configure(ScriptExecutionContext&, WebCodecsVideoDecoderConfig&&);
     ExceptionOr<void> decode(Ref<WebCodecsEncodedVideoChunk>&&);
     ExceptionOr<void> flush(Ref<DeferredPromise>&&);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.idl
@@ -30,6 +30,7 @@
     EnabledBySetting=WebCodecsVideoEnabled,
     Exposed=(Window,DedicatedWorker),
     InterfaceName=VideoDecoder,
+    JSCustomMarkFunction,
 ] interface WebCodecsVideoDecoder : EventTarget {
     [CallWith=CurrentScriptExecutionContext] constructor(WebCodecsVideoDecoderInit init);
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h
@@ -41,6 +41,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(WebCodecsVideoFrame&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.idl
@@ -23,7 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_CODECS,
-    IsStrongCallback
-] callback WebCodecsVideoFrameOutputCallback = undefined(WebCodecsVideoFrame output);
+[ Conditional=WEB_CODECS ] callback WebCodecsVideoFrameOutputCallback = undefined(WebCodecsVideoFrame output);

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -729,6 +729,7 @@ bindings/js/JSCSSStyleValueCustom.cpp
 bindings/js/JSCSSTransformComponentCustom.cpp
 bindings/js/JSUndoItemCustom.cpp
 bindings/js/JSWebAnimationCustom.cpp
+bindings/js/JSWebCodecsVideoDecoderCustom.cpp
 bindings/js/JSWebGL2RenderingContextCustom.cpp
 bindings/js/JSWebGLRenderingContextCustom.cpp
 bindings/js/JSWebXRSessionCustom.cpp

--- a/Source/WebCore/bindings/js/JSWebCodecsVideoDecoderCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebCodecsVideoDecoderCustom.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEB_CODECS)
+#include "JSWebCodecsVideoDecoder.h"
+
+#include "WebCodecsErrorCallback.h"
+#include "WebCodecsVideoFrameOutputCallback.h"
+
+#include <JavaScriptCore/JSCInlines.h>
+
+namespace WebCore {
+
+template <typename Visitor>
+void JSWebCodecsVideoDecoder::visitAdditionalChildren(Visitor& visitor)
+{
+    wrapped().outputCallbackConcurrently().visitJSFunction(visitor);
+    wrapped().errorCallbackConcurrently().visitJSFunction(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWebCodecsVideoDecoder);
+
+}
+
+#endif


### PR DESCRIPTION
#### 8f7312114c32d445fa64b1bf6075160948a9befe
<pre>
WebCodecs VideoDecoder callbacks leak the Document object
<a href="https://bugs.webkit.org/show_bug.cgi?id=276277">https://bugs.webkit.org/show_bug.cgi?id=276277</a>
<a href="https://rdar.apple.com/131208814">rdar://131208814</a>

Reviewed by Youenn Fablet.

WebCodecsVideoDecoder holds refs to the required output and error
callbacks. They are strong and never cleared which cause them to leak
anything they capture. Interestingly, they manage to leak the Document
even without explicitly capturing the object.

In order to keep them as non-nullable refs we can make the callbacks
Weak and use JSWebCodecsVideoDecoder::visitAdditionalChildren to keep
them alive as long as the owning wrapper is alive.

* LayoutTests/http/tests/resources/document-leak-test.js: Added.
(createFrames):
(iframeForMessage):
(iframeLeaked):
(iframeSentMessage):
(runDocumentLeakTest):
* LayoutTests/http/tests/webcodecs/resources/video-decoder-callbacks-frame.html: Added.
* LayoutTests/http/tests/webcodecs/video-decoder-callbacks-do-not-leak-expected.txt: Added.
* LayoutTests/http/tests/webcodecs/video-decoder-callbacks-do-not-leak.html: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.h:
* Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.idl:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h:
(WebCore::WebCodecsVideoDecoder::outputCallbackConcurrently):
(WebCore::WebCodecsVideoDecoder::errorCallbackConcurrently):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.idl:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSWebCodecsVideoDecoderCustom.cpp: Added.
(WebCore::JSWebCodecsVideoDecoder::visitAdditionalChildren):

Canonical link: <a href="https://commits.webkit.org/280738@main">https://commits.webkit.org/280738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74842f0bd8e0bd8156593b1169d03dda6c68472b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61017 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7840 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46480 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5548 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27344 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31243 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6882 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6843 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62696 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7245 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53739 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53827 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12708 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1118 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32552 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33637 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->