### PR TITLE
[WebGPU] Crash in RenderBundleEncoder::setBindGroup

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-276279-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-276279-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-276279.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-276279.html
@@ -1,0 +1,29330 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ */
+function pseudoSubmit(device) {
+  for (let i = 0; i < 63; i++) {
+    device.createCommandEncoder();
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter();
+let device0 = await adapter0.requestDevice({
+  label: '\u9108\uf6c6\u28bd\u0ad8\ue825\u053c',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 7,
+    maxColorAttachmentBytesPerSample: 33,
+    maxVertexAttributes: 24,
+    maxVertexBufferArrayStride: 11996,
+    maxStorageTexturesPerShaderStage: 36,
+    maxStorageBuffersPerShaderStage: 26,
+    maxDynamicStorageBuffersPerPipelineLayout: 47657,
+    maxDynamicUniformBuffersPerPipelineLayout: 13169,
+    maxBindingsPerBindGroup: 7223,
+    maxTextureArrayLayers: 1254,
+    maxTextureDimension1D: 9920,
+    maxTextureDimension2D: 12523,
+    maxVertexBuffers: 11,
+    maxBindGroupsPlusVertexBuffers: 26,
+    minStorageBufferOffsetAlignment: 64,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 173505103,
+    maxStorageBufferBindingSize: 267964045,
+    maxUniformBuffersPerShaderStage: 24,
+    maxSampledTexturesPerShaderStage: 20,
+    maxInterStageShaderVariables: 44,
+    maxInterStageShaderComponents: 124,
+    maxSamplersPerShaderStage: 19,
+  },
+});
+let imageData0 = new ImageData(104, 188);
+let commandEncoder0 = device0.createCommandEncoder();
+let img0 = await imageWithData(6, 227, '#d54f5841', '#23a05807');
+let commandEncoder1 = device0.createCommandEncoder({label: '\u6970\udd5c\u23e6'});
+let computePassEncoder0 = commandEncoder1.beginComputePass({label: '\u{1fbee}\ua18e\u5deb\u050e\ue112\u7551\u{1ff30}\u6900\u0942'});
+let img1 = await imageWithData(121, 269, '#4939d170', '#690c891f');
+let commandEncoder2 = device0.createCommandEncoder();
+let texture0 = device0.createTexture({
+  label: '\u{1fd31}\ub8ec\u04d0\u1517\u4131\ucf80\u{1ff07}\u0748',
+  size: [768],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device0.queue.submit([]);
+} catch {}
+let imageData1 = new ImageData(192, 204);
+let texture1 = device0.createTexture({
+  size: [3239, 1, 1],
+  mipLevelCount: 9,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler0 = device0.createSampler({
+  label: '\u3dc5\ue648\u9a52',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 0.8146,
+  lodMaxClamp: 58.29,
+});
+let texture2 = device0.createTexture({
+  label: '\uc4ed\u{1f92c}\u03ee\u{1fd9b}\u93a8\u9312\u{1ffd3}\u0cdb',
+  size: {width: 1619, height: 1, depthOrArrayLayers: 52},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let textureView0 = texture0.createView({label: '\ueb51\u98ef\u{1f748}\u0267\u9e78\u2f97\u0742\ue897', aspect: 'all'});
+let sampler1 = device0.createSampler({
+  label: '\u{1faa2}\u461f\u{1fdc2}\u2f4e\u0763\u008a\ue647\u6677\u{1fa0d}',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 5.421,
+  lodMaxClamp: 45.81,
+  maxAnisotropy: 6,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 303 */
+{offset: 303, bytesPerRow: 48}, {width: 19, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 50, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 26 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 5,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder();
+let texture3 = device0.createTexture({
+  size: {width: 96, height: 2, depthOrArrayLayers: 1218},
+  mipLevelCount: 5,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView1 = texture1.createView({
+  label: '\u0805\u042e\u1f05\u{1ff5a}\u2fae\u{1fb1d}\u9daf\ub57a\u498a',
+  dimension: '2d-array',
+  baseMipLevel: 6,
+  mipLevelCount: 2,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet0 = device0.createQuerySet({label: '\ubecd\ueb70\u05ca\u{1fff5}\u{1fca6}\u0315\u0eae\u0c1d\uf0ea', type: 'occlusion', count: 2658});
+let textureView2 = texture0.createView({label: '\u0fd4\u2983\u{1f6c4}', baseArrayLayer: 0});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 404, height: 1, depthOrArrayLayers: 13}
+*/
+{
+  source: img1,
+  origin: { x: 11, y: 17 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\u8966\u7655\u{1fbf1}\ub2d5\u0210\u0f66',
+  entries: [
+    {
+      binding: 513,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 3739,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let querySet1 = device0.createQuerySet({
+  label: '\ucc92\u{1fcb3}\u0f36\u1368\uf57d\u0bc6\u8f8f\ub0b2\u6f25\u{1fb42}',
+  type: 'occlusion',
+  count: 1710,
+});
+let commandBuffer0 = commandEncoder3.finish({label: '\u1334\u7fff\u5469\u0970\u31e5\u538c\u4e42\u281d\u4aea\u{1fbf1}'});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u{1fb16}\ub4b7\u{1fb3f}\u491f\u{1f82a}\u{1f65a}\u34f1\u0c70\u902d\uf8b3\uefa4',
+  colorFormats: ['rgba32sint', 'rgba32uint', 'r8unorm'],
+});
+try {
+renderBundleEncoder0.setVertexBuffer(2753, undefined);
+} catch {}
+document.body.prepend(img0);
+let imageData2 = new ImageData(224, 244);
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u0a55\u14ae\u9b82\ua2a5\udd3f\u18c1\u2295',
+  entries: [
+    {
+      binding: 1293,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\ud875\u67a0\uc3fb\u0fd5\u0764\u4290\u0c31\uada9\u26b5\u{1ff9f}'});
+let videoFrame0 = new VideoFrame(img1, {timestamp: 0});
+let commandEncoder4 = device0.createCommandEncoder({label: '\u0d65\u{1fcfd}\u{1fafd}\uc2d7\ud8b4\u052d\u10a0\u{1fceb}'});
+let textureView3 = texture2.createView({label: '\u08fd\u0ece\u{1fcae}\ucf94', baseMipLevel: 4, mipLevelCount: 1});
+let renderBundle1 = renderBundleEncoder0.finish({});
+let sampler2 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 70.99,
+  lodMaxClamp: 85.19,
+});
+let img2 = await imageWithData(138, 290, '#c0923fa4', '#662fae17');
+let commandEncoder5 = device0.createCommandEncoder({label: '\u2acc\ua3fd\u0ff5\u0889\ub0e6\u14d0\uc92a\u0d1d\u{1f87d}'});
+let texture4 = device0.createTexture({
+  label: '\uc122\u722a\ue262\u{1fa9e}\u00e0\ub7e5\uf44c\u0b81',
+  size: {width: 96, height: 2, depthOrArrayLayers: 1554},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint'],
+});
+let computePassEncoder1 = commandEncoder2.beginComputePass({label: '\u{1fa1b}\u{1f9ee}\u{1fa57}\u9bfd'});
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 5,
+  origin: {x: 74, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 31},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 202, height: 1, depthOrArrayLayers: 6}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 47 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView4 = texture4.createView({label: '\ud003\u{1f96b}\u18a1', baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 179},
+  aspect: 'all',
+},
+{width: 40, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 50, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 33, y: 36 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 5,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView5 = texture1.createView({
+  label: '\u{1f852}\ucb80\u3f8d\u{1fa87}\u0a72\u0fab\u51a8\u03aa\u7ba4\u{1fe8f}',
+  baseMipLevel: 2,
+  mipLevelCount: 5,
+});
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 8,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 19},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let querySet2 = device0.createQuerySet({label: '\u0e46\u0e6d\u{1f649}\u6e3c\u{1f927}\uf669\u2bc9\u6432\u042b', type: 'occlusion', count: 2525});
+let renderBundle2 = renderBundleEncoder0.finish({label: '\u9216\u0660\u1460\u32eb\u0d95\uc01d\u{1fb28}\u1b66\u1452\u5167'});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 202, height: 1, depthOrArrayLayers: 6}
+*/
+{
+  source: img1,
+  origin: { x: 22, y: 92 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 16, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img2);
+let video0 = await videoWithData();
+let textureView6 = texture2.createView({label: '\u0e2a\ud8ea\u{1f774}\uefbe\ufba8\u7f0c\uf42d', baseMipLevel: 4, mipLevelCount: 1});
+try {
+computePassEncoder0.insertDebugMarker('\u019f');
+} catch {}
+let commandBuffer1 = commandEncoder2.finish();
+let textureView7 = texture4.createView({
+  label: '\u08bd\u0200\ueb4f\u04c1\u578b\u0f09\u05c7\ub70a\u{1f77c}\u{1fe54}\ud7c4',
+  baseMipLevel: 1,
+  baseArrayLayer: 0,
+});
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 256},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout1, bindGroupLayout1]});
+let buffer0 = device0.createBuffer({
+  label: '\ub560\uc20d\u9266\u29cc\u04f6\ucf62\u23a1\u{1f7f9}\u36e6\u{1f851}',
+  size: 225674,
+  usage: GPUBufferUsage.COPY_SRC,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 71, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(16)), /* required buffer size: 5_529 */
+{offset: 361, bytesPerRow: 323, rowsPerImage: 4}, {width: 139, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 50, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise0;
+} catch {}
+let img3 = await imageWithData(88, 223, '#c34033de', '#b2a7f3cd');
+let commandEncoder6 = device0.createCommandEncoder();
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\u41c1\uac7a\u0831',
+  colorFormats: ['rgba32sint', 'rgba32uint', 'r8unorm'],
+  stencilReadOnly: true,
+});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 645, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 81},
+  aspect: 'all',
+},
+{width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle3 = renderBundleEncoder0.finish({label: '\uf166\uf3ae\u8fab\uf432\u44b8'});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture({
+  /* bytesInLastRow: 58 widthInBlocks: 58 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 70201 */
+  offset: 1849,
+  bytesPerRow: 256,
+  rowsPerImage: 267,
+  buffer: buffer0,
+}, {
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 58, height: 0, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let video1 = await videoWithData();
+let shaderModule0 = device0.createShaderModule({
+  label: '\u872f\u023d\u6aa8\ude48\u98e9\u{1f894}\u616a\u0d9b\u44e8',
+  code: `@group(1) @binding(1293)
+var<storage, read_write> n0: array<u32>;
+@group(0) @binding(1293)
+var<storage, read_write> type0: array<u32>;
+
+@compute @workgroup_size(6, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec2<f32>,
+  @location(1) f1: vec4<u32>,
+  @location(0) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @builtin(vertex_index) f0: u32,
+  @location(15) f1: vec2<f32>,
+  @location(17) f2: f16,
+  @builtin(instance_index) f3: u32,
+  @location(3) f4: vec3<u32>,
+  @location(6) f5: vec3<f16>,
+  @location(19) f6: f16,
+  @location(18) f7: vec2<u32>,
+  @location(16) f8: vec3<u32>,
+  @location(10) f9: vec3<f32>,
+  @location(23) f10: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(20) a0: vec4<u32>, @location(14) a1: vec2<f32>, @location(7) a2: vec2<f32>, @location(13) a3: vec2<f16>, @location(8) a4: vec4<i32>, @location(11) a5: vec2<f16>, @location(1) a6: vec3<u32>, @location(4) a7: vec3<f32>, a8: S0, @location(9) a9: vec4<u32>, @location(12) a10: f16, @location(21) a11: vec2<i32>, @location(5) a12: f32, @location(2) a13: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let textureView8 = texture3.createView({
+  label: '\u0b86\ua712\u0baa\u3dd4\u{1fe82}\ud99e\ua013\u6817\u{1ff92}',
+  dimension: '2d',
+  baseMipLevel: 3,
+  baseArrayLayer: 731,
+});
+try {
+renderBundleEncoder1.insertDebugMarker('\u45db');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 187_507 */
+{offset: 775, bytesPerRow: 342, rowsPerImage: 182}, {width: 83, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 809, height: 1, depthOrArrayLayers: 26}
+*/
+{
+  source: img2,
+  origin: { x: 1, y: 28 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  label: '\ua828\uae7b\ua93d\ud52b\u{1fd5a}',
+  code: `@group(0) @binding(1293)
+var<storage, read_write> local0: array<u32>;
+@group(1) @binding(1293)
+var<storage, read_write> field0: array<u32>;
+
+@compute @workgroup_size(7, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(1) f1: vec4<u32>,
+  @location(2) f2: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(2) f0: vec3<u32>,
+  @location(20) f1: u32,
+  @location(6) f2: vec4<f16>,
+  @location(5) f3: vec2<u32>,
+  @location(0) f4: vec3<f16>,
+  @location(23) f5: vec3<u32>,
+  @location(7) f6: vec4<u32>,
+  @location(14) f7: vec4<u32>,
+  @location(9) f8: f16,
+  @location(21) f9: vec4<f16>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(16) a1: f32, @location(12) a2: vec3<f32>, @location(3) a3: u32, @location(18) a4: vec4<i32>, @builtin(instance_index) a5: u32, @location(13) a6: vec4<u32>, @location(17) a7: f32, @location(15) a8: vec2<u32>, @location(1) a9: u32, a10: S1, @location(11) a11: vec2<f16>, @location(10) a12: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture5 = device0.createTexture({
+  size: [768, 16, 351],
+  mipLevelCount: 10,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler3 = device0.createSampler({
+  label: '\u242b\u8da8\u0f66\u0df4\u{1fc3d}\u00cb',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 16.90,
+  lodMaxClamp: 74.72,
+  compare: 'always',
+});
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 8,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 31, y: 0, z: 6},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+  label: '\u{1f8b5}\u77cc\u0a1d\u0ddc\u77fa\ud09f',
+  layout: bindGroupLayout1,
+  entries: [{binding: 1293, resource: sampler3}],
+});
+let buffer1 = device0.createBuffer({
+  label: '\u06d7\u02c6\u1ed5\u08d7\uf9f9\u0bb5\u2add\u63c0\u{1fa25}\u{1f77f}\u0cac',
+  size: 26820,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let textureView9 = texture2.createView({label: '\u2b00\u0182\udd8c', baseMipLevel: 6});
+let computePassEncoder2 = commandEncoder6.beginComputePass();
+let renderBundle4 = renderBundleEncoder0.finish({label: '\u06d5\u{1ff39}'});
+try {
+renderBundleEncoder1.setVertexBuffer(6001, undefined, 3702453104, 226489891);
+} catch {}
+let buffer2 = device0.createBuffer({
+  label: '\u060f\u0f61\u3f42\u03f8',
+  size: 103075,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder7 = device0.createCommandEncoder({});
+let texture6 = device0.createTexture({
+  label: '\u1196\u0908\u{1fda6}\u09d0\ue48e\uc504\u0ce8\u0bf4\u5811\u0cd8\u562b',
+  size: [384, 8, 1218],
+  mipLevelCount: 8,
+  format: 'etc2-rgb8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['etc2-rgb8unorm'],
+});
+let computePassEncoder3 = commandEncoder4.beginComputePass({});
+let externalTexture2 = device0.importExternalTexture({label: '\u9915\u0b15\ue821\u5abf\u{1f85f}\uf867\ucaba', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder1.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(buffer0, 7688, buffer2, 86688, 13388);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 9860, new Int16Array(26675), 13937, 2820);
+} catch {}
+let pipeline0 = await device0.createRenderPipelineAsync({
+  label: '\ucc8c\u0323\uefa5\ucfb8\u0379\u2fd4',
+  layout: pipelineLayout0,
+  multisample: {},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint'}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r8unorm'}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3652,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 448, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 20, shaderLocation: 6},
+          {format: 'uint32x4', offset: 156, shaderLocation: 5},
+          {format: 'uint16x4', offset: 972, shaderLocation: 7},
+          {format: 'unorm8x2', offset: 34, shaderLocation: 0},
+          {format: 'uint32', offset: 916, shaderLocation: 14},
+          {format: 'uint32x3', offset: 676, shaderLocation: 2},
+          {format: 'float32x2', offset: 460, shaderLocation: 9},
+          {format: 'float16x4', offset: 76, shaderLocation: 17},
+          {format: 'uint32x4', offset: 1048, shaderLocation: 20},
+          {format: 'snorm8x4', offset: 16, shaderLocation: 21},
+          {format: 'uint32', offset: 364, shaderLocation: 3},
+          {format: 'float32', offset: 156, shaderLocation: 16},
+          {format: 'uint32x2', offset: 912, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 4120,
+        attributes: [
+          {format: 'sint32', offset: 796, shaderLocation: 18},
+          {format: 'sint8x4', offset: 72, shaderLocation: 10},
+          {format: 'uint8x4', offset: 180, shaderLocation: 23},
+          {format: 'uint16x2', offset: 736, shaderLocation: 15},
+          {format: 'float32x3', offset: 440, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 52,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 0, shaderLocation: 1}],
+      },
+    ],
+  },
+});
+let querySet3 = device0.createQuerySet({label: '\ueeea\u66bc\u{1fedb}\u08de', type: 'occlusion', count: 3516});
+let texture7 = device0.createTexture({
+  label: '\u20c4\ue6e1\u18d7\u0c5c\u0946\u1148\ue864\u{1fa09}\u2079',
+  size: {width: 404, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2480 */
+  offset: 2480,
+  bytesPerRow: 0,
+  rowsPerImage: 64,
+  buffer: buffer0,
+}, {
+  texture: texture6,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+}, {width: 0, height: 4, depthOrArrayLayers: 265});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let externalTexture3 = device0.importExternalTexture({label: '\u1fa8\u0561\uaf14', source: video1, colorSpace: 'srgb'});
+try {
+renderBundleEncoder1.setBindGroup(5, bindGroup0, new Uint32Array(677), 517, 0);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(buffer0, 157416, buffer2, 15108, 26228);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder1.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 12832 widthInBlocks: 802 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 22320 */
+  offset: 22320,
+  bytesPerRow: 13056,
+  rowsPerImage: 30,
+  buffer: buffer2,
+}, {width: 802, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 18},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 23652, new BigUint64Array(59681), 967, 1316);
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `@group(0) @binding(1293)
+var<storage, read_write> local1: array<u32>;
+@group(1) @binding(1293)
+var<storage, read_write> local2: array<u32>;
+
+@compute @workgroup_size(5, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @builtin(position) f0: vec4<f32>,
+  @builtin(front_facing) f1: bool,
+  @builtin(sample_index) f2: u32
+}
+struct FragmentOutput0 {
+  @location(2) f0: f32,
+  @location(7) f1: f32,
+  @location(1) f2: vec4<u32>,
+  @location(0) f3: vec4<i32>,
+  @builtin(sample_mask) f4: u32
+}
+
+@fragment
+fn fragment0(a0: S3) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(11) f0: vec2<i32>,
+  @location(21) f1: vec2<f32>,
+  @location(12) f2: vec2<i32>,
+  @location(13) f3: vec3<u32>,
+  @location(16) f4: vec3<f16>,
+  @builtin(instance_index) f5: u32,
+  @location(22) f6: i32,
+  @location(5) f7: vec4<f16>,
+  @location(23) f8: vec2<f32>,
+  @location(14) f9: vec3<i32>,
+  @location(2) f10: vec3<f32>,
+  @location(8) f11: vec3<f16>,
+  @location(0) f12: vec2<f16>,
+  @location(7) f13: u32,
+  @location(19) f14: vec2<f32>,
+  @location(9) f15: vec3<f32>,
+  @location(1) f16: vec2<u32>,
+  @location(18) f17: vec4<f32>,
+  @location(4) f18: vec3<u32>,
+  @location(20) f19: vec3<u32>,
+  @location(17) f20: vec4<f16>,
+  @location(3) f21: u32
+}
+
+@vertex
+fn vertex0(@location(6) a0: i32, @builtin(vertex_index) a1: u32, a2: S2, @location(15) a3: i32, @location(10) a4: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 23344, new Int16Array(46474), 3273, 6516);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let textureView10 = texture0.createView({});
+let renderBundle5 = renderBundleEncoder1.finish({label: '\u5b12\u{1ff94}\ub956\u{1fc6e}\u0c99\ud477'});
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 18},
+  aspect: 'all',
+},
+{width: 34, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({label: '\u9a44\u00f6\u022d\ue57e\u025f'});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 264});
+let textureView11 = texture7.createView({
+  label: '\u{1fa2a}\u{1fd73}\u26e8\u{1ffa8}\u66c6\u5d98\u0c5a\udfad\u{1f7e5}\u2912',
+  dimension: '2d-array',
+  format: 'rgba8unorm-srgb',
+  baseMipLevel: 2,
+  arrayLayerCount: 1,
+});
+let renderBundle6 = renderBundleEncoder1.finish({label: '\u0ca2\u4cc8\u{1f67f}\u039a\ucb70\u80b5\u004c\u0bb7\u7b32'});
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 14},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(48)), /* required buffer size: 22_572_655 */
+{offset: 91, bytesPerRow: 818, rowsPerImage: 189}, {width: 42, height: 1, depthOrArrayLayers: 147});
+} catch {}
+let sampler4 = device0.createSampler({
+  label: '\u{1f82e}\u{1fa5d}\u3b0e\u027a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 69.56,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup0, new Uint32Array(4842), 982, 0);
+} catch {}
+try {
+commandEncoder7.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3584 widthInBlocks: 224 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 14976 */
+  offset: 11392,
+  buffer: buffer2,
+}, {width: 224, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer2, 26340, 40848);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline1 = await device0.createComputePipelineAsync({
+  label: '\ufc5b\u047f\u04ef',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder9 = device0.createCommandEncoder({label: '\u0059\u2529\u1e6b\u0c6b\u016d'});
+let renderBundle7 = renderBundleEncoder0.finish({label: '\uad15\u00a9\u{1fb75}'});
+let externalTexture4 = device0.importExternalTexture({label: '\uf1cd\u07db\ub85a\u8263\u4c87', source: videoFrame0, colorSpace: 'srgb'});
+try {
+texture0.destroy();
+} catch {}
+try {
+commandEncoder0.insertDebugMarker('\u{1f6c6}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 8088, new DataView(new ArrayBuffer(42909)), 35284, 5036);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 132},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(80)), /* required buffer size: 34_027_311 */
+{offset: 831, bytesPerRow: 648, rowsPerImage: 178}, {width: 300, height: 0, depthOrArrayLayers: 296});
+} catch {}
+let canvas1 = document.createElement('canvas');
+let textureView12 = texture5.createView({label: '\uefc6\u4c73', dimension: '3d', baseMipLevel: 5, mipLevelCount: 4});
+try {
+computePassEncoder2.setBindGroup(5, bindGroup0);
+} catch {}
+try {
+commandEncoder5.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 71, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 41664 widthInBlocks: 2604 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 19360 */
+  offset: 19360,
+  buffer: buffer2,
+}, {width: 2604, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 13648, new Int16Array(39524), 14157, 8484);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 809, height: 1, depthOrArrayLayers: 26}
+*/
+{
+  source: img3,
+  origin: { x: 1, y: 6 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 21, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline2 = device0.createComputePipeline({
+  label: '\u82f7\u05a2\ue125\udc00',
+  layout: 'auto',
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+try {
+canvas0.getContext('webgl2');
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+  label: '\uee6b\u84c1\u03e4\u03fc\u175d\u05a7',
+  layout: bindGroupLayout1,
+  entries: [{binding: 1293, resource: sampler3}],
+});
+let textureView13 = texture6.createView({label: '\ud30d\u0d67\u075a', dimension: '2d', baseMipLevel: 6, mipLevelCount: 1, baseArrayLayer: 832});
+let computePassEncoder4 = commandEncoder5.beginComputePass({});
+try {
+device0.queue.writeBuffer(buffer2, 6060, new BigUint64Array(4703), 3740, 16);
+} catch {}
+let promise1 = device0.createRenderPipelineAsync({
+  label: '\ub03b\u9aff\u7780\u083f\u{1fc4d}\uf2f4\u0c5b\ub322\u243a\uf827',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba32uint', writeMask: 0}, {format: 'r8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'never', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'keep'},
+    stencilReadMask: 369415242,
+    stencilWriteMask: 591588802,
+    depthBias: 2029037482,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2628,
+        attributes: [
+          {format: 'uint16x4', offset: 1428, shaderLocation: 1},
+          {format: 'float16x4', offset: 156, shaderLocation: 17},
+          {format: 'float32x3', offset: 436, shaderLocation: 16},
+          {format: 'uint32x2', offset: 868, shaderLocation: 7},
+          {format: 'uint32x4', offset: 604, shaderLocation: 23},
+          {format: 'sint32x4', offset: 208, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 620, shaderLocation: 6},
+          {format: 'float32x4', offset: 440, shaderLocation: 9},
+          {format: 'uint32', offset: 208, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 44,
+        attributes: [
+          {format: 'uint32x3', offset: 12, shaderLocation: 15},
+          {format: 'uint8x2', offset: 10, shaderLocation: 5},
+          {format: 'uint8x2', offset: 0, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 20, shaderLocation: 12},
+          {format: 'uint16x4', offset: 0, shaderLocation: 3},
+          {format: 'uint8x2', offset: 2, shaderLocation: 14},
+          {format: 'uint16x2', offset: 0, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 1860,
+        attributes: [
+          {format: 'sint32x3', offset: 296, shaderLocation: 18},
+          {format: 'snorm8x4', offset: 568, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 6908, attributes: [{format: 'float16x2', offset: 424, shaderLocation: 21}]},
+      {arrayStride: 1404, attributes: [{format: 'snorm8x2', offset: 584, shaderLocation: 11}]},
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u{1fe37}\u9be8\ucc0d\u51d4\uf404\u0d14\u{1fab1}\ucd1d\u085e\u4fe6'});
+let texture8 = device0.createTexture({
+  size: [96, 2, 8],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundle8 = renderBundleEncoder1.finish({label: '\ud6be\u21b3\u03cb\u03e5\ue14e\ube7e\u0dbc\u{1ffc4}\u627b\u4d11\u2a09'});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(buffer1, 5860, buffer2, 17880, 1004);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer2, 34568, 51884);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u0bbc');
+} catch {}
+let pipeline3 = await device0.createComputePipelineAsync({
+  label: '\u01ec\u03d4\u00f1\u4c21\u5e4f\u7c75\u11cf\u07ba\u0e36\u{1f7b6}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let promise2 = device0.createRenderPipelineAsync({
+  label: '\uc02b\u{1fd36}\u61bd\u0718\u{1fecd}\uc9e0\u{1feee}\u{1f9e0}',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'invert'},
+    stencilReadMask: 2515674626,
+    stencilWriteMask: 973702151,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3100,
+        attributes: [
+          {format: 'float32', offset: 784, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 508, shaderLocation: 5},
+          {format: 'sint32x2', offset: 104, shaderLocation: 15},
+          {format: 'float16x4', offset: 364, shaderLocation: 23},
+          {format: 'uint8x2', offset: 200, shaderLocation: 1},
+          {format: 'float32', offset: 108, shaderLocation: 21},
+          {format: 'uint8x2', offset: 516, shaderLocation: 20},
+          {format: 'uint16x2', offset: 184, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 1488, shaderLocation: 18},
+          {format: 'sint16x4', offset: 424, shaderLocation: 22},
+          {format: 'sint8x2', offset: 1456, shaderLocation: 6},
+          {format: 'uint16x2', offset: 368, shaderLocation: 4},
+          {format: 'sint16x2', offset: 232, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 1000, shaderLocation: 19},
+        ],
+      },
+      {arrayStride: 1924, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 1656,
+        attributes: [
+          {format: 'float32x3', offset: 12, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 256, shaderLocation: 8},
+          {format: 'float16x4', offset: 312, shaderLocation: 2},
+          {format: 'uint32x3', offset: 104, shaderLocation: 13},
+          {format: 'uint32x2', offset: 28, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 736, stepMode: 'instance', attributes: []},
+      {arrayStride: 2824, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 32,
+        attributes: [
+          {format: 'sint32', offset: 0, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 16, shaderLocation: 0},
+          {format: 'sint32x3', offset: 4, shaderLocation: 11},
+          {format: 'float32x3', offset: 0, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 2, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw', unclippedDepth: true},
+});
+canvas0.height = 1297;
+let imageBitmap0 = await createImageBitmap(img2);
+try {
+canvas1.getContext('webgl2');
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder();
+let computePassEncoder5 = commandEncoder1.beginComputePass({label: '\ud0a9\u7d47\u631c\u02c5\uef75\ub3b5\u{1f696}'});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint', 'rgba32uint', 'r8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let sampler5 = device0.createSampler({
+  label: '\u{1f81d}\u677f\u{1f814}\u77bb\uf107\u1c04\u012c\u05f4',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 10.41,
+});
+try {
+renderBundleEncoder2.setBindGroup(5, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder7.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 836, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4896 widthInBlocks: 306 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 37632 */
+  offset: 32736,
+  rowsPerImage: 172,
+  buffer: buffer2,
+}, {width: 306, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer2, 20496, 60096);
+dissociateBuffer(device0, buffer2);
+} catch {}
+canvas1.width = 307;
+let commandEncoder12 = device0.createCommandEncoder({label: '\u053b\u85ce\ua161'});
+let querySet5 = device0.createQuerySet({label: '\u0b4f\uf40f\u540b\u{1febf}\u031d', type: 'occlusion', count: 2375});
+let textureView14 = texture5.createView({label: '\uc6c2\u{1fca6}\u0ddd\u2b09\uc787\u19a7', aspect: 'all', baseMipLevel: 5, mipLevelCount: 3});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder0.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 8336 */
+  offset: 8288,
+  buffer: buffer2,
+}, {width: 3, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 6,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 16, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  label: '\u1901\u4dbb',
+  code: `@group(1) @binding(1293)
+var<storage, read_write> local3: array<u32>;
+@group(0) @binding(1293)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(8, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<f32>,
+  @location(4) f1: vec2<u32>,
+  @location(5) f2: vec3<i32>,
+  @location(3) f3: vec3<f32>,
+  @location(2) f4: vec4<f32>,
+  @location(1) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @location(12) f0: u32,
+  @location(9) f1: vec4<f16>,
+  @location(14) f2: vec3<f32>,
+  @location(0) f3: i32,
+  @location(2) f4: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec2<i32>, a1: S4, @location(20) a2: vec3<f16>, @location(23) a3: vec4<f32>, @location(6) a4: vec4<u32>, @location(16) a5: f32, @location(11) a6: vec2<u32>, @location(4) a7: vec4<i32>, @builtin(instance_index) a8: u32, @location(1) a9: vec2<u32>, @location(18) a10: vec2<i32>, @location(13) a11: vec4<u32>, @location(19) a12: vec4<u32>, @location(7) a13: u32, @location(22) a14: u32, @location(8) a15: f16, @location(21) a16: vec4<f16>, @location(15) a17: vec4<f16>, @location(3) a18: vec4<f16>, @location(17) a19: u32, @location(10) a20: vec3<u32>, @builtin(vertex_index) a21: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u07f4\ua14c\u00d1\udbb3\u058a',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout0, bindGroupLayout1, bindGroupLayout1, bindGroupLayout1],
+});
+let commandEncoder13 = device0.createCommandEncoder({label: '\u0f04\u381a\u0959'});
+let querySet6 = device0.createQuerySet({label: '\u7403\uaadf\u5cd2\u0f74', type: 'occlusion', count: 3338});
+let textureView15 = texture7.createView({
+  label: '\u0d8b\ucd32\ua5ac\u14df\u0757\udac4\u{1fc06}\u0e54\u{1ffda}\u0dca',
+  format: 'rgba8unorm-srgb',
+  baseMipLevel: 2,
+});
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(4832), 2376, 0);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer0, 128792, buffer2, 81332, 16988);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder11.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 8496 */
+  offset: 8496,
+  bytesPerRow: 0,
+  rowsPerImage: 192,
+  buffer: buffer0,
+}, {
+  texture: texture6,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1134});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer2, 66060, 1420);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+renderBundleEncoder2.insertDebugMarker('\u0ceb');
+} catch {}
+gc();
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 3595});
+let computePassEncoder6 = commandEncoder9.beginComputePass({label: '\uaa9e\u2dd5\u2b60\u5f57\u0faa\u00b2\u{1fa7f}\u09cf\u2399\u0919'});
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL}, {format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 956,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 40, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 118, shaderLocation: 16},
+          {format: 'uint8x4', offset: 180, shaderLocation: 23},
+          {format: 'snorm8x2', offset: 168, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 24, shaderLocation: 12},
+          {format: 'float32', offset: 40, shaderLocation: 11},
+          {format: 'uint32x3', offset: 396, shaderLocation: 2},
+          {format: 'uint32x3', offset: 32, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 232, shaderLocation: 17},
+          {format: 'sint16x2', offset: 376, shaderLocation: 18},
+          {format: 'uint32x3', offset: 84, shaderLocation: 13},
+          {format: 'sint32', offset: 84, shaderLocation: 10},
+          {format: 'uint16x4', offset: 208, shaderLocation: 14},
+          {format: 'float16x2', offset: 496, shaderLocation: 0},
+          {format: 'uint32x2', offset: 224, shaderLocation: 3},
+          {format: 'uint32x3', offset: 168, shaderLocation: 20},
+          {format: 'uint16x4', offset: 228, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 200,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 4, shaderLocation: 21}],
+      },
+      {arrayStride: 2840, attributes: []},
+      {arrayStride: 44, attributes: [{format: 'uint32x3', offset: 0, shaderLocation: 1}]},
+      {arrayStride: 2420, attributes: [{format: 'uint8x4', offset: 28, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 76, y: 0, z: 427},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 8_648_050 */
+{offset: 540, bytesPerRow: 281, rowsPerImage: 223}, {width: 8, height: 4, depthOrArrayLayers: 139});
+} catch {}
+try {
+bindGroup1.label = '\u0634\u0351\u4749\u1aae\u2f6d\uda45\u0dc0';
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  label: '\u36ab\u{1ff7d}\u31ef',
+  code: `@group(0) @binding(1293)
+var<storage, read_write> type1: array<u32>;
+
+@compute @workgroup_size(7, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(2) f1: vec4<f32>,
+  @location(1) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(9) a0: vec4<f16>, @location(40) a1: vec4<f16>, @location(11) a2: vec2<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(40) f0: vec4<f16>,
+  @location(11) f1: vec2<f16>,
+  @builtin(position) f2: vec4<f32>,
+  @location(18) f3: u32,
+  @location(9) f4: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec4<f32>, @location(1) a1: vec4<u32>, @location(4) a2: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder14 = device0.createCommandEncoder();
+let texture9 = device0.createTexture({
+  label: '\u77a9\u{1fdf6}\u9d19\u089a\uda98\u0ec2\u{1f84a}\u08fe\ud20f\u03a7',
+  size: {width: 768, height: 16, depthOrArrayLayers: 330},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder7 = commandEncoder12.beginComputePass({label: '\u44e3\u201d\u6d48\ud3fb\ue1f1\u07b2\u093c\u0bc8'});
+try {
+renderBundleEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let promise3 = buffer2.mapAsync(GPUMapMode.READ, 0, 15744);
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 960 */
+  offset: 960,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {
+  texture: texture9,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline5 = await device0.createComputePipelineAsync({
+  label: '\u252b\u475b\u{1fd5b}\u3745\u{1fab8}\u3f2c\u08c1\ueb49\ua3c3\u0bd6',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let canvas2 = document.createElement('canvas');
+let commandEncoder15 = device0.createCommandEncoder({label: '\u{1fd6b}\u68fb\ud182\ue37f\u79ef\u0ed5\u07ab\ucc60\u86e9\u6b9e\u0c35'});
+let commandBuffer2 = commandEncoder15.finish();
+let texture10 = device0.createTexture({
+  label: '\u{1faad}\uf2d5\u{1fd1e}\uc387\ue424\u{1ffbc}\u997b\u{1f645}',
+  size: {width: 809, height: 1, depthOrArrayLayers: 1234},
+  mipLevelCount: 2,
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderBundleEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer1, 8424, buffer2, 88972, 4804);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder0.clearBuffer(buffer2, 65876, 7772);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let imageBitmap1 = await createImageBitmap(video1);
+let buffer3 = device0.createBuffer({
+  label: '\u{1fab7}\uc611\u5b19\u{1f9e0}\u09cb\ua407\u42da\u6b1d\u{1fdbb}',
+  size: 70688,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture11 = device0.createTexture({
+  label: '\ub65e\u912f\u0ed4\u0c72\u0056\u{1fa39}\uab74',
+  size: {width: 809, height: 1, depthOrArrayLayers: 942},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+let textureView16 = texture1.createView({label: '\u{1fed3}\u1dd8', dimension: '2d-array', aspect: 'all', baseMipLevel: 3, mipLevelCount: 1});
+try {
+renderBundleEncoder2.setVertexBuffer(1, buffer3, 32352, 10848);
+} catch {}
+let promise4 = device0.popErrorScope();
+try {
+commandEncoder10.clearBuffer(buffer2, 39444, 27904);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({label: '\u6f43\u9dfb\ue065\u10e3\ua3ce'});
+let texture12 = device0.createTexture({
+  label: '\u691c\u3d9a\u04e5\u052a\u294c\ud864\u26bc\u{1f70d}\u{1f9ca}\u0693',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+let textureView17 = texture12.createView({});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg16float', 'rg11b10ufloat', 'rgba16float', 'rg11b10ufloat', 'r8uint', 'r8sint'],
+  depthReadOnly: false,
+  stencilReadOnly: false,
+});
+try {
+computePassEncoder4.setBindGroup(4, bindGroup1);
+} catch {}
+try {
+commandEncoder0.clearBuffer(buffer2, 101808, 528);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let texture13 = device0.createTexture({
+  label: '\uaac3\u936f\ud13a\uf8e4\u84cc\ue859\u7a6e\u57a5',
+  size: {width: 768, height: 16, depthOrArrayLayers: 1261},
+  mipLevelCount: 11,
+  dimension: '3d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView18 = texture6.createView({
+  label: '\ub64c\ucc2f\udac9\u304e\ud400\u6cc7\u{1ff13}\u{1f9bb}\u{1f8d5}',
+  baseMipLevel: 7,
+  baseArrayLayer: 429,
+  arrayLayerCount: 380,
+});
+let renderBundle9 = renderBundleEncoder2.finish();
+let sampler6 = device0.createSampler({
+  label: '\u029a\u{1fffb}\uaf2a\u8b6b\u{1fc34}\u967e\ufe4d\ua824\u{1f7ea}\u204c\u{1fb1d}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 79.13,
+});
+try {
+computePassEncoder7.setBindGroup(5, bindGroup0, new Uint32Array(1581), 1245, 0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(6, bindGroup1);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(buffer1, 4968, buffer2, 37356, 5304);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 3},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(72)), /* required buffer size: 877_069 */
+{offset: 931, bytesPerRow: 2158, rowsPerImage: 196}, {width: 537, height: 14, depthOrArrayLayers: 3});
+} catch {}
+let pipeline6 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule2, entryPoint: 'compute0'}});
+try {
+canvas2.getContext('webgl2');
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({label: '\uaba8\u87b9\uf6dc\u0078\u0544\u0f30\u{1ff96}\uc438\u{1fd93}\u8e50'});
+let texture14 = device0.createTexture({
+  label: '\u34d7\u0b77\u{1ffdb}\u150c\u2b70\u{1fa73}\u20d1\u{1fa8c}\u2616',
+  size: {width: 809},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder8 = commandEncoder11.beginComputePass({});
+let sampler7 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 63.81,
+  maxAnisotropy: 17,
+});
+try {
+commandEncoder17.clearBuffer(buffer2, 69800, 2248);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let imageBitmap2 = await createImageBitmap(imageData2);
+let textureView19 = texture12.createView({label: '\u{1f6b7}\u05fb\u8028\uc9c5\u50dc\ubf58\u088c\u{1fd15}\u47e7\u0af2\u1a6c'});
+try {
+computePassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(6, buffer3, 13256, 30916);
+} catch {}
+try {
+buffer2.destroy();
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(buffer0, 47776, buffer2, 45956, 3556);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 10,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 14, y: 1, z: 316},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  label: '\ud6fa\u6c40\u2850\u2075',
+  code: `@group(1) @binding(1293)
+var<storage, read_write> local4: array<u32>;
+@group(0) @binding(1293)
+var<storage, read_write> n1: array<u32>;
+
+@compute @workgroup_size(1, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec4<i32>,
+  @location(2) f1: vec4<f32>,
+  @location(3) f2: vec4<f32>,
+  @location(1) f3: vec4<f32>,
+  @builtin(sample_mask) f4: u32,
+  @location(4) f5: vec2<u32>,
+  @location(0) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S5 {
+  @location(20) f0: vec3<u32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(15) a1: vec2<f16>, @location(13) a2: vec4<f32>, @location(5) a3: vec4<u32>, @location(17) a4: vec3<f16>, a5: S5, @location(0) a6: vec3<i32>, @location(8) a7: vec3<f32>, @location(1) a8: vec4<f16>, @location(11) a9: vec3<i32>, @builtin(vertex_index) a10: u32, @location(19) a11: vec2<i32>, @location(22) a12: u32, @location(9) a13: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let bindGroup2 = device0.createBindGroup({
+  label: '\u{1fda8}\u996c\u5048\uaa82',
+  layout: bindGroupLayout1,
+  entries: [{binding: 1293, resource: sampler3}],
+});
+let buffer4 = device0.createBuffer({
+  label: '\u01bd\uddb2\u59d3\u08a8',
+  size: 63104,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder18 = device0.createCommandEncoder({label: '\ua012\u71de\u061c\u9c3a\u0856\u{1fba9}\ue98d\u0a7a\u4738'});
+let textureView20 = texture12.createView({label: '\u0c29\u{1f689}\u0db2\u031b\u0cc6\uf549'});
+let externalTexture6 = device0.importExternalTexture({
+  label: '\u9d40\u{1fcfb}\u43ba\uf5f3\u{1f8b2}\u{1f7d8}\ue6b6\ud7ed\u{1fa60}\u0c76\u{1fbab}',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+buffer0.unmap();
+} catch {}
+try {
+  await buffer4.mapAsync(GPUMapMode.WRITE, 0, 17168);
+} catch {}
+let pipeline7 = device0.createRenderPipeline({
+  label: '\u0d35\u{1fe54}',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint'}, {format: 'rgba32uint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9196,
+        attributes: [
+          {format: 'uint32', offset: 1820, shaderLocation: 13},
+          {format: 'float32x4', offset: 1432, shaderLocation: 16},
+          {format: 'uint16x2', offset: 84, shaderLocation: 15},
+          {format: 'float16x2', offset: 3752, shaderLocation: 6},
+          {format: 'sint8x4', offset: 2476, shaderLocation: 18},
+          {format: 'uint32x3', offset: 604, shaderLocation: 2},
+          {format: 'uint32x2', offset: 1088, shaderLocation: 3},
+          {format: 'uint8x2', offset: 1070, shaderLocation: 23},
+          {format: 'uint32x2', offset: 320, shaderLocation: 1},
+          {format: 'uint32x4', offset: 3756, shaderLocation: 20},
+          {format: 'float16x2', offset: 2252, shaderLocation: 0},
+          {format: 'sint8x4', offset: 936, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 1944,
+        attributes: [
+          {format: 'float32x2', offset: 284, shaderLocation: 11},
+          {format: 'uint32x4', offset: 156, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 592, shaderLocation: 17},
+          {format: 'uint8x4', offset: 1028, shaderLocation: 7},
+          {format: 'uint32x2', offset: 504, shaderLocation: 14},
+          {format: 'float32x2', offset: 540, shaderLocation: 21},
+          {format: 'snorm8x2', offset: 550, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 472, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let bindGroup3 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 1293, resource: sampler3}]});
+let commandEncoder19 = device0.createCommandEncoder({});
+let renderBundle10 = renderBundleEncoder2.finish({});
+try {
+renderBundleEncoder3.setVertexBuffer(4, buffer3, 35316, 32301);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(4, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(8, buffer3, 44936, 19885);
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 4},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 116 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 30340 */
+  offset: 3460,
+  bytesPerRow: 256,
+  rowsPerImage: 105,
+  buffer: buffer2,
+}, {width: 29, height: 0, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 495},
+  aspect: 'all',
+},
+{width: 42, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageData3 = new ImageData(236, 88);
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u{1f601}\u{1fe24}\u0992\u40c9\u25ff\u{1f7c8}\u06ea\u2017\u97d6\u6100',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout1, bindGroupLayout0, bindGroupLayout0],
+});
+let commandEncoder20 = device0.createCommandEncoder();
+let textureView21 = texture9.createView({label: '\uc5f3\uce48\u3c8f\uca0b\u{1f644}\u{1fb6c}\u{1feeb}\u1610\u994c', baseMipLevel: 9});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder7.setBindGroup(6, bindGroup3);
+} catch {}
+try {
+commandEncoder14.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 52208 */
+  offset: 2448,
+  bytesPerRow: 256,
+  rowsPerImage: 194,
+  buffer: buffer2,
+}, {width: 6, height: 1, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+externalTexture7.label = '\u0f8e\u{1fae2}';
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  label: '\u{1f799}\u46ec',
+  code: `@group(1) @binding(513)
+var<storage, read_write> function1: array<u32>;
+@group(3) @binding(1293)
+var<storage, read_write> global0: array<u32>;
+@group(2) @binding(513)
+var<storage, read_write> function2: array<u32>;
+@group(2) @binding(3739)
+var<storage, read_write> type2: array<u32>;
+@group(5) @binding(3739)
+var<storage, read_write> parameter0: array<u32>;
+@group(1) @binding(3739)
+var<storage, read_write> function3: array<u32>;
+@group(0) @binding(513)
+var<storage, read_write> function4: array<u32>;
+@group(4) @binding(3739)
+var<storage, read_write> field1: array<u32>;
+@group(5) @binding(513)
+var<storage, read_write> local5: array<u32>;
+@group(4) @binding(513)
+var<storage, read_write> function5: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S7 {
+  @location(22) f0: vec4<u32>,
+  @location(39) f1: vec3<f16>
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec2<u32>,
+  @location(1) f1: vec4<f32>,
+  @location(3) f2: vec4<f32>,
+  @location(6) f3: vec3<u32>,
+  @location(2) f4: vec4<f32>,
+  @location(0) f5: vec3<f32>,
+  @location(5) f6: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(16) a0: vec3<f16>, @location(2) a1: vec4<u32>, @location(15) a2: vec2<f32>, @builtin(position) a3: vec4<f32>, @location(31) a4: u32, @location(9) a5: vec3<i32>, @location(1) a6: vec3<f16>, @location(25) a7: f32, @location(34) a8: vec2<f32>, @location(43) a9: vec2<f16>, @builtin(front_facing) a10: bool, @location(26) a11: i32, @builtin(sample_index) a12: u32, @location(12) a13: vec4<i32>, @location(10) a14: vec2<u32>, a15: S7, @location(33) a16: vec4<u32>, @location(24) a17: u32, @location(38) a18: vec4<f16>, @location(11) a19: vec2<i32>, @location(4) a20: f16, @location(19) a21: vec3<u32>, @location(14) a22: vec4<f16>, @location(27) a23: u32, @location(17) a24: u32, @builtin(sample_mask) a25: u32, @location(21) a26: vec3<u32>, @location(29) a27: vec4<i32>, @location(7) a28: vec4<f16>, @location(36) a29: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(20) f0: vec4<f16>,
+  @location(4) f1: vec3<f16>,
+  @location(17) f2: vec4<f16>,
+  @location(3) f3: vec2<i32>,
+  @location(6) f4: vec3<i32>,
+  @location(10) f5: vec4<u32>,
+  @location(19) f6: vec4<u32>
+}
+struct VertexOutput0 {
+  @location(43) f5: vec2<f16>,
+  @location(10) f6: vec2<u32>,
+  @builtin(position) f7: vec4<f32>,
+  @location(25) f8: f32,
+  @location(13) f9: i32,
+  @location(21) f10: vec3<u32>,
+  @location(22) f11: vec4<u32>,
+  @location(34) f12: vec2<f32>,
+  @location(14) f13: vec4<f16>,
+  @location(11) f14: vec2<i32>,
+  @location(7) f15: vec4<f16>,
+  @location(27) f16: u32,
+  @location(15) f17: vec2<f32>,
+  @location(33) f18: vec4<u32>,
+  @location(31) f19: u32,
+  @location(12) f20: vec4<i32>,
+  @location(24) f21: u32,
+  @location(19) f22: vec3<u32>,
+  @location(36) f23: vec4<f16>,
+  @location(26) f24: i32,
+  @location(38) f25: vec4<f16>,
+  @location(16) f26: vec3<f16>,
+  @location(4) f27: f16,
+  @location(2) f28: vec4<u32>,
+  @location(1) f29: vec3<f16>,
+  @location(29) f30: vec4<i32>,
+  @location(9) f31: vec3<i32>,
+  @location(17) f32: u32,
+  @location(39) f33: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec2<f32>, @location(7) a1: vec4<i32>, @location(5) a2: vec3<i32>, @location(18) a3: vec4<i32>, @location(13) a4: vec3<f32>, @location(16) a5: f32, @location(23) a6: f16, a7: S6, @location(12) a8: vec4<f16>, @builtin(vertex_index) a9: u32, @location(9) a10: vec3<u32>, @builtin(instance_index) a11: u32, @location(22) a12: vec2<f16>, @location(8) a13: vec4<f32>, @location(2) a14: vec4<f32>, @location(0) a15: vec4<u32>, @location(1) a16: vec3<f32>, @location(14) a17: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder21 = device0.createCommandEncoder({label: '\u5a2b\uf304\u00eb\u{1fc98}\u442b\u{1f986}\u0517\u3d56\u6d5a'});
+let querySet8 = device0.createQuerySet({
+  label: '\u0ab5\u0b72\u9828\u8915\ud548\u0aa2\u{1f8ba}\ucfa6\u9e21\u{1fb3a}',
+  type: 'occlusion',
+  count: 1118,
+});
+let texture15 = device0.createTexture({
+  size: {width: 404},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+let renderBundle11 = renderBundleEncoder3.finish({});
+try {
+computePassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 50},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(16)), /* required buffer size: 74_464_735 */
+{offset: 740, bytesPerRow: 391, rowsPerImage: 205}, {width: 72, height: 0, depthOrArrayLayers: 930});
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder();
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 192, height: 4, depthOrArrayLayers: 82}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 9, y: 79 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 29, y: 0, z: 9},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline8 = device0.createComputePipeline({
+  label: '\u{1fde9}\u0bea\u0acc\u304f\u0353\uc352',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+canvas2.height = 203;
+let bindGroupLayout2 = device0.createBindGroupLayout({label: '\ue43d\ua9f8\ube2d\u9602\u097e', entries: []});
+let textureView22 = texture11.createView({
+  label: '\u{1ffd3}\u76ee\u6be5\u741a\u{1fbd5}\u6116\u{1febc}\u3433\ub714\u0fea\u{1fecb}',
+  format: 'r8sint',
+  baseMipLevel: 6,
+});
+let externalTexture8 = device0.importExternalTexture({
+  label: '\ua8d6\uccda\uec03\u4ed5\u378c\u5b85\u{1ffba}\ue61a\u02a1\u330b\u{1f68b}',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 19695 */
+  offset: 19695,
+  bytesPerRow: 256,
+  buffer: buffer1,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 40, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 110, y: 0, z: 56},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+gc();
+let buffer5 = device0.createBuffer({
+  label: '\u{1fa44}\u961f\u1355',
+  size: 23108,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: true,
+});
+let commandBuffer3 = commandEncoder16.finish({label: '\u04a0\u{1fe77}\ud559\u76af\u956c\uc037\u0f82\u{1f8f4}\u{1f60c}\u0527\u9a87'});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\udcbd\u08a8\u0ce7\u{1f719}\u2536\u2df7\u099d\uc3d1\u0e0f',
+  colorFormats: ['rg16float', 'rg11b10ufloat', 'rgba16float', 'rg11b10ufloat', 'r8uint', 'r8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle12 = renderBundleEncoder1.finish({label: '\u0533\u{1fabb}\ub119\u2f73'});
+try {
+renderBundleEncoder4.setBindGroup(6, bindGroup3, new Uint32Array(7103), 5998, 0);
+} catch {}
+try {
+commandEncoder0.copyBufferToBuffer(buffer1, 4768, buffer2, 26336, 16992);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet0, 663, 881, buffer5, 13568);
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({label: '\u0402\u0fe6\u026f\uef9b'});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u04f8\u7b1c\uc524\u53cc\u0027\ue39a\u0183\u01a3\uc871\u429d\u{1f78b}',
+  colorFormats: ['rgba32sint', 'rgba32uint', 'r8unorm'],
+  stencilReadOnly: true,
+});
+let externalTexture9 = device0.importExternalTexture({label: '\ub88a\u{1ffeb}', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup2, new Uint32Array(4668), 2319, 0);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup2, new Uint32Array(1932), 1888, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 404, height: 1, depthOrArrayLayers: 13}
+*/
+{
+  source: canvas2,
+  origin: { x: 48, y: 6 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 45, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u{1f7a4}\u6fea\u5b07\ue773\uda18',
+  colorFormats: ['rg16float', 'rg11b10ufloat', 'rgba16float', 'rg11b10ufloat', 'r8uint', 'r8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler8 = device0.createSampler({
+  label: '\ue2e3\u2ddf\ubb33\u0387\u0b63\u{1f973}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 78.76,
+  lodMaxClamp: 88.68,
+});
+let externalTexture10 = device0.importExternalTexture({label: '\ua210\u{1fa01}\u{1fbab}\u4f3f', source: videoFrame0});
+try {
+renderBundleEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture({
+  /* bytesInLastRow: 81 widthInBlocks: 81 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 61071 */
+  offset: 61071,
+  rowsPerImage: 112,
+  buffer: buffer0,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 81, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder4.clearBuffer(buffer2, 19068, 22976);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(querySet5, 1500, 529, buffer5, 5376);
+} catch {}
+let pipeline9 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}}});
+try {
+pipeline9.label = '\ude02\u02f9\ue72e';
+} catch {}
+let querySet9 = device0.createQuerySet({label: '\ua24b\u751e', type: 'occlusion', count: 112});
+let textureView23 = texture13.createView({label: '\u{1fc66}\u8ec6\u0591\u0747\ueb29\u0999\u2fc5', baseMipLevel: 1, mipLevelCount: 5});
+let renderBundle13 = renderBundleEncoder3.finish({label: '\u{1fa16}\u{1f7fb}'});
+try {
+renderBundleEncoder5.setVertexBuffer(0, buffer3, 0, 3683);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer1, 1072, buffer2, 63276, 24220);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder8.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 10,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5556 */
+  offset: 5556,
+  rowsPerImage: 17,
+  buffer: buffer2,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+renderBundleEncoder4.insertDebugMarker('\u04d7');
+} catch {}
+try {
+window.someLabel = textureView7.label;
+} catch {}
+let querySet10 = device0.createQuerySet({label: '\u6424\ua716\u2ec4\ue3a8\u8b0b', type: 'occlusion', count: 502});
+let textureView24 = texture7.createView({
+  label: '\u0506\u{1f945}\u90c4\u0fd3\u{1fd6f}\uf6d2\u{1fae1}\u7d6b\u{1ff5e}\u0947\u55d8',
+  format: 'rgba8unorm-srgb',
+  baseMipLevel: 2,
+});
+let renderBundle14 = renderBundleEncoder5.finish();
+let sampler9 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.59,
+  lodMaxClamp: 85.91,
+  maxAnisotropy: 10,
+});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+let commandEncoder24 = device0.createCommandEncoder({label: '\u{1f8d4}\u2e9f\u{1ff6f}\u5d80\u0b78\u62cb\u0fa8\u0448\ufa5e\u894f'});
+let querySet11 = device0.createQuerySet({label: '\ucbfa\u53bf\u3d89', type: 'occlusion', count: 2820});
+let commandBuffer4 = commandEncoder5.finish();
+let renderBundle15 = renderBundleEncoder1.finish({label: '\u{1fa70}\u990b\u{1fea3}\ue649\u7cda\u1fd6'});
+let externalTexture12 = device0.importExternalTexture({label: '\uee24\u46be\ud65b\u{1fbe1}\u46dd\u3288\uda83\u8da2', source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(8, buffer3);
+} catch {}
+try {
+  await buffer1.mapAsync(GPUMapMode.WRITE, 5408, 316);
+} catch {}
+let bindGroup4 = device0.createBindGroup({layout: bindGroupLayout2, entries: []});
+let texture16 = device0.createTexture({
+  label: '\u0fbc\ub361\u0c86\u7d73\u{1f92e}\u6869\ud7f3\u444a\uc431\u5569',
+  size: [809],
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({label: '\u{1fb0d}\u042c', colorFormats: ['rgba32sint', 'rgba32uint', 'r8unorm'], depthReadOnly: true});
+try {
+computePassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 58, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 768, height: 16, depthOrArrayLayers: 330}
+*/
+{
+  source: imageData2,
+  origin: { x: 14, y: 34 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 88, y: 2, z: 21},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 41, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap3 = await createImageBitmap(img3);
+let texture17 = device0.createTexture({
+  size: {width: 404, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 8,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8uint', 'r8uint', 'r8uint'],
+});
+let textureView25 = texture3.createView({
+  label: '\u2879\u33a2\u136b',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 665,
+  arrayLayerCount: 238,
+});
+let computePassEncoder9 = commandEncoder14.beginComputePass({label: '\u0bc2\u0b1b\u00b1\u7b01\ucf2f\u7de5\u{1faa9}\uf333\u{1f73c}\u405a\ud32d'});
+let renderBundle16 = renderBundleEncoder1.finish();
+let externalTexture13 = device0.importExternalTexture({label: '\u8786\ubd5a', source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder4.setBindGroup(6, bindGroup0);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 1048 widthInBlocks: 262 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 135772 */
+  offset: 11844,
+  bytesPerRow: 1280,
+  rowsPerImage: 19,
+  buffer: buffer0,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 109, y: 2, z: 11},
+  aspect: 'all',
+}, {width: 262, height: 2, depthOrArrayLayers: 6});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder0.resolveQuerySet(querySet4, 151, 74, buffer5, 1280);
+} catch {}
+let videoFrame1 = new VideoFrame(video1, {timestamp: 0});
+let bindGroup5 = device0.createBindGroup({
+  label: '\u08d0\u{1ff3d}\u2849\u01f8\u0a36\u0c9c\udd33\ub6bf\u{1ff77}\u5b00\uca90',
+  layout: bindGroupLayout1,
+  entries: [{binding: 1293, resource: sampler3}],
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u3df8\u01eb\ubee4\u0b33',
+  colorFormats: ['rgba32sint', 'rgba32uint', 'r8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let sampler10 = device0.createSampler({
+  label: '\u7422\u06cd\u35c1',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 96.48,
+  lodMaxClamp: 97.15,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup0, new Uint32Array(6518), 2039, 0);
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(querySet8, 902, 172, buffer5, 16384);
+} catch {}
+canvas2.width = 618;
+let buffer6 = device0.createBuffer({
+  label: '\u0a36\uf7e9\u052f\u{1fa68}\u9acc\u8ebf',
+  size: 229133,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandBuffer5 = commandEncoder20.finish();
+let texture18 = device0.createTexture({
+  label: '\u{1fefd}\u0f5a\ufea4\u00a9\ud235\u0351\u869c\u486a\ufb1c',
+  size: [809, 1, 991],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let sampler11 = device0.createSampler({
+  label: '\u79d4\u{1fc95}\ud4ac\u{1f746}\u02e6\u7d5d',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.78,
+  lodMaxClamp: 99.61,
+  compare: 'never',
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder5.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(7, buffer3, 6264, 50849);
+} catch {}
+let pipeline10 = device0.createComputePipeline({
+  label: '\u{1f887}\u{1f7f4}\u68e7\u58f4\u0887\u0cff\uf4fe',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let buffer7 = device0.createBuffer({
+  label: '\u005e\uc7f4\u0e0c\u{1fb69}\ud241\u0138\u0ab6\u0ed9',
+  size: 76435,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder25 = device0.createCommandEncoder({label: '\ub015\u0986\u848e\u0b4f\u0949\u{1ffd3}\u5e98\u00cc\u34a3\u0c52'});
+let textureView26 = texture6.createView({
+  label: '\u{1f91b}\u093e\u2170\u1dd7\u{1fc67}\u0f52\u7b90\ue728\u3be2',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 6,
+  baseArrayLayer: 279,
+});
+let renderBundle17 = renderBundleEncoder0.finish({label: '\u{1fb09}\u{1f6e2}\u114b'});
+let sampler12 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 92.81,
+  lodMaxClamp: 93.79,
+  compare: 'always',
+});
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(8, buffer3, 0, 47352);
+} catch {}
+canvas1.width = 2335;
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({label: '\u539a\u2276\uda84\u06c5\u0b53\u09c4'});
+let textureView27 = texture17.createView({label: '\u0455\u974e', aspect: 'all', format: 'r8uint', baseMipLevel: 3, mipLevelCount: 4});
+let externalTexture14 = device0.importExternalTexture({label: '\u{1fef5}\u00ce', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 174 widthInBlocks: 174 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 10291 */
+  offset: 10117,
+  buffer: buffer7,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 174, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 142, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder6.resolveQuerySet(querySet9, 96, 5, buffer5, 8192);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 14824, new BigUint64Array(20162), 2050, 1236);
+} catch {}
+let pipeline11 = await device0.createComputePipelineAsync({
+  label: '\u0a7f\u{1f70d}\u4973\uc426\ub1e2\u7843\u{1fc96}\u6b2c\u{1fa66}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder27 = device0.createCommandEncoder({label: '\u{1fcaa}\u9f95\u1a0f'});
+let commandBuffer6 = commandEncoder25.finish({label: '\u29e2\u945b\u4163\u0ff3\ua29c\u064c\u3f35\ufc8b\u84a4\u0183'});
+let textureView28 = texture15.createView({label: '\u0641\u87b3\u{1f639}\u05da\u5fd6\ueebd\u8698'});
+let computePassEncoder10 = commandEncoder27.beginComputePass();
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 22748, new DataView(new ArrayBuffer(63729)), 31372, 8140);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 202, height: 1, depthOrArrayLayers: 6}
+*/
+{
+  source: img2,
+  origin: { x: 4, y: 35 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 83, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder({label: '\u{1fdd7}\u7dc3\u08b8\u{1ff99}\u0c94'});
+let texture19 = device0.createTexture({
+  label: '\u{1ff9c}\u067f\u06f3\u0031\u0582\u6014',
+  size: [192, 4, 81],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let textureView29 = texture14.createView({label: '\ubc25\u5f9a\u0dc5\ue713\u{1f972}\ud869\u{1f62c}', dimension: '1d', arrayLayerCount: 1});
+try {
+renderBundleEncoder6.setVertexBuffer(3, buffer3, 34848, 831);
+} catch {}
+try {
+  await buffer6.mapAsync(GPUMapMode.READ, 0, 91216);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer2, 160, 19376);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 48, height: 1, depthOrArrayLayers: 20}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 4, y: 62 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline12 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}}});
+let offscreenCanvas0 = new OffscreenCanvas(663, 789);
+let texture20 = device0.createTexture({
+  label: '\uc46c\u01bd\u0315\u4298\u0784\uc522\u{1f921}',
+  size: [96, 2, 129],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView30 = texture16.createView({label: '\u0e36\u{1ffdf}\uae02\u{1fded}\u{1feec}', baseMipLevel: 0, arrayLayerCount: 1});
+let sampler13 = device0.createSampler({
+  label: '\ue8a6\u9034\udc82',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 63.34,
+  lodMaxClamp: 93.57,
+  compare: 'not-equal',
+});
+let externalTexture15 = device0.importExternalTexture({label: '\u06c8\u54b6\u0a35\u{1f96b}\u0638\u4941\u1e46\ud2c6\uc0d8\ufb78', source: videoFrame0});
+try {
+renderBundleEncoder4.setVertexBuffer(9, buffer3, 0, 69987);
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 28628 */
+  offset: 28628,
+  bytesPerRow: 0,
+  rowsPerImage: 26,
+  buffer: buffer7,
+}, {
+  texture: texture13,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 4});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder18.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 68, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 107 widthInBlocks: 107 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2672 */
+  offset: 2672,
+  buffer: buffer2,
+}, {width: 107, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(querySet6, 129, 1054, buffer5, 14080);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 8, depthOrArrayLayers: 165}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 8, y: 7 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 29, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 28, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let bindGroupLayout3 = pipeline9.getBindGroupLayout(1);
+let buffer8 = device0.createBuffer({label: '\u0873\uaa03', size: 115133, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder29 = device0.createCommandEncoder({label: '\u0893\uf096\u7ce3\u2d7e\u84bb'});
+let textureView31 = texture5.createView({label: '\ud466\uaa58\u22ba', baseMipLevel: 4});
+let computePassEncoder11 = commandEncoder6.beginComputePass({label: '\u4b8f\u0fb9\uf76d\u0901\u6959\u0a12\ube7a\u0054\u9ebc'});
+let renderBundle18 = renderBundleEncoder6.finish({label: '\uf813\u{1ff2a}'});
+let arrayBuffer0 = buffer5.getMappedRange();
+try {
+commandEncoder26.copyBufferToBuffer(buffer0, 68524, buffer2, 29756, 60064);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder4.copyBufferToTexture({
+  /* bytesInLastRow: 5 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1286 */
+  offset: 1286,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline13 = device0.createRenderPipeline({
+  label: '\u29e4\u4963\u{1fe8e}\ud150\u04b4\u{1f937}\u6536\u85f9\u99d2',
+  layout: pipelineLayout1,
+  multisample: {},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one'},
+  },
+}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r8uint'}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthCompare: 'always',
+    stencilFront: {compare: 'not-equal', depthFailOp: 'increment-wrap', passOp: 'keep'},
+    stencilBack: {failOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 1929271119,
+    stencilWriteMask: 2994079543,
+    depthBias: 673973180,
+    depthBiasClamp: 566.1993747666123,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 228,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 32, shaderLocation: 11},
+          {format: 'float32x3', offset: 36, shaderLocation: 23},
+          {format: 'sint16x2', offset: 16, shaderLocation: 18},
+          {format: 'sint8x2', offset: 48, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 56, shaderLocation: 3},
+          {format: 'uint16x4', offset: 92, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 164, shaderLocation: 21},
+          {format: 'unorm16x4', offset: 32, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 76, shaderLocation: 15},
+          {format: 'uint16x2', offset: 20, shaderLocation: 6},
+          {format: 'uint32x4', offset: 36, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 40, shaderLocation: 9},
+          {format: 'uint32x4', offset: 24, shaderLocation: 12},
+          {format: 'sint32x3', offset: 16, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 12, shaderLocation: 16},
+          {format: 'float16x4', offset: 68, shaderLocation: 14},
+          {format: 'uint32x2', offset: 4, shaderLocation: 10},
+          {format: 'uint32x3', offset: 0, shaderLocation: 19},
+          {format: 'sint32x2', offset: 32, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 1908,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 128, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 268, shaderLocation: 20},
+          {format: 'float32x2', offset: 136, shaderLocation: 8},
+          {format: 'uint32x3', offset: 284, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 440,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 116, shaderLocation: 17}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'front'},
+});
+let imageData4 = new ImageData(192, 92);
+let texture21 = device0.createTexture({
+  label: '\u7163\u{1f6ac}\u8fba\u00bb\udafa\u{1f875}\ud5cf',
+  size: [404, 1, 546],
+  mipLevelCount: 2,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView32 = texture21.createView({
+  label: '\u{1f7aa}\u5370\u3993\ub1b8\u2503\u{1f808}',
+  baseMipLevel: 1,
+  baseArrayLayer: 186,
+  arrayLayerCount: 158,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u01d3\ubcaf\u83ce\u0b94\u2213\ud130\u0efc\u{1f784}',
+  colorFormats: ['rg16float', 'rg11b10ufloat', 'rgba16float', 'rg11b10ufloat', 'r8uint', 'r8sint'],
+});
+try {
+renderBundleEncoder8.setBindGroup(6, bindGroup3, new Uint32Array(4990), 2744, 0);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder22.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 120, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 109 widthInBlocks: 109 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 15794 */
+  offset: 15794,
+  buffer: buffer2,
+}, {width: 109, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 134},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(64)), /* required buffer size: 8_244_918 */
+{offset: 142, bytesPerRow: 1224, rowsPerImage: 15}, {width: 71, height: 1, depthOrArrayLayers: 450});
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline9);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 12},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer0), /* required buffer size: 6_253_673 */
+{offset: 431, bytesPerRow: 236, rowsPerImage: 207}, {width: 186, height: 1, depthOrArrayLayers: 129});
+} catch {}
+try {
+window.someLabel = externalTexture10.label;
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({label: '\u0289\u00a6\u{1f8c4}\u74ec\u00ca\u2eea\u0592\u0270\uabbe\u7aa2\u03c2'});
+let textureView33 = texture17.createView({label: '\u{1fb2f}\ub621\u08e1\ue04d\ub045', aspect: 'all', baseMipLevel: 3, mipLevelCount: 4});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  label: '\u{1ff96}\u079c\u{1fbfe}',
+  entries: [
+    {binding: 5361, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 6937, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+  ],
+});
+let pipelineLayout3 = device0.createPipelineLayout({
+  label: '\u08f8\ud681\u03d0\u3e4b\u0417\u5620',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout3, bindGroupLayout4, bindGroupLayout2],
+});
+let commandEncoder31 = device0.createCommandEncoder({label: '\u45ca\uf257\uac60\u0f3c\u7b7c'});
+let texture22 = device0.createTexture({
+  label: '\u3019\u{1f929}\u{1f8ea}\ub955\u629e\u{1fd8a}\u389e',
+  size: [404],
+  dimension: '1d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg11b10ufloat', 'rg11b10ufloat', 'rg11b10ufloat'],
+});
+try {
+renderBundleEncoder7.insertDebugMarker('\u3ae5');
+} catch {}
+gc();
+let bindGroup6 = device0.createBindGroup({label: '\u0d6c\u{1f90a}\u0988\u{1fa52}', layout: bindGroupLayout2, entries: []});
+let texture23 = device0.createTexture({
+  label: '\u559e\u3003\u59b8\ucc33\u07e7\u0f4d',
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+let computePassEncoder12 = commandEncoder8.beginComputePass();
+try {
+commandEncoder22.copyBufferToBuffer(buffer5, 21824, buffer6, 189752, 1048);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder4.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 144 widthInBlocks: 144 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 9378 */
+  offset: 9234,
+  bytesPerRow: 256,
+  buffer: buffer2,
+}, {width: 144, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder29.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 2,
+  origin: {x: 12, y: 3, z: 186},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.submit([commandBuffer3, commandBuffer4, commandBuffer6, commandBuffer1]);
+} catch {}
+let buffer9 = device0.createBuffer({
+  label: '\u2316\u9432\u{1fb84}\u0dbd\ud2db\ue99f\ubfbd',
+  size: 124599,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let textureView34 = texture18.createView({dimension: '2d', baseArrayLayer: 664});
+let sampler14 = device0.createSampler({
+  label: '\u6fc9\ueca4\u2130\u{1ff73}\ubb57\u9fb1\u{1fa4b}\u4c8e',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.278,
+  lodMaxClamp: 46.62,
+  maxAnisotropy: 3,
+});
+let externalTexture16 = device0.importExternalTexture({
+  label: '\u5eeb\u4cf2\u{1f73f}\u4d9a\u3c85\u6387\uc516\uc9d0\u{1f7fc}',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 20980 */
+  offset: 20980,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {
+  texture: texture17,
+  mipLevel: 4,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let texture24 = device0.createTexture({
+  label: '\u{1fdc3}\u0c2b\uec9e\u7910\u0858\udb6e\uea1c\u0ca5\u84bb',
+  size: [768],
+  dimension: '1d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg11b10ufloat', 'rg11b10ufloat'],
+});
+let computePassEncoder13 = commandEncoder30.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(9, buffer3, 0);
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(querySet1, 819, 836, buffer5, 15104);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 97, y: 46 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  label: '\u0e40\u{1f710}\u41f5\u7155\u06ab\u0e0a',
+  code: `@group(4) @binding(3739)
+var<storage, read_write> n2: array<u32>;
+@group(2) @binding(3739)
+var<storage, read_write> type3: array<u32>;
+@group(2) @binding(513)
+var<storage, read_write> local6: array<u32>;
+@group(1) @binding(513)
+var<storage, read_write> local7: array<u32>;
+@group(5) @binding(513)
+var<storage, read_write> n3: array<u32>;
+@group(4) @binding(513)
+var<storage, read_write> field2: array<u32>;
+@group(5) @binding(3739)
+var<storage, read_write> n4: array<u32>;
+@group(0) @binding(3739)
+var<storage, read_write> type4: array<u32>;
+@group(1) @binding(3739)
+var<storage, read_write> n5: array<u32>;
+
+@compute @workgroup_size(6, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(2) f1: vec4<f32>,
+  @location(0) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(15) f0: vec2<u32>,
+  @location(4) f1: vec4<u32>,
+  @location(13) f2: vec4<i32>,
+  @location(18) f3: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec3<f32>, @location(11) a1: i32, @location(16) a2: f16, @location(23) a3: i32, @location(8) a4: vec4<i32>, a5: S8, @location(1) a6: i32, @location(3) a7: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer10 = device0.createBuffer({
+  label: '\u017f\u095f\u7f55\u75bb\u0be2\u{1f9a0}\ue675\u0cd3\u0b65',
+  size: 628047,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let querySet12 = device0.createQuerySet({
+  label: '\u4781\u{1fb4c}\u{1ffbf}\u08f5\u79b8\u52d2\u70da\u8143\ue4a3\u09b4\u65ec',
+  type: 'occlusion',
+  count: 117,
+});
+let texture25 = device0.createTexture({
+  label: '\ueb4d\u5cde\u5e1a\u0c08\u{1f799}\u070f\u0aec',
+  size: {width: 809},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+let externalTexture17 = device0.importExternalTexture({label: '\u{1fd57}\u09a6\u{1fc79}', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder5.setPipeline(pipeline3);
+} catch {}
+let promise7 = buffer9.mapAsync(GPUMapMode.READ, 121040, 3424);
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 1876, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 821,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 4189,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 79516314, hasDynamicOffset: false },
+    },
+  ],
+});
+let texture26 = device0.createTexture({
+  size: [1619, 1, 1],
+  mipLevelCount: 8,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler15 = device0.createSampler({
+  label: '\u80cc\u1bce\u808d\u0e10\u3e0b\u61f2\ucf47\u0428',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 9.379,
+});
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup4, new Uint32Array(6338), 5866, 0);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 1344 widthInBlocks: 336 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 27552 */
+  offset: 27552,
+  buffer: buffer7,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 336, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 62, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 548, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 185},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 12_662_088 */
+{offset: 648, bytesPerRow: 352, rowsPerImage: 218}, {width: 124, height: 0, depthOrArrayLayers: 166});
+} catch {}
+document.body.prepend(canvas1);
+let textureView35 = texture1.createView({
+  label: '\u0680\u9a68\ubfb6\u0fce\ufff6\u69fd\u9d5a\u8191',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let renderBundle19 = renderBundleEncoder2.finish({label: '\uf7f1\u0eb9'});
+try {
+computePassEncoder7.setBindGroup(5, bindGroup3, new Uint32Array(7995), 4610, 0);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(6, buffer3, 0, 48460);
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer9, 110300, 7228);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet3, 456, 1514, buffer5, 10496);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+  label: '\u1a49\u{1f9ca}\u69bf\u{1fc2b}\u{1fa88}\ue485',
+  layout: bindGroupLayout3,
+  entries: [{binding: 1293, resource: sampler13}],
+});
+try {
+computePassEncoder7.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer2, 94828, 4752);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 32 */
+{offset: 32}, {width: 16, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline14 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint'}, {format: 'rgba32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8unorm'}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2488,
+        attributes: [
+          {format: 'unorm16x2', offset: 272, shaderLocation: 15},
+          {format: 'float32x3', offset: 744, shaderLocation: 14},
+          {format: 'uint16x2', offset: 0, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 48, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 1108, shaderLocation: 7},
+          {format: 'uint8x4', offset: 88, shaderLocation: 9},
+          {format: 'uint32x2', offset: 160, shaderLocation: 18},
+          {format: 'snorm8x2', offset: 1268, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 948, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 704, shaderLocation: 13},
+          {format: 'sint32x2', offset: 296, shaderLocation: 21},
+          {format: 'sint16x2', offset: 72, shaderLocation: 8},
+          {format: 'uint32', offset: 168, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 228,
+        attributes: [
+          {format: 'uint32x4', offset: 52, shaderLocation: 20},
+          {format: 'uint32x3', offset: 20, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 2932,
+        attributes: [
+          {format: 'uint8x4', offset: 1024, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 36, shaderLocation: 23},
+        ],
+      },
+      {arrayStride: 2356, stepMode: 'instance', attributes: []},
+      {arrayStride: 136, attributes: [{format: 'unorm8x4', offset: 0, shaderLocation: 6}]},
+      {
+        arrayStride: 404,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 18, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 52, shaderLocation: 19},
+          {format: 'unorm16x2', offset: 72, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 76, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back', unclippedDepth: true},
+});
+let offscreenCanvas1 = new OffscreenCanvas(677, 842);
+let bindGroup8 = device0.createBindGroup({layout: bindGroupLayout2, entries: []});
+let commandEncoder32 = device0.createCommandEncoder({label: '\u4b3e\u031b\u70b4\u099a\u7cc6\u9bae\ub046\u0c3b\u5a9f\u14dc\u0b2c'});
+let computePassEncoder14 = commandEncoder24.beginComputePass({});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u9c11\u{1f8be}',
+  colorFormats: ['rgba32sint', 'rgba32uint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(4, bindGroup6, new Uint32Array(7922), 2972, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer3, 7708, 36460);
+} catch {}
+try {
+commandEncoder10.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 146 widthInBlocks: 146 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 29979 */
+  offset: 29979,
+  buffer: buffer2,
+}, {width: 146, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 384, height: 8, depthOrArrayLayers: 165}
+*/
+{
+  source: imageData4,
+  origin: { x: 7, y: 3 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 49, y: 2, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let texture27 = device0.createTexture({
+  label: '\u{1f6ee}\u{1f9d6}',
+  size: {width: 432, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'astc-12x12-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView36 = texture2.createView({
+  label: '\u6a64\u{1f8fe}\ufd18\u{1f778}\ubea0\u03bf\u{1fcb8}\u1618',
+  mipLevelCount: 3,
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder6.setBindGroup(5, bindGroup0, new Uint32Array(8228), 3592, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(8, buffer3, 43372);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer10, 624120, buffer2, 76384, 2424);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 208 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 8288 */
+  offset: 8080,
+  bytesPerRow: 256,
+  buffer: buffer2,
+}, {width: 156, height: 12, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet6, 2804, 512, buffer5, 10240);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let img4 = await imageWithData(39, 13, '#3554c54f', '#1973a8e3');
+let commandEncoder33 = device0.createCommandEncoder({});
+let textureView37 = texture3.createView({
+  label: '\u{1f9a1}\u{1fd82}',
+  format: 'rgba32uint',
+  baseMipLevel: 1,
+  mipLevelCount: 4,
+  baseArrayLayer: 395,
+  arrayLayerCount: 46,
+});
+let computePassEncoder15 = commandEncoder17.beginComputePass({});
+let sampler16 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.37,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(811, 174);
+let pipelineLayout4 = device0.createPipelineLayout({
+  label: '\u{1fa97}\uaf64\u{1ffea}\uc12d\u{1f876}\uaf2f',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout1, bindGroupLayout3, bindGroupLayout2],
+});
+let buffer11 = device0.createBuffer({
+  label: '\u{1f86d}\u{1fcd9}\ufdea\ubdd2\u0039\u06e8\u0937',
+  size: 285300,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let sampler17 = device0.createSampler({
+  label: '\u2ffc\u{1fb6a}\u0cb9\u2d02\u00a5\uc259\u89d2\u1276\u216c',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 90.77,
+  lodMaxClamp: 91.53,
+});
+try {
+computePassEncoder12.setBindGroup(5, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(4, bindGroup2);
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(buffer7, 58132, buffer9, 90968, 17304);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder33.clearBuffer(buffer11);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let pipeline15 = await promise2;
+let canvas3 = document.createElement('canvas');
+let imageData5 = new ImageData(32, 120);
+let shaderModule8 = device0.createShaderModule({
+  label: '\ue6b6\u0dde\ud569\u04f6\ud630\u{1fb77}\u{1fc90}\u3685',
+  code: `@group(1) @binding(1293)
+var<storage, read_write> local8: array<u32>;
+
+@compute @workgroup_size(3, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(0) f1: vec4<i32>,
+  @location(2) f2: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @location(10) f0: f32,
+  @location(19) f1: vec4<f16>,
+  @location(14) f2: f16,
+  @location(2) f3: vec3<i32>,
+  @location(20) f4: u32,
+  @location(0) f5: vec2<u32>,
+  @location(4) f6: vec2<u32>,
+  @location(13) f7: vec4<f16>,
+  @location(22) f8: u32,
+  @location(11) f9: vec4<f32>,
+  @location(8) f10: vec3<f16>,
+  @location(23) f11: vec3<f16>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(3) a1: f32, @location(18) a2: vec3<f32>, @builtin(vertex_index) a3: u32, @location(5) a4: f32, @location(7) a5: vec4<i32>, @location(12) a6: vec4<f16>, @location(17) a7: vec4<u32>, @location(9) a8: f32, a9: S9, @location(21) a10: vec2<f16>, @location(6) a11: vec2<u32>, @location(1) a12: u32, @location(16) a13: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture28 = device0.createTexture({
+  label: '\uc400\u04a3\u0bd7\u{1f6c3}\u9f8c',
+  size: [384],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+});
+let textureView38 = texture0.createView({
+  label: '\u{1ffc5}\u105d\u47a9\u4860\ubbc3\ud7fa\u3368\uc91b\u3b43\u053e',
+  baseMipLevel: 0,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint', 'rgba32uint', 'r8unorm'], sampleCount: 1});
+try {
+commandEncoder4.clearBuffer(buffer9, 35840, 30808);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0, commandBuffer2]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet13 = device0.createQuerySet({label: '\ud0b2\u{1fef8}\uc463\ud374\u9cf7', type: 'occlusion', count: 1567});
+let commandBuffer7 = commandEncoder32.finish({label: '\u{1ff1a}\u6a26\u0583\uce8b\u053a\u{1fe05}'});
+let texture29 = device0.createTexture({
+  label: '\u7886\u{1fa6d}\u04be\u0c02\u{1fb0e}\ue3bd\u{1fcde}\u08c8\u2877\ua77a\u02bd',
+  size: {width: 1619, height: 1, depthOrArrayLayers: 421},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+let textureView39 = texture13.createView({label: '\u7d61\u{1f97f}', baseMipLevel: 6, mipLevelCount: 2, baseArrayLayer: 0});
+try {
+computePassEncoder12.setBindGroup(6, bindGroup0);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(6, bindGroup0, new Uint32Array(7583), 7293, 0);
+} catch {}
+try {
+commandEncoder33.resolveQuerySet(querySet5, 1640, 704, buffer5, 15104);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 109},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer0), /* required buffer size: 7_399_876 */
+{offset: 517, bytesPerRow: 2411, rowsPerImage: 33}, {width: 143, height: 0, depthOrArrayLayers: 94});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 404, height: 1, depthOrArrayLayers: 546}
+*/
+{
+  source: imageData1,
+  origin: { x: 18, y: 9 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 47},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 75, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let offscreenCanvas3 = new OffscreenCanvas(936, 80);
+let commandEncoder34 = device0.createCommandEncoder({label: '\u0547\ue18b\u{1fc16}\u4288\ud37e\u0809\u{1f99e}\uc4a1\ucbf0\u{1fb3b}'});
+let querySet14 = device0.createQuerySet({label: '\ue9b1\uf977', type: 'occlusion', count: 3517});
+try {
+commandEncoder22.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 94, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 203 widthInBlocks: 203 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 67246 */
+  offset: 67246,
+  buffer: buffer2,
+}, {width: 203, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\ua06e\ua93f\u5f00\u01a4\u41f9\u03bb\udae9\ua8db\u0b1e',
+  colorFormats: ['rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle20 = renderBundleEncoder4.finish({label: '\u{1f729}\u720a\uf56b\u{1f822}\ue27d\u{1f997}\u21b5\ub19d\u89b5\u{1fd72}'});
+try {
+renderBundleEncoder10.setBindGroup(6, bindGroup1, new Uint32Array(8087), 1805, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(0, buffer3, 54776, 8287);
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer11);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let pipeline16 = await device0.createRenderPipelineAsync({
+  label: '\uaf5b\u9f2b\u414c\u{1face}\u{1f62b}',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater', failOp: 'invert', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 805145645,
+    stencilWriteMask: 3792208552,
+    depthBias: -258105211,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3580, attributes: [{format: 'uint16x2', offset: 1212, shaderLocation: 1}]},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 1492, attributes: [{format: 'unorm10-10-10-2', offset: 52, shaderLocation: 4}]},
+      {arrayStride: 11996, stepMode: 'instance', attributes: []},
+      {arrayStride: 6684, attributes: []},
+      {
+        arrayStride: 456,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm8x4', offset: 40, shaderLocation: 8}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+let canvas4 = document.createElement('canvas');
+let imageBitmap4 = await createImageBitmap(video0);
+let bindGroup9 = device0.createBindGroup({label: '\u420d\u0783', layout: bindGroupLayout2, entries: []});
+let textureView40 = texture28.createView({label: '\ud78e\u2574\u{1fc66}\u8947\u1382\ufac0\u3bbc\u0f9f\u4c3c'});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\uda2d\uc142\u04f3\u6d3d\u0405',
+  colorFormats: ['rg16float', 'rg11b10ufloat', 'rgba16float', 'rg11b10ufloat', 'r8uint', 'r8sint'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder11.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(0, buffer3, 0, 12968);
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer6, 221020, 2628);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+let video2 = await videoWithData();
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder22.resolveQuerySet(querySet7, 3047, 297, buffer5, 13568);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 7124, new BigUint64Array(64919), 38268);
+} catch {}
+let pipeline17 = await device0.createComputePipelineAsync({
+  label: '\u5f75\u{1fb6c}\u{1fb82}\u{1fdc4}\ua2fb',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder35 = device0.createCommandEncoder({label: '\u39a4\u31e1\ua380\u40ed\u3ab8\u05aa\u3b1b'});
+let texture30 = device0.createTexture({
+  label: '\u3e40\uee8d\ue1ea\u0776\u{1ff0c}\u9d51',
+  size: {width: 1619, height: 1, depthOrArrayLayers: 1592},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float'],
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\u0182\u8fcb\u0d50\u57c1\u7fff\u{1fe56}\u0f65\u{1f8d1}\u2ebd',
+  colorFormats: ['rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture18 = device0.importExternalTexture({label: '\uf204\u5631\u{1f8c4}\u0aef\u0d34\u0abd\u02dd\u02a0', source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder8.setBindGroup(6, bindGroup7, new Uint32Array(7564), 5302, 0);
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 15 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 32348 */
+  offset: 32348,
+  buffer: buffer7,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 71, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(24)), /* required buffer size: 788_191 */
+{offset: 607, bytesPerRow: 293, rowsPerImage: 128}, {width: 184, height: 0, depthOrArrayLayers: 22});
+} catch {}
+let pipeline18 = device0.createComputePipeline({
+  label: '\u0c7f\u{1fad9}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(canvas3);
+try {
+canvas4.getContext('webgl');
+} catch {}
+let bindGroup10 = device0.createBindGroup({layout: bindGroupLayout2, entries: []});
+let commandEncoder36 = device0.createCommandEncoder({});
+let computePassEncoder16 = commandEncoder33.beginComputePass({label: '\u2797\u1e7b\u{1fd7a}\ud3be\u0ff1\u49a7\u{1fd72}\u9558\u{1fd3d}'});
+let externalTexture19 = device0.importExternalTexture({label: '\u1407\u0196\u0dee\u325e', source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer5, 1288, buffer11, 235108, 1816);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer6, 220688, 3912);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 78988, new DataView(new ArrayBuffer(59887)), 47972, 2980);
+} catch {}
+try {
+canvas3.getContext('webgl');
+} catch {}
+let querySet15 = device0.createQuerySet({label: '\u0c74\u8604\u{1f9a9}\u0f31\ua8cf\u0f83\u0e90', type: 'occlusion', count: 410});
+let textureView41 = texture30.createView({baseMipLevel: 2, mipLevelCount: 1, arrayLayerCount: 1});
+let sampler18 = device0.createSampler({
+  label: '\u3370\ueccd\u{1fe58}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 90.22,
+  lodMaxClamp: 93.36,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder12.setBindGroup(4, bindGroup9);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 758, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer6, 197116, 21904);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(querySet0, 193, 1063, buffer5, 3840);
+} catch {}
+try {
+commandEncoder0.pushDebugGroup('\u{1febe}');
+} catch {}
+let pipeline19 = device0.createComputePipeline({
+  label: '\u{1fb6c}\u8f17\u47d6\u0fd3\u93ae\u057f\u058c\u{1fe4a}\u3222\u5f17\ud186',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let pipeline20 = device0.createRenderPipeline({
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r8sint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {
+      compare: 'greater',
+      failOp: 'increment-wrap',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'increment-clamp',
+    },
+    stencilBack: {compare: 'equal', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 1245949064,
+    stencilWriteMask: 1871666552,
+    depthBiasSlopeScale: 453.2970570964999,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2540,
+        attributes: [
+          {format: 'snorm16x2', offset: 184, shaderLocation: 16},
+          {format: 'uint32x3', offset: 56, shaderLocation: 1},
+          {format: 'uint32x3', offset: 20, shaderLocation: 19},
+          {format: 'float32', offset: 172, shaderLocation: 20},
+          {format: 'uint8x4', offset: 80, shaderLocation: 22},
+          {format: 'float32x3', offset: 52, shaderLocation: 2},
+          {format: 'uint16x4', offset: 664, shaderLocation: 17},
+          {format: 'uint32x4', offset: 1280, shaderLocation: 12},
+          {format: 'sint32x3', offset: 256, shaderLocation: 0},
+          {format: 'sint8x4', offset: 1096, shaderLocation: 4},
+          {format: 'float16x2', offset: 452, shaderLocation: 9},
+          {format: 'uint8x4', offset: 416, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 1260,
+        attributes: [
+          {format: 'float32x3', offset: 80, shaderLocation: 8},
+          {format: 'float32', offset: 116, shaderLocation: 21},
+          {format: 'float32x2', offset: 12, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 56, shaderLocation: 15},
+          {format: 'uint16x4', offset: 576, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 244, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 1024, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1104,
+        attributes: [
+          {format: 'sint16x2', offset: 8, shaderLocation: 5},
+          {format: 'uint8x2', offset: 8, shaderLocation: 7},
+          {format: 'uint32x3', offset: 60, shaderLocation: 6},
+          {format: 'uint32x4', offset: 264, shaderLocation: 10},
+          {format: 'sint8x4', offset: 100, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 384,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 48, shaderLocation: 23}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let shaderModule9 = device0.createShaderModule({
+  code: `@group(1) @binding(1293)
+var<storage, read_write> parameter1: array<u32>;
+@group(2) @binding(6937)
+var<storage, read_write> type5: array<u32>;
+@group(0) @binding(5361)
+var<storage, read_write> field3: array<u32>;
+
+@compute @workgroup_size(5, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+  @location(40) f0: vec2<i32>,
+  @location(1) f1: vec4<f32>,
+  @builtin(sample_index) f2: u32,
+  @location(31) f3: vec4<f32>,
+  @location(33) f4: vec3<i32>,
+  @location(5) f5: i32,
+  @location(12) f6: vec2<f32>,
+  @location(20) f7: vec3<u32>,
+  @location(16) f8: u32,
+  @location(30) f9: vec3<i32>,
+  @location(23) f10: vec3<u32>
+}
+struct FragmentOutput0 {
+  @location(7) f0: i32,
+  @location(1) f1: vec4<u32>,
+  @location(0) f2: vec4<i32>,
+  @location(2) f3: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(27) a0: u32, @location(19) a1: u32, @location(39) a2: vec4<f32>, @location(17) a3: vec4<f32>, @location(9) a4: vec4<f16>, a5: S10, @location(43) a6: vec3<i32>, @location(38) a7: vec3<u32>, @location(6) a8: vec3<f16>, @location(14) a9: f16, @builtin(position) a10: vec4<f32>, @builtin(front_facing) a11: bool, @location(2) a12: f16, @builtin(sample_mask) a13: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(40) f34: vec2<i32>,
+  @location(2) f35: f16,
+  @location(9) f36: vec4<f16>,
+  @location(43) f37: vec3<i32>,
+  @location(20) f38: vec3<u32>,
+  @location(1) f39: vec4<f32>,
+  @location(19) f40: u32,
+  @location(6) f41: vec3<f16>,
+  @builtin(position) f42: vec4<f32>,
+  @location(27) f43: u32,
+  @location(14) f44: f16,
+  @location(12) f45: vec2<f32>,
+  @location(17) f46: vec4<f32>,
+  @location(16) f47: u32,
+  @location(33) f48: vec3<i32>,
+  @location(38) f49: vec3<u32>,
+  @location(39) f50: vec4<f32>,
+  @location(31) f51: vec4<f32>,
+  @location(30) f52: vec3<i32>,
+  @location(23) f53: vec3<u32>,
+  @location(5) f54: i32
+}
+
+@vertex
+fn vertex0(@location(23) a0: i32, @location(15) a1: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let computePassEncoder17 = commandEncoder10.beginComputePass({label: '\u792f\uc3a7\u6976'});
+let sampler19 = device0.createSampler({
+  label: '\uc8f8\u8c76\u0b0f\u0650\u030e',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 4.874,
+  lodMaxClamp: 65.70,
+  maxAnisotropy: 9,
+});
+try {
+commandEncoder27.clearBuffer(buffer9, 40848, 48352);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(querySet3, 1052, 1499, buffer5, 3328);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 7768, new DataView(new ArrayBuffer(55724)));
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup11 = device0.createBindGroup({label: '\u0506\u{1f63b}\u0111', layout: bindGroupLayout2, entries: []});
+let commandEncoder37 = device0.createCommandEncoder({label: '\u2304\u068d'});
+let texture31 = device0.createTexture({
+  label: '\u0fe3\u8e7e\ud971\u{1fb94}\u{1f6f6}\u07cc',
+  size: {width: 384, height: 8, depthOrArrayLayers: 253},
+  dimension: '3d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler20 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 0.2218,
+  lodMaxClamp: 98.70,
+});
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 52092, new BigUint64Array(32703), 20913);
+} catch {}
+let pipeline21 = await device0.createComputePipelineAsync({
+  label: '\u489b\u01c8\u{1fd93}\uf376\u{1f676}\u2d55\u{1f640}\u{1fe9a}\u6b0f\u{1f646}\u{1f8af}',
+  layout: 'auto',
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let promise8 = device0.createRenderPipelineAsync({
+  label: '\uf0c7\u1036',
+  layout: 'auto',
+  multisample: {mask: 0x228b4628},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint'}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8unorm', writeMask: GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5504,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint16x2', offset: 492, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 2072, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 1868, attributes: [{format: 'snorm16x2', offset: 76, shaderLocation: 4}]},
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let commandEncoder38 = device0.createCommandEncoder({label: '\u{1fecd}\ud6e5\u7ff3\uf98b\u0f0b'});
+let computePassEncoder18 = commandEncoder37.beginComputePass({label: '\u023f\u7675\u{1f88f}\u36a6\u{1f8de}\u0a2c\u00bd'});
+try {
+renderBundleEncoder12.setIndexBuffer(buffer3, 'uint16');
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 150 widthInBlocks: 150 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 12141 */
+  offset: 12141,
+  buffer: buffer10,
+}, {
+  texture: texture26,
+  mipLevel: 2,
+  origin: {x: 105, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 150, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder31.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 721 widthInBlocks: 721 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3179 */
+  offset: 3179,
+  buffer: buffer11,
+}, {width: 721, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer11);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet15, 379, 20, buffer5, 17152);
+} catch {}
+let promise9 = device0.createComputePipelineAsync({
+  label: '\u01e7\u951d\u7fe6\u8321\u{1fc7c}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule5, entryPoint: 'compute0'},
+});
+let textureView42 = texture3.createView({
+  label: '\u7b9d\u3871\uf9a6\u21d8\ua5f8\u8932\u4f68\uc4be\u0326\u2c39\u6410',
+  dimension: '2d',
+  baseMipLevel: 1,
+  baseArrayLayer: 779,
+});
+let renderBundle21 = renderBundleEncoder10.finish({label: '\u10f6\ueec8\u{1f8d4}\u308e'});
+try {
+renderBundleEncoder9.setVertexBuffer(8, buffer3);
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 21320 */
+  offset: 21320,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 126, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 202, height: 1, depthOrArrayLayers: 546}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 8, y: 24 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 17, y: 0, z: 25},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture32 = device0.createTexture({
+  label: '\u052a\u9a92\u848c',
+  size: {width: 1619},
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+let renderBundle22 = renderBundleEncoder12.finish({label: '\u{1ff49}\u0049\u45de\u638d'});
+try {
+commandEncoder22.copyBufferToTexture({
+  /* bytesInLastRow: 156 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 22064 */
+  offset: 22064,
+  rowsPerImage: 136,
+  buffer: buffer7,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 39, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let pipeline22 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout4,
+  multisample: {mask: 0xdde1608f},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgba32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8unorm'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {passOp: 'invert'},
+    stencilBack: {failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'replace'},
+    stencilReadMask: 181169915,
+    stencilWriteMask: 2291214811,
+    depthBiasSlopeScale: 645.5039557985906,
+    depthBiasClamp: 464.4467953100176,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1328, attributes: [{format: 'uint32x2', offset: 588, shaderLocation: 15}]},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 28,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 0, shaderLocation: 23}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let gpuCanvasContext2 = offscreenCanvas3.getContext('webgpu');
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\u005e\ub6c9\u{1fe55}\u4752',
+  entries: [
+    {
+      binding: 6253,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 37988531, hasDynamicOffset: false },
+    },
+    {
+      binding: 1006,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let bindGroup12 = device0.createBindGroup({
+  label: '\u0b1f\uab1c\ued89\u05d9\u012e\ufbb0\u2b23\u04e9\ue76c',
+  layout: bindGroupLayout2,
+  entries: [],
+});
+let commandEncoder39 = device0.createCommandEncoder({label: '\u6647\u0d85'});
+let textureView43 = texture29.createView({
+  label: '\u{1fe61}\uaf04\uf7e6\u3753\u0738\u{1fda7}',
+  baseMipLevel: 1,
+  baseArrayLayer: 231,
+  arrayLayerCount: 115,
+});
+let renderBundle23 = renderBundleEncoder10.finish({label: '\ud7ea\u8930\u3377\ub4de\ue192\u{1ff30}'});
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer3, 'uint32', 9708, 610);
+} catch {}
+let promise11 = buffer11.mapAsync(GPUMapMode.READ);
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 664, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer11);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise12 = device0.createComputePipelineAsync({
+  label: '\u65d7\uc5e1\u0c6b\u0dba\u0710\u4994\u35cb\u{1fe3c}',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let buffer12 = device0.createBuffer({
+  label: '\uf23d\u6669\ucc4e\ue568\u5127\u0c4a',
+  size: 3310,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let computePassEncoder19 = commandEncoder23.beginComputePass({label: '\u6417\ud7d2\u028d\u1ff9\u9fbe\u656f\ub382\u9820\u{1ff79}\u081a'});
+let renderBundle24 = renderBundleEncoder9.finish({label: '\u25c1\u4604\ufcea\u0d8b'});
+let sampler21 = device0.createSampler({
+  label: '\u0ee1\u0940\u0b70\u6306\u2dfc\ub124\u{1fabb}',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.83,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder17.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(10, buffer3, 46380, 15639);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 9 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2334 */
+  offset: 2334,
+  buffer: buffer10,
+}, {
+  texture: texture2,
+  mipLevel: 4,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+offscreenCanvas2.getContext('2d');
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({label: '\u712c\u{1f60d}\u3141\ud81f\u9622\uc319'});
+let texture33 = device0.createTexture({
+  label: '\uadd8\u1e8a\u0ce5\u50f3\u{1fc87}\ue89e\u7458\u{1f9a2}\u08a4\u005d',
+  size: {width: 384, height: 8, depthOrArrayLayers: 1218},
+  mipLevelCount: 5,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba32sint'],
+});
+let textureView44 = texture22.createView({label: '\u0368\uebec\ud726\u8eda\u{1f9df}\uf9c9\u5bcb\u074e', format: 'rg11b10ufloat'});
+let renderBundle25 = renderBundleEncoder14.finish({label: '\u12b1\uf66c\u8643\u6734\u{1f7cd}\u70b9\uea19'});
+try {
+commandEncoder40.resolveQuerySet(querySet4, 259, 4, buffer5, 6400);
+} catch {}
+let pipeline23 = device0.createComputePipeline({
+  label: '\u0a9d\u6de2\u723e\u{1f62f}\uca38\uf290\u{1fa58}\ud574',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let querySet16 = device0.createQuerySet({label: '\uffa6\u{1f73c}\u{1fc4d}\u{1f9a6}\ubd5a\uaaf1\u0e91', type: 'occlusion', count: 2776});
+let textureView45 = texture22.createView({});
+let renderBundle26 = renderBundleEncoder7.finish();
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 17 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 18098 */
+  offset: 18098,
+  buffer: buffer7,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 17, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer7);
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  label: '\u{1f815}\ucb0c\u7732\u552d\u23ef\u096b\u0cb3\u9500',
+  code: `@group(5) @binding(513)
+var<storage, read_write> global1: array<u32>;
+@group(1) @binding(513)
+var<storage, read_write> field4: array<u32>;
+@group(0) @binding(513)
+var<storage, read_write> field5: array<u32>;
+@group(0) @binding(3739)
+var<storage, read_write> global2: array<u32>;
+@group(1) @binding(3739)
+var<storage, read_write> function6: array<u32>;
+@group(5) @binding(3739)
+var<storage, read_write> global3: array<u32>;
+@group(3) @binding(1293)
+var<storage, read_write> function7: array<u32>;
+@group(4) @binding(513)
+var<storage, read_write> type6: array<u32>;
+@group(2) @binding(513)
+var<storage, read_write> type7: array<u32>;
+
+@compute @workgroup_size(4, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(3) f1: vec4<f32>,
+  @location(0) f2: vec3<f32>,
+  @location(1) f3: vec4<f32>,
+  @location(4) f4: vec2<u32>,
+  @location(5) f5: vec2<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @location(11) f0: i32,
+  @location(16) f1: u32,
+  @location(10) f2: u32
+}
+
+@vertex
+fn vertex0(@location(20) a0: vec4<f16>, @location(22) a1: vec2<f32>, @builtin(vertex_index) a2: u32, a3: S11, @location(6) a4: vec4<i32>, @location(2) a5: vec2<f16>, @location(4) a6: f32, @location(12) a7: vec4<f32>, @location(9) a8: vec2<i32>, @location(8) a9: vec4<i32>, @location(15) a10: vec2<f16>, @location(14) a11: i32, @location(18) a12: vec3<i32>, @location(7) a13: f16, @builtin(instance_index) a14: u32, @location(1) a15: f32, @location(5) a16: vec2<f16>, @location(19) a17: u32, @location(21) a18: vec2<i32>, @location(0) a19: vec3<f32>, @location(23) a20: vec4<f16>, @location(17) a21: f32, @location(3) a22: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let buffer13 = device0.createBuffer({
+  label: '\u{1f7f5}\u896c',
+  size: 317498,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture34 = device0.createTexture({
+  label: '\u03d8\uf23a\u102f\udff8\ud6fd',
+  size: [809, 1, 218],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView46 = texture6.createView({label: '\u072f\u3a18', dimension: '2d', baseMipLevel: 4, baseArrayLayer: 527, arrayLayerCount: 1});
+try {
+computePassEncoder13.setBindGroup(4, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(4, bindGroup2, new Uint32Array(6844), 2432, 0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder0.resolveQuerySet(querySet14, 1338, 1597, buffer5, 256);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(48)), /* required buffer size: 293 */
+{offset: 293, rowsPerImage: 286}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 404, height: 1, depthOrArrayLayers: 546}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 68, y: 0 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 201},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline24 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}}});
+let pipeline25 = await promise8;
+gc();
+let commandEncoder41 = device0.createCommandEncoder({label: '\u0950\ueaba\u{1f990}\u0853\u4344\u95da'});
+let textureView47 = texture34.createView({label: '\u06b6\u0572\ue0ea', baseMipLevel: 1, mipLevelCount: 6});
+let sampler22 = device0.createSampler({
+  label: '\u0305\u{1fc38}\ue95e\u0884\uc424\u0a86\uf99b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 61.02,
+  lodMaxClamp: 73.37,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder19.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(0, bindGroup9, new Uint32Array(8841), 1857, 0);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder29.resolveQuerySet(querySet14, 1821, 1684, buffer5, 8448);
+} catch {}
+try {
+externalTexture12.label = '\u{1f96f}\u0e37\u04a9\u0728\u3def\u11a2\u7fdf\u9cf0\u08ad\u0ddd';
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+  label: '\ucd73\uf550\u{1fd08}\ue7fa\u1631\u9c08\u0a9b\u04b9\u5172',
+  code: `@group(0) @binding(5361)
+var<storage, read_write> parameter2: array<u32>;
+@group(0) @binding(6937)
+var<storage, read_write> function8: array<u32>;
+@group(1) @binding(1293)
+var<storage, read_write> local9: array<u32>;
+@group(2) @binding(6937)
+var<storage, read_write> global4: array<u32>;
+@group(2) @binding(5361)
+var<storage, read_write> field6: array<u32>;
+
+@compute @workgroup_size(4, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<f32>,
+  @location(4) f1: vec4<u32>,
+  @location(5) f2: vec3<i32>,
+  @location(0) f3: vec4<f32>,
+  @location(2) f4: vec4<f32>,
+  @location(3) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(27) a0: vec2<f32>, @location(36) a1: vec3<u32>, @location(2) a2: vec3<u32>, @location(19) a3: vec3<i32>, @location(1) a4: vec4<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f55: vec4<f32>,
+  @location(6) f56: vec3<f32>,
+  @location(39) f57: vec2<i32>,
+  @location(17) f58: vec3<f32>,
+  @location(25) f59: u32,
+  @location(33) f60: vec3<u32>,
+  @location(11) f61: vec3<u32>,
+  @location(1) f62: vec4<i32>,
+  @location(0) f63: vec3<f32>,
+  @location(2) f64: vec3<u32>,
+  @location(24) f65: vec3<f16>,
+  @location(27) f66: vec2<f32>,
+  @location(36) f67: vec3<u32>,
+  @location(22) f68: vec4<u32>,
+  @location(38) f69: f32,
+  @location(16) f70: f32,
+  @location(32) f71: f32,
+  @location(29) f72: vec4<u32>,
+  @location(19) f73: vec3<i32>,
+  @location(43) f74: i32,
+  @location(28) f75: vec2<f16>,
+  @location(41) f76: vec2<f32>,
+  @location(14) f77: vec3<f16>,
+  @location(18) f78: vec4<f32>,
+  @location(35) f79: vec2<f32>,
+  @location(26) f80: f32
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let bindGroup13 = device0.createBindGroup({
+  label: '\u0d3e\u01e5\u129a\u47cb\u8dc8',
+  layout: bindGroupLayout4,
+  entries: [{binding: 5361, resource: externalTexture17}, {binding: 6937, resource: sampler14}],
+});
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\u{1ff4a}\uc524\ufac2\u4cd5\u26b5\u0aaf\uc6e3\u8397\u9881',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout0, bindGroupLayout0, bindGroupLayout2],
+});
+let commandEncoder42 = device0.createCommandEncoder({label: '\uaafd\u0834\u0d5a\ue55b\u573c'});
+let texture35 = device0.createTexture({
+  label: '\u3001\u02b6\u03db\ue86f\u{1fdd2}\u0792\ucb83\u1557\u{1f6bc}\u0d2c',
+  size: {width: 768},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+let textureView48 = texture25.createView({label: '\u1802\udef9\u2c81\u0166\ub260\u0351\u5159'});
+let renderBundle27 = renderBundleEncoder9.finish({label: '\u02b3\u5489\uad33\u058a\u0669\u0722\ufe7a\uf8ac\u83ef\u1f6a\u0d32'});
+let externalTexture20 = device0.importExternalTexture({label: '\u7ae8\u{1f931}\u1c0a\u0288\u940a', source: video2, colorSpace: 'display-p3'});
+try {
+commandEncoder29.clearBuffer(buffer9, 50816, 56792);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+  await promise7;
+} catch {}
+try {
+renderBundleEncoder0.label = '\u0eb4\u0d37\u7b65';
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder({label: '\u41e2\uf0d4\u{1fa5d}\u0615\u4d42'});
+let querySet17 = device0.createQuerySet({label: '\uf78e\u5b5c\u0d27\u03f9\u{1f632}\u{1fc44}', type: 'occlusion', count: 864});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], sampleCount: 1, depthReadOnly: true});
+let sampler23 = device0.createSampler({
+  label: '\ued8c\u{1fefe}\u22af\u{1fca0}\u{1f90a}\u959f\u38f4\u0ad2\u0e79',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 45.31,
+  maxAnisotropy: 20,
+});
+let externalTexture21 = device0.importExternalTexture({
+  label: '\u{1f920}\u0e0c\u4a74\uccdf\u{1ff78}\u2a58\u01ff\u0940\u6376\u{1fe6f}\u{1fe62}',
+  source: videoFrame1,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder15.setVertexBuffer(0, buffer13);
+} catch {}
+let promise13 = adapter0.requestAdapterInfo();
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\u3758\ud1c0\u{1f6a8}\u{1f61b}\ucdf8\ud30c\u947b\u643b\u0383',
+  entries: [
+    {
+      binding: 5712,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 32803172, hasDynamicOffset: false },
+    },
+    {
+      binding: 201,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 2418,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer14 = device0.createBuffer({
+  label: '\uba69\u{1fb4e}',
+  size: 328052,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+  mappedAtCreation: true,
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u5afa\u9ae2\u0a5d\u{1fbf7}\u09ed\u019e\u028c\ua41e\u0b85\u7dc0',
+  colorFormats: ['rg16float', 'rg11b10ufloat', 'rgba16float', 'rg11b10ufloat', 'r8uint', 'r8sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture22 = device0.importExternalTexture({
+  label: '\u5f93\u06f4\u0d73\u062c\u{1fd93}\u09b8\u132c\u9571\u{1ff4a}',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder5.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(4, bindGroup13);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer7, 9944, buffer11, 267784, 2328);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder22.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 724 widthInBlocks: 724 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 12978 */
+  offset: 12978,
+  buffer: buffer2,
+}, {width: 724, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup14 = device0.createBindGroup({label: '\u0cfa\uc607\u4f4c\u{1f944}', layout: bindGroupLayout2, entries: []});
+let pipelineLayout6 = device0.createPipelineLayout({
+  label: '\u3feb\u24ff\u4fff\u0111\ua5b2\ud42f\u025a\uaaf7\ud063',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout3, bindGroupLayout2],
+});
+let commandEncoder44 = device0.createCommandEncoder({label: '\u56ac\u8b61\ucb3f\u088e'});
+let textureView49 = texture34.createView({
+  label: '\u5647\u0fb0\u0b40\u0b48\u0a5a\u09d1\u{1ff28}\u{1f79b}\u2103',
+  format: 'rgba32float',
+  baseMipLevel: 4,
+  mipLevelCount: 4,
+});
+let arrayBuffer1 = buffer1.getMappedRange(5408, 192);
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 190, y: 2, z: 508},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 148, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer6, 5132, 30204);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 7,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 3_077 */
+{offset: 297, bytesPerRow: 252, rowsPerImage: 11}, {width: 2, height: 1, depthOrArrayLayers: 2});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let buffer15 = device0.createBuffer({
+  label: '\u0395\ub134\u299d\u0cd8\u0f79\u{1f97f}\u6abb\u092c\u{1fef7}\u{1f78b}',
+  size: 92444,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder45 = device0.createCommandEncoder({label: '\u4566\ub0d8'});
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 115 widthInBlocks: 115 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 9434 */
+  offset: 9319,
+  rowsPerImage: 88,
+  buffer: buffer2,
+}, {width: 115, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder0.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 404, height: 1, depthOrArrayLayers: 546}
+*/
+{
+  source: canvas1,
+  origin: { x: 10, y: 38 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 464},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 66, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame2 = videoFrame0.clone();
+let bindGroup15 = device0.createBindGroup({
+  label: '\u6244\u5f5d\u{1fc0a}\u7fd7\u0604\u7f5f\u0125',
+  layout: bindGroupLayout4,
+  entries: [{binding: 5361, resource: externalTexture6}, {binding: 6937, resource: sampler2}],
+});
+let pipelineLayout7 = device0.createPipelineLayout({
+  label: '\u1a48\u0535\u4635\u30a0\u{1f9c6}\u05a3\u252e\u4b07\u{1fd96}\u{1f93f}\u1670',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout3, bindGroupLayout3],
+});
+let querySet18 = device0.createQuerySet({label: '\ufeda\u{1f875}\ufd55\u8404\u{1fd16}\u{1fde7}\u6a1e\ubf4c', type: 'occlusion', count: 1469});
+let commandBuffer8 = commandEncoder40.finish({label: '\u{1ff7f}\u{1fe30}\u{1fa54}\u1100'});
+let textureView50 = texture30.createView({
+  label: '\u9234\u5d64\u{1f63a}\ua7d9\u0d80\u{1fa1e}\u024e',
+  format: 'rgba16float',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+try {
+buffer5.destroy();
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 6,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder43.clearBuffer(buffer11);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(8)), /* required buffer size: 42 */
+{offset: 42}, {width: 676, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise10;
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({label: '\u03f4\u21e6\u95a2\u76b1\uda10'});
+let querySet19 = device0.createQuerySet({
+  label: '\u{1f72c}\u0d47\u{1fcf8}\u8c41\u{1fc13}\u2a59\u4272\ud88f\u0989\u{1fae7}\u0217',
+  type: 'occlusion',
+  count: 3374,
+});
+let textureView51 = texture12.createView({label: '\ucc74\u3d39\u4701\ucc38\u797c', dimension: '1d', mipLevelCount: 1});
+let renderBundle28 = renderBundleEncoder1.finish({label: '\u2889\u0825\u{1f9ab}\u879f\u0910\u05aa'});
+let sampler24 = device0.createSampler({
+  label: '\u03f2\ua442\uc39a\u{1f74c}\uebee\u4a27\u0faa\u{1fee4}\u5c53\u87f7',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 10.38,
+  lodMaxClamp: 80.99,
+});
+try {
+computePassEncoder19.setBindGroup(5, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(10, buffer3, 7364);
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 792 widthInBlocks: 198 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4204 */
+  offset: 4204,
+  buffer: buffer7,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 158, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 198, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 665 widthInBlocks: 665 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 19719 */
+  offset: 19054,
+  buffer: buffer2,
+}, {width: 665, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline26 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src', dstFactor: 'dst'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'constant'},
+    alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'r8uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 818974656,
+    stencilWriteMask: 598263919,
+    depthBiasSlopeScale: 382.00701435364067,
+    depthBiasClamp: 434.1101339396895,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 3820, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 4008, shaderLocation: 16},
+          {format: 'sint32x3', offset: 8504, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 6448, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 424, shaderLocation: 20},
+          {format: 'sint32', offset: 792, shaderLocation: 18},
+          {format: 'uint32x4', offset: 4224, shaderLocation: 17},
+          {format: 'uint8x4', offset: 9716, shaderLocation: 22},
+          {format: 'uint16x2', offset: 780, shaderLocation: 6},
+          {format: 'float16x4', offset: 4752, shaderLocation: 23},
+          {format: 'uint32x2', offset: 1300, shaderLocation: 11},
+          {format: 'uint32x3', offset: 3588, shaderLocation: 13},
+          {format: 'sint32x2', offset: 64, shaderLocation: 0},
+          {format: 'float32x2', offset: 2120, shaderLocation: 9},
+          {format: 'uint16x4', offset: 3548, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 3120,
+        attributes: [
+          {format: 'sint32x4', offset: 236, shaderLocation: 5},
+          {format: 'float32x4', offset: 984, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 2572, attributes: []},
+      {
+        arrayStride: 8804,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 572, shaderLocation: 7},
+          {format: 'float32x3', offset: 672, shaderLocation: 14},
+          {format: 'float16x4', offset: 1524, shaderLocation: 3},
+          {format: 'uint32x4', offset: 2072, shaderLocation: 19},
+          {format: 'uint32x4', offset: 1384, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 140, shaderLocation: 21},
+        ],
+      },
+      {arrayStride: 1016, stepMode: 'instance', attributes: []},
+      {arrayStride: 896, attributes: [{format: 'unorm8x4', offset: 116, shaderLocation: 8}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+document.body.prepend(video0);
+let promise14 = navigator.gpu.requestAdapter();
+let imageBitmap5 = await createImageBitmap(offscreenCanvas3);
+let commandEncoder47 = device0.createCommandEncoder({});
+let textureView52 = texture23.createView({});
+let arrayBuffer2 = buffer4.getMappedRange(10296, 3580);
+try {
+commandEncoder21.copyBufferToBuffer(buffer12, 508, buffer6, 80352, 1944);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline27 = await device0.createRenderPipelineAsync({
+  label: '\u{1ffdc}\u{1fb96}',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {
+  format: 'rgba32uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'zero'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 172,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 20, shaderLocation: 16},
+          {format: 'uint32x3', offset: 4, shaderLocation: 3},
+          {format: 'float16x2', offset: 28, shaderLocation: 11},
+          {format: 'sint8x2', offset: 18, shaderLocation: 21},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 15},
+          {format: 'sint32x3', offset: 0, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 48, shaderLocation: 19},
+          {format: 'unorm8x2', offset: 42, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 4, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 16, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 7},
+          {format: 'float16x2', offset: 8, shaderLocation: 13},
+          {format: 'uint8x4', offset: 36, shaderLocation: 20},
+          {format: 'uint32', offset: 4, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 3096,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 308, shaderLocation: 10},
+          {format: 'float32', offset: 872, shaderLocation: 17},
+          {format: 'uint8x2', offset: 126, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 20, shaderLocation: 5},
+          {format: 'uint32x4', offset: 912, shaderLocation: 18},
+          {format: 'snorm16x2', offset: 836, shaderLocation: 23},
+          {format: 'unorm16x2', offset: 856, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 2416,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint16x4', offset: 208, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroup16 = device0.createBindGroup({
+  label: '\u{1f936}\u777f\u{1ff5e}\u7f16\u68f5\u0f98',
+  layout: bindGroupLayout3,
+  entries: [{binding: 1293, resource: sampler12}],
+});
+let buffer16 = device0.createBuffer({size: 198935, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder19.setBindGroup(4, bindGroup13, []);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline18);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(4, bindGroup1, new Uint32Array(5409), 4141, 0);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer10, 549156, buffer9, 48756, 12512);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 10786 */
+  offset: 10786,
+  rowsPerImage: 19,
+  buffer: buffer7,
+}, {
+  texture: texture17,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+let commandBuffer9 = commandEncoder31.finish({});
+try {
+renderBundleEncoder15.setVertexBuffer(0, buffer3, 0);
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(querySet15, 245, 55, buffer5, 0);
+} catch {}
+try {
+  await promise13;
+} catch {}
+let buffer17 = device0.createBuffer({label: '\u0fa5\u5075\u0b2a', size: 325203, usage: GPUBufferUsage.COPY_SRC, mappedAtCreation: false});
+let querySet20 = device0.createQuerySet({
+  label: '\u05c1\ue299\u4ce6\u{1febf}\u0f2a\u0fba\ud258\u02ba\u{1fff6}\uf7d0',
+  type: 'occlusion',
+  count: 2063,
+});
+let textureView53 = texture10.createView({label: '\u0fd2\ucc1e\u0825\u{1f815}', baseArrayLayer: 622, arrayLayerCount: 600});
+let externalTexture23 = device0.importExternalTexture({source: video0});
+let arrayBuffer3 = buffer14.getMappedRange(234824, 86916);
+try {
+commandEncoder27.copyBufferToBuffer(buffer12, 216, buffer9, 102412, 1224);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 40},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 201_586_826 */
+{offset: 16, bytesPerRow: 3174, rowsPerImage: 301}, {width: 181, height: 1, depthOrArrayLayers: 212});
+} catch {}
+try {
+  await promise3;
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup6, new Uint32Array(7996), 3050, 0);
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 384 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 118672 */
+  offset: 16,
+  bytesPerRow: 512,
+  rowsPerImage: 23,
+  buffer: buffer10,
+}, {
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 24, height: 2, depthOrArrayLayers: 11});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder34.copyTextureToBuffer({
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 128 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 47552 */
+  offset: 47552,
+  buffer: buffer2,
+}, {width: 96, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder42.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder17.pushDebugGroup('\u0ea7');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 50, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 6, y: 18 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 5,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise4;
+} catch {}
+let canvas5 = document.createElement('canvas');
+try {
+canvas5.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({entries: []});
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 1301});
+let sampler25 = device0.createSampler({
+  label: '\u22d4\u3a9d\udad1',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.381,
+  lodMaxClamp: 73.43,
+  maxAnisotropy: 2,
+});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline28 = await promise9;
+let imageData6 = new ImageData(40, 216);
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\u0f2c\udcc1\u{1faf4}\u{1fd4f}\u55f9\u8cf5\u0f8d\ud809\uad84\u2166',
+  bindGroupLayouts: [bindGroupLayout7, bindGroupLayout5],
+});
+let buffer18 = device0.createBuffer({size: 390286, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder49 = device0.createCommandEncoder({label: '\u08df\u81f4\ub99f\u0a98\u{1fdf2}'});
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 586});
+let textureView54 = texture32.createView({});
+try {
+renderBundleEncoder16.setIndexBuffer(buffer14, 'uint16', 56388, 108207);
+} catch {}
+try {
+commandEncoder44.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 11168 widthInBlocks: 698 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 336 */
+  offset: 336,
+  buffer: buffer2,
+}, {width: 698, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData7 = new ImageData(148, 12);
+let textureView55 = texture25.createView({mipLevelCount: 1});
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(9, buffer13, 23024);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer7, 16104, buffer9, 20456, 2192);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder49.resolveQuerySet(querySet17, 239, 569, buffer13, 175872);
+} catch {}
+try {
+computePassEncoder17.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(72)), /* required buffer size: 1_000 */
+{offset: 1000}, {width: 361, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline29 = device0.createComputePipeline({layout: pipelineLayout6, compute: {module: shaderModule0, entryPoint: 'compute0'}});
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  label: '\u00f6\u{1f6f4}\u0546\u0e35',
+  entries: [
+    {
+      binding: 1994,
+      visibility: 0,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 756,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 3340, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder50 = device0.createCommandEncoder();
+let computePassEncoder20 = commandEncoder27.beginComputePass({});
+let sampler26 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 29.62,
+  compare: 'less-equal',
+  maxAnisotropy: 4,
+});
+try {
+renderBundleEncoder11.setVertexBuffer(1, buffer13, 0, 175299);
+} catch {}
+try {
+  await promise11;
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder();
+let querySet23 = device0.createQuerySet({label: '\u4edc\u4664\u{1f667}\uc23d\u07c3\u9289\u4636\u84ae', type: 'occlusion', count: 1208});
+let texture36 = device0.createTexture({
+  label: '\u732d\u{1fa55}\u5f9c\ub449\u{1fadd}\uc0d6\ucd6c\u{1fcab}\u{1fcc2}',
+  size: [768],
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8uint'],
+});
+let sampler27 = device0.createSampler({
+  label: '\u{1fbb1}\udf77\u03d3\u2ba6\u{1f6e7}\u4c58\u{1f676}\uef3b\u06fb\u5ac6\u{1fb49}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.16,
+  lodMaxClamp: 99.94,
+  compare: 'never',
+  maxAnisotropy: 16,
+});
+let externalTexture24 = device0.importExternalTexture({
+  label: '\u1b52\uee97\u{1f86b}\u{1fde0}\u0985\u{1fa98}\uf658\u{1fcbc}',
+  source: videoFrame1,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 118},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer3), /* required buffer size: 18_224_706 */
+{offset: 874, bytesPerRow: 319, rowsPerImage: 148}, {width: 3, height: 0, depthOrArrayLayers: 387});
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder();
+let texture37 = device0.createTexture({
+  label: '\u7a34\u3596\u033b\u{1f7d6}\u740a\u{1f7ce}\u20d1\u{1f9f1}\u2b28\uf9c2',
+  size: {width: 2616, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'astc-8x5-unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-8x5-unorm'],
+});
+let textureView56 = texture22.createView({label: '\u0341\u0ad6\u{1f76f}\u622c\u014a'});
+let renderBundle29 = renderBundleEncoder1.finish({label: '\u{1f68c}\udf20\u{1f71a}\u25d5\u01f2'});
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(6, bindGroup9, new Uint32Array(6370), 5389, 0);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(buffer5, 2620, buffer6, 60860, 7268);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 143},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 3});
+} catch {}
+try {
+commandEncoder39.clearBuffer(buffer9, 110512, 9660);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let video3 = await videoWithData();
+let computePassEncoder21 = commandEncoder7.beginComputePass({label: '\u05d1\ue94b\u{1fd71}'});
+try {
+renderBundleEncoder11.drawIndexed(17, 84, 1_672_976_645, -2_020_887_883, 11_265_776);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer3, 18168);
+} catch {}
+let texture38 = device0.createTexture({
+  label: '\u1fb7\u6058\u7615\u007e\u5251',
+  size: [384],
+  dimension: '1d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView57 = texture10.createView({label: '\u{1f909}\u0665\u{1f9b7}\u481d\u223d', dimension: '2d', baseArrayLayer: 482});
+let sampler28 = device0.createSampler({
+  label: '\ued57\uf0a2\u{1f9c9}\u95de\u{1f88b}\uf4f0\u0722\u0d3c\udc34\u1416',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 16.73,
+  lodMaxClamp: 29.43,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder12.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(310, 45, 600_570_390, 502_905_746);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer14, 13336);
+} catch {}
+try {
+commandEncoder48.pushDebugGroup('\u4900');
+} catch {}
+try {
+commandEncoder48.popDebugGroup();
+} catch {}
+let pipeline30 = await device0.createComputePipelineAsync({
+  label: '\ued4b\ue8dc\u307e\u09d2\u0245\u1df2\u06fa\uadca\u2441',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline31 = device0.createRenderPipeline({
+  label: '\u{1faf3}\u{1fdb7}',
+  layout: pipelineLayout8,
+  multisample: {},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: 0}, {format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 784, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 1008, shaderLocation: 8},
+          {format: 'uint32x2', offset: 1032, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+let video4 = await videoWithData();
+let texture39 = device0.createTexture({
+  label: '\u3864\u99aa\u0553\u1f8f',
+  size: [192, 4, 1218],
+  mipLevelCount: 2,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle30 = renderBundleEncoder10.finish({label: '\uf235\u0041\u0368\u1f92\u{1fff1}\ue22b\u{1fcd7}\u00b7\u934d'});
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer8, 11184);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(7, buffer13, 245396, 69313);
+} catch {}
+try {
+commandEncoder42.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 6,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1872 */
+  offset: 1840,
+  buffer: buffer2,
+}, {width: 8, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder22.resolveQuerySet(querySet23, 924, 58, buffer5, 8960);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let texture40 = device0.createTexture({
+  label: '\u626d\u2fa1\u80a0\u6460',
+  size: {width: 384, height: 8, depthOrArrayLayers: 221},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r8sint'],
+});
+let sampler29 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'mirror-repeat', lodMinClamp: 98.07, lodMaxClamp: 98.94});
+let externalTexture25 = device0.importExternalTexture({label: '\ua21b\u687e\ub7bd\u{1f6de}\u{1fdd1}\u266a', source: videoFrame2, colorSpace: 'srgb'});
+try {
+renderBundleEncoder11.drawIndirect(buffer14, 74508);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline31);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(5, buffer3);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 64, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 194, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 202, height: 1, depthOrArrayLayers: 546}
+*/
+{
+  source: canvas2,
+  origin: { x: 55, y: 61 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 37, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline32 = await promise1;
+let texture41 = device0.createTexture({
+  size: [384, 8, 1218],
+  mipLevelCount: 7,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba32sint'],
+});
+let textureView58 = texture24.createView({label: '\u{1f8d4}\u75e4'});
+let externalTexture26 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder7.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer8, 9220);
+} catch {}
+try {
+buffer12.destroy();
+} catch {}
+let promise15 = buffer18.mapAsync(GPUMapMode.WRITE, 54328, 82444);
+try {
+commandEncoder43.copyBufferToBuffer(buffer1, 26800, buffer9, 29264, 16);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({label: '\u{1fc45}\u{1feb6}\u6031\u0d6f\u3592\u{1f9e9}\u78c5\udddf'});
+let querySet24 = device0.createQuerySet({
+  label: '\u{1fa2c}\u{1f8f1}\u{1fc75}\u0ae5\u8fbe\ubcb8\u0798\ua346\u{1f9c7}\u{1f99f}\u{1f965}',
+  type: 'occlusion',
+  count: 3149,
+});
+let computePassEncoder22 = commandEncoder36.beginComputePass({label: '\u0377\u{1f999}\ubd39\u{1fbac}\u7808\u{1f9c9}\u0300\u51d3\u1c77'});
+let renderBundle31 = renderBundleEncoder6.finish({label: '\ud909\ue254'});
+let sampler30 = device0.createSampler({
+  label: '\u2e5c\u3ec7\u0040\ua707\u{1fdb4}\uf3de\ua6cb\u05d1\ufbce',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 42.41,
+  lodMaxClamp: 94.19,
+  compare: 'not-equal',
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(4, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder11.draw(833, 78);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer14, 45792);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(5565, undefined, 0, 4214604524);
+} catch {}
+try {
+commandEncoder51.copyBufferToTexture({
+  /* bytesInLastRow: 690 widthInBlocks: 690 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 16501 */
+  offset: 16501,
+  buffer: buffer17,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 690, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder29.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 42, y: 0, z: 6},
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline33 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}}});
+let promise16 = navigator.gpu.requestAdapter({});
+let commandEncoder54 = device0.createCommandEncoder({label: '\udff6\uaeb8\u0f68\u0c58\u0422\u{1ffdc}\ub383\u651f\u219b\u{1fe52}\u6f85'});
+let texture42 = device0.createTexture({
+  label: '\u0772\ub8c4\u0b7c',
+  size: [96],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView59 = texture2.createView({label: '\u062c\u{1fd46}\u37b5\u43ea\u9035\u58fd\u4baa', mipLevelCount: 5});
+let renderBundle32 = renderBundleEncoder0.finish();
+let sampler31 = device0.createSampler({
+  label: '\u973d\u{1f8a3}\ue227\uef7d\u0a79',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 14.32,
+  lodMaxClamp: 96.36,
+});
+let externalTexture27 = device0.importExternalTexture({label: '\ub0f9\u0306\u2099\u{1fd0d}\ue9d1', source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder19.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(5, bindGroup16, []);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer14, 'uint16', 67386, 136716);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 155, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer2), /* required buffer size: 9 */
+{offset: 9}, {width: 1274, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video0.height = 237;
+let textureView60 = texture21.createView({label: '\u2cd9\u{1fa99}', dimension: '2d', baseMipLevel: 1, baseArrayLayer: 296, arrayLayerCount: 1});
+try {
+renderBundleEncoder11.drawIndexed(158, 14, 189_454_376);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer14, 27356);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(5, buffer13);
+} catch {}
+try {
+commandEncoder37.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 75, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 162, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer6, 45416, 70500);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline34 = device0.createRenderPipeline({
+  label: '\u0ecc\u7b73\u8f26\u454d\u8367\u7967\u6201\u1ea1\u0810\u9578',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.RED}, {format: 'rgba16float'}, {format: 'rg11b10ufloat'}, {format: 'r8uint', writeMask: GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1180,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 176, shaderLocation: 9},
+          {format: 'uint16x2', offset: 56, shaderLocation: 5},
+          {format: 'sint8x4', offset: 244, shaderLocation: 19},
+          {format: 'sint32', offset: 236, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 372, shaderLocation: 1},
+          {format: 'float32x2', offset: 172, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 264, shaderLocation: 8},
+          {format: 'uint8x2', offset: 98, shaderLocation: 22},
+          {format: 'sint8x2', offset: 54, shaderLocation: 11},
+          {format: 'uint32x4', offset: 28, shaderLocation: 20},
+          {format: 'float16x4', offset: 156, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 140, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder55 = device0.createCommandEncoder({label: '\u{1f9a4}\u99ce\u0562\uef80\u35ff\u3b7a\uaaa7\u02f9\u832b'});
+let querySet25 = device0.createQuerySet({label: '\u{1fd36}\u{1ffbc}\u{1ffec}\u{1fc30}\u{1f86c}\u0912', type: 'occlusion', count: 1803});
+let renderBundle33 = renderBundleEncoder0.finish({});
+try {
+renderBundleEncoder11.drawIndirect(buffer8, 13792);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 614 widthInBlocks: 614 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2593 */
+  offset: 2593,
+  bytesPerRow: 1024,
+  buffer: buffer2,
+}, {width: 614, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer6, 73176, 54340);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 10},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 641 */
+{offset: 641}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+  label: '\u0757\u6610\u3a3b\u7dda\ua464\u8c6b\u0edb\u0d72\u{1fea4}\u{1ffd5}',
+  layout: bindGroupLayout4,
+  entries: [{binding: 6937, resource: sampler6}, {binding: 5361, resource: externalTexture25}],
+});
+let commandBuffer10 = commandEncoder29.finish({label: '\u0065\u07c6\u{1ffb1}\u3b7d\u0e03\u0871\u0c96\ua5d0\u{1fb78}\uf89b\u5857'});
+let texture43 = device0.createTexture({
+  label: '\u87b8\u{1f635}\uff13\ub964\ue183\u{1fae9}\u1127\u{1fab7}\ub8a4\u0d00\u{1f9ea}',
+  size: [96, 2, 1218],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8uint'],
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\u0d6a\u{1fdee}\ufb10\u{1fe1d}\u{1fff6}',
+  colorFormats: ['rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(833, 23, 283_441_891, 672_217_970, 74_051_748);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer8, 24592);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let renderPassEncoder0 = commandEncoder26.beginRenderPass({
+  label: '\ua954\u938f\ua2d9\u08d9\ubfea\u{1f801}\u3aa1',
+  colorAttachments: [{
+  view: textureView60,
+  clearValue: { r: 917.3, g: -261.2, b: 52.00, a: -241.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 1154208457,
+});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup13, new Uint32Array(7488), 1072, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(4, bindGroup16);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(10, buffer13, 183256);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(53, 280, 209_791_853, 311_108_077);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer8, 7012);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer14, 91056);
+} catch {}
+try {
+renderBundleEncoder15.insertDebugMarker('\u{1fcb4}');
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(439, 264);
+let textureView61 = texture34.createView({label: '\u233d\u710d\u{1feaa}\u7d3b\u0729\u7c96\u7c85\u33a5', baseMipLevel: 7});
+let computePassEncoder23 = commandEncoder45.beginComputePass({});
+let renderBundle34 = renderBundleEncoder2.finish({label: '\u{1fc9e}\u{1f8b8}\u08e7\u6a38\u{1fafd}\u080c\uff6e'});
+let sampler32 = device0.createSampler({
+  label: '\u0515\u8256\u{1fa41}\u7c59\u85a8\u0816\u61ff\ua4d8',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 27.24,
+});
+try {
+renderPassEncoder0.setBindGroup(6, bindGroup10);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer3, 'uint32', 62076, 355);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer13);
+} catch {}
+try {
+renderBundleEncoder11.draw(54, 81);
+} catch {}
+try {
+commandEncoder22.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 7,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16460 */
+  offset: 16460,
+  bytesPerRow: 0,
+  rowsPerImage: 89,
+  buffer: buffer2,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 7,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 703 */
+{offset: 703}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 809, height: 1, depthOrArrayLayers: 26}
+*/
+{
+  source: canvas2,
+  origin: { x: 65, y: 48 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 56, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder1 = commandEncoder47.beginRenderPass({
+  label: '\u0460\u{1fcb6}\u04c4\u4872\u8131\u4725\u0993\u04f7\u{1fbc4}',
+  colorAttachments: [{view: textureView61, depthSlice: 0, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 876560042,
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.setViewport(1.043, 0.6163, 0.3545, 0.1482, 0.6811, 0.9615);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup15, new Uint32Array(7687), 33, 0);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer3, 9312);
+} catch {}
+let pipeline35 = device0.createComputePipeline({
+  label: '\uaf20\u{1f91b}\u0564\u{1fe18}',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let pipeline36 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: 0}, {format: 'rgba32uint', writeMask: 0}, {format: 'r8unorm'}],
+},
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1808,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 88, shaderLocation: 22},
+          {format: 'float32x2', offset: 392, shaderLocation: 10},
+          {format: 'uint16x2', offset: 360, shaderLocation: 16},
+          {format: 'uint8x2', offset: 442, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 112, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 180, shaderLocation: 5},
+          {format: 'uint8x2', offset: 92, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 216, shaderLocation: 23},
+          {format: 'unorm8x2', offset: 18, shaderLocation: 18},
+          {format: 'float32', offset: 360, shaderLocation: 21},
+          {format: 'unorm8x2', offset: 48, shaderLocation: 9},
+          {format: 'uint16x2', offset: 304, shaderLocation: 0},
+          {format: 'uint8x4', offset: 24, shaderLocation: 1},
+          {format: 'uint32x4', offset: 460, shaderLocation: 20},
+          {format: 'unorm8x4', offset: 472, shaderLocation: 11},
+          {format: 'float32x3', offset: 236, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 968, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 6356, shaderLocation: 19},
+          {format: 'uint8x4', offset: 2252, shaderLocation: 17},
+          {format: 'sint16x4', offset: 924, shaderLocation: 7},
+          {format: 'unorm8x2', offset: 2900, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 1936, stepMode: 'instance', attributes: []},
+      {arrayStride: 760, stepMode: 'vertex', attributes: []},
+      {arrayStride: 0, attributes: [{format: 'float16x4', offset: 1176, shaderLocation: 14}]},
+      {arrayStride: 580, stepMode: 'instance', attributes: []},
+      {arrayStride: 1536, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 3268,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 20, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', unclippedDepth: true},
+});
+let offscreenCanvas5 = new OffscreenCanvas(809, 327);
+let imageData8 = new ImageData(32, 132);
+let commandEncoder56 = device0.createCommandEncoder();
+let querySet26 = device0.createQuerySet({label: '\u4c25\u1d6a\u08bf\u4ba2\u3a74\ud6ef\u07a2', type: 'occlusion', count: 2614});
+let renderPassEncoder2 = commandEncoder22.beginRenderPass({
+  colorAttachments: [{
+  view: textureView60,
+  clearValue: { r: 321.0, g: -711.4, b: 778.9, a: 135.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 346975587,
+});
+let renderBundle35 = renderBundleEncoder14.finish({label: '\uc985\ub240\u{1fb45}\u0a27\u{1f9fb}\u0be2\u0411\u854e\ucd7f'});
+let sampler33 = device0.createSampler({
+  label: '\u3018\u1244\u{1f934}\u{1ffb3}\u{1fb18}\u643f\u6efc\u{1fb6c}\u{1ffd6}\u0ddf',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 87.70,
+  lodMaxClamp: 96.65,
+});
+try {
+renderPassEncoder2.setScissorRect(110, 0, 25, 0);
+} catch {}
+try {
+renderPassEncoder2.setViewport(138.5, 0.2140, 35.28, 0.3836, 0.9254, 0.9490);
+} catch {}
+try {
+commandEncoder0.copyBufferToBuffer(buffer7, 21488, buffer6, 90296, 46908);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder19.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(935), /* required buffer size: 935 */
+{offset: 935, bytesPerRow: 415, rowsPerImage: 12}, {width: 348, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 404, height: 1, depthOrArrayLayers: 546}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 17, y: 3 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 49, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline37 = device0.createComputePipeline({
+  label: '\u{1fdf7}\u2307\u5714\u{1fa5c}\u0843\u4510\u07c6\uebbf\u{1fdbf}\ub99c\u{1fe8f}',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let video5 = await videoWithData();
+let bindGroup18 = device0.createBindGroup({layout: bindGroupLayout3, entries: [{binding: 1293, resource: sampler12}]});
+let buffer19 = device0.createBuffer({
+  label: '\u{1f73c}\u503b\u0557\u9c85\uf7d2\u0801\u0e91\u{1fcbb}\u{1f8f3}',
+  size: 295118,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder24 = commandEncoder28.beginComputePass({label: '\u52b3\uc475\u6b1f\u{1f846}\ua1a2\ucf05'});
+try {
+computePassEncoder21.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(2568);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer19, 257716, 8248);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(4, 101, 1_963_096_077, 178_518_652);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer19, 'uint16', 116730, 163982);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(7, buffer3, 0, 34556);
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer5, 11104, buffer6, 116016, 9144);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 341, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 75, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 57, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer11 = commandEncoder37.finish({label: '\u9646\u{1f90c}\u318a\uff0c\u3612\u0006'});
+let textureView62 = texture12.createView({baseMipLevel: 0});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  label: '\u2519\u5963\u{1faf9}\u0119\ub7be',
+  colorFormats: ['rgba32sint', 'rgba32uint', 'r8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler34 = device0.createSampler({
+  label: '\ub684\u072c\ub3fd\u{1fcc2}\u{1f602}\u2754',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMinClamp: 52.49,
+  lodMaxClamp: 58.40,
+});
+try {
+computePassEncoder11.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(2, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder2.setViewport(140.5, 0.5613, 8.605, 0.1423, 0.8315, 0.9812);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(41, 6, 431_612_884, 1_134_146_674, 38_754_440);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer14, 'uint32', 303224, 14269);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer17, 215280, buffer11, 172884, 80860);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet6, 1668, 1058, buffer13, 227840);
+} catch {}
+try {
+commandEncoder49.pushDebugGroup('\u0444');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise6;
+} catch {}
+offscreenCanvas2.height = 169;
+let shaderModule12 = device0.createShaderModule({
+  label: '\u{1fdbd}\ud2b3\ud9d4\u3d11\u811b\u1086',
+  code: `@group(1) @binding(1293)
+var<storage, read_write> field7: array<u32>;
+
+@compute @workgroup_size(1, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(3) f1: vec3<f32>,
+  @location(0) f2: vec4<f32>,
+  @location(4) f3: vec3<u32>,
+  @builtin(sample_mask) f4: u32,
+  @location(5) f5: vec4<i32>,
+  @location(2) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(0) f0: vec2<u32>,
+  @location(7) f1: vec4<u32>,
+  @location(19) f2: vec4<u32>,
+  @location(23) f3: i32,
+  @location(17) f4: vec2<f32>,
+  @location(11) f5: vec2<u32>,
+  @location(3) f6: vec3<f32>,
+  @location(13) f7: f32,
+  @location(10) f8: vec4<i32>,
+  @location(15) f9: vec4<f32>,
+  @location(20) f10: i32,
+  @location(1) f11: vec4<f16>,
+  @location(21) f12: vec4<f16>,
+  @location(6) f13: vec4<f16>,
+  @location(16) f14: vec2<f16>,
+  @location(2) f15: u32,
+  @location(4) f16: f16,
+  @location(22) f17: f32
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec3<f16>, a1: S12, @location(8) a2: vec4<i32>, @builtin(vertex_index) a3: u32, @location(12) a4: vec4<f16>, @location(9) a5: i32, @location(18) a6: vec4<f16>, @location(14) a7: u32, @builtin(instance_index) a8: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let querySet27 = device0.createQuerySet({type: 'occlusion', count: 1947});
+let textureView63 = texture43.createView({
+  label: '\u56cc\ue439\u{1fcc7}\ud7e0\u00a2\ucc50\u0780\ue57d\ua386',
+  baseArrayLayer: 526,
+  arrayLayerCount: 496,
+});
+let computePassEncoder25 = commandEncoder21.beginComputePass({label: '\u{1f755}\u0fa9\u5b67'});
+let renderBundle36 = renderBundleEncoder15.finish();
+try {
+computePassEncoder6.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle22, renderBundle36, renderBundle25, renderBundle25, renderBundle25, renderBundle36, renderBundle36, renderBundle35]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer3, 0, 37901);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(7989, undefined);
+} catch {}
+try {
+texture20.destroy();
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer15, 7916, buffer2, 4428, 66484);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder42.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 141},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(querySet11, 2313, 476, buffer5, 9472);
+} catch {}
+try {
+commandEncoder49.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline38 = await device0.createRenderPipelineAsync({
+  label: '\u{1f858}\u1538\ue81d\ud901',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0xed31fd3a},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'dst'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'src'},
+    alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'dst'},
+  },
+  writeMask: 0,
+}, {format: 'rgba16float', writeMask: 0}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'src'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'src'},
+  },
+  writeMask: 0,
+}, {format: 'r8uint'}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1100,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 292, shaderLocation: 18},
+          {format: 'uint8x4', offset: 136, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 168, shaderLocation: 23},
+          {format: 'uint32x2', offset: 276, shaderLocation: 22},
+          {format: 'sint32x4', offset: 40, shaderLocation: 0},
+          {format: 'uint32', offset: 576, shaderLocation: 12},
+          {format: 'uint32x2', offset: 52, shaderLocation: 13},
+          {format: 'float32x2', offset: 232, shaderLocation: 14},
+          {format: 'float16x4', offset: 172, shaderLocation: 8},
+          {format: 'sint32x4', offset: 600, shaderLocation: 4},
+          {format: 'uint8x2', offset: 462, shaderLocation: 6},
+          {format: 'uint32', offset: 68, shaderLocation: 7},
+          {format: 'uint8x4', offset: 128, shaderLocation: 19},
+          {format: 'float32', offset: 120, shaderLocation: 15},
+          {format: 'sint32x3', offset: 92, shaderLocation: 5},
+          {format: 'float16x2', offset: 48, shaderLocation: 20},
+          {format: 'float32x3', offset: 20, shaderLocation: 21},
+          {format: 'float32x2', offset: 316, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 584,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 176, shaderLocation: 17},
+          {format: 'uint32x4', offset: 256, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 76, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 58, shaderLocation: 2},
+          {format: 'uint8x2', offset: 32, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 212, attributes: [{format: 'float32x2', offset: 20, shaderLocation: 16}]},
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: false},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(canvas0);
+let imageBitmap6 = await createImageBitmap(img1);
+let videoFrame3 = new VideoFrame(img1, {timestamp: 0});
+let commandEncoder57 = device0.createCommandEncoder({label: '\ufa3a\u{1f9f0}\u{1fd38}\u4b57'});
+let texture44 = device0.createTexture({
+  label: '\u4db5\u0d42\uae14\uef18',
+  size: [404, 1, 1],
+  mipLevelCount: 6,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32sint'],
+});
+let computePassEncoder26 = commandEncoder44.beginComputePass({label: '\u05ab\u{1f968}\uee29\u7243\u60a4\u5681\u{1f8f0}\u044b\u42ac\u7191'});
+let renderPassEncoder3 = commandEncoder55.beginRenderPass({
+  label: '\u{1fc2a}\u9992\u9d45\u250d\u58de',
+  colorAttachments: [{
+  view: textureView61,
+  depthSlice: 0,
+  clearValue: { r: 887.7, g: -254.0, b: -697.3, a: 80.61, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet16,
+  maxDrawCount: 24601758,
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup14, new Uint32Array(2214), 1378, 0);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(146, 55);
+} catch {}
+try {
+commandEncoder54.resolveQuerySet(querySet10, 420, 7, buffer13, 63744);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\u97c9');
+} catch {}
+try {
+device0.queue.submit([commandBuffer7, commandBuffer10, commandBuffer5, commandBuffer11]);
+} catch {}
+gc();
+let querySet28 = device0.createQuerySet({label: '\u2714\u0bd0\u{1f710}\uae80\u0b0e\u{1fffd}', type: 'occlusion', count: 2433});
+let commandBuffer12 = commandEncoder24.finish();
+let textureView64 = texture39.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 353});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\u2b14\u0845\ud5cb\u{1f908}\u263c\u0631\u3fc0\u65be\u4731\u0d44\u0825',
+  colorFormats: ['rgba32float'],
+});
+let renderBundle37 = renderBundleEncoder7.finish({label: '\u0211\u{1f88c}\u0c6b\ua4fe\u{1fa32}\u{1f71c}\u0f40\u{1f8e8}'});
+try {
+renderPassEncoder1.executeBundles([renderBundle36, renderBundle25, renderBundle25, renderBundle25, renderBundle36]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer3, 'uint32', 4796);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer8, 29884);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 113, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 597 */
+{offset: 103}, {width: 494, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise17 = device0.createComputePipelineAsync({
+  label: '\u0a3b\u5937\ubf91\u2a03\u4b3c\ua9c5\u47f2\u{1f62c}\u0d84\ucd54\u{1fcfc}',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+canvas3.height = 346;
+let canvas6 = document.createElement('canvas');
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle35, renderBundle25, renderBundle22, renderBundle25, renderBundle25, renderBundle35, renderBundle35, renderBundle36, renderBundle22, renderBundle36]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(35.48, 0.7056, 161.8, 0.06592, 0.7788, 0.9209);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(10, buffer3, 41588);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder11.draw(21, 26, 155_305_832, 1_136_611_916);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer3, 61392);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer19, 'uint32', 69180, 125666);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline36);
+} catch {}
+try {
+commandEncoder35.resolveQuerySet(querySet21, 15, 1236, buffer13, 293888);
+} catch {}
+let pipeline39 = await device0.createRenderPipelineAsync({
+  label: '\u81cc\u0e8f\u{1fed0}\uad5c\u{1ff1f}',
+  layout: pipelineLayout4,
+  multisample: {},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba32sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba32uint'}, {format: 'r8unorm', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {
+      compare: 'less-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'increment-clamp',
+      passOp: 'increment-clamp',
+    },
+    stencilReadMask: 2198458344,
+    stencilWriteMask: 3170631562,
+    depthBiasSlopeScale: 593.5480632274513,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 624,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 24, shaderLocation: 23},
+          {format: 'uint16x4', offset: 60, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+  await promise15;
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({label: '\u15a4\u6bac\u4711\u0e98\u0028\u{1fed1}\u8f4a\u0aeb\u{1fbbd}\u8bb7\ua900'});
+let computePassEncoder27 = commandEncoder56.beginComputePass({});
+let externalTexture28 = device0.importExternalTexture({label: '\u13dd\uc00b\u1350\uc851\ud329\u0558\u{1f962}', source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup18, new Uint32Array(5588), 4004, 0);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(188, 0, 14, 1);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline34);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer0, 65428, buffer11, 2564, 64472);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder39.resolveQuerySet(querySet16, 1140, 1014, buffer13, 77056);
+} catch {}
+try {
+device0.queue.submit([commandBuffer9, commandBuffer8, commandBuffer12]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer3), /* required buffer size: 88 */
+{offset: 36}, {width: 52, height: 1, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let sampler35 = device0.createSampler({
+  label: '\uf2f4\u97ec\u{1ff8b}\u617b\u16e9\u4389',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 32.28,
+  compare: 'less',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder13.setPipeline(pipeline18);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 703 */
+{offset: 677, bytesPerRow: 78}, {width: 26, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise18 = device0.createRenderPipelineAsync({
+  label: '\ub297\u4d46\u08ad\u{1f618}\uc8c3\u0a92\u8dff',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16float', writeMask: GPUColorWrite.GREEN}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'zero'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rg11b10ufloat', writeMask: 0}, {format: 'r8uint', writeMask: GPUColorWrite.ALL}, {format: 'r8sint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilBack: {compare: 'greater', failOp: 'replace', depthFailOp: 'zero', passOp: 'invert'},
+    stencilReadMask: 3306238509,
+    stencilWriteMask: 1683206639,
+    depthBiasClamp: -30.350048023102403,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1388,
+        attributes: [
+          {format: 'uint32', offset: 136, shaderLocation: 7},
+          {format: 'uint32', offset: 596, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 140, shaderLocation: 16},
+          {format: 'snorm16x4', offset: 400, shaderLocation: 9},
+          {format: 'uint32x2', offset: 176, shaderLocation: 22},
+          {format: 'sint32x3', offset: 580, shaderLocation: 4},
+          {format: 'uint32x4', offset: 252, shaderLocation: 19},
+          {format: 'snorm16x2', offset: 104, shaderLocation: 20},
+          {format: 'unorm10-10-10-2', offset: 52, shaderLocation: 21},
+          {format: 'sint8x4', offset: 92, shaderLocation: 5},
+          {format: 'uint32x4', offset: 232, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 80, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 284, shaderLocation: 23},
+          {format: 'unorm16x4', offset: 324, shaderLocation: 3},
+          {format: 'uint32x4', offset: 216, shaderLocation: 1},
+          {format: 'sint16x2', offset: 56, shaderLocation: 0},
+          {format: 'uint8x4', offset: 32, shaderLocation: 17},
+          {format: 'sint16x4', offset: 28, shaderLocation: 18},
+          {format: 'uint32x2', offset: 568, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 80, shaderLocation: 8},
+          {format: 'uint32x2', offset: 384, shaderLocation: 10},
+          {format: 'unorm8x4', offset: 104, shaderLocation: 2},
+          {format: 'float32x3', offset: 184, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 228, stepMode: 'vertex', attributes: []},
+      {arrayStride: 2140, stepMode: 'instance', attributes: []},
+      {arrayStride: 604, attributes: [{format: 'uint32x2', offset: 16, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+try {
+offscreenCanvas4.getContext('webgpu');
+} catch {}
+let texture45 = device0.createTexture({
+  label: '\u0781\u0bd7\u533c\u7663\u{1f927}\u0a01\ub787\u{1fe8b}\u9865\u3899',
+  size: {width: 384},
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder3.beginOcclusionQuery(468);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(0, buffer3, 36268, 30384);
+} catch {}
+try {
+offscreenCanvas5.getContext('2d');
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  label: '\u{1fd8a}\uf789\u{1fe0b}\u8376\u2b35\u{1faba}\u{1f843}\ud699\u0342\u4c45',
+  code: `@group(2) @binding(1293)
+var<storage, read_write> parameter3: array<u32>;
+@group(0) @binding(1293)
+var<storage, read_write> parameter4: array<u32>;
+
+@compute @workgroup_size(2, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(2) f1: f32,
+  @location(0) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @location(23) a1: vec3<f32>, @location(8) a2: vec3<i32>, @location(39) a3: f16, @location(6) a4: f16, @location(4) a5: u32, @location(32) a6: f16) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(36) f81: vec4<f16>,
+  @location(4) f82: u32,
+  @location(41) f83: vec3<f32>,
+  @location(1) f84: f32,
+  @builtin(position) f85: vec4<f32>,
+  @location(17) f86: vec3<f16>,
+  @location(13) f87: vec2<f16>,
+  @location(18) f88: vec4<u32>,
+  @location(6) f89: f16,
+  @location(43) f90: vec2<f16>,
+  @location(29) f91: vec3<u32>,
+  @location(42) f92: u32,
+  @location(7) f93: vec2<i32>,
+  @location(11) f94: vec3<f16>,
+  @location(32) f95: f16,
+  @location(34) f96: vec4<i32>,
+  @location(23) f97: vec3<f32>,
+  @location(37) f98: i32,
+  @location(24) f99: vec4<f16>,
+  @location(10) f100: vec4<i32>,
+  @location(3) f101: u32,
+  @location(26) f102: f16,
+  @location(33) f103: i32,
+  @location(2) f104: vec3<f16>,
+  @location(38) f105: vec4<u32>,
+  @location(14) f106: vec2<f32>,
+  @location(31) f107: vec2<f16>,
+  @location(16) f108: u32,
+  @location(8) f109: vec3<i32>,
+  @location(25) f110: vec2<f32>,
+  @location(39) f111: f16,
+  @location(40) f112: f32
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec4<f16>, @location(17) a1: vec2<u32>, @location(23) a2: u32, @location(3) a3: vec2<f32>, @location(1) a4: vec3<u32>, @location(10) a5: vec4<u32>, @location(13) a6: vec3<f32>, @location(20) a7: vec2<i32>, @location(16) a8: vec3<i32>, @location(0) a9: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let commandEncoder59 = device0.createCommandEncoder({label: '\u{1f60e}\u081d\ua43d\u0553\u9f51'});
+let textureView65 = texture19.createView({baseMipLevel: 3});
+let renderBundle38 = renderBundleEncoder18.finish({label: '\u7b0b\u{1fe0b}'});
+let sampler36 = device0.createSampler({
+  label: '\u0d98\u{1f66c}\u6124\u0f14\u3181\u0cd6\u{1f64d}\u0e91',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 13.09,
+  lodMaxClamp: 90.03,
+  maxAnisotropy: 8,
+});
+let externalTexture29 = device0.importExternalTexture({label: '\u{1fcdd}\u2065\u640c\u9850\ubfa9\u5e62\u{1fed9}', source: videoFrame3});
+try {
+computePassEncoder26.setBindGroup(5, bindGroup18);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(5, 1, 0, 0);
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1664 widthInBlocks: 208 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 10088 */
+  offset: 10088,
+  buffer: buffer2,
+}, {width: 208, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 369 */
+{offset: 369, rowsPerImage: 273}, {width: 701, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline40 = device0.createComputePipeline({
+  label: '\u{1ffe1}\u0067\u0bf5\u7db2\u{1f6da}\u19c3\u751b\u004b\uc726\u98c3',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(img0);
+let shaderModule14 = device0.createShaderModule({
+  label: '\ue82e\ubad1\ue963\uc248\u0457\u{1fe9b}',
+  code: `@group(0) @binding(1293)
+var<storage, read_write> function9: array<u32>;
+@group(1) @binding(1293)
+var<storage, read_write> n6: array<u32>;
+
+@compute @workgroup_size(7, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+  @location(24) f0: vec4<i32>,
+  @location(17) f1: vec4<i32>,
+  @builtin(front_facing) f2: bool,
+  @location(13) f3: vec3<i32>,
+  @location(22) f4: vec2<f16>,
+  @location(6) f5: vec3<u32>,
+  @location(27) f6: i32,
+  @builtin(position) f7: vec4<f32>,
+  @location(28) f8: vec3<i32>,
+  @location(29) f9: vec2<i32>,
+  @location(12) f10: vec3<i32>,
+  @location(38) f11: vec3<i32>,
+  @location(34) f12: vec4<f16>,
+  @location(15) f13: vec3<i32>,
+  @location(7) f14: vec4<f32>,
+  @builtin(sample_index) f15: u32,
+  @location(35) f16: vec3<f32>,
+  @location(23) f17: vec3<i32>,
+  @location(26) f18: vec2<f16>,
+  @builtin(sample_mask) f19: u32,
+  @location(2) f20: vec3<i32>
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4<i32>,
+  @location(1) f2: vec4<u32>,
+  @location(2) f3: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(3) a0: f16, a1: S13, @location(41) a2: vec4<i32>, @location(16) a3: vec3<f32>, @location(19) a4: vec4<f16>, @location(37) a5: vec4<u32>, @location(42) a6: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(17) f113: vec4<i32>,
+  @location(13) f114: vec3<i32>,
+  @location(29) f115: vec2<i32>,
+  @builtin(position) f116: vec4<f32>,
+  @location(38) f117: vec3<i32>,
+  @location(19) f118: vec4<f16>,
+  @location(41) f119: vec4<i32>,
+  @location(16) f120: vec3<f32>,
+  @location(6) f121: vec3<u32>,
+  @location(12) f122: vec3<i32>,
+  @location(15) f123: vec3<i32>,
+  @location(27) f124: i32,
+  @location(28) f125: vec3<i32>,
+  @location(22) f126: vec2<f16>,
+  @location(24) f127: vec4<i32>,
+  @location(42) f128: vec3<f32>,
+  @location(2) f129: vec3<i32>,
+  @location(23) f130: vec3<i32>,
+  @location(7) f131: vec4<f32>,
+  @location(35) f132: vec3<f32>,
+  @location(37) f133: vec4<u32>,
+  @location(26) f134: vec2<f16>,
+  @location(3) f135: f16,
+  @location(34) f136: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec4<f32>, @location(16) a1: vec2<f32>, @location(19) a2: vec2<i32>, @location(6) a3: vec4<u32>, @location(4) a4: vec2<i32>, @location(14) a5: vec2<i32>, @location(7) a6: vec2<u32>, @location(17) a7: vec2<f32>, @builtin(vertex_index) a8: u32, @location(20) a9: vec4<i32>, @location(11) a10: vec3<i32>, @location(2) a11: f32, @builtin(instance_index) a12: u32, @location(13) a13: vec4<i32>, @location(3) a14: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup19 = device0.createBindGroup({layout: bindGroupLayout8, entries: []});
+let pipelineLayout9 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout6, bindGroupLayout1, bindGroupLayout0, bindGroupLayout5],
+});
+let externalTexture30 = device0.importExternalTexture({source: video0, colorSpace: 'srgb'});
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -687.0, g: 946.7, b: 195.6, a: -320.9, });
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(buffer0, 88608, buffer11, 228244, 15960);
+dissociateBuffer(device0, buffer0);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let pipeline41 = device0.createRenderPipeline({
+  label: '\ud5f8\u0ca4',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba32uint', writeMask: GPUColorWrite.BLUE}, {format: 'r8unorm', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilReadMask: 1941676023,
+    stencilWriteMask: 2794508569,
+    depthBias: 160408340,
+    depthBiasSlopeScale: 534.0296523710917,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 120,
+        attributes: [
+          {format: 'snorm8x2', offset: 56, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 36, shaderLocation: 19},
+          {format: 'float32', offset: 0, shaderLocation: 11},
+          {format: 'uint8x2', offset: 22, shaderLocation: 22},
+          {format: 'sint16x4', offset: 52, shaderLocation: 2},
+          {format: 'uint16x2', offset: 24, shaderLocation: 6},
+          {format: 'sint16x4', offset: 4, shaderLocation: 7},
+          {format: 'uint32x2', offset: 0, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 1892, shaderLocation: 18},
+          {format: 'snorm16x4', offset: 2228, shaderLocation: 12},
+          {format: 'uint32', offset: 1032, shaderLocation: 4},
+          {format: 'uint32x2', offset: 792, shaderLocation: 1},
+          {format: 'uint32', offset: 16, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 1064,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 268, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 328, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 3},
+          {format: 'float32', offset: 52, shaderLocation: 9},
+          {format: 'uint32x3', offset: 148, shaderLocation: 16},
+          {format: 'uint32', offset: 240, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 3068,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 80, shaderLocation: 8}],
+      },
+      {
+        arrayStride: 928,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 144, shaderLocation: 21},
+          {format: 'unorm10-10-10-2', offset: 76, shaderLocation: 23},
+        ],
+      },
+      {arrayStride: 1360, attributes: [{format: 'float32x3', offset: 612, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', unclippedDepth: true},
+});
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 1613});
+let textureView66 = texture31.createView({label: '\u06f1\u468e\uc9f9\u0aac\u12d5\u0ff0', baseArrayLayer: 0});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '\u954b\uaa31\u0db3\u568a\ub414\u{1f847}',
+  colorFormats: ['rgba32float'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle36]);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -50.67, g: -945.0, b: 235.5, a: 373.7, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(140, 1, 40, 0);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(1, buffer19, 0, 288036);
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 442 widthInBlocks: 442 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2174 */
+  offset: 2174,
+  buffer: buffer7,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 442, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+let texture46 = device0.createTexture({
+  size: [96, 2, 499],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView67 = texture23.createView({label: '\u07a8\u5dd8\uf051\u0d89\u9168', mipLevelCount: 1});
+let computePassEncoder28 = commandEncoder4.beginComputePass({label: '\u98e6\u2f86\u49a0\ub158'});
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer3, 0, 31914);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 868 */
+{offset: 868}, {width: 369, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule15 = device0.createShaderModule({
+  label: '\u{1f754}\u0073\u3e73\u7d90\u0acb',
+  code: `@group(1) @binding(3739)
+var<storage, read_write> function10: array<u32>;
+@group(2) @binding(513)
+var<storage, read_write> parameter5: array<u32>;
+@group(1) @binding(513)
+var<storage, read_write> parameter6: array<u32>;
+@group(2) @binding(3739)
+var<storage, read_write> n7: array<u32>;
+
+@compute @workgroup_size(7, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec3<i32>,
+  @location(4) f1: vec3<u32>,
+  @location(2) f2: vec4<f32>,
+  @location(1) f3: vec3<f32>,
+  @location(3) f4: vec3<f32>,
+  @location(0) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(23) a0: u32, @location(32) a1: i32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(22) f0: vec2<i32>,
+  @location(2) f1: vec4<i32>,
+  @location(18) f2: vec2<f16>,
+  @location(21) f3: vec2<u32>,
+  @location(7) f4: u32,
+  @location(8) f5: vec3<u32>,
+  @location(4) f6: i32,
+  @location(3) f7: u32,
+  @location(17) f8: f32,
+  @location(19) f9: vec3<i32>,
+  @location(12) f10: f32,
+  @builtin(instance_index) f11: u32
+}
+struct VertexOutput0 {
+  @location(0) f137: vec2<u32>,
+  @location(12) f138: vec4<f32>,
+  @location(16) f139: vec3<f16>,
+  @location(23) f140: u32,
+  @location(38) f141: u32,
+  @location(7) f142: vec4<u32>,
+  @location(29) f143: vec3<f16>,
+  @location(18) f144: vec2<u32>,
+  @location(41) f145: vec2<i32>,
+  @location(2) f146: vec2<f16>,
+  @location(17) f147: vec3<f32>,
+  @location(32) f148: i32,
+  @location(37) f149: u32,
+  @location(43) f150: vec2<f32>,
+  @builtin(position) f151: vec4<f32>,
+  @location(33) f152: vec4<u32>,
+  @location(14) f153: vec4<i32>,
+  @location(9) f154: vec4<u32>,
+  @location(35) f155: f32,
+  @location(30) f156: vec3<u32>,
+  @location(1) f157: i32
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3<f16>, @location(0) a1: vec4<f16>, @location(11) a2: u32, @location(1) a3: vec3<i32>, @location(23) a4: i32, @location(20) a5: vec2<f32>, @location(14) a6: vec4<u32>, @location(5) a7: f32, a8: S14) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\uc2f3\u{1f95e}\u9964\u{1fc98}\u0b7a\u0171',
+  entries: [
+    {binding: 5691, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 4082,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 1185, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder60 = device0.createCommandEncoder({label: '\uf0d9\u04e4\u{1f8a0}'});
+let textureView68 = texture23.createView({
+  label: '\u785a\u{1fb13}\u818e\ufb3d\u087a\u39da\u{1fdf4}\u07e8\u332d\u{1f747}\u317b',
+  dimension: '1d',
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthReadOnly: true, stencilReadOnly: true});
+let sampler37 = device0.createSampler({
+  label: '\u99e0\u{1f899}\u7b5d\u0c90\u{1ffa6}\ud93a\uad1c\ua8ee\u3681\u090a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 99.18,
+});
+try {
+computePassEncoder22.setPipeline(pipeline40);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(39, 0, 18, 0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(2313);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline25);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer4, 56836, buffer9, 67020, 340);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let pipeline42 = await promise18;
+let querySet30 = device0.createQuerySet({label: '\u00cf\u46b9\ufbf3\uf6f1\u0555\u474f\u0f5b\u2345\u0ea6\u4639', type: 'occlusion', count: 789});
+let texture47 = device0.createTexture({
+  size: [384, 8, 1783],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView69 = texture11.createView({label: '\u6855\u{1fc33}\u500b', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder29 = commandEncoder39.beginComputePass({label: '\u0203\ueeb0\ucc99\udb09\u{1f705}'});
+let externalTexture31 = device0.importExternalTexture({source: videoFrame2});
+try {
+renderPassEncoder0.setScissorRect(136, 0, 11, 0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(2792);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(8, buffer3, 0, 44655);
+} catch {}
+try {
+commandEncoder54.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 295 widthInBlocks: 295 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 16591 */
+  offset: 16591,
+  buffer: buffer2,
+}, {width: 295, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder49.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 272},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 96, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+gc();
+let offscreenCanvas6 = new OffscreenCanvas(276, 494);
+let imageData9 = new ImageData(108, 132);
+let buffer20 = device0.createBuffer({
+  label: '\u0940\uf70e\ud7b9\u0ea3\uc890\u01bc',
+  size: 592050,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let textureView70 = texture3.createView({label: '\u0677\u0898', dimension: '2d', baseMipLevel: 3, baseArrayLayer: 1119});
+try {
+renderPassEncoder0.setBindGroup(6, bindGroup2);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(2122);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(138.3, 0.2770, 14.44, 0.1861, 0.5000, 0.9783);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer19, 'uint16', 254114, 26807);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(6, buffer19);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder42.copyTextureToBuffer({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1424 widthInBlocks: 356 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 49180 */
+  offset: 49180,
+  buffer: buffer2,
+}, {width: 356, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder51.resolveQuerySet(querySet19, 2787, 356, buffer13, 148992);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\ubbd0');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 859_312 */
+{offset: 900, bytesPerRow: 160, rowsPerImage: 145}, {width: 3, height: 1, depthOrArrayLayers: 38});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let video6 = await videoWithData();
+let commandEncoder61 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder17.setIndexBuffer(buffer14, 'uint16', 208562, 74852);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(5, buffer19, 0, 155938);
+} catch {}
+try {
+commandEncoder53.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 67, y: 0, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 89, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 242, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline43 = device0.createRenderPipeline({
+  label: '\u3296\u097b',
+  layout: pipelineLayout2,
+  multisample: {mask: 0x740118eb},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1024,
+        attributes: [
+          {format: 'float32', offset: 140, shaderLocation: 21},
+          {format: 'uint16x4', offset: 264, shaderLocation: 14},
+          {format: 'uint32x2', offset: 332, shaderLocation: 20},
+          {format: 'uint32x3', offset: 52, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 16, shaderLocation: 9},
+          {format: 'uint16x4', offset: 288, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 84, shaderLocation: 17},
+          {format: 'uint16x4', offset: 292, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 24, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 272, shaderLocation: 11},
+          {format: 'uint32x2', offset: 12, shaderLocation: 3},
+          {format: 'sint8x4', offset: 304, shaderLocation: 10},
+          {format: 'float32x3', offset: 84, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 372, shaderLocation: 6},
+          {format: 'uint8x2', offset: 742, shaderLocation: 1},
+          {format: 'uint8x4', offset: 268, shaderLocation: 23},
+          {format: 'snorm16x4', offset: 32, shaderLocation: 0},
+          {format: 'sint32', offset: 8, shaderLocation: 18},
+          {format: 'uint8x4', offset: 36, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 1152,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 48, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front', unclippedDepth: true},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let img5 = await imageWithData(283, 117, '#3104408c', '#d5546650');
+let commandEncoder62 = device0.createCommandEncoder({label: '\uc9bb\uf031\uff80'});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle35, renderBundle35, renderBundle36, renderBundle36, renderBundle25, renderBundle22, renderBundle36, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -694.2, g: 133.4, b: 243.2, a: -879.8, });
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(2656);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer14, 'uint16');
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas6.getContext('webgpu');
+let commandEncoder63 = device0.createCommandEncoder();
+let texture48 = device0.createTexture({
+  size: {width: 809, height: 1, depthOrArrayLayers: 961},
+  mipLevelCount: 4,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView71 = texture25.createView({baseMipLevel: 0});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], stencilReadOnly: true});
+let renderBundle39 = renderBundleEncoder14.finish({label: '\u0be1\ub43f\ubc9e\ua3b1\u10d2\u0ab2\u{1fdf4}\u2409\u1dbb\u0bdf'});
+try {
+  await buffer16.mapAsync(GPUMapMode.WRITE, 0, 193920);
+} catch {}
+try {
+commandEncoder49.clearBuffer(buffer6, 134208, 94052);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3872,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let texture49 = device0.createTexture({
+  label: '\u0963\u82f6\u11da\u00c1\u3ac8\u003d\u24e5',
+  size: [3239, 1, 1],
+  mipLevelCount: 9,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  label: '\u0189\ubf67\uf7f1\u3f11',
+  colorFormats: ['rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(6, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer19, 'uint32', 86072, 56354);
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer6, 174696, 44496);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 137, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer0), /* required buffer size: 22 */
+{offset: 22, bytesPerRow: 526}, {width: 57, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(420, 756);
+let imageBitmap7 = await createImageBitmap(offscreenCanvas0);
+let querySet31 = device0.createQuerySet({label: '\u7089\u2973\u{1fcb7}\ud964\u0d2a\u88bc', type: 'occlusion', count: 4054});
+let commandBuffer13 = commandEncoder43.finish();
+let externalTexture32 = device0.importExternalTexture({
+  label: '\u0164\u3616\u374d\u{1fee2}\u{1f705}\u{1f7c9}\ue738\u{1f7e1}',
+  source: videoFrame2,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder3.setStencilReference(611);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(5, buffer13, 65492, 104228);
+} catch {}
+try {
+  await buffer15.mapAsync(GPUMapMode.WRITE);
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer19, 21848, buffer11, 265452, 16708);
+dissociateBuffer(device0, buffer19);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 384 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2496 */
+  offset: 2496,
+  bytesPerRow: 512,
+  buffer: buffer2,
+}, {width: 24, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer6, 160304, 41692);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder58.resolveQuerySet(querySet16, 1494, 439, buffer20, 512768);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 202, height: 1, depthOrArrayLayers: 546}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 15, y: 68 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 75, y: 0, z: 59},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline44 = await promise17;
+let computePassEncoder30 = commandEncoder58.beginComputePass();
+let sampler38 = device0.createSampler({
+  label: '\u2374\u0442\u7a38\ue623\u053b',
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.380,
+  lodMaxClamp: 84.59,
+  maxAnisotropy: 13,
+});
+let externalTexture33 = device0.importExternalTexture({label: '\uafad\uf02d\u09a8\u04cc\u{1f7d0}\u53c5\u6096\u4851\u{1fca0}\u9efc\u376d', source: video1});
+try {
+computePassEncoder22.setBindGroup(4, bindGroup13);
+} catch {}
+try {
+renderPassEncoder0.setViewport(84.28, 0.2455, 63.16, 0.03263, 0.6372, 0.7757);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(7, buffer19, 0);
+} catch {}
+let arrayBuffer4 = buffer11.getMappedRange(36576, 69700);
+try {
+commandEncoder52.copyBufferToBuffer(buffer1, 24608, buffer6, 124332, 524);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 56, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer9, 34784, 88500);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder61.insertDebugMarker('\u{1fa84}');
+} catch {}
+let pipeline45 = device0.createComputePipeline({
+  label: '\u25be\u{1f6c1}\u03f2',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas8 = new OffscreenCanvas(277, 983);
+let img6 = await imageWithData(172, 198, '#55602285', '#cbad56b9');
+let texture50 = device0.createTexture({
+  label: '\u017c\u010f\ucaec\u{1fe12}\uaad7\u0434',
+  size: [809, 1, 1],
+  mipLevelCount: 7,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32float', 'rgba32float'],
+});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  label: '\u02c4\u0068\ub2a0',
+  colorFormats: ['rg16float', 'rg11b10ufloat', 'rgba16float', 'rg11b10ufloat', 'r8uint', 'r8sint'],
+  depthReadOnly: true,
+});
+let externalTexture34 = device0.importExternalTexture({label: '\u0832\u{1feec}\u{1ffc5}', source: videoFrame0});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -910.5, g: -490.8, b: 964.6, a: 443.3, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(41.04, 0.4115, 24.13, 0.2385, 0.8459, 0.9499);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer19, 'uint16', 244066, 15456);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 29 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 102542 */
+  offset: 10353,
+  bytesPerRow: 512,
+  rowsPerImage: 180,
+  buffer: buffer19,
+}, {
+  texture: texture2,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 29, height: 1, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(querySet15, 193, 55, buffer13, 129280);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 25},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 250_127 */
+{offset: 80, bytesPerRow: 84, rowsPerImage: 93}, {width: 63, height: 1, depthOrArrayLayers: 33});
+} catch {}
+let pipeline46 = await promise12;
+let offscreenCanvas9 = new OffscreenCanvas(907, 1024);
+let img7 = await imageWithData(89, 286, '#904a33c4', '#ae1c70d0');
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  label: '\u037c\u1f5b\u0ad3\u0ec2\u{1fcd4}\u0837\ub6f7\u{1fa41}\u0655',
+  entries: [{binding: 156, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let bindGroupLayout13 = pipeline32.getBindGroupLayout(1);
+let textureView72 = texture24.createView({label: '\u4dc8\u{1fdb0}\u0ed1\u5be2'});
+let renderPassEncoder4 = commandEncoder35.beginRenderPass({
+  label: '\u0f9b\u6339\ub0a4\ucd2d\u98fe\u{1f80a}\u73c8\u63a9\u{1fc13}\u0572',
+  colorAttachments: [{
+  view: textureView61,
+  depthSlice: 0,
+  clearValue: { r: 722.9, g: -123.2, b: 350.2, a: -869.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+let externalTexture35 = device0.importExternalTexture({label: '\ua379\u481b\uae8b\u78b2\ub510\ue8f5\u57bb\uff3f\u98b4', source: video0});
+try {
+renderPassEncoder4.setStencilReference(976);
+} catch {}
+try {
+renderPassEncoder4.setViewport(5.579, 0.1810, 0.04603, 0.6508, 0.4913, 0.9980);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(6, buffer3, 0, 58698);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(buffer15, 71184, buffer11, 269772, 1352);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder18.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 7,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline47 = await device0.createRenderPipelineAsync({
+  label: '\ud78b\u5953',
+  layout: pipelineLayout2,
+  multisample: {mask: 0xc317bb26},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rgba32uint'}, {format: 'r8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint16x2', offset: 2888, shaderLocation: 10},
+          {format: 'uint16x4', offset: 3480, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 1604, shaderLocation: 0},
+          {format: 'uint8x4', offset: 312, shaderLocation: 15},
+          {format: 'uint32x3', offset: 2516, shaderLocation: 13},
+          {format: 'uint16x2', offset: 204, shaderLocation: 3},
+          {format: 'uint8x2', offset: 362, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 3098, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 2148, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 1748,
+        attributes: [
+          {format: 'snorm16x2', offset: 28, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 144, shaderLocation: 6},
+          {format: 'sint8x2', offset: 170, shaderLocation: 18},
+          {format: 'snorm8x2', offset: 708, shaderLocation: 12},
+          {format: 'uint32', offset: 36, shaderLocation: 23},
+          {format: 'snorm8x4', offset: 188, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 2364,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 1172, shaderLocation: 2},
+          {format: 'uint32x4', offset: 236, shaderLocation: 5},
+          {format: 'float32x2', offset: 200, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 984,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 60, shaderLocation: 20},
+          {format: 'uint32', offset: 280, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front', unclippedDepth: true},
+});
+try {
+window.someLabel = externalTexture31.label;
+} catch {}
+let commandEncoder64 = device0.createCommandEncoder({});
+try {
+computePassEncoder15.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(4, bindGroup15, new Uint32Array(4539), 1534, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer19, 276084, 3815);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(5, bindGroup10);
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 683, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 50, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+  label: '\u9225\udd58\uae90\u7d72\u{1fc98}\ud990\u8711\u097a\u740a\u147f\u{1f604}',
+  layout: bindGroupLayout13,
+  entries: [{binding: 1293, resource: sampler30}],
+});
+let textureView73 = texture6.createView({
+  label: '\ub1b7\ud355\uaff9\u0ab1\u{1f77d}\ue485\u{1f9fa}\uda89\u0193\u0108\ubb96',
+  dimension: '2d',
+  baseMipLevel: 7,
+  baseArrayLayer: 846,
+  arrayLayerCount: 1,
+});
+let externalTexture36 = device0.importExternalTexture({source: videoFrame3, colorSpace: 'display-p3'});
+try {
+renderPassEncoder3.setViewport(4.524, 0.8367, 0.3162, 0.09765, 0.3326, 0.5221);
+} catch {}
+try {
+commandEncoder60.resolveQuerySet(querySet28, 2042, 195, buffer13, 62208);
+} catch {}
+let pipeline48 = device0.createComputePipeline({
+  label: '\u0b93\u46cd\uea19\u{1fa2b}\u8f77\u{1f989}\u5af8\udd72',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame4 = new VideoFrame(video6, {timestamp: 0});
+let computePassEncoder31 = commandEncoder63.beginComputePass({});
+let sampler39 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.48,
+  lodMaxClamp: 27.72,
+  compare: 'less-equal',
+});
+let externalTexture37 = device0.importExternalTexture({source: video1, colorSpace: 'srgb'});
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer13, 84776, 70762);
+} catch {}
+let pipeline49 = device0.createComputePipeline({
+  label: '\u{1fee2}\u8472\u0d25\u3e35',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let pipeline50 = device0.createRenderPipeline({
+  label: '\uab5f\u{1fc60}\u4c92\u0c06\u2083\uc71b',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: 0}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5648,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32', offset: 768, shaderLocation: 13},
+          {format: 'uint32x4', offset: 220, shaderLocation: 15},
+          {format: 'uint8x4', offset: 144, shaderLocation: 3},
+          {format: 'uint32x4', offset: 496, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 1200, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 1282, shaderLocation: 21},
+          {format: 'unorm16x2', offset: 384, shaderLocation: 0},
+          {format: 'float16x4', offset: 900, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 100, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 1964, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 550, shaderLocation: 9},
+          {format: 'float16x2', offset: 1224, shaderLocation: 12},
+          {format: 'uint32x3', offset: 1372, shaderLocation: 20},
+          {format: 'uint8x2', offset: 412, shaderLocation: 1},
+          {format: 'sint8x4', offset: 1200, shaderLocation: 18},
+          {format: 'uint32', offset: 3028, shaderLocation: 14},
+          {format: 'uint32x2', offset: 1080, shaderLocation: 23},
+          {format: 'uint16x4', offset: 132, shaderLocation: 5},
+          {format: 'float32', offset: 3304, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 1880,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32', offset: 124, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroup21 = device0.createBindGroup({
+  label: '\u3851\u6922\u12c4',
+  layout: bindGroupLayout1,
+  entries: [{binding: 1293, resource: sampler26}],
+});
+let commandEncoder65 = device0.createCommandEncoder({label: '\ua457\u0967\u0bb0\ud0b7\u{1fd93}\u034f\ue7c8\u{1f6c4}\u{1faa5}'});
+let computePassEncoder32 = commandEncoder18.beginComputePass();
+try {
+computePassEncoder23.setBindGroup(5, bindGroup16, new Uint32Array(1287), 1257, 0);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(91);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(0, 0, 1, 1);
+} catch {}
+try {
+renderPassEncoder4.setViewport(4.782, 0.3899, 0.8407, 0.07035, 0.6357, 0.9782);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(7, buffer3, 0, 11483);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer5, 6504, buffer9, 14312, 15464);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer6, 222168, 6196);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 56},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 6_999_844 */
+{offset: 310, bytesPerRow: 1521, rowsPerImage: 107}, {width: 1413, height: 1, depthOrArrayLayers: 44});
+} catch {}
+let img8 = await imageWithData(165, 120, '#ef8d08b6', '#bfb711ff');
+let imageData10 = new ImageData(124, 40);
+let querySet32 = device0.createQuerySet({label: '\ue552\u{1fa1c}\u8d64\u94d1\u1bfb\ub4f8', type: 'occlusion', count: 1726});
+let renderBundle40 = renderBundleEncoder3.finish({label: '\u298c\u{1f890}\u{1f8b6}\u2b8f\u{1fe6f}'});
+let sampler40 = device0.createSampler({
+  label: '\u{1f8ae}\u{1f998}\u{1fda8}\u468f\u8a55\ud230',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 35.66,
+  lodMaxClamp: 47.95,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder4.setStencilReference(3894);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(9, buffer3, 44744, 19917);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 2,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 71, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 26, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 24, height: 1, depthOrArrayLayers: 10}
+*/
+{
+  source: img2,
+  origin: { x: 0, y: 122 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 5,
+  origin: {x: 4, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video0.width = 256;
+let commandEncoder66 = device0.createCommandEncoder({label: '\u0dc4\u633c\u{1ffaa}\u{1fe58}\u063d\u4ef3\u{1f78b}\u3df9'});
+let querySet33 = device0.createQuerySet({type: 'occlusion', count: 1515});
+let externalTexture38 = device0.importExternalTexture({source: video0, colorSpace: 'srgb'});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup21, new Uint32Array(1818), 1791, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle25]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(189, 0, 11, 1);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(2308);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer19, 104824, 117894);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(5, bindGroup5, new Uint32Array(8875), 5374, 0);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 4,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 12},
+  aspect: 'all',
+},
+{width: 27, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder60.clearBuffer(buffer2, 74328, 22412);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(querySet6, 2043, 1263, buffer20, 17408);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+document.body.prepend(img8);
+let promise20 = navigator.gpu.requestAdapter();
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+gc();
+let imageData11 = new ImageData(172, 100);
+try {
+  await promise19;
+} catch {}
+let video7 = await videoWithData();
+offscreenCanvas7.width = 351;
+let canvas7 = document.createElement('canvas');
+gc();
+video4.height = 216;
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas7.getContext('webgpu');
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+document.body.prepend(canvas5);
+offscreenCanvas4.width = 2458;
+let imageData12 = new ImageData(220, 104);
+try {
+adapter0.label = '\u{1f9be}\u5d3f';
+} catch {}
+let canvas8 = document.createElement('canvas');
+let img9 = await imageWithData(184, 171, '#9cb86760', '#089de58a');
+gc();
+let imageBitmap8 = await createImageBitmap(imageData12);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let img10 = await imageWithData(198, 48, '#6200c560', '#2f193a22');
+document.body.prepend(video2);
+let imageData13 = new ImageData(96, 188);
+let img11 = await imageWithData(2, 169, '#b5835478', '#e9259407');
+let offscreenCanvas10 = new OffscreenCanvas(299, 632);
+let video8 = await videoWithData();
+try {
+offscreenCanvas10.getContext('bitmaprenderer');
+} catch {}
+let video9 = await videoWithData();
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let video10 = await videoWithData();
+gc();
+try {
+adapter0.label = '\u694a\u02bd\u8bc5\u0b6a\u3077\ua1bf\ua8be\ub67f\u093b';
+} catch {}
+let imageBitmap9 = await createImageBitmap(imageData7);
+let offscreenCanvas11 = new OffscreenCanvas(981, 12);
+let adapter1 = await promise16;
+let videoFrame5 = new VideoFrame(video7, {timestamp: 0});
+let videoFrame6 = new VideoFrame(canvas7, {timestamp: 0});
+try {
+adapter1.label = '\u0e74\u0120\uacab\u4d7f\u9841\u{1fef2}';
+} catch {}
+try {
+canvas6.getContext('bitmaprenderer');
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas11.getContext('webgpu');
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let img12 = await imageWithData(45, 100, '#afb1bf12', '#382f104f');
+try {
+querySet4.label = '\u055d\u{1fc92}\u{1fd3a}\u{1fa70}\u00f6\ueba0\u7a7a\u9621\u1692\u034d';
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+adapter0.label = '\u46cb\u0010\u7ffb\u0741';
+} catch {}
+offscreenCanvas4.width = 1366;
+let imageData14 = new ImageData(132, 244);
+document.body.prepend(img2);
+try {
+offscreenCanvas8.getContext('webgpu');
+} catch {}
+try {
+externalTexture38.label = '\u0965\u0798\u4ff4\u1866\ubb4f\ue855\u1d96';
+} catch {}
+let textureView74 = texture13.createView({label: '\u6f7b\u11de\ue307\u5bd9\u{1fbf3}\u8286', baseMipLevel: 8, mipLevelCount: 1});
+let renderPassEncoder5 = commandEncoder59.beginRenderPass({
+  colorAttachments: [{
+  view: textureView60,
+  clearValue: { r: 485.8, g: 839.9, b: 377.1, a: -899.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet15,
+});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  label: '\u2cb0\u2241\uc025\u384c\ub76f\u{1ff25}\u0dd8\u0888\u4cb8\u0317\u0228',
+  colorFormats: ['rg16float', 'rg11b10ufloat', 'rgba16float', 'rg11b10ufloat', 'r8uint', 'r8sint'],
+  stencilReadOnly: true,
+});
+let sampler41 = device0.createSampler({
+  label: '\ue334\u0496',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 70.81,
+  lodMaxClamp: 76.52,
+});
+try {
+renderPassEncoder4.setBlendConstant({ r: -145.2, g: 489.9, b: -418.1, a: -716.9, });
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer3, 'uint16', 8446, 48774);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(10, buffer19, 44924, 165567);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(5, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer19, 182676, 51663);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer18, 335240, buffer2, 39508, 43128);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 102, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 112, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 189, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder42.clearBuffer(buffer9, 64912, 52720);
+dissociateBuffer(device0, buffer9);
+} catch {}
+let pipeline51 = device0.createRenderPipeline({
+  label: '\u090e\u3929\u{1fd3f}\u{1f7da}\u0ff6\u09d4\u9333',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: 0}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'zero', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilReadMask: 803836186,
+    stencilWriteMask: 721697310,
+    depthBiasClamp: 861.8822518869707,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3084, stepMode: 'instance', attributes: []},
+      {arrayStride: 1660, attributes: [{format: 'float32x3', offset: 904, shaderLocation: 8}]},
+      {
+        arrayStride: 2352,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 72, shaderLocation: 1}],
+      },
+      {arrayStride: 436, attributes: []},
+      {
+        arrayStride: 680,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32x2', offset: 28, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+video4.width = 221;
+try {
+offscreenCanvas9.getContext('bitmaprenderer');
+} catch {}
+try {
+canvas7.getContext('2d');
+} catch {}
+let imageData15 = new ImageData(32, 172);
+gc();
+let imageData16 = new ImageData(252, 188);
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+canvas1.height = 854;
+let video11 = await videoWithData();
+gc();
+try {
+adapter1.label = '\u{1f818}\ue183\u1723\ud846';
+} catch {}
+let gpuCanvasContext6 = canvas8.getContext('webgpu');
+try {
+videoFrame3.close();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(476, 742);
+let videoFrame7 = new VideoFrame(imageBitmap9, {timestamp: 0});
+let gpuCanvasContext7 = offscreenCanvas12.getContext('webgpu');
+let canvas9 = document.createElement('canvas');
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let canvas10 = document.createElement('canvas');
+try {
+shaderModule9.label = '\u288e\u00b2\u1b91\u9cec\u0c52';
+} catch {}
+try {
+canvas9.getContext('webgpu');
+} catch {}
+let imageData17 = new ImageData(24, 188);
+let video12 = await videoWithData();
+try {
+adapter0.label = '\ud5c2\ub143';
+} catch {}
+let img13 = await imageWithData(116, 183, '#6901cf06', '#3447c600');
+try {
+canvas10.getContext('2d');
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let imageBitmap10 = await createImageBitmap(imageData12);
+let video13 = await videoWithData();
+let canvas11 = document.createElement('canvas');
+let gpuCanvasContext8 = canvas11.getContext('webgpu');
+let imageBitmap11 = await createImageBitmap(img2);
+let imageData18 = new ImageData(84, 168);
+canvas7.width = 677;
+gc();
+let canvas12 = document.createElement('canvas');
+let video14 = await videoWithData();
+let promise21 = adapter1.requestDevice({
+  label: '\ub4b4\u0f4f\u{1fdd1}\u6884\u0e5b\u00aa',
+  defaultQueue: {label: '\u0285\u06a0'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 7,
+    maxColorAttachmentBytesPerSample: 55,
+    maxVertexAttributes: 24,
+    maxVertexBufferArrayStride: 40740,
+    maxStorageTexturesPerShaderStage: 34,
+    maxStorageBuffersPerShaderStage: 25,
+    maxDynamicStorageBuffersPerPipelineLayout: 45519,
+    maxDynamicUniformBuffersPerPipelineLayout: 56019,
+    maxBindingsPerBindGroup: 9128,
+    maxTextureArrayLayers: 540,
+    maxTextureDimension1D: 16282,
+    maxTextureDimension2D: 9476,
+    maxVertexBuffers: 12,
+    maxBindGroupsPlusVertexBuffers: 28,
+    minStorageBufferOffsetAlignment: 64,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 33297536,
+    maxStorageBufferBindingSize: 216131340,
+    maxUniformBuffersPerShaderStage: 33,
+    maxSampledTexturesPerShaderStage: 30,
+    maxInterStageShaderVariables: 112,
+    maxInterStageShaderComponents: 70,
+    maxSamplersPerShaderStage: 20,
+  },
+});
+try {
+canvas12.getContext('bitmaprenderer');
+} catch {}
+let img14 = await imageWithData(241, 263, '#14ed5dec', '#971bba8b');
+try {
+adapter1.label = '\u0cad\uc839\u0c31\u32b5\u{1fed5}';
+} catch {}
+let video15 = await videoWithData();
+let videoFrame8 = new VideoFrame(imageBitmap5, {timestamp: 0});
+let img15 = await imageWithData(92, 234, '#cd200206', '#29ba4b20');
+let imageData19 = new ImageData(76, 76);
+let offscreenCanvas13 = new OffscreenCanvas(890, 887);
+let gpuCanvasContext9 = offscreenCanvas13.getContext('webgpu');
+let offscreenCanvas14 = new OffscreenCanvas(1015, 229);
+let imageData20 = new ImageData(220, 220);
+let gpuCanvasContext10 = offscreenCanvas14.getContext('webgpu');
+let canvas13 = document.createElement('canvas');
+let imageBitmap12 = await createImageBitmap(imageData9);
+let img16 = await imageWithData(237, 76, '#e32e26e8', '#83d48801');
+canvas2.width = 1484;
+let img17 = await imageWithData(145, 33, '#2077d644', '#814ff5d4');
+let gpuCanvasContext11 = canvas13.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let video16 = await videoWithData();
+let imageData21 = new ImageData(232, 176);
+let imageData22 = new ImageData(12, 56);
+let video17 = await videoWithData();
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+gc();
+let imageBitmap13 = await createImageBitmap(video8);
+try {
+adapter0.label = '\u0523\u0111\u456b\u7182\u089b';
+} catch {}
+let offscreenCanvas15 = new OffscreenCanvas(779, 818);
+let imageBitmap14 = await createImageBitmap(canvas8);
+try {
+offscreenCanvas15.getContext('webgl2');
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2212,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 42727523, hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer21 = device0.createBuffer({
+  label: '\u97e2\u0245\uf8f3\u{1ffac}',
+  size: 119812,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture51 = device0.createTexture({
+  label: '\u{1fe7d}\uf457\u{1fa5c}\u6dca\u008a\u1d7c\u0d4e\u{1f75f}\u09d7',
+  size: {width: 1619, height: 1, depthOrArrayLayers: 17},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg11b10ufloat', 'rg11b10ufloat', 'rg11b10ufloat'],
+});
+try {
+computePassEncoder27.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle35]);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(7, buffer13, 280464, 13792);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer17, 211048, buffer11, 171772, 28668);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture({
+  /* bytesInLastRow: 9568 widthInBlocks: 598 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 25808 */
+  offset: 25808,
+  buffer: buffer7,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 598, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder54.copyTextureToBuffer({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5376 widthInBlocks: 336 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 9520 */
+  offset: 4144,
+  rowsPerImage: 250,
+  buffer: buffer2,
+}, {width: 336, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline52 = await device0.createComputePipelineAsync({
+  label: '\u3086\u9b32',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let imageData23 = new ImageData(96, 76);
+let canvas14 = document.createElement('canvas');
+let img18 = await imageWithData(91, 277, '#003fd3b8', '#b799c351');
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+video8.height = 138;
+gc();
+try {
+canvas14.getContext('webgpu');
+} catch {}
+let canvas15 = document.createElement('canvas');
+let buffer22 = device0.createBuffer({
+  label: '\u{1f9ce}\u{1f886}\ua7d2\u0ee4',
+  size: 314948,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder67 = device0.createCommandEncoder({label: '\u0893\ube37\u0a7f\u{1f607}\u0590\u{1fda2}\u58f7\ud3e7\u{1fbf8}\u8852\u2e7f'});
+let renderBundle41 = renderBundleEncoder2.finish({});
+let sampler42 = device0.createSampler({
+  label: '\u{1f74c}\ub6d2',
+  addressModeU: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 44.79,
+  lodMaxClamp: 82.78,
+});
+try {
+computePassEncoder13.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(1719);
+} catch {}
+try {
+renderPassEncoder4.setViewport(4.855, 0.3763, 0.8226, 0.1352, 0.1359, 0.9944);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet14, 2354, 272, buffer20, 145408);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline53 = await device0.createComputePipelineAsync({
+  label: '\u002b\u{1fcfb}\u6cb0',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule15, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame9 = new VideoFrame(canvas12, {timestamp: 0});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+gc();
+let imageData24 = new ImageData(24, 24);
+document.body.prepend(video13);
+let commandEncoder68 = device0.createCommandEncoder({});
+let externalTexture39 = device0.importExternalTexture({
+  label: '\u09ce\u{1f87d}\uff0f\u40f4\u{1faf5}\u00fb\u{1ff90}\u031f\u062a\u0b89',
+  source: video13,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder3.setScissorRect(0, 1, 4, 0);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(10, buffer19);
+} catch {}
+try {
+  await buffer22.mapAsync(GPUMapMode.WRITE, 0, 63672);
+} catch {}
+try {
+commandEncoder60.copyTextureToTexture({
+  texture: texture41,
+  mipLevel: 4,
+  origin: {x: 4, y: 0, z: 76},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder49.resolveQuerySet(querySet23, 40, 612, buffer21, 90112);
+} catch {}
+let pipeline54 = device0.createRenderPipeline({
+  label: '\u4036\u2b7d\u{1f613}\u0b3c\uc47e',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r8unorm'}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 76,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 24, shaderLocation: 20},
+          {format: 'uint32x4', offset: 0, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 2, shaderLocation: 21},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 596,
+        attributes: [
+          {format: 'snorm8x4', offset: 68, shaderLocation: 11},
+          {format: 'uint16x2', offset: 196, shaderLocation: 3},
+          {format: 'uint8x4', offset: 48, shaderLocation: 7},
+          {format: 'uint16x2', offset: 12, shaderLocation: 23},
+          {format: 'unorm10-10-10-2', offset: 20, shaderLocation: 16},
+          {format: 'float16x2', offset: 36, shaderLocation: 0},
+          {format: 'uint16x2', offset: 200, shaderLocation: 1},
+          {format: 'float16x4', offset: 40, shaderLocation: 9},
+          {format: 'sint32x3', offset: 40, shaderLocation: 10},
+          {format: 'uint32', offset: 32, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 76, shaderLocation: 17},
+          {format: 'uint32x2', offset: 52, shaderLocation: 2},
+          {format: 'sint8x2', offset: 168, shaderLocation: 18},
+          {format: 'uint32', offset: 20, shaderLocation: 15},
+          {format: 'uint32x4', offset: 8, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 244, attributes: [{format: 'unorm8x4', offset: 68, shaderLocation: 12}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front'},
+});
+document.body.prepend(canvas4);
+let canvas16 = document.createElement('canvas');
+let buffer23 = device0.createBuffer({
+  label: '\u0565\u0dd4\u01c7\udc80\ucedd\u0570\u{1fbc6}\u07ee',
+  size: 90894,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView75 = texture21.createView({
+  label: '\u{1ffc8}\u0512\u{1f8cb}\u{1f813}\u0033\u646d\u07a2\u3ba3',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  baseArrayLayer: 482,
+  arrayLayerCount: 31,
+});
+let renderPassEncoder6 = commandEncoder51.beginRenderPass({
+  label: '\u{1fdac}\uece8\u244a\u5a17',
+  colorAttachments: [{view: textureView60, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet33,
+  maxDrawCount: 920928068,
+});
+let renderBundle42 = renderBundleEncoder15.finish();
+let sampler43 = device0.createSampler({
+  label: '\u309d\u{1f750}\u026b\u{1fd1a}\u01fa\ucc3a',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 23.28,
+  compare: 'never',
+  maxAnisotropy: 1,
+});
+let externalTexture40 = device0.importExternalTexture({label: '\u{1fe7b}\u01b0\u065a', source: video15, colorSpace: 'srgb'});
+try {
+renderPassEncoder4.executeBundles([renderBundle25, renderBundle36, renderBundle22, renderBundle36, renderBundle42, renderBundle35, renderBundle42, renderBundle22, renderBundle25, renderBundle35]);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(4, buffer19, 0, 160943);
+} catch {}
+try {
+commandEncoder65.copyTextureToTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 59, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder67.clearBuffer(buffer6, 1200, 90912);
+dissociateBuffer(device0, buffer6);
+} catch {}
+video1.height = 254;
+gc();
+let video18 = await videoWithData();
+try {
+canvas15.getContext('webgl');
+} catch {}
+document.body.prepend(video10);
+gc();
+let imageBitmap15 = await createImageBitmap(canvas10);
+let imageData25 = new ImageData(72, 140);
+let videoFrame10 = new VideoFrame(canvas5, {timestamp: 0});
+gc();
+let texture52 = device0.createTexture({
+  label: '\u0ad1\uce1b\u2dfd\uabd9\u{1fa6a}',
+  size: [384, 8, 233],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+});
+let sampler44 = device0.createSampler({
+  label: '\u{1f794}\uf06d',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 37.52,
+  lodMaxClamp: 91.04,
+});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup12, new Uint32Array(9581), 7329, 0);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(179);
+} catch {}
+try {
+renderPassEncoder4.setViewport(2.227, 0.6442, 1.219, 0.00234, 0.4790, 0.9432);
+} catch {}
+try {
+commandEncoder61.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 640 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 22352 */
+  offset: 22352,
+  bytesPerRow: 1024,
+  buffer: buffer2,
+}, {width: 40, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 202, height: 1, depthOrArrayLayers: 961}
+*/
+{
+  source: imageBitmap11,
+  origin: { x: 48, y: 15 },
+  flipY: true,
+}, {
+  texture: texture48,
+  mipLevel: 2,
+  origin: {x: 16, y: 0, z: 89},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas2);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img19 = await imageWithData(242, 198, '#2f103a75', '#b897495f');
+let videoFrame11 = new VideoFrame(imageBitmap3, {timestamp: 0});
+let gpuCanvasContext12 = canvas16.getContext('webgpu');
+let video19 = await videoWithData();
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let videoFrame12 = new VideoFrame(imageBitmap2, {timestamp: 0});
+canvas8.width = 1928;
+let canvas17 = document.createElement('canvas');
+try {
+canvas17.getContext('2d');
+} catch {}
+try {
+commandEncoder17.label = '\u4559\u3e02\uce4b\u9ba7\ub34b\ud8ed';
+} catch {}
+let adapter2 = await promise14;
+let img20 = await imageWithData(79, 49, '#74c410ef', '#ccf29d97');
+document.body.prepend(img13);
+let videoFrame13 = new VideoFrame(img2, {timestamp: 0});
+offscreenCanvas0.height = 164;
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let video20 = await videoWithData();
+let imageData26 = new ImageData(164, 140);
+try {
+adapter2.label = '\u5d52\u0f68\u5ac3\u2a93\ud7ed\u9870';
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(554, 801);
+let imageData27 = new ImageData(212, 160);
+document.body.prepend(canvas12);
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let imageBitmap16 = await createImageBitmap(imageBitmap1);
+let imageData28 = new ImageData(12, 236);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder();
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: 651.7, g: 165.9, b: 60.27, a: 895.1, });
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer14, 'uint16', 229238, 72795);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline27);
+} catch {}
+try {
+commandEncoder66.copyTextureToBuffer({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5424 widthInBlocks: 339 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 20192 */
+  offset: 20192,
+  buffer: buffer2,
+}, {width: 339, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture34,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 72, y: 0, z: 107},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer3), /* required buffer size: 57_290_115 */
+{offset: 3, bytesPerRow: 8712, rowsPerImage: 274}, {width: 1063, height: 0, depthOrArrayLayers: 25});
+} catch {}
+let pipeline55 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint'}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {
+  format: 'r8unorm',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {failOp: 'invert', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilWriteMask: 4294967295,
+    depthBias: 651003100,
+    depthBiasSlopeScale: 310.4237383825319,
+    depthBiasClamp: 940.9083312364082,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3088,
+        attributes: [
+          {format: 'uint32x2', offset: 1264, shaderLocation: 17},
+          {format: 'sint32x4', offset: 60, shaderLocation: 7},
+          {format: 'float32x3', offset: 1588, shaderLocation: 18},
+          {format: 'unorm10-10-10-2', offset: 240, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 400, shaderLocation: 12},
+          {format: 'uint8x4', offset: 316, shaderLocation: 1},
+          {format: 'float16x4', offset: 1932, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 456, shaderLocation: 19},
+          {format: 'unorm16x4', offset: 2024, shaderLocation: 21},
+          {format: 'uint16x4', offset: 12, shaderLocation: 6},
+          {format: 'uint32x4', offset: 116, shaderLocation: 16},
+          {format: 'uint8x2', offset: 600, shaderLocation: 4},
+          {format: 'float32x2', offset: 40, shaderLocation: 3},
+          {format: 'uint16x2', offset: 388, shaderLocation: 20},
+          {format: 'snorm8x2', offset: 446, shaderLocation: 14},
+          {format: 'sint8x4', offset: 56, shaderLocation: 2},
+          {format: 'uint16x2', offset: 144, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 1256, shaderLocation: 9},
+          {format: 'snorm16x2', offset: 244, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'unorm16x4', offset: 844, shaderLocation: 11},
+          {format: 'float32x3', offset: 3744, shaderLocation: 23},
+          {format: 'float32', offset: 9344, shaderLocation: 10},
+          {format: 'uint8x2', offset: 588, shaderLocation: 22},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+let imageBitmap17 = await createImageBitmap(video2);
+try {
+offscreenCanvas16.getContext('webgl');
+} catch {}
+let img21 = await imageWithData(257, 199, '#4be2c245', '#462e10ac');
+let video21 = await videoWithData();
+let imageData29 = new ImageData(188, 116);
+gc();
+let imageBitmap18 = await createImageBitmap(imageData19);
+let offscreenCanvas17 = new OffscreenCanvas(780, 291);
+let device1 = await promise21;
+let bindGroupLayout15 = device1.createBindGroupLayout({label: '\u032a\u9e42\u{1fc8f}\u91df\u{1fec2}\u{1fa10}\u66a8\ub6ce\ua610', entries: []});
+let bindGroup22 = device1.createBindGroup({layout: bindGroupLayout15, entries: []});
+let querySet34 = device1.createQuerySet({type: 'occlusion', count: 67});
+let texture53 = device1.createTexture({
+  label: '\u46dc\u{1fbe9}\u35ab\u753b\u044a\u7552\uf825',
+  size: [288, 64, 422],
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint'],
+});
+let textureView76 = texture53.createView({label: '\u0fc0\u0bed\u0755'});
+let externalTexture41 = device1.importExternalTexture({label: '\u{1fe8c}\u007a\u6493\u{1f64d}\uc63a\u6c7d\u4857\u0bdf', source: video21, colorSpace: 'srgb'});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+gc();
+let texture54 = device1.createTexture({
+  size: [384, 20, 31],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32uint', 'rg32uint', 'rg32uint'],
+});
+let sampler45 = device1.createSampler({
+  label: '\u0ed7\u{1fbed}\udd29\u{1fa1c}\u{1feff}\u0c61\ueb3b\u{1f8e1}\u{1fa64}\u9055',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.56,
+  maxAnisotropy: 18,
+});
+let promise22 = device1.queue.onSubmittedWorkDone();
+let img22 = await imageWithData(86, 250, '#54220b1a', '#9be24228');
+let videoFrame14 = new VideoFrame(canvas2, {timestamp: 0});
+let bindGroupLayout16 = device1.createBindGroupLayout({
+  label: '\u0831\u8512\uc579\u7bcd\u{1fb29}\u{1f7c3}\u{1fb3c}\u{1fae5}\u1096\u{1fb1c}',
+  entries: [
+    {binding: 2376, visibility: 0, externalTexture: {}},
+    {
+      binding: 3155,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder70 = device1.createCommandEncoder({label: '\u2f4a\ud3f7\u071d\u0e06\u6227\ue518\u0b9c\u2a1d'});
+let renderBundleEncoder26 = device1.createRenderBundleEncoder({label: '\u6545\u9ead\u35e7', colorFormats: ['rg16uint'], stencilReadOnly: true});
+try {
+querySet34.destroy();
+} catch {}
+let imageBitmap19 = await createImageBitmap(imageData9);
+let offscreenCanvas18 = new OffscreenCanvas(11, 877);
+let imageData30 = new ImageData(232, 40);
+try {
+window.someLabel = device1.queue.label;
+} catch {}
+let bindGroupLayout17 = device1.createBindGroupLayout({
+  label: '\uff6c\u3ea1\u{1fe73}\u726a\u2715\ueb78\udf3f',
+  entries: [
+    {
+      binding: 8803,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 4292, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let pipelineLayout10 = device1.createPipelineLayout({label: '\ub037\u5633\u9f29\uef65', bindGroupLayouts: [bindGroupLayout17]});
+let querySet35 = device1.createQuerySet({type: 'occlusion', count: 3833});
+let computePassEncoder33 = commandEncoder70.beginComputePass({label: '\udfe5\u01cb\u{1fd07}\u00d0\u{1fc56}'});
+let sampler46 = device1.createSampler({
+  label: '\u9e3e\u6845\u{1fa4b}\u99ed\ud91b\ud9a9\u38fd',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 11.45,
+  lodMaxClamp: 49.76,
+  maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder26.setBindGroup(4, bindGroup22);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 177},
+  aspect: 'all',
+}, new DataView(arrayBuffer1), /* required buffer size: 548_489 */
+{offset: 961, bytesPerRow: 688, rowsPerImage: 122}, {width: 142, height: 64, depthOrArrayLayers: 7});
+} catch {}
+gc();
+let promise23 = adapter2.requestAdapterInfo();
+try {
+offscreenCanvas17.getContext('bitmaprenderer');
+} catch {}
+let buffer24 = device1.createBuffer({
+  label: '\u8a3e\u{1fc1e}\u0db0\ua671\u0e43\u0e2a',
+  size: 5764,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX,
+});
+let commandEncoder71 = device1.createCommandEncoder({label: '\u{1ff95}\u{1fb08}\u1be1\u867f\u3a4a\u{1ff56}\u05c4\uc09a\u078f\ue87b\uacec'});
+let computePassEncoder34 = commandEncoder71.beginComputePass({});
+let renderBundle43 = renderBundleEncoder26.finish();
+let sampler47 = device1.createSampler({
+  label: '\u68c5\uaa99\u0cbd\u{1fb37}\u0efa\u3cab\u{1fa0d}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 84.02,
+  lodMaxClamp: 97.14,
+});
+let externalTexture42 = device1.importExternalTexture({source: video18, colorSpace: 'display-p3'});
+try {
+device1.queue.writeBuffer(buffer24, 244, new BigUint64Array(35072), 20870, 40);
+} catch {}
+offscreenCanvas12.height = 1333;
+let bindGroupLayout18 = device1.createBindGroupLayout({label: '\u68e2\u0bea\u9a38\u082e', entries: []});
+let texture55 = device1.createTexture({
+  label: '\u24ed\u{1f897}\u{1fa15}\u789f\udd2c\u00be',
+  size: {width: 72, height: 16, depthOrArrayLayers: 105},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle44 = renderBundleEncoder26.finish({label: '\uea06\uad71\u5063\ucc82\u9c68\u{1f687}\u3882\u0c20\u{1f6b4}\u0d49\ubfab'});
+let sampler48 = device1.createSampler({
+  label: '\u{1fa7f}\u0d56\u{1faf8}\u84a1\ua313\u{1ff84}\u618e',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 0.09881,
+  lodMaxClamp: 21.08,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup22, new Uint32Array(8453), 1198, 0);
+} catch {}
+try {
+querySet35.destroy();
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+let buffer25 = device0.createBuffer({
+  label: '\u103b\ua0a6\u509a\u{1f9f8}\u{1fa62}\u1582',
+  size: 78427,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder72 = device0.createCommandEncoder({});
+let textureView77 = texture18.createView({label: '\u07de\u{1f9bc}\ucd5c', dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 291});
+try {
+renderPassEncoder3.setBindGroup(6, bindGroup21, []);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer17, 241940, buffer9, 68148, 55700);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 480 widthInBlocks: 120 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 366520 */
+  offset: 11224,
+  bytesPerRow: 512,
+  rowsPerImage: 57,
+  buffer: buffer10,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 161, y: 1, z: 86},
+  aspect: 'all',
+}, {width: 120, height: 10, depthOrArrayLayers: 13});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(querySet11, 502, 2001, buffer20, 354304);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 809, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video14,
+  origin: { x: 3, y: 0 },
+  flipY: false,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 70, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData31 = new ImageData(256, 60);
+let shaderModule16 = device1.createShaderModule({
+  code: `@group(0) @binding(4292)
+var<storage, read_write> n8: array<u32>;
+
+@compute @workgroup_size(3, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S15 {
+  @location(15) f0: f16,
+  @location(83) f1: vec3<u32>,
+  @location(18) f2: vec4<i32>,
+  @location(98) f3: vec2<f16>,
+  @location(57) f4: vec2<f16>,
+  @location(91) f5: vec4<i32>,
+  @location(74) f6: vec3<f16>,
+  @location(19) f7: vec2<i32>,
+  @location(76) f8: vec4<f32>,
+  @builtin(sample_index) f9: u32,
+  @location(48) f10: vec4<f32>,
+  @location(54) f11: f32,
+  @location(7) f12: u32,
+  @location(1) f13: vec3<u32>,
+  @location(50) f14: vec4<i32>,
+  @location(111) f15: vec3<u32>,
+  @builtin(sample_mask) f16: u32,
+  @location(110) f17: vec4<u32>
+}
+struct FragmentOutput0 {
+  @location(7) f0: vec3<u32>,
+  @location(0) f1: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(3) a0: f32, @location(87) a1: f16, @location(104) a2: i32, @location(95) a3: f32, @builtin(position) a4: vec4<f32>, @location(94) a5: u32, @location(102) a6: vec2<f32>, @builtin(front_facing) a7: bool, @location(96) a8: vec4<f16>, @location(107) a9: vec2<u32>, @location(71) a10: vec4<i32>, a11: S15, @location(105) a12: vec3<i32>, @location(49) a13: vec2<f32>, @location(63) a14: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(57) f158: vec2<f16>,
+  @location(71) f159: vec4<i32>,
+  @location(107) f160: vec2<u32>,
+  @location(98) f161: vec2<f16>,
+  @location(111) f162: vec3<u32>,
+  @location(102) f163: vec2<f32>,
+  @location(19) f164: vec2<i32>,
+  @location(76) f165: vec4<f32>,
+  @location(1) f166: vec3<u32>,
+  @location(48) f167: vec4<f32>,
+  @location(96) f168: vec4<f16>,
+  @location(105) f169: vec3<i32>,
+  @location(110) f170: vec4<u32>,
+  @location(49) f171: vec2<f32>,
+  @location(74) f172: vec3<f16>,
+  @location(63) f173: vec3<u32>,
+  @location(3) f174: f32,
+  @location(94) f175: u32,
+  @location(104) f176: i32,
+  @location(91) f177: vec4<i32>,
+  @location(15) f178: f16,
+  @builtin(position) f179: vec4<f32>,
+  @location(95) f180: f32,
+  @location(87) f181: f16,
+  @location(7) f182: u32,
+  @location(18) f183: vec4<i32>,
+  @location(83) f184: vec3<u32>,
+  @location(54) f185: f32,
+  @location(50) f186: vec4<i32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout19 = device1.createBindGroupLayout({
+  label: '\u48e0\u{1fdf8}\u9169\u1ecf\u0630\ud8ef',
+  entries: [
+    {
+      binding: 5282,
+      visibility: 0,
+      storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 7949, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {
+      binding: 8384,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder73 = device1.createCommandEncoder();
+let querySet36 = device1.createQuerySet({label: '\uf307\u{1f970}\u{1fbe0}\u5ab8\u4371\u4a8b\u06f5', type: 'occlusion', count: 3501});
+let commandBuffer14 = commandEncoder73.finish({});
+let textureView78 = texture54.createView({
+  label: '\ud372\u0777\u0de2\u8194\u5302\ube16\u00f8\u04b2\u9b11\u610d\u556a',
+  format: 'rg32uint',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+try {
+device1.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer1), /* required buffer size: 32_734 */
+{offset: 92, bytesPerRow: 243, rowsPerImage: 22}, {width: 10, height: 3, depthOrArrayLayers: 7});
+} catch {}
+let promise24 = adapter1.requestAdapterInfo();
+try {
+adapter1.label = '\ub11a\u8d5f';
+} catch {}
+let commandEncoder74 = device1.createCommandEncoder({label: '\uf095\u590e\u{1faf2}\u47e5\u3c27\u0ef5\u7779\u{1fe38}\uafc8\ue3eb'});
+let commandBuffer15 = commandEncoder74.finish({label: '\u0af7\u4099'});
+let texture56 = device1.createTexture({
+  label: '\u90d7\uadaa\u{1f6dd}\u{1fbc5}\ua31d\u23bd\u9233\u11c3',
+  size: {width: 96, height: 5, depthOrArrayLayers: 7},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView79 = texture56.createView({baseMipLevel: 1, mipLevelCount: 1});
+let renderBundleEncoder27 = device1.createRenderBundleEncoder({
+  label: '\u5572\u{1fbff}\u1fca\uef36\u57a8\u{1ffaa}\u9701\u{1fcfd}\u{1f813}',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder27.setVertexBuffer(10, buffer24);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let canvas18 = document.createElement('canvas');
+let bindGroup23 = device0.createBindGroup({layout: bindGroupLayout1, entries: [{binding: 1293, resource: sampler11}]});
+let commandEncoder75 = device0.createCommandEncoder({});
+let computePassEncoder35 = commandEncoder46.beginComputePass({label: '\ue31e\u0f80\uf028\u{1fec9}\u1184\u6092\ua60a'});
+let renderPassEncoder7 = commandEncoder66.beginRenderPass({
+  colorAttachments: [{
+  view: textureView61,
+  depthSlice: 0,
+  clearValue: { r: 653.9, g: 116.3, b: -306.8, a: 198.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet21,
+});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(189);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+computePassEncoder7.pushDebugGroup('\u1d60');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 1_007 */
+{offset: 371}, {width: 636, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 202, height: 1, depthOrArrayLayers: 6}
+*/
+{
+  source: imageData14,
+  origin: { x: 20, y: 38 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 7, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline56 = device0.createRenderPipeline({
+  label: '\u{1f925}\u0735\u3798\u25d5\u{1fc52}\u4e8e',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'dst'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8uint'}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilReadMask: 1325924249,
+    stencilWriteMask: 3915289670,
+    depthBiasClamp: 918.836206496563,
+  },
+  vertex: {module: shaderModule11, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', unclippedDepth: true},
+});
+document.body.prepend(video15);
+try {
+  await promise24;
+} catch {}
+let imageData32 = new ImageData(100, 164);
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let offscreenCanvas19 = new OffscreenCanvas(562, 210);
+let offscreenCanvas20 = new OffscreenCanvas(467, 715);
+try {
+  await promise22;
+} catch {}
+offscreenCanvas14.width = 961;
+let videoFrame15 = new VideoFrame(img1, {timestamp: 0});
+let buffer26 = device1.createBuffer({
+  label: '\u0fad\u7752',
+  size: 286588,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder76 = device1.createCommandEncoder({});
+let textureView80 = texture53.createView({});
+let renderBundle45 = renderBundleEncoder27.finish({});
+let arrayBuffer5 = buffer26.getMappedRange();
+try {
+device1.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer2), /* required buffer size: 259_513 */
+{offset: 796, bytesPerRow: 197, rowsPerImage: 131}, {width: 14, height: 4, depthOrArrayLayers: 11});
+} catch {}
+let pipeline57 = device1.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}}});
+let bindGroup24 = device1.createBindGroup({layout: bindGroupLayout15, entries: []});
+let commandEncoder77 = device1.createCommandEncoder({label: '\u0f5f\u8092\u6437\u{1ff7b}\u45bb\u9f46\u0852\u0ae6\u{1fed8}\u96bc\u0dbd'});
+let renderPassEncoder8 = commandEncoder77.beginRenderPass({
+  label: '\uea3e\u95cf\u62ac\u0ec3\u3232\u8f5a\u06ca\u6bc4',
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 0,
+  clearValue: { r: -286.4, g: 778.0, b: 957.0, a: -221.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet35,
+  maxDrawCount: 209345852,
+});
+let renderBundleEncoder28 = device1.createRenderBundleEncoder({
+  label: '\uf2c8\u5516\u41cc\u7bf4',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: 175.7, g: 646.6, b: 884.9, a: -432.2, });
+} catch {}
+try {
+buffer26.destroy();
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture55,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder34.insertDebugMarker('\u9220');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 1324, new Int16Array(6976), 4125, 564);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 6, y: 8, z: 300},
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(0)), /* required buffer size: 1_124_124 */
+{offset: 768, bytesPerRow: 731, rowsPerImage: 150}, {width: 135, height: 37, depthOrArrayLayers: 11});
+} catch {}
+let texture57 = device1.createTexture({
+  label: '\u3dc2\u08a3\u00de\ub51b\u3f75\u262e\u0e51\u24af\u5644\ua5ca',
+  size: [75, 3, 7],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder8.setViewport(44.81, 0.3212, 2.043, 1.663, 0.5154, 0.5722);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(7, buffer24, 2392, 3122);
+} catch {}
+try {
+commandEncoder76.copyTextureToBuffer({
+  texture: texture55,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 154252 */
+  offset: 636,
+  bytesPerRow: 256,
+  rowsPerImage: 200,
+  buffer: buffer26,
+}, {width: 4, height: 1, depthOrArrayLayers: 4});
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture55,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let shaderModule17 = device1.createShaderModule({
+  label: '\ud0d8\u0535\u{1f93f}\ue50c\u035f\u08c2',
+  code: `@group(0) @binding(8803)
+var<storage, read_write> field8: array<u32>;
+
+@compute @workgroup_size(7, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S17 {
+  @location(86) f0: vec4<f32>,
+  @location(41) f1: vec3<f32>,
+  @location(99) f2: f32,
+  @location(109) f3: vec4<i32>,
+  @location(5) f4: vec3<f16>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec2<u32>,
+  @builtin(sample_mask) f1: u32,
+  @location(1) f2: vec3<u32>,
+  @location(3) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(61) a0: vec3<u32>, @location(57) a1: vec4<f16>, @location(95) a2: f16, @location(49) a3: f16, @location(43) a4: vec4<f16>, @location(65) a5: vec2<f32>, @location(23) a6: f32, @location(78) a7: vec2<f32>, @location(85) a8: vec3<f32>, a9: S17, @location(21) a10: vec3<u32>, @builtin(sample_index) a11: u32, @builtin(position) a12: vec4<f32>, @builtin(front_facing) a13: bool, @builtin(sample_mask) a14: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(19) f0: vec4<f32>,
+  @location(1) f1: vec4<f16>,
+  @location(22) f2: vec3<f32>,
+  @location(17) f3: vec4<f16>,
+  @location(12) f4: vec3<i32>,
+  @location(8) f5: vec3<u32>,
+  @builtin(instance_index) f6: u32,
+  @location(14) f7: f16,
+  @location(15) f8: vec2<f32>,
+  @location(7) f9: vec2<i32>,
+  @location(10) f10: vec2<u32>,
+  @location(2) f11: i32
+}
+struct VertexOutput0 {
+  @location(57) f187: vec4<f16>,
+  @location(61) f188: vec3<u32>,
+  @location(49) f189: f16,
+  @location(41) f190: vec3<f32>,
+  @location(95) f191: f16,
+  @builtin(position) f192: vec4<f32>,
+  @location(99) f193: f32,
+  @location(109) f194: vec4<i32>,
+  @location(85) f195: vec3<f32>,
+  @location(43) f196: vec4<f16>,
+  @location(78) f197: vec2<f32>,
+  @location(65) f198: vec2<f32>,
+  @location(86) f199: vec4<f32>,
+  @location(5) f200: vec3<f16>,
+  @location(21) f201: vec3<u32>,
+  @location(23) f202: f32
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec2<f32>, a1: S16, @location(9) a2: vec4<f32>, @location(4) a3: f32, @location(20) a4: i32, @location(11) a5: f16, @location(3) a6: vec3<f32>, @location(0) a7: vec4<f16>, @location(5) a8: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture58 = device1.createTexture({
+  size: {width: 1134, height: 1, depthOrArrayLayers: 250},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let textureView81 = texture58.createView({label: '\u8b85\u{1ffe5}\u{1f6fc}\u0b3e\ub4a2\uf7e4\u04fd\uc35b', aspect: 'all'});
+let renderPassEncoder9 = commandEncoder76.beginRenderPass({
+  label: '\u04fe\u{1fddd}\u{1f976}\u528f\u019e',
+  colorAttachments: [{
+  view: textureView81,
+  depthSlice: 146,
+  clearValue: { r: -363.4, g: -515.0, b: 201.1, a: -649.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet34,
+  maxDrawCount: 1087531412,
+});
+let renderBundleEncoder29 = device1.createRenderBundleEncoder({label: '\ubc23\uaf7c\u8763\u{1f66f}', colorFormats: ['rg16uint'], depthReadOnly: true});
+let externalTexture43 = device1.importExternalTexture({label: '\u9f66\u0989', source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline57);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(2063);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(240, 1, 554, 0);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(6, buffer24);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline58 = device1.createComputePipeline({
+  label: '\u19df\u{1fefb}\u859d\u4ecf\u{1f888}\ud8d7\u08a2\ueae8\uace1\uacd4\u27f0',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule16, entryPoint: 'compute0'},
+});
+try {
+  await promise23;
+} catch {}
+document.body.prepend(canvas1);
+let offscreenCanvas21 = new OffscreenCanvas(509, 889);
+try {
+window.someLabel = querySet36.label;
+} catch {}
+let texture59 = device1.createTexture({
+  label: '\u293b\u0118\u{1f6f3}\u0006\u{1fe6f}\uc32c',
+  size: {width: 300, height: 12, depthOrArrayLayers: 28},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let sampler49 = device1.createSampler({
+  label: '\u{1fce4}\u0d6c\u0526\u{1fb2f}\u839b\u2fef\u{1fe8e}\ubb0c\ue1df\u0a69',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  lodMinClamp: 72.60,
+  lodMaxClamp: 85.86,
+});
+try {
+computePassEncoder34.setPipeline(pipeline57);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(62);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(2, buffer24);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(0)), /* required buffer size: 302_512 */
+{offset: 192, bytesPerRow: 100, rowsPerImage: 151}, {width: 5, height: 4, depthOrArrayLayers: 21});
+} catch {}
+try {
+offscreenCanvas21.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder78 = device1.createCommandEncoder();
+let querySet37 = device1.createQuerySet({type: 'occlusion', count: 2512});
+let textureView82 = texture58.createView({});
+let renderPassEncoder10 = commandEncoder78.beginRenderPass({
+  label: '\u5863\u9fba\u11f6\u7b48\u17aa\u{1f9d0}',
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 118,
+  clearValue: { r: 721.3, g: -398.1, b: 488.9, a: 838.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet35,
+  maxDrawCount: 418690601,
+});
+try {
+renderPassEncoder9.setBindGroup(5, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(5, bindGroup24);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 106},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 1_303_370 */
+{offset: 555, bytesPerRow: 275, rowsPerImage: 167}, {width: 35, height: 62, depthOrArrayLayers: 29});
+} catch {}
+let gpuCanvasContext13 = offscreenCanvas18.getContext('webgpu');
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+offscreenCanvas20.height = 1179;
+let videoFrame16 = new VideoFrame(img2, {timestamp: 0});
+let videoFrame17 = new VideoFrame(canvas1, {timestamp: 0});
+let pipelineLayout11 = device1.createPipelineLayout({label: '\u{1febe}\u05d1\u0f81\u9652', bindGroupLayouts: []});
+let textureView83 = texture55.createView({label: '\u{1f800}\u81a1\u953c\ubc49\u041d\u360f\ue502', dimension: '3d', baseMipLevel: 5});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(4, bindGroup22);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(1887);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(0, bindGroup24);
+} catch {}
+let textureView84 = texture56.createView({label: '\u169e\u2dc2\u7aa1\u1e17\u0436\u{1f66b}\u05a5\u780b\u058e\u2ceb\u0bd3'});
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup24, []);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(6, bindGroup22, new Uint32Array(4456), 2625, 0);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(850);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(24, 0, 100, 1);
+} catch {}
+try {
+renderPassEncoder9.setViewport(713.8, 0.6165, 70.66, 0.2417, 0.8073, 0.8295);
+} catch {}
+let pipeline59 = device1.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule16, entryPoint: 'compute0'}});
+let imageData33 = new ImageData(108, 220);
+let commandEncoder79 = device0.createCommandEncoder({label: '\u0494\u88a1\u{1fced}\u4d74\ub3a8'});
+let externalTexture44 = device0.importExternalTexture({label: '\u{1f70d}\u22e4\u4e49\u0cd7\u{1f625}\u72e6\u0d25', source: video7, colorSpace: 'display-p3'});
+try {
+  await buffer10.mapAsync(GPUMapMode.WRITE, 0, 529856);
+} catch {}
+try {
+commandEncoder79.resolveQuerySet(querySet28, 1480, 508, buffer13, 223232);
+} catch {}
+let pipeline60 = await device0.createRenderPipelineAsync({
+  label: '\u59b1\udd32\u4a8d\u38d8\u4050\ua6f3\ub4c0\u{1ff14}\u0290\ub290\uf0ce',
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16float'}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'constant'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rgba16float', writeMask: 0}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4520,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 72, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 40, shaderLocation: 9},
+          {format: 'float16x2', offset: 20, shaderLocation: 3},
+          {format: 'sint8x2', offset: 40, shaderLocation: 4},
+          {format: 'sint32x2', offset: 852, shaderLocation: 0},
+          {format: 'uint32x3', offset: 68, shaderLocation: 1},
+          {format: 'uint32x4', offset: 1348, shaderLocation: 22},
+          {format: 'unorm8x2', offset: 146, shaderLocation: 20},
+          {format: 'unorm8x4', offset: 356, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 1420, shaderLocation: 16},
+          {format: 'uint16x2', offset: 2380, shaderLocation: 17},
+          {format: 'uint32', offset: 548, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 174, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 4296,
+        attributes: [
+          {format: 'sint8x2', offset: 1716, shaderLocation: 5},
+          {format: 'sint32x2', offset: 412, shaderLocation: 18},
+          {format: 'uint16x2', offset: 496, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 112, shaderLocation: 15},
+          {format: 'uint32x4', offset: 36, shaderLocation: 6},
+          {format: 'float32x2', offset: 1432, shaderLocation: 23},
+          {format: 'uint32x2', offset: 56, shaderLocation: 19},
+          {format: 'uint32', offset: 428, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 562, shaderLocation: 14},
+          {format: 'uint8x4', offset: 400, shaderLocation: 12},
+          {format: 'uint16x4', offset: 652, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let pipelineLayout12 = device1.createPipelineLayout({
+  label: '\ud3ec\u09ed\ua305\u0493\u0022\u9518\u0739\u02bd\u8077\u2726\u6843',
+  bindGroupLayouts: [bindGroupLayout19, bindGroupLayout15, bindGroupLayout17, bindGroupLayout17, bindGroupLayout15, bindGroupLayout18],
+});
+let renderBundleEncoder30 = device1.createRenderBundleEncoder({
+  label: '\ua52f\u0c8a\u06d8\u0be4\u506c\u0e2f\u6958\u6f9c',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: 291.4, g: -705.0, b: 738.4, a: 572.0, });
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(505, 0, 389, 0);
+} catch {}
+try {
+renderPassEncoder8.setViewport(4.731, 1.570, 27.29, 0.4189, 0.4148, 0.7171);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer24, 2232, 1739);
+} catch {}
+try {
+computePassEncoder34.insertDebugMarker('\u0fc3');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 44_523 */
+{offset: 367, bytesPerRow: 354, rowsPerImage: 31}, {width: 65, height: 1, depthOrArrayLayers: 5});
+} catch {}
+let pipeline61 = await device1.createComputePipelineAsync({
+  label: '\u57f0\u{1ffdf}\uc4ea\u093d\u{1fff2}\udf0f\u033a',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+let pipeline62 = device1.createRenderPipeline({
+  label: '\u{1fc3c}\u{1fb7d}\u{1fdce}\u0523\u4563',
+  layout: pipelineLayout12,
+  multisample: {count: 4, mask: 0xe44f03fc},
+  fragment: {module: shaderModule17, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16uint'}]},
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 15668,
+        attributes: [
+          {format: 'sint32x3', offset: 14128, shaderLocation: 7},
+          {format: 'float16x2', offset: 3608, shaderLocation: 15},
+          {format: 'unorm16x4', offset: 4944, shaderLocation: 1},
+          {format: 'uint32x3', offset: 292, shaderLocation: 10},
+          {format: 'sint32x2', offset: 7560, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 8304,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 908, shaderLocation: 8},
+          {format: 'snorm8x2', offset: 106, shaderLocation: 17},
+          {format: 'unorm8x4', offset: 428, shaderLocation: 6},
+          {format: 'sint32x4', offset: 1480, shaderLocation: 12},
+          {format: 'float32', offset: 428, shaderLocation: 22},
+          {format: 'snorm16x4', offset: 344, shaderLocation: 19},
+          {format: 'float32', offset: 40, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 556, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 212, shaderLocation: 4},
+          {format: 'float32', offset: 2040, shaderLocation: 9},
+          {format: 'float32', offset: 256, shaderLocation: 3},
+          {format: 'float16x4', offset: 2840, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 60, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 2900, attributes: []},
+      {
+        arrayStride: 5460,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 336, shaderLocation: 20}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: true},
+});
+gc();
+let offscreenCanvas22 = new OffscreenCanvas(26, 860);
+let buffer27 = device1.createBuffer({
+  label: '\u0916\u{1f82e}\u0874',
+  size: 115336,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundle46 = renderBundleEncoder27.finish({label: '\u{1fe4f}\u0047\u2feb\u8c90\u0a64\u37a8\u0903\u41f8\u7026'});
+try {
+renderPassEncoder10.setBlendConstant({ r: 923.1, g: -143.4, b: 71.04, a: -196.5, });
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(6, buffer24, 0);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 26, y: 5, z: 40},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer4), /* required buffer size: 614_916 */
+{offset: 576, bytesPerRow: 540, rowsPerImage: 65}, {width: 90, height: 33, depthOrArrayLayers: 18});
+} catch {}
+let promise25 = device1.queue.onSubmittedWorkDone();
+let gpuCanvasContext14 = offscreenCanvas20.getContext('webgpu');
+let bindGroup25 = device1.createBindGroup({layout: bindGroupLayout15, entries: []});
+let commandEncoder80 = device1.createCommandEncoder({label: '\u{1face}\u02ad\u0df7\ueaee\u072e\u59c3\u{1fe02}\u0816'});
+let texture60 = device1.createTexture({
+  label: '\u{1f956}\u963e\uabe8\ue0d5\u5945\u0313\u0e46\u0c72\u2169\uc6cc',
+  size: {width: 1134, height: 1, depthOrArrayLayers: 169},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let textureView85 = texture58.createView({label: '\uefcb\u4332\u5f2c\u4ed2\u9f82\u5cfb\uf941'});
+let renderPassEncoder11 = commandEncoder80.beginRenderPass({
+  label: '\u02f8\u3ec7\u{1fff6}\u068a\u0917\u275f\u{1fb86}\u0eea',
+  colorAttachments: [{
+  view: textureView81,
+  depthSlice: 27,
+  clearValue: { r: -212.6, g: 593.0, b: 285.9, a: 827.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet36,
+});
+let renderBundleEncoder31 = device1.createRenderBundleEncoder({label: '\uf64e\u38ab\u{1f662}\u4dca\ub893\ud631', colorFormats: ['rg16uint'], depthReadOnly: true});
+let sampler50 = device1.createSampler({
+  label: '\u06ec\u{1f62d}\u21e9\u09cf\u3eab\u93db\uf50f\u3baf\u8b9d\u0abe\u0300',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 13.08,
+  lodMaxClamp: 95.58,
+});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup25, new Uint32Array(1632), 1426, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(9, buffer24, 3208, 1782);
+} catch {}
+let pipeline63 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout10,
+  multisample: {count: 4, mask: 0xed2e4799},
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {
+      compare: 'greater-equal',
+      failOp: 'decrement-wrap',
+      depthFailOp: 'increment-wrap',
+      passOp: 'decrement-clamp',
+    },
+    stencilWriteMask: 3365794104,
+    depthBiasSlopeScale: 438.3428521450419,
+    depthBiasClamp: 463.76980912199804,
+  },
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 20,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 12, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 4, shaderLocation: 0},
+          {format: 'float32', offset: 0, shaderLocation: 19},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 3},
+          {format: 'float32x4', offset: 0, shaderLocation: 14},
+          {format: 'sint32x3', offset: 0, shaderLocation: 2},
+          {format: 'float16x2', offset: 0, shaderLocation: 17},
+          {format: 'float32', offset: 12, shaderLocation: 11},
+          {format: 'float32', offset: 0, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 5},
+          {format: 'uint32x3', offset: 0, shaderLocation: 10},
+          {format: 'sint16x4', offset: 0, shaderLocation: 20},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 2100, attributes: []},
+      {
+        arrayStride: 22520,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 2716, shaderLocation: 7}],
+      },
+      {
+        arrayStride: 16536,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 1380, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 1020, shaderLocation: 9},
+          {format: 'snorm16x2', offset: 1684, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 1388, shaderLocation: 22},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let offscreenCanvas23 = new OffscreenCanvas(51, 622);
+try {
+offscreenCanvas22.getContext('webgpu');
+} catch {}
+let img23 = await imageWithData(263, 261, '#8567b687', '#49a2575d');
+try {
+offscreenCanvas23.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder81 = device1.createCommandEncoder({});
+let renderBundleEncoder32 = device1.createRenderBundleEncoder({label: '\ub86d\u{1fb8b}\u0abc\u1453\udfc8\ufc74\u01ad\u22c5\ud738\u337f', colorFormats: ['rg16uint']});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(0, buffer24, 4740);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 3504, new Int16Array(8963), 455, 312);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(782), /* required buffer size: 782 */
+{offset: 782}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise26 = device1.createComputePipelineAsync({
+  label: '\u{1faaa}\u0c3f\u0823\u{1fa00}\uced9\uc5b7',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+let pipeline64 = device1.createRenderPipeline({
+  label: '\ua912\u04b3\ue37e\u7162',
+  layout: pipelineLayout12,
+  multisample: {count: 1, mask: 0x4eae37f7},
+  fragment: {module: shaderModule16, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16uint'}]},
+  vertex: {module: shaderModule16, entryPoint: 'vertex0', buffers: []},
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+let canvas19 = document.createElement('canvas');
+let imageBitmap20 = await createImageBitmap(imageData33);
+let commandBuffer16 = commandEncoder81.finish({label: '\uf184\u{1fa0c}\u02bb'});
+let texture61 = device1.createTexture({
+  size: [96, 5, 290],
+  mipLevelCount: 3,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup25, new Uint32Array(9920), 1498, 0);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline64);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 2660, new DataView(new ArrayBuffer(53347)), 11867, 1064);
+} catch {}
+let pipeline65 = device1.createRenderPipeline({
+  label: '\u0060\u08cd\ud191\u17df\ua9c3\u0dff',
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {module: shaderModule16, entryPoint: 'vertex0', buffers: []},
+});
+let bindGroup26 = device1.createBindGroup({layout: bindGroupLayout18, entries: []});
+let texture62 = gpuCanvasContext9.getCurrentTexture();
+let sampler51 = device1.createSampler({
+  label: '\u3c40\u01e7\u3135\u8a2c',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 4.044,
+  lodMaxClamp: 99.83,
+});
+try {
+renderPassEncoder10.setViewport(697.0, 0.1934, 95.19, 0.3259, 0.2034, 0.6099);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer26, 1_904_087_005);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(162);
+} catch {}
+let videoFrame18 = new VideoFrame(video10, {timestamp: 0});
+let shaderModule18 = device1.createShaderModule({
+  label: '\u005d\ua92e\u0876\u00a2\u89ec\u{1fb9a}\u02f8\u4d97',
+  code: `@group(0) @binding(4292)
+var<storage, read_write> field9: array<u32>;
+
+@compute @workgroup_size(5, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S19 {
+  @location(109) f0: vec4<f32>,
+  @location(91) f1: vec4<f32>,
+  @location(6) f2: vec2<u32>,
+  @location(57) f3: vec3<f32>,
+  @location(108) f4: vec3<u32>,
+  @location(26) f5: vec4<f16>,
+  @location(102) f6: vec4<f32>,
+  @location(80) f7: vec2<u32>,
+  @location(106) f8: vec4<i32>,
+  @location(21) f9: vec2<i32>,
+  @location(49) f10: vec3<u32>,
+  @location(110) f11: vec3<f32>,
+  @location(58) f12: vec2<f32>,
+  @location(105) f13: vec3<i32>,
+  @location(33) f14: vec4<f32>,
+  @location(44) f15: vec2<i32>,
+  @location(62) f16: vec4<i32>,
+  @location(39) f17: vec4<f16>,
+  @location(82) f18: i32,
+  @location(27) f19: f32,
+  @location(42) f20: vec2<i32>,
+  @location(69) f21: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(111) a0: vec4<i32>, a1: S19, @location(35) a2: vec3<u32>, @builtin(sample_mask) a3: u32) -> @location(200) vec3<u32> {
+return vec3<u32>();
+}
+
+struct S18 {
+  @location(0) f0: vec2<f32>,
+  @location(12) f1: vec2<f32>,
+  @location(17) f2: vec4<f32>,
+  @location(3) f3: vec4<u32>,
+  @location(6) f4: vec3<f16>,
+  @location(7) f5: vec2<i32>,
+  @location(22) f6: f32,
+  @location(5) f7: vec3<u32>,
+  @location(10) f8: u32,
+  @location(14) f9: f32,
+  @location(9) f10: vec3<f16>
+}
+struct VertexOutput0 {
+  @location(111) f203: vec4<i32>,
+  @location(33) f204: vec4<f32>,
+  @location(58) f205: vec2<f32>,
+  @location(69) f206: vec2<f32>,
+  @location(105) f207: vec3<i32>,
+  @location(26) f208: vec4<f16>,
+  @location(35) f209: vec3<u32>,
+  @location(39) f210: vec4<f16>,
+  @location(109) f211: vec4<f32>,
+  @location(108) f212: vec3<u32>,
+  @location(57) f213: vec3<f32>,
+  @location(6) f214: vec2<u32>,
+  @location(82) f215: i32,
+  @location(49) f216: vec3<u32>,
+  @builtin(position) f217: vec4<f32>,
+  @location(106) f218: vec4<i32>,
+  @location(91) f219: vec4<f32>,
+  @location(21) f220: vec2<i32>,
+  @location(110) f221: vec3<f32>,
+  @location(42) f222: vec2<i32>,
+  @location(44) f223: vec2<i32>,
+  @location(102) f224: vec4<f32>,
+  @location(62) f225: vec4<i32>,
+  @location(27) f226: f32,
+  @location(80) f227: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec2<f32>, @location(18) a1: vec3<f32>, @location(21) a2: f32, @location(8) a3: vec2<i32>, @builtin(instance_index) a4: u32, @location(20) a5: f32, @location(2) a6: vec2<i32>, @location(1) a7: vec3<f32>, @builtin(vertex_index) a8: u32, a9: S18, @location(23) a10: vec4<f32>, @location(16) a11: f32, @location(19) a12: vec2<u32>, @location(15) a13: vec4<f32>, @location(13) a14: vec3<u32>, @location(4) a15: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView86 = texture55.createView({label: '\u0c7a\uee80\u0307\u602b\u01e8\ua02f', dimension: '3d', mipLevelCount: 1});
+let renderBundleEncoder33 = device1.createRenderBundleEncoder({
+  label: '\u02f4\ufd5a\u0015\u6b00\ud022\u{1fe13}\u2e57\u0f2e',
+  colorFormats: ['rg16uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(269);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup26, new Uint32Array(465), 246, 0);
+} catch {}
+try {
+texture57.destroy();
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer27, 14676, new Int16Array(2315), 1492, 140);
+} catch {}
+let texture63 = device1.createTexture({
+  label: '\u{1fe63}\u91e9\u9e5b\ud465\u2078',
+  size: {width: 150, height: 6, depthOrArrayLayers: 439},
+  mipLevelCount: 5,
+  dimension: '2d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let textureView87 = texture56.createView({label: '\u9c3f\u0bd6', aspect: 'all', baseMipLevel: 0, mipLevelCount: 1});
+try {
+renderPassEncoder9.beginOcclusionQuery(59);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(1121, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(422, 476, 608_758_384, 122_637_146);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(1);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer26, 328_778_620);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline64);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 40_270 */
+{offset: 420, bytesPerRow: 229, rowsPerImage: 87}, {width: 1, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let pipeline66 = device1.createComputePipeline({layout: pipelineLayout12, compute: {module: shaderModule18, entryPoint: 'compute0'}});
+let imageBitmap21 = await createImageBitmap(videoFrame17);
+let commandBuffer17 = commandEncoder57.finish({label: '\u8719\u04a7\uc188'});
+let textureView88 = texture41.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1061});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({colorFormats: ['rgba32sint', 'rgba32uint', 'r8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder3.beginOcclusionQuery(966);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(1812);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer19, 'uint16', 11644, 172081);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline34);
+} catch {}
+try {
+commandEncoder79.clearBuffer(buffer2, 40, 61296);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+computePassEncoder7.popDebugGroup();
+} catch {}
+let shaderModule19 = device1.createShaderModule({
+  label: '\u4b18\u0500\u{1f9b0}\u9bff\u011c',
+  code: `@group(0) @binding(8803)
+var<storage, read_write> field10: array<u32>;
+@group(0) @binding(4292)
+var<storage, read_write> function11: array<u32>;
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(20) a0: vec4<f16>, @location(13) a1: vec2<u32>, @location(41) a2: vec2<u32>, @location(35) a3: u32, @location(17) a4: vec3<f32>, @location(94) a5: f32, @location(43) a6: vec4<f32>, @location(63) a7: vec4<u32>, @location(24) a8: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S20 {
+  @location(10) f0: vec2<f16>,
+  @location(0) f1: f16,
+  @location(7) f2: vec2<f32>,
+  @location(12) f3: i32,
+  @location(23) f4: vec2<i32>,
+  @location(13) f5: vec2<u32>,
+  @builtin(instance_index) f6: u32,
+  @location(1) f7: f16,
+  @location(5) f8: f16,
+  @location(6) f9: vec3<u32>
+}
+struct VertexOutput0 {
+  @location(101) f228: vec4<i32>,
+  @location(35) f229: u32,
+  @location(33) f230: vec4<f32>,
+  @location(19) f231: vec2<f16>,
+  @location(17) f232: vec3<f32>,
+  @location(2) f233: f32,
+  @location(10) f234: vec2<i32>,
+  @location(30) f235: u32,
+  @location(91) f236: vec3<u32>,
+  @location(0) f237: vec3<f32>,
+  @location(43) f238: vec4<f32>,
+  @location(51) f239: vec2<f16>,
+  @builtin(position) f240: vec4<f32>,
+  @location(76) f241: i32,
+  @location(98) f242: u32,
+  @location(62) f243: i32,
+  @location(24) f244: vec3<u32>,
+  @location(86) f245: vec2<f16>,
+  @location(20) f246: vec4<f16>,
+  @location(94) f247: f32,
+  @location(90) f248: f16,
+  @location(85) f249: vec4<u32>,
+  @location(38) f250: vec3<u32>,
+  @location(63) f251: vec4<u32>,
+  @location(77) f252: vec3<i32>,
+  @location(50) f253: vec3<f32>,
+  @location(78) f254: vec3<f32>,
+  @location(22) f255: vec2<f32>,
+  @location(13) f256: vec2<u32>,
+  @location(41) f257: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: f32, @location(22) a1: vec3<f32>, @location(4) a2: u32, a3: S20, @location(20) a4: vec4<f32>, @location(9) a5: vec4<f16>, @location(18) a6: vec3<i32>, @location(8) a7: vec3<u32>, @location(15) a8: vec4<f32>, @location(3) a9: vec4<i32>, @location(16) a10: i32, @location(11) a11: f32, @location(21) a12: f16, @builtin(vertex_index) a13: u32, @location(2) a14: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup27 = device1.createBindGroup({
+  label: '\u{1f6c5}\ua412\u071c\u002c\u3964\u5549\ud483\u{1fcbb}',
+  layout: bindGroupLayout17,
+  entries: [{binding: 4292, resource: externalTexture42}, {binding: 8803, resource: externalTexture42}],
+});
+let querySet38 = device1.createQuerySet({label: '\u{1fc2e}\u{1fc24}\u0750\u538b\u23c7\u957f', type: 'occlusion', count: 855});
+let texture64 = device1.createTexture({
+  label: '\u3b70\u9bfe\uffb5\u6916\u1eec\uf70b',
+  size: [36],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView89 = texture63.createView({
+  label: '\u499a\u0ac1\ufc95\u4291\uc35c\u9994\ua907\ucb09\u1ea4',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 222,
+  arrayLayerCount: 181,
+});
+let renderBundleEncoder35 = device1.createRenderBundleEncoder({label: '\u6643\u7bab\u0330\u63db\udeb3\u{1fc30}\u9c9f\u0a8d\u{1f6c6}', colorFormats: ['rg16uint']});
+let sampler52 = device1.createSampler({
+  label: '\u0828\u2dbf',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 84.88,
+  lodMaxClamp: 97.57,
+});
+try {
+computePassEncoder33.setPipeline(pipeline61);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(1120, 1, 9, 0);
+} catch {}
+try {
+renderPassEncoder10.setViewport(694.6, 0.1010, 265.2, 0.3268, 0.6360, 0.9571);
+} catch {}
+try {
+renderPassEncoder11.draw(75, 292, 481_592_703);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(255, 203, 462_242, 1_661_089_023, 355_014_194);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(3, bindGroup26, []);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(2, bindGroup22, new Uint32Array(9061), 6446, 0);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(265, 133);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(1, buffer24, 0, 4350);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+  await buffer27.mapAsync(GPUMapMode.READ, 25552, 34332);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 1176, new Float32Array(60694), 1588, 96);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter2.label = '\u0da2\u0069\u7fe6\uf19d\u0614';
+} catch {}
+try {
+canvas18.getContext('2d');
+} catch {}
+let gpuCanvasContext15 = canvas19.getContext('webgpu');
+let offscreenCanvas24 = new OffscreenCanvas(1020, 516);
+let img24 = await imageWithData(209, 10, '#629347f3', '#fd98baeb');
+let texture65 = device1.createTexture({
+  label: '\ufc2c\ucd5c\u04e0\u0a5f',
+  size: {width: 288, height: 64, depthOrArrayLayers: 422},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8unorm', 'r8unorm'],
+});
+let renderBundle47 = renderBundleEncoder30.finish({label: '\u6f0b\u09e7\uc6d6\ud169\ua5e7\u90ae\u8917\u5963\u{1fa2f}\ua708'});
+let sampler53 = device1.createSampler({
+  label: '\u0ba1\u9bed\u{1fc76}\u{1fd60}\u655e\ubc0f\u00a2\u60be',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+});
+try {
+renderPassEncoder11.drawIndexed(143, 28, 1_881_637_630, 43_354_698, 1_437_170_979);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer24, 3748, 1278);
+} catch {}
+try {
+renderBundleEncoder31.draw(10);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline64);
+} catch {}
+let promise27 = device1.createComputePipelineAsync({
+  label: '\ube9e\u6fc9\ue852',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+try {
+offscreenCanvas24.getContext('webgl2');
+} catch {}
+try {
+externalTexture7.label = '\u{1fcc5}\u049b\u06b6\u0cd7\u{1f9fe}\u{1ff82}\u0775\u3925\u0b84\u{1fa91}\ue248';
+} catch {}
+let canvas20 = document.createElement('canvas');
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(canvas4);
+let offscreenCanvas25 = new OffscreenCanvas(514, 813);
+let commandEncoder82 = device1.createCommandEncoder({label: '\u03db\u3ebd\u16b1\u7ae1\u2e08'});
+let textureView90 = texture59.createView({
+  label: '\u{1f90c}\u13e7\u{1fa4b}\ub6fc\ua5da\u6b8f\u0055\ub200\u091b\uac25',
+  format: 'rg16uint',
+  mipLevelCount: 2,
+  arrayLayerCount: 1,
+});
+let externalTexture45 = device1.importExternalTexture({label: '\u0034\uccac\u3a2b\u2810', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder34.setBindGroup(5, bindGroup26);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(30);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: -479.3, g: 186.3, b: 531.6, a: -179.8, });
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(373, 1, 477, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(210, 23, 1_033_009_859, 1_206_104_723);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer24, 179_348_179);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline65);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(863, undefined, 0, 1273738217);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(3, bindGroup26, new Uint32Array(2143), 1193, 0);
+} catch {}
+try {
+renderBundleEncoder31.draw(250, 12, 1_276_751_891, 1_338_885_715);
+} catch {}
+let gpuCanvasContext16 = canvas20.getContext('webgpu');
+gc();
+let img25 = await imageWithData(143, 291, '#034c61b4', '#31c4100b');
+let texture66 = device1.createTexture({
+  label: '\uc656\u{1fa9e}\u06b7\ua6e5\u978f\u00ae\u37ff\u{1fc81}\u61af',
+  size: [4536],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let textureView91 = texture61.createView({
+  label: '\u2f3f\ub2cc\u725e\u8ffe\ubab0\u668f\u6aa3\u086f\u0bcc\u4b09\uf400',
+  baseMipLevel: 2,
+  baseArrayLayer: 39,
+  arrayLayerCount: 10,
+});
+let computePassEncoder36 = commandEncoder82.beginComputePass({label: '\u{1ff72}\uf61a\u2d65\u5bcb\u{1fccb}\u08e1'});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(1, bindGroup25, new Uint32Array(2324), 1172, 0);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(810, 1, 98, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(427);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer24, 48_812_391);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline65);
+} catch {}
+offscreenCanvas3.width = 670;
+let bindGroupLayout20 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 7160,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder83 = device1.createCommandEncoder({label: '\u{1f708}\u{1fe54}\ubd0b\u78ec\u{1fed6}\u{1f82f}\u0b2a\u{1f847}\u0805'});
+let querySet39 = device1.createQuerySet({type: 'occlusion', count: 3474});
+let textureView92 = texture55.createView({label: '\u9828\uf3da\u0dfd\u3496', baseMipLevel: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(3, 332, 41_875_243, 601_522_564, 37_407_014);
+} catch {}
+try {
+renderBundleEncoder35.draw(270, 263, 923_880_787, 674_230_568);
+} catch {}
+let imageBitmap22 = await createImageBitmap(offscreenCanvas11);
+let imageData34 = new ImageData(160, 204);
+let bindGroupLayout21 = device1.createBindGroupLayout({label: '\uc392\uf81a\u0424\u3af0\u8571\u0908\u7c6f\u070a\u{1fba2}\u{1ff48}\u{1f83d}', entries: []});
+let buffer28 = device1.createBuffer({
+  label: '\u{1f6c0}\u788f\u0f50\u{1f766}\u0a1d\u7f8e\u{1f647}\ua013\u0e8d\u35d8',
+  size: 101072,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder84 = device1.createCommandEncoder();
+let textureView93 = texture59.createView({label: '\u5400\u9d0b\u0748\u8fda\u590e\u737d\ua455\u030d\u86b5', format: 'rg16uint', baseMipLevel: 2});
+let computePassEncoder37 = commandEncoder83.beginComputePass({label: '\u29ee\u923d\u0b7d\u1331\u0d1c\u{1f84c}\u6e1c'});
+let renderBundleEncoder36 = device1.createRenderBundleEncoder({
+  label: '\u228b\u0d0e\ub332\ue7ff\u{1f8d2}\u5968\u{1fe66}\u0726\u0ea4\u1a78\u00fc',
+  colorFormats: ['rg16uint'],
+  stencilReadOnly: false,
+});
+let renderBundle48 = renderBundleEncoder32.finish({});
+try {
+renderPassEncoder9.beginOcclusionQuery(16);
+} catch {}
+try {
+renderPassEncoder9.setViewport(111.0, 0.4496, 225.7, 0.02665, 0.2501, 0.4038);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer24, 0);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+commandEncoder84.copyTextureToBuffer({
+  texture: texture59,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 92 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 36972 */
+  offset: 36972,
+  rowsPerImage: 202,
+  buffer: buffer26,
+}, {width: 23, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer26);
+} catch {}
+let promise28 = device1.createComputePipelineAsync({
+  label: '\ud619\u0502\u5155\u{1fb02}\u09cd\u8d30\u{1f752}\u243f\ue269\u00fb',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule18, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup28 = device1.createBindGroup({
+  label: '\u{1f972}\ufd18\uedba\u04a9\u03b9',
+  layout: bindGroupLayout17,
+  entries: [{binding: 8803, resource: externalTexture43}, {binding: 4292, resource: externalTexture41}],
+});
+let textureView94 = texture55.createView({
+  label: '\u0503\u07d0\u0fbc\uae6a\u0b89\u{1f783}\u0cd2\u7ac5\u05d6\u4a8a',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let computePassEncoder38 = commandEncoder84.beginComputePass({label: '\u27bb\u0f03\u{1fc2c}\ue9d9\u{1fbf7}\u{1f789}\u36e7\u8e5d\ude44\u897c'});
+let sampler54 = device1.createSampler({mipmapFilter: 'nearest', lodMinClamp: 35.34, lodMaxClamp: 58.99});
+try {
+computePassEncoder38.setPipeline(pipeline59);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(2996);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(9, buffer24);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let pipeline67 = await promise26;
+let pipeline68 = await device1.createRenderPipelineAsync({
+  label: '\u{1f699}\uf12b\u4e84\uf813',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3956,
+        attributes: [
+          {format: 'unorm16x2', offset: 244, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 130, shaderLocation: 22},
+          {format: 'snorm16x2', offset: 144, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 448, shaderLocation: 21},
+          {format: 'sint32x4', offset: 284, shaderLocation: 18},
+          {format: 'uint16x2', offset: 228, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 312,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm8x4', offset: 28, shaderLocation: 20},
+          {format: 'uint8x2', offset: 30, shaderLocation: 13},
+          {format: 'uint32', offset: 72, shaderLocation: 6},
+          {format: 'unorm10-10-10-2', offset: 76, shaderLocation: 14},
+          {format: 'float32x3', offset: 68, shaderLocation: 5},
+          {format: 'uint32', offset: 28, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 76, shaderLocation: 9},
+          {format: 'sint8x4', offset: 20, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 7},
+          {format: 'float16x2', offset: 180, shaderLocation: 15},
+          {format: 'sint32', offset: 56, shaderLocation: 23},
+          {format: 'uint32x4', offset: 112, shaderLocation: 2},
+          {format: 'sint32x4', offset: 8, shaderLocation: 16},
+          {format: 'float16x2', offset: 184, shaderLocation: 0},
+          {format: 'sint32x2', offset: 24, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 8, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+});
+let bindGroup29 = device1.createBindGroup({
+  label: '\u3b1c\udb8c\u6c5f\u{1fe79}\u055c\u018f\u02c4\u06b5\u5207',
+  layout: bindGroupLayout17,
+  entries: [{binding: 4292, resource: externalTexture45}, {binding: 8803, resource: externalTexture45}],
+});
+let commandEncoder85 = device1.createCommandEncoder({label: '\u{1fee5}\u{1faba}\u0c48\u04d1\u5064\u006e\u4b2c\u258b\ua854'});
+let textureView95 = texture64.createView({label: '\u{1fdcc}\ubccb\u0132\u0d7f\u6625\u{1f683}\u9ddf\u854e\u0ac3\u8735'});
+let renderPassEncoder12 = commandEncoder85.beginRenderPass({
+  label: '\uce46\u{1fe80}\u97d7',
+  colorAttachments: [{
+  view: textureView94,
+  depthSlice: 2,
+  clearValue: { r: 316.7, g: -248.2, b: 246.6, a: 791.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 747119792,
+});
+let renderBundleEncoder37 = device1.createRenderBundleEncoder({label: '\u0821\u0777', colorFormats: ['rg16uint'], stencilReadOnly: true});
+try {
+computePassEncoder36.setPipeline(pipeline67);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer27, 400_909_164);
+} catch {}
+try {
+renderBundleEncoder35.setBindGroup(6, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder31.draw(64, 228, 99_276_491, 38_649_257);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(9, buffer24, 0, 2861);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 1624, new Int16Array(6886), 5196, 148);
+} catch {}
+let promise29 = device1.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(img3);
+let bindGroupLayout22 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 9122,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32float', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 6342,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let bindGroup30 = device1.createBindGroup({label: '\ucafe\u0806\u{1feea}', layout: bindGroupLayout21, entries: []});
+let textureView96 = texture59.createView({label: '\u9093\u{1f89f}\uc870\u2af4\u939d\u47f2\u88d3', baseMipLevel: 1});
+let renderBundle49 = renderBundleEncoder37.finish({label: '\u8930\ub62f\u7c10'});
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder11.draw(392, 448, 35_351_627, 253_397_476);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 22},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(48)), /* required buffer size: 5_466_096 */
+{offset: 176, bytesPerRow: 248, rowsPerImage: 190}, {width: 32, height: 0, depthOrArrayLayers: 117});
+} catch {}
+let video22 = await videoWithData();
+try {
+offscreenCanvas19.getContext('webgl');
+} catch {}
+let bindGroupLayout23 = device1.createBindGroupLayout({
+  label: '\ufde5\u9400\ue725\ud3b3\u094c\u0345\u9b24\u{1ffd5}\u232f',
+  entries: [
+    {binding: 3078, visibility: 0, externalTexture: {}},
+    {
+      binding: 6764,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 114643337, hasDynamicOffset: true },
+    },
+  ],
+});
+let bindGroup31 = device1.createBindGroup({
+  label: '\u{1ff01}\ue056\ub817\u07d5\u016b\u9d3f\u391b\u5bd9\u0689\ue244',
+  layout: bindGroupLayout21,
+  entries: [],
+});
+let commandEncoder86 = device1.createCommandEncoder({label: '\u0931\u{1fde7}\u0827\u0e87\u{1fcb3}\u{1fc05}\u{1f839}\u{1f7d6}\u0465'});
+let querySet40 = device1.createQuerySet({
+  label: '\u2710\u70a6\uef7f\u9a7f\ue2b2\u4119\u{1f7be}\u{1fa7f}\u9748\u5aea\u0846',
+  type: 'occlusion',
+  count: 3504,
+});
+let renderPassEncoder13 = commandEncoder86.beginRenderPass({
+  label: '\u79e0\u052c\ua74d\u555e\u27cd\uf140\u0f37\u07f7\u043a',
+  colorAttachments: [{view: textureView82, depthSlice: 108, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet39,
+});
+try {
+renderPassEncoder12.setBindGroup(6, bindGroup28, new Uint32Array(4623), 3271, 0);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(149, 0, 69, 0);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(3517);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer24, 761_104_637);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup26, new Uint32Array(8712), 255, 0);
+} catch {}
+try {
+renderBundleEncoder31.draw(379, 192);
+} catch {}
+try {
+buffer26.unmap();
+} catch {}
+let pipeline69 = device1.createRenderPipeline({
+  label: '\ue1e2\u69f0',
+  layout: pipelineLayout10,
+  multisample: {count: 1, mask: 0xe883a1a6},
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', failOp: 'replace', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilWriteMask: 1297335303,
+    depthBias: 382194291,
+    depthBiasClamp: 336.7192969995307,
+  },
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 12156,
+        attributes: [
+          {format: 'sint32', offset: 4828, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 2024, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 7968,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint16x2', offset: 3528, shaderLocation: 10},
+          {format: 'float32x3', offset: 124, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 1056, shaderLocation: 1},
+          {format: 'sint32x4', offset: 228, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 716, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 64, shaderLocation: 0},
+          {format: 'float32x2', offset: 2024, shaderLocation: 4},
+          {format: 'float16x4', offset: 1300, shaderLocation: 19},
+          {format: 'sint32x2', offset: 20, shaderLocation: 20},
+          {format: 'uint32x2', offset: 816, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 804, shaderLocation: 15},
+          {format: 'float32', offset: 124, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 568, shaderLocation: 17},
+          {format: 'float16x4', offset: 208, shaderLocation: 3},
+          {format: 'float32', offset: 2976, shaderLocation: 9},
+          {format: 'sint32', offset: 944, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 980,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 412, shaderLocation: 22}],
+      },
+    ],
+  },
+});
+let imageData35 = new ImageData(140, 36);
+let texture67 = device1.createTexture({
+  label: '\u05d9\u23b2\u{1fcdc}\uebf1\u0ac5\u04fb\u1bba\u060e\u6d59\u0cca\u0b8f',
+  size: [300, 12, 209],
+  mipLevelCount: 6,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle50 = renderBundleEncoder35.finish({});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+computePassEncoder37.setBindGroup(5, bindGroup28, new Uint32Array(3766), 1358, 0);
+} catch {}
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline57);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: -115.2, g: -479.0, b: -267.2, a: -828.6, });
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(15, 0, 606, 1);
+} catch {}
+try {
+renderPassEncoder11.draw(216, 134, 521_783_639, 189_867_196);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder31.draw(261, 37);
+} catch {}
+try {
+commandEncoder70.resolveQuerySet(querySet37, 1566, 166, buffer28, 77568);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 3160, new Float32Array(19887), 14274, 204);
+} catch {}
+let texture68 = device1.createTexture({
+  label: '\u{1fb30}\u7ad0\uf9c2\ud34d\u0fb9\u05f2\u821e\u21be\u0f62',
+  size: {width: 2268},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView97 = texture58.createView({});
+let renderPassEncoder14 = commandEncoder70.beginRenderPass({
+  label: '\ud326\u{1f631}\u844f\u93ff',
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 0,
+  clearValue: { r: 531.1, g: 178.0, b: -663.0, a: 260.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet36,
+  maxDrawCount: 19072308,
+});
+let sampler55 = device1.createSampler({
+  label: '\u2c5a\u4712\udaf3\u{1f76f}\uc2cf\u2bf3\u0fc1\u578b\u{1f85a}\u0817',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 47.26,
+});
+try {
+renderPassEncoder9.executeBundles([renderBundle46, renderBundle46, renderBundle47, renderBundle43, renderBundle43, renderBundle47, renderBundle50, renderBundle49, renderBundle45]);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline64);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6, buffer24, 68, 3767);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(3, 135, 1_119_431_686, 814_248_528);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(2, buffer24, 0, 4374);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 120, y: 2, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 3_875 */
+{offset: 615, bytesPerRow: 548}, {width: 65, height: 6, depthOrArrayLayers: 1});
+} catch {}
+let promise30 = device1.createComputePipelineAsync({
+  label: '\u0a4c\u{1f99f}\u67af\u0d94',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let bindGroupLayout24 = device1.createBindGroupLayout({
+  label: '\u{1ff0e}\u0af4\u8727\u{1f6a5}\u0e29\uab29\u9e87\u0a3f\u516f',
+  entries: [
+    {
+      binding: 1997,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 3226,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 2724,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'bgra8unorm', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let textureView98 = texture61.createView({
+  label: '\u82e9\u5e03\ud14d\u0df0\u623e\u4b29\u009d\u{1fafd}\u2366',
+  dimension: '2d',
+  mipLevelCount: 2,
+  baseArrayLayer: 175,
+});
+try {
+renderPassEncoder9.draw(456);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline68);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(9009, undefined, 0, 1963355576);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(6, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(3, buffer24, 200);
+} catch {}
+let canvas21 = document.createElement('canvas');
+let buffer29 = device1.createBuffer({size: 1048576, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView99 = texture68.createView({label: '\ue8a5\u37b2'});
+let sampler56 = device1.createSampler({
+  label: '\u{1fc99}\uec3d\u{1f9b5}\u4f15\u14dc\u{1f8c4}\u06fb\u0f10',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 30.92,
+});
+try {
+renderPassEncoder11.setBindGroup(4, bindGroup24);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle50, renderBundle45, renderBundle45, renderBundle48, renderBundle44, renderBundle49, renderBundle47, renderBundle48, renderBundle47, renderBundle46]);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(762, 0, 340, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(355);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer26, 768_232_423);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1939, undefined, 3801813893, 237098486);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(3, 274, 477_404_611);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise31 = device1.createComputePipelineAsync({
+  label: '\u88fa\u084e\u0fe9\u{1fe1c}\u29b7\u3228\u{1f88c}',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+let texture69 = device1.createTexture({
+  label: '\u0d95\u0918\u{1f7ba}\uc850',
+  size: [384, 20, 1],
+  mipLevelCount: 4,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+renderPassEncoder11.draw(222, 18, 52_323_335, 235_225_256);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer24, 327_570_921);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(173);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(3, buffer24, 0, 1510);
+} catch {}
+try {
+gpuCanvasContext16.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 400, new Int16Array(26127), 25488, 84);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 222 */
+{offset: 222, rowsPerImage: 158}, {width: 11, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas21.getContext('webgpu');
+} catch {}
+let shaderModule20 = device1.createShaderModule({
+  label: '\u{1f60e}\u3bbb\u06af\u8bb3\u9166\u650b\u0840\u415a\u{1ff57}\u6007',
+  code: `@group(0) @binding(8384)
+var<storage, read_write> global5: array<u32>;
+@group(0) @binding(5282)
+var<storage, read_write> parameter7: array<u32>;
+@group(2) @binding(4292)
+var<storage, read_write> type8: array<u32>;
+@group(0) @binding(7949)
+var<storage, read_write> function12: array<u32>;
+
+@compute @workgroup_size(3, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec2<i32>,
+  @location(7) f1: vec4<f32>,
+  @location(0) f2: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(52) a0: vec4<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S21 {
+  @location(3) f0: u32,
+  @location(2) f1: vec2<f32>,
+  @location(21) f2: f16,
+  @location(6) f3: vec2<f32>,
+  @location(18) f4: f32,
+  @location(5) f5: vec4<f16>,
+  @location(16) f6: vec2<f16>,
+  @location(22) f7: vec2<f16>,
+  @location(11) f8: vec4<u32>,
+  @location(14) f9: vec3<u32>,
+  @location(1) f10: f16,
+  @location(9) f11: vec3<f16>,
+  @location(12) f12: vec2<f32>,
+  @location(4) f13: f16
+}
+struct VertexOutput0 {
+  @location(69) f258: i32,
+  @location(110) f259: vec2<f16>,
+  @location(37) f260: i32,
+  @location(104) f261: vec2<u32>,
+  @location(20) f262: vec4<f16>,
+  @location(26) f263: u32,
+  @location(42) f264: vec4<f32>,
+  @location(31) f265: vec2<i32>,
+  @location(74) f266: vec3<f32>,
+  @location(52) f267: vec4<u32>,
+  @location(19) f268: vec3<f16>,
+  @location(49) f269: vec2<u32>,
+  @location(6) f270: vec3<f16>,
+  @location(34) f271: vec3<i32>,
+  @builtin(position) f272: vec4<f32>,
+  @location(18) f273: vec3<u32>,
+  @location(58) f274: vec4<i32>,
+  @location(41) f275: vec4<f32>,
+  @location(109) f276: vec4<f32>,
+  @location(43) f277: vec3<f16>,
+  @location(7) f278: vec4<f16>,
+  @location(28) f279: f16,
+  @location(67) f280: vec2<u32>,
+  @location(66) f281: vec2<u32>,
+  @location(79) f282: vec3<f16>,
+  @location(46) f283: i32,
+  @location(77) f284: vec2<f32>,
+  @location(91) f285: vec2<i32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(17) a1: vec3<u32>, @location(20) a2: vec3<f32>, @location(13) a3: i32, @location(23) a4: vec2<f32>, a5: S21) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let querySet41 = device1.createQuerySet({label: '\u01db\u1a84\uc2ad\u0e86', type: 'occlusion', count: 2103});
+let textureView100 = texture60.createView({aspect: 'all'});
+try {
+renderPassEncoder14.executeBundles([renderBundle50, renderBundle46, renderBundle49, renderBundle46, renderBundle47]);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(3288);
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(160, 647, 665_397_104, 612_771_930, 632_412_204);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer26, 1_225_916_325);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+video5.height = 44;
+let offscreenCanvas26 = new OffscreenCanvas(117, 721);
+let pipelineLayout13 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout16, bindGroupLayout21, bindGroupLayout15, bindGroupLayout21]});
+let commandEncoder87 = device1.createCommandEncoder({});
+let texture70 = device1.createTexture({
+  label: '\u04bf\u40fd\u9070\u{1f875}\u0151\u{1f6b2}\u5b60\ubaa6\u0111\u92e8',
+  size: {width: 768, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 8,
+  format: 'astc-8x8-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm-srgb', 'astc-8x8-unorm'],
+});
+let renderPassEncoder15 = commandEncoder87.beginRenderPass({
+  label: '\u{1feca}\u5a38\u3d9a\ue511\ub8a2\u{1ffbf}\u1ffd',
+  colorAttachments: [{
+  view: textureView85,
+  depthSlice: 151,
+  clearValue: { r: -319.5, g: 505.5, b: -822.1, a: 305.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet40,
+});
+try {
+renderPassEncoder14.executeBundles([renderBundle48, renderBundle46]);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer29, 986_497_032);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer24, 100);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(5, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(1, bindGroup27, new Uint32Array(9056), 341, 0);
+} catch {}
+try {
+renderBundleEncoder29.draw(343, 156);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline64);
+} catch {}
+try {
+renderPassEncoder12.pushDebugGroup('\u{1fed7}');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 25},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer4), /* required buffer size: 2_334_389 */
+{offset: 764, bytesPerRow: 147, rowsPerImage: 125}, {width: 1, height: 0, depthOrArrayLayers: 128});
+} catch {}
+let video23 = await videoWithData();
+let commandEncoder88 = device1.createCommandEncoder();
+let texture71 = device1.createTexture({
+  label: '\uab90\u01bc\u06cd\u1d70\u{1f83d}\u5550\u6690\u45de\u68f8\ueaf1',
+  size: [2268],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let textureView101 = texture55.createView({
+  label: '\u{1fbda}\u052e\u34d0\u{1f8bd}\u02d3\u{1fa84}\ue33c\ua953\u15d6\u{1fcc2}',
+  format: 'rg16uint',
+  mipLevelCount: 2,
+  baseArrayLayer: 0,
+});
+let renderPassEncoder16 = commandEncoder88.beginRenderPass({
+  label: '\u154b\u{1fd3d}\u0e98\u{1fc3c}\u5ab3\ue3eb\u0efe\u0a4a\u0b99\u0450\u009f',
+  colorAttachments: [{
+  view: textureView81,
+  depthSlice: 214,
+  clearValue: { r: -394.0, g: -164.1, b: 532.4, a: 58.81, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet35,
+});
+let renderBundleEncoder38 = device1.createRenderBundleEncoder({label: '\u3927\ue5a9\u{1fc93}', colorFormats: ['rg16uint'], depthReadOnly: true});
+let sampler57 = device1.createSampler({
+  label: '\uc441\u0ae1\u08ae\uba13\u9bc7\ud006\u0e6d',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.27,
+  lodMaxClamp: 39.25,
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder13.beginOcclusionQuery(556);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(101, 1, 67, 0);
+} catch {}
+try {
+renderPassEncoder14.draw(28, 53, 1_170_864_675);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(9, buffer24, 0);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(5, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder31.draw(178, 307, 2_628_653_232, 478_984_002);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(8, 199, 96_692_952, 497_318_489);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(8, buffer24, 5464, 196);
+} catch {}
+gc();
+let bindGroup32 = device1.createBindGroup({
+  label: '\ufe87\u6a4e\uf7d7\u71b4\ua6b3',
+  layout: bindGroupLayout17,
+  entries: [{binding: 8803, resource: externalTexture43}, {binding: 4292, resource: externalTexture41}],
+});
+let textureView102 = texture67.createView({
+  label: '\u67e0\u1dc0\u{1fa8e}\u{1fd3a}\ud61c\u0f41\ua883',
+  dimension: '2d',
+  aspect: 'all',
+  format: 'rg16uint',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 149,
+});
+try {
+computePassEncoder36.setPipeline(pipeline59);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle44]);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(611, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder11.draw(74, 102, 771_462_940);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer26, 20_244_905);
+} catch {}
+let pipeline70 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout11,
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'zero'},
+    stencilBack: {compare: 'not-equal', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 4005813732,
+    stencilWriteMask: 4245064322,
+    depthBias: -864586768,
+  },
+  vertex: {module: shaderModule16, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'ccw', unclippedDepth: true},
+});
+let video24 = await videoWithData();
+try {
+adapter0.label = '\u{1fc97}\u5291\u{1f982}\uf330\u7ee5\u087a\ue9f4\u{1fdf4}';
+} catch {}
+let video25 = await videoWithData();
+let bindGroup33 = device1.createBindGroup({layout: bindGroupLayout21, entries: []});
+let texture72 = device1.createTexture({
+  label: '\u0d43\u14b7\u2982',
+  size: {width: 96, height: 5, depthOrArrayLayers: 7},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let textureView103 = texture54.createView({label: '\u88fd\u{1ff4e}\u6aff\uad20\u0422', baseMipLevel: 4, mipLevelCount: 1});
+let renderBundle51 = renderBundleEncoder36.finish({label: '\u0765\uc8b0\u00b4\u2c3a\u0e9c\uabcf\u42a3\u7bf3\u5951\u0367'});
+let externalTexture46 = device1.importExternalTexture({
+  label: '\u02e2\u0b32\u0ea3\udcd3\u{1fd82}\u0a90\u483f\ubf9d',
+  source: videoFrame18,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(2553);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(166, 19, 1_488_480_248, 11_603_539, 345_675_452);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer27, 38_512_337);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer29, 1_057_845_598);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer24, 5544, 77);
+} catch {}
+try {
+renderBundleEncoder29.draw(246, 72, 1_454_254_796, 44_275_748);
+} catch {}
+let video26 = await videoWithData();
+try {
+computePassEncoder37.setPipeline(pipeline57);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: 701.0, g: -96.15, b: 717.4, a: -436.3, });
+} catch {}
+try {
+renderPassEncoder14.draw(56, 335, 720_769_343, 1_334_954_075);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup29, new Uint32Array(6417), 5815, 0);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(6, buffer24, 0);
+} catch {}
+try {
+commandEncoder84.copyBufferToBuffer(buffer29, 1027108, buffer27, 75688, 15484);
+dissociateBuffer(device1, buffer29);
+dissociateBuffer(device1, buffer27);
+} catch {}
+let imageData36 = new ImageData(92, 120);
+try {
+offscreenCanvas26.getContext('2d');
+} catch {}
+let commandEncoder89 = device1.createCommandEncoder();
+let computePassEncoder39 = commandEncoder84.beginComputePass({label: '\u02b0\u443e\udf8c\uc84c\u530d\u224d\u{1fc46}\u0bc0'});
+let renderBundleEncoder39 = device1.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(993, 1, 85, 0);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(1680);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(3, bindGroup32, new Uint32Array(3159), 1485, 0);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline65);
+} catch {}
+try {
+commandEncoder89.copyTextureToBuffer({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 789, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5916 widthInBlocks: 1479 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 568 */
+  offset: 568,
+  buffer: buffer26,
+}, {width: 1479, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+commandEncoder71.clearBuffer(buffer27);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+commandEncoder71.resolveQuerySet(querySet40, 2505, 184, buffer28, 4096);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext17 = offscreenCanvas25.getContext('webgpu');
+let buffer30 = device1.createBuffer({label: '\u{1fd85}\u{1fa11}\u{1f863}\u7862\u11c8\u05af', size: 209300, usage: GPUBufferUsage.STORAGE});
+let computePassEncoder40 = commandEncoder71.beginComputePass({label: '\u0ba3\u2a71\u4750\u6f48'});
+let renderPassEncoder17 = commandEncoder89.beginRenderPass({
+  label: '\u08ef\u{1fdd9}\u0b60\u{1fae9}\u0978\u0046\u{1f943}\u02fc\ue644',
+  colorAttachments: [{
+  view: textureView97,
+  depthSlice: 237,
+  clearValue: { r: 229.8, g: 44.39, b: 498.7, a: 651.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet34,
+  maxDrawCount: 893969382,
+});
+let externalTexture47 = device1.importExternalTexture({label: '\u{1f7e2}\u6a4d', source: videoFrame12, colorSpace: 'srgb'});
+try {
+renderPassEncoder11.drawIndirect(buffer26, 866_107_573);
+} catch {}
+try {
+renderBundleEncoder31.draw(266, 292, 1_440_019_188);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(203, 49, 210_363_143);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 531 */
+{offset: 531}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder90 = device1.createCommandEncoder({label: '\u0b0f\u{1f605}\u8ab3\u8a26\u3940\u0cc6\u0602\u0602\uc772'});
+let textureView104 = texture65.createView({baseMipLevel: 5, mipLevelCount: 2});
+let computePassEncoder41 = commandEncoder90.beginComputePass({});
+try {
+renderPassEncoder14.setBindGroup(5, bindGroup28, []);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.drawIndexed(263, 244, 1_471_644_002, 59_879_654, 1_034_244_763);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer24, 768_190_319);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(1, bindGroup29, new Uint32Array(1532), 1372, 0);
+} catch {}
+try {
+renderBundleEncoder39.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(1, buffer24, 0, 2355);
+} catch {}
+let buffer31 = device1.createBuffer({label: '\u{1f9c9}\u1f7f\u{1fd4a}\u4587', size: 863056, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder91 = device1.createCommandEncoder({label: '\u8220\u0b17\ub920\uaeee\u0750\u4180\u0624'});
+let computePassEncoder42 = commandEncoder91.beginComputePass({label: '\u0ed5\u07fb\u{1ffe7}'});
+let sampler58 = device1.createSampler({
+  label: '\u05f0\ub07c\u{1fbaf}\u05e0\u47cb\u00ca\u{1f88c}',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.01,
+  lodMaxClamp: 69.43,
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder9.setStencilReference(655);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(7, buffer24, 5616, 88);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(4, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(139, 340, 922_212_932, 1_854_154_355, 925_368_041);
+} catch {}
+let pipeline71 = device1.createComputePipeline({
+  label: '\u1993\u0e11\uc2f8\u{1f7b4}\u88c0\u2f2f\u47fa\u002f\ufce6\u{1fdfa}\u58ad',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise25;
+} catch {}
+let imageBitmap23 = await createImageBitmap(video5);
+try {
+window.someLabel = sampler27.label;
+} catch {}
+let imageData37 = new ImageData(192, 216);
+let imageBitmap24 = await createImageBitmap(video14);
+let bindGroupLayout25 = device1.createBindGroupLayout({
+  label: '\u0696\u{1fe46}\u0b17\u{1f758}\u0bad\u{1fc61}\uafee',
+  entries: [
+    {binding: 9052, visibility: 0, externalTexture: {}},
+    {
+      binding: 5950,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 3308,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder92 = device1.createCommandEncoder({label: '\u33fd\u0d9d\u059f\u{1f7b7}\u{1f8db}\u043d\u{1f718}\u64b4\u6f72\u0f3e'});
+let texture73 = device1.createTexture({
+  label: '\u0f67\ucaf7\u{1fa02}\u{1f6c2}\u6170\uc021\ub93f\u073e\u2da7\u83c8\u091d',
+  size: [72, 16, 105],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let textureView105 = texture60.createView({label: '\u{1f85b}\u058f\u243e\u2357\u5f91\u0a09\u5eb1\u223a\u{1fbb6}'});
+let renderBundle52 = renderBundleEncoder37.finish({label: '\u{1f812}\u00db\ue257'});
+try {
+computePassEncoder36.setBindGroup(6, bindGroup28);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup24, new Uint32Array(4055), 1165, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle48, renderBundle43]);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: -449.0, g: -771.0, b: 886.6, a: 437.2, });
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer24, 111_282_262);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer28, 328_887_104);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(99, 188);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+  await buffer31.mapAsync(GPUMapMode.WRITE, 588712, 269476);
+} catch {}
+try {
+commandEncoder92.clearBuffer(buffer24);
+dissociateBuffer(device1, buffer24);
+} catch {}
+try {
+commandEncoder92.resolveQuerySet(querySet37, 558, 666, buffer28, 71680);
+} catch {}
+let bindGroup34 = device1.createBindGroup({
+  label: '\u0f7d\u{1feaf}\u47da\u{1fb6e}\u0b43\u{1fe51}',
+  layout: bindGroupLayout17,
+  entries: [{binding: 4292, resource: externalTexture47}, {binding: 8803, resource: externalTexture46}],
+});
+let commandEncoder93 = device1.createCommandEncoder({label: '\u5f4e\uc1df\u0ccb\u9b9c'});
+let textureView106 = texture71.createView({label: '\u2994\u7345\u0f60\u{1fa94}\uc119\u{1fcd1}', format: 'rg16uint', mipLevelCount: 1});
+try {
+renderPassEncoder14.setScissorRect(11, 1, 6, 1);
+} catch {}
+try {
+renderPassEncoder14.draw(220, 93);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer27, 105_619_140);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(5, buffer24, 0, 2053);
+} catch {}
+let arrayBuffer6 = buffer31.getMappedRange(603664, 43128);
+try {
+commandEncoder93.copyBufferToBuffer(buffer29, 374040, buffer26, 26496, 171216);
+dissociateBuffer(device1, buffer29);
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+commandEncoder93.resolveQuerySet(querySet37, 1880, 87, buffer28, 45568);
+} catch {}
+let promise32 = device1.createComputePipelineAsync({
+  label: '\ua113\u{1f6a1}\u06c6\u0005\u8de6\uca29\u{1fd88}\uc1be\u0978\ub758',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule18, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas27 = new OffscreenCanvas(264, 112);
+let shaderModule21 = device1.createShaderModule({
+  label: '\u{1f8c3}\ue34f\u7775\u09fb\u55b7\u5df3\u69b2',
+  code: `@group(0) @binding(8384)
+var<storage, read_write> parameter8: array<u32>;
+@group(2) @binding(4292)
+var<storage, read_write> local10: array<u32>;
+@group(2) @binding(8803)
+var<storage, read_write> function13: array<u32>;
+@group(3) @binding(8803)
+var<storage, read_write> parameter9: array<u32>;
+@group(3) @binding(4292)
+var<storage, read_write> type9: array<u32>;
+@group(0) @binding(7949)
+var<storage, read_write> type10: array<u32>;
+@group(0) @binding(5282)
+var<storage, read_write> type11: array<u32>;
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+  @builtin(front_facing) f0: bool,
+  @builtin(sample_index) f1: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, a1: S22, @builtin(position) a2: vec4<f32>) -> @location(200) vec3<u32> {
+return vec3<u32>();
+}
+
+
+
+@vertex
+fn vertex0(@location(11) a0: vec3<f16>, @location(13) a1: vec2<u32>, @location(10) a2: vec4<u32>, @location(19) a3: vec3<u32>, @location(18) a4: f32, @location(17) a5: vec2<i32>, @location(5) a6: vec4<i32>, @builtin(instance_index) a7: u32, @location(4) a8: vec4<f16>, @location(21) a9: vec4<u32>, @location(12) a10: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout26 = device1.createBindGroupLayout({
+  label: '\u{1f8ac}\ucb48\u5969\ub1ee\uedc9\u1444\ud668',
+  entries: [
+    {
+      binding: 1828,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {binding: 5448, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder94 = device1.createCommandEncoder();
+let renderPassEncoder18 = commandEncoder93.beginRenderPass({
+  colorAttachments: [{view: textureView81, depthSlice: 31, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet41,
+  maxDrawCount: 1007044890,
+});
+let externalTexture48 = device1.importExternalTexture({
+  label: '\u4f07\u{1fc44}\u{1fba4}\u769a\u0a08\uaa07\u{1f884}\u36ad\u68c7',
+  source: video7,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder18.setViewport(211.4, 0.04577, 228.4, 0.9093, 0.09121, 0.5109);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer28, 200_540_631);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexed(515, 8, 1_781_402_079, 993_432_403, 34_941_232);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline65);
+} catch {}
+try {
+commandEncoder94.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 293092 */
+  offset: 6864,
+  bytesPerRow: 256,
+  rowsPerImage: 223,
+  buffer: buffer29,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 4, depthOrArrayLayers: 6});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder94.copyTextureToTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 7, height: 2, depthOrArrayLayers: 2});
+} catch {}
+let pipeline72 = await promise32;
+let gpuCanvasContext18 = offscreenCanvas27.getContext('webgpu');
+document.body.prepend(canvas9);
+video24.width = 236;
+let texture74 = device1.createTexture({
+  label: '\u955a\ue487\u43bd\u647e\uee04\u01e4\uf40a\u{1f6ba}\u4d5d',
+  size: [144, 32, 211],
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder43 = commandEncoder94.beginComputePass({label: '\u{1f95b}\u{1f979}\u0367\ubfbf\u9060\u03d6\u7834'});
+let renderBundle53 = renderBundleEncoder32.finish({label: '\u8ad3\u8d15\u{1fd00}\u0ffe\ube08'});
+let sampler59 = device1.createSampler({
+  label: '\ud51e\u33d2\u{1f96c}\u070c',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 4.270,
+  lodMaxClamp: 65.90,
+  compare: 'never',
+});
+try {
+renderPassEncoder14.executeBundles([renderBundle45, renderBundle48]);
+} catch {}
+try {
+renderPassEncoder13.draw(28, 117, 682_883_784, 46_215_637);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer28, 405_962_956);
+} catch {}
+try {
+renderBundleEncoder29.draw(599);
+} catch {}
+try {
+renderBundleEncoder28.drawIndexed(266, 86, 881_766_587, 666_994_485, 192_855_199);
+} catch {}
+let pipeline73 = device1.createRenderPipeline({
+  label: '\u{1f9d1}\udf66\ufd8d\u{1ff24}',
+  layout: pipelineLayout10,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}],
+},
+  vertex: {module: shaderModule16, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', unclippedDepth: true},
+});
+let commandBuffer18 = commandEncoder92.finish({});
+let texture75 = device1.createTexture({
+  label: '\u795e\u449f',
+  size: {width: 384},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint'],
+});
+try {
+computePassEncoder41.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer29, 416_939_598);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer29, 83_836_383);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder31.draw(95, 707, 200_104_269);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 1},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer4), /* required buffer size: 12_854_375 */
+{offset: 780, bytesPerRow: 303, rowsPerImage: 169}, {width: 8, height: 3, depthOrArrayLayers: 252});
+} catch {}
+let imageData38 = new ImageData(220, 68);
+let externalTexture49 = device1.importExternalTexture({label: '\uc0bd\u{1fdbb}\u7891\udfe9', source: video23, colorSpace: 'srgb'});
+try {
+renderPassEncoder14.draw(6, 41, 1_737_032_478, 1_402_772_361);
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(263, 363, 716_850_523);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer26, 416_549_069);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, buffer24);
+} catch {}
+try {
+renderBundleEncoder28.draw(261, 148);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexed(349, 125);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(4, buffer24, 1800, 2389);
+} catch {}
+try {
+renderPassEncoder12.popDebugGroup();
+} catch {}
+let shaderModule22 = device1.createShaderModule({
+  label: '\u62dd\u{1f8b5}\u{1fd93}\u044c\u{1fbb8}\u079f\u08ca',
+  code: `@group(2) @binding(8803)
+var<storage, read_write> n9: array<u32>;
+@group(0) @binding(8384)
+var<storage, read_write> global6: array<u32>;
+@group(3) @binding(8803)
+var<storage, read_write> parameter10: array<u32>;
+@group(3) @binding(4292)
+var<storage, read_write> n10: array<u32>;
+@group(0) @binding(7949)
+var<storage, read_write> type12: array<u32>;
+@group(0) @binding(5282)
+var<storage, read_write> n11: array<u32>;
+
+@compute @workgroup_size(7, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<u32>,
+  @location(4) f1: vec3<u32>,
+  @builtin(sample_mask) f2: u32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S23 {
+  @location(14) f0: f32,
+  @location(18) f1: vec3<f32>,
+  @location(23) f2: vec4<f16>,
+  @location(22) f3: vec2<i32>,
+  @location(21) f4: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(19) a0: f32, @location(4) a1: vec2<f16>, @location(17) a2: vec3<u32>, @location(7) a3: f32, @builtin(instance_index) a4: u32, @location(20) a5: vec4<i32>, @location(6) a6: vec4<f16>, @location(13) a7: vec2<u32>, @location(2) a8: vec2<f32>, @location(11) a9: vec4<i32>, @location(9) a10: vec4<f16>, @location(15) a11: vec3<i32>, @location(12) a12: vec3<f32>, @location(3) a13: vec3<f16>, @location(1) a14: vec3<u32>, @builtin(vertex_index) a15: u32, a16: S23, @location(10) a17: vec2<f16>, @location(0) a18: vec2<f16>, @location(8) a19: f32, @location(16) a20: vec3<f16>, @location(5) a21: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture76 = device1.createTexture({
+  label: '\u06be\ue244\u{1fcc5}\ud998\u05d8\uc332\u0001',
+  size: {width: 384, height: 20, depthOrArrayLayers: 31},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16uint'],
+});
+let renderBundle54 = renderBundleEncoder28.finish({label: '\u{1fd61}\uda41'});
+try {
+renderPassEncoder13.beginOcclusionQuery(2339);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(3, buffer24, 0);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+let video27 = await videoWithData();
+gc();
+let texture77 = gpuCanvasContext9.getCurrentTexture();
+let textureView107 = texture58.createView({});
+let renderBundle55 = renderBundleEncoder35.finish({});
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(3143);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer26, 697_377_935);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer24, 848_811_459);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder39.draw(22, 57);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline65);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 1540, new Float32Array(48180), 45336, 32);
+} catch {}
+let imageBitmap25 = await createImageBitmap(canvas14);
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let textureView108 = texture72.createView({label: '\u0dd3\u2721\u7822\uad6d\u387d\u9604\ua46e', mipLevelCount: 2});
+let renderBundleEncoder40 = device1.createRenderBundleEncoder({
+  label: '\u25af\u0860\ubf32\u3fb5\u0730\u{1fc78}\u97e8\u{1fdda}\u640a',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder37.setPipeline(pipeline58);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder13.draw(146, 148, 871_269_267, 801_624_910);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer24, 0, 5188);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline64);
+} catch {}
+document.body.prepend(canvas15);
+gc();
+let commandEncoder95 = device1.createCommandEncoder();
+let textureView109 = texture73.createView({label: '\uab92\u27d4\u3741\uf9c1\uae51\u29ee', baseMipLevel: 1, mipLevelCount: 2});
+let renderPassEncoder19 = commandEncoder95.beginRenderPass({
+  label: '\u6e90\u{1f798}\u3b1e\u0bc7\ua272\u0cd4\u{1f712}\ufb04\u1bf1\u{1fa2a}',
+  colorAttachments: [{
+  view: textureView94,
+  depthSlice: 0,
+  clearValue: { r: 857.6, g: -109.8, b: -923.3, a: -347.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 529855814,
+});
+let renderBundleEncoder41 = device1.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder11.draw(54);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(6, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(1, buffer24, 0, 2887);
+} catch {}
+let promise33 = device1.queue.onSubmittedWorkDone();
+try {
+  await promise29;
+} catch {}
+document.body.prepend(img16);
+gc();
+let imageData39 = new ImageData(76, 100);
+let bindGroupLayout27 = device1.createBindGroupLayout({
+  label: '\u{1fda8}\u6e12\u9bd7\u3720\u0401',
+  entries: [
+    {
+      binding: 8217,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let querySet42 = device1.createQuerySet({label: '\u{1f65d}\u{1fae8}\uad3e\u{1f8d2}\u0fce\u060c\ud3bf', type: 'occlusion', count: 96});
+let sampler60 = device1.createSampler({
+  label: '\u0d09\u{1fae8}\u0af8\u5e2a',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.38,
+  lodMaxClamp: 99.47,
+  maxAnisotropy: 17,
+});
+let externalTexture50 = device1.importExternalTexture({
+  label: '\ud83f\u07fc\u2ffe\u{1fdaa}\u003b\u{1f8f8}\u{1f80b}\u01e2\u0cb4\u0893\u9a67',
+  source: video18,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(71, 22, 305_450_482, -1_957_531_380, 1_278_688_007);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer28, 110_613_374);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(4, buffer24);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup31, new Uint32Array(9164), 3629, 0);
+} catch {}
+try {
+renderBundleEncoder39.draw(220, 61);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(1, buffer24, 4012, 809);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 724, new BigUint64Array(10594), 6716, 8);
+} catch {}
+try {
+  await promise33;
+} catch {}
+let commandEncoder96 = device1.createCommandEncoder({label: '\ua10c\u{1fe67}\u12d6\u921c\u0b63\u67a7\u0120\u{1f8d8}\u02ca\uacf9\u81ed'});
+let querySet43 = device1.createQuerySet({label: '\u0337\u0ae9\u92b1\u28f0\u{1f847}\ub306', type: 'occlusion', count: 2210});
+let textureView110 = texture63.createView({
+  label: '\u{1faa9}\u8ab4\ue418\u{1fe13}',
+  dimension: '2d',
+  baseMipLevel: 0,
+  mipLevelCount: 3,
+  baseArrayLayer: 208,
+});
+let renderPassEncoder20 = commandEncoder96.beginRenderPass({
+  label: '\u0d48\u0617\u0177\u0c45',
+  colorAttachments: [{
+  view: textureView86,
+  depthSlice: 79,
+  clearValue: { r: 662.0, g: 206.8, b: 576.7, a: -564.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet41,
+  maxDrawCount: 1178479780,
+});
+let renderBundle56 = renderBundleEncoder30.finish({label: '\u0d5c\u8520'});
+let sampler61 = device1.createSampler({
+  label: '\u{1fbe9}\u0c78',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 63.68,
+  lodMaxClamp: 91.17,
+});
+try {
+renderPassEncoder17.setScissorRect(878, 0, 160, 1);
+} catch {}
+try {
+renderPassEncoder19.setViewport(0.3143, 0.5060, 0.1604, 0.06501, 0.4389, 0.7372);
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(135);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer30, 276_182_482);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer27, 1_125_208_200);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(1, bindGroup30, new Uint32Array(8487), 6662, 0);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexed(37, 494, 875_235_169, 265_245_966, 208_644_832);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 2268, new Int16Array(11291), 2187, 912);
+} catch {}
+let videoFrame19 = new VideoFrame(offscreenCanvas19, {timestamp: 0});
+let bindGroupLayout28 = device1.createBindGroupLayout({
+  label: '\u4d96\u6fde\u038e\u0c8d\u9c65',
+  entries: [
+    {binding: 7872, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 6474,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32float', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder97 = device1.createCommandEncoder({label: '\ue131\u0162\u2426\uaf49\ud47f\u0ad2'});
+let texture78 = device1.createTexture({
+  label: '\u71da\u3bb7\u4442\u0a86\u{1f91d}',
+  size: [96, 5, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView111 = texture58.createView({label: '\u0245\u{1fd30}\u{1fd0a}\u0766\u4fc5\u7a6e', aspect: 'all'});
+let computePassEncoder44 = commandEncoder97.beginComputePass({label: '\u0363\u0c5c\u0eb0\u093d\u44f2\u{1fb98}\u00ae\u{1ffa5}\u0ad5\ub1d8\u9c54'});
+let renderBundleEncoder42 = device1.createRenderBundleEncoder({label: '\u09b9\u3e90\u67ac\u0c73', colorFormats: ['rg16uint'], depthReadOnly: true});
+let externalTexture51 = device1.importExternalTexture({label: '\u1ff8\u3ea8\ude5f\u84af\u0bef\u2c43', source: video4, colorSpace: 'srgb'});
+try {
+computePassEncoder36.setPipeline(pipeline66);
+} catch {}
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder31.draw(29, 74, 698_517_867, 289_130_691);
+} catch {}
+try {
+renderPassEncoder11.insertDebugMarker('\u{1f92e}');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 212, new Int16Array(15723), 7151, 32);
+} catch {}
+let texture79 = device1.createTexture({
+  label: '\ud136\u0210\u46bc\u0002\u{1fb87}',
+  size: {width: 96, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  dimension: '2d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let renderBundle57 = renderBundleEncoder41.finish({label: '\u0d83\u0ffd\u{1fcc4}\u073a\u{1f62d}\u0812\u9c70\u0f69\uce6e'});
+try {
+computePassEncoder42.setPipeline(pipeline57);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: 920.5, g: 2.030, b: 589.4, a: -392.2, });
+} catch {}
+try {
+renderPassEncoder11.draw(9, 103, 656_317_812, 147_504_421);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer28, 826_008_449);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline74 = await promise28;
+let pipeline75 = device1.createRenderPipeline({
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'greater', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilBack: {compare: 'never', failOp: 'zero', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 4189684287,
+    stencilWriteMask: 2988718298,
+    depthBiasSlopeScale: 237.32733754341427,
+  },
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 40740, attributes: [{format: 'snorm16x2', offset: 4552, shaderLocation: 15}]},
+      {
+        arrayStride: 6684,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x4', offset: 696, shaderLocation: 23},
+          {format: 'snorm8x2', offset: 52, shaderLocation: 10},
+          {format: 'unorm8x4', offset: 100, shaderLocation: 11},
+          {format: 'sint32', offset: 528, shaderLocation: 16},
+          {format: 'float32', offset: 652, shaderLocation: 5},
+          {format: 'sint32x4', offset: 464, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 216, shaderLocation: 1},
+          {format: 'uint32x2', offset: 100, shaderLocation: 13},
+          {format: 'sint8x4', offset: 412, shaderLocation: 3},
+          {format: 'uint16x2', offset: 820, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 928, shaderLocation: 9},
+          {format: 'uint16x2', offset: 144, shaderLocation: 2},
+          {format: 'uint32x4', offset: 212, shaderLocation: 6},
+          {format: 'uint16x2', offset: 1136, shaderLocation: 8},
+          {format: 'sint8x2', offset: 1242, shaderLocation: 18},
+          {format: 'float16x4', offset: 3824, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 2502, shaderLocation: 21},
+          {format: 'snorm8x2', offset: 1106, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 688,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 172, shaderLocation: 7}],
+      },
+      {
+        arrayStride: 16408,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm16x4', offset: 104, shaderLocation: 22}],
+      },
+      {arrayStride: 16420, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 4412,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 1228, shaderLocation: 20}],
+      },
+    ],
+  },
+});
+let bindGroup35 = device1.createBindGroup({label: '\u09e5\u6ea0\u6d0e', layout: bindGroupLayout21, entries: []});
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderPassEncoder15.setViewport(713.2, 0.01416, 106.2, 0.07007, 0.7788, 0.9024);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer28, 1_017_048_275);
+} catch {}
+try {
+renderBundleEncoder33.drawIndexed(88, 114);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline64);
+} catch {}
+gc();
+let commandEncoder98 = device1.createCommandEncoder({});
+let texture80 = device1.createTexture({
+  label: '\u9a3f\ua210\u6aa3\u71e8\u0ee7\ued82\u{1ffaf}',
+  size: [288, 64, 422],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView112 = texture71.createView({label: '\u{1f97e}\u{1f81c}\u{1fff0}\u{1fd43}\u4b00\u{1fd0a}', baseArrayLayer: 0});
+let renderPassEncoder21 = commandEncoder98.beginRenderPass({
+  label: '\u6918\u0b60\u00dc\u0d95\u9440\u6a40\u09ce\u{1f978}',
+  colorAttachments: [{view: textureView81, depthSlice: 113, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet39,
+  maxDrawCount: 782951429,
+});
+let renderBundle58 = renderBundleEncoder38.finish({label: '\ub096\u036a\u{1fc3e}\u{1fc69}\u5397\u{1fdaf}\u05d0\u2f54\u{1fa86}\u818f'});
+try {
+renderPassEncoder21.beginOcclusionQuery(1803);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setViewport(38.80, 0.1037, 6.990, 0.3028, 0.8174, 0.8676);
+} catch {}
+try {
+renderPassEncoder13.draw(18, 383, 14_220_447, 882_213_421);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(8, buffer24);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup35, []);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline68);
+} catch {}
+let canvas22 = document.createElement('canvas');
+let imageData40 = new ImageData(248, 36);
+let bindGroupLayout29 = device1.createBindGroupLayout({
+  label: '\u0444\u{1fdfe}\u0c05\u7341\u0f2a\uf04b\ubc1d\u09ab\u0bf5',
+  entries: [
+    {
+      binding: 1519,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 6703,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+let querySet44 = device1.createQuerySet({label: '\u6c27\u{1f998}\u037e\u1882\u0188', type: 'occlusion', count: 3262});
+let texture81 = device1.createTexture({
+  label: '\u2b18\ud18a\u{1f939}\u03ca',
+  size: [75, 3, 7],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let textureView113 = texture74.createView({label: '\uc33b\uff9d\u0797'});
+let renderBundle59 = renderBundleEncoder41.finish({label: '\ua78a\udc5a\uca6e\u06f5'});
+let sampler62 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 37.02,
+  lodMaxClamp: 79.99,
+});
+try {
+renderPassEncoder19.setBindGroup(5, bindGroup31, new Uint32Array(0), 0, 0);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline68);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer24, 740);
+} catch {}
+try {
+renderBundleEncoder39.draw(96, 293, 161_202_408, 503_443_967);
+} catch {}
+try {
+device1.queue.submit([commandBuffer16, commandBuffer18]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 116, new DataView(new ArrayBuffer(3505)), 1697);
+} catch {}
+let promise34 = adapter0.requestAdapterInfo();
+let offscreenCanvas28 = new OffscreenCanvas(289, 264);
+let video28 = await videoWithData();
+try {
+  await promise34;
+} catch {}
+offscreenCanvas20.width = 70;
+let canvas23 = document.createElement('canvas');
+let shaderModule23 = device1.createShaderModule({
+  label: '\ub8e7\ub309\u4cd0\u277c\u0fae\u66ad\ub39c\ubd2e\u{1f8d3}',
+  code: `@group(0) @binding(8803)
+var<storage, read_write> parameter11: array<u32>;
+@group(0) @binding(4292)
+var<storage, read_write> n12: array<u32>;
+
+@compute @workgroup_size(5, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S24 {
+  @location(74) f0: vec4<i32>,
+  @location(15) f1: vec4<f32>,
+  @location(3) f2: vec4<f32>,
+  @location(88) f3: f32,
+  @location(82) f4: vec3<u32>,
+  @location(16) f5: vec2<f16>,
+  @location(51) f6: vec3<i32>,
+  @location(31) f7: vec2<u32>,
+  @location(106) f8: i32,
+  @location(1) f9: vec4<f32>,
+  @location(72) f10: i32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec3<u32>,
+  @builtin(sample_mask) f1: u32,
+  @location(4) f2: i32
+}
+
+@fragment
+fn fragment0(@location(90) a0: i32, @location(47) a1: vec4<u32>, a2: S24, @location(27) a3: vec3<f32>, @location(109) a4: vec4<u32>, @location(8) a5: u32, @location(71) a6: vec3<f16>, @location(56) a7: vec3<u32>, @location(67) a8: f32, @location(92) a9: vec3<f16>, @location(20) a10: vec3<f32>, @location(60) a11: vec3<i32>, @location(49) a12: vec2<f32>, @location(39) a13: vec4<u32>, @location(37) a14: vec3<f16>, @builtin(position) a15: vec4<f32>, @location(100) a16: vec2<f16>, @builtin(front_facing) a17: bool, @location(84) a18: u32, @builtin(sample_index) a19: u32, @builtin(sample_mask) a20: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(20) f286: vec3<f32>,
+  @location(60) f287: vec3<i32>,
+  @location(92) f288: vec3<f16>,
+  @location(3) f289: vec4<f32>,
+  @location(71) f290: vec3<f16>,
+  @location(51) f291: vec3<i32>,
+  @location(100) f292: vec2<f16>,
+  @location(37) f293: vec3<f16>,
+  @builtin(position) f294: vec4<f32>,
+  @location(88) f295: f32,
+  @location(106) f296: i32,
+  @location(16) f297: vec2<f16>,
+  @location(84) f298: u32,
+  @location(47) f299: vec4<u32>,
+  @location(39) f300: vec4<u32>,
+  @location(49) f301: vec2<f32>,
+  @location(1) f302: vec4<f32>,
+  @location(27) f303: vec3<f32>,
+  @location(15) f304: vec4<f32>,
+  @location(72) f305: i32,
+  @location(109) f306: vec4<u32>,
+  @location(74) f307: vec4<i32>,
+  @location(56) f308: vec3<u32>,
+  @location(67) f309: f32,
+  @location(8) f310: u32,
+  @location(31) f311: vec2<u32>,
+  @location(82) f312: vec3<u32>,
+  @location(90) f313: i32
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec2<u32>, @location(7) a1: vec2<f16>, @location(21) a2: vec2<f32>, @builtin(vertex_index) a3: u32, @location(6) a4: vec3<f16>, @location(1) a5: vec2<i32>, @builtin(instance_index) a6: u32, @location(16) a7: f16, @location(20) a8: vec2<f16>, @location(10) a9: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture82 = device1.createTexture({
+  size: {width: 288, height: 64, depthOrArrayLayers: 422},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let textureView114 = texture69.createView({label: '\u016a\u01a6', format: 'rg16uint', baseMipLevel: 3});
+let sampler63 = device1.createSampler({
+  label: '\u2bbd\u3c17\u{1f71b}\u{1fefa}\u0182\u0c7f',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 60.51,
+  lodMaxClamp: 65.59,
+});
+try {
+renderPassEncoder15.executeBundles([renderBundle58, renderBundle44, renderBundle49, renderBundle48]);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder29.draw(61);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline64);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: video5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 9, y: 4, z: 13},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline76 = await device1.createRenderPipelineAsync({
+  label: '\u25be\u0bdb\u{1fd2b}\ubd96\u097b\u32dd\u33be',
+  layout: 'auto',
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 4528,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 336, shaderLocation: 3},
+          {format: 'unorm16x4', offset: 4388, shaderLocation: 0},
+          {format: 'sint16x2', offset: 196, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 1944, shaderLocation: 6},
+          {format: 'sint16x2', offset: 16, shaderLocation: 15},
+          {format: 'float32x2', offset: 376, shaderLocation: 4},
+          {format: 'uint32x4', offset: 588, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 312, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 52, shaderLocation: 23},
+          {format: 'unorm8x2', offset: 2346, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 882, shaderLocation: 16},
+          {format: 'uint32', offset: 92, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 232, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 520, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 13560, shaderLocation: 10},
+          {format: 'sint32x3', offset: 9604, shaderLocation: 20},
+        ],
+      },
+      {arrayStride: 11192, attributes: []},
+      {
+        arrayStride: 5408,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32', offset: 916, shaderLocation: 11}],
+      },
+      {
+        arrayStride: 980,
+        attributes: [
+          {format: 'sint16x2', offset: 184, shaderLocation: 21},
+          {format: 'uint32x2', offset: 96, shaderLocation: 1},
+          {format: 'float16x4', offset: 68, shaderLocation: 18},
+          {format: 'sint16x4', offset: 84, shaderLocation: 22},
+          {format: 'float32', offset: 32, shaderLocation: 19},
+          {format: 'snorm16x4', offset: 12, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 1660,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm8x4', offset: 128, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let gpuCanvasContext19 = canvas22.getContext('webgpu');
+let textureView115 = texture65.createView({label: '\u2978\u5153\uc4f3', baseMipLevel: 2});
+let renderBundle60 = renderBundleEncoder39.finish({label: '\u909a\u080a\u2f0d\u{1f61e}\u{1fa02}\uc1e6\ue118\u02ad\u05d8\u4038\u346e'});
+try {
+renderPassEncoder21.setBlendConstant({ r: 701.7, g: 429.9, b: 140.6, a: -746.3, });
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(2, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder18.setViewport(297.9, 0.8314, 279.9, 0.02658, 0.6998, 0.8361);
+} catch {}
+try {
+renderPassEncoder14.draw(214, 10, 442_000_331, 1_174_775_274);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer27, 43_740_903);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer26, 242_009_223);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(5, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder29.draw(662);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline64);
+} catch {}
+try {
+buffer29.destroy();
+} catch {}
+let promise35 = device1.queue.onSubmittedWorkDone();
+let commandEncoder99 = device1.createCommandEncoder({});
+let textureView116 = texture56.createView({label: '\u9a17\ue0c6', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder45 = commandEncoder99.beginComputePass();
+let externalTexture52 = device1.importExternalTexture({
+  label: '\u038d\u{1f89e}\u{1fa2b}\u{1fc2a}\u{1ff7b}\u0246\u63c5\u70de\u8144\uca31\u4105',
+  source: videoFrame8,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle46, renderBundle47, renderBundle57, renderBundle45, renderBundle50, renderBundle52]);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(759, 0, 215, 0);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer28, 306_236_427);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: imageBitmap18,
+  origin: { x: 3, y: 9 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 109},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 5, depthOrArrayLayers: 0});
+} catch {}
+gc();
+try {
+offscreenCanvas28.getContext('webgpu');
+} catch {}
+let querySet45 = device1.createQuerySet({label: '\u55bd\u039b\u0496\u8511\u29ea\u66d1', type: 'occlusion', count: 3459});
+let renderBundle61 = renderBundleEncoder41.finish({label: '\u0003\u8ea7\u8c8b\u032f\u5fc6'});
+let externalTexture53 = device1.importExternalTexture({source: videoFrame5});
+try {
+renderPassEncoder9.executeBundles([renderBundle57, renderBundle44, renderBundle45, renderBundle51, renderBundle49, renderBundle60, renderBundle61, renderBundle60, renderBundle55]);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: 739.5, g: -484.1, b: 971.9, a: -45.89, });
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(1199);
+} catch {}
+try {
+renderPassEncoder11.setViewport(361.7, 0.6669, 250.6, 0.1953, 0.4104, 0.4217);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup27, []);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 516, new Int16Array(35195), 2334, 556);
+} catch {}
+let buffer32 = device1.createBuffer({size: 35774, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder100 = device1.createCommandEncoder({label: '\u421b\u03a5\u{1fe31}\udafc'});
+let querySet46 = device1.createQuerySet({label: '\u032e\u4921\ub0ec\u407d\u0d68\ua6fb\u08dc\u2021', type: 'occlusion', count: 365});
+let texture83 = device1.createTexture({
+  label: '\u{1f7ca}\u51e6\u7f58\u09fd\u{1feed}\ue7a4\u0c28\ubecf\u{1f938}\u073b\ua8a5',
+  size: {width: 1134, height: 1, depthOrArrayLayers: 466},
+  dimension: '2d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView117 = texture83.createView({label: '\ua193\u3d48', dimension: '2d', baseArrayLayer: 116});
+let renderPassEncoder22 = commandEncoder100.beginRenderPass({
+  label: '\u6928\u{1fd80}\u417c\uce9f\u0048\uf108\u57ac\u9a22\ue207',
+  colorAttachments: [{
+  view: textureView86,
+  depthSlice: 89,
+  clearValue: { r: 329.5, g: -809.8, b: 287.7, a: 719.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 962261780,
+});
+let renderBundleEncoder43 = device1.createRenderBundleEncoder({label: '\ub530\u047d\u78ac', colorFormats: ['rg16uint'], depthReadOnly: true});
+try {
+computePassEncoder45.setPipeline(pipeline59);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(4, bindGroup25);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(1160);
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(1089, 1, 45, 0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer24, 0);
+} catch {}
+try {
+renderBundleEncoder42.draw(285, 148, 430_231_310, 1_817_014_361);
+} catch {}
+let promise36 = device1.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let imageBitmap26 = await createImageBitmap(offscreenCanvas15);
+try {
+window.someLabel = externalTexture16.label;
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let querySet47 = device1.createQuerySet({label: '\u{1ffec}\u65a8\u{1f63e}\u0c63\uce1c\u528b', type: 'occlusion', count: 2341});
+let texture84 = device1.createTexture({
+  label: '\u0ec1\u00c0\u0bbf\u38a7\u01ad\u{1fe91}\u00d9',
+  size: [288, 64, 422],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder21.setScissorRect(432, 0, 399, 0);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(137, 45, 1_711_865_694, 4_174_497, 418_545_485);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer30, 937_968_982);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(0, buffer24);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+gpuCanvasContext19.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 1732, new BigUint64Array(65171), 44198, 100);
+} catch {}
+let bindGroupLayout30 = device1.createBindGroupLayout({
+  label: '\udabd\u407f\u6786\u00d9',
+  entries: [
+    {binding: 5900, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 5550,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 23,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let buffer33 = device1.createBuffer({
+  label: '\u{1fef4}\u{1fcb4}\u8288\u7855\u{1fcf6}\u062f\u9bf5\u289b',
+  size: 84946,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder101 = device1.createCommandEncoder({label: '\u47b1\u9715\u{1f886}\u8731\u3f6a'});
+let texture85 = device1.createTexture({
+  size: {width: 75},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder23 = commandEncoder101.beginRenderPass({
+  label: '\u0d2a\u39a9\udd6a\u0767\u082b\u03d2\u06f6',
+  colorAttachments: [{
+  view: textureView83,
+  depthSlice: 0,
+  clearValue: { r: -303.0, g: -939.2, b: 607.8, a: 798.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet45,
+  maxDrawCount: 236734128,
+});
+let renderBundle62 = renderBundleEncoder26.finish();
+let sampler64 = device1.createSampler({
+  label: '\ufcce\ue573\u{1fc2d}\u{1fbe7}\u{1f6fe}\u098d\ue3bb\u6a73\u0cd1',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.42,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder37.setPipeline(pipeline57);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(2, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder13.draw(332, 66, 83_871_167);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(37, 184, 551_319_297, -2_124_591_831, 985_365_069);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer28, 1_948_516_601);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer26, 326_100_337);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 1440, new DataView(new ArrayBuffer(24473)), 5214, 1016);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let canvas24 = document.createElement('canvas');
+let commandEncoder102 = device1.createCommandEncoder();
+let computePassEncoder46 = commandEncoder102.beginComputePass({label: '\u6f37\u001a'});
+let renderBundleEncoder44 = device1.createRenderBundleEncoder({colorFormats: ['rg16uint'], sampleCount: 1, stencilReadOnly: true});
+try {
+renderPassEncoder14.beginOcclusionQuery(1323);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle62, renderBundle52, renderBundle43, renderBundle46, renderBundle60, renderBundle62, renderBundle62, renderBundle55, renderBundle46, renderBundle50]);
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(24, 9, 33, 1);
+} catch {}
+try {
+renderPassEncoder9.setViewport(729.2, 0.4897, 176.7, 0.1642, 0.9116, 0.9770);
+} catch {}
+try {
+renderPassEncoder14.draw(403, 26, 11_557_884, 373_548_985);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer24, 695_226_130);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline64);
+} catch {}
+try {
+buffer26.destroy();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 991 */
+{offset: 535}, {width: 114, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline77 = await device1.createRenderPipelineAsync({
+  label: '\u003c\u{1ffec}',
+  layout: pipelineLayout11,
+  multisample: {count: 4, mask: 0xadc18284},
+  fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 6628,
+        attributes: [
+          {format: 'unorm16x4', offset: 3156, shaderLocation: 21},
+          {format: 'snorm16x2', offset: 1332, shaderLocation: 10},
+          {format: 'sint32', offset: 292, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 104, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 17680,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 640, shaderLocation: 9},
+          {format: 'float16x2', offset: 4748, shaderLocation: 7},
+          {format: 'float32', offset: 1116, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 340, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+});
+try {
+  await promise36;
+} catch {}
+let bindGroupLayout31 = pipeline61.getBindGroupLayout(4);
+let textureView118 = texture67.createView({baseMipLevel: 5, baseArrayLayer: 26, arrayLayerCount: 56});
+try {
+computePassEncoder43.setPipeline(pipeline58);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle43, renderBundle49, renderBundle44, renderBundle52, renderBundle46]);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(0, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(2663);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer32, 849_854_109);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(5, buffer24);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 412, new Float32Array(32203), 14460, 368);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 56},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 269_445 */
+{offset: 519, bytesPerRow: 1107, rowsPerImage: 199}, {width: 258, height: 44, depthOrArrayLayers: 2});
+} catch {}
+let pipeline78 = await device1.createRenderPipelineAsync({
+  label: '\u{1fae9}\u{1f9ff}\u3d0a\uefb5\u0df4',
+  layout: pipelineLayout12,
+  multisample: {count: 4, mask: 0x6c205123},
+  fragment: {module: shaderModule22, entryPoint: 'fragment0', targets: [{format: 'rg16uint'}]},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'replace'},
+    stencilReadMask: 3301336914,
+    stencilWriteMask: 2111112901,
+    depthBias: 236271594,
+  },
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 14168,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 272, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 2284, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 984, shaderLocation: 18},
+          {format: 'uint8x2', offset: 1478, shaderLocation: 13},
+          {format: 'float32x3', offset: 1728, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 2232, shaderLocation: 16},
+          {format: 'sint8x4', offset: 6432, shaderLocation: 21},
+          {format: 'unorm16x2', offset: 304, shaderLocation: 19},
+          {format: 'float32x3', offset: 2468, shaderLocation: 4},
+          {format: 'unorm8x2', offset: 2832, shaderLocation: 10},
+          {format: 'sint8x2', offset: 862, shaderLocation: 22},
+          {format: 'sint32x2', offset: 1776, shaderLocation: 11},
+          {format: 'sint32', offset: 620, shaderLocation: 20},
+          {format: 'uint16x2', offset: 344, shaderLocation: 17},
+          {format: 'uint8x2', offset: 84, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 196, shaderLocation: 3},
+          {format: 'sint32x4', offset: 2932, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 264,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 4, shaderLocation: 6},
+          {format: 'float32x4', offset: 44, shaderLocation: 12},
+          {format: 'sint8x4', offset: 68, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 6700, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2260,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 1146, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 384, shaderLocation: 0},
+          {format: 'float16x4', offset: 176, shaderLocation: 23},
+          {format: 'float32x4', offset: 300, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back', unclippedDepth: true},
+});
+try {
+canvas24.getContext('webgl2');
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: -857.9, g: -526.3, b: 838.2, a: -881.3, });
+} catch {}
+try {
+renderPassEncoder11.draw(205, 53, 2_632_186_742, 711_547_452);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(252);
+} catch {}
+try {
+renderBundleEncoder42.draw(973);
+} catch {}
+try {
+device1.queue.submit([commandBuffer14]);
+} catch {}
+let pipeline79 = await promise30;
+let canvas25 = document.createElement('canvas');
+let img26 = await imageWithData(9, 166, '#da560bb8', '#686a91b2');
+let canvas26 = document.createElement('canvas');
+let buffer34 = device1.createBuffer({
+  label: '\ua838\u24e8\u0e03\u{1fed7}\ub6e5\u322c\u86a9',
+  size: 759730,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false,
+});
+let commandEncoder103 = device1.createCommandEncoder({});
+let renderPassEncoder24 = commandEncoder103.beginRenderPass({
+  label: '\u{1fbc4}\u22b9\u583d\u31a0\u{1f8fb}\uf77a\u{1fa14}',
+  colorAttachments: [{
+  view: textureView102,
+  clearValue: { r: -805.0, g: 257.1, b: 525.1, a: -67.34, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet40,
+});
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer32, 760_931_687);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer30, 1_437_717_915);
+} catch {}
+try {
+renderBundleEncoder31.draw(465, 4, 3_288_363, 771_134_462);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 80844, new DataView(new ArrayBuffer(20334)), 17850, 244);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(40)), /* required buffer size: 1_652_250 */
+{offset: 963, bytesPerRow: 237, rowsPerImage: 199}, {width: 27, height: 3, depthOrArrayLayers: 36});
+} catch {}
+let pipeline80 = device1.createRenderPipeline({
+  label: '\u1531\u{1fcee}\u43a7\u782d',
+  layout: pipelineLayout13,
+  multisample: {count: 4, mask: 0x72485006},
+  fragment: {
+  module: shaderModule21,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule21,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3732,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 580, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 544, shaderLocation: 4},
+          {format: 'uint8x4', offset: 144, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 184, shaderLocation: 11},
+          {format: 'sint8x2', offset: 294, shaderLocation: 17},
+          {format: 'uint32x4', offset: 316, shaderLocation: 19},
+          {format: 'uint32x2', offset: 292, shaderLocation: 21},
+          {format: 'unorm16x4', offset: 88, shaderLocation: 18},
+          {format: 'uint32x2', offset: 180, shaderLocation: 10},
+          {format: 'float32', offset: 368, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+});
+let imageData41 = new ImageData(96, 152);
+try {
+adapter1.label = '\u346c\u{1f88e}\ud655\u{1fdef}\u1cd9\ub733\uf57e';
+} catch {}
+let bindGroup36 = device0.createBindGroup({label: '\uec4a\ubae7\u6f76', layout: bindGroupLayout8, entries: []});
+let querySet48 = device0.createQuerySet({label: '\u3697\u8c22\uf35f\u{1f7ce}\u6796\ud2de\u0324\u0a7b', type: 'occlusion', count: 707});
+let textureView119 = texture1.createView({label: '\ub61b\u{1fe0c}\u{1fcd9}', baseMipLevel: 8, mipLevelCount: 1});
+let renderBundleEncoder45 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg16float', 'rg11b10ufloat', 'rgba16float', 'rg11b10ufloat', 'r8uint', 'r8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle63 = renderBundleEncoder23.finish({label: '\udada\u0b6d\ud3f5\u6d8a\u0961\u{1f626}'});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer19, 0, 53400);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer3, 'uint16');
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline34);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 101, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: offscreenCanvas10,
+  origin: { x: 51, y: 176 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 4,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline81 = await device0.createRenderPipelineAsync({
+  label: '\u0091\uaa6c\u0eb3\u{1ffd5}\u0332\u0eac\u02d5\u0c29\u{1f614}',
+  layout: pipelineLayout1,
+  multisample: {count: 4, mask: 0x89f2518d},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'zero'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba16float', writeMask: 0}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r8uint', writeMask: GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 476,
+        attributes: [
+          {format: 'sint32x2', offset: 60, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 120, shaderLocation: 23},
+          {format: 'unorm16x4', offset: 212, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 7},
+          {format: 'sint16x2', offset: 168, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 12, shaderLocation: 12},
+          {format: 'uint16x2', offset: 236, shaderLocation: 19},
+          {format: 'unorm8x4', offset: 56, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 200, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 4, shaderLocation: 20},
+          {format: 'unorm16x2', offset: 20, shaderLocation: 5},
+          {format: 'sint16x4', offset: 0, shaderLocation: 18},
+          {format: 'sint16x4', offset: 0, shaderLocation: 8},
+          {format: 'uint8x4', offset: 12, shaderLocation: 3},
+          {format: 'sint32x4', offset: 68, shaderLocation: 9},
+          {format: 'float16x4', offset: 20, shaderLocation: 17},
+          {format: 'float16x4', offset: 36, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 1100,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 320, shaderLocation: 0},
+          {format: 'uint32', offset: 364, shaderLocation: 16},
+          {format: 'uint8x4', offset: 196, shaderLocation: 10},
+          {format: 'sint32x2', offset: 80, shaderLocation: 11},
+          {format: 'sint32x2', offset: 96, shaderLocation: 21},
+          {format: 'unorm10-10-10-2', offset: 104, shaderLocation: 22},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let videoFrame20 = new VideoFrame(imageBitmap24, {timestamp: 0});
+let querySet49 = device1.createQuerySet({label: '\u0d89\u{1fa2e}\uee5d\u{1fbac}', type: 'occlusion', count: 2748});
+let sampler65 = device1.createSampler({
+  label: '\ud5ef\u0e0c\u0442\u0221\u{1f83f}\u0357\u3ed4\u023b\uf0e8\ubd7c',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 69.25,
+});
+try {
+computePassEncoder40.setPipeline(pipeline67);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer28, 241_994_875);
+} catch {}
+try {
+renderBundleEncoder29.draw(63, 202);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(12);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer24);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: offscreenCanvas12,
+  origin: { x: 281, y: 71 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 24, y: 10, z: 17},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 14, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let pipeline82 = device1.createComputePipeline({
+  label: '\u92c7\ub2cb\u{1ffc7}\u{1ffe9}\ub92c\u3a04\u796f\udec2\u0481\u0773\u1911',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule23, entryPoint: 'compute0', constants: {}},
+});
+let video29 = await videoWithData();
+try {
+canvas25.getContext('webgpu');
+} catch {}
+let video30 = await videoWithData();
+try {
+canvas26.getContext('webgpu');
+} catch {}
+offscreenCanvas17.height = 333;
+gc();
+let pipelineLayout14 = device0.createPipelineLayout({
+  label: '\u0407\u6c27\u9736\u{1fed2}\u09c1\udbca\u{1fd65}\u6347\u00bc\u6723',
+  bindGroupLayouts: [bindGroupLayout12, bindGroupLayout9, bindGroupLayout14, bindGroupLayout1, bindGroupLayout5, bindGroupLayout6],
+});
+let textureView120 = texture9.createView({baseMipLevel: 3, mipLevelCount: 4});
+let sampler66 = device0.createSampler({
+  label: '\u038d\u0338\uedfc',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 5.446,
+  lodMaxClamp: 50.56,
+});
+try {
+computePassEncoder22.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(5, bindGroup8);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer19, 'uint32');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise37 = device0.queue.onSubmittedWorkDone();
+let pipeline83 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba32sint', writeMask: 0}, {format: 'rgba32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'greater', failOp: 'zero', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'never', failOp: 'zero', passOp: 'increment-clamp'},
+    stencilReadMask: 1782725916,
+    stencilWriteMask: 2946718837,
+    depthBias: -812438251,
+    depthBiasSlopeScale: 828.3358968556191,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1748,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 108, shaderLocation: 10},
+          {format: 'uint32x3', offset: 24, shaderLocation: 13},
+          {format: 'uint32x2', offset: 132, shaderLocation: 3},
+          {format: 'uint32', offset: 1204, shaderLocation: 20},
+          {format: 'uint16x2', offset: 700, shaderLocation: 7},
+          {format: 'uint32x3', offset: 16, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 688,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 64, shaderLocation: 14},
+          {format: 'uint32x4', offset: 88, shaderLocation: 5},
+          {format: 'uint32x2', offset: 200, shaderLocation: 15},
+          {format: 'sint8x2', offset: 0, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 948,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 136, shaderLocation: 12},
+          {format: 'float32x4', offset: 88, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 100, shaderLocation: 16},
+          {format: 'snorm8x4', offset: 20, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 36, shaderLocation: 11},
+          {format: 'float16x4', offset: 120, shaderLocation: 17},
+          {format: 'snorm16x4', offset: 92, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 2860,
+        attributes: [
+          {format: 'uint32x3', offset: 356, shaderLocation: 23},
+          {format: 'uint32x4', offset: 168, shaderLocation: 1},
+          {format: 'float32', offset: 284, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let canvas27 = document.createElement('canvas');
+try {
+canvas27.getContext('webgpu');
+} catch {}
+let bindGroupLayout32 = device1.createBindGroupLayout({
+  label: '\u1be2\u0c4d\u{1fbd4}\u6628\u33a8\u1a77',
+  entries: [
+    {
+      binding: 5067,
+      visibility: 0,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 3947,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 7457,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+let commandEncoder104 = device1.createCommandEncoder();
+let querySet50 = device1.createQuerySet({
+  label: '\u0002\u{1fa7b}\u7b48\u453f\u1ac1\u13e6\u{1fc09}\u{1fb5f}\u04fb',
+  type: 'occlusion',
+  count: 1828,
+});
+let texture86 = device1.createTexture({
+  label: '\ud243\u04f4\u79f9\u{1fddd}\u610c',
+  size: [150, 6, 1],
+  mipLevelCount: 7,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let computePassEncoder47 = commandEncoder104.beginComputePass();
+let sampler67 = device1.createSampler({
+  label: '\ua5f5\uf3d5\u37c6\u362b\ubd27\u{1fcc1}\u{1f990}\u0759\u{1f621}\u6b39\u0597',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 66.81,
+  lodMaxClamp: 76.60,
+});
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup26, new Uint32Array(2920), 2774, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle59, renderBundle46, renderBundle54, renderBundle50, renderBundle47, renderBundle43, renderBundle55, renderBundle54, renderBundle45, renderBundle53]);
+} catch {}
+try {
+renderPassEncoder11.draw(204, 22);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline64);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(6, buffer24, 1168);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder29.draw(187, 74);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(5, buffer24, 4588, 29);
+} catch {}
+let buffer35 = device1.createBuffer({size: 35212, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let textureView121 = texture85.createView({label: '\u6e69\u0e13\u{1fb85}\u726a'});
+try {
+renderPassEncoder20.setViewport(45.57, 7.982, 25.25, 0.1562, 0.1201, 0.6256);
+} catch {}
+try {
+renderPassEncoder13.draw(362, 216, 437_637_293);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer27, 1_685_879_925);
+} catch {}
+try {
+device1.queue.submit([commandBuffer15]);
+} catch {}
+let pipeline84 = await promise31;
+let offscreenCanvas29 = new OffscreenCanvas(922, 300);
+let bindGroup37 = device0.createBindGroup({
+  label: '\u3736\udf86\u2a3b\u7107\u4e13\u2b61\u{1f724}\u555e\u0730\u0d8f\u4315',
+  layout: bindGroupLayout12,
+  entries: [{binding: 156, resource: externalTexture1}],
+});
+let querySet51 = device0.createQuerySet({type: 'occlusion', count: 3169});
+try {
+renderPassEncoder7.setScissorRect(4, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer14, 'uint16', 82716, 203365);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer13);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline34);
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 58800 */
+  offset: 9900,
+  bytesPerRow: 256,
+  rowsPerImage: 191,
+  buffer: buffer2,
+}, {width: 1, height: 1, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder69.copyTextureToTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(querySet20, 661, 304, buffer20, 98816);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline85 = device0.createComputePipeline({
+  label: '\ua93b\u{1fbba}',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder105 = device1.createCommandEncoder({label: '\u21f3\u4d9c\u6ee5\u54fe\u0062\u0822\u0dbb\u026a\u0345\u{1f9a6}'});
+let texture87 = device1.createTexture({
+  size: [2075, 5, 1],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'astc-5x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder40.setPipeline(pipeline67);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: 23.49, g: -205.9, b: -789.2, a: -35.06, });
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(471, 0, 204, 0);
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(3588);
+} catch {}
+try {
+commandEncoder105.clearBuffer(buffer34, 131544, 40496);
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+commandEncoder105.resolveQuerySet(querySet50, 1038, 254, buffer28, 8448);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+  await promise37;
+} catch {}
+let imageData42 = new ImageData(192, 184);
+try {
+canvas23.getContext('webgl');
+} catch {}
+try {
+device0.label = '\u04c1\u{1fe1a}\u0c14\u{1fc9a}\u{1fe11}\u00d2\u45c0\u032e\u885d';
+} catch {}
+let texture88 = device0.createTexture({
+  label: '\u67d5\u0387\u721f\ue41f',
+  size: [404, 1, 22],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32uint'],
+});
+let textureView122 = texture44.createView({label: '\u7eba\u0ee2\u2203', mipLevelCount: 3});
+let computePassEncoder48 = commandEncoder48.beginComputePass({label: '\u0da7\u05bc\ua36f\u0c37\uea94'});
+let renderBundle64 = renderBundleEncoder22.finish({});
+let sampler68 = device0.createSampler({
+  label: '\u0514\u9ad2\ub99e\u095f\ucada\uf80c\u{1fb5f}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.44,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder8.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(5, bindGroup5);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 277.5, g: 703.0, b: -671.0, a: -418.8, });
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(778);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(6, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder45.setIndexBuffer(buffer3, 'uint32', 19044);
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(buffer22, 205236, buffer6, 60592, 76756);
+dissociateBuffer(device0, buffer22);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 43 widthInBlocks: 43 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 11228 */
+  offset: 11185,
+  buffer: buffer19,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 43, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup38 = device1.createBindGroup({
+  label: '\u0509\u{1fc8f}\u{1fa59}\u753e\u{1fa1b}\u{1fc32}\u1432\ud4e9\u0707\uaf2d',
+  layout: bindGroupLayout31,
+  entries: [],
+});
+let texture89 = device1.createTexture({
+  label: '\ud7d8\u{1ffea}\u7672\u676b\u078c\uf44a\u8962\ue7eb\uf208\u05f6',
+  size: [9072, 1, 14],
+  mipLevelCount: 6,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView123 = texture80.createView({label: '\uefc3\u66a0\u87f0\u77ed\ub0d1\u254d\u9f47\u0988', baseMipLevel: 1});
+try {
+renderBundleEncoder29.setBindGroup(0, bindGroup33, new Uint32Array(933), 695, 0);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(5, buffer24, 0);
+} catch {}
+try {
+commandEncoder105.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 114424 */
+  offset: 72912,
+  bytesPerRow: 256,
+  rowsPerImage: 81,
+  buffer: buffer29,
+}, {
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 1, depthOrArrayLayers: 3});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder105.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 69},
+  aspect: 'all',
+},
+{width: 39, height: 6, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder105.clearBuffer(buffer34, 717312, 29680);
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+offscreenCanvas29.getContext('2d');
+} catch {}
+let textureView124 = texture77.createView({label: '\u{1fb24}\ud25f', format: 'bgra8unorm-srgb'});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup32, new Uint32Array(6555), 4897, 0);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(86);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer31, 279_560_436);
+} catch {}
+try {
+commandEncoder105.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 21296 */
+  offset: 21296,
+  buffer: buffer32,
+}, {
+  texture: texture70,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 84616, new Float32Array(47305), 27709, 1900);
+} catch {}
+let promise38 = device1.queue.onSubmittedWorkDone();
+let imageData43 = new ImageData(64, 220);
+try {
+querySet43.label = '\u4aa1\u0c4c\u99c1\u052c\ud6da\u83d1\ua474\u9172\u044a\uc81e\u0dce';
+} catch {}
+let querySet52 = device1.createQuerySet({
+  label: '\uc738\u2ed3\u0ad5\u1604\u958c\u2cea\u{1f662}\u9f32\u1f88\u0a1c',
+  type: 'occlusion',
+  count: 2970,
+});
+let renderPassEncoder25 = commandEncoder105.beginRenderPass({
+  label: '\u{1f6af}\u0dc5\u0537\u855c\u0eb6\uc148\u0738\u42ac\ude7a',
+  colorAttachments: [{
+  view: textureView85,
+  depthSlice: 107,
+  clearValue: { r: -522.5, g: 809.6, b: -886.1, a: 128.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet39,
+  maxDrawCount: 22730171,
+});
+let sampler69 = device1.createSampler({
+  label: '\u0fbe\u2b91\u{1f8d8}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 81.75,
+  lodMaxClamp: 96.76,
+});
+try {
+renderPassEncoder18.setBlendConstant({ r: 120.5, g: -379.2, b: 40.01, a: -556.3, });
+} catch {}
+try {
+renderPassEncoder11.draw(49, 21, 1_111_054_306, 2_212_070_769);
+} catch {}
+try {
+renderBundleEncoder29.draw(18, 24, 1_609_107_141);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexed(7);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer24, 4824, 229);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 61504, new Int16Array(36382), 8140, 11876);
+} catch {}
+let pipeline86 = await device1.createRenderPipelineAsync({
+  label: '\ue616\u0afb\uca74\ucfaf\ubea1\u{1fb9e}\u02f3\u176b\u{1fff9}\u{1f973}\u{1fb4d}',
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule16, entryPoint: 'vertex0', constants: {}, buffers: []},
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let offscreenCanvas30 = new OffscreenCanvas(853, 210);
+let bindGroupLayout33 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1281,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder106 = device1.createCommandEncoder({});
+let querySet53 = device1.createQuerySet({label: '\u5b83\u0970\u451c\ue23e\u085d\u10cd\ucd53\u{1f856}', type: 'occlusion', count: 2155});
+let renderPassEncoder26 = commandEncoder106.beginRenderPass({
+  label: '\u{1f68a}\ue76b\u287c\u4fe6\u{1f910}\ub008\ua328',
+  colorAttachments: [{
+  view: textureView117,
+  clearValue: { r: 544.3, g: -260.7, b: 795.4, a: -736.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet41,
+  maxDrawCount: 931580051,
+});
+let sampler70 = device1.createSampler({
+  label: '\u07a2\u0fa6\u{1f632}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.24,
+  compare: 'less-equal',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder40.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(1083);
+} catch {}
+try {
+renderPassEncoder11.draw(18, 298, 1_042_273_099, 72_247_824);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer35, 10_690_179);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(10, buffer24);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(4, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder31.draw(309, 277, 2_103_375_103, 1_850_296_884);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(6, 14, 45_675_884, 349_927_872, 1_060_324_822);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(11, buffer24, 3748, 1357);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 114, y: 3, z: 258},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer1), /* required buffer size: 1_593_257 */
+{offset: 997, bytesPerRow: 460, rowsPerImage: 95}, {width: 50, height: 42, depthOrArrayLayers: 37});
+} catch {}
+let gpuCanvasContext20 = offscreenCanvas30.getContext('webgpu');
+let img27 = await imageWithData(91, 275, '#dd87d049', '#2f1a2330');
+let texture90 = device1.createTexture({
+  label: '\u9893\u085a\u8792\u22db\uf671\uc41d\ub70b\ue1ca',
+  size: {width: 288, height: 64, depthOrArrayLayers: 422},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView125 = texture63.createView({
+  label: '\u21a2\u935f\u{1fd18}\ufba2\ue475\ua8e6\u2e82',
+  baseMipLevel: 1,
+  baseArrayLayer: 148,
+  arrayLayerCount: 185,
+});
+try {
+computePassEncoder40.setPipeline(pipeline72);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(2899);
+} catch {}
+try {
+renderPassEncoder14.draw(220, 154, 389_065_774, 195_267_430);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer31, 1_821_392_952);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(246, 299, 63_395_252);
+} catch {}
+try {
+renderBundleEncoder42.pushDebugGroup('\u2fc2');
+} catch {}
+try {
+gpuCanvasContext19.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 192, new Int16Array(53223), 41825, 512);
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter({});
+let pipelineLayout15 = device1.createPipelineLayout({
+  label: '\u5803\u86b2\uda92\uf6b6',
+  bindGroupLayouts: [bindGroupLayout29, bindGroupLayout19, bindGroupLayout15, bindGroupLayout32, bindGroupLayout23, bindGroupLayout20, bindGroupLayout19],
+});
+let commandEncoder107 = device1.createCommandEncoder({label: '\u0ea4\ufcba\u0dba\ua017\u34d3\uc096\ue831\u017b\u0921'});
+let textureView126 = texture85.createView({mipLevelCount: 1});
+let computePassEncoder49 = commandEncoder107.beginComputePass({label: '\ua689\u01a7\u8b01\u96ab\u{1f936}\u{1fca5}\u{1f76b}\u{1fc3d}\u{1f8c2}'});
+try {
+renderPassEncoder9.beginOcclusionQuery(58);
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant({ r: -931.3, g: 398.7, b: 325.1, a: -332.7, });
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(122, 31, 806_300_975, 526_175_745, 2_192_947_024);
+} catch {}
+try {
+renderPassEncoder18.drawIndirect(buffer29, 53_521_420);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline86);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(5, bindGroup24, []);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 542020, new Float32Array(46652), 6495, 9072);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 684_505 */
+{offset: 35, bytesPerRow: 150, rowsPerImage: 304}, {width: 5, height: 4, depthOrArrayLayers: 16});
+} catch {}
+let pipeline87 = device1.createRenderPipeline({
+  label: '\u0fe8\u465c',
+  layout: pipelineLayout13,
+  multisample: {},
+  fragment: {module: shaderModule19, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16uint'}]},
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 18304,
+        attributes: [
+          {format: 'uint16x2', offset: 2072, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 300, shaderLocation: 20},
+          {format: 'unorm10-10-10-2', offset: 256, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 2064, shaderLocation: 11},
+          {format: 'float32x3', offset: 2356, shaderLocation: 14},
+          {format: 'sint32', offset: 6484, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 2856, shaderLocation: 5},
+          {format: 'uint16x4', offset: 696, shaderLocation: 6},
+          {format: 'float16x4', offset: 1316, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 8404,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint16x4', offset: 900, shaderLocation: 3},
+          {format: 'uint16x2', offset: 392, shaderLocation: 8},
+          {format: 'sint32', offset: 1404, shaderLocation: 18},
+          {format: 'uint32x3', offset: 1996, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 4, shaderLocation: 1},
+          {format: 'unorm8x4', offset: 752, shaderLocation: 0},
+          {format: 'uint32', offset: 3248, shaderLocation: 4},
+          {format: 'float32', offset: 584, shaderLocation: 22},
+          {format: 'snorm8x2', offset: 982, shaderLocation: 7},
+          {format: 'snorm16x2', offset: 1428, shaderLocation: 21},
+          {format: 'snorm16x2', offset: 92, shaderLocation: 15},
+          {format: 'sint16x2', offset: 6548, shaderLocation: 23},
+          {format: 'sint32x4', offset: 4280, shaderLocation: 16},
+        ],
+      },
+    ],
+  },
+});
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let videoFrame21 = new VideoFrame(img26, {timestamp: 0});
+let bindGroupLayout34 = device1.createBindGroupLayout({label: '\ue1aa\u0626', entries: []});
+let bindGroup39 = device1.createBindGroup({layout: bindGroupLayout31, entries: []});
+let textureView127 = texture81.createView({
+  label: '\ud4ea\u0a75\u{1fb1a}\u61c2\u0a55\uf187\u{1f7e3}\u0b4e\u0824\u0819',
+  dimension: '3d',
+  baseMipLevel: 1,
+  mipLevelCount: 4,
+});
+let renderBundleEncoder46 = device1.createRenderBundleEncoder({
+  label: '\u6280\ue38b\u0e30\u{1f959}\u0b77\ubeca\uf7d1\u0834\u{1fb34}',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(1, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder18.draw(55);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer31, 127_235_193);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer28, 171_983_314);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(1, buffer24, 0, 1135);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let img28 = await imageWithData(239, 215, '#001fc7a4', '#3519bc1c');
+let videoFrame22 = new VideoFrame(img13, {timestamp: 0});
+gc();
+let imageData44 = new ImageData(188, 148);
+try {
+  await promise35;
+} catch {}
+let bindGroupLayout35 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 346,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let texture91 = device1.createTexture({
+  size: {width: 288, height: 64, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(14, 1, 2, 0);
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(1185);
+} catch {}
+try {
+renderPassEncoder25.setViewport(862.9, 0.02265, 144.0, 0.9748, 0.4087, 0.5104);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(120, 35);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer27, 174_222_018);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(1, bindGroup35, new Uint32Array(7126), 1146, 0);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(19);
+} catch {}
+try {
+renderBundleEncoder42.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise39 = device1.createRenderPipelineAsync({
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule16, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+  await promise38;
+} catch {}
+document.body.prepend(img23);
+let video31 = await videoWithData();
+let videoFrame23 = new VideoFrame(img25, {timestamp: 0});
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+let promise40 = adapter1.requestAdapterInfo();
+let shaderModule24 = device1.createShaderModule({
+  label: '\u7241\ub8b2',
+  code: `@group(3) @binding(5067)
+var<storage, read_write> global7: array<u32>;
+@group(6) @binding(7949)
+var<storage, read_write> global8: array<u32>;
+@group(1) @binding(5282)
+var<storage, read_write> field11: array<u32>;
+@group(1) @binding(8384)
+var<storage, read_write> n13: array<u32>;
+@group(0) @binding(1519)
+var<storage, read_write> type13: array<u32>;
+@group(3) @binding(3947)
+var<storage, read_write> n14: array<u32>;
+@group(3) @binding(7457)
+var<storage, read_write> function14: array<u32>;
+@group(0) @binding(6703)
+var<storage, read_write> field12: array<u32>;
+@group(4) @binding(6764)
+var<storage, read_write> field13: array<u32>;
+@group(6) @binding(8384)
+var<storage, read_write> type14: array<u32>;
+@group(6) @binding(5282)
+var<storage, read_write> type15: array<u32>;
+@group(1) @binding(7949)
+var<storage, read_write> function15: array<u32>;
+
+@compute @workgroup_size(5, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4<u32>,
+  @location(7) f2: u32,
+  @location(2) f3: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: vec4<f16>, @location(3) a1: vec3<f32>, @location(15) a2: u32, @location(23) a3: vec4<i32>, @location(8) a4: vec3<u32>, @location(2) a5: f32, @location(21) a6: vec4<f16>, @location(17) a7: vec4<u32>, @location(9) a8: vec2<f16>, @location(11) a9: vec3<f32>, @location(14) a10: vec2<f32>, @location(10) a11: vec3<u32>, @builtin(instance_index) a12: u32, @location(0) a13: vec4<f16>, @location(22) a14: u32, @location(4) a15: vec3<f16>, @location(6) a16: f32, @location(7) a17: vec2<f16>, @location(5) a18: vec2<f16>, @location(20) a19: i32, @location(13) a20: vec4<f16>, @location(12) a21: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let querySet54 = device1.createQuerySet({label: '\u{1fcbe}\u{1f943}\ud90e\u0bb8\ufc61\u0feb', type: 'occlusion', count: 3682});
+let texture92 = device1.createTexture({
+  size: {width: 288, height: 64, depthOrArrayLayers: 422},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let textureView128 = texture92.createView({label: '\u{1fdf8}\u{1f9ec}\u1a30\u4783\uf505\u06ea\ua024\ue5f2\u{1f609}\uaf75', mipLevelCount: 1});
+try {
+computePassEncoder43.setBindGroup(6, bindGroup28);
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline82);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(1664);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(3372);
+} catch {}
+let arrayBuffer7 = buffer35.getMappedRange(33152);
+try {
+  await buffer32.mapAsync(GPUMapMode.WRITE, 16720, 13308);
+} catch {}
+try {
+gpuCanvasContext15.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(24)), /* required buffer size: 65_656 */
+{offset: 232, bytesPerRow: 232, rowsPerImage: 47}, {width: 7, height: 0, depthOrArrayLayers: 7});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: video25,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 11, y: 5, z: 24},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder108 = device1.createCommandEncoder({label: '\u{1fabb}\u02b9\u{1fae3}\u00dc\u758e\u{1fb83}\u0622\ua937\u{1fa43}\ua062\u052d'});
+let renderPassEncoder27 = commandEncoder108.beginRenderPass({
+  label: '\u0268\u043d\uadf7\u0372\ue1eb\uf922',
+  colorAttachments: [{
+  view: textureView111,
+  depthSlice: 84,
+  clearValue: { r: -407.2, g: -961.7, b: -740.6, a: 168.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet45,
+  maxDrawCount: 15808877,
+});
+try {
+renderPassEncoder21.executeBundles([renderBundle47, renderBundle54, renderBundle46, renderBundle45, renderBundle55, renderBundle48, renderBundle57, renderBundle45]);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: 30.98, g: -304.9, b: -208.7, a: -314.3, });
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(441);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline64);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 1216, new Int16Array(19833), 16596, 1028);
+} catch {}
+try {
+adapter2.label = '\uc117\u{1fa72}\ub082\uf7b3\ud395';
+} catch {}
+let shaderModule25 = device0.createShaderModule({
+  code: `@group(0) @binding(1293)
+var<storage, read_write> type16: array<u32>;
+
+@compute @workgroup_size(6, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(7) a0: i32, @location(5) a1: vec3<u32>, @location(13) a2: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup40 = device0.createBindGroup({
+  label: '\u456a\u{1f62e}\uea77\ufbd0',
+  layout: bindGroupLayout10,
+  entries: [
+    {binding: 5691, resource: sampler19},
+    {binding: 4082, resource: sampler18},
+    {binding: 1185, resource: externalTexture14},
+  ],
+});
+let textureView129 = texture19.createView({label: '\u879c\u0c70\u1d97\u{1ffbd}\u{1f918}\ued4a\u009c\u{1fcc4}\u01fb\u0497', baseMipLevel: 3});
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer3, 'uint32', 51412, 16701);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(8, buffer3, 1164, 7306);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer14, 'uint32', 240220, 51195);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer10, 74636, buffer9, 97240, 15780);
+dissociateBuffer(device0, buffer10);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder42.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 10,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11200 */
+  offset: 11200,
+  buffer: buffer2,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer2, 63452, 3552);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder54.resolveQuerySet(querySet7, 75, 3107, buffer21, 6144);
+} catch {}
+let pipeline88 = device0.createRenderPipeline({
+  label: '\ud30a\u{1fc84}\u{1fe6d}\u0be0\u2c08\u05d0',
+  layout: pipelineLayout14,
+  multisample: {count: 4, mask: 0xafb3eb95},
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16float', writeMask: 0}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {
+  format: 'r8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'never', failOp: 'invert', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilReadMask: 924674734,
+    depthBias: -1057581069,
+    depthBiasSlopeScale: -57.66857395148144,
+    depthBiasClamp: 993.698847996558,
+  },
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'snorm8x4', offset: 904, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 960, shaderLocation: 18},
+          {format: 'unorm16x2', offset: 3684, shaderLocation: 12},
+          {format: 'float32x2', offset: 7308, shaderLocation: 3},
+          {format: 'float16x2', offset: 1888, shaderLocation: 5},
+          {format: 'sint32x4', offset: 5076, shaderLocation: 23},
+          {format: 'uint8x4', offset: 388, shaderLocation: 14},
+          {format: 'uint8x2', offset: 1092, shaderLocation: 7},
+          {format: 'uint8x2', offset: 3788, shaderLocation: 2},
+          {format: 'uint32x2', offset: 2484, shaderLocation: 0},
+          {format: 'unorm10-10-10-2', offset: 1548, shaderLocation: 17},
+          {format: 'sint8x2', offset: 4182, shaderLocation: 20},
+          {format: 'sint32x3', offset: 576, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 2252, shaderLocation: 22},
+          {format: 'unorm10-10-10-2', offset: 448, shaderLocation: 21},
+          {format: 'unorm8x2', offset: 316, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 2412,
+        attributes: [
+          {format: 'snorm16x4', offset: 68, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 736, shaderLocation: 6},
+          {format: 'sint32x4', offset: 132, shaderLocation: 10},
+          {format: 'sint32x2', offset: 1064, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 3868,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 300, shaderLocation: 15}],
+      },
+      {
+        arrayStride: 2532,
+        attributes: [
+          {format: 'snorm8x4', offset: 64, shaderLocation: 13},
+          {format: 'uint32', offset: 84, shaderLocation: 19},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 480, stepMode: 'instance', attributes: []},
+      {arrayStride: 40, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 4568,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 1794, shaderLocation: 11}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let videoFrame24 = new VideoFrame(offscreenCanvas16, {timestamp: 0});
+let texture93 = device1.createTexture({
+  size: {width: 768, height: 40, depthOrArrayLayers: 62},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let textureView130 = texture61.createView({
+  label: '\u0363\u{1f8ec}\u015d\ucd25\u0d84\ucd90\u{1f63d}\u0e4c\u4de4\uc873\u4e1d',
+  baseMipLevel: 2,
+  baseArrayLayer: 149,
+  arrayLayerCount: 98,
+});
+let renderBundle65 = renderBundleEncoder41.finish({});
+let sampler71 = device1.createSampler({
+  label: '\u012c\uc83e\u02f5',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 78.74,
+  lodMaxClamp: 82.39,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder25.setBlendConstant({ r: -859.1, g: -835.5, b: 775.4, a: 158.8, });
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline86);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer24);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 316, new Float32Array(16414), 104, 88);
+} catch {}
+let pipeline89 = device1.createRenderPipeline({
+  layout: pipelineLayout13,
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 40412,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 5640, shaderLocation: 1},
+          {format: 'uint32', offset: 380, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 8096, shaderLocation: 6},
+          {format: 'float32x2', offset: 3916, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 2516, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 8332, shaderLocation: 22},
+          {format: 'snorm16x4', offset: 1452, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 3964, shaderLocation: 19},
+          {format: 'uint32', offset: 7656, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 7112, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 5532, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 680,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 148, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 44, shaderLocation: 11},
+          {format: 'sint32x2', offset: 152, shaderLocation: 7},
+          {format: 'unorm10-10-10-2', offset: 224, shaderLocation: 5},
+          {format: 'float32x2', offset: 196, shaderLocation: 14},
+          {format: 'sint32x4', offset: 112, shaderLocation: 20},
+          {format: 'sint32x4', offset: 248, shaderLocation: 2},
+          {format: 'float16x2', offset: 136, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', cullMode: 'front'},
+});
+try {
+window.someLabel = querySet41.label;
+} catch {}
+let pipelineLayout16 = device1.createPipelineLayout({
+  label: '\u1fff\u346f',
+  bindGroupLayouts: [bindGroupLayout16, bindGroupLayout34, bindGroupLayout19, bindGroupLayout33, bindGroupLayout35, bindGroupLayout15],
+});
+let textureView131 = texture68.createView({
+  label: '\u{1f75e}\u{1fd01}\u091d\u{1f7b9}\u034a\u1c18\u{1fc1e}\u36f4\u{1fa78}\u965f',
+  dimension: '1d',
+  format: 'rg16uint',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let externalTexture54 = device1.importExternalTexture({
+  label: '\u{1f766}\u{1fb38}\u7acc\u0722\u{1ff29}\u8311\u0c14\u8341',
+  source: video15,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder47.dispatchWorkgroups(5);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline58);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(450, 0, 435, 0);
+} catch {}
+try {
+renderPassEncoder14.draw(506, 21, 454_107_090, 583_358_747);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline87);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(11, buffer24, 2776, 2938);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(111, 56, 974_394_837);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline64);
+} catch {}
+try {
+gpuCanvasContext15.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 44928, new DataView(new ArrayBuffer(8595)), 3550, 892);
+} catch {}
+let pipeline90 = await device1.createComputePipelineAsync({
+  label: '\u09e4\u7b31\u065f\u{1ff20}\u8a40\u{1f660}\u08fe',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule20, entryPoint: 'compute0'},
+});
+let pipeline91 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout15,
+  multisample: {mask: 0x1380649e},
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilReadMask: 3822010815,
+    stencilWriteMask: 1016404936,
+    depthBias: -1075769011,
+    depthBiasSlopeScale: 91.562079580937,
+    depthBiasClamp: 863.1659678380005,
+  },
+  vertex: {module: shaderModule16, entryPoint: 'vertex0', constants: {}, buffers: []},
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder109 = device1.createCommandEncoder({label: '\u0c0d\u8c9c\u{1fc4f}\u0f98\u5c4e\uba91'});
+let renderPassEncoder28 = commandEncoder109.beginRenderPass({
+  label: '\u07f5\u0bfd\u8e68\u8f7a\u47bb\ue685\u1a7d\u0422\u8e08\ude3d\u650d',
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 94,
+  clearValue: { r: 475.5, g: 107.6, b: 222.4, a: -570.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet54,
+  maxDrawCount: 1135881062,
+});
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderPassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder14.draw(182, 361, 446_026_156);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(11, buffer24, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 2812, new BigUint64Array(9304), 5746);
+} catch {}
+let canvas28 = document.createElement('canvas');
+let img29 = await imageWithData(149, 46, '#97356f69', '#ded8f860');
+let shaderModule26 = device1.createShaderModule({
+  label: '\u{1fa42}\ue405\u{1f726}\uec92\u4cbc\u5522\u8e62\u081d',
+  code: `@group(0) @binding(1519)
+var<storage, read_write> global9: array<u32>;
+@group(3) @binding(3947)
+var<storage, read_write> local11: array<u32>;
+@group(3) @binding(5067)
+var<storage, read_write> type17: array<u32>;
+@group(3) @binding(7457)
+var<storage, read_write> global10: array<u32>;
+@group(1) @binding(8384)
+var<storage, read_write> global11: array<u32>;
+@group(1) @binding(5282)
+var<storage, read_write> local12: array<u32>;
+@group(5) @binding(7160)
+var<storage, read_write> type18: array<u32>;
+@group(1) @binding(7949)
+var<storage, read_write> global12: array<u32>;
+@group(4) @binding(6764)
+var<storage, read_write> global13: array<u32>;
+@group(6) @binding(8384)
+var<storage, read_write> n15: array<u32>;
+@group(6) @binding(7949)
+var<storage, read_write> n16: array<u32>;
+
+@compute @workgroup_size(1, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S26 {
+  @location(28) f0: u32,
+  @location(104) f1: vec4<i32>,
+  @location(73) f2: vec4<i32>,
+  @location(108) f3: vec3<i32>,
+  @location(33) f4: i32,
+  @location(34) f5: vec3<f32>,
+  @location(79) f6: vec2<u32>,
+  @location(80) f7: vec4<u32>,
+  @location(59) f8: vec3<u32>,
+  @location(84) f9: f32,
+  @location(95) f10: vec3<u32>,
+  @location(0) f11: vec2<f16>,
+  @location(89) f12: vec2<u32>,
+  @location(12) f13: vec4<i32>,
+  @location(94) f14: vec3<f32>,
+  @location(32) f15: vec3<f16>,
+  @location(111) f16: vec4<f32>,
+  @location(46) f17: vec4<f32>,
+  @location(11) f18: f16,
+  @location(78) f19: f32,
+  @location(97) f20: vec3<f32>,
+  @location(41) f21: vec3<f32>,
+  @builtin(front_facing) f22: bool,
+  @location(58) f23: f32,
+  @builtin(sample_index) f24: u32
+}
+
+@fragment
+fn fragment0(@location(96) a0: vec3<f32>, @location(23) a1: vec2<u32>, @location(14) a2: f16, @location(4) a3: i32, a4: S26, @location(102) a5: i32, @location(101) a6: f32, @location(98) a7: f16, @builtin(sample_mask) a8: u32, @builtin(position) a9: vec4<f32>) -> @location(200) vec4<u32> {
+return vec4<u32>();
+}
+
+struct S25 {
+  @builtin(instance_index) f0: u32,
+  @location(3) f1: vec4<i32>,
+  @location(10) f2: vec2<f32>,
+  @location(17) f3: vec3<f16>,
+  @location(0) f4: vec2<f32>,
+  @location(15) f5: vec2<i32>,
+  @location(19) f6: vec4<i32>,
+  @location(12) f7: i32,
+  @location(21) f8: vec4<f32>,
+  @location(1) f9: vec3<f16>,
+  @location(18) f10: i32,
+  @location(22) f11: vec3<f32>,
+  @location(4) f12: u32,
+  @location(8) f13: vec2<i32>,
+  @builtin(vertex_index) f14: u32,
+  @location(20) f15: vec2<f16>,
+  @location(2) f16: vec4<i32>,
+  @location(23) f17: vec4<u32>,
+  @location(16) f18: vec2<f32>
+}
+struct VertexOutput0 {
+  @location(23) f314: vec2<u32>,
+  @location(0) f315: vec2<f16>,
+  @location(80) f316: vec4<u32>,
+  @location(98) f317: f16,
+  @location(14) f318: f16,
+  @location(96) f319: vec3<f32>,
+  @location(12) f320: vec4<i32>,
+  @location(33) f321: i32,
+  @location(111) f322: vec4<f32>,
+  @location(34) f323: vec3<f32>,
+  @location(102) f324: i32,
+  @location(79) f325: vec2<u32>,
+  @location(104) f326: vec4<i32>,
+  @builtin(position) f327: vec4<f32>,
+  @location(101) f328: f32,
+  @location(58) f329: f32,
+  @location(28) f330: u32,
+  @location(32) f331: vec3<f16>,
+  @location(4) f332: i32,
+  @location(108) f333: vec3<i32>,
+  @location(41) f334: vec3<f32>,
+  @location(95) f335: vec3<u32>,
+  @location(94) f336: vec3<f32>,
+  @location(84) f337: f32,
+  @location(78) f338: f32,
+  @location(11) f339: f16,
+  @location(59) f340: vec3<u32>,
+  @location(46) f341: vec4<f32>,
+  @location(97) f342: vec3<f32>,
+  @location(89) f343: vec2<u32>,
+  @location(73) f344: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec2<u32>, @location(14) a1: f32, @location(7) a2: f16, @location(11) a3: u32, @location(9) a4: vec4<f32>, a5: S25, @location(5) a6: vec3<u32>, @location(13) a7: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet55 = device1.createQuerySet({label: '\u00fa\ucf97\ua5c1\u5f83\u4004\uf1ac\u0760\u9b1c\u6bc1', type: 'occlusion', count: 2550});
+try {
+renderPassEncoder24.setVertexBuffer(10, buffer24, 3456, 2283);
+} catch {}
+let arrayBuffer8 = buffer27.getMappedRange(25552, 23992);
+try {
+device1.queue.writeBuffer(buffer35, 1512, new DataView(new ArrayBuffer(63006)), 8135, 4996);
+} catch {}
+let pipeline92 = await device1.createComputePipelineAsync({layout: pipelineLayout12, compute: {module: shaderModule26, entryPoint: 'compute0', constants: {}}});
+let promise41 = adapter1.requestAdapterInfo();
+let commandEncoder110 = device1.createCommandEncoder({label: '\u18f9\u0e89\u44d0\u{1ffec}\ubc7c\u{1f72e}\uf04f\ue5ce\u0f4d\u7bc3'});
+let texture94 = device1.createTexture({
+  size: {width: 768, height: 40, depthOrArrayLayers: 62},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder49.setBindGroup(5, bindGroup26, new Uint32Array(1067), 727, 0);
+} catch {}
+try {
+renderPassEncoder19.draw(14, 959);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder29.draw(323, 13, 440_225_359, 52_152_190);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(19, 237, 416_089_624);
+} catch {}
+try {
+commandEncoder110.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 39836 */
+  offset: 39836,
+  buffer: buffer33,
+}, {
+  texture: texture81,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer33);
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer35);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 6592, new DataView(new ArrayBuffer(32161)), 22860, 928);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: video12,
+  origin: { x: 0, y: 3 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 15, y: 0, z: 27},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise41;
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let textureView132 = texture67.createView({
+  label: '\u{1ff49}\u{1fd95}\ua473\uadce\u5b49\ue256\uc6a8',
+  dimension: '2d-array',
+  baseMipLevel: 5,
+  baseArrayLayer: 39,
+  arrayLayerCount: 123,
+});
+try {
+renderPassEncoder11.setBindGroup(5, bindGroup35, new Uint32Array(1938), 1401, 0);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer33, 106_867_191);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer24, 3696, 734);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(6, buffer24, 3944, 1);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder110.resolveQuerySet(querySet46, 55, 167, buffer28, 75008);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 22, y: 2 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 8, y: 6, z: 37},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let pipeline93 = await device1.createComputePipelineAsync({
+  label: '\u2074\ucc67\u{1f885}\u08ec\ub2f1\u9d5c\ue921\u031e\u44d7\u{1ff83}',
+  layout: 'auto',
+  compute: {module: shaderModule24, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+document.body.prepend(video15);
+let imageData45 = new ImageData(212, 196);
+let commandEncoder111 = device1.createCommandEncoder({});
+let textureView133 = texture55.createView({label: '\u05cc\u8a64\u{1f935}\u{1fda3}\u0f7e', baseMipLevel: 5, baseArrayLayer: 0});
+let renderPassEncoder29 = commandEncoder110.beginRenderPass({
+  label: '\u04d1\ub7e7\u0a2f\u28ad\ucc8a\ubd01\u{1fe9d}\ude09',
+  colorAttachments: [{
+  view: textureView94,
+  depthSlice: 2,
+  clearValue: { r: -386.0, g: -419.8, b: 790.8, a: -496.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet39,
+  maxDrawCount: 617328457,
+});
+let sampler72 = device1.createSampler({
+  label: '\uf15f\u0f89\uc8a8\u{1f8fb}\ub248\uf8c7\u{1fb7d}\u0935',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.96,
+  lodMaxClamp: 85.08,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: 340.3, g: -937.9, b: 579.9, a: 990.2, });
+} catch {}
+try {
+renderPassEncoder19.drawIndexed(261, 143, 859_828_526, 241_180_071, 631_607_806);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer27, 32_929_194);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(4, bindGroup32, new Uint32Array(7954), 2758, 0);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline64);
+} catch {}
+let promise42 = buffer35.mapAsync(GPUMapMode.READ);
+try {
+commandEncoder111.copyTextureToBuffer({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 7960 widthInBlocks: 1990 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11900 */
+  offset: 11900,
+  rowsPerImage: 163,
+  buffer: buffer26,
+}, {width: 1990, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+gpuCanvasContext20.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 25},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer6), /* required buffer size: 1_971_567 */
+{offset: 287, bytesPerRow: 724, rowsPerImage: 245}, {width: 138, height: 28, depthOrArrayLayers: 12});
+} catch {}
+canvas24.height = 1249;
+gc();
+let bindGroupLayout36 = device1.createBindGroupLayout({label: '\ua259\u0f60\ueb00\u0e03\u09b2', entries: []});
+let commandEncoder112 = device1.createCommandEncoder({label: '\u{1f95b}\u084a\u0f19\u5e3e\ufeed\u057c\u7cdb'});
+let texture95 = device1.createTexture({
+  label: '\u0ae0\u6681\u0a1b\u{1f6d0}',
+  size: {width: 36, height: 8, depthOrArrayLayers: 52},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundle66 = renderBundleEncoder37.finish({label: '\u{1ffee}\uefff\u{1f6e1}\u{1fddf}\ud4ed\u63a2\u5bd4'});
+try {
+renderPassEncoder14.setViewport(28.65, 1.505, 12.91, 0.01289, 0.1714, 0.5374);
+} catch {}
+try {
+renderPassEncoder15.draw(312);
+} catch {}
+try {
+renderPassEncoder18.drawIndexed(73, 55, 693_326_405, 398_829_747, 524_651_088);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup24, new Uint32Array(7117), 509, 0);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(20, 8, 918_364_644);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(0, buffer24, 3400, 294);
+} catch {}
+let bindGroupLayout37 = device1.createBindGroupLayout({
+  label: '\u07cf\uf1fe\uda82\ube1a',
+  entries: [
+    {
+      binding: 8635,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 6100,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let bindGroup41 = device1.createBindGroup({layout: bindGroupLayout36, entries: []});
+let textureView134 = texture87.createView({dimension: '2d-array', baseMipLevel: 3, baseArrayLayer: 0});
+let renderBundleEncoder47 = device1.createRenderBundleEncoder({
+  label: '\u588a\u{1f864}\uf052\u{1fcef}\u2701\udc64\u0935\u8e5f\u{1fcc8}\u16a3\u0bc2',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder24.setStencilReference(2313);
+} catch {}
+try {
+renderPassEncoder20.setViewport(28.11, 5.506, 6.621, 8.391, 0.4523, 0.4852);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer27, 300_604_450);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(1, buffer24, 3140, 2485);
+} catch {}
+let pipeline94 = await device1.createComputePipelineAsync({
+  label: '\uc99a\u085f\u0666\u{1fe92}\u52ff\u8123\u02c5\u41fc\u0efb\u{1f74a}',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+let pipeline95 = device1.createRenderPipeline({
+  label: '\uaf7d\u803b\ub608\u12ae\u0e24\u{1fcc2}\uff1b\u01ad\u0d3a',
+  layout: pipelineLayout12,
+  multisample: {count: 4, mask: 0xa59e0013},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    stencilReadMask: 773353111,
+    stencilWriteMask: 1063129066,
+  },
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 14892,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 776, shaderLocation: 16}],
+      },
+      {
+        arrayStride: 2164,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm16x4', offset: 668, shaderLocation: 10},
+          {format: 'float16x4', offset: 352, shaderLocation: 6},
+          {format: 'float32x2', offset: 332, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 1596,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 32, shaderLocation: 21},
+          {format: 'uint32', offset: 484, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 308, shaderLocation: 20},
+          {format: 'sint32x3', offset: 520, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let bindGroup42 = device1.createBindGroup({label: '\u088a\ua10b\u8449\u0e97', layout: bindGroupLayout36, entries: []});
+let commandEncoder113 = device1.createCommandEncoder({label: '\uc048\ua6d9'});
+let textureView135 = texture93.createView({
+  label: '\u2304\u9aec\uef77\u{1fee1}\u{1fc77}\u1b6f\u19c5\u{1faa7}',
+  format: 'rg16uint',
+  baseMipLevel: 4,
+  mipLevelCount: 3,
+});
+let renderBundleEncoder48 = device1.createRenderBundleEncoder({label: '\u07bd\u8c84', colorFormats: ['rg16uint'], stencilReadOnly: true});
+try {
+renderPassEncoder24.setBindGroup(4, bindGroup22);
+} catch {}
+try {
+renderPassEncoder29.setViewport(0.6769, 0.1867, 0.7938, 0.7779, 0.1563, 0.7169);
+} catch {}
+try {
+renderPassEncoder18.drawIndexed(10);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer30, 395_283_300);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(10, buffer24, 0, 2228);
+} catch {}
+try {
+commandEncoder113.copyTextureToTexture({
+  texture: texture55,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 4, y: 29, z: 32},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let pipeline96 = device1.createComputePipeline({
+  label: '\u689a\u547e\u6406\u{1f708}\ubdf3\u{1fcb0}\u0583\u4035',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule20, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext21 = canvas28.getContext('webgpu');
+canvas23.width = 598;
+let offscreenCanvas31 = new OffscreenCanvas(994, 818);
+let video32 = await videoWithData();
+try {
+adapter1.label = '\uac89\u0084';
+} catch {}
+let commandEncoder114 = device1.createCommandEncoder({label: '\u{1ff94}\u2d5e\ufc2a\u01cc\u1839\u2a8a\ue614\u{1fa11}\u{1f657}\u0dc3\u0e92'});
+let computePassEncoder50 = commandEncoder113.beginComputePass();
+let renderPassEncoder30 = commandEncoder114.beginRenderPass({
+  label: '\u6ff6\u8fc4\u0813\u{1fa67}\u3b26\u3c36\u1091\u508e\u0397\u03cb\u420a',
+  colorAttachments: [{
+  view: textureView114,
+  clearValue: { r: -893.9, g: -828.7, b: -807.1, a: 624.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet53,
+});
+let externalTexture55 = device1.importExternalTexture({label: '\u{1f79b}\udfb2\u531b\u2b0e\u2f1e', source: videoFrame16, colorSpace: 'srgb'});
+try {
+computePassEncoder47.dispatchWorkgroups(3, 4, 5);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(4, bindGroup33, []);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle65, renderBundle51, renderBundle52, renderBundle57, renderBundle44]);
+} catch {}
+try {
+renderPassEncoder14.draw(276, 31, 2_572_467, 451_161_842);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(84);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer30, 1_293_530_257);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(8, buffer24, 0, 3026);
+} catch {}
+try {
+renderBundleEncoder29.draw(738);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexed(9);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline86);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(11, buffer24, 0, 2058);
+} catch {}
+try {
+commandEncoder112.clearBuffer(buffer27, 69796);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+gpuCanvasContext15.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder115 = device1.createCommandEncoder();
+let commandBuffer19 = commandEncoder112.finish({label: '\u0130\u09eb\u4bde\u{1fb0e}\u{1fa07}\ua4ca\u1959\u07ae\u0893\u272c'});
+let renderPassEncoder31 = commandEncoder115.beginRenderPass({
+  colorAttachments: [{
+  view: textureView94,
+  depthSlice: 2,
+  clearValue: { r: -914.1, g: -207.4, b: 347.6, a: -308.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet49,
+  maxDrawCount: 518827808,
+});
+let renderBundle67 = renderBundleEncoder36.finish({label: '\ude21\u5a3e\u265a\u019a\u{1fc17}\u4884\u7225'});
+try {
+renderPassEncoder14.drawIndirect(buffer24, 512_145_165);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline87);
+} catch {}
+try {
+computePassEncoder37.insertDebugMarker('\u03ee');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 90804, new Float32Array(49888), 37168, 1136);
+} catch {}
+let querySet56 = device1.createQuerySet({label: '\u7156\u4676', type: 'occlusion', count: 3787});
+let texture96 = device1.createTexture({
+  label: '\u541a\udea5\u1b0f\u04d4\u06ad\u2ce5\ue33d\u8dbc\ubab1',
+  size: [4536, 1, 1],
+  mipLevelCount: 7,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let renderPassEncoder32 = commandEncoder111.beginRenderPass({
+  label: '\u0e3b\u31e4\u0a23\ua438\u0fea\ud41a\ufc82\ucbb0\u7727\u{1fa6a}',
+  colorAttachments: [{
+  view: textureView128,
+  depthSlice: 271,
+  clearValue: { r: -259.9, g: -585.2, b: -247.8, a: 519.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet52,
+});
+let renderBundle68 = renderBundleEncoder47.finish({label: '\u0a33\ubb4a\u{1fe05}\u0d93\u340f\u{1f6ef}\ub18a\u0847\udaaf'});
+try {
+computePassEncoder42.setBindGroup(1, bindGroup28, new Uint32Array(6102), 4556, 0);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer28, 323_369_298);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(2, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder44.drawIndexed(170, 116);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(10, buffer24, 4096);
+} catch {}
+try {
+  await buffer33.mapAsync(GPUMapMode.WRITE, 48728, 23492);
+} catch {}
+let pipeline97 = await device1.createRenderPipelineAsync({
+  label: '\u347f\u0ea3',
+  layout: pipelineLayout12,
+  multisample: {mask: 0x4f8ca41e},
+  fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {failOp: 'replace', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilReadMask: 2362577129,
+    stencilWriteMask: 317606229,
+    depthBias: -1450942300,
+    depthBiasSlopeScale: 236.53612497879982,
+    depthBiasClamp: 265.8467094418135,
+  },
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 6648,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 3608, shaderLocation: 17},
+          {format: 'float32x4', offset: 2008, shaderLocation: 12},
+          {format: 'sint32x3', offset: 40, shaderLocation: 22},
+          {format: 'snorm16x2', offset: 292, shaderLocation: 9},
+          {format: 'sint32x2', offset: 16, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 180, shaderLocation: 23},
+          {format: 'sint8x4', offset: 212, shaderLocation: 15},
+          {format: 'unorm16x4', offset: 388, shaderLocation: 7},
+          {format: 'uint16x2', offset: 756, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 808, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 5064, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 40, shaderLocation: 4},
+          {format: 'sint8x4', offset: 728, shaderLocation: 11},
+          {format: 'snorm8x2', offset: 628, shaderLocation: 14},
+          {format: 'float16x4', offset: 2356, shaderLocation: 16},
+          {format: 'uint8x2', offset: 1812, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 728, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 2720,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm8x4', offset: 960, shaderLocation: 18},
+          {format: 'unorm8x4', offset: 480, shaderLocation: 0},
+          {format: 'sint8x4', offset: 224, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 4172,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 228, shaderLocation: 8}],
+      },
+      {
+        arrayStride: 3852,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 176, shaderLocation: 19},
+          {format: 'snorm16x2', offset: 572, shaderLocation: 2},
+          {format: 'sint32x2', offset: 340, shaderLocation: 20},
+        ],
+      },
+    ],
+  },
+});
+let bindGroup43 = device1.createBindGroup({
+  label: '\u0b5b\u6e1e\u1c4f\u{1f7bd}\u{1f792}\u42bb\u4db9\u015c\u1ab8',
+  layout: bindGroupLayout20,
+  entries: [{binding: 7160, resource: textureView134}],
+});
+let textureView136 = texture94.createView({baseMipLevel: 1, mipLevelCount: 5});
+let sampler73 = device1.createSampler({
+  label: '\u{1f9d9}\uace5\u{1ffc7}\u000f\u5749\u6cca\u{1fd81}\u0e3e\u035c\u0b90',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.80,
+  lodMaxClamp: 73.86,
+  compare: 'equal',
+  maxAnisotropy: 2,
+});
+let externalTexture56 = device1.importExternalTexture({label: '\u0a96\u2d81\udbd4\ubb5b\uc5ca\u0429\u{1fe3c}', source: video11, colorSpace: 'srgb'});
+try {
+renderPassEncoder23.beginOcclusionQuery(1815);
+} catch {}
+try {
+renderPassEncoder20.setViewport(0.8543, 3.430, 9.041, 10.60, 0.9485, 0.9769);
+} catch {}
+try {
+renderPassEncoder19.draw(11, 77, 816_992_362);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(116, 402, 67_808_078, 46_041_766, 194_941_104);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer27, 266_442_608);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer34, 26_796_946);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(1, buffer24, 5172);
+} catch {}
+try {
+renderBundleEncoder29.insertDebugMarker('\u5b49');
+} catch {}
+let pipeline98 = await device1.createRenderPipelineAsync({
+  label: '\u014a\ufc12\u{1f98d}\u{1fb07}',
+  layout: pipelineLayout16,
+  multisample: {count: 4, mask: 0x551f7480},
+  fragment: {
+  module: shaderModule24,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {
+    module: shaderModule24,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 20688,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 3580, shaderLocation: 4},
+          {format: 'uint16x2', offset: 492, shaderLocation: 8},
+          {format: 'uint32x3', offset: 3004, shaderLocation: 15},
+          {format: 'sint16x4', offset: 4652, shaderLocation: 23},
+          {format: 'snorm8x2', offset: 2674, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 1148, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 2100,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 216, shaderLocation: 11},
+          {format: 'uint32x4', offset: 128, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 452, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 19036,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 480, shaderLocation: 22},
+          {format: 'uint32', offset: 524, shaderLocation: 17},
+          {format: 'snorm8x4', offset: 3888, shaderLocation: 14},
+          {format: 'float32x3', offset: 288, shaderLocation: 7},
+          {format: 'sint8x4', offset: 16, shaderLocation: 20},
+          {format: 'unorm8x4', offset: 4020, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 1224,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x4', offset: 264, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 140, shaderLocation: 12},
+          {format: 'float32x4', offset: 28, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 5092,
+        attributes: [
+          {format: 'unorm16x2', offset: 852, shaderLocation: 21},
+          {format: 'unorm8x4', offset: 1776, shaderLocation: 3},
+          {format: 'unorm16x4', offset: 852, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+});
+let video33 = await videoWithData();
+let gpuCanvasContext22 = offscreenCanvas31.getContext('webgpu');
+let adapter4 = await promise20;
+let imageBitmap27 = await createImageBitmap(imageBitmap0);
+let bindGroup44 = device1.createBindGroup({layout: bindGroupLayout18, entries: []});
+let buffer36 = device1.createBuffer({label: '\u{1f6c0}\u2ff8\u020e\u18f7', size: 19749, usage: GPUBufferUsage.MAP_READ});
+let textureView137 = texture83.createView({
+  label: '\u{1fd41}\u0ca6\u9a5c\u{1f946}\u0343\u{1fd68}\u{1f7ed}\u666e\ud821',
+  baseArrayLayer: 373,
+  arrayLayerCount: 27,
+});
+try {
+computePassEncoder47.dispatchWorkgroups(5, 5, 2);
+} catch {}
+try {
+renderPassEncoder20.draw(272, 145, 581_867_624, 963_643_366);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(331, 327, 246_877_541, 580_488_548, 105_421_459);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(136, 17, 2_652_388_667, 179_211_161, 486_106_244);
+} catch {}
+let video34 = await videoWithData();
+let offscreenCanvas32 = new OffscreenCanvas(954, 707);
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+let videoFrame25 = new VideoFrame(offscreenCanvas23, {timestamp: 0});
+try {
+renderPassEncoder28.setBindGroup(4, bindGroup31);
+} catch {}
+try {
+renderPassEncoder29.setBlendConstant({ r: -179.2, g: 437.6, b: 321.4, a: -315.5, });
+} catch {}
+try {
+renderPassEncoder20.draw(132, 192, 552_464_466, 594_699_734);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(357);
+} catch {}
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer33, 1_050_720_565);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(6, buffer24, 0, 4391);
+} catch {}
+let gpuCanvasContext23 = offscreenCanvas32.getContext('webgpu');
+try {
+  await promise42;
+} catch {}
+let canvas29 = document.createElement('canvas');
+let gpuCanvasContext24 = canvas29.getContext('webgpu');
+try {
+  await promise40;
+} catch {}
+gc();
+let bindGroupLayout38 = pipeline62.getBindGroupLayout(4);
+let bindGroup45 = device1.createBindGroup({label: '\u0540\u727e\u{1f7d9}\ub86b\u{1fad2}\u64b1\u0043', layout: bindGroupLayout18, entries: []});
+let commandEncoder116 = device1.createCommandEncoder({});
+let textureView138 = texture85.createView({label: '\u947a\uce0a\u59d1\u0df3\u17f6\u59c1\u0754'});
+let computePassEncoder51 = commandEncoder116.beginComputePass({label: '\u0b13\ua7d9\ub54c\u{1fc39}\u0251\ub007\u08a6\u{1f971}\u1a9a'});
+try {
+computePassEncoder39.setPipeline(pipeline93);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup28, new Uint32Array(5539), 1602, 0);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(2, bindGroup30, new Uint32Array(2321), 986, 0);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexed(86, 264, 939_100_222, 636_840_948, 145_901_369);
+} catch {}
+try {
+computePassEncoder42.insertDebugMarker('\u0451');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 1584, new BigUint64Array(6431), 6070);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let offscreenCanvas33 = new OffscreenCanvas(958, 929);
+let commandBuffer20 = commandEncoder54.finish({label: '\uf701\u4bb7\ua1de\uda88'});
+let texture97 = device0.createTexture({
+  size: [768, 16, 154],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8uint', 'r8uint'],
+});
+let textureView139 = texture51.createView({
+  label: '\u5634\u{1fb30}\u04fd\u{1fb21}\uab86\u8426\u00fe\ua004\u{1fe40}\u{1fd86}\u494f',
+  baseMipLevel: 7,
+  mipLevelCount: 1,
+});
+let renderBundleEncoder49 = device0.createRenderBundleEncoder({
+  label: '\u{1f6c5}\u67d2\u0034\u3b74\u{1fe14}\u{1fd92}\u0cbf\u5ca3\u7e04\u59b7\u{1f762}',
+  colorFormats: ['rgba32sint', 'rgba32uint', 'r8unorm'],
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder4.setBindGroup(4, bindGroup23, new Uint32Array(782), 446, 0);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(6, bindGroup0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let pipeline99 = await device0.createComputePipelineAsync({
+  label: '\u9bb2\u8d32\u00d1',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+let imageData46 = new ImageData(204, 196);
+try {
+adapter1.label = '\u{1f8c6}\ueaff\u2b39\u0f75\u{1f61f}\ude08\u6990\u{1fce6}\u{1f74d}\ue034\u0cd6';
+} catch {}
+let gpuCanvasContext25 = offscreenCanvas33.getContext('webgpu');
+offscreenCanvas26.height = 259;
+let externalTexture57 = device1.importExternalTexture({label: '\u130a\ud733\u617b', source: videoFrame16, colorSpace: 'display-p3'});
+try {
+renderPassEncoder20.draw(286, 182, 2_581_103_083, 2_911_975_246);
+} catch {}
+try {
+renderPassEncoder19.drawIndexed(262, 187, 31_836_357, 9_931_640);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer29, 40_756_031);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline87);
+} catch {}
+try {
+renderBundleEncoder31.draw(5, 153, 1_042_483_084, 142_589_866);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(218, 88, 1_812_822_443);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(5, buffer24, 908, 2601);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: imageBitmap19,
+  origin: { x: 3, y: 81 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 0, y: 6, z: 34},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 67, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline100 = await promise27;
+let commandEncoder117 = device1.createCommandEncoder();
+let textureView140 = texture67.createView({
+  label: '\u4822\u0e39\ud182\u{1f90b}\u1633\u90fe\u05ab\u08c8\u3236',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 104,
+  arrayLayerCount: 46,
+});
+let renderPassEncoder33 = commandEncoder117.beginRenderPass({
+  label: '\u0df6\u204e\ub225\u5438\u7b79\u2709\u0c8f\u0adc\u0c70\u0c1a',
+  colorAttachments: [{
+  view: textureView86,
+  depthSlice: 13,
+  clearValue: { r: -462.8, g: -829.4, b: 811.7, a: 406.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet34,
+  maxDrawCount: 206795503,
+});
+let externalTexture58 = device1.importExternalTexture({label: '\u6a05\u4c1b\u32ca', source: videoFrame3, colorSpace: 'display-p3'});
+try {
+renderPassEncoder14.beginOcclusionQuery(2261);
+} catch {}
+try {
+renderPassEncoder32.setScissorRect(36, 31, 9, 8);
+} catch {}
+try {
+renderPassEncoder15.draw(34);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline86);
+} catch {}
+try {
+renderBundleEncoder29.draw(92, 35, 3_216_559_451, 160_295_820);
+} catch {}
+let querySet57 = device1.createQuerySet({label: '\u{1f620}\u0aef\u0086\u25aa\u6986', type: 'occlusion', count: 1798});
+let texture98 = device1.createTexture({
+  label: '\u412c\u{1f696}\ubbdd\uc58e\uc561\u01ef\u35b7\u0a15',
+  size: [9072, 1, 134],
+  mipLevelCount: 11,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler74 = device1.createSampler({
+  label: '\ufbd1\u09eb',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMinClamp: 68.14,
+  lodMaxClamp: 98.57,
+});
+let externalTexture59 = device1.importExternalTexture({label: '\ue708\u0ce0', source: video4, colorSpace: 'srgb'});
+try {
+computePassEncoder47.dispatchWorkgroups(1, 5, 3);
+} catch {}
+try {
+renderPassEncoder32.beginOcclusionQuery(700);
+} catch {}
+try {
+renderPassEncoder14.draw(67, 27, 322_533_852);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(1, bindGroup38, new Uint32Array(1561), 587, 0);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline68);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer5), /* required buffer size: 69 */
+{offset: 69}, {width: 374, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: canvas2,
+  origin: { x: 38, y: 10 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 6, y: 3, z: 52},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 15, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline101 = await device1.createComputePipelineAsync({
+  label: '\u{1ffa1}\u2a48\uc526\u4653\uf4d9',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let buffer37 = device1.createBuffer({
+  label: '\u{1f714}\u04db\u0eac\u6f7b\u2ff1\uff6c\u2f44\u0226\u{1f827}',
+  size: 61396,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let renderBundleEncoder50 = device1.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder24.setBindGroup(4, bindGroup39, new Uint32Array(4216), 318, 0);
+} catch {}
+try {
+renderPassEncoder26.draw(15);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(2, buffer24, 3376);
+} catch {}
+try {
+gpuCanvasContext22.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 7, y: 3 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 25, y: 22, z: 148},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 32, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder118 = device1.createCommandEncoder({label: '\u0db5\u82e9\u{1f96c}\u552c\u{1fcaa}\u4140\u{1fae4}\u{1f75c}\u7014\u7889'});
+let texture99 = device1.createTexture({
+  label: '\u{1f7e0}\uf8de\u01f1\u0de2\u671b\u334e\uddd9\ub856\u{1fd17}\u{1f940}',
+  size: {width: 72, height: 16, depthOrArrayLayers: 1},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView141 = texture64.createView({label: '\uac51\uf874\u{1f70c}\u0841'});
+let renderPassEncoder34 = commandEncoder118.beginRenderPass({
+  colorAttachments: [{
+  view: textureView94,
+  depthSlice: 1,
+  clearValue: { r: 552.8, g: -367.4, b: -581.7, a: -251.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet35,
+  maxDrawCount: 739061168,
+});
+let renderBundleEncoder51 = device1.createRenderBundleEncoder({label: '\ub11f\u05da\u0366\uac9e\u0d44\u1463', colorFormats: ['rg16uint'], depthReadOnly: true});
+let renderBundle69 = renderBundleEncoder43.finish({label: '\u0e61\u91c6'});
+try {
+renderPassEncoder32.executeBundles([renderBundle62, renderBundle45, renderBundle55, renderBundle66, renderBundle57, renderBundle59]);
+} catch {}
+try {
+renderPassEncoder31.setScissorRect(2, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline86);
+} catch {}
+try {
+device1.queue.submit([commandBuffer19]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 539 */
+{offset: 539}, {width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup46 = device1.createBindGroup({label: '\uaec6\u0663\uc0d5\u4497\udf5c\uda79\u0380', layout: bindGroupLayout38, entries: []});
+let texture100 = device1.createTexture({
+  label: '\ub17c\u0633\u0305\u{1fc89}\ua789\u{1fdab}\u{1fac8}\u{1fd51}\u064f',
+  size: {width: 768, height: 40, depthOrArrayLayers: 62},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let renderBundleEncoder52 = device1.createRenderBundleEncoder({label: '\u6e82\u7a18\u{1fc66}\u{1ffa2}\u96ea\u{1f62e}\u82e9\u0b6e', colorFormats: ['rg16uint']});
+let externalTexture60 = device1.importExternalTexture({source: videoFrame23, colorSpace: 'display-p3'});
+try {
+renderPassEncoder20.drawIndirect(buffer31, 390_121_495);
+} catch {}
+try {
+renderBundleEncoder44.draw(71, 412, 640_544_059);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(4, buffer24, 2212, 1961);
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline84);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle50, renderBundle52, renderBundle54, renderBundle61, renderBundle66, renderBundle53, renderBundle51, renderBundle43, renderBundle52]);
+} catch {}
+try {
+renderPassEncoder19.draw(153, 44, 230_930_119, 339_139_396);
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline86);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline102 = await device1.createComputePipelineAsync({
+  label: '\u{1fba5}\u{1fd97}\ua058\ub986\uf98a\u9b52',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule22, entryPoint: 'compute0', constants: {}},
+});
+let canvas30 = document.createElement('canvas');
+try {
+computePassEncoder46.setPipeline(pipeline84);
+} catch {}
+try {
+renderPassEncoder26.drawIndexedIndirect(buffer26, 214_480_102);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer35, 279_552_872);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(8, buffer24, 0, 5133);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(99, 42, 324_794_310, 317_730_479);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 99560, new Int16Array(19881), 3801, 1448);
+} catch {}
+let img30 = await imageWithData(5, 69, '#e2727150', '#0d51aad7');
+let video35 = await videoWithData();
+let imageData47 = new ImageData(216, 4);
+try {
+canvas30.getContext('webgl2');
+} catch {}
+let commandEncoder119 = device1.createCommandEncoder({label: '\u2bae\u{1fe50}\u0094\u8d3c\u{1ff28}\u326a\u{1f9ba}\u65ba\u07c6\u0342'});
+let texture101 = device1.createTexture({
+  label: '\uf560\u{1fd95}\u8678\u{1f99b}\u0d24\u95cf\uc27c\u1267',
+  size: [75, 3, 1],
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let renderBundleEncoder53 = device1.createRenderBundleEncoder({label: '\u09cc\u4e87\ubf4a\u{1f6c1}', colorFormats: ['rg16uint'], stencilReadOnly: true});
+let sampler75 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 70.39,
+  lodMaxClamp: 79.70,
+});
+try {
+computePassEncoder37.setPipeline(pipeline94);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(18, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder23.setViewport(1.829, 0.1249, 0.1307, 0.8504, 0.1069, 0.3255);
+} catch {}
+try {
+renderPassEncoder26.draw(85, 112, 21_578_509, 28_859_837);
+} catch {}
+try {
+renderPassEncoder26.drawIndexed(10);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer32, 4_294_967_295);
+} catch {}
+let arrayBuffer9 = buffer27.getMappedRange(49544, 1904);
+try {
+device1.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 100},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer2), /* required buffer size: 287_228 */
+{offset: 644, bytesPerRow: 402, rowsPerImage: 218}, {width: 90, height: 59, depthOrArrayLayers: 4});
+} catch {}
+let promise43 = adapter1.requestAdapterInfo();
+let shaderModule27 = device1.createShaderModule({
+  label: '\u{1fd59}\uaaf0\u{1fe64}\ud3f5\u99d6\ud025\u{1f8f4}',
+  code: `@group(4) @binding(346)
+var<storage, read_write> local13: array<u32>;
+@group(3) @binding(1281)
+var<storage, read_write> global14: array<u32>;
+@group(0) @binding(3155)
+var<storage, read_write> parameter12: array<u32>;
+@group(0) @binding(2376)
+var<storage, read_write> parameter13: array<u32>;
+@group(2) @binding(5282)
+var<storage, read_write> function16: array<u32>;
+@group(2) @binding(8384)
+var<storage, read_write> parameter14: array<u32>;
+@group(2) @binding(7949)
+var<storage, read_write> parameter15: array<u32>;
+
+@compute @workgroup_size(7, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(73) a0: f16, @location(36) a1: i32, @location(98) a2: u32, @location(14) a3: vec2<f16>, @location(83) a4: vec2<f32>, @location(1) a5: vec3<f16>, @location(27) a6: u32, @location(7) a7: vec2<u32>, @location(81) a8: i32, @location(102) a9: vec4<u32>, @location(70) a10: vec2<f32>, @location(29) a11: i32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S27 {
+  @location(12) f0: u32,
+  @location(3) f1: i32,
+  @location(2) f2: vec2<i32>,
+  @location(10) f3: vec4<f16>,
+  @location(11) f4: i32
+}
+struct VertexOutput0 {
+  @location(28) f345: vec2<f32>,
+  @location(13) f346: vec4<i32>,
+  @location(8) f347: vec2<f32>,
+  @location(81) f348: i32,
+  @location(54) f349: f16,
+  @location(86) f350: vec2<i32>,
+  @location(109) f351: vec2<u32>,
+  @location(14) f352: vec2<f16>,
+  @location(12) f353: vec4<f16>,
+  @location(59) f354: vec3<f16>,
+  @location(73) f355: f16,
+  @location(11) f356: vec3<f32>,
+  @location(45) f357: vec3<f32>,
+  @builtin(position) f358: vec4<f32>,
+  @location(98) f359: u32,
+  @location(7) f360: vec2<u32>,
+  @location(36) f361: i32,
+  @location(95) f362: vec2<f32>,
+  @location(29) f363: i32,
+  @location(101) f364: vec2<u32>,
+  @location(35) f365: f32,
+  @location(41) f366: vec3<f16>,
+  @location(27) f367: u32,
+  @location(96) f368: vec3<u32>,
+  @location(37) f369: vec3<i32>,
+  @location(42) f370: f32,
+  @location(1) f371: vec3<f16>,
+  @location(83) f372: vec2<f32>,
+  @location(4) f373: vec3<f16>,
+  @location(84) f374: i32,
+  @location(6) f375: i32,
+  @location(70) f376: vec2<f32>,
+  @location(91) f377: u32,
+  @location(102) f378: vec4<u32>,
+  @location(76) f379: vec2<i32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(9) a1: vec2<u32>, @location(13) a2: vec2<f32>, @location(0) a3: vec3<f32>, @location(23) a4: vec2<i32>, @location(19) a5: vec2<u32>, @location(7) a6: f16, @location(1) a7: vec4<f16>, @location(14) a8: vec4<f16>, @location(22) a9: f16, @location(16) a10: vec4<f16>, @location(18) a11: vec4<i32>, @location(20) a12: vec4<f16>, @location(15) a13: vec2<i32>, a14: S27, @location(4) a15: f16, @location(6) a16: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderPassEncoder22.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder29.draw(277, 101, 1_899_048_777);
+} catch {}
+try {
+renderBundleEncoder44.drawIndexed(64, 164, 377_796_199, 761_914_462);
+} catch {}
+try {
+commandEncoder119.copyBufferToBuffer(buffer33, 84148, buffer34, 418212, 512);
+dissociateBuffer(device1, buffer33);
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer34, 330584, 58152);
+dissociateBuffer(device1, buffer34);
+} catch {}
+let offscreenCanvas34 = new OffscreenCanvas(430, 705);
+let videoFrame26 = new VideoFrame(offscreenCanvas14, {timestamp: 0});
+let commandEncoder120 = device1.createCommandEncoder();
+let querySet58 = device1.createQuerySet({label: '\u0e8c\u0c42\u3423\u{1fdfb}\u{1f7e0}\u58b4\u10c6', type: 'occlusion', count: 3344});
+let texture102 = device1.createTexture({
+  label: '\u5c6f\u27ef\uac9d\u2a8e\u0817',
+  size: {width: 9072},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView142 = texture64.createView({});
+let renderPassEncoder35 = commandEncoder119.beginRenderPass({
+  label: '\u0a96\u{1f766}\uab6a',
+  colorAttachments: [{
+  view: textureView94,
+  depthSlice: 0,
+  clearValue: { r: -891.3, g: 376.8, b: 50.63, a: 601.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet58,
+  maxDrawCount: 1030979644,
+});
+let renderBundleEncoder54 = device1.createRenderBundleEncoder({colorFormats: ['rg16uint'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+let renderBundle70 = renderBundleEncoder54.finish({label: '\u069d\u7918\u12eb\u0bed\ue3aa\ub207\u{1fd02}\u0ccb\ua897\u0dbc\uda79'});
+try {
+renderPassEncoder20.drawIndexed(429, 28);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(5, bindGroup45);
+} catch {}
+try {
+renderBundleEncoder52.draw(197, 13);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(5, buffer24, 1200, 2557);
+} catch {}
+try {
+commandEncoder120.copyBufferToBuffer(buffer29, 1011224, buffer27, 43412, 23608);
+dissociateBuffer(device1, buffer29);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: imageData17,
+  origin: { x: 2, y: 21 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 154, y: 0, z: 258},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext26 = offscreenCanvas34.getContext('webgpu');
+let imageData48 = new ImageData(176, 148);
+try {
+  await promise43;
+} catch {}
+let bindGroup47 = device1.createBindGroup({
+  label: '\u07dd\u3b1f\u{1ff69}\ubc9b\u2f52\u0b38\u0f1d\u0b97',
+  layout: bindGroupLayout35,
+  entries: [{binding: 346, resource: {buffer: buffer30, offset: 168064}}],
+});
+let buffer38 = device1.createBuffer({
+  label: '\u3670\u04f5\u0560\u6bac\uddc1\u{1fafc}\u08bd\u{1ff9f}\u4393\uc2a6\uba08',
+  size: 503329,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let querySet59 = device1.createQuerySet({type: 'occlusion', count: 2783});
+let computePassEncoder52 = commandEncoder120.beginComputePass({label: '\ufd18\u0793\u{1fede}\u0b20\u8c05\u753e\u3e00\ueea3\u04aa'});
+let renderBundle71 = renderBundleEncoder30.finish();
+let sampler76 = device1.createSampler({
+  label: '\ue6df\u{1f9c5}\u{1fe63}\uca20\u825d\u{1f8ad}\ue0bd',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 38.54,
+  lodMaxClamp: 72.88,
+});
+let externalTexture61 = device1.importExternalTexture({source: videoFrame10});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup28, new Uint32Array(6004), 2058, 0);
+} catch {}
+try {
+renderPassEncoder33.beginOcclusionQuery(7);
+} catch {}
+try {
+renderPassEncoder23.setViewport(1.184, 0.7483, 0.2388, 0.1598, 0.8535, 0.9057);
+} catch {}
+try {
+renderPassEncoder26.drawIndexed(181, 15, 198_541_511, -1_990_074_512, 746_035_861);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer34, 35_441_866);
+} catch {}
+try {
+renderBundleEncoder31.draw(74);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(9, 60);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(9, buffer24, 2124, 1892);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 952, new Float32Array(42970), 17505, 204);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: video21,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 39},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline103 = device1.createRenderPipeline({
+  label: '\u{1fb72}\udf5e\u0c42\u83ab\u1e98\ue035\u8b1f\ub8c5',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 13516,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 3276, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 3200, shaderLocation: 12},
+          {format: 'float32x4', offset: 3440, shaderLocation: 19},
+          {format: 'snorm8x2', offset: 36, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 7392,
+        attributes: [
+          {format: 'snorm8x2', offset: 1484, shaderLocation: 0},
+          {format: 'uint8x2', offset: 526, shaderLocation: 13},
+          {format: 'float32x4', offset: 832, shaderLocation: 23},
+          {format: 'unorm16x2', offset: 524, shaderLocation: 14},
+          {format: 'float32', offset: 1380, shaderLocation: 2},
+          {format: 'float16x4', offset: 952, shaderLocation: 7},
+          {format: 'sint8x4', offset: 148, shaderLocation: 22},
+          {format: 'unorm16x2', offset: 612, shaderLocation: 6},
+          {format: 'uint32', offset: 660, shaderLocation: 1},
+          {format: 'sint32', offset: 32, shaderLocation: 20},
+          {format: 'unorm16x4', offset: 916, shaderLocation: 18},
+          {format: 'snorm8x2', offset: 956, shaderLocation: 10},
+          {format: 'sint16x4', offset: 380, shaderLocation: 5},
+          {format: 'sint32', offset: 340, shaderLocation: 21},
+          {format: 'float32x3', offset: 208, shaderLocation: 16},
+          {format: 'snorm16x4', offset: 848, shaderLocation: 9},
+          {format: 'uint16x2', offset: 764, shaderLocation: 17},
+          {format: 'float32x3', offset: 2060, shaderLocation: 8},
+          {format: 'sint8x2', offset: 2318, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 11628, attributes: []},
+      {arrayStride: 2048, attributes: []},
+      {arrayStride: 9264, stepMode: 'vertex', attributes: []},
+      {arrayStride: 1932, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint8x2', offset: 7608, shaderLocation: 11}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', unclippedDepth: true},
+});
+let sampler77 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.93,
+  lodMaxClamp: 26.16,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(6, bindGroup24);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle65, renderBundle58, renderBundle60, renderBundle53, renderBundle53, renderBundle65, renderBundle71, renderBundle43]);
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(603, 1, 85, 0);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(116, 491, 205_535_234, 14_567_344, 2_629_324_717);
+} catch {}
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer35, 42_611_708);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup46, new Uint32Array(8335), 6440, 0);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(3, buffer24, 0, 779);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer34, 18360, new Int16Array(37578), 24350, 2220);
+} catch {}
+let pipeline104 = device1.createComputePipeline({
+  label: '\u49cc\u6fb0',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap28 = await createImageBitmap(offscreenCanvas12);
+let buffer39 = device1.createBuffer({label: '\u0c06\u{1f967}', size: 109168, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture103 = device1.createTexture({
+  label: '\u707e\u00c2\u{1fa85}\uacc8',
+  size: {width: 300, height: 12, depthOrArrayLayers: 75},
+  mipLevelCount: 3,
+  format: 'astc-5x4-unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['astc-5x4-unorm-srgb', 'astc-5x4-unorm', 'astc-5x4-unorm-srgb'],
+});
+let renderBundle72 = renderBundleEncoder38.finish({label: '\ucfe0\u06ab\ub4be\u0251\u5384\u8639\u{1fe58}\ub449\u3c83\u21dc'});
+try {
+renderPassEncoder14.setPipeline(pipeline68);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(10, buffer24, 5720);
+} catch {}
+try {
+renderBundleEncoder52.draw(5, 41, 1_949_272_501);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let textureView143 = texture56.createView({label: '\u{1ff79}\uf9f0\u38e4\u0030\u30c2\u80bc\u0a92', baseMipLevel: 1});
+let renderBundle73 = renderBundleEncoder51.finish();
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup47);
+} catch {}
+try {
+renderPassEncoder26.draw(404, 59, 477_873_900);
+} catch {}
+try {
+renderPassEncoder19.drawIndexed(429, 61);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline86);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(2, buffer24, 0, 4053);
+} catch {}
+try {
+renderBundleEncoder44.drawIndexed(49, 236, 8_991_580, 302_591_710, 701_248_158);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline64);
+} catch {}
+try {
+gpuCanvasContext19.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 26},
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 2_168_222 */
+{offset: 321, bytesPerRow: 709, rowsPerImage: 49}, {width: 61, height: 20, depthOrArrayLayers: 63});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: canvas2,
+  origin: { x: 59, y: 4 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 6, y: 7, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 252, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let querySet60 = device1.createQuerySet({label: '\ubef6\u0f19\u8272\uaf35\u0561\u0171\u0654', type: 'occlusion', count: 3053});
+let textureView144 = texture67.createView({
+  label: '\u0820\u8290\u72ff\u0b31\u77d0',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 2,
+  mipLevelCount: 4,
+  baseArrayLayer: 109,
+  arrayLayerCount: 1,
+});
+let sampler78 = device1.createSampler({
+  label: '\uf141\u70b2\ue9ab\u75c4\u17d8\u193e\u30b9\u6b52\u23c9',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 68.31,
+  lodMaxClamp: 76.27,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder35.setBindGroup(5, bindGroup44);
+} catch {}
+try {
+renderPassEncoder28.beginOcclusionQuery(3124);
+} catch {}
+try {
+renderPassEncoder28.drawIndexed(426, 345, 590_559_432, -1_901_046_360, 618_028_100);
+} catch {}
+try {
+renderPassEncoder22.drawIndirect(buffer26, 33_042_384);
+} catch {}
+let pipeline105 = device1.createRenderPipeline({
+  label: '\u05bf\u75ae\u0445\u2bc4\u0f09\uf1cd\u054b\u03f1\u0066\u7933',
+  layout: pipelineLayout15,
+  multisample: {count: 1, mask: 0x47ea1445},
+  fragment: {module: shaderModule16, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16uint'}]},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'zero', depthFailOp: 'keep', passOp: 'zero'},
+    stencilReadMask: 2221421120,
+    stencilWriteMask: 4121470361,
+    depthBiasSlopeScale: 350.7464378664133,
+  },
+  vertex: {module: shaderModule16, entryPoint: 'vertex0', constants: {}, buffers: []},
+});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let buffer40 = device1.createBuffer({label: '\u{1fc0f}\ufd9e\u6ae9\uc3de\u2c02', size: 173207, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder121 = device1.createCommandEncoder({label: '\ub320\u{1fda0}\u0390\uab6f\u86d1\u0de2\u4f9d\u7485'});
+let texture104 = device1.createTexture({
+  label: '\u2b03\u{1f7c0}\udfa0\u{1f862}\u5c98',
+  size: [600],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let textureView145 = texture60.createView({});
+try {
+renderPassEncoder33.executeBundles([renderBundle46, renderBundle47, renderBundle69, renderBundle58, renderBundle72, renderBundle58, renderBundle45, renderBundle58, renderBundle46, renderBundle52]);
+} catch {}
+try {
+renderPassEncoder24.setStencilReference(2177);
+} catch {}
+try {
+renderPassEncoder31.setViewport(1.575, 0.2949, 0.3945, 0.2199, 0.3583, 0.7233);
+} catch {}
+try {
+renderPassEncoder26.draw(179, 218, 246_575_413, 297_743_796);
+} catch {}
+try {
+renderPassEncoder22.drawIndexed(613, 224, 1_324_109_653, 241_095_333, 1_812_312_918);
+} catch {}
+try {
+renderPassEncoder26.drawIndexedIndirect(buffer30, 67_084_629);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(2, buffer24, 3884, 65);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+let commandEncoder122 = device1.createCommandEncoder({label: '\u07b5\ud4fa'});
+let textureView146 = texture72.createView({label: '\u0725\u2217\u0921\u2566\ube1c\u0846\u{1f82c}\u{1f98b}', mipLevelCount: 2});
+let renderBundle74 = renderBundleEncoder32.finish({label: '\u0279\u05ce\u0746'});
+let sampler79 = device1.createSampler({
+  label: '\u0784\u0dd2\u0a0a\u0fab\u36b8\ued3e\uebf6',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 95.86,
+});
+try {
+renderPassEncoder28.setScissorRect(779, 0, 110, 0);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(2051);
+} catch {}
+try {
+renderPassEncoder26.draw(1, 310, 271_072_841);
+} catch {}
+try {
+renderPassEncoder19.drawIndexed(84, 153, 31_999_075, 735_671_582, 706_975_745);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup45);
+} catch {}
+try {
+renderBundleEncoder44.drawIndexed(29, 158, 137_904_630);
+} catch {}
+try {
+commandEncoder121.copyTextureToBuffer({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 118, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 856 widthInBlocks: 214 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 65976 */
+  offset: 65976,
+  bytesPerRow: 1280,
+  rowsPerImage: 236,
+  buffer: buffer26,
+}, {width: 214, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let querySet61 = device0.createQuerySet({label: '\u0788\u{1f88e}\u82f5\ufbec\u6cd9\u022b\u{1fd7d}', type: 'occlusion', count: 1479});
+try {
+renderBundleEncoder24.setPipeline(pipeline60);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(10, buffer13);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer11, 114556);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder42.resolveQuerySet(querySet9, 14, 82, buffer5, 21760);
+} catch {}
+try {
+gpuCanvasContext22.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline106 = await device0.createRenderPipelineAsync({
+  label: '\u01d0\u{1f6c6}\u{1f888}\u526b\ud466\u43bd\u{1fcf5}',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x11927089},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'src-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rgba16float', writeMask: GPUColorWrite.ALL}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.ALL}, {
+  format: 'r8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less', depthFailOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less', depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    depthBias: 305324975,
+    depthBiasClamp: 709.0487224882073,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 76,
+        attributes: [
+          {format: 'sint32', offset: 4, shaderLocation: 3},
+          {format: 'uint8x2', offset: 8, shaderLocation: 0},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 2},
+          {format: 'float32x3', offset: 0, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 28, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 4, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 8, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 2028,
+        attributes: [
+          {format: 'sint8x4', offset: 696, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 468, shaderLocation: 13},
+          {format: 'uint32', offset: 520, shaderLocation: 19},
+          {format: 'sint16x2', offset: 28, shaderLocation: 6},
+          {format: 'sint32x3', offset: 4, shaderLocation: 18},
+          {format: 'sint8x4', offset: 168, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 512, shaderLocation: 1},
+          {format: 'float16x4', offset: 208, shaderLocation: 22},
+          {format: 'snorm8x4', offset: 48, shaderLocation: 23},
+        ],
+      },
+      {
+        arrayStride: 1808,
+        attributes: [
+          {format: 'uint16x2', offset: 0, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 88, shaderLocation: 20},
+          {format: 'unorm10-10-10-2', offset: 76, shaderLocation: 8},
+          {format: 'float32x2', offset: 4, shaderLocation: 16},
+          {format: 'uint8x2', offset: 404, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let offscreenCanvas35 = new OffscreenCanvas(765, 914);
+try {
+offscreenCanvas35.getContext('bitmaprenderer');
+} catch {}
+let canvas31 = document.createElement('canvas');
+let shaderModule28 = device1.createShaderModule({
+  label: '\u70dd\u0669\u0377\u96d3\u{1f8de}\u0f7e\u0f67\u{1f8f2}',
+  code: `@group(0) @binding(3155)
+var<storage, read_write> function17: array<u32>;
+@group(0) @binding(2376)
+var<storage, read_write> n17: array<u32>;
+
+@compute @workgroup_size(3, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S29 {
+  @location(86) f0: vec4<i32>,
+  @location(40) f1: vec2<i32>,
+  @location(98) f2: f16,
+  @builtin(sample_mask) f3: u32
+}
+
+@fragment
+fn fragment0(a0: S29, @location(20) a1: vec4<i32>) -> @location(200) vec4<u32> {
+return vec4<u32>();
+}
+
+struct S28 {
+  @location(0) f0: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(39) f380: vec4<f16>,
+  @location(40) f381: vec2<i32>,
+  @location(102) f382: vec3<u32>,
+  @location(14) f383: vec4<i32>,
+  @location(89) f384: i32,
+  @location(83) f385: vec4<i32>,
+  @location(92) f386: i32,
+  @location(56) f387: u32,
+  @location(54) f388: vec2<f32>,
+  @location(84) f389: f16,
+  @location(98) f390: f16,
+  @location(20) f391: vec4<i32>,
+  @location(63) f392: vec3<i32>,
+  @location(38) f393: vec2<f32>,
+  @location(94) f394: i32,
+  @builtin(position) f395: vec4<f32>,
+  @location(93) f396: f16,
+  @location(109) f397: vec4<i32>,
+  @location(43) f398: vec3<i32>,
+  @location(96) f399: vec2<i32>,
+  @location(99) f400: i32,
+  @location(35) f401: vec3<u32>,
+  @location(49) f402: vec3<u32>,
+  @location(17) f403: vec4<f32>,
+  @location(29) f404: vec2<f32>,
+  @location(78) f405: f32,
+  @location(42) f406: i32,
+  @location(97) f407: vec3<f16>,
+  @location(90) f408: vec4<f32>,
+  @location(86) f409: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(20) a0: vec2<u32>, a1: S28, @location(22) a2: f32, @location(2) a3: vec2<f32>, @location(9) a4: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture105 = device1.createTexture({
+  label: '\u{1f980}\u{1fbea}\u01d1\u006d\u{1fbbb}\ubf0d',
+  size: {width: 75, height: 3, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16uint'],
+});
+let texture106 = gpuCanvasContext22.getCurrentTexture();
+let renderPassEncoder36 = commandEncoder121.beginRenderPass({
+  label: '\u0fca\u0434\u3a3e\u018d',
+  colorAttachments: [{
+  view: textureView143,
+  depthSlice: 1,
+  clearValue: { r: -613.9, g: 843.4, b: -312.2, a: -455.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet52,
+  maxDrawCount: 99728244,
+});
+let externalTexture62 = device1.importExternalTexture({source: video27, colorSpace: 'srgb'});
+try {
+renderPassEncoder11.beginOcclusionQuery(780);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer40, 2_832_914_280);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(13, 227, 76_614_002, 113_171_772, 824_362_024);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline86);
+} catch {}
+let promise44 = buffer34.mapAsync(GPUMapMode.READ, 471936, 272628);
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture56,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture72,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 29, height: 2, depthOrArrayLayers: 3});
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 3_183_889 */
+{offset: 532, bytesPerRow: 1069, rowsPerImage: 96}, {width: 295, height: 8, depthOrArrayLayers: 32});
+} catch {}
+let bindGroup48 = device1.createBindGroup({
+  label: '\u{1ff4b}\u4589\uc538\u91ba\u7dee\u0e78\u0d59\u2710\u{1fa37}\u0501\uabfa',
+  layout: bindGroupLayout27,
+  entries: [{binding: 8217, resource: {buffer: buffer30, offset: 76800, size: 408}}],
+});
+let querySet62 = device1.createQuerySet({type: 'occlusion', count: 372});
+let textureView147 = texture55.createView({label: '\u0416\u8530\u01dd\u5256\u01d9', baseMipLevel: 4});
+let computePassEncoder53 = commandEncoder122.beginComputePass();
+try {
+renderPassEncoder14.executeBundles([renderBundle47]);
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant({ r: 811.8, g: 647.8, b: 805.7, a: -527.5, });
+} catch {}
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer31, 2_182_699_097);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer26, 387_624_953);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline68);
+} catch {}
+let pipeline107 = device1.createComputePipeline({
+  label: '\u{1fc5d}\u0ae7\u08b6\u43c1\u06c5\u0bc1\ub357\u8b13',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule16, entryPoint: 'compute0'},
+});
+let pipeline108 = device1.createRenderPipeline({
+  label: '\u{1fb7a}\u9bba\u0ac2',
+  layout: pipelineLayout16,
+  multisample: {count: 4, mask: 0xc74d1f5},
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2788,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 152, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 96, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 160, shaderLocation: 22},
+          {format: 'unorm8x4', offset: 244, shaderLocation: 21},
+          {format: 'unorm8x4', offset: 740, shaderLocation: 0},
+          {format: 'sint32x4', offset: 400, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 812, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 52, shaderLocation: 5},
+          {format: 'uint32x4', offset: 516, shaderLocation: 4},
+          {format: 'sint8x4', offset: 776, shaderLocation: 23},
+          {format: 'float32x3', offset: 72, shaderLocation: 1},
+          {format: 'uint8x2', offset: 22, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 6316,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 192, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 48, shaderLocation: 15},
+          {format: 'sint16x2', offset: 620, shaderLocation: 18},
+          {format: 'snorm8x2', offset: 746, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 2024,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 80, shaderLocation: 12},
+          {format: 'float32x2', offset: 356, shaderLocation: 20},
+          {format: 'uint16x2', offset: 920, shaderLocation: 8},
+          {format: 'float32', offset: 4, shaderLocation: 10},
+          {format: 'uint8x4', offset: 60, shaderLocation: 13},
+          {format: 'sint8x2', offset: 160, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+});
+let gpuCanvasContext27 = canvas31.getContext('webgpu');
+document.body.prepend(video8);
+try {
+  await promise44;
+} catch {}
+let shaderModule29 = device1.createShaderModule({
+  label: '\ufb85\u62ae\u{1f747}\u0884\u2a36\ube61\u{1fe75}\u6952\uea73\ua00c',
+  code: `@group(2) @binding(8384)
+var<storage, read_write> local14: array<u32>;
+@group(3) @binding(1281)
+var<storage, read_write> global15: array<u32>;
+@group(0) @binding(2376)
+var<storage, read_write> n18: array<u32>;
+@group(2) @binding(5282)
+var<storage, read_write> parameter16: array<u32>;
+@group(4) @binding(346)
+var<storage, read_write> n19: array<u32>;
+@group(0) @binding(3155)
+var<storage, read_write> n20: array<u32>;
+
+@compute @workgroup_size(1, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S31 {
+  @location(13) f0: vec2<u32>,
+  @location(14) f1: vec3<f32>,
+  @location(27) f2: vec4<u32>,
+  @location(18) f3: f32,
+  @location(77) f4: i32,
+  @location(58) f5: vec2<f16>,
+  @location(63) f6: f16,
+  @location(84) f7: vec2<f32>,
+  @location(43) f8: vec2<i32>,
+  @location(34) f9: vec4<f16>,
+  @location(106) f10: vec2<i32>,
+  @builtin(sample_index) f11: u32,
+  @location(108) f12: f16,
+  @location(81) f13: vec4<u32>,
+  @builtin(front_facing) f14: bool
+}
+
+@fragment
+fn fragment0(@location(97) a0: u32, @location(39) a1: vec4<f16>, @location(35) a2: vec3<u32>, @location(46) a3: vec4<u32>, @location(70) a4: u32, @builtin(sample_mask) a5: u32, @location(5) a6: vec3<u32>, @location(89) a7: vec3<i32>, @location(20) a8: vec4<u32>, a9: S31, @location(61) a10: vec4<u32>, @location(25) a11: u32, @location(110) a12: vec2<i32>, @location(33) a13: vec3<i32>, @location(101) a14: vec4<f16>, @location(32) a15: vec4<u32>, @builtin(position) a16: vec4<f32>) -> @location(200) vec2<u32> {
+return vec2<u32>();
+}
+
+struct S30 {
+  @location(12) f0: f16,
+  @location(7) f1: f32,
+  @location(11) f2: vec3<u32>,
+  @builtin(vertex_index) f3: u32,
+  @location(18) f4: vec3<f32>,
+  @location(23) f5: vec2<u32>,
+  @location(1) f6: vec4<f32>,
+  @location(15) f7: u32
+}
+struct VertexOutput0 {
+  @location(43) f410: vec2<i32>,
+  @location(101) f411: vec4<f16>,
+  @location(18) f412: f32,
+  @location(61) f413: vec4<u32>,
+  @location(106) f414: vec2<i32>,
+  @builtin(position) f415: vec4<f32>,
+  @location(110) f416: vec2<i32>,
+  @location(34) f417: vec4<f16>,
+  @location(20) f418: vec4<u32>,
+  @location(63) f419: f16,
+  @location(77) f420: i32,
+  @location(27) f421: vec4<u32>,
+  @location(39) f422: vec4<f16>,
+  @location(81) f423: vec4<u32>,
+  @location(13) f424: vec2<u32>,
+  @location(70) f425: u32,
+  @location(33) f426: vec3<i32>,
+  @location(35) f427: vec3<u32>,
+  @location(25) f428: u32,
+  @location(46) f429: vec4<u32>,
+  @location(58) f430: vec2<f16>,
+  @location(32) f431: vec4<u32>,
+  @location(5) f432: vec3<u32>,
+  @location(108) f433: f16,
+  @location(97) f434: u32,
+  @location(14) f435: vec3<f32>,
+  @location(89) f436: vec3<i32>,
+  @location(84) f437: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec2<i32>, @location(0) a1: vec3<u32>, @location(4) a2: vec3<f32>, @location(10) a3: f16, @location(14) a4: vec3<i32>, @location(6) a5: vec4<f16>, @builtin(instance_index) a6: u32, @location(16) a7: vec3<u32>, a8: S30, @location(5) a9: vec3<f16>, @location(13) a10: vec3<u32>, @location(9) a11: vec4<f32>, @location(17) a12: f32, @location(21) a13: vec2<i32>, @location(20) a14: vec3<u32>, @location(2) a15: f16, @location(3) a16: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup49 = device1.createBindGroup({label: '\udfcd\ubde2\uff7b', layout: bindGroupLayout36, entries: []});
+let pipelineLayout17 = device1.createPipelineLayout({label: '\u49d1\uc4ac\u{1fb09}\u00db\u0ef7\u0f8b', bindGroupLayouts: [bindGroupLayout25]});
+let sampler80 = device1.createSampler({
+  label: '\u{1f9d7}\u069e\u0f60\u{1ff16}\u071c\u0710\u05cc\u0004',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  lodMinClamp: 39.36,
+  lodMaxClamp: 61.40,
+});
+try {
+computePassEncoder41.setPipeline(pipeline94);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+renderPassEncoder36.setStencilReference(1092);
+} catch {}
+try {
+renderPassEncoder22.draw(353, 138, 801_014_960, 992_628_097);
+} catch {}
+try {
+renderPassEncoder28.drawIndexed(89, 151, 406_059_853, 49_605_863, 338_213_179);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(9, buffer24, 5520, 139);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(2, bindGroup38);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(8, buffer24, 4276, 101);
+} catch {}
+try {
+renderBundleEncoder29.insertDebugMarker('\u{1fbca}');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture78,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer3), /* required buffer size: 437 */
+{offset: 381}, {width: 14, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline109 = device1.createRenderPipeline({
+  label: '\u0d01\u{1fe12}\u6b3b\u9499\ub368\u9e89\u44c2\u051f\u07a7',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x45a4716f},
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {failOp: 'zero', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    stencilReadMask: 3598714232,
+    stencilWriteMask: 4075288972,
+    depthBias: -924996177,
+    depthBiasClamp: 541.0528419377171,
+  },
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1592,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 444, shaderLocation: 4},
+          {format: 'float16x4', offset: 504, shaderLocation: 9},
+          {format: 'sint8x4', offset: 188, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 36, shaderLocation: 1},
+          {format: 'float32', offset: 48, shaderLocation: 5},
+          {format: 'sint8x4', offset: 4, shaderLocation: 20},
+          {format: 'float32x4', offset: 220, shaderLocation: 15},
+          {format: 'uint16x2', offset: 80, shaderLocation: 10},
+          {format: 'uint32x2', offset: 1584, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 100, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 148, shaderLocation: 0},
+          {format: 'float16x2', offset: 64, shaderLocation: 14},
+          {format: 'sint32x2', offset: 24, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 72, shaderLocation: 11},
+          {format: 'float16x4', offset: 88, shaderLocation: 19},
+          {format: 'float16x2', offset: 296, shaderLocation: 17},
+          {format: 'sint16x2', offset: 464, shaderLocation: 12},
+          {format: 'snorm8x2', offset: 88, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 292, shaderLocation: 22},
+        ],
+      },
+    ],
+  },
+});
+let canvas32 = document.createElement('canvas');
+let texture107 = device1.createTexture({
+  label: '\u8124\uae7a\u286e\u525a\u6b01\u{1f7f2}\u0eb4\u{1f92d}',
+  size: [75, 3, 7],
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let textureView148 = texture106.createView({});
+let externalTexture63 = device1.importExternalTexture({label: '\u9481\ua417', source: videoFrame1});
+try {
+computePassEncoder39.dispatchWorkgroups(5);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(0, 0, 6, 1);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+let promise45 = buffer36.mapAsync(GPUMapMode.READ, 0, 10072);
+try {
+gpuCanvasContext26.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 512, new Float32Array(59862), 40176, 496);
+} catch {}
+let buffer41 = device1.createBuffer({
+  label: '\u0ec3\u55cd\u{1fd9c}\u0ab8\u42fc\u09a5\u0a21\u64fc',
+  size: 320488,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let texture108 = device1.createTexture({
+  label: '\u5c9f\u0246\u{1fc63}\u0af0',
+  size: {width: 300, height: 12, depthOrArrayLayers: 1},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView149 = texture53.createView({label: '\u0669\u3e2e'});
+try {
+renderPassEncoder28.setBlendConstant({ r: -139.9, g: -987.6, b: 517.4, a: -281.4, });
+} catch {}
+try {
+renderPassEncoder11.setViewport(363.7, 0.1633, 376.3, 0.6334, 0.5629, 0.9757);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(53);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexedIndirect(buffer41, 104492);
+} catch {}
+try {
+renderBundleEncoder42.drawIndirect(buffer41, 47476);
+} catch {}
+let pipeline110 = device1.createRenderPipeline({
+  label: '\uf911\ue0e8\u20aa\u03af\uc92a\u9cfe\u07ce',
+  layout: pipelineLayout16,
+  fragment: {module: shaderModule26, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16uint'}]},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'equal', failOp: 'invert', depthFailOp: 'invert', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 3609532432,
+    stencilWriteMask: 4294967295,
+    depthBiasSlopeScale: 454.33769011155584,
+  },
+  vertex: {
+    module: shaderModule26,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 3368,
+        attributes: [
+          {format: 'uint32', offset: 368, shaderLocation: 23},
+          {format: 'snorm16x4', offset: 380, shaderLocation: 22},
+          {format: 'sint32', offset: 1300, shaderLocation: 19},
+          {format: 'float32x3', offset: 4, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 116, shaderLocation: 17},
+          {format: 'sint8x4', offset: 268, shaderLocation: 13},
+          {format: 'sint32x3', offset: 620, shaderLocation: 8},
+          {format: 'uint8x4', offset: 340, shaderLocation: 4},
+          {format: 'uint8x4', offset: 1084, shaderLocation: 5},
+          {format: 'sint32x4', offset: 1972, shaderLocation: 15},
+          {format: 'float32', offset: 1708, shaderLocation: 7},
+          {format: 'unorm10-10-10-2', offset: 328, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 132, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 200, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 1182, shaderLocation: 9},
+          {format: 'uint8x4', offset: 308, shaderLocation: 6},
+          {format: 'float16x2', offset: 560, shaderLocation: 21},
+          {format: 'sint16x4', offset: 1144, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 16, shaderLocation: 20},
+          {format: 'float32', offset: 624, shaderLocation: 16},
+        ],
+      },
+      {arrayStride: 19932, attributes: []},
+      {
+        arrayStride: 4112,
+        attributes: [
+          {format: 'sint32x2', offset: 56, shaderLocation: 18},
+          {format: 'sint16x4', offset: 560, shaderLocation: 12},
+          {format: 'sint8x4', offset: 1272, shaderLocation: 2},
+          {format: 'uint8x2', offset: 522, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+});
+let imageData49 = new ImageData(252, 136);
+let bindGroupLayout39 = pipeline73.getBindGroupLayout(0);
+let querySet63 = device1.createQuerySet({type: 'occlusion', count: 3543});
+let texture109 = device1.createTexture({
+  label: '\ue38f\uf4cf\u7bff\u0275\u74f1',
+  size: {width: 600, height: 24, depthOrArrayLayers: 56},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let textureView150 = texture69.createView({
+  label: '\u0902\u94ec\ub1e0\uc2ad\u{1f8fe}\u0a03\ufecb\ud174\u0144\u1221\u711d',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+});
+let sampler81 = device1.createSampler({
+  label: '\u0e64\u000d',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.47,
+  lodMaxClamp: 94.74,
+  compare: 'less-equal',
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder53.end();
+} catch {}
+try {
+renderPassEncoder35.beginOcclusionQuery(2366);
+} catch {}
+try {
+renderPassEncoder23.setBlendConstant({ r: 663.2, g: 444.0, b: 584.3, a: -507.4, });
+} catch {}
+try {
+renderPassEncoder24.draw(97, 70, 383_803_065, 386_818_336);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer26, 1_315_210_471);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(8, buffer41, 156636, 17086);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder52.draw(31, 134, 406_660_526, 290_314_739);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(6, buffer24, 4284, 595);
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture72,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 22, height: 2, depthOrArrayLayers: 3});
+} catch {}
+let promise46 = adapter3.requestDevice({label: '\u098b\u00ce\u945e\u{1f701}\u{1f9bd}\u4669\ud0c6\u{1f605}\ud7ff'});
+let gpuCanvasContext28 = canvas32.getContext('webgpu');
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let pipelineLayout18 = device1.createPipelineLayout({label: '\u0fde\u0f78\u{1ff75}\ua9e9\u8652\u7d76', bindGroupLayouts: []});
+let commandEncoder123 = device1.createCommandEncoder();
+let sampler82 = device1.createSampler({
+  label: '\u{1fb5b}\ue34b\u00dc\u07e3\u6053\uaa3a\u45ac\u0a51',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 34.21,
+  lodMaxClamp: 37.75,
+});
+try {
+renderPassEncoder11.setBindGroup(6, bindGroup28, new Uint32Array(5065), 607, 0);
+} catch {}
+try {
+renderPassEncoder20.draw(69, 443);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(7, buffer41);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(4, bindGroup35);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexed(225, 5, 834_095_063, 691_594_203, 140_674_654);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexedIndirect(buffer41, 13072);
+} catch {}
+try {
+renderBundleEncoder42.drawIndirect(buffer41, 49588);
+} catch {}
+try {
+renderBundleEncoder53.setPipeline(pipeline65);
+} catch {}
+let commandBuffer21 = commandEncoder123.finish({label: '\u2786\u{1f801}\u6564\u342a\u4afa\ub57b'});
+let texture110 = device1.createTexture({
+  label: '\u{1ffb2}\u3476\ubc3d\ue2be\ub7f9\u0900\u08d1\u9766\u10d4\u{1fa42}\u0612',
+  size: [144],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler83 = device1.createSampler({
+  label: '\u{1fda2}\u06e5\u948e',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.64,
+  maxAnisotropy: 6,
+});
+let externalTexture64 = device1.importExternalTexture({label: '\ufced\uacb3\u0416\u49d0', source: videoFrame17, colorSpace: 'srgb'});
+try {
+computePassEncoder39.dispatchWorkgroups(1, 4);
+} catch {}
+try {
+renderPassEncoder19.draw(131, 80, 343_402_541, 173_407_060);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+renderBundleEncoder40.draw(501, 992, 688_510_967, 329_323_409);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexedIndirect(buffer41, 111124);
+} catch {}
+let promise47 = buffer38.mapAsync(GPUMapMode.WRITE, 0, 167572);
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 23248 */
+  offset: 23248,
+  bytesPerRow: 256,
+  buffer: buffer29,
+}, {
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder122.resolveQuerySet(querySet49, 1129, 661, buffer28, 25344);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 432, new DataView(new ArrayBuffer(6472)), 2417, 8);
+} catch {}
+let shaderModule30 = device1.createShaderModule({
+  code: `@group(2) @binding(5282)
+var<storage, read_write> n21: array<u32>;
+@group(0) @binding(3155)
+var<storage, read_write> function18: array<u32>;
+@group(4) @binding(346)
+var<storage, read_write> global16: array<u32>;
+@group(2) @binding(8384)
+var<storage, read_write> n22: array<u32>;
+@group(3) @binding(1281)
+var<storage, read_write> global17: array<u32>;
+
+@compute @workgroup_size(7, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S33 {
+  @location(34) f0: vec3<u32>,
+  @location(56) f1: vec4<f32>,
+  @location(76) f2: vec2<f32>,
+  @location(19) f3: i32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec3<u32>
+}
+
+@fragment
+fn fragment0(a0: S33, @location(52) a1: vec4<f32>, @builtin(sample_mask) a2: u32, @location(20) a3: vec4<i32>, @location(55) a4: f32, @location(27) a5: vec4<f16>, @location(41) a6: vec2<i32>, @location(17) a7: vec3<i32>, @location(32) a8: f32, @builtin(front_facing) a9: bool, @location(102) a10: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S32 {
+  @location(13) f0: vec2<f32>,
+  @location(2) f1: vec2<i32>,
+  @location(21) f2: i32,
+  @location(16) f3: vec4<f32>,
+  @location(18) f4: vec4<f16>,
+  @location(1) f5: vec2<f16>,
+  @location(20) f6: vec2<i32>,
+  @location(0) f7: f16,
+  @location(8) f8: vec3<u32>,
+  @location(4) f9: f32,
+  @location(22) f10: vec2<u32>,
+  @location(17) f11: vec4<i32>,
+  @location(10) f12: f32,
+  @location(11) f13: vec3<f32>,
+  @location(6) f14: vec2<i32>,
+  @location(9) f15: vec4<i32>,
+  @location(5) f16: vec4<f16>,
+  @location(3) f17: vec3<u32>,
+  @location(15) f18: vec4<f16>,
+  @location(7) f19: vec2<i32>,
+  @location(12) f20: f16,
+  @location(14) f21: i32,
+  @location(19) f22: vec3<u32>,
+  @location(23) f23: f32
+}
+struct VertexOutput0 {
+  @location(19) f438: i32,
+  @location(28) f439: vec4<f32>,
+  @location(34) f440: vec3<u32>,
+  @location(56) f441: vec4<f32>,
+  @location(95) f442: vec4<f16>,
+  @location(41) f443: vec2<i32>,
+  @location(102) f444: vec2<u32>,
+  @location(27) f445: vec4<f16>,
+  @builtin(position) f446: vec4<f32>,
+  @location(30) f447: vec4<f16>,
+  @location(20) f448: vec4<i32>,
+  @location(55) f449: f32,
+  @location(32) f450: f32,
+  @location(51) f451: vec2<i32>,
+  @location(106) f452: vec3<f32>,
+  @location(36) f453: vec4<f16>,
+  @location(39) f454: vec2<f32>,
+  @location(68) f455: vec4<u32>,
+  @location(52) f456: vec4<f32>,
+  @location(59) f457: vec3<i32>,
+  @location(76) f458: vec2<f32>,
+  @location(17) f459: vec3<i32>,
+  @location(24) f460: vec3<f32>,
+  @location(83) f461: vec2<f32>,
+  @location(91) f462: vec4<f32>
+}
+
+@vertex
+fn vertex0(a0: S32, @builtin(vertex_index) a1: u32, @builtin(instance_index) a2: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet64 = device1.createQuerySet({
+  label: '\u0dc9\u{1fc42}\u{1f694}\ub3bd\uc6bc\u057e\u015f\u{1fa94}\u068c\ud330',
+  type: 'occlusion',
+  count: 3666,
+});
+let commandBuffer22 = commandEncoder122.finish({label: '\u72af\u2d52\ub863'});
+let texture111 = device1.createTexture({
+  label: '\u{1ff5c}\u1811\u{1f60c}\u002d\ubdca\uf567\ucc4e',
+  size: [150, 6, 1],
+  mipLevelCount: 5,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder22.drawIndirect(buffer29, 424_074_085);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexed(552, 831, 768_280_502, 360_075_706, 96_381_505);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexedIndirect(buffer41, 2848);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer8), /* required buffer size: 2_392_981 */
+{offset: 176, bytesPerRow: 305, rowsPerImage: 89}, {width: 20, height: 14, depthOrArrayLayers: 89});
+} catch {}
+let commandEncoder124 = device1.createCommandEncoder({label: '\u0dd3\u{1fd73}\u4bc6\uf649\u07e9\u0233\uaf81\u006e'});
+let texture112 = device1.createTexture({
+  label: '\ud753\u314d\u664b\u192e\ud29a',
+  size: {width: 288, height: 64, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  sampleCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let textureView151 = texture95.createView({});
+let renderPassEncoder37 = commandEncoder124.beginRenderPass({
+  label: '\u0072\u{1ffd2}\uba46\uce16\u{1f757}\u839c\u{1f879}',
+  colorAttachments: [{
+  view: textureView94,
+  depthSlice: 1,
+  clearValue: { r: -292.7, g: 749.6, b: 463.1, a: 407.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet54,
+});
+let renderBundle75 = renderBundleEncoder51.finish({label: '\u0e53\u7be5\ucf7c\u2388\u{1fe20}\ud579\u{1f704}\u{1fa6a}\u6f93\uec0d'});
+let sampler84 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.66,
+  lodMaxClamp: 87.05,
+  compare: 'less-equal',
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.setViewport(674.9, 0.7221, 71.21, 0.2634, 0.03654, 0.7845);
+} catch {}
+try {
+renderPassEncoder22.drawIndexed(436);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer35, 512_737_892);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline86);
+} catch {}
+try {
+renderBundleEncoder48.drawIndirect(buffer41, 7736);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline64);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(0)), /* required buffer size: 350_080 */
+{offset: 976, bytesPerRow: 137, rowsPerImage: 283}, {width: 7, height: 2, depthOrArrayLayers: 10});
+} catch {}
+let commandEncoder125 = device1.createCommandEncoder({label: '\u1855\u5ffa\u8498\u1221\ud04f'});
+let texture113 = gpuCanvasContext9.getCurrentTexture();
+let textureView152 = texture86.createView({baseMipLevel: 4, mipLevelCount: 2});
+let renderBundle76 = renderBundleEncoder54.finish();
+try {
+computePassEncoder39.setPipeline(pipeline101);
+} catch {}
+try {
+renderPassEncoder33.setScissorRect(12, 5, 3, 7);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(75, 138, 405_253_048, 644_049_621, 110_636_364);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer28, 111_807_105);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(11, buffer24, 0, 2513);
+} catch {}
+try {
+renderBundleEncoder29.draw(121, 146);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexed(411, 16, 1_060_917_791);
+} catch {}
+try {
+renderBundleEncoder31.drawIndirect(buffer41, 30288);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(9, buffer41);
+} catch {}
+try {
+commandEncoder125.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2064 */
+  offset: 2016,
+  buffer: buffer29,
+}, {
+  texture: texture70,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 24, height: 8, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+}, new ArrayBuffer(798_997), /* required buffer size: 798_997 */
+{offset: 868, bytesPerRow: 257, rowsPerImage: 194}, {width: 36, height: 2, depthOrArrayLayers: 17});
+} catch {}
+try {
+window.someLabel = pipeline97.label;
+} catch {}
+let bindGroupLayout40 = device1.createBindGroupLayout({
+  label: '\u8873\u432d\uce5e\u5a9b',
+  entries: [
+    {binding: 4792, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 3954, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 6649,
+      visibility: 0,
+      buffer: { type: 'storage', minBindingSize: 55587940, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder126 = device1.createCommandEncoder({});
+let commandBuffer23 = commandEncoder125.finish();
+let renderPassEncoder38 = commandEncoder126.beginRenderPass({
+  colorAttachments: [{
+  view: textureView94,
+  depthSlice: 0,
+  clearValue: { r: 658.0, g: 741.8, b: 193.6, a: 903.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet49,
+  maxDrawCount: 546006108,
+});
+let renderBundleEncoder55 = device1.createRenderBundleEncoder({label: '\u{1fe62}\ub5f0\ue5ed', colorFormats: ['rg16uint']});
+let sampler85 = device1.createSampler({
+  label: '\u8c03\u05eb\u9207\udb2f\u77ef\ua310',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 71.92,
+  lodMaxClamp: 89.40,
+});
+try {
+renderPassEncoder20.drawIndexed(233, 36, 779_333_043, 108_935_771, 782_607_947);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline87);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexedIndirect(buffer41, 6232);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline86);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(5, buffer41);
+} catch {}
+let pipeline111 = device1.createRenderPipeline({
+  label: '\u523e\u0ece\uc7a6\uf312\u{1fe5f}\u749b\uca95\ua449\u{1fd16}\u0c57\ue283',
+  layout: pipelineLayout18,
+  fragment: {
+  module: shaderModule21,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'never', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 2242348472,
+    depthBias: -1502733749,
+    depthBiasSlopeScale: 703.41912542933,
+  },
+  vertex: {
+    module: shaderModule21,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9372,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 3396, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 2252, shaderLocation: 18},
+          {format: 'sint16x2', offset: 380, shaderLocation: 5},
+          {format: 'uint8x2', offset: 2192, shaderLocation: 13},
+          {format: 'uint8x4', offset: 24, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 15748, shaderLocation: 10},
+          {format: 'float16x4', offset: 1424, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 7456,
+        attributes: [
+          {format: 'uint8x2', offset: 806, shaderLocation: 19},
+          {format: 'float32x2', offset: 3476, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 636, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: false},
+});
+let shaderModule31 = device1.createShaderModule({
+  label: '\u4f25\u0be5\u3318\u63a8\u0618\u45b7\u8b80\u0944\u{1fd3d}\u68c0\u0f01',
+  code: `@group(0) @binding(4292)
+var<storage, read_write> parameter17: array<u32>;
+@group(0) @binding(8803)
+var<storage, read_write> local15: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(3) f1: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S34 {
+  @location(4) f0: vec3<f16>,
+  @location(10) f1: vec4<f16>,
+  @location(22) f2: vec4<f32>,
+  @location(20) f3: vec2<f32>,
+  @location(12) f4: vec3<u32>,
+  @location(5) f5: vec4<i32>,
+  @location(1) f6: vec3<u32>,
+  @location(13) f7: vec2<u32>,
+  @location(7) f8: vec4<i32>,
+  @location(23) f9: vec2<f16>,
+  @builtin(vertex_index) f10: u32,
+  @location(16) f11: vec3<f16>,
+  @location(6) f12: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec3<f32>, @location(2) a1: vec2<u32>, @location(19) a2: vec4<i32>, @location(17) a3: vec4<i32>, a4: S34, @location(3) a5: vec4<f16>, @location(9) a6: vec3<i32>, @location(8) a7: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundleEncoder56 = device1.createRenderBundleEncoder({label: '\u{1ffd1}\u0aea\u5add\u{1ff6d}\uc784\ubdc2', colorFormats: ['rg16uint']});
+let sampler86 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 96.19,
+});
+try {
+computePassEncoder49.setPipeline(pipeline61);
+} catch {}
+try {
+renderPassEncoder11.draw(249, 24, 311_559_262, 977_487_302);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(119, 459, 369_717_292);
+} catch {}
+try {
+renderBundleEncoder52.draw(159, 98, 1_382_463_179, 424_479_111);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(357, 39);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexedIndirect(buffer41, 95636);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(75, undefined, 1265384210, 1174296364);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 3},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 10_856_480 */
+{offset: 792, bytesPerRow: 3008, rowsPerImage: 212}, {width: 353, height: 5, depthOrArrayLayers: 18});
+} catch {}
+let pipeline112 = await device1.createComputePipelineAsync({
+  label: '\u0403\uc036',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule26, entryPoint: 'compute0', constants: {}},
+});
+let device2 = await promise46;
+canvas13.width = 987;
+let imageData50 = new ImageData(124, 104);
+let videoFrame27 = new VideoFrame(video9, {timestamp: 0});
+try {
+window.someLabel = sampler67.label;
+} catch {}
+try {
+computePassEncoder46.setBindGroup(5, bindGroup27, new Uint32Array(3791), 643, 0);
+} catch {}
+try {
+renderPassEncoder30.beginOcclusionQuery(175);
+} catch {}
+try {
+renderPassEncoder36.setScissorRect(22, 0, 13, 0);
+} catch {}
+try {
+renderPassEncoder18.setViewport(686.6, 0.3020, 120.0, 0.4273, 0.7820, 0.8918);
+} catch {}
+try {
+renderPassEncoder20.draw(282, 33);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer41, 466_467_126);
+} catch {}
+try {
+renderPassEncoder28.drawIndirect(buffer41, 476_704_398);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(8, buffer41, 162980, 29329);
+} catch {}
+try {
+  await promise47;
+} catch {}
+let offscreenCanvas36 = new OffscreenCanvas(909, 326);
+let imageData51 = new ImageData(236, 84);
+try {
+  await promise45;
+} catch {}
+let texture114 = device2.createTexture({
+  label: '\ud047\u5076\udfd1\u9adb\u05fd\u4887\u86c9\u083a\u92c3\u83aa\ud243',
+  size: [570, 3, 43],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg32uint'],
+});
+let bindGroupLayout41 = device2.createBindGroupLayout({
+  label: '\u08b0\u0e99\u74da',
+  entries: [
+    {
+      binding: 479,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 103832517, hasDynamicOffset: false },
+    },
+  ],
+});
+let texture115 = device2.createTexture({
+  label: '\u03ba\u{1f9d9}\u87ac\u02fb\ue7c4\u1e31\u10fb\u02b4\u{1fb5f}\u{1ff76}\u089d',
+  size: {width: 302},
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView153 = texture114.createView({
+  label: '\u1225\u8c05\u98f2\u0049\u07a4\u5b44\u03fe\u0ef7\uc670\u07d5\u3e4a',
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let canvas33 = document.createElement('canvas');
+let commandEncoder127 = device2.createCommandEncoder();
+let textureView154 = texture115.createView({label: '\u5f22\u03e5\u{1fb29}\u0fb9\u{1fd9b}\u00da\u0682'});
+let renderBundleEncoder57 = device2.createRenderBundleEncoder({
+  label: '\ubafc\udf79\u03a1\u0ffe\u0582\u{1fe01}',
+  colorFormats: ['rg16uint'],
+  depthStencilFormat: 'depth24plus',
+  stencilReadOnly: true,
+});
+let sampler87 = device2.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.63,
+  lodMaxClamp: 90.39,
+  maxAnisotropy: 1,
+});
+let imageBitmap29 = await createImageBitmap(imageBitmap3);
+let bindGroupLayout42 = device2.createBindGroupLayout({
+  label: '\ufdde\ua305\ude89',
+  entries: [
+    {
+      binding: 179,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+try {
+device2.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer2), /* required buffer size: 391 */
+{offset: 391, bytesPerRow: 1199}, {width: 269, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView155 = texture56.createView({label: '\uf9c9\u{1fb7e}\u09ee\u72a4\u9e33', mipLevelCount: 2, arrayLayerCount: 1});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderPassEncoder35.beginOcclusionQuery(1435);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle70, renderBundle75, renderBundle58, renderBundle52, renderBundle57, renderBundle55, renderBundle69]);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant({ r: -487.3, g: -906.8, b: 334.7, a: -612.0, });
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(472, 1, 246, 0);
+} catch {}
+try {
+renderPassEncoder32.setViewport(10.52, 54.45, 244.2, 0.1594, 0.5038, 0.6060);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(438, 70);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer26, 1_232_859_446);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer41, 7924);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(10, buffer41, 253664, 39389);
+} catch {}
+let computePassEncoder54 = commandEncoder127.beginComputePass({label: '\u{1f916}\u67c2\u15f1\u{1f6a6}\u0884\u{1f625}\u{1fa99}\u{1f664}'});
+let renderBundle77 = renderBundleEncoder57.finish({label: '\u0b34\u3420\u000f'});
+let bindGroupLayout43 = device1.createBindGroupLayout({label: '\u0399\ufdf7\uf7a9\u{1fd08}\u44a9\u{1ff64}\u{1f969}\u4a4f', entries: []});
+let texture116 = device1.createTexture({
+  label: '\u55cc\u{1f817}\u08d0\u4318\u0e33\u048f',
+  size: [9072, 1, 85],
+  mipLevelCount: 11,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler88 = device1.createSampler({
+  label: '\u1e1a\u{1f84b}\u3111',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 33.10,
+  lodMaxClamp: 78.25,
+  maxAnisotropy: 2,
+});
+let externalTexture65 = device1.importExternalTexture({
+  label: '\u22d7\u09b9\u39eb\u0fd5\u02bb\u07aa\u0fe8\ud0a5\u{1fa2b}\u{1fe9a}\u4134',
+  source: video4,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder20.setStencilReference(2589);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(253, 379, 1_371_479_691);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(1, bindGroup47);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline86);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 112, new BigUint64Array(4764), 463, 76);
+} catch {}
+try {
+adapter2.label = '\u014f\u0d16\u00fa\uc18a\u{1f9de}\u97a6\ua4b3\ub9c1\ub103\u7168\u8ef3';
+} catch {}
+let textureView156 = texture112.createView({baseMipLevel: 3, mipLevelCount: 1});
+let renderBundleEncoder58 = device1.createRenderBundleEncoder({
+  label: '\u7060\u{1fa47}\ubde0\u{1fc52}\u0ccd',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder9.beginOcclusionQuery(41);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(11, buffer24, 488, 2312);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(4, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder40.draw(12, 274, 336_304_367, 591_537_927);
+} catch {}
+try {
+renderBundleEncoder52.drawIndirect(buffer41, 63372);
+} catch {}
+let pipeline113 = await device1.createRenderPipelineAsync({
+  label: '\u5cdb\u8c14\u7389',
+  layout: pipelineLayout17,
+  fragment: {
+  module: shaderModule28,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule28,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 10108, shaderLocation: 2},
+          {format: 'float32x3', offset: 1228, shaderLocation: 0},
+          {format: 'float16x4', offset: 452, shaderLocation: 22},
+          {format: 'snorm16x2', offset: 4564, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 35136,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 3586, shaderLocation: 20}],
+      },
+    ],
+  },
+});
+try {
+canvas33.getContext('webgpu');
+} catch {}
+let shaderModule32 = device0.createShaderModule({
+  label: '\u08ef\uafed\ua32d\u06fe\uec65\u0035',
+  code: `@group(1) @binding(821)
+var<storage, read_write> n23: array<u32>;
+@group(1) @binding(1876)
+var<storage, read_write> field14: array<u32>;
+@group(0) @binding(201)
+var<storage, read_write> function19: array<u32>;
+
+@compute @workgroup_size(2, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec3<u32>,
+  @location(2) f1: vec4<f32>,
+  @location(3) f2: vec4<f32>,
+  @location(1) f3: vec3<f32>,
+  @location(5) f4: vec2<i32>,
+  @builtin(sample_mask) f5: u32,
+  @location(0) f6: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(0) a0: vec3<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S35 {
+  @location(10) f0: vec4<f32>
+}
+struct VertexOutput0 {
+  @location(39) f463: vec2<i32>,
+  @location(7) f464: f32,
+  @location(0) f465: vec3<f16>,
+  @location(43) f466: vec3<u32>,
+  @location(36) f467: vec3<f16>,
+  @location(15) f468: vec2<i32>,
+  @location(28) f469: vec2<f16>,
+  @location(25) f470: vec2<f32>,
+  @location(30) f471: vec2<f16>,
+  @location(38) f472: f16,
+  @location(4) f473: vec3<f16>,
+  @location(18) f474: vec2<f16>,
+  @location(10) f475: vec4<f32>,
+  @location(21) f476: f16,
+  @location(26) f477: vec4<u32>,
+  @location(8) f478: vec2<u32>,
+  @location(31) f479: vec2<i32>,
+  @location(17) f480: vec4<f16>,
+  @builtin(position) f481: vec4<f32>,
+  @location(42) f482: vec3<f16>,
+  @location(35) f483: vec3<u32>,
+  @location(24) f484: vec3<i32>,
+  @location(6) f485: vec4<f16>,
+  @location(13) f486: vec2<u32>,
+  @location(40) f487: vec2<i32>,
+  @location(12) f488: vec2<f32>,
+  @location(20) f489: vec2<i32>,
+  @location(41) f490: vec2<f16>,
+  @location(29) f491: vec2<u32>,
+  @location(32) f492: vec2<i32>,
+  @location(27) f493: vec2<f16>,
+  @location(33) f494: vec3<f32>,
+  @location(3) f495: f32,
+  @location(23) f496: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2<i32>, @location(21) a1: vec3<f32>, @location(17) a2: vec2<f32>, @location(8) a3: vec4<f16>, @location(14) a4: vec2<u32>, @location(19) a5: vec2<i32>, @location(11) a6: f32, @location(22) a7: vec3<i32>, @location(6) a8: i32, @location(23) a9: u32, @location(18) a10: vec2<f32>, @location(5) a11: vec4<u32>, @location(0) a12: vec4<f16>, @location(20) a13: vec4<i32>, @builtin(vertex_index) a14: u32, @location(9) a15: vec2<f32>, @location(13) a16: vec2<i32>, @location(12) a17: vec4<i32>, @location(16) a18: f32, @location(2) a19: vec4<u32>, @location(15) a20: vec4<u32>, @location(4) a21: vec3<i32>, a22: S35, @location(7) a23: vec4<u32>, @location(3) a24: vec4<u32>, @builtin(instance_index) a25: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder128 = device0.createCommandEncoder();
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(1296);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setViewport(129.6, 0.2190, 2.766, 0.3402, 0.8987, 0.9977);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(6, bindGroup4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer20]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 809, height: 1, depthOrArrayLayers: 961}
+*/
+{
+  source: img13,
+  origin: { x: 28, y: 60 },
+  flipY: true,
+}, {
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 185, y: 0, z: 401},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline114 = device0.createComputePipeline({layout: pipelineLayout7, compute: {module: shaderModule5, entryPoint: 'compute0'}});
+document.body.prepend(img28);
+let imageData52 = new ImageData(152, 8);
+let pipelineLayout19 = device2.createPipelineLayout({label: '\u4673\u04dc\u2847\u48bd', bindGroupLayouts: [bindGroupLayout41, bindGroupLayout41]});
+let sampler89 = device2.createSampler({
+  label: '\u0807\u6d75\uc59d\u0346\u68f6\u3db4\u{1f616}\u3cee\u0361',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.69,
+  maxAnisotropy: 14,
+});
+let buffer42 = device1.createBuffer({label: '\ue300\ud457\u{1f708}\u{1fb55}', size: 100620, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder129 = device1.createCommandEncoder();
+let querySet65 = device1.createQuerySet({type: 'occlusion', count: 908});
+let textureView157 = texture82.createView({label: '\u{1ff73}\ucdb4'});
+let sampler90 = device1.createSampler({
+  label: '\u0c06\u40f5\u82d5\u4d1e\u{1fc04}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 79.80,
+  compare: 'greater',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder47.setBindGroup(4, bindGroup27, new Uint32Array(5462), 3426, 0);
+} catch {}
+try {
+computePassEncoder42.end();
+} catch {}
+try {
+renderPassEncoder19.drawIndexed(359, 419, 1_025_023_735, 116_694_609, 9_184_649);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder42.drawIndirect(buffer41, 133836);
+} catch {}
+try {
+renderBundleEncoder56.setPipeline(pipeline113);
+} catch {}
+try {
+commandEncoder91.clearBuffer(buffer27);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 1076, new BigUint64Array(39229), 28708, 72);
+} catch {}
+try {
+adapter2.label = '\uee1f\u0f80\u0bfd\u0147\ub90c';
+} catch {}
+let commandEncoder130 = device2.createCommandEncoder({label: '\u38ae\u5cbf\u{1f824}\u10f9\u9a9f\u6b98'});
+let renderBundle78 = renderBundleEncoder57.finish();
+try {
+gpuCanvasContext12.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let shaderModule33 = device2.createShaderModule({
+  label: '\u85de\ubcdb\u{1fa24}',
+  code: `@group(0) @binding(479)
+var<storage, read_write> field15: array<u32>;
+@group(1) @binding(479)
+var<storage, read_write> parameter18: array<u32>;
+
+@compute @workgroup_size(5, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @builtin(frag_depth) f1: f32,
+  @location(0) f2: vec4<u32>,
+  @location(5) f3: i32
+}
+
+@fragment
+fn fragment0(@location(3) a0: vec2<u32>, @location(14) a1: vec3<u32>, @location(13) a2: vec2<f32>, @location(10) a3: vec4<f16>, @location(9) a4: vec3<f32>, @location(2) a5: f16, @location(0) a6: vec3<f32>, @location(12) a7: vec3<u32>, @builtin(sample_mask) a8: u32, @location(4) a9: vec4<f32>, @builtin(front_facing) a10: bool, @location(8) a11: vec3<f16>, @location(7) a12: vec3<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S36 {
+  @location(5) f0: vec3<f32>,
+  @location(3) f1: f16,
+  @location(10) f2: u32,
+  @location(4) f3: vec3<f16>,
+  @location(14) f4: f16,
+  @location(8) f5: vec3<f16>,
+  @location(11) f6: u32,
+  @location(2) f7: i32
+}
+struct VertexOutput0 {
+  @location(12) f497: vec3<u32>,
+  @location(9) f498: vec3<f32>,
+  @location(1) f499: f32,
+  @location(3) f500: vec2<u32>,
+  @builtin(position) f501: vec4<f32>,
+  @location(0) f502: vec3<f32>,
+  @location(8) f503: vec3<f16>,
+  @location(10) f504: vec4<f16>,
+  @location(5) f505: vec3<f32>,
+  @location(4) f506: vec4<f32>,
+  @location(13) f507: vec2<f32>,
+  @location(6) f508: vec3<i32>,
+  @location(15) f509: vec3<f32>,
+  @location(14) f510: vec3<u32>,
+  @location(2) f511: f16,
+  @location(11) f512: vec3<f32>,
+  @location(7) f513: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec2<i32>, a1: S36, @location(7) a2: vec3<u32>, @location(0) a3: vec2<i32>, @location(1) a4: vec2<i32>, @location(12) a5: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet66 = device2.createQuerySet({type: 'occlusion', count: 3433});
+let texture117 = device2.createTexture({
+  label: '\u3aea\u4665\u0bf7\uca19\ua023\u{1fbe9}',
+  size: {width: 605, height: 48, depthOrArrayLayers: 320},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let renderBundleEncoder59 = device2.createRenderBundleEncoder({
+  label: '\u45bd\ub3b1\ue388\u{1ff89}\u33d6\u03ee\u{1f873}\ufba9\uefe0\u758e\u{1fabc}',
+  colorFormats: ['rg16uint'],
+  depthStencilFormat: 'depth24plus',
+});
+let sampler91 = device2.createSampler({
+  label: '\u9787\ubac9\u{1faa3}\u5c17\u{1f8ca}\u{1fc24}\u49b1\uda7a\u01e0\u{1ff69}',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 75.73,
+  compare: 'less',
+  maxAnisotropy: 3,
+});
+try {
+gpuCanvasContext5.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+window.someLabel = externalTexture42.label;
+} catch {}
+let buffer43 = device1.createBuffer({size: 224537, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandBuffer24 = commandEncoder129.finish({});
+let textureView158 = texture85.createView({label: '\u5537\ua52d\ub9da\u{1f89a}\u{1f7c5}\u0f21\u7260\u67c0', aspect: 'all'});
+let computePassEncoder55 = commandEncoder91.beginComputePass({label: '\u0f69\u{1f7c1}\u8df3'});
+let sampler92 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 96.89,
+});
+try {
+computePassEncoder40.setPipeline(pipeline104);
+} catch {}
+try {
+renderPassEncoder30.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle46, renderBundle56, renderBundle44, renderBundle67, renderBundle49, renderBundle67, renderBundle45]);
+} catch {}
+try {
+renderPassEncoder29.setScissorRect(1, 0, 0, 1);
+} catch {}
+try {
+renderPassEncoder15.draw(191, 81, 897_971_809, 473_747_059);
+} catch {}
+try {
+renderBundleEncoder48.draw(78);
+} catch {}
+canvas11.height = 3;
+let commandEncoder131 = device2.createCommandEncoder({label: '\u0512\u03a7\u{1fffb}\u8a64\u0861\u{1f741}\ucbf9'});
+let textureView159 = texture117.createView({label: '\u0754\u8e48\uc68d\u8c7e\u71d3\u3443\u{1fd70}', baseMipLevel: 3});
+let externalTexture66 = device2.importExternalTexture({
+  label: '\u1991\uec7a\u030f\u30f8\u1f26\u8115\u0cac\u{1f957}\ucf3b',
+  source: video33,
+  colorSpace: 'display-p3',
+});
+try {
+device2.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(24)), /* required buffer size: 405 */
+{offset: 405, bytesPerRow: 1376}, {width: 286, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline115 = await device2.createComputePipelineAsync({
+  label: '\u4128\u81b5\u{1fa6f}\ua31e',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule33, entryPoint: 'compute0'},
+});
+let pipeline116 = device2.createRenderPipeline({
+  layout: pipelineLayout19,
+  fragment: {module: shaderModule33, entryPoint: 'fragment0', targets: [{format: 'rg16uint', writeMask: 0}]},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less', depthFailOp: 'invert', passOp: 'invert'},
+    stencilBack: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp'},
+    stencilWriteMask: 387154,
+    depthBiasSlopeScale: 283.8319430332729,
+    depthBiasClamp: 41.58819032854353,
+  },
+  vertex: {
+    module: shaderModule33,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2048,
+        attributes: [
+          {format: 'float32', offset: 416, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 140, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 148,
+        attributes: [
+          {format: 'unorm16x4', offset: 12, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 20, shaderLocation: 12},
+          {format: 'sint8x4', offset: 0, shaderLocation: 1},
+          {format: 'uint32x3', offset: 136, shaderLocation: 10},
+          {format: 'sint8x4', offset: 36, shaderLocation: 6},
+          {format: 'uint32x3', offset: 24, shaderLocation: 7},
+          {format: 'float16x2', offset: 40, shaderLocation: 4},
+          {format: 'sint32x3', offset: 16, shaderLocation: 0},
+          {format: 'uint32x3', offset: 8, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 532,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32', offset: 132, shaderLocation: 2}],
+      },
+      {arrayStride: 0, attributes: [{format: 'snorm16x4', offset: 620, shaderLocation: 5}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+video34.width = 286;
+let imageData53 = new ImageData(220, 116);
+let videoFrame28 = new VideoFrame(videoFrame10, {timestamp: 0});
+try {
+adapter0.label = '\u0ff5\u0d22\u2f3d\u{1f93e}\u{1f632}\u{1fa7e}\u2176';
+} catch {}
+let commandEncoder132 = device2.createCommandEncoder();
+let texture118 = device2.createTexture({
+  label: '\u65c6\u{1f92b}',
+  size: {width: 24, height: 1, depthOrArrayLayers: 149},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder56 = commandEncoder130.beginComputePass({label: '\u{1f869}\u0434\u0110\u3f61\u9152\u6a58'});
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+renderBundleEncoder59.setVertexBuffer(8935, undefined, 0, 2695143056);
+} catch {}
+try {
+gpuCanvasContext22.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline117 = await device2.createRenderPipelineAsync({
+  label: '\u1a84\u05b7\uc7cc\u6291\u04be\u01ec\u{1fa47}\ua4c4\u2290\u{1fc78}\u0664',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule33,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 1649471615,
+    stencilWriteMask: 1256335530,
+    depthBias: 229366295,
+    depthBiasSlopeScale: 950.9629768976138,
+  },
+  vertex: {
+    module: shaderModule33,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 52,
+        attributes: [
+          {format: 'sint16x4', offset: 0, shaderLocation: 6},
+          {format: 'sint16x2', offset: 8, shaderLocation: 2},
+          {format: 'uint8x4', offset: 4, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 436,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 172, shaderLocation: 5},
+          {format: 'uint32x2', offset: 160, shaderLocation: 7},
+          {format: 'float16x2', offset: 20, shaderLocation: 14},
+          {format: 'float16x4', offset: 20, shaderLocation: 12},
+          {format: 'sint32x3', offset: 188, shaderLocation: 0},
+          {format: 'sint32x3', offset: 176, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 36, shaderLocation: 4},
+          {format: 'uint32x4', offset: 144, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 106, shaderLocation: 8},
+          {format: 'float32x4', offset: 152, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'front',
+  unclippedDepth: false,
+},
+});
+let bindGroupLayout44 = device2.createBindGroupLayout({
+  label: '\u4170\u0f1b\u0cc1\u{1fc73}\uc955\ue816',
+  entries: [
+    {
+      binding: 429,
+      visibility: 0,
+      storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let texture119 = device2.createTexture({
+  label: '\u0b28\ue832\u31e3\u193f\uaf36\u906c\u518f\u0fe0\u2a17',
+  size: {width: 605},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint'],
+});
+let textureView160 = texture117.createView({label: '\u81e4\u06e6\u90f0\u06d4\u027d\ua23f', baseMipLevel: 3, mipLevelCount: 1});
+let renderBundle79 = renderBundleEncoder57.finish({label: '\u3508\u32a8'});
+let externalTexture67 = device2.importExternalTexture({source: videoFrame11, colorSpace: 'display-p3'});
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let imageData54 = new ImageData(20, 232);
+let textureView161 = texture68.createView({label: '\u6427\u{1fde0}\u035f\uc1a9\u0dbc\u0046'});
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer39, 334_187_677);
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer36, 1_449_894_804);
+} catch {}
+try {
+renderBundleEncoder48.drawIndexedIndirect(buffer41, 79696);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer41, 11004);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline68);
+} catch {}
+try {
+device1.queue.submit([commandBuffer21]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: video6,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 31, y: 2, z: 110},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video36 = document.createElement('video');
+try {
+window.someLabel = device2.label;
+} catch {}
+let commandBuffer25 = commandEncoder132.finish();
+let renderPassEncoder39 = commandEncoder131.beginRenderPass({
+  label: '\u03d1\u{1fde6}',
+  colorAttachments: [{
+  view: textureView160,
+  depthSlice: 34,
+  clearValue: { r: 714.0, g: -271.9, b: -420.3, a: -310.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet66,
+  maxDrawCount: 91754670,
+});
+try {
+renderPassEncoder39.setBlendConstant({ r: -785.5, g: -982.2, b: -674.9, a: -163.6, });
+} catch {}
+try {
+commandEncoder130.copyTextureToTexture({
+  texture: texture117,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture118,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 8});
+} catch {}
+let pipeline118 = await device2.createComputePipelineAsync({
+  label: '\u0aaa\u0f7c\u79ad\u2f41',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule33, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder133 = device1.createCommandEncoder({label: '\ubfa6\u0a70\u026b\u0aa9\u0ae9'});
+let texture120 = device1.createTexture({
+  label: '\uf089\uc0df\u00bb\u8da9\u0461\u{1f9e6}\u90c5\uac8e',
+  size: {width: 2268},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder40 = commandEncoder133.beginRenderPass({
+  label: '\ub71a\u2ccb\ufa12\u24c7\u05cd\u{1f8e6}\u{1ff2c}\u860b\u0234\u0cc1\u059d',
+  colorAttachments: [{
+  view: textureView87,
+  depthSlice: 6,
+  clearValue: { r: -138.9, g: 707.2, b: 219.2, a: 575.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet40,
+  maxDrawCount: 123808825,
+});
+try {
+renderPassEncoder14.setBlendConstant({ r: -11.98, g: -246.1, b: -347.4, a: -415.2, });
+} catch {}
+try {
+renderPassEncoder19.drawIndexedIndirect(buffer26, 518_859_403);
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer42, 18_618_859);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline113);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(4, buffer41, 199572, 114234);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexed(227, 65);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexedIndirect(buffer41, 42904);
+} catch {}
+let pipeline119 = await device1.createRenderPipelineAsync({
+  label: '\u8284\uc57e\u34e0\u839b\udd28',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule31,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule31,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2512,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 632, shaderLocation: 16},
+          {format: 'unorm10-10-10-2', offset: 436, shaderLocation: 10},
+          {format: 'sint16x4', offset: 608, shaderLocation: 17},
+          {format: 'float32x3', offset: 232, shaderLocation: 23},
+          {format: 'uint8x4', offset: 352, shaderLocation: 2},
+          {format: 'uint32x3', offset: 828, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 204, shaderLocation: 4},
+          {format: 'uint16x4', offset: 108, shaderLocation: 6},
+          {format: 'uint8x2', offset: 410, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 5752,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32', offset: 516, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 428, shaderLocation: 15},
+          {format: 'sint8x4', offset: 1356, shaderLocation: 9},
+          {format: 'uint16x4', offset: 380, shaderLocation: 8},
+          {format: 'sint32', offset: 648, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 764, shaderLocation: 22},
+        ],
+      },
+      {arrayStride: 1232, attributes: []},
+      {arrayStride: 1528, attributes: []},
+      {
+        arrayStride: 3752,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 1772, shaderLocation: 3},
+          {format: 'sint32x2', offset: 492, shaderLocation: 19},
+        ],
+      },
+      {arrayStride: 7520, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 3304,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 1080, shaderLocation: 7},
+          {format: 'float32x4', offset: 172, shaderLocation: 20},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'back'},
+});
+try {
+offscreenCanvas36.getContext('2d');
+} catch {}
+gc();
+let videoFrame29 = new VideoFrame(img27, {timestamp: 0});
+let renderBundle80 = renderBundleEncoder59.finish({label: '\u0fad\ubc61\u2582\ufe06\u0d0c\u{1ff72}\ue301\u{1fb3e}\u03c3'});
+let sampler93 = device2.createSampler({
+  label: '\u32b0\u0d64\u7750\u{1f9fc}\u3ff2\u{1fcc7}\u8eb3\uad65\u3594\ue0cb',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.24,
+  lodMaxClamp: 84.51,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder54.setPipeline(pipeline118);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(8446, undefined, 3423949287, 8483000);
+} catch {}
+let pipeline120 = device2.createComputePipeline({
+  label: '\u2bcd\u44e3\ucce2\ue66c\u0e63\u0458\uc88c\u6db0\u06ec\u{1fc07}',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule33, entryPoint: 'compute0'},
+});
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let textureView162 = texture54.createView({label: '\u{1f6a8}\u0d62\u04db\u5f55\uc675\u055b\u{1f739}\u043e', baseMipLevel: 2, mipLevelCount: 2});
+let externalTexture68 = device1.importExternalTexture({label: '\u2680\u705d\u4649\uf1a9\u{1fc74}\u{1f626}', source: videoFrame18, colorSpace: 'display-p3'});
+try {
+renderPassEncoder33.setPipeline(pipeline87);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline87);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: imageData41,
+  origin: { x: 1, y: 15 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 26, y: 3, z: 22},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline121 = await device1.createComputePipelineAsync({
+  label: '\u2246\u3aee\u9fb3\u{1fddb}\u0bd9\u{1fed4}',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule22, entryPoint: 'compute0', constants: {}},
+});
+let pipeline122 = await promise39;
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+document.body.prepend(img10);
+let texture121 = device2.createTexture({
+  size: {width: 605, height: 48, depthOrArrayLayers: 71},
+  mipLevelCount: 3,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView163 = texture117.createView({label: '\u2739\u0cd8\u829e\uc729\u6c26\u0093\u{1fb75}\u9faa\ucc8c', baseMipLevel: 2, mipLevelCount: 6});
+let renderBundle81 = renderBundleEncoder59.finish({label: '\u7228\u{1fcda}\u3ab8\u98fa\u9360\u0019\u02ad\u{1ffb9}\u06d4\u{1fdc5}'});
+try {
+renderPassEncoder39.setStencilReference(1931);
+} catch {}
+try {
+renderPassEncoder39.setViewport(61.71, 1.656, 8.282, 0.6978, 0.5597, 0.9737);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(1422, undefined);
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let commandEncoder134 = device1.createCommandEncoder({label: '\u{1f9fb}\u069a\u04c5\uc9ad\u0d47\u0d9f\u0659'});
+try {
+renderPassEncoder11.setBindGroup(5, bindGroup31, new Uint32Array(7237), 581, 0);
+} catch {}
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.setViewport(15.07, 0.5297, 1.360, 0.2659, 0.1478, 0.3429);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(614, 14, 395_862_206, 276_807_258, 526_295_016);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer43, 56_442_678);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexed(66, 126);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(7, buffer41, 0, 165079);
+} catch {}
+try {
+commandEncoder134.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 23160 */
+  offset: 23160,
+  bytesPerRow: 256,
+  rowsPerImage: 99,
+  buffer: buffer29,
+}, {
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer29);
+} catch {}
+let texture122 = device1.createTexture({
+  label: '\u4903\u47a5\u5cb7\u0f02\u33df',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let textureView164 = texture69.createView({label: '\u9fa2\u335e', dimension: '2d-array', mipLevelCount: 2});
+let sampler94 = device1.createSampler({
+  label: '\u6543\u{1f736}\uadf5',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 22.53,
+  lodMaxClamp: 39.62,
+  compare: 'less',
+});
+try {
+renderPassEncoder15.drawIndirect(buffer30, 1_975_329_681);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(10, buffer24, 2676);
+} catch {}
+try {
+commandEncoder134.copyTextureToTexture({
+  texture: texture122,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture100,
+  mipLevel: 2,
+  origin: {x: 6, y: 1, z: 3},
+  aspect: 'all',
+},
+{width: 56, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline123 = await device1.createRenderPipelineAsync({
+  label: '\u5436\u5d5f\uf392',
+  layout: pipelineLayout15,
+  fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'never', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilReadMask: 981459900,
+    stencilWriteMask: 600154172,
+    depthBias: -93211606,
+    depthBiasSlopeScale: 647.7184420104168,
+  },
+  vertex: {
+    module: shaderModule30,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 3772,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 240, shaderLocation: 17},
+          {format: 'snorm16x4', offset: 520, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 822, shaderLocation: 10},
+          {format: 'sint32x4', offset: 208, shaderLocation: 9},
+          {format: 'sint32', offset: 20, shaderLocation: 20},
+          {format: 'float16x2', offset: 24, shaderLocation: 16},
+          {format: 'float32x2', offset: 744, shaderLocation: 12},
+          {format: 'uint32x2', offset: 600, shaderLocation: 19},
+          {format: 'sint32', offset: 1808, shaderLocation: 21},
+          {format: 'sint32', offset: 128, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 64, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 516,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x3', offset: 56, shaderLocation: 1},
+          {format: 'sint32x2', offset: 20, shaderLocation: 7},
+          {format: 'float32', offset: 12, shaderLocation: 0},
+          {format: 'uint8x4', offset: 88, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 5648,
+        attributes: [
+          {format: 'uint8x4', offset: 2836, shaderLocation: 8},
+          {format: 'float16x2', offset: 1244, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 32, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 5284,
+        attributes: [
+          {format: 'sint16x4', offset: 544, shaderLocation: 6},
+          {format: 'float32x2', offset: 440, shaderLocation: 23},
+          {format: 'float32x3', offset: 2736, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 7180,
+        attributes: [
+          {format: 'float32x2', offset: 1164, shaderLocation: 11},
+          {format: 'sint8x2', offset: 712, shaderLocation: 14},
+          {format: 'uint32', offset: 848, shaderLocation: 22},
+        ],
+      },
+      {arrayStride: 4164, stepMode: 'instance', attributes: []},
+      {arrayStride: 3404, attributes: []},
+      {arrayStride: 2536, attributes: [{format: 'snorm8x4', offset: 152, shaderLocation: 13}]},
+    ],
+  },
+});
+let commandEncoder135 = device1.createCommandEncoder({label: '\u0370\u0985\u804d\u{1fdc4}\uad0b\u{1fdb5}\u0141\u0537'});
+let computePassEncoder57 = commandEncoder134.beginComputePass({});
+try {
+computePassEncoder44.setPipeline(pipeline84);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup22, new Uint32Array(8244), 4033, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle57, renderBundle67, renderBundle71, renderBundle44, renderBundle66, renderBundle53]);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(1743);
+} catch {}
+try {
+renderPassEncoder19.draw(93, 218);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer26, 124_330_606);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(0, buffer41, 124456, 115538);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexedIndirect(buffer41, 11996);
+} catch {}
+try {
+commandEncoder135.copyBufferToBuffer(buffer33, 20532, buffer35, 13848, 9748);
+dissociateBuffer(device1, buffer33);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder135.copyTextureToTexture({
+  texture: texture55,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture116,
+  mipLevel: 3,
+  origin: {x: 251, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture123 = device2.createTexture({
+  label: '\u5b56\u{1fef3}\u{1f8eb}\u{1f8b7}',
+  size: {width: 1210},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let renderBundleEncoder60 = device2.createRenderBundleEncoder({
+  label: '\ucfd2\u{1f86a}\u0337\uf65f\u2a5e\u8528\ueb75\u0cf6\uedae\u7c70',
+  colorFormats: ['rg16uint'],
+  depthStencilFormat: 'depth24plus',
+});
+try {
+computePassEncoder54.setPipeline(pipeline120);
+} catch {}
+let promise48 = device2.popErrorScope();
+try {
+  await promise48;
+} catch {}
+let querySet67 = device1.createQuerySet({
+  label: '\u{1f714}\u036b\udf20\u{1fa6c}\u38ed\ufe2d\u3c35\u5784\u83e5\ua3c8',
+  type: 'occlusion',
+  count: 3507,
+});
+let textureView165 = texture116.createView({label: '\u8b23\ue433\ua608\u{1feed}', baseMipLevel: 10, baseArrayLayer: 65, arrayLayerCount: 8});
+let renderPassEncoder41 = commandEncoder135.beginRenderPass({
+  label: '\u082e\u5405\u7a7f\u09ad\u0400\ue6bb',
+  colorAttachments: [{view: textureView150, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet34,
+  maxDrawCount: 1099523196,
+});
+let renderBundleEncoder61 = device1.createRenderBundleEncoder({
+  label: '\u2dfd\uc9f2\u{1f668}\ub316\u07a8\u0689\u063f\u06e2\u05b1\u77ff\u857a',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler95 = device1.createSampler({
+  label: '\ub3e6\u2bf5\u{1fbcb}\u0cc6\u63b3\u06a0\u{1f696}\u2518\uec07\u940e',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 44.36,
+  lodMaxClamp: 84.35,
+  compare: 'greater',
+});
+try {
+renderPassEncoder38.end();
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle73, renderBundle52, renderBundle46, renderBundle56, renderBundle53, renderBundle62, renderBundle69, renderBundle47, renderBundle47, renderBundle65]);
+} catch {}
+try {
+renderPassEncoder40.setScissorRect(42, 0, 42, 5);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(91, 182);
+} catch {}
+try {
+renderBundleEncoder53.draw(439, 420, 128_227_852, 374_961_597);
+} catch {}
+try {
+renderBundleEncoder55.setPipeline(pipeline113);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(6, buffer41, 118324, 160689);
+} catch {}
+let promise49 = device1.popErrorScope();
+try {
+device1.queue.submit([commandBuffer24, commandBuffer22]);
+} catch {}
+let promise50 = device1.queue.onSubmittedWorkDone();
+let pipeline124 = await device1.createComputePipelineAsync({
+  label: '\u6cac\uefcd\u{1f70c}\uaec0\uc285\u482b\uab9e\ua735',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule27, entryPoint: 'compute0'},
+});
+let pipeline125 = await device1.createRenderPipelineAsync({
+  label: '\u3c36\u0101\u{1fb3b}\u766d\u979c',
+  layout: pipelineLayout12,
+  multisample: {count: 4, mask: 0xdc646817},
+  fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 292,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 40, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 156, shaderLocation: 2},
+          {format: 'float32x4', offset: 132, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 28, shaderLocation: 19},
+          {format: 'sint32', offset: 4, shaderLocation: 11},
+          {format: 'float16x2', offset: 88, shaderLocation: 18},
+          {format: 'sint8x2', offset: 80, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 28, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 28, shaderLocation: 16},
+          {format: 'snorm8x4', offset: 140, shaderLocation: 6},
+          {format: 'uint16x4', offset: 64, shaderLocation: 1},
+          {format: 'sint8x2', offset: 14, shaderLocation: 21},
+          {format: 'unorm8x2', offset: 12, shaderLocation: 10},
+          {format: 'sint32x2', offset: 100, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 14, shaderLocation: 9},
+          {format: 'sint32x3', offset: 100, shaderLocation: 20},
+          {format: 'float32x3', offset: 0, shaderLocation: 7},
+          {format: 'sint32x3', offset: 20, shaderLocation: 22},
+          {format: 'unorm8x2', offset: 2, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 1004,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 40, shaderLocation: 8}],
+      },
+      {
+        arrayStride: 8080,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 200, shaderLocation: 23}],
+      },
+      {
+        arrayStride: 900,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 26, shaderLocation: 13},
+          {format: 'float32x4', offset: 20, shaderLocation: 3},
+          {format: 'uint16x2', offset: 132, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+  await promise50;
+} catch {}
+let imageBitmap30 = await createImageBitmap(canvas13);
+let querySet68 = device1.createQuerySet({type: 'occlusion', count: 1462});
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup24, new Uint32Array(9745), 7107, 0);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder41.setBlendConstant({ r: -12.30, g: -738.6, b: -881.6, a: 209.4, });
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(170, 1, 60, 0);
+} catch {}
+try {
+renderPassEncoder28.draw(67, 158, 80_195_089, 223_234_594);
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline87);
+} catch {}
+try {
+buffer26.destroy();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer43, 18472, new Float32Array(3562), 3034, 60);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture78,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(974), /* required buffer size: 974 */
+{offset: 898}, {width: 19, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline126 = await device1.createRenderPipelineAsync({
+  label: '\u0097\uc3f7\u8835\u0f42\u988e\uf5a4\u6bac\u0480\u6374\ubbf7\u61c0',
+  layout: pipelineLayout16,
+  fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'never', failOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', failOp: 'invert', depthFailOp: 'decrement-clamp'},
+    stencilReadMask: 2156420403,
+    stencilWriteMask: 1762654882,
+    depthBias: 853195917,
+    depthBiasSlopeScale: 524.8441680738,
+  },
+  vertex: {
+    module: shaderModule30,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 696,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 4, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 372, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 72, shaderLocation: 18},
+          {format: 'uint32x3', offset: 152, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 28, shaderLocation: 16},
+          {format: 'sint32x4', offset: 40, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 32, shaderLocation: 15},
+          {format: 'float32', offset: 300, shaderLocation: 5},
+          {format: 'sint32x3', offset: 304, shaderLocation: 7},
+          {format: 'sint8x4', offset: 532, shaderLocation: 17},
+          {format: 'unorm8x2', offset: 166, shaderLocation: 12},
+          {format: 'uint16x4', offset: 592, shaderLocation: 3},
+          {format: 'float32x2', offset: 108, shaderLocation: 1},
+          {format: 'uint8x4', offset: 68, shaderLocation: 22},
+          {format: 'sint32x4', offset: 208, shaderLocation: 2},
+          {format: 'sint32x4', offset: 140, shaderLocation: 6},
+          {format: 'sint16x4', offset: 16, shaderLocation: 20},
+          {format: 'float32', offset: 84, shaderLocation: 10},
+          {format: 'uint8x4', offset: 76, shaderLocation: 19},
+        ],
+      },
+      {
+        arrayStride: 6940,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 1168, shaderLocation: 4},
+          {format: 'sint8x4', offset: 372, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 7740,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 236, shaderLocation: 21}],
+      },
+      {arrayStride: 0, attributes: [{format: 'float16x4', offset: 2792, shaderLocation: 23}]},
+      {arrayStride: 5628, attributes: []},
+      {arrayStride: 632, stepMode: 'instance', attributes: []},
+      {arrayStride: 768, stepMode: 'instance', attributes: []},
+      {arrayStride: 7076, attributes: []},
+      {arrayStride: 40740, attributes: [{format: 'snorm16x4', offset: 2468, shaderLocation: 0}]},
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let computePassEncoder58 = commandEncoder130.beginComputePass({label: '\u068a\u0edb\u{1fd4c}\u0493'});
+let externalTexture69 = device2.importExternalTexture({source: video17, colorSpace: 'srgb'});
+try {
+renderPassEncoder39.end();
+} catch {}
+let promise51 = device2.createComputePipelineAsync({
+  label: '\uf921\u{1f99b}\u9947\u7da0\u{1fd49}\uf10e\u{1f623}\u873e\u{1fdeb}\u{1fd75}',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule33, entryPoint: 'compute0', constants: {}},
+});
+canvas12.width = 429;
+let buffer44 = device2.createBuffer({label: '\u{1ffff}\u0b63', size: 253479, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder136 = device2.createCommandEncoder();
+let sampler96 = device2.createSampler({
+  label: '\u26bf\u0eda\uea1d\u6cff\ub999\u{1f8b2}\uaee1\u9755\u0d44',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 97.02,
+  compare: 'greater',
+});
+try {
+computePassEncoder54.setPipeline(pipeline118);
+} catch {}
+let pipeline127 = await promise51;
+let imageBitmap31 = await createImageBitmap(canvas18);
+let imageData55 = new ImageData(92, 172);
+let shaderModule34 = device2.createShaderModule({
+  label: '\u3c26\uf6a0\u05cf\uc5ae\u0d49\u081a\u{1fc19}\u6768\u6766',
+  code: `@group(1) @binding(479)
+var<storage, read_write> field16: array<u32>;
+@group(0) @binding(479)
+var<storage, read_write> n24: array<u32>;
+
+@compute @workgroup_size(7, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(frag_depth) f0: f32,
+  @location(0) f1: vec3<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S37 {
+  @location(14) f0: vec2<f32>,
+  @location(9) f1: vec2<f16>,
+  @location(10) f2: vec3<u32>,
+  @location(2) f3: u32,
+  @location(8) f4: vec3<f16>,
+  @location(5) f5: f32,
+  @location(13) f6: vec3<f16>,
+  @location(12) f7: i32,
+  @builtin(instance_index) f8: u32
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec2<i32>, a1: S37, @builtin(vertex_index) a2: u32, @location(4) a3: vec3<i32>, @location(3) a4: vec3<f16>, @location(1) a5: vec4<f32>, @location(6) a6: u32, @location(11) a7: vec2<i32>, @location(15) a8: vec3<u32>, @location(0) a9: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let commandEncoder137 = device2.createCommandEncoder({label: '\u27e4\u2f72'});
+try {
+computePassEncoder58.setPipeline(pipeline127);
+} catch {}
+try {
+  await promise49;
+} catch {}
+let textureView166 = texture109.createView({label: '\u0e83\ubaa4\u458c\ueb6d'});
+let renderBundle82 = renderBundleEncoder43.finish();
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup47);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle61, renderBundle82, renderBundle72, renderBundle71, renderBundle65, renderBundle72, renderBundle62, renderBundle73]);
+} catch {}
+try {
+renderPassEncoder14.setViewport(14.46, 1.481, 28.30, 0.02512, 0.7989, 0.9056);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer35, 134_415_879);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(7, buffer24, 0, 4570);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: imageData21,
+  origin: { x: 30, y: 118 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 20, y: 6, z: 79},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 29, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let querySet69 = device2.createQuerySet({label: '\ub2c0\u0b78\u2b9f\u722e', type: 'occlusion', count: 183});
+let commandBuffer26 = commandEncoder137.finish({label: '\u81e6\u0f99\ue40f\u08bc\u038e'});
+let texture124 = device2.createTexture({
+  size: {width: 302, height: 24, depthOrArrayLayers: 41},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r32sint'],
+});
+let textureView167 = texture114.createView({label: '\u07a3\u0cea\ub2f7\u0ffc\u0809\u0308\u9ac0\u0429', baseMipLevel: 2});
+try {
+commandEncoder136.copyTextureToTexture({
+  texture: texture118,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 14},
+  aspect: 'all',
+},
+{
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let computePassEncoder59 = commandEncoder34.beginComputePass({label: '\uec07\u06fa\u{1ffff}'});
+let renderBundleEncoder62 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthReadOnly: true, stencilReadOnly: false});
+try {
+renderPassEncoder3.setVertexBuffer(10, buffer13, 0, 120925);
+} catch {}
+try {
+commandEncoder79.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 208, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 297 widthInBlocks: 297 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 82604 */
+  offset: 82307,
+  buffer: buffer2,
+}, {width: 297, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder128.copyTextureToTexture({
+  texture: texture47,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 170},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 2,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 180, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder67.clearBuffer(buffer9, 123368, 784);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let shaderModule35 = device2.createShaderModule({
+  code: `@group(1) @binding(479)
+var<storage, read_write> parameter19: array<u32>;
+
+@compute @workgroup_size(5, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(2) f1: u32,
+  @location(5) f2: u32,
+  @location(3) f3: vec4<u32>,
+  @location(0) f4: vec3<i32>,
+  @location(4) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S38 {
+  @location(11) f0: vec4<f16>,
+  @location(4) f1: vec2<u32>,
+  @builtin(vertex_index) f2: u32
+}
+
+@vertex
+fn vertex0(@location(10) a0: u32, @location(1) a1: vec2<u32>, @location(3) a2: f16, @location(12) a3: vec3<u32>, @location(13) a4: vec3<f32>, @location(9) a5: u32, @location(0) a6: vec3<f32>, @location(6) a7: vec4<i32>, @location(7) a8: vec2<u32>, @location(8) a9: vec3<u32>, @location(14) a10: vec4<i32>, @location(15) a11: vec2<f32>, @location(5) a12: f16, @location(2) a13: vec3<i32>, a14: S38, @builtin(instance_index) a15: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderPassEncoder42 = commandEncoder136.beginRenderPass({
+  label: '\ud064\u0df4\u334f\u{1fb0a}',
+  colorAttachments: [{
+  view: textureView160,
+  depthSlice: 26,
+  clearValue: { r: 713.0, g: -254.4, b: 871.1, a: 61.08, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 321754741,
+});
+let renderBundle83 = renderBundleEncoder59.finish({label: '\u0732\u43fa\u{1f62e}\u3a4a\u0aa3\u4f09\u0460\u99b8\u06f4\ue4a2'});
+try {
+renderPassEncoder42.setScissorRect(40, 0, 35, 3);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(9536, undefined, 0, 4209767525);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let textureView168 = texture83.createView({baseArrayLayer: 277, arrayLayerCount: 35});
+let renderBundle84 = renderBundleEncoder36.finish({});
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+renderPassEncoder22.setScissorRect(63, 4, 3, 5);
+} catch {}
+try {
+renderPassEncoder22.draw(156, 303, 1_106_290_955, 904_661_488);
+} catch {}
+try {
+renderPassEncoder28.drawIndexedIndirect(buffer31, 52_491_439);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer35, 1_681_927_962);
+} catch {}
+try {
+renderBundleEncoder29.draw(227);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexed(193, 15, 240_105_394, 79_143_888, 458_823_454);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer41, 17428);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(1, buffer24, 936);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroupLayout45 = pipeline120.getBindGroupLayout(1);
+let buffer45 = device2.createBuffer({
+  label: '\u22e3\u0b75\u0f01\u{1fb8a}\u05eb\u0971\u{1f7f4}\u5676\u7b5f',
+  size: 81286,
+  usage: GPUBufferUsage.INDEX,
+});
+let querySet70 = device2.createQuerySet({label: '\u604d\uc184\u0b67\u5a15\u0776\u0f79\u9cc9\u0158\u01d5', type: 'occlusion', count: 79});
+try {
+renderPassEncoder42.setBlendConstant({ r: 638.8, g: -852.5, b: 939.1, a: 261.8, });
+} catch {}
+try {
+renderPassEncoder42.setStencilReference(2064);
+} catch {}
+try {
+renderPassEncoder42.insertDebugMarker('\uc14c');
+} catch {}
+let pipeline128 = await device2.createRenderPipelineAsync({
+  label: '\u2b5f\u{1fbcd}\u0189\ucb45\u32ff\u{1fb87}\u26da',
+  layout: pipelineLayout19,
+  multisample: {count: 4, mask: 0x6fb89aed},
+  fragment: {
+  module: shaderModule34,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 1483876997,
+    depthBias: 1612584731,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule34,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 312,
+        attributes: [
+          {format: 'float32x2', offset: 12, shaderLocation: 8},
+          {format: 'uint32x3', offset: 16, shaderLocation: 15},
+          {format: 'float32x4', offset: 4, shaderLocation: 9},
+          {format: 'sint32x2', offset: 8, shaderLocation: 12},
+          {format: 'uint8x2', offset: 84, shaderLocation: 0},
+          {format: 'sint32x3', offset: 52, shaderLocation: 7},
+          {format: 'float16x2', offset: 20, shaderLocation: 13},
+          {format: 'float16x2', offset: 20, shaderLocation: 14},
+          {format: 'uint8x2', offset: 184, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 48,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 4, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 176, shaderLocation: 11}],
+      },
+      {
+        arrayStride: 832,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 84, shaderLocation: 3},
+          {format: 'sint32x3', offset: 40, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 264,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 40, shaderLocation: 1}, {format: 'uint32', offset: 28, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'back'},
+});
+let querySet71 = device2.createQuerySet({label: '\u{1f6c7}\u{1fa56}\udd5b', type: 'occlusion', count: 392});
+let commandEncoder138 = device2.createCommandEncoder({label: '\u{1fa77}\u0b6a\u0b4b\uebdf\u42f9\u921a\u{1fb64}\u0923\u4f6e\ued68'});
+let textureView169 = texture124.createView({label: '\u{1f9ee}\uff50\ud643\u5235\u2430', mipLevelCount: 3});
+let renderBundle85 = renderBundleEncoder57.finish({});
+try {
+computePassEncoder58.end();
+} catch {}
+try {
+renderPassEncoder42.setBlendConstant({ r: -221.5, g: 219.1, b: 681.8, a: 848.6, });
+} catch {}
+try {
+renderBundleEncoder60.setIndexBuffer(buffer45, 'uint16', 47580, 20654);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 272 */
+{offset: 272}, {width: 192, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData56 = new ImageData(220, 12);
+let querySet72 = device2.createQuerySet({label: '\u4922\u{1fdf2}', type: 'occlusion', count: 2563});
+let textureView170 = texture115.createView({label: '\uade1\ua889\uda28\u5163\u04be\u307f\u{1fa86}\u0c6e\u0b73', baseArrayLayer: 0});
+let externalTexture70 = device2.importExternalTexture({label: '\u84e6\u{1fd04}\u{1ff53}\ua56e\ue617\u0c89\u38db\u48f7', source: videoFrame15});
+try {
+renderPassEncoder42.setScissorRect(69, 2, 0, 0);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(1352, undefined, 0, 693603372);
+} catch {}
+let commandEncoder139 = device1.createCommandEncoder({label: '\u7da3\u0a09\u{1fded}\u08da'});
+let commandBuffer27 = commandEncoder139.finish({label: '\u{1f9e1}\u6d0d\u{1f765}\u{1fa47}'});
+let externalTexture71 = device1.importExternalTexture({
+  label: '\u00e8\u394a\u{1fd1b}\u0022\u6e9b\uadef\u22c1\u4128\u303f\u0fb6',
+  source: videoFrame6,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder40.end();
+} catch {}
+try {
+renderPassEncoder31.setScissorRect(1, 0, 1, 1);
+} catch {}
+try {
+renderPassEncoder28.setViewport(941.6, 0.4378, 131.9, 0.5195, 0.9659, 0.9883);
+} catch {}
+try {
+renderPassEncoder28.drawIndirect(buffer27, 649_933_963);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(3, buffer24, 0, 2098);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(15);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder56.insertDebugMarker('\u77d2');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 40, new Int16Array(55444), 16804, 440);
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let shaderModule36 = device2.createShaderModule({
+  label: '\ua4ef\u{1fe46}\ud393\ud1c3\u29de\ucc4b\u{1fbf5}\u7dfc',
+  code: `@group(0) @binding(479)
+var<storage, read_write> global18: array<u32>;
+@group(1) @binding(479)
+var<storage, read_write> field17: array<u32>;
+
+@compute @workgroup_size(2, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S39 {
+  @location(4) f0: vec3<f32>,
+  @location(15) f1: vec2<f16>,
+  @location(10) f2: vec2<i32>,
+  @location(2) f3: vec2<f16>,
+  @builtin(front_facing) f4: bool
+}
+struct FragmentOutput0 {
+  @location(2) f0: u32,
+  @location(7) f1: i32,
+  @location(3) f2: vec4<u32>,
+  @location(0) f3: i32,
+  @location(5) f4: vec3<f32>,
+  @location(1) f5: vec2<u32>
+}
+
+@fragment
+fn fragment0(@location(14) a0: vec3<f16>, a1: S39, @builtin(sample_index) a2: u32, @builtin(sample_mask) a3: u32, @builtin(position) a4: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(14) f514: vec3<f16>,
+  @location(2) f515: vec2<f16>,
+  @location(15) f516: vec2<f16>,
+  @builtin(position) f517: vec4<f32>,
+  @location(4) f518: vec3<f32>,
+  @location(10) f519: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec4<i32>, @location(6) a1: vec4<f32>, @location(7) a2: f32, @location(3) a3: vec4<f32>, @location(11) a4: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let commandEncoder140 = device2.createCommandEncoder({label: '\u95d1\u{1fabd}\u5c45\u7c06\u{1f804}\u{1f7e5}\u06bc\u6a97\u9d0a\u{1fed8}\uf45d'});
+let commandBuffer28 = commandEncoder138.finish({label: '\u{1f6e3}\ua737\u88be'});
+let textureView171 = texture117.createView({label: '\u0eae\u0ba7\ud91c\u9a75\u8447\uc3df', format: 'rg16uint', baseMipLevel: 1, mipLevelCount: 5});
+let computePassEncoder60 = commandEncoder140.beginComputePass({label: '\ue060\u{1f6cc}\u88cf\u1a67'});
+try {
+renderBundleEncoder60.setIndexBuffer(buffer45, 'uint32', 544, 51572);
+} catch {}
+try {
+  await buffer44.mapAsync(GPUMapMode.READ, 168656, 2692);
+} catch {}
+try {
+commandEncoder130.clearBuffer(buffer44, 142300, 89832);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let bindGroupLayout46 = device2.createBindGroupLayout({
+  label: '\ufe1e\u1b9c',
+  entries: [
+    {binding: 333, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 24,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let pipelineLayout20 = device2.createPipelineLayout({
+  label: '\u{1fa45}\u00fe\uba22\ufabf\u793f\u{1ff80}\u2ab7\u0751\u0d59',
+  bindGroupLayouts: [bindGroupLayout44, bindGroupLayout42, bindGroupLayout46],
+});
+let textureView172 = texture121.createView({label: '\uaffa\u{1f93e}\u2600', dimension: '2d', baseMipLevel: 2, baseArrayLayer: 36});
+try {
+commandEncoder130.clearBuffer(buffer44, 144988, 2768);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+renderBundleEncoder60.insertDebugMarker('\u70bc');
+} catch {}
+try {
+gpuCanvasContext25.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap32 = await createImageBitmap(canvas14);
+let sampler97 = device2.createSampler({
+  label: '\u0769\ua2af\uaae5\u8ec1\u9862\u6d00\u4208\u042b\u0b16\u06b2',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.985,
+  compare: 'always',
+  maxAnisotropy: 16,
+});
+let externalTexture72 = device2.importExternalTexture({label: '\uec23\u4903\u0663', source: videoFrame18, colorSpace: 'srgb'});
+try {
+renderBundleEncoder60.setVertexBuffer(7107, undefined, 0);
+} catch {}
+try {
+commandEncoder130.copyTextureToTexture({
+  texture: texture114,
+  mipLevel: 1,
+  origin: {x: 34, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 89, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 58, height: 1, depthOrArrayLayers: 5});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 8, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(72)), /* required buffer size: 350_435 */
+{offset: 541, bytesPerRow: 4267, rowsPerImage: 82}, {width: 500, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer45, 'uint16', 52622);
+} catch {}
+try {
+gpuCanvasContext17.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline129 = device2.createRenderPipeline({
+  layout: pipelineLayout20,
+  fragment: {
+  module: shaderModule33,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'equal', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 3860602719,
+    stencilWriteMask: 3516293639,
+    depthBiasSlopeScale: 401.8944633412571,
+  },
+  vertex: {
+    module: shaderModule33,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 180,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 44, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 24, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 8, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 4, shaderLocation: 3},
+          {format: 'sint16x2', offset: 60, shaderLocation: 1},
+          {format: 'sint32x3', offset: 0, shaderLocation: 0},
+          {format: 'float32', offset: 16, shaderLocation: 8},
+          {format: 'float32x2', offset: 8, shaderLocation: 4},
+          {format: 'sint32x2', offset: 24, shaderLocation: 2},
+          {format: 'uint32x4', offset: 80, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 992, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 156,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 0, shaderLocation: 6},
+          {format: 'uint16x2', offset: 4, shaderLocation: 10},
+        ],
+      },
+      {arrayStride: 556, attributes: [{format: 'uint32', offset: 24, shaderLocation: 11}]},
+    ],
+  },
+});
+let bindGroup50 = device2.createBindGroup({
+  label: '\ud457\u6e35\u6839\uf37c\ua242\u0692',
+  layout: bindGroupLayout46,
+  entries: [{binding: 333, resource: sampler87}, {binding: 24, resource: externalTexture66}],
+});
+let commandEncoder141 = device2.createCommandEncoder({label: '\u0285\u02bb\u3f30\u2422\u0152\u{1fc49}\u0b21\u{1fb2e}\u7566\uc20f'});
+let texture125 = device2.createTexture({
+  label: '\u0164\u25ae\u{1fefc}\u0e5c\u{1f8c2}\u09db\ua3e6\u{1fc78}\u8139\u092c\u248c',
+  size: {width: 1210, height: 96, depthOrArrayLayers: 71},
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint'],
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup50, new Uint32Array(5726), 2231, 0);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+renderBundleEncoder60.setBindGroup(2, bindGroup50);
+} catch {}
+try {
+commandEncoder141.copyTextureToTexture({
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 403, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder130.clearBuffer(buffer44, 123800, 6856);
+dissociateBuffer(device2, buffer44);
+} catch {}
+let renderBundle86 = renderBundleEncoder57.finish({label: '\u9095\u60b1\u063e\u053a\u277a'});
+let externalTexture73 = device2.importExternalTexture({label: '\u8ed4\ufbc4\u{1fe80}\u6066\ud4b7\u0eb4\u4753', source: videoFrame26, colorSpace: 'srgb'});
+try {
+renderPassEncoder42.setBindGroup(3, bindGroup50, new Uint32Array(2276), 1954, 0);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer45, 'uint16', 77248, 63);
+} catch {}
+try {
+commandEncoder130.copyTextureToTexture({
+  texture: texture117,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 83, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder141.clearBuffer(buffer44, 99280, 62232);
+dissociateBuffer(device2, buffer44);
+} catch {}
+canvas4.width = 455;
+let commandEncoder142 = device2.createCommandEncoder({});
+let commandBuffer29 = commandEncoder142.finish({});
+let renderBundle87 = renderBundleEncoder60.finish();
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder42.setViewport(20.43, 3.573, 26.50, 1.457, 0.6812, 0.7648);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(306, undefined, 929054090);
+} catch {}
+try {
+querySet69.destroy();
+} catch {}
+try {
+device2.queue.submit([commandBuffer28]);
+} catch {}
+let pipeline130 = await device2.createRenderPipelineAsync({
+  layout: pipelineLayout20,
+  multisample: {count: 1, mask: 0x9aa5773d},
+  fragment: {
+  module: shaderModule36,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rg8uint', writeMask: 0}, {format: 'r32uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule36,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1464, attributes: [{format: 'sint8x4', offset: 8, shaderLocation: 0}]},
+      {
+        arrayStride: 808,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 48, shaderLocation: 7}],
+      },
+      {
+        arrayStride: 16,
+        attributes: [
+          {format: 'uint8x2', offset: 0, shaderLocation: 11},
+          {format: 'float32x4', offset: 0, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'back'},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas37 = new OffscreenCanvas(593, 445);
+let imageData57 = new ImageData(204, 64);
+let imageBitmap33 = await createImageBitmap(video13);
+let bindGroupLayout47 = device0.createBindGroupLayout({
+  label: '\u{1fffa}\u5b99\u913b\u2382\u1b54\ub3c6\u664d\u{1f8dc}\u4f36\u03ed\u910d',
+  entries: [{binding: 1134, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let pipelineLayout21 = device0.createPipelineLayout({
+  label: '\u0735\u0c7a\u0b0f\u5e87\u9512\u{1f6e2}\u02a4\u0c5b',
+  bindGroupLayouts: [bindGroupLayout6, bindGroupLayout0, bindGroupLayout12, bindGroupLayout5, bindGroupLayout1],
+});
+let textureView173 = texture28.createView({label: '\u768b\u7132\u0561\u{1f919}\ud2aa\u2a57\u{1ff7e}\ud9c7\u6cab\u7976\u0a04'});
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(3, 1, 1, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(2.533, 0.6362, 0.3638, 0.06767, 0.6741, 0.8260);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer3, 38184, 23891);
+} catch {}
+try {
+renderBundleEncoder62.setVertexBuffer(6, buffer3);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer11);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+gc();
+let img31 = await imageWithData(233, 73, '#f4c1a807', '#f9eb7fa6');
+try {
+adapter3.label = '\u01ba\u5980\udb52\u9d8a';
+} catch {}
+video17.height = 231;
+let imageData58 = new ImageData(28, 188);
+let pipelineLayout22 = device2.createPipelineLayout({label: '\u039d\u{1fa71}\ue1c9\u7079\u9f54\u0ae9\u{1f6c0}', bindGroupLayouts: []});
+let querySet73 = device2.createQuerySet({label: '\u4560\u95dc\u6b06\u8d8d\uef2d\u52a3\u02b3', type: 'occlusion', count: 651});
+let textureView174 = texture124.createView({baseMipLevel: 1, mipLevelCount: 1});
+let sampler98 = device2.createSampler({
+  label: '\u67d6\u63f6\u07c5\u93bb',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 30.82,
+  lodMaxClamp: 94.58,
+  compare: 'greater',
+});
+let externalTexture74 = device2.importExternalTexture({label: '\udaed\ue949\u9a78\ubd82', source: video24, colorSpace: 'srgb'});
+try {
+computePassEncoder54.setPipeline(pipeline120);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup50, new Uint32Array(9702), 9600, 0);
+} catch {}
+try {
+renderPassEncoder42.setStencilReference(3635);
+} catch {}
+try {
+renderPassEncoder42.setViewport(13.35, 0.9711, 38.81, 3.162, 0.4792, 0.5290);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(157), /* required buffer size: 157 */
+{offset: 157}, {width: 271, height: 1, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let gpuCanvasContext29 = offscreenCanvas37.getContext('webgpu');
+let commandEncoder143 = device0.createCommandEncoder();
+let texture126 = device0.createTexture({
+  label: '\u{1ffab}\u{1fcb8}\u{1fd33}\ud329\u{1f886}\uc4c2\uc2a0',
+  size: [404, 1, 26],
+  mipLevelCount: 8,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float'],
+});
+let textureView175 = texture30.createView({format: 'rgba16float', baseMipLevel: 1});
+let renderBundleEncoder63 = device0.createRenderBundleEncoder({
+  label: '\u03f5\u0dc8\u03ff\u0a93\u055c',
+  colorFormats: ['rg16float', 'rg11b10ufloat', 'rgba16float', 'rg11b10ufloat', 'r8uint', 'r8sint'],
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(1077);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer14, 'uint16');
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline60);
+} catch {}
+try {
+commandEncoder79.clearBuffer(buffer9, 68628, 45076);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 809, height: 1, depthOrArrayLayers: 961}
+*/
+{
+  source: offscreenCanvas10,
+  origin: { x: 187, y: 131 },
+  flipY: true,
+}, {
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let commandEncoder144 = device2.createCommandEncoder({label: '\u13ab\u0647\u0307\u074a\u7f4b'});
+try {
+renderPassEncoder42.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(8736, undefined);
+} catch {}
+try {
+commandEncoder141.clearBuffer(buffer44, 186932, 46192);
+dissociateBuffer(device2, buffer44);
+} catch {}
+let pipeline131 = await device2.createComputePipelineAsync({
+  label: '\u07eb\ud0f5',
+  layout: pipelineLayout20,
+  compute: {module: shaderModule34, entryPoint: 'compute0', constants: {}},
+});
+let canvas34 = document.createElement('canvas');
+let buffer46 = device2.createBuffer({
+  label: '\u6eaa\u4426\u{1f68c}\udf33\u2a3e\uc101\u8823\u37f0\u2e22\u{1fff0}',
+  size: 370566,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder145 = device2.createCommandEncoder({label: '\u557e\u96bb\u7b97\ua408\u7903\u0af9\uce84\u2ca3\u0ebd\u081a\u0bfc'});
+let externalTexture75 = device2.importExternalTexture({
+  label: '\ua14c\u04da\u1ef6\u{1f9f6}\u1021\u9f55\u15e6\u4007\u06ce',
+  source: video23,
+  colorSpace: 'srgb',
+});
+try {
+commandEncoder130.copyTextureToBuffer({
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 53, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 784 widthInBlocks: 196 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2056 */
+  offset: 2056,
+  buffer: buffer46,
+}, {width: 196, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer46);
+} catch {}
+try {
+canvas34.getContext('2d');
+} catch {}
+let bindGroup51 = device1.createBindGroup({layout: bindGroupLayout36, entries: []});
+let pipelineLayout23 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout20, bindGroupLayout37, bindGroupLayout24, bindGroupLayout30]});
+let commandEncoder146 = device1.createCommandEncoder();
+let textureView176 = texture65.createView({label: '\u0c8c\u{1f998}\u0464\u1db9', aspect: 'all', baseMipLevel: 4, mipLevelCount: 1});
+try {
+computePassEncoder57.setPipeline(pipeline59);
+} catch {}
+try {
+renderPassEncoder41.setViewport(10.61, 1.527, 10.59, 0.4666, 0.7376, 0.7661);
+} catch {}
+try {
+renderPassEncoder28.drawIndexed(12, 74, 263_923_532, 214_506_162, 6_327_656);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer31, 51_080_304);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(4, buffer24);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexedIndirect(buffer41, 119520);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder146.copyBufferToBuffer(buffer33, 58612, buffer35, 19752, 8984);
+dissociateBuffer(device1, buffer33);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder146.clearBuffer(buffer26);
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer6), /* required buffer size: 97 */
+{offset: 97}, {width: 14, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: imageData11,
+  origin: { x: 3, y: 7 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 206},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 19, depthOrArrayLayers: 0});
+} catch {}
+let pipeline132 = device1.createComputePipeline({
+  label: '\ua2ee\u3db8\u{1fd3f}\u9818\u0115\u0fb3\ud3dc\u0aee\u7b52',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule23, entryPoint: 'compute0', constants: {}},
+});
+let pipeline133 = device1.createRenderPipeline({
+  label: '\u09da\u7701',
+  layout: pipelineLayout16,
+  fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilReadMask: 1647051788,
+    stencilWriteMask: 2613207609,
+    depthBiasSlopeScale: 395.44294705752634,
+  },
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 6084, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 52,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 0, shaderLocation: 20},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 1212,
+        attributes: [
+          {format: 'uint16x4', offset: 0, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 76, shaderLocation: 16},
+          {format: 'float16x4', offset: 16, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 6328,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 192, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 1908, shaderLocation: 6},
+          {format: 'float16x4', offset: 1700, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+});
+gc();
+let imageData59 = new ImageData(240, 40);
+let commandEncoder147 = device2.createCommandEncoder({});
+let texture127 = device2.createTexture({
+  label: '\ue79a\u{1ff24}\u4aca\u06c9\u4572\u{1f644}\u9b65\u{1f6f7}',
+  size: {width: 48, height: 2, depthOrArrayLayers: 190},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint', 'rg8uint', 'rg8uint'],
+});
+let textureView177 = texture121.createView({
+  label: '\u{1ff08}\ub3c0',
+  dimension: '2d',
+  aspect: 'depth-only',
+  format: 'depth24plus',
+  baseMipLevel: 1,
+  baseArrayLayer: 30,
+});
+let renderBundle88 = renderBundleEncoder60.finish({label: '\u3f6b\uca73'});
+try {
+computePassEncoder54.setBindGroup(1, bindGroup50);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline118);
+} catch {}
+try {
+commandEncoder141.copyTextureToBuffer({
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 31, y: 3, z: 5},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1632 widthInBlocks: 816 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 102636 */
+  offset: 652,
+  bytesPerRow: 1792,
+  buffer: buffer46,
+}, {width: 816, height: 57, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer46);
+} catch {}
+try {
+commandEncoder145.copyTextureToTexture({
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 135, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 499, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder140.clearBuffer(buffer46, 8236, 263964);
+dissociateBuffer(device2, buffer46);
+} catch {}
+let pipeline134 = await device2.createComputePipelineAsync({
+  label: '\u{1fe81}\u7fe2\u{1fd0f}\u0bb8\u2f58',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule34, entryPoint: 'compute0', constants: {}},
+});
+let pipeline135 = device2.createRenderPipeline({
+  label: '\u06f4\u{1fe92}\u4b53\ub299\u46af\u0da3\u07ae\ue9d8',
+  layout: pipelineLayout22,
+  fragment: {
+  module: shaderModule33,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilWriteMask: 1625954226,
+    depthBiasSlopeScale: 897.6939869143284,
+  },
+  vertex: {
+    module: shaderModule33,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 144,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 4, shaderLocation: 6},
+          {format: 'float16x4', offset: 4, shaderLocation: 5},
+          {format: 'sint32x3', offset: 4, shaderLocation: 2},
+          {format: 'uint32', offset: 16, shaderLocation: 11},
+          {format: 'float16x4', offset: 0, shaderLocation: 4},
+          {format: 'sint32x2', offset: 4, shaderLocation: 0},
+          {format: 'sint32x4', offset: 4, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 40, shaderLocation: 3},
+          {format: 'uint32x3', offset: 16, shaderLocation: 7},
+          {format: 'uint32x3', offset: 132, shaderLocation: 10},
+          {format: 'float32x2', offset: 52, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 12, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 132, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let videoFrame30 = new VideoFrame(imageBitmap23, {timestamp: 0});
+let commandEncoder148 = device2.createCommandEncoder({label: '\u0937\u7428\u{1fe9f}\u012d\u{1fd1c}'});
+let renderBundleEncoder64 = device2.createRenderBundleEncoder({
+  label: '\u0add\u0c6d\u00d6\u{1f706}\u{1fd7b}',
+  colorFormats: ['r32sint', 'rg8uint', 'r32uint', 'rgba8uint'],
+  sampleCount: 1,
+});
+try {
+computePassEncoder54.setPipeline(pipeline131);
+} catch {}
+try {
+commandEncoder147.copyTextureToTexture({
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 25},
+  aspect: 'all',
+},
+{
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 185, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 19, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder145.clearBuffer(buffer46, 29700, 308796);
+dissociateBuffer(device2, buffer46);
+} catch {}
+try {
+renderBundleEncoder64.insertDebugMarker('\u{1fe9b}');
+} catch {}
+try {
+device2.queue.writeBuffer(buffer46, 1240, new Int16Array(43220), 23791, 212);
+} catch {}
+let pipeline136 = await device2.createComputePipelineAsync({
+  label: '\u{1f880}\u547e\u{1f804}\u5a7f\u{1ffa5}\u0d19\ufb88\uee04',
+  layout: 'auto',
+  compute: {module: shaderModule36, entryPoint: 'compute0'},
+});
+video1.width = 117;
+let querySet74 = device1.createQuerySet({label: '\u5cd7\u0582\u0446\u8c57\u{1f971}', type: 'occlusion', count: 118});
+let renderPassEncoder43 = commandEncoder146.beginRenderPass({
+  label: '\ufb8e\u3d8b\u{1fad3}\u88b9\u392f\u{1fd2c}',
+  colorAttachments: [{
+  view: textureView81,
+  depthSlice: 180,
+  clearValue: { r: 367.3, g: -729.8, b: -3.222, a: 511.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet43,
+});
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+renderPassEncoder31.beginOcclusionQuery(2350);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle61, renderBundle53, renderBundle50, renderBundle55, renderBundle49, renderBundle52, renderBundle58]);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer35, 641_813_623);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline68);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(4, buffer41);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(6, bindGroup45, new Uint32Array(7328), 7327, 0);
+} catch {}
+try {
+renderBundleEncoder42.drawIndirect(buffer41, 4300);
+} catch {}
+try {
+texture61.destroy();
+} catch {}
+try {
+commandEncoder71.clearBuffer(buffer24);
+dissociateBuffer(device1, buffer24);
+} catch {}
+let commandEncoder149 = device1.createCommandEncoder({label: '\u02ff\u{1f63b}\u{1fe89}\u{1fc7d}\u08f9\ufaa7\uc76e\u0b08\u0b61'});
+let renderPassEncoder44 = commandEncoder71.beginRenderPass({
+  colorAttachments: [{
+  view: textureView111,
+  depthSlice: 36,
+  clearValue: { r: 515.3, g: -370.9, b: 135.3, a: -517.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 251688240,
+});
+try {
+renderPassEncoder41.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+renderPassEncoder19.drawIndexed(379, 29, 318_663_268);
+} catch {}
+try {
+renderPassEncoder28.drawIndexedIndirect(buffer42, 462_723_269);
+} catch {}
+try {
+renderBundleEncoder29.draw(199, 158);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(7, buffer41, 145500, 165614);
+} catch {}
+try {
+commandEncoder149.copyTextureToTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 11},
+  aspect: 'all',
+},
+{
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 123, y: 6, z: 80},
+  aspect: 'all',
+},
+{width: 102, height: 1, depthOrArrayLayers: 202});
+} catch {}
+try {
+gpuCanvasContext14.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let querySet75 = device1.createQuerySet({
+  label: '\u{1fe86}\u9ee8\u6ec5\u6dba\u{1fd03}\u041a\u01e6\u{1facb}\u0e64',
+  type: 'occlusion',
+  count: 1972,
+});
+let textureView178 = texture57.createView({baseMipLevel: 2});
+let renderBundle89 = renderBundleEncoder46.finish({});
+try {
+computePassEncoder37.setBindGroup(4, bindGroup35, new Uint32Array(6197), 982, 0);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: 514.8, g: 453.9, b: -511.1, a: -615.9, });
+} catch {}
+try {
+renderPassEncoder28.drawIndirect(buffer33, 345_273_761);
+} catch {}
+try {
+renderBundleEncoder53.draw(91, 121);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer41, 43560);
+} catch {}
+try {
+commandEncoder149.copyBufferToTexture({
+  /* bytesInLastRow: 128 widthInBlocks: 32 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 29612 */
+  offset: 28972,
+  bytesPerRow: 256,
+  rowsPerImage: 251,
+  buffer: buffer29,
+}, {
+  texture: texture112,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 32, height: 3, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder149.clearBuffer(buffer35);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: canvas23,
+  origin: { x: 0, y: 6 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 46, y: 56, z: 23},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 16, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder150 = device2.createCommandEncoder({});
+let textureView179 = texture115.createView({format: 'rg16float'});
+try {
+renderPassEncoder42.setIndexBuffer(buffer45, 'uint16', 64230, 4089);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(6022, undefined, 2599510169, 1689281620);
+} catch {}
+try {
+  await buffer46.mapAsync(GPUMapMode.READ, 0, 285612);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer9), /* required buffer size: 7_484_297 */
+{offset: 233, bytesPerRow: 196, rowsPerImage: 258}, {width: 9, height: 0, depthOrArrayLayers: 149});
+} catch {}
+let promise52 = device2.queue.onSubmittedWorkDone();
+let canvas35 = document.createElement('canvas');
+let bindGroup52 = device1.createBindGroup({layout: bindGroupLayout18, entries: []});
+let textureView180 = texture89.createView({dimension: '2d-array', baseMipLevel: 3, mipLevelCount: 2, baseArrayLayer: 5, arrayLayerCount: 7});
+let renderPassEncoder45 = commandEncoder149.beginRenderPass({
+  colorAttachments: [{view: textureView79, depthSlice: 1, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet62,
+  maxDrawCount: 9328491,
+});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup41, []);
+} catch {}
+try {
+renderPassEncoder22.drawIndexedIndirect(buffer42, 1_453_006_758);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline122);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(8, buffer24, 0, 4204);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(359, 11, 874_878_724, 35_366_032, 2_259_986_850);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer41, 49340);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline86);
+} catch {}
+let pipeline137 = await device1.createComputePipelineAsync({
+  label: '\u6b33\u{1f604}\u{1ffe4}\u8184\u{1ffd3}\u93fa\u5e72\u{1fddb}\u{1f87a}\ube2f',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let canvas36 = document.createElement('canvas');
+let buffer47 = device1.createBuffer({
+  label: '\u0ff7\ud124\u2515\ucf8f',
+  size: 121197,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let textureView181 = texture69.createView({
+  label: '\u{1f9b9}\u9f14\uefd5\ua633\u0584\uc516\u1a80',
+  aspect: 'all',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder49.setPipeline(pipeline79);
+} catch {}
+try {
+renderPassEncoder31.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder45.setBlendConstant({ r: 769.4, g: 695.8, b: 424.8, a: 421.2, });
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(199, 424, 450_580_553, 167_497_740, 3_185_024_092);
+} catch {}
+try {
+renderPassEncoder43.drawIndirect(buffer38, 82_612_483);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer24, 0, 159);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(0, bindGroup49);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexedIndirect(buffer41, 2764);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(7, buffer41, 0, 108489);
+} catch {}
+let pipeline138 = await device1.createComputePipelineAsync({
+  label: '\u0e33\u{1f841}\u{1f8b6}\u0de5',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+let pipeline139 = device1.createRenderPipeline({
+  label: '\u7b15\ub060\uf866\u3f42\u2365\u005d',
+  layout: 'auto',
+  multisample: {mask: 0x95963a3f},
+  fragment: {module: shaderModule31, entryPoint: 'fragment0', targets: [{format: 'rg16uint'}]},
+  vertex: {
+    module: shaderModule31,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 15924,
+        attributes: [
+          {format: 'float32x3', offset: 1776, shaderLocation: 16},
+          {format: 'sint16x2', offset: 1820, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 12680,
+        attributes: [
+          {format: 'sint32x2', offset: 6868, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 304, shaderLocation: 22},
+          {format: 'sint8x4', offset: 6116, shaderLocation: 5},
+          {format: 'sint32x3', offset: 3376, shaderLocation: 19},
+          {format: 'sint8x4', offset: 7068, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 288, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 16460,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 3056, shaderLocation: 8},
+          {format: 'float16x4', offset: 640, shaderLocation: 20},
+          {format: 'unorm8x2', offset: 7396, shaderLocation: 4},
+          {format: 'uint8x4', offset: 88, shaderLocation: 6},
+          {format: 'uint32x3', offset: 1280, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 1080, shaderLocation: 23},
+          {format: 'uint32x3', offset: 1128, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 484, shaderLocation: 10},
+          {format: 'uint32', offset: 800, shaderLocation: 13},
+          {format: 'uint8x4', offset: 988, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 13972,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x4', offset: 2088, shaderLocation: 15}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', unclippedDepth: true},
+});
+let img32 = await imageWithData(294, 133, '#5f877ff8', '#8e27d0ac');
+try {
+computePassEncoder54.setBindGroup(1, bindGroup50, new Uint32Array(2475), 1556, 0);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline134);
+} catch {}
+try {
+renderPassEncoder42.end();
+} catch {}
+try {
+renderBundleEncoder64.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+renderBundleEncoder64.insertDebugMarker('\u01bc');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 1},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(32)), /* required buffer size: 345 */
+{offset: 345, bytesPerRow: 1021}, {width: 98, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder151 = device2.createCommandEncoder({label: '\u0b18\u0a3a'});
+let textureView182 = texture115.createView({label: '\u{1f707}\u0a64\u7b7e\u{1fece}'});
+let computePassEncoder61 = commandEncoder141.beginComputePass({});
+try {
+renderBundleEncoder64.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+renderBundleEncoder64.setPipeline(pipeline130);
+} catch {}
+try {
+  await promise52;
+} catch {}
+let promise53 = navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+try {
+window.someLabel = commandEncoder64.label;
+} catch {}
+let bindGroupLayout48 = pipeline130.getBindGroupLayout(0);
+let textureView183 = texture119.createView({baseMipLevel: 0, mipLevelCount: 1});
+let sampler99 = device2.createSampler({
+  label: '\ud19b\ufb74\u{1f9b7}\u{1fb52}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 8.260,
+  lodMaxClamp: 45.89,
+});
+try {
+gpuCanvasContext17.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise54 = adapter0.requestAdapterInfo();
+let bindGroupLayout49 = device1.createBindGroupLayout({
+  entries: [
+    {binding: 4841, visibility: 0, buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false }},
+    {binding: 3563, visibility: 0, externalTexture: {}},
+    {
+      binding: 2609,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+try {
+computePassEncoder49.setPipeline(pipeline66);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexed(71, 248, 311_949_745);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer41, 57960);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise54;
+} catch {}
+try {
+window.someLabel = device1.label;
+} catch {}
+let textureView184 = texture100.createView({label: '\u10d4\u07ba\u{1ff3f}\ud472\u1ae3', baseMipLevel: 7, mipLevelCount: 2, arrayLayerCount: 1});
+let sampler100 = device1.createSampler({
+  label: '\uc6bc\u505e\u0182\ud6aa',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 81.02,
+  lodMaxClamp: 85.03,
+});
+try {
+computePassEncoder55.end();
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline137);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 638.1, g: -237.7, b: 36.83, a: 789.6, });
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(14, 139, 13_548_016, -1_660_969_419, 1_088_350_469);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(295, 165, 1_623_530_411, -1_478_427_575, 1_115_710_574);
+} catch {}
+try {
+renderBundleEncoder31.drawIndirect(buffer41, 145708);
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 4,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture55,
+  mipLevel: 3,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let renderBundle90 = renderBundleEncoder59.finish({label: '\u{1fa25}\u0281\u{1f8fe}\u{1fcc8}\u9b78\u053c'});
+try {
+computePassEncoder61.setPipeline(pipeline118);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(5138, undefined, 3709276157, 102393411);
+} catch {}
+try {
+device2.queue.submit([commandBuffer25]);
+} catch {}
+let commandEncoder152 = device2.createCommandEncoder({label: '\u{1fbc2}\u4b25\u{1ff5d}\u{1fa36}\ucceb\u0d13\ud477\ubd1b'});
+let texture128 = device2.createTexture({
+  label: '\ua549\u1d7d\u00f9\u089f\u27a3\u0861\uf1fc\u0c58\uac50\u0c5a\u{1f89e}',
+  size: {width: 570, height: 3, depthOrArrayLayers: 130},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32sint'],
+});
+let textureView185 = texture117.createView({baseMipLevel: 2, mipLevelCount: 6, arrayLayerCount: 1});
+let renderBundle91 = renderBundleEncoder64.finish({label: '\u0d9c\u068e\ubedd\u0410\u0d79\u{1f950}\ud547\ue9c4\u0aac'});
+let sampler101 = device2.createSampler({
+  label: '\u{1f6c2}\u0330\u03e9\u0666\u0ff8\u0ac5\u{1fde9}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 13,
+});
+try {
+commandEncoder151.clearBuffer(buffer44, 137696, 78132);
+dissociateBuffer(device2, buffer44);
+} catch {}
+let imageData60 = new ImageData(220, 240);
+let commandEncoder153 = device1.createCommandEncoder({label: '\ub96c\ua996\u81bb\u{1f876}\u{1f86f}\ua2ea\udb47\u{1f7e1}\u{1fb48}\u{1fddf}\u0f88'});
+try {
+renderPassEncoder29.end();
+} catch {}
+try {
+renderPassEncoder41.setBlendConstant({ r: 339.6, g: -599.1, b: 975.0, a: -344.6, });
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(917, 1, 32, 0);
+} catch {}
+try {
+renderPassEncoder20.draw(16, 38, 1_134_364_040, 4_379_897);
+} catch {}
+try {
+renderPassEncoder43.drawIndexedIndirect(buffer30, 1_403_302_194);
+} catch {}
+try {
+renderPassEncoder43.drawIndirect(buffer28, 632_632_998);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(6, bindGroup35);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(10, buffer41, 12552, 261107);
+} catch {}
+let promise55 = device1.popErrorScope();
+try {
+buffer39.unmap();
+} catch {}
+try {
+commandEncoder153.copyTextureToTexture({
+  texture: texture92,
+  mipLevel: 1,
+  origin: {x: 24, y: 7, z: 24},
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 1, depthOrArrayLayers: 6});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer43, 8704, new DataView(new ArrayBuffer(61111)), 47185, 740);
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(938, 131);
+let pipelineLayout24 = device2.createPipelineLayout({label: '\uab1c\ua6ca\u4411', bindGroupLayouts: [bindGroupLayout48, bindGroupLayout42]});
+let commandEncoder154 = device2.createCommandEncoder({});
+let texture129 = device2.createTexture({
+  size: [160, 384, 21],
+  mipLevelCount: 3,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let externalTexture76 = device2.importExternalTexture({label: '\u{1f90f}\u{1f6d0}', source: video4, colorSpace: 'srgb'});
+try {
+commandEncoder154.copyTextureToTexture({
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 19},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline140 = device2.createRenderPipeline({
+  layout: pipelineLayout22,
+  fragment: {
+  module: shaderModule36,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rg8uint', writeMask: GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba8uint'}],
+},
+  vertex: {
+    module: shaderModule36,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint16x2', offset: 332, shaderLocation: 0},
+          {format: 'unorm10-10-10-2', offset: 80, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 36,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 0, shaderLocation: 6}],
+      },
+      {
+        arrayStride: 704,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 180, shaderLocation: 3},
+          {format: 'uint8x4', offset: 200, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+window.someLabel = externalTexture17.label;
+} catch {}
+let img33 = await imageWithData(257, 238, '#d978d916', '#af11143f');
+let querySet76 = device2.createQuerySet({label: '\uaa7c\u{1fa0a}\u0f92\u603f\u0fd3\u33a8\u06d3', type: 'occlusion', count: 1896});
+let renderBundle92 = renderBundleEncoder60.finish({label: '\u006f\u0c5d'});
+try {
+commandEncoder154.clearBuffer(buffer44, 29828, 79308);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+gpuCanvasContext21.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise56 = device2.queue.onSubmittedWorkDone();
+let gpuCanvasContext30 = offscreenCanvas38.getContext('webgpu');
+let canvas37 = document.createElement('canvas');
+try {
+window.someLabel = externalTexture42.label;
+} catch {}
+let renderPassEncoder46 = commandEncoder153.beginRenderPass({
+  label: '\ufdb4\u942b\u{1ff8f}\u{1f889}\u57dd\u02c2\u0b80\ub9ce\u{1ff6c}\u3c9c',
+  colorAttachments: [{
+  view: textureView114,
+  clearValue: { r: 311.3, g: 59.31, b: -774.6, a: -158.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet34,
+  maxDrawCount: 621254921,
+});
+try {
+renderPassEncoder26.setViewport(616.9, 0.8933, 395.7, 0.04029, 0.2906, 0.6993);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer31, 396_640_565);
+} catch {}
+try {
+renderBundleEncoder40.draw(388);
+} catch {}
+try {
+renderBundleEncoder31.drawIndirect(buffer41, 112244);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(9, buffer41, 281228, 17392);
+} catch {}
+try {
+commandEncoder91.resolveQuerySet(querySet52, 180, 1400, buffer42, 46592);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 86, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 860 */
+{offset: 860, rowsPerImage: 163}, {width: 218, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: imageData41,
+  origin: { x: 3, y: 18 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 5, y: 5, z: 86},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 37, depthOrArrayLayers: 0});
+} catch {}
+let pipeline141 = device1.createComputePipeline({layout: pipelineLayout23, compute: {module: shaderModule18, entryPoint: 'compute0', constants: {}}});
+try {
+canvas37.getContext('webgpu');
+} catch {}
+let buffer48 = device2.createBuffer({
+  size: 404751,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let textureView186 = texture117.createView({label: '\ud716\u480a\uac5f\u0814\u{1fc3b}\u{1f68e}\u7620\u{1f783}', baseMipLevel: 7});
+let renderBundleEncoder65 = device2.createRenderBundleEncoder({
+  label: '\ud885\ue1f6\ue212\u1bea',
+  colorFormats: ['r32sint', 'rg8uint', 'r32uint', 'rgba8uint'],
+  stencilReadOnly: false,
+});
+let renderBundle93 = renderBundleEncoder65.finish({label: '\u02b1\u0300\ubee8\u{1f70d}\u6ba3\u83c8\uc382'});
+let externalTexture77 = device2.importExternalTexture({
+  label: '\uc732\ua7b5\u079a\u0adb\ua13a\ua0d6\u0e0a\u31b7\u0657',
+  source: videoFrame23,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder54.setPipeline(pipeline134);
+} catch {}
+let querySet77 = device2.createQuerySet({type: 'occlusion', count: 3844});
+let arrayBuffer10 = buffer46.getMappedRange(0, 24232);
+try {
+buffer48.destroy();
+} catch {}
+try {
+commandEncoder151.copyBufferToBuffer(buffer48, 26348, buffer44, 35124, 184684);
+dissociateBuffer(device2, buffer48);
+dissociateBuffer(device2, buffer44);
+} catch {}
+try {
+commandEncoder154.copyBufferToTexture({
+  /* bytesInLastRow: 948 widthInBlocks: 237 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 34776 */
+  offset: 34776,
+  buffer: buffer48,
+}, {
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 237, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer48);
+} catch {}
+try {
+commandEncoder152.copyTextureToTexture({
+  texture: texture128,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture128,
+  mipLevel: 3,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext19.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipeline142 = device2.createRenderPipeline({
+  label: '\ud653\u06cc\u549a',
+  layout: pipelineLayout19,
+  multisample: {mask: 0x22d84dc7},
+  fragment: {
+  module: shaderModule35,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rg8uint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rgba8uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule35,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 40,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 0, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 4, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 15},
+          {format: 'uint8x2', offset: 2, shaderLocation: 10},
+          {format: 'sint32x4', offset: 0, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 4, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 0},
+          {format: 'uint32x4', offset: 0, shaderLocation: 4},
+          {format: 'uint32', offset: 8, shaderLocation: 9},
+          {format: 'uint8x4', offset: 4, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 12, shaderLocation: 3},
+          {format: 'float32x3', offset: 8, shaderLocation: 11},
+          {format: 'uint8x2', offset: 0, shaderLocation: 7},
+          {format: 'sint32', offset: 0, shaderLocation: 14},
+          {format: 'uint16x4', offset: 12, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 664,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 48, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front'},
+});
+try {
+device2.destroy();
+} catch {}
+try {
+  await promise55;
+} catch {}
+let canvas38 = document.createElement('canvas');
+let imageData61 = new ImageData(192, 112);
+let buffer49 = device1.createBuffer({label: '\u{1f91b}\u08ee', size: 71856, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder155 = device1.createCommandEncoder({});
+let texture130 = device1.createTexture({
+  label: '\u0b85\u87ef\ud9d1\uf2d8',
+  size: [300],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView187 = texture55.createView({label: '\u5266\u06bd', baseMipLevel: 4, mipLevelCount: 1});
+try {
+computePassEncoder50.setBindGroup(6, bindGroup34, new Uint32Array(5749), 2477, 0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(6, bindGroup32);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle43, renderBundle46, renderBundle75, renderBundle44, renderBundle89]);
+} catch {}
+try {
+renderPassEncoder34.setBlendConstant({ r: 191.3, g: 679.2, b: -394.1, a: 170.4, });
+} catch {}
+try {
+renderPassEncoder44.setScissorRect(976, 1, 150, 0);
+} catch {}
+try {
+renderPassEncoder43.draw(271, 240, 1_194_016_231, 97_185_698);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer27, 335_188_233);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexed(66, 98, 470_890_893, 247_167_168, 241_073_151);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer41, 113328);
+} catch {}
+try {
+renderBundleEncoder58.setPipeline(pipeline86);
+} catch {}
+try {
+commandEncoder155.copyTextureToBuffer({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3068 */
+  offset: 3068,
+  buffer: buffer43,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer43);
+} catch {}
+try {
+commandEncoder155.resolveQuerySet(querySet75, 1329, 556, buffer28, 59136);
+} catch {}
+let promise57 = device1.createComputePipelineAsync({layout: pipelineLayout17, compute: {module: shaderModule30, entryPoint: 'compute0', constants: {}}});
+let offscreenCanvas39 = new OffscreenCanvas(374, 584);
+let bindGroupLayout50 = device0.createBindGroupLayout({entries: []});
+let computePassEncoder62 = commandEncoder64.beginComputePass({label: '\u00db\u7814\u26d8\u{1f79f}\u31ac'});
+let renderPassEncoder47 = commandEncoder42.beginRenderPass({
+  label: '\u5ed1\u027b\u0cc9',
+  colorAttachments: [{
+  view: textureView60,
+  clearValue: { r: 759.8, g: -230.5, b: -762.9, a: 831.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet8,
+});
+let externalTexture78 = device0.importExternalTexture({label: '\u9548\u{1fdc5}\ub3e9\u06f6\u0bdc\u13ee\u35ff\u{1f94f}', source: video13});
+try {
+renderPassEncoder6.setViewport(48.88, 0.1011, 81.72, 0.5533, 0.2004, 0.6557);
+} catch {}
+let promise58 = device0.queue.onSubmittedWorkDone();
+let pipeline143 = await device0.createRenderPipelineAsync({
+  label: '\u{1ff67}\u0b00\u681f\u0510\u06c5',
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba32sint', writeMask: GPUColorWrite.GREEN}, {
+  format: 'rgba32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {depthFailOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'zero'},
+  },
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1580,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 452, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 156, shaderLocation: 3},
+          {format: 'sint8x4', offset: 80, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 64, shaderLocation: 18},
+          {format: 'sint8x4', offset: 328, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 788, attributes: []},
+      {
+        arrayStride: 32,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 14, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 7},
+          {format: 'sint16x4', offset: 0, shaderLocation: 23},
+          {format: 'uint8x4', offset: 0, shaderLocation: 15},
+          {format: 'uint32', offset: 0, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 2732,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 644, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let videoFrame31 = new VideoFrame(offscreenCanvas17, {timestamp: 0});
+let commandBuffer30 = commandEncoder155.finish({label: '\u0c1f\u{1fd29}\ud62f\u4329\u0cef\u5b0a\u0fb7\u22d8\u0f4e\u3c74\u90ca'});
+let textureView188 = texture120.createView({});
+let computePassEncoder63 = commandEncoder91.beginComputePass({label: '\uf47a\u63fc\u7b3c\u{1fd75}\u1c7a\uae26'});
+let sampler102 = device1.createSampler({
+  label: '\u6fc4\u{1fc01}\ud381\u0530\ud157\u{1fdc9}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.53,
+  compare: 'less',
+  maxAnisotropy: 12,
+});
+let externalTexture79 = device1.importExternalTexture({
+  label: '\u{1fccd}\u{1fe14}\u{1fd06}\u{1f993}\u{1f623}\u{1fb16}\u{1f9bc}\u78ff\uade2\u0b57',
+  source: video24,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder31.executeBundles([renderBundle56, renderBundle51]);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(2604);
+} catch {}
+try {
+renderPassEncoder24.setViewport(7.565, 0.03433, 7.242, 0.2223, 0.1041, 0.6697);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer26, 82_091_404);
+} catch {}
+try {
+renderBundleEncoder56.setPipeline(pipeline113);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture122,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer9), /* required buffer size: 630 */
+{offset: 630}, {width: 54, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas36.getContext('webgl');
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let textureView189 = texture89.createView({
+  label: '\u{1fa77}\u{1fdd0}\u{1f75f}\ud223\u0b6c\u0831\u5856\u5355',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 3,
+  arrayLayerCount: 7,
+});
+let renderBundle94 = renderBundleEncoder41.finish({label: '\ud60d\ue934\ubedd\u0f95\u{1fbfa}\u07f7\ufa15\u{1fcfe}'});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup44, new Uint32Array(1325), 205, 0);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline59);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder31.setViewport(1.631, 0.5321, 0.3622, 0.06642, 0.3850, 0.5574);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline68);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(10, buffer24);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(4, bindGroup22, new Uint32Array(9878), 7182, 0);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexedIndirect(buffer41, 2312);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer49, 14360, new Float32Array(42487), 17122, 5868);
+} catch {}
+let video37 = await videoWithData();
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+adapter3.label = '\u0da6\u04c9\u5563\u5b90\u0248';
+} catch {}
+let gpuCanvasContext31 = canvas35.getContext('webgpu');
+let canvas39 = document.createElement('canvas');
+let buffer50 = device1.createBuffer({label: '\u{1f92b}\u039e\u{1f69c}\u0643\u3d75\ua919', size: 168640, usage: GPUBufferUsage.UNIFORM});
+let texture131 = device1.createTexture({
+  label: '\ue429\u03ca\u02ad\u{1faa0}',
+  size: [1134, 1, 1126],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+try {
+computePassEncoder52.setBindGroup(6, bindGroup49);
+} catch {}
+try {
+computePassEncoder44.setBindGroup(0, bindGroup31, new Uint32Array(9790), 9518, 0);
+} catch {}
+try {
+renderPassEncoder30.beginOcclusionQuery(869);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder43.draw(73, 138, 335_292_588, 239_090_605);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: canvas34,
+  origin: { x: 101, y: 45 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 4, y: 1, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 13, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule37 = device1.createShaderModule({
+  label: '\u04fb\uca54\uc925',
+  code: `@group(2) @binding(8384)
+var<storage, read_write> n25: array<u32>;
+@group(0) @binding(2376)
+var<storage, read_write> function20: array<u32>;
+@group(4) @binding(346)
+var<storage, read_write> n26: array<u32>;
+@group(2) @binding(7949)
+var<storage, read_write> function21: array<u32>;
+@group(0) @binding(3155)
+var<storage, read_write> global19: array<u32>;
+
+@compute @workgroup_size(2, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<u32>,
+  @location(3) f1: i32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S40 {
+  @location(17) f0: f16,
+  @location(9) f1: i32,
+  @location(10) f2: vec4<f32>,
+  @location(0) f3: f16,
+  @location(3) f4: u32,
+  @location(4) f5: i32,
+  @location(11) f6: vec4<u32>,
+  @location(5) f7: i32,
+  @location(15) f8: vec3<i32>,
+  @location(13) f9: vec2<f32>,
+  @location(20) f10: vec3<f32>,
+  @builtin(instance_index) f11: u32,
+  @builtin(vertex_index) f12: u32
+}
+
+@vertex
+fn vertex0(@location(19) a0: vec2<u32>, @location(8) a1: vec3<u32>, @location(1) a2: vec3<f32>, @location(16) a3: i32, @location(2) a4: vec3<u32>, @location(6) a5: vec2<f16>, @location(18) a6: vec4<f32>, @location(7) a7: vec4<i32>, @location(22) a8: vec4<f32>, @location(14) a9: vec2<u32>, @location(12) a10: f32, @location(23) a11: vec3<i32>, @location(21) a12: vec4<i32>, a13: S40) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView190 = texture76.createView({label: '\u3249\ua771\u{1f85c}\u0ac4\u033e\uffd6\u9800\uce6b', baseMipLevel: 3, mipLevelCount: 3});
+try {
+renderPassEncoder40.setBindGroup(5, bindGroup26);
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(167, 1, 337, 0);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer26, 551_317_508);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline68);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(6, buffer24, 540, 150);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(6, bindGroup30, []);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(26, 566);
+} catch {}
+try {
+renderBundleEncoder31.drawIndirect(buffer41, 14120);
+} catch {}
+try {
+gpuCanvasContext29.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer3), /* required buffer size: 91_414 */
+{offset: 810, bytesPerRow: 302, rowsPerImage: 150}, {width: 1, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let bindGroup53 = device1.createBindGroup({
+  label: '\ua84c\u5a5e\u025a\uaba0',
+  layout: bindGroupLayout35,
+  entries: [{binding: 346, resource: {buffer: buffer30, offset: 162496, size: 27940}}],
+});
+let commandEncoder156 = device1.createCommandEncoder({label: '\u9d25\ua91c\u{1f8a3}'});
+let querySet78 = device1.createQuerySet({label: '\uf2ca\u{1f832}\u99db\u0ff4\u{1f82c}\u0ab6', type: 'occlusion', count: 2183});
+let textureView191 = texture68.createView({label: '\u089c\u0a85\uc781\u{1f7fd}\u4f68\u016d\u770d\u0f45', arrayLayerCount: 1});
+let renderPassEncoder48 = commandEncoder156.beginRenderPass({
+  label: '\ue300\u02ba\u0958\u2598\ucd7d\u08bb\u0684',
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 5,
+  clearValue: { r: 852.8, g: -712.9, b: -237.1, a: -590.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 140217503,
+});
+try {
+computePassEncoder43.setBindGroup(6, bindGroup33, new Uint32Array(6006), 3482, 0);
+} catch {}
+try {
+renderPassEncoder43.drawIndirect(buffer32, 855_470_664);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(4, bindGroup52);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexed(53, 100, 45_851_742, 447_955_804, 1_478_662_798);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(7, buffer41, 0, 318244);
+} catch {}
+let canvas40 = document.createElement('canvas');
+try {
+canvas39.getContext('webgpu');
+} catch {}
+let texture132 = gpuCanvasContext22.getCurrentTexture();
+let textureView192 = texture65.createView({label: '\u0abb\u225b\u{1faa0}\uc89a\u0a1f', baseMipLevel: 1, mipLevelCount: 3});
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderPassEncoder32.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder32.setStencilReference(1531);
+} catch {}
+try {
+renderPassEncoder22.draw(162, 37, 646_883_821, 288_944_240);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline103);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(2, bindGroup27, new Uint32Array(7039), 379, 0);
+} catch {}
+try {
+renderBundleEncoder40.draw(149);
+} catch {}
+try {
+renderBundleEncoder58.drawIndexed(52, 79, 738_711_965, 321_811_129, 400_481_843);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexedIndirect(buffer41, 44984);
+} catch {}
+try {
+renderBundleEncoder58.setPipeline(pipeline139);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(3, buffer41, 38996, 155584);
+} catch {}
+try {
+canvas38.getContext('bitmaprenderer');
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+  await promise56;
+} catch {}
+let imageBitmap34 = await createImageBitmap(img17);
+try {
+offscreenCanvas39.getContext('webgl2');
+} catch {}
+let bindGroupLayout51 = device1.createBindGroupLayout({
+  label: '\u6678\u98c1\ucc09\u6c9f\udfe1',
+  entries: [
+    {
+      binding: 8605,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder157 = device1.createCommandEncoder();
+let renderBundleEncoder66 = device1.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle95 = renderBundleEncoder26.finish({label: '\u{1fe03}\u06e3\u6cec\u1e4a\u{1ff55}\u07c3\u2918\u47cb\u5a89\uca71\udb25'});
+try {
+computePassEncoder47.setBindGroup(4, bindGroup39);
+} catch {}
+try {
+renderPassEncoder22.drawIndexed(224, 29, 743_543_015, -2_125_747_466);
+} catch {}
+try {
+renderPassEncoder22.drawIndexedIndirect(buffer33, 1_049_552_486);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(4, bindGroup47);
+} catch {}
+try {
+renderBundleEncoder29.draw(325, 360, 868_237_653, 21_942_078);
+} catch {}
+try {
+commandEncoder157.copyBufferToBuffer(buffer29, 909936, buffer47, 50288, 5140);
+dissociateBuffer(device1, buffer29);
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+commandEncoder157.copyTextureToBuffer({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 324 */
+  offset: 324,
+  buffer: buffer43,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer43);
+} catch {}
+let gpuCanvasContext32 = canvas40.getContext('webgpu');
+let commandBuffer31 = commandEncoder157.finish({label: '\u7b0f\u0a08\uaab4\u1f63'});
+try {
+renderPassEncoder26.beginOcclusionQuery(533);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(2824);
+} catch {}
+try {
+renderPassEncoder26.draw(101, 303);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(6, bindGroup39, new Uint32Array(5893), 737, 0);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexed(9, 126, 1_050_534_800);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise58;
+} catch {}
+let offscreenCanvas40 = new OffscreenCanvas(867, 522);
+let imageData62 = new ImageData(116, 204);
+let imageBitmap35 = await createImageBitmap(imageData9);
+let shaderModule38 = device1.createShaderModule({
+  label: '\u44d7\ud9d3\u0f38\u08c7\u0afe\uef62\u3850\ua259',
+  code: `@group(3) @binding(8803)
+var<storage, read_write> parameter20: array<u32>;
+@group(2) @binding(8803)
+var<storage, read_write> type19: array<u32>;
+@group(0) @binding(5282)
+var<storage, read_write> n27: array<u32>;
+@group(2) @binding(4292)
+var<storage, read_write> field18: array<u32>;
+@group(0) @binding(8384)
+var<storage, read_write> local16: array<u32>;
+
+@compute @workgroup_size(5, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(7) f0: vec3<i32>,
+  @location(0) f1: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, @builtin(position) a2: vec4<f32>, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(19) a0: vec2<f16>, @location(21) a1: vec2<u32>, @location(2) a2: vec4<f16>, @location(7) a3: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder158 = device1.createCommandEncoder({label: '\uecee\u02ab\u0051\u36cc\u{1f940}\ufddf\u0082\u0465'});
+let textureView193 = texture99.createView({
+  label: '\u06a4\u08d7\ud4d6\u{1f619}\u7903\u0529\u19f9\u072c\u0376\u3606',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+});
+let renderPassEncoder49 = commandEncoder158.beginRenderPass({
+  label: '\ua42a\u0d77\ucb96\u{1fe72}',
+  colorAttachments: [{
+  view: textureView166,
+  depthSlice: 22,
+  clearValue: { r: 941.1, g: 635.1, b: -210.9, a: 828.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet52,
+  maxDrawCount: 590323303,
+});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup25, []);
+} catch {}
+try {
+renderPassEncoder43.drawIndexed(76);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer50, 30_812_664);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline139);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexed(162, 274, 243_396_285, 7_126_083);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer41, 19108);
+} catch {}
+try {
+renderBundleEncoder56.setPipeline(pipeline65);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 2_530_035 */
+{offset: 255, bytesPerRow: 425, rowsPerImage: 180}, {width: 45, height: 13, depthOrArrayLayers: 34});
+} catch {}
+offscreenCanvas2.width = 701;
+let videoFrame32 = new VideoFrame(video22, {timestamp: 0});
+let renderBundle96 = renderBundleEncoder47.finish({label: '\uc981\uaca1'});
+let sampler103 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 50.60,
+  lodMaxClamp: 58.01,
+  compare: 'less',
+});
+try {
+renderPassEncoder40.setBlendConstant({ r: 75.06, g: 10.71, b: 140.6, a: -492.5, });
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(7, buffer41, 0, 33405);
+} catch {}
+try {
+renderBundleEncoder56.drawIndexedIndirect(buffer41, 16212);
+} catch {}
+try {
+renderBundleEncoder31.drawIndirect(buffer41, 732);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline68);
+} catch {}
+let canvas41 = document.createElement('canvas');
+let commandEncoder159 = device2.createCommandEncoder({label: '\ue1cc\u744b\u3146\ufe84\u0774\u065a'});
+let commandBuffer32 = commandEncoder147.finish({});
+let textureView194 = texture117.createView({mipLevelCount: 9});
+let computePassEncoder64 = commandEncoder144.beginComputePass();
+try {
+computePassEncoder61.setBindGroup(1, bindGroup50);
+} catch {}
+let canvas42 = document.createElement('canvas');
+let pipelineLayout25 = device1.createPipelineLayout({
+  label: '\u0b94\uc25f\ua033\u6901\ua761\u{1f648}',
+  bindGroupLayouts: [bindGroupLayout22, bindGroupLayout33, bindGroupLayout22],
+});
+let commandEncoder160 = device1.createCommandEncoder();
+let querySet79 = device1.createQuerySet({
+  label: '\ue52e\u011b\u084c\ub9d2\ua9c7\u74d4\u{1f7ed}\u514d\ub72e\u5165',
+  type: 'occlusion',
+  count: 2733,
+});
+let renderPassEncoder50 = commandEncoder160.beginRenderPass({
+  label: '\u0156\ua279\u49ce\u{1fbcc}\u3fcb\u55c5',
+  colorAttachments: [{
+  view: textureView85,
+  depthSlice: 242,
+  clearValue: { r: -954.3, g: -714.3, b: -17.28, a: -599.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet53,
+  maxDrawCount: 1123469815,
+});
+try {
+renderPassEncoder18.setViewport(353.0, 0.01672, 106.6, 0.7189, 0.4276, 0.7933);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer50, 911_627_828);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder42.drawIndirect(buffer41, 19724);
+} catch {}
+let pipeline144 = device1.createComputePipeline({
+  label: '\ub424\u{1f9b1}',
+  layout: pipelineLayout23,
+  compute: {module: shaderModule29, entryPoint: 'compute0', constants: {}},
+});
+try {
+adapter2.label = '\u{1fde0}\u8e76\u9044\u036f';
+} catch {}
+let imageBitmap36 = await createImageBitmap(video29);
+let shaderModule39 = device1.createShaderModule({
+  label: '\u{1fbbc}\u0ad8\u0c60\ub88a\uac8f\u{1f680}\u0bbe\u15dc\u{1f928}',
+  code: `@group(4) @binding(346)
+var<storage, read_write> field19: array<u32>;
+@group(2) @binding(5282)
+var<storage, read_write> field20: array<u32>;
+@group(0) @binding(2376)
+var<storage, read_write> global20: array<u32>;
+@group(0) @binding(3155)
+var<storage, read_write> global21: array<u32>;
+@group(2) @binding(7949)
+var<storage, read_write> n28: array<u32>;
+@group(2) @binding(8384)
+var<storage, read_write> type20: array<u32>;
+
+@compute @workgroup_size(5, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0() -> @location(200) vec2<u32> {
+return vec2<u32>();
+}
+
+struct S41 {
+  @location(12) f0: vec4<f16>,
+  @location(20) f1: vec2<i32>,
+  @location(2) f2: vec4<f16>,
+  @location(5) f3: vec2<i32>,
+  @location(8) f4: vec2<u32>,
+  @location(15) f5: vec3<f16>,
+  @location(13) f6: vec3<u32>,
+  @location(14) f7: vec2<f16>,
+  @location(1) f8: vec3<f16>,
+  @location(9) f9: vec4<f32>,
+  @location(3) f10: vec2<f32>,
+  @location(4) f11: vec2<f32>,
+  @location(0) f12: i32,
+  @location(17) f13: vec3<f16>,
+  @location(16) f14: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec2<i32>, @location(6) a1: vec2<f16>, @location(11) a2: vec3<f32>, a3: S41, @builtin(vertex_index) a4: u32, @location(7) a5: vec3<i32>, @location(23) a6: vec4<f32>, @location(10) a7: f16, @location(19) a8: u32, @location(22) a9: f32, @location(18) a10: vec4<f32>, @builtin(instance_index) a11: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let texture133 = device1.createTexture({
+  label: '\u735c\u{1f815}\u{1f847}\u6929\u{1fcc3}',
+  size: {width: 192, height: 10, depthOrArrayLayers: 15},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView195 = texture104.createView({label: '\u0372\u061c\u38c9\u0ef2\u{1f927}\u0588\u669a\u{1f6f1}\ufa9f\u8e79', baseArrayLayer: 0});
+let renderBundleEncoder67 = device1.createRenderBundleEncoder({label: '\u5efd\u77cb\u{1f66a}', colorFormats: ['rg16uint'], stencilReadOnly: true});
+let externalTexture80 = device1.importExternalTexture({label: '\u34a1\u158b\ufefe\u7860', source: video19, colorSpace: 'display-p3'});
+try {
+renderPassEncoder36.draw(206, 217);
+} catch {}
+try {
+renderPassEncoder28.drawIndexed(200, 224, 1_315_059_344, 167_404_962);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer42, 1_015_497_606);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(9214, undefined, 2632465111, 76156391);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(7, buffer41, 32884, 13462);
+} catch {}
+let pipeline145 = await device1.createRenderPipelineAsync({
+  label: '\u0626\u3d3a\u2060\u{1fc52}\u0c0d\u3223\ua730\u001f\u0476\u{1ff2d}',
+  layout: pipelineLayout11,
+  fragment: {module: shaderModule26, entryPoint: 'fragment0', targets: [{format: 'rg16uint'}]},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap'},
+    stencilReadMask: 647926920,
+    depthBiasSlopeScale: 0.0,
+  },
+  vertex: {
+    module: shaderModule26,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 860,
+        attributes: [
+          {format: 'float16x2', offset: 32, shaderLocation: 17},
+          {format: 'uint8x2', offset: 18, shaderLocation: 4},
+          {format: 'sint16x2', offset: 856, shaderLocation: 13},
+          {format: 'sint32x4', offset: 176, shaderLocation: 15},
+          {format: 'sint32x3', offset: 268, shaderLocation: 12},
+          {format: 'sint8x4', offset: 36, shaderLocation: 18},
+          {format: 'float32x4', offset: 88, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 74, shaderLocation: 7},
+          {format: 'sint32x4', offset: 36, shaderLocation: 2},
+          {format: 'sint32x4', offset: 56, shaderLocation: 3},
+          {format: 'float32', offset: 4, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 156, shaderLocation: 9},
+          {format: 'uint32x4', offset: 272, shaderLocation: 5},
+          {format: 'sint32', offset: 228, shaderLocation: 19},
+          {format: 'snorm8x2', offset: 254, shaderLocation: 22},
+          {format: 'snorm16x2', offset: 152, shaderLocation: 21},
+          {format: 'float32', offset: 84, shaderLocation: 0},
+          {format: 'float32x4', offset: 0, shaderLocation: 10},
+          {format: 'uint32', offset: 88, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'uint32', offset: 1500, shaderLocation: 11}]},
+      {
+        arrayStride: 260,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint16x4', offset: 4, shaderLocation: 23},
+          {format: 'sint16x4', offset: 28, shaderLocation: 8},
+          {format: 'float16x2', offset: 8, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 18844,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 2808, shaderLocation: 20}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', unclippedDepth: true},
+});
+try {
+gpuCanvasContext30.unconfigure();
+} catch {}
+let imageData63 = new ImageData(80, 64);
+let gpuCanvasContext33 = canvas41.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+video10.height = 134;
+let video38 = await videoWithData();
+let gpuCanvasContext34 = offscreenCanvas40.getContext('webgpu');
+let bindGroupLayout52 = device1.createBindGroupLayout({
+  label: '\u02c7\u51d3\u545e\u093e\u9aa4',
+  entries: [
+    {binding: 3415, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 8861,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 8136,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32float', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder161 = device1.createCommandEncoder();
+let querySet80 = device1.createQuerySet({
+  label: '\uaea7\u7840\ua2ae\u98da\u0208\u{1fd5f}\ubc84\u870d\u{1ff81}\ueded\ucc28',
+  type: 'occlusion',
+  count: 2032,
+});
+let textureView196 = texture106.createView({label: '\ub748\uff08\ua148\u48ea\u74b3', dimension: '2d-array', baseMipLevel: 0});
+let computePassEncoder65 = commandEncoder161.beginComputePass();
+let renderBundle97 = renderBundleEncoder67.finish({});
+try {
+renderPassEncoder20.draw(20, 344, 1_261_938_257, 1_195_502_591);
+} catch {}
+try {
+renderPassEncoder43.drawIndexed(34, 370, 551_149_781, 243_951_531, 158_264_073);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer37, 217_033_513);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexedIndirect(buffer41, 4952);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer41, 19568);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer49, 31596, new Float32Array(51538), 25214, 560);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 371 */
+{offset: 371}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: video7,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 57, y: 3, z: 20},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+try {
+canvas42.getContext('webgpu');
+} catch {}
+let shaderModule40 = device1.createShaderModule({
+  code: `@group(2) @binding(1997)
+var<storage, read_write> parameter21: array<u32>;
+@group(2) @binding(3226)
+var<storage, read_write> parameter22: array<u32>;
+@group(3) @binding(5550)
+var<storage, read_write> local17: array<u32>;
+@group(3) @binding(5900)
+var<storage, read_write> field21: array<u32>;
+@group(1) @binding(8635)
+var<storage, read_write> field22: array<u32>;
+@group(3) @binding(23)
+var<storage, read_write> field23: array<u32>;
+
+@compute @workgroup_size(7, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<u32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S42 {
+  @location(13) f0: vec3<u32>,
+  @location(22) f1: vec3<f32>,
+  @location(20) f2: vec4<f32>,
+  @location(23) f3: vec3<f32>,
+  @location(5) f4: f32,
+  @location(6) f5: vec4<f16>,
+  @location(4) f6: vec4<f16>,
+  @location(14) f7: vec4<f32>,
+  @location(0) f8: u32,
+  @location(9) f9: f16,
+  @location(18) f10: vec4<f16>,
+  @location(8) f11: vec4<u32>,
+  @location(19) f12: vec3<u32>,
+  @location(1) f13: vec2<f32>,
+  @location(16) f14: vec4<u32>,
+  @location(7) f15: vec4<f16>,
+  @location(12) f16: i32,
+  @location(3) f17: vec3<i32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(2) a1: i32, @builtin(vertex_index) a2: u32, @location(17) a3: vec4<i32>, @location(21) a4: vec3<f16>, a5: S42, @location(15) a6: i32, @location(10) a7: vec4<f32>, @location(11) a8: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder162 = device1.createCommandEncoder({});
+let renderPassEncoder51 = commandEncoder162.beginRenderPass({
+  colorAttachments: [{
+  view: textureView97,
+  depthSlice: 159,
+  clearValue: { r: -241.2, g: 326.9, b: 511.1, a: -927.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet54,
+  maxDrawCount: 587435254,
+});
+let renderBundle98 = renderBundleEncoder51.finish({});
+let externalTexture81 = device1.importExternalTexture({
+  label: '\u136d\u{1fc23}\u{1fd2f}\u{1f89c}\uaa5b\u30e4\u4c5d\ue199\u{1f9c7}\u0c6f\u7cdc',
+  source: video17,
+});
+try {
+renderPassEncoder44.setBlendConstant({ r: -865.9, g: 979.6, b: -807.4, a: 118.0, });
+} catch {}
+try {
+renderPassEncoder49.setStencilReference(3149);
+} catch {}
+try {
+renderBundleEncoder31.draw(57, 256);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexedIndirect(buffer41, 5404);
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline113);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(0, buffer24, 2784, 2603);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer43, 1788, new Int16Array(40566), 13684, 2004);
+} catch {}
+let commandEncoder163 = device1.createCommandEncoder();
+let textureView197 = texture80.createView({label: '\u0e9a\u5ed0', dimension: '3d', baseMipLevel: 1});
+let renderPassEncoder52 = commandEncoder163.beginRenderPass({
+  label: '\u209f\u8abb\u0ba7\u9388\u00e3\u0aa4\u899c\u4ee3\ufcb7\u0d24',
+  colorAttachments: [{
+  view: textureView94,
+  depthSlice: 0,
+  clearValue: { r: 666.7, g: 699.6, b: -153.2, a: 725.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet55,
+  maxDrawCount: 298899927,
+});
+let externalTexture82 = device1.importExternalTexture({label: '\u95d6\u0f60', source: videoFrame10, colorSpace: 'display-p3'});
+try {
+renderPassEncoder35.executeBundles([renderBundle59, renderBundle49, renderBundle82, renderBundle96, renderBundle98]);
+} catch {}
+try {
+renderPassEncoder18.setBlendConstant({ r: -511.9, g: 340.1, b: 233.5, a: 928.4, });
+} catch {}
+try {
+renderPassEncoder43.drawIndirect(buffer30, 83_899_496);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline103);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(138, 99, 131_579_365, 367_923_870, 99_916_121);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexedIndirect(buffer41, 39228);
+} catch {}
+let pipeline146 = await promise57;
+let imageBitmap37 = await createImageBitmap(img8);
+let promise59 = adapter4.requestAdapterInfo();
+let buffer51 = device1.createBuffer({label: '\u04e3\u0fe8\u0f81\u9518\u0368\u6079\u{1ff03}', size: 189826, usage: GPUBufferUsage.STORAGE});
+let renderBundle99 = renderBundleEncoder36.finish({});
+try {
+renderPassEncoder19.executeBundles([renderBundle59]);
+} catch {}
+try {
+renderPassEncoder30.setBlendConstant({ r: -95.46, g: -177.4, b: 975.6, a: -272.6, });
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(1, 1, 1, 0);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline68);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(4, buffer24);
+} catch {}
+try {
+renderBundleEncoder56.drawIndirect(buffer41, 27532);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(3, buffer24, 3288);
+} catch {}
+try {
+gpuCanvasContext14.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline147 = await device1.createComputePipelineAsync({
+  label: '\u781f\u{1f7bf}\u7f07\u6c5c\u51ce\ua790\u0d1a\u016f\udd55',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule24, entryPoint: 'compute0', constants: {}},
+});
+let imageData64 = new ImageData(152, 120);
+let textureView198 = texture70.createView({label: '\u08f4\u0779\u{1fc78}', format: 'astc-8x8-unorm', baseMipLevel: 5, mipLevelCount: 2});
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup53, new Uint32Array(9372), 7767, 0);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(530);
+} catch {}
+try {
+renderPassEncoder35.setScissorRect(1, 1, 1, 0);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder29.drawIndirect(buffer41, 54044);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline86);
+} catch {}
+try {
+buffer51.unmap();
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: offscreenCanvas30,
+  origin: { x: 89, y: 11 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 25, y: 0, z: 27},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline148 = device1.createComputePipeline({
+  label: '\u1b14\uae63\u722d\u{1fbfe}',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule37, entryPoint: 'compute0', constants: {}},
+});
+let textureView199 = texture108.createView({label: '\u53f2\uafdb\u{1fd69}\u56f5\u4ec0\u{1f84e}\u3d60'});
+try {
+renderPassEncoder49.executeBundles([renderBundle53, renderBundle44, renderBundle54, renderBundle50, renderBundle73, renderBundle74, renderBundle61, renderBundle96]);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(11, buffer24, 0, 79);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline113);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: imageData44,
+  origin: { x: 6, y: 6 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 53, y: 3, z: 105},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 40, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder68 = device1.createRenderBundleEncoder({colorFormats: ['rg16uint'], stencilReadOnly: true});
+try {
+renderPassEncoder24.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(3671);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline68);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(4, buffer24, 0, 4590);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexedIndirect(buffer41, 116548);
+} catch {}
+let promise60 = buffer49.mapAsync(GPUMapMode.READ, 32064);
+try {
+device1.queue.writeTexture({
+  texture: texture122,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer10), /* required buffer size: 890 */
+{offset: 890, bytesPerRow: 61, rowsPerImage: 195}, {width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap38 = await createImageBitmap(video3);
+try {
+  await promise59;
+} catch {}
+try {
+adapter2.label = '\u0752\u0907';
+} catch {}
+document.body.prepend(canvas35);
+gc();
+let offscreenCanvas41 = new OffscreenCanvas(579, 718);
+try {
+offscreenCanvas41.getContext('webgl');
+} catch {}
+document.body.prepend(img17);
+let buffer52 = device1.createBuffer({
+  label: '\u5aa9\u0b9e\u5e05\u0e5a\u01cd\u07ff',
+  size: 110750,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+try {
+computePassEncoder39.setPipeline(pipeline100);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant({ r: -221.3, g: -726.8, b: 530.8, a: 666.0, });
+} catch {}
+try {
+renderPassEncoder11.draw(100, 346);
+} catch {}
+try {
+renderPassEncoder28.drawIndirect(buffer27, 2_128_831_857);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline139);
+} catch {}
+try {
+renderBundleEncoder56.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(4, buffer24, 936);
+} catch {}
+try {
+computePassEncoder63.pushDebugGroup('\ub7fc');
+} catch {}
+let img34 = await imageWithData(123, 117, '#0484f443', '#ad768060');
+let imageData65 = new ImageData(96, 148);
+let querySet81 = device1.createQuerySet({
+  label: '\u6ef5\u0318\ub7f5\u{1fde1}\u9f6d\u0c9f\u4545\uaef3\u0607\u6cc4\u{1fa5e}',
+  type: 'occlusion',
+  count: 323,
+});
+let textureView200 = texture104.createView({});
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+renderPassEncoder28.drawIndexed(66, 128, 434_297_748, 846_525_606, 1_387_395_232);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer31, 344_844_430);
+} catch {}
+try {
+renderPassEncoder28.drawIndirect(buffer37, 289_388_700);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(8, buffer24);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexedIndirect(buffer41, 26268);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer41, 19852);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(2, buffer24, 0, 2800);
+} catch {}
+try {
+computePassEncoder63.popDebugGroup();
+} catch {}
+try {
+computePassEncoder37.insertDebugMarker('\u20db');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: imageData48,
+  origin: { x: 1, y: 24 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 123, y: 4, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas42 = new OffscreenCanvas(648, 980);
+let commandEncoder164 = device1.createCommandEncoder({});
+let renderBundle100 = renderBundleEncoder68.finish({label: '\udc8f\u19cc\u{1fca1}\u{1f9c3}\u{1fb98}\u879e\u3381\uf66a\ud2b9\u0cd7\uf087'});
+try {
+renderPassEncoder51.setBlendConstant({ r: -589.7, g: -431.1, b: 128.4, a: -242.6, });
+} catch {}
+try {
+renderBundleEncoder29.draw(256, 136, 38_964_647, 316_088_881);
+} catch {}
+try {
+renderBundleEncoder42.drawIndexed(58, 136, 505_855_841, 571_789_500, 792_346_870);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(9, buffer41, 0);
+} catch {}
+try {
+commandEncoder164.copyBufferToBuffer(buffer29, 797012, buffer43, 215188, 9144);
+dissociateBuffer(device1, buffer29);
+dissociateBuffer(device1, buffer43);
+} catch {}
+try {
+commandEncoder164.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 27972 */
+  offset: 27936,
+  buffer: buffer29,
+}, {
+  texture: texture105,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder164.copyTextureToTexture({
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 1095, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline149 = device1.createComputePipeline({
+  label: '\ue1f0\uc484\u{1f97e}\u{1ff05}\ufb53\ubada\uff0e\u3d44',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule28, entryPoint: 'compute0', constants: {}},
+});
+let pipeline150 = device1.createRenderPipeline({
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    stencilBack: {failOp: 'invert', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilReadMask: 370084534,
+    depthBias: -1973831936,
+    depthBiasClamp: 710.4491209590478,
+  },
+  vertex: {
+    module: shaderModule30,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 2668,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 296, shaderLocation: 1},
+          {format: 'uint32x3', offset: 112, shaderLocation: 22},
+          {format: 'sint32', offset: 524, shaderLocation: 2},
+          {format: 'uint8x2', offset: 1302, shaderLocation: 19},
+          {format: 'float32', offset: 384, shaderLocation: 11},
+          {format: 'float32x3', offset: 28, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 64, shaderLocation: 10},
+          {format: 'sint32x2', offset: 740, shaderLocation: 14},
+          {format: 'float32x3', offset: 908, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 28, shaderLocation: 0},
+          {format: 'sint8x2', offset: 634, shaderLocation: 9},
+          {format: 'sint32x4', offset: 20, shaderLocation: 6},
+          {format: 'uint32x4', offset: 360, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 662, shaderLocation: 23},
+          {format: 'uint8x2', offset: 222, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 176, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 552, shaderLocation: 4},
+          {format: 'sint8x2', offset: 204, shaderLocation: 21},
+          {format: 'float16x4', offset: 24, shaderLocation: 15},
+          {format: 'sint32x3', offset: 4, shaderLocation: 7},
+          {format: 'unorm10-10-10-2', offset: 940, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 4472,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 116, shaderLocation: 20},
+          {format: 'unorm10-10-10-2', offset: 1224, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 11208,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 1898, shaderLocation: 17}],
+      },
+    ],
+  },
+});
+let offscreenCanvas43 = new OffscreenCanvas(61, 703);
+let texture134 = device1.createTexture({
+  label: '\u00aa\u{1f8f8}\u{1fb56}\u004e\ubc05\ud09a\u{1f98b}\u{1fb2a}\u0c21\u{1ff36}',
+  size: [300, 12, 28],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView201 = texture131.createView({dimension: '3d', format: 'rg16uint', baseMipLevel: 2, mipLevelCount: 1});
+let computePassEncoder66 = commandEncoder164.beginComputePass({label: '\u033f\u0376\u0a1a\u{1f91d}\u7bb3\uda3b\u{1f96b}\u0194\u0b18'});
+let renderBundleEncoder69 = device1.createRenderBundleEncoder({
+  label: '\u2946\u1f1f\u{1fdeb}\uce85\u0f02\u445b\u4f64\u{1fd17}\ua0d9\ubb0c\uc572',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder44.setViewport(672.3, 0.5678, 372.9, 0.2221, 0.1599, 0.7018);
+} catch {}
+try {
+renderPassEncoder36.drawIndexed(19, 584, 71_139_145, 135_119_373);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline119);
+} catch {}
+try {
+renderBundleEncoder53.draw(231, 46, 945_475_990, 511_763_453);
+} catch {}
+let imageData66 = new ImageData(68, 88);
+let img35 = await imageWithData(176, 45, '#f483ca87', '#10ed14b3');
+try {
+offscreenCanvas42.getContext('webgpu');
+} catch {}
+let gpuCanvasContext35 = offscreenCanvas43.getContext('webgpu');
+let commandEncoder165 = device0.createCommandEncoder();
+let texture135 = device0.createTexture({
+  label: '\u7c2b\u{1ff22}\u6fa9\u0612\u6aa2\u7e18',
+  size: [1619],
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float'],
+});
+try {
+renderPassEncoder7.setViewport(3.851, 0.9856, 0.9332, 0.00616, 0.8177, 0.9974);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer14, 'uint16', 291502);
+} catch {}
+try {
+commandEncoder65.copyBufferToBuffer(buffer4, 18500, buffer9, 73200, 5624);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture46,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 18},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 127, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 26});
+} catch {}
+try {
+commandEncoder165.resolveQuerySet(querySet14, 2989, 126, buffer5, 11520);
+} catch {}
+let bindGroupLayout53 = pipeline119.getBindGroupLayout(0);
+let querySet82 = device1.createQuerySet({
+  label: '\ud89d\u01da\u8b6e\u{1fa7e}\u0df8\u{1fa63}\ue3f5\u{1f72c}\u0f9a\u{1fb5f}\u{1ff19}',
+  type: 'occlusion',
+  count: 788,
+});
+let textureView202 = texture60.createView({label: '\uc16e\u075d\u{1fad0}\u{1fe22}\u19d1', dimension: '3d', aspect: 'all'});
+try {
+computePassEncoder39.dispatchWorkgroups(2, 3, 5);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(5, bindGroup47, []);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.draw(242, 103, 1_629_564_568, 643_793_375);
+} catch {}
+try {
+renderPassEncoder28.drawIndirect(buffer49, 196_551_223);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(2, buffer41, 117324, 26708);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer41, 219920);
+} catch {}
+try {
+  await promise60;
+} catch {}
+try {
+querySet9.label = '\u04ac\u0755';
+} catch {}
+let commandBuffer33 = commandEncoder62.finish({label: '\u66f9\u{1fbc3}\uf9e3\u{1f9db}\u5370\u9228\u08b1\ufdef\u4d13\u4745\u{1fb17}'});
+try {
+renderPassEncoder47.setBindGroup(4, bindGroup9);
+} catch {}
+try {
+renderPassEncoder6.setViewport(69.26, 0.6142, 4.300, 0.05536, 0.8945, 0.9305);
+} catch {}
+try {
+renderBundleEncoder63.setPipeline(pipeline34);
+} catch {}
+try {
+commandEncoder0.copyBufferToBuffer(buffer18, 69584, buffer11, 71448, 8520);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder128.clearBuffer(buffer9, 26412, 9840);
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+let video39 = await videoWithData();
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let querySet83 = device1.createQuerySet({label: '\u05de\u0596\u{1fe70}', type: 'occlusion', count: 3727});
+let texture136 = device1.createTexture({
+  label: '\ue01e\u039f\u{1f7d3}\u672c\u04ca\u009c\u097b\u3959\u{1f819}\u{1ff59}',
+  size: {width: 384, height: 20, depthOrArrayLayers: 31},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+try {
+computePassEncoder57.setBindGroup(6, bindGroup28, new Uint32Array(5782), 4545, 0);
+} catch {}
+try {
+computePassEncoder39.dispatchWorkgroups(4, 3);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(5, bindGroup49);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(234, 546, 1_622_966_564, 415_739_426, 711_010_800);
+} catch {}
+try {
+renderBundleEncoder56.drawIndexedIndirect(buffer41, 49332);
+} catch {}
+try {
+renderBundleEncoder61.setPipeline(pipeline103);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(8, buffer24, 860, 1302);
+} catch {}
+try {
+computePassEncoder49.insertDebugMarker('\u08af');
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let shaderModule41 = device1.createShaderModule({
+  label: '\ue940\u16d9',
+  code: `@group(0) @binding(3155)
+var<storage, read_write> type21: array<u32>;
+@group(0) @binding(2376)
+var<storage, read_write> function22: array<u32>;
+
+@compute @workgroup_size(6, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S44 {
+  @location(26) f0: vec2<f32>,
+  @location(70) f1: f32,
+  @location(14) f2: vec3<f16>,
+  @location(83) f3: vec2<u32>,
+  @location(63) f4: vec3<f16>,
+  @location(64) f5: vec4<i32>,
+  @location(100) f6: vec4<f16>,
+  @location(46) f7: vec3<f16>,
+  @location(11) f8: vec3<f32>,
+  @builtin(sample_index) f9: u32,
+  @location(0) f10: u32,
+  @location(67) f11: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(108) a0: vec4<f16>, @location(62) a1: f32, @location(41) a2: f16, @location(21) a3: vec4<u32>, @location(103) a4: vec2<f32>, @location(102) a5: vec4<i32>, @location(97) a6: i32, @location(6) a7: f16, @location(104) a8: i32, @location(92) a9: vec4<f32>, @location(1) a10: vec2<u32>, @location(43) a11: i32, @location(99) a12: vec3<f16>, @builtin(position) a13: vec4<f32>, @location(86) a14: vec2<f32>, @location(85) a15: vec4<i32>, a16: S44, @location(90) a17: vec2<f32>, @location(31) a18: vec4<f16>, @builtin(front_facing) a19: bool, @builtin(sample_mask) a20: u32) -> @location(200) vec4<u32> {
+return vec4<u32>();
+}
+
+struct S43 {
+  @location(20) f0: f32,
+  @location(16) f1: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(108) f520: vec4<f16>,
+  @location(102) f521: vec4<i32>,
+  @location(64) f522: vec4<i32>,
+  @location(90) f523: vec2<f32>,
+  @location(21) f524: vec4<u32>,
+  @location(62) f525: f32,
+  @location(63) f526: vec3<f16>,
+  @location(86) f527: vec2<f32>,
+  @location(97) f528: i32,
+  @location(103) f529: vec2<f32>,
+  @location(83) f530: vec2<u32>,
+  @location(46) f531: vec3<f16>,
+  @location(26) f532: vec2<f32>,
+  @location(11) f533: vec3<f32>,
+  @location(31) f534: vec4<f16>,
+  @location(67) f535: vec3<f32>,
+  @location(92) f536: vec4<f32>,
+  @location(0) f537: u32,
+  @location(6) f538: f16,
+  @location(70) f539: f32,
+  @location(14) f540: vec3<f16>,
+  @builtin(position) f541: vec4<f32>,
+  @location(85) f542: vec4<i32>,
+  @location(100) f543: vec4<f16>,
+  @location(104) f544: i32,
+  @location(41) f545: f16,
+  @location(99) f546: vec3<f16>,
+  @location(1) f547: vec2<u32>,
+  @location(43) f548: i32
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, a1: S43, @builtin(vertex_index) a2: u32, @location(3) a3: vec4<u32>, @location(8) a4: vec2<u32>, @location(15) a5: vec3<u32>, @location(13) a6: vec3<u32>, @location(2) a7: vec3<i32>, @location(21) a8: vec2<u32>, @location(17) a9: vec2<i32>, @location(10) a10: vec4<u32>, @location(6) a11: vec3<f16>, @location(1) a12: vec3<f32>, @location(18) a13: vec2<u32>, @location(9) a14: i32, @location(7) a15: vec4<i32>, @location(22) a16: vec3<f32>, @location(4) a17: i32, @location(0) a18: i32, @location(19) a19: vec2<i32>, @location(5) a20: vec3<i32>, @location(14) a21: i32, @location(12) a22: u32, @location(23) a23: vec4<f32>, @location(11) a24: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundleEncoder70 = device1.createRenderBundleEncoder({
+  label: '\u0532\u04d9\u9db1\u10e9\u0119\u73af\ud757\u{1f6eb}\u{1fc70}\u{1fa50}\u{1fa39}',
+  colorFormats: ['rg16uint'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder26.beginOcclusionQuery(798);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline65);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(5, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder40.draw(12, 146, 60_426_097, 108_759_594);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexed(103, 116, 351_076_582, 34_606_675, 551_650_202);
+} catch {}
+try {
+renderBundleEncoder58.setPipeline(pipeline64);
+} catch {}
+try {
+gpuCanvasContext31.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise61 = adapter2.requestAdapterInfo();
+try {
+  await promise61;
+} catch {}
+let querySet84 = device1.createQuerySet({label: '\u6452\u6f2c\u0b7a\u1707\u0b6b\u{1fdee}', type: 'occlusion', count: 704});
+let renderBundleEncoder71 = device1.createRenderBundleEncoder({label: '\u6c6d\u6f72\uf46c\u5ea6\u{1f82e}', colorFormats: ['rg16uint']});
+try {
+computePassEncoder50.setBindGroup(6, bindGroup44, new Uint32Array(4923), 4827, 0);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(44);
+} catch {}
+try {
+renderPassEncoder19.drawIndexed(588, 55, 83_069_594, 18_135_285, 33_546_684);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(3, buffer41, 40044);
+} catch {}
+try {
+renderBundleEncoder58.drawIndirect(buffer41, 60300);
+} catch {}
+let arrayBuffer11 = buffer32.getMappedRange(28512, 536);
+try {
+device1.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 2_921_896 */
+{offset: 30, bytesPerRow: 1438, rowsPerImage: 84}, {width: 161, height: 16, depthOrArrayLayers: 25});
+} catch {}
+let pipeline151 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout15,
+  multisample: {mask: 0x5a486d72},
+  fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilReadMask: 294739202,
+    stencilWriteMask: 3252597648,
+  },
+  vertex: {
+    module: shaderModule27,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 356,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 124, shaderLocation: 14},
+          {format: 'float16x4', offset: 64, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 176, shaderLocation: 16},
+          {format: 'sint8x4', offset: 88, shaderLocation: 3},
+          {format: 'unorm8x4', offset: 4, shaderLocation: 13},
+          {format: 'sint32x2', offset: 4, shaderLocation: 11},
+          {format: 'uint32x2', offset: 28, shaderLocation: 19},
+          {format: 'uint16x4', offset: 16, shaderLocation: 9},
+          {format: 'sint32x3', offset: 168, shaderLocation: 15},
+          {format: 'float16x2', offset: 64, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 192, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 16244,
+        attributes: [
+          {format: 'unorm8x2', offset: 186, shaderLocation: 6},
+          {format: 'float16x4', offset: 3088, shaderLocation: 20},
+          {format: 'unorm16x4', offset: 4356, shaderLocation: 22},
+          {format: 'sint16x4', offset: 3404, shaderLocation: 2},
+          {format: 'sint32', offset: 2000, shaderLocation: 18},
+          {format: 'snorm8x4', offset: 3252, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'sint32x2', offset: 112, shaderLocation: 23}]},
+      {arrayStride: 636, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 5584,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 980, shaderLocation: 10},
+          {format: 'uint16x2', offset: 584, shaderLocation: 12},
+          {format: 'float32x4', offset: 300, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+let commandEncoder166 = device1.createCommandEncoder({label: '\uc236\u{1fe86}\u1536\u0406\u{1f733}\u1a20\u5393\u{1fd14}\ue202\ub7b3\uc78a'});
+let computePassEncoder67 = commandEncoder166.beginComputePass({label: '\u{1fca9}\u{1f651}\ub252\u{1f992}\uda75\u{1fd20}\u{1fa23}\u0403\u{1fe04}\u{1fabc}'});
+try {
+computePassEncoder49.setPipeline(pipeline82);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(1804);
+} catch {}
+try {
+renderPassEncoder11.draw(245, 91, 1_496_781_723, 302_069_342);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(335, 57, 461_394_477, 134_753_043, 694_650_685);
+} catch {}
+try {
+renderBundleEncoder56.draw(121, 61, 1_918_530_976, 520_773_788);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(342, 305, 626_005_508, 803_623_493, 1_037_479_258);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer41, 15320);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 1,
+  origin: {x: 1477, y: 0, z: 2},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 33_672_971 */
+{offset: 255, bytesPerRow: 6431, rowsPerImage: 119}, {width: 1553, height: 0, depthOrArrayLayers: 45});
+} catch {}
+let pipeline152 = await device1.createComputePipelineAsync({
+  label: '\u{1fbb6}\u{1f638}\uab29\u9044',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+let shaderModule42 = device1.createShaderModule({
+  label: '\u353a\uad25\u{1ff97}',
+  code: `@group(2) @binding(3226)
+var<storage, read_write> parameter23: array<u32>;
+@group(3) @binding(5550)
+var<storage, read_write> field24: array<u32>;
+@group(1) @binding(6100)
+var<storage, read_write> parameter24: array<u32>;
+@group(0) @binding(7160)
+var<storage, read_write> global22: array<u32>;
+@group(2) @binding(2724)
+var<storage, read_write> local18: array<u32>;
+@group(1) @binding(8635)
+var<storage, read_write> global23: array<u32>;
+
+@compute @workgroup_size(2, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: i32,
+  @location(0) f1: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(front_facing) a2: bool, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S45 {
+  @location(23) f0: vec2<u32>,
+  @location(16) f1: vec2<i32>,
+  @location(7) f2: u32,
+  @location(13) f3: vec3<u32>,
+  @location(14) f4: f32,
+  @location(6) f5: i32
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec2<f32>, @location(9) a1: vec2<u32>, @location(1) a2: i32, @location(19) a3: vec3<f16>, @location(10) a4: vec4<f16>, @location(12) a5: vec3<f16>, @location(8) a6: vec4<u32>, @location(21) a7: u32, @location(2) a8: vec2<i32>, @location(20) a9: vec2<f32>, @location(11) a10: f16, @location(18) a11: vec4<i32>, @location(15) a12: vec4<f16>, @location(0) a13: f32, @location(4) a14: vec3<i32>, a15: S45, @location(17) a16: vec3<f32>, @location(5) a17: f32, @location(22) a18: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView203 = texture80.createView({baseMipLevel: 1});
+try {
+renderPassEncoder37.beginOcclusionQuery(543);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.draw(229, 38, 85_166_450, 263_809_388);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(282);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+renderBundleEncoder58.draw(338, 5, 2_481_124_543);
+} catch {}
+try {
+renderBundleEncoder58.drawIndexedIndirect(buffer41, 59212);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(6, buffer24, 0, 336);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer0), /* required buffer size: 599 */
+{offset: 599}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap39 = await createImageBitmap(canvas27);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let img36 = await imageWithData(116, 264, '#d7ed40bd', '#25a630ff');
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let texture137 = device1.createTexture({
+  size: {width: 150, height: 6, depthOrArrayLayers: 356},
+  mipLevelCount: 6,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let textureView204 = texture112.createView({
+  label: '\u{1f95e}\uffdd\u6b99\u{1fb0e}\u0f3a\u2f92\u0c91',
+  dimension: '2d-array',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+});
+let sampler104 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.29,
+  lodMaxClamp: 83.88,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder52.setBindGroup(2, bindGroup47);
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline59);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(11, 0, 5, 1);
+} catch {}
+try {
+renderPassEncoder36.drawIndexed(191, 234, 1_414_588_970, 55_547_161, 11_164_171);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder58.draw(0, 41);
+} catch {}
+try {
+  await buffer43.mapAsync(GPUMapMode.READ, 0, 221328);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture122,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(64)), /* required buffer size: 112 */
+{offset: 112}, {width: 53, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+document.body.prepend(img31);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img37 = await imageWithData(33, 157, '#e6d64cc6', '#86861a1d');
+let imageBitmap40 = await createImageBitmap(offscreenCanvas0);
+let bindGroupLayout54 = device1.createBindGroupLayout({
+  label: '\u{1fcb1}\u062f',
+  entries: [
+    {
+      binding: 530,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 2252,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 6376,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder167 = device1.createCommandEncoder({label: '\u7cea\u{1feda}\u0a4b\u0cef\u3f09'});
+let textureView205 = texture82.createView({label: '\uac72\u09ef\ua5f4\ud7b0\u00fd\u{1f767}\ue40d\u50fc'});
+let computePassEncoder68 = commandEncoder167.beginComputePass({});
+let sampler105 = device1.createSampler({
+  label: '\u8068\u{1fc8b}\u0bcb\u0154',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 48.13,
+  lodMaxClamp: 75.78,
+  maxAnisotropy: 9,
+});
+let externalTexture83 = device1.importExternalTexture({source: videoFrame17, colorSpace: 'srgb'});
+try {
+computePassEncoder43.setBindGroup(5, bindGroup25);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline100);
+} catch {}
+try {
+renderPassEncoder36.beginOcclusionQuery(217);
+} catch {}
+try {
+renderPassEncoder33.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle49, renderBundle56, renderBundle98, renderBundle45, renderBundle61, renderBundle94, renderBundle65, renderBundle58, renderBundle82]);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(1656);
+} catch {}
+try {
+renderPassEncoder34.setViewport(0.05061, 0.9718, 0.8043, 0.00266, 0.7436, 0.9896);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer41, 1_853_411_185);
+} catch {}
+try {
+renderPassEncoder52.drawIndirect(buffer30, 1_720_174_424);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer41, 0, 44988);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexed(20, 156, 818_189_612, 313_939_905, 547_830_770);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: video5,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 186, y: 0, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipeline153 = device1.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule38, entryPoint: 'compute0', constants: {}}});
+let buffer53 = device1.createBuffer({size: 10264, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let commandEncoder168 = device1.createCommandEncoder({label: '\u{1fa0f}\u074b\u5671\u050a\ucd6f\u{1fe44}\u004c'});
+let querySet85 = device1.createQuerySet({
+  label: '\u01ef\u035e\u0565\u10b7\u0fd2\ufc8b\ua0f7\u0bfb\u9c60\u{1f839}\u8e7d',
+  type: 'occlusion',
+  count: 1443,
+});
+let textureView206 = texture134.createView({label: '\u0544\u950f'});
+let renderPassEncoder53 = commandEncoder168.beginRenderPass({
+  label: '\u1622\u010b\u3e65\u04af\ua362\u0e27\u36b4\ubc6c\ua6ee\u043f\u0bae',
+  colorAttachments: [{view: textureView94, depthSlice: 1, loadOp: 'load', storeOp: 'discard'}],
+});
+let renderBundle101 = renderBundleEncoder42.finish({label: '\u511c\u0618\u0034\u{1f968}\u759d'});
+try {
+renderPassEncoder41.beginOcclusionQuery(1);
+} catch {}
+try {
+renderPassEncoder24.setStencilReference(3607);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline119);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(8, buffer24, 1336);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer53, 176, new Float32Array(34188), 18857, 304);
+} catch {}
+try {
+window.someLabel = externalTexture36.label;
+} catch {}
+let pipelineLayout26 = device0.createPipelineLayout({
+  label: '\u0667\u79e2\u11ac',
+  bindGroupLayouts: [bindGroupLayout9, bindGroupLayout14, bindGroupLayout4, bindGroupLayout7, bindGroupLayout5],
+});
+let texture138 = device0.createTexture({
+  label: '\u{1f803}\u{1fbb9}\u2a46\u88c9\u{1fbf6}\u071d\u0816\u0161\u0f3b\u02fb\u5ab4',
+  size: [809],
+  dimension: '1d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView207 = texture35.createView({aspect: 'all'});
+let computePassEncoder69 = commandEncoder67.beginComputePass({label: '\u03ea\ub33c\u{1fe4d}\u08d6'});
+try {
+computePassEncoder30.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: 289.9, g: 485.0, b: -983.3, a: -109.5, });
+} catch {}
+try {
+commandEncoder38.clearBuffer(buffer2, 76184, 25908);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let bindGroupLayout55 = device1.createBindGroupLayout({
+  label: '\u03d4\u60ea\u{1fae5}\u31a8\u1380\uccb6\u09f4\u{1ff69}\ubfdb\u{1f6fa}\u576b',
+  entries: [
+    {binding: 5910, visibility: 0, externalTexture: {}},
+    {
+      binding: 7363,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {
+      binding: 8375,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let textureView208 = texture103.createView({
+  label: '\u088f\u0993\u10cd\ub7ad\ufb79\u0fa5\u8897',
+  baseMipLevel: 1,
+  baseArrayLayer: 43,
+  arrayLayerCount: 21,
+});
+try {
+computePassEncoder43.setPipeline(pipeline152);
+} catch {}
+try {
+renderPassEncoder50.beginOcclusionQuery(1451);
+} catch {}
+try {
+renderPassEncoder51.executeBundles([renderBundle60, renderBundle51, renderBundle43, renderBundle60, renderBundle95, renderBundle89, renderBundle55]);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline103);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline139);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(5, buffer24);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+document.body.prepend(canvas27);
+let commandEncoder169 = device1.createCommandEncoder({label: '\uccdb\u0cca\u9fb8\u8b39\u{1fafc}'});
+let commandBuffer34 = commandEncoder169.finish({label: '\u0680\u09cb\u054e'});
+let textureView209 = texture67.createView({label: '\ua163\u901c\u56d7\u0922\u0cf1', baseMipLevel: 5, baseArrayLayer: 141, arrayLayerCount: 31});
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder31.setStencilReference(1887);
+} catch {}
+try {
+renderPassEncoder30.setViewport(40.87, 0.6505, 7.099, 0.9570, 0.1713, 0.8651);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer33, 637_665_900);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(6, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder70.setBindGroup(5, bindGroup29, new Uint32Array(3719), 829, 0);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexedIndirect(buffer41, 41988);
+} catch {}
+let pipeline154 = device1.createComputePipeline({layout: pipelineLayout12, compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}}});
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let video40 = await videoWithData();
+let buffer54 = device1.createBuffer({
+  label: '\u{1fc06}\u2ad4\u6a62\u{1f633}\u8a2a\u{1fc3d}\u{1f887}\u0604',
+  size: 16083,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let texture139 = device1.createTexture({
+  size: {width: 150, height: 6, depthOrArrayLayers: 14},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let textureView210 = texture131.createView({label: '\uc732\u107c\u4ff6', baseMipLevel: 1, mipLevelCount: 2, arrayLayerCount: 1});
+let renderBundle102 = renderBundleEncoder46.finish({});
+let externalTexture84 = device1.importExternalTexture({source: videoFrame7, colorSpace: 'srgb'});
+try {
+computePassEncoder49.dispatchWorkgroups(3, 1);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle99, renderBundle45, renderBundle47, renderBundle43, renderBundle97]);
+} catch {}
+try {
+renderPassEncoder45.setStencilReference(2336);
+} catch {}
+try {
+renderPassEncoder28.drawIndirect(buffer27, 199_047_110);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer54, 'uint32', 5916, 680);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(5, bindGroup42);
+} catch {}
+try {
+gpuCanvasContext21.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 276 */
+{offset: 276}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline155 = device1.createRenderPipeline({
+  label: '\u01b8\uecaa\u57d4\u0e27',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x53d238c0},
+  fragment: {module: shaderModule28, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16uint'}]},
+  vertex: {
+    module: shaderModule28,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 17932,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 4740, shaderLocation: 22}],
+      },
+      {
+        arrayStride: 13028,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 940, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 2568, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 6992,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32x4', offset: 56, shaderLocation: 20}],
+      },
+      {arrayStride: 3804, attributes: [{format: 'float32x2', offset: 460, shaderLocation: 0}]},
+    ],
+  },
+});
+let video41 = await videoWithData();
+gc();
+document.body.prepend(canvas6);
+let shaderModule43 = device1.createShaderModule({
+  label: '\u0373\u54ea\u{1fce7}\u1871\u8f12\uc95d\u{1f842}\ua3d4\u0726\ud76a',
+  code: `@group(2) @binding(9122)
+var<storage, read_write> n29: array<u32>;
+@group(0) @binding(9122)
+var<storage, read_write> global24: array<u32>;
+@group(0) @binding(6342)
+var<storage, read_write> global25: array<u32>;
+@group(2) @binding(6342)
+var<storage, read_write> global26: array<u32>;
+
+@compute @workgroup_size(1, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(78) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S46 {
+  @location(8) f0: vec3<i32>,
+  @location(23) f1: vec2<i32>,
+  @location(22) f2: vec2<i32>,
+  @location(14) f3: vec2<u32>,
+  @location(0) f4: vec2<i32>,
+  @location(11) f5: vec4<u32>,
+  @location(19) f6: i32,
+  @location(18) f7: vec2<f16>,
+  @location(16) f8: i32,
+  @location(9) f9: vec4<f32>,
+  @location(20) f10: vec3<i32>,
+  @location(4) f11: vec3<f16>
+}
+struct VertexOutput0 {
+  @location(14) f549: vec2<u32>,
+  @location(25) f550: vec4<i32>,
+  @location(9) f551: vec3<f32>,
+  @location(48) f552: vec4<f32>,
+  @location(20) f553: u32,
+  @location(40) f554: vec4<u32>,
+  @location(111) f555: vec2<i32>,
+  @location(89) f556: vec2<f32>,
+  @location(80) f557: vec4<f16>,
+  @location(109) f558: vec4<u32>,
+  @location(97) f559: vec2<f16>,
+  @location(78) f560: vec4<f32>,
+  @location(38) f561: vec4<u32>,
+  @location(87) f562: vec4<i32>,
+  @location(44) f563: vec2<i32>,
+  @location(82) f564: vec4<f16>,
+  @location(42) f565: vec2<u32>,
+  @builtin(position) f566: vec4<f32>,
+  @location(16) f567: u32,
+  @location(35) f568: vec3<f32>,
+  @location(59) f569: f32,
+  @location(18) f570: vec3<f16>,
+  @location(62) f571: u32,
+  @location(79) f572: vec2<i32>,
+  @location(72) f573: i32,
+  @location(58) f574: vec3<u32>,
+  @location(99) f575: u32,
+  @location(22) f576: vec2<f16>
+}
+
+@vertex
+fn vertex0(a0: S46, @location(2) a1: u32, @location(7) a2: vec4<f16>, @location(6) a3: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder170 = device1.createCommandEncoder({label: '\uaec2\u07f2\u0f8c\u{1ff86}\u7a52\u09c7\udb01\u380d\u06b5\u{1ff7d}\u331c'});
+let computePassEncoder70 = commandEncoder170.beginComputePass({});
+let externalTexture85 = device1.importExternalTexture({source: videoFrame2, colorSpace: 'srgb'});
+try {
+renderPassEncoder46.setBindGroup(1, bindGroup45);
+} catch {}
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder44.setScissorRect(252, 0, 388, 1);
+} catch {}
+try {
+renderPassEncoder32.setStencilReference(3963);
+} catch {}
+try {
+renderPassEncoder19.drawIndexed(60, 201, 931_898_843, 200_733_727, 1_351_793_455);
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer43, 648_910_563);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder70.setVertexBuffer(10, buffer41, 249844, 28258);
+} catch {}
+let pipeline156 = await device1.createRenderPipelineAsync({
+  label: '\u{1fd18}\u0375\ucb7a\u{1fc07}\ue84c\u0e71',
+  layout: pipelineLayout18,
+  multisample: {},
+  fragment: {module: shaderModule29, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16uint'}]},
+  vertex: {
+    module: shaderModule29,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 18584,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 5072, shaderLocation: 12},
+          {format: 'uint16x4', offset: 1544, shaderLocation: 20},
+          {format: 'unorm8x4', offset: 9616, shaderLocation: 10},
+          {format: 'uint16x4', offset: 284, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 396, shaderLocation: 17},
+          {format: 'sint8x2', offset: 1520, shaderLocation: 8},
+          {format: 'float32x4', offset: 11512, shaderLocation: 4},
+          {format: 'uint32x2', offset: 6180, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 3384,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 780, shaderLocation: 21},
+          {format: 'float32x2', offset: 304, shaderLocation: 3},
+          {format: 'float32x4', offset: 1056, shaderLocation: 5},
+          {format: 'uint32x2', offset: 232, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 304, shaderLocation: 9},
+          {format: 'float16x2', offset: 88, shaderLocation: 2},
+          {format: 'uint8x2', offset: 584, shaderLocation: 0},
+          {format: 'sint32x4', offset: 52, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 1770, shaderLocation: 1},
+          {format: 'uint32x3', offset: 568, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 328, shaderLocation: 6},
+          {format: 'uint8x2', offset: 1028, shaderLocation: 23},
+          {format: 'float32x4', offset: 0, shaderLocation: 18},
+        ],
+      },
+      {arrayStride: 2076, attributes: [{format: 'unorm16x4', offset: 148, shaderLocation: 7}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder171 = device2.createCommandEncoder({});
+let querySet86 = device2.createQuerySet({label: '\u2d01\u0e27\u{1f654}\u6948\uab31\u8f40', type: 'occlusion', count: 1441});
+let textureView211 = texture125.createView({
+  label: '\u92c9\udba2\u8cae\u7deb\ucd44\u{1ff3f}\uaa65\u{1fe73}\u06d8',
+  baseArrayLayer: 26,
+  arrayLayerCount: 21,
+});
+try {
+computePassEncoder61.setPipeline(pipeline127);
+} catch {}
+document.body.prepend(video30);
+let buffer55 = device1.createBuffer({label: '\u0b2d\u0a55', size: 313416, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder172 = device1.createCommandEncoder({label: '\u{1f9f6}\u{1ff18}\u093a\ua7fe\u0c9e\u016f\u3897'});
+let texture140 = device1.createTexture({
+  size: [192],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView212 = texture122.createView({
+  label: '\u0c36\u4891\u{1fb15}\u{1fa82}\u{1fe0a}\u55ae\u3a07\u48a3\uc42d\u0631\u{1f767}',
+  arrayLayerCount: 1,
+});
+let renderPassEncoder54 = commandEncoder172.beginRenderPass({
+  colorAttachments: [{
+  view: textureView143,
+  depthSlice: 2,
+  clearValue: { r: -853.7, g: 90.12, b: -808.8, a: 912.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 548255247,
+});
+let renderBundleEncoder72 = device1.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthReadOnly: true});
+let externalTexture86 = device1.importExternalTexture({source: video28, colorSpace: 'display-p3'});
+try {
+renderPassEncoder37.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+renderPassEncoder18.setBlendConstant({ r: 482.1, g: -111.5, b: -160.3, a: 567.2, });
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer35, 49_649_243);
+} catch {}
+try {
+renderBundleEncoder56.draw(72, 109, 447_445_928, 125_140_577);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexedIndirect(buffer41, 2052);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer41, 16800);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(2, buffer24, 3040, 1672);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer52, 32304, new Int16Array(36805), 35300, 36);
+} catch {}
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+let imageData67 = new ImageData(252, 224);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let offscreenCanvas44 = new OffscreenCanvas(723, 607);
+let bindGroup54 = device1.createBindGroup({
+  label: '\u0371\u0ced\u0f60\u0732\u0a85\ue7aa\ufd1f\uf04b\u8910',
+  layout: bindGroupLayout39,
+  entries: [{binding: 8803, resource: externalTexture79}, {binding: 4292, resource: externalTexture60}],
+});
+let querySet87 = device1.createQuerySet({
+  label: '\u8b2d\u5001\u{1fd99}\u0410\u{1fff9}\u{1f66e}\u3f32\u{1fd54}\u42e3\u9ac3\ubad4',
+  type: 'occlusion',
+  count: 1170,
+});
+let textureView213 = texture62.createView({label: '\u08b0\u{1fec7}\u{1f83a}\u0efe\u0c2f\u{1f821}\u0ed4', dimension: '2d-array'});
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+renderPassEncoder50.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle82, renderBundle84, renderBundle101, renderBundle72, renderBundle71, renderBundle97, renderBundle55, renderBundle100, renderBundle101, renderBundle72]);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: 624.7, g: 129.7, b: -933.1, a: -39.19, });
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(326, 0, 306, 1);
+} catch {}
+try {
+renderPassEncoder33.drawIndexed(31, 62);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline87);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(4, buffer41);
+} catch {}
+try {
+renderBundleEncoder58.draw(181, 173, 219_799_904, 58_007_686);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer41, 40296);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer41, 9528);
+} catch {}
+try {
+renderBundleEncoder70.setPipeline(pipeline119);
+} catch {}
+try {
+renderPassEncoder20.insertDebugMarker('\u9a55');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 90 */
+{offset: 90}, {width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline157 = device1.createRenderPipeline({
+  label: '\u2a85\u0577\u{1ff96}\uf741\ub8ed\u0204',
+  layout: pipelineLayout18,
+  fragment: {module: shaderModule20, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16uint'}]},
+  vertex: {
+    module: shaderModule20,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 7096,
+        attributes: [
+          {format: 'float16x2', offset: 2028, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 356, shaderLocation: 21},
+          {format: 'snorm16x4', offset: 1184, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 11056,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 36, shaderLocation: 17}],
+      },
+      {
+        arrayStride: 508,
+        attributes: [
+          {format: 'uint16x4', offset: 116, shaderLocation: 14},
+          {format: 'float32', offset: 100, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 112, shaderLocation: 5},
+          {format: 'float32x4', offset: 132, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 32, shaderLocation: 23},
+          {format: 'unorm8x2', offset: 24, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 8, shaderLocation: 18},
+          {format: 'unorm16x4', offset: 44, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 1420,
+        attributes: [
+          {format: 'float16x2', offset: 140, shaderLocation: 12},
+          {format: 'float32x3', offset: 44, shaderLocation: 20},
+          {format: 'uint32x4', offset: 404, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 13100, attributes: []},
+      {arrayStride: 5848, attributes: [{format: 'uint32', offset: 836, shaderLocation: 3}]},
+      {arrayStride: 11960, attributes: [{format: 'snorm8x2', offset: 1744, shaderLocation: 6}]},
+      {arrayStride: 7144, stepMode: 'instance', attributes: []},
+      {arrayStride: 4720, attributes: [{format: 'sint8x4', offset: 1648, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', cullMode: 'back', unclippedDepth: true},
+});
+let textureView214 = texture93.createView({
+  label: '\u{1fdac}\uedfc\ucd7c\u643c\u006f\uf428\u7756\u0a8c\u{1fd2a}\u4bd5',
+  baseMipLevel: 4,
+  mipLevelCount: 5,
+});
+let renderBundleEncoder73 = device1.createRenderBundleEncoder({
+  label: '\u0fd2\u0cc2\uf6cc\ude72\ue1e2\u0378',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle103 = renderBundleEncoder41.finish({label: '\ua509\u{1fa8e}\u0a82\u0367'});
+try {
+computePassEncoder49.dispatchWorkgroups(3, 1);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(2, bindGroup27, new Uint32Array(7380), 6328, 0);
+} catch {}
+try {
+renderPassEncoder52.drawIndirect(buffer35, 252_051_209);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer54, 'uint32', 2964);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline113);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(10, buffer24, 0, 1867);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(6, bindGroup51, new Uint32Array(3231), 1723, 0);
+} catch {}
+try {
+renderBundleEncoder40.draw(41, 92, 599_682_014, 184_341_072);
+} catch {}
+try {
+renderBundleEncoder50.drawIndirect(buffer41, 115744);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture133,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 257_096 */
+{offset: 484, bytesPerRow: 456, rowsPerImage: 281}, {width: 85, height: 1, depthOrArrayLayers: 3});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: video38,
+  origin: { x: 9, y: 0 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 4, y: 25, z: 43},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline158 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout13,
+  multisample: {mask: 0x1f4c1d49},
+  fragment: {
+  module: shaderModule40,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 4078976790,
+  },
+  vertex: {
+    module: shaderModule40,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 40740,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 19372, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 1332, shaderLocation: 18},
+          {format: 'unorm10-10-10-2', offset: 8080, shaderLocation: 22},
+          {format: 'unorm8x2', offset: 1146, shaderLocation: 10},
+          {format: 'float32x4', offset: 2896, shaderLocation: 9},
+          {format: 'uint32x2', offset: 2868, shaderLocation: 8},
+          {format: 'sint32', offset: 3388, shaderLocation: 11},
+          {format: 'sint16x4', offset: 2268, shaderLocation: 17},
+          {format: 'uint8x4', offset: 3828, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 7372, shaderLocation: 21},
+          {format: 'sint8x2', offset: 4676, shaderLocation: 12},
+          {format: 'uint32x3', offset: 1552, shaderLocation: 0},
+          {format: 'uint32x3', offset: 5740, shaderLocation: 19},
+          {format: 'uint16x2', offset: 1808, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 410, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 1352,
+        attributes: [
+          {format: 'sint32', offset: 32, shaderLocation: 3},
+          {format: 'sint32', offset: 500, shaderLocation: 15},
+          {format: 'sint32x4', offset: 216, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 164, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 3564,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 52, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 240, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 36, shaderLocation: 23},
+          {format: 'unorm8x2', offset: 442, shaderLocation: 20},
+          {format: 'float32x2', offset: 1416, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+offscreenCanvas44.getContext('webgpu');
+} catch {}
+offscreenCanvas3.width = 958;
+let imageBitmap41 = await createImageBitmap(video6);
+let textureView215 = texture136.createView({label: '\u0253\u68e1\u18f9\u03bc', mipLevelCount: 2, arrayLayerCount: 1});
+let sampler106 = device1.createSampler({
+  label: '\u08d0\u9001\u0f96\u0da3\u792c\udc5c\u0841',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 36.29,
+});
+try {
+renderPassEncoder49.beginOcclusionQuery(1984);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle46, renderBundle74, renderBundle47, renderBundle68, renderBundle101, renderBundle89, renderBundle46, renderBundle54, renderBundle62]);
+} catch {}
+try {
+renderPassEncoder34.setBlendConstant({ r: 776.2, g: 960.0, b: 870.5, a: -818.7, });
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(2, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(11, buffer41);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(4, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexed(473, 314, 267_742_832);
+} catch {}
+let pipeline159 = await device1.createComputePipelineAsync({
+  label: '\u6c17\u{1fe48}\u{1fce0}\u{1f7fe}\u14f7\u74f8\u95a5\ubeb4',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule22, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(video23);
+video34.width = 29;
+let commandEncoder173 = device1.createCommandEncoder({label: '\u{1f94a}\u{1f79c}\u3249\u005c\u0094\u{1f659}\ue3cc\u09d7\u1667\u{1f8a6}\u0cac'});
+let querySet88 = device1.createQuerySet({label: '\u1a1b\u3861\uf66e', type: 'occlusion', count: 1544});
+let renderBundleEncoder74 = device1.createRenderBundleEncoder({colorFormats: ['rg16uint'], stencilReadOnly: false});
+try {
+renderPassEncoder31.beginOcclusionQuery(561);
+} catch {}
+try {
+renderPassEncoder41.setBlendConstant({ r: 638.9, g: 150.0, b: 87.90, a: -99.90, });
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer42, 1_595_163_767);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer54, 'uint32', 3564, 2693);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline157);
+} catch {}
+try {
+renderBundleEncoder56.draw(75, 173, 990_531_843, 186_831_848);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexed(21, 165, 85_340_366, -2_059_596_699, 433_201_082);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexedIndirect(buffer41, 40188);
+} catch {}
+try {
+commandEncoder173.resolveQuerySet(querySet40, 1194, 953, buffer40, 80384);
+} catch {}
+let img38 = await imageWithData(270, 292, '#6fc11168', '#02cf3ef5');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let bindGroup55 = device1.createBindGroup({label: '\u082c\u15d8\ue43d\u{1f99b}', layout: bindGroupLayout38, entries: []});
+let renderBundle104 = renderBundleEncoder67.finish();
+try {
+computePassEncoder49.dispatchWorkgroupsIndirect(buffer41, 10552);
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline82);
+} catch {}
+try {
+renderPassEncoder31.setStencilReference(54);
+} catch {}
+try {
+renderPassEncoder11.draw(161, 164, 869_253_131, 1_572_702_577);
+} catch {}
+try {
+renderPassEncoder52.drawIndirect(buffer34, 760_983_476);
+} catch {}
+try {
+renderBundleEncoder56.drawIndexed(123, 69, 112_779_336, 501_921_611, 1_971_400_321);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexedIndirect(buffer41, 103044);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(7, buffer41);
+} catch {}
+try {
+commandEncoder173.copyTextureToBuffer({
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 392 widthInBlocks: 98 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11640 */
+  offset: 10736,
+  bytesPerRow: 512,
+  buffer: buffer47,
+}, {width: 98, height: 2, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer47);
+} catch {}
+try {
+commandEncoder173.clearBuffer(buffer27);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer47, 1524, new Float32Array(20402), 1783, 1084);
+} catch {}
+let pipeline160 = await device1.createRenderPipelineAsync({
+  label: '\u09ac\ue37d\u4769\u08cf\u21d9',
+  layout: pipelineLayout16,
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'equal', failOp: 'invert', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'keep'},
+    stencilWriteMask: 933566188,
+    depthBias: 1613631240,
+  },
+  vertex: {
+    module: shaderModule42,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 6772,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 872, shaderLocation: 19},
+          {format: 'snorm16x4', offset: 576, shaderLocation: 17},
+          {format: 'uint32x2', offset: 800, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 792, shaderLocation: 12},
+          {format: 'uint16x2', offset: 344, shaderLocation: 8},
+          {format: 'float32', offset: 1156, shaderLocation: 20},
+          {format: 'float16x4', offset: 360, shaderLocation: 5},
+          {format: 'uint32x4', offset: 916, shaderLocation: 23},
+          {format: 'uint8x2', offset: 162, shaderLocation: 13},
+          {format: 'sint16x2', offset: 2680, shaderLocation: 18},
+          {format: 'float16x2', offset: 628, shaderLocation: 15},
+          {format: 'sint32x2', offset: 292, shaderLocation: 6},
+          {format: 'sint32', offset: 3352, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 4592,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 1020, shaderLocation: 3},
+          {format: 'uint16x2', offset: 88, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 17764,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint16x4', offset: 1648, shaderLocation: 16}],
+      },
+      {
+        arrayStride: 1160,
+        attributes: [
+          {format: 'uint16x2', offset: 16, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 124, shaderLocation: 14},
+          {format: 'sint8x4', offset: 28, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 324, shaderLocation: 0},
+          {format: 'sint8x4', offset: 12, shaderLocation: 2},
+          {format: 'float16x2', offset: 8, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 6408,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 1088, shaderLocation: 11},
+          {format: 'uint16x2', offset: 860, shaderLocation: 22},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'front', unclippedDepth: true},
+});
+gc();
+video22.width = 245;
+document.body.prepend(video4);
+let textureView216 = texture85.createView({label: '\u{1f783}\u0b34\u3e39\uf4b3\u052a\u4a43\u{1ff0a}'});
+let renderPassEncoder55 = commandEncoder173.beginRenderPass({
+  label: '\u048d\u23ff\ua7a7',
+  colorAttachments: [{view: textureView82, depthSlice: 26, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet42,
+  maxDrawCount: 535331004,
+});
+let renderBundle105 = renderBundleEncoder46.finish({label: '\u0e20\u{1fa9c}\uec03\u{1ff0a}\ue005\u{1fd26}\u0a4d\u6a54\u0bf7\u{1fff3}'});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+renderPassEncoder33.drawIndexedIndirect(buffer35, 228_628_548);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(6, bindGroup51);
+} catch {}
+try {
+renderBundleEncoder56.drawIndexedIndirect(buffer41, 38796);
+} catch {}
+try {
+renderBundleEncoder58.insertDebugMarker('\ud9a8');
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline161 = device1.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule40, entryPoint: 'compute0', constants: {}}});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let texture141 = device1.createTexture({
+  size: [300, 12, 96],
+  mipLevelCount: 6,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let textureView217 = texture109.createView({label: '\u{1fdf9}\ua22b\u0a73\u1f34\u291f\u0f1b\u0dee\u717d', baseMipLevel: 0});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+renderPassEncoder33.beginOcclusionQuery(37);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle49, renderBundle53, renderBundle57, renderBundle102, renderBundle62, renderBundle59, renderBundle55, renderBundle49, renderBundle61]);
+} catch {}
+try {
+renderPassEncoder30.setStencilReference(1721);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer32, 179_511_409);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer43, 392_380_506);
+} catch {}
+try {
+renderBundleEncoder58.drawIndexed(42, 168, 1_209_532_439, 203_511_346, 720_448_270);
+} catch {}
+try {
+renderBundleEncoder56.drawIndexedIndirect(buffer41, 20088);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 4,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 872 */
+{offset: 872}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout56 = device1.createBindGroupLayout({
+  label: '\u0618\u041e\u{1f83c}\u{1ff30}\uf569\uc788\u9534\uef47\u{1fd74}',
+  entries: [
+    {
+      binding: 4534,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let bindGroup56 = device1.createBindGroup({label: '\u2f62\u0b06\u4d79\u9541', layout: bindGroupLayout36, entries: []});
+let pipelineLayout27 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout35]});
+let commandEncoder174 = device1.createCommandEncoder({label: '\ude29\u0549\u{1fe90}\uc6f0\ubce5\uff09\ud1a5\u001e\u998a\u5cd8'});
+let querySet89 = device1.createQuerySet({
+  label: '\u035a\u{1fb30}\u2277\u0117\u180d\u0f9c\udd62\ufd43\ue8c9\u0074\uba74',
+  type: 'occlusion',
+  count: 3295,
+});
+let texture142 = device1.createTexture({
+  label: '\u2f6b\u0948\ue46b\u02fa\u0fb3\u{1f9ef}',
+  size: [75],
+  dimension: '1d',
+  format: 'rgb9e5ufloat',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder71 = commandEncoder174.beginComputePass({label: '\u0bce\u0708\ue486\u0452\u2278\u6b49'});
+let renderBundle106 = renderBundleEncoder72.finish({label: '\u012d\u9827\u055e\u9722\u0403'});
+let sampler107 = device1.createSampler({
+  label: '\ufe89\uead7\u2758\u0fad\u2817\u{1ff3f}\uea90\u{1fe31}\u14d4',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 54.87,
+  lodMaxClamp: 63.60,
+});
+let externalTexture87 = device1.importExternalTexture({
+  label: '\uff71\u1b83\uc20c\u{1fc3c}\u190f\u071d\ud375\ua0ff\u45e0\u70af\u3a89',
+  source: video19,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder66.setPipeline(pipeline132);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+renderPassEncoder45.beginOcclusionQuery(335);
+} catch {}
+try {
+renderPassEncoder36.setViewport(30.35, 1.346, 2.451, 0.5927, 0.1992, 0.4051);
+} catch {}
+try {
+renderPassEncoder41.draw(87, 54, 529_200_758, 420_422_625);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer27, 787_294_508);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(3, buffer24);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(0, bindGroup29, new Uint32Array(7595), 7155, 0);
+} catch {}
+try {
+renderBundleEncoder53.drawIndexedIndirect(buffer41, 120620);
+} catch {}
+try {
+renderBundleEncoder50.drawIndirect(buffer41, 15572);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(4, buffer24, 0, 3386);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 16, y: 1, z: 2},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer1), /* required buffer size: 563_150 */
+{offset: 170, bytesPerRow: 1033, rowsPerImage: 90}, {width: 257, height: 5, depthOrArrayLayers: 7});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: imageBitmap30,
+  origin: { x: 243, y: 12 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 7, y: 3, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout28 = device1.createPipelineLayout({
+  label: '\ub074\ub536\ud91e\u6815\u8b68\ud606\ub55c\u{1ff06}',
+  bindGroupLayouts: [bindGroupLayout23, bindGroupLayout17, bindGroupLayout22],
+});
+let commandEncoder175 = device1.createCommandEncoder({label: '\u9bcb\u06b3\u0eea\u072e\u{1f885}\u0577\uc7c7\u7989\uf253\ue331'});
+let computePassEncoder72 = commandEncoder175.beginComputePass({label: '\u9429\u0cd6\u8357\u{1fd1d}\u14b1\u9c5d\u09aa\u{1fed1}\ufdab\uc6a6\u0e87'});
+try {
+renderPassEncoder52.drawIndexedIndirect(buffer43, 207_074_751);
+} catch {}
+try {
+renderBundleEncoder58.drawIndexedIndirect(buffer41, 74208);
+} catch {}
+let pipeline162 = device1.createRenderPipeline({
+  label: '\u3d51\u3f1d\u7590\u3459',
+  layout: pipelineLayout27,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule31,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule31,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'snorm8x2', offset: 2470, shaderLocation: 15},
+          {format: 'sint32x2', offset: 10704, shaderLocation: 19},
+          {format: 'unorm8x2', offset: 4980, shaderLocation: 10},
+          {format: 'sint16x4', offset: 7744, shaderLocation: 5},
+          {format: 'uint16x2', offset: 12804, shaderLocation: 13},
+          {format: 'float32x3', offset: 6208, shaderLocation: 23},
+          {format: 'sint32x2', offset: 4148, shaderLocation: 7},
+          {format: 'uint32x3', offset: 14492, shaderLocation: 1},
+          {format: 'sint16x4', offset: 148, shaderLocation: 17},
+          {format: 'unorm8x4', offset: 11500, shaderLocation: 20},
+          {format: 'uint8x2', offset: 2482, shaderLocation: 2},
+          {format: 'uint32x4', offset: 2980, shaderLocation: 6},
+          {format: 'float16x2', offset: 3284, shaderLocation: 3},
+          {format: 'sint32x3', offset: 11512, shaderLocation: 9},
+          {format: 'uint16x2', offset: 1984, shaderLocation: 12},
+          {format: 'float16x4', offset: 29792, shaderLocation: 22},
+          {format: 'float32x2', offset: 3420, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 4996,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 684, shaderLocation: 4},
+          {format: 'uint32x2', offset: 1524, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+let bindGroup57 = device1.createBindGroup({label: '\u06ef\u3024\ub75c\u{1faf8}\ub32d\u3451', layout: bindGroupLayout21, entries: []});
+let renderBundle107 = renderBundleEncoder26.finish({label: '\u0aa5\u0010\uce0b\u95a9\u09d5\u{1fabc}\u{1fe50}\u{1fba7}\u0314\u{1fbea}'});
+try {
+computePassEncoder39.end();
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline149);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer38, 821_433_371);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer54, 'uint32', 784);
+} catch {}
+try {
+renderBundleEncoder29.draw(61, 185, 1_108_203_571);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer41, 2872);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(4712, undefined, 1932654475, 873457376);
+} catch {}
+try {
+commandEncoder84.copyBufferToTexture({
+  /* bytesInLastRow: 140 widthInBlocks: 35 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12816 */
+  offset: 12816,
+  buffer: buffer29,
+}, {
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 35, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let videoFrame33 = new VideoFrame(img2, {timestamp: 0});
+let commandEncoder176 = device1.createCommandEncoder();
+let texture143 = device1.createTexture({
+  label: '\u242d\u{1f9a1}\u061e\u6e25\u{1f782}\u184b\u0e1f',
+  size: [36],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundleEncoder75 = device1.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthReadOnly: false, stencilReadOnly: true});
+try {
+renderPassEncoder45.setBlendConstant({ r: -829.8, g: 966.2, b: 156.4, a: 637.4, });
+} catch {}
+try {
+renderPassEncoder54.setStencilReference(2573);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer55, 537_893_390);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline122);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer41, 0, 269270);
+} catch {}
+try {
+renderBundleEncoder58.drawIndexed(252, 76, 364_396_056, 230_025_793, 33_462_608);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexedIndirect(buffer41, 17012);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer41, 34080);
+} catch {}
+try {
+renderBundleEncoder74.setIndexBuffer(buffer54, 'uint32');
+} catch {}
+try {
+commandEncoder84.copyTextureToTexture({
+  texture: texture56,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 28, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: offscreenCanvas9,
+  origin: { x: 507, y: 49 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 55, y: 5, z: 48},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let adapter5 = await promise53;
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let textureView218 = texture139.createView({format: 'rg16uint'});
+let computePassEncoder73 = commandEncoder176.beginComputePass();
+try {
+computePassEncoder45.setPipeline(pipeline153);
+} catch {}
+try {
+renderPassEncoder37.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.draw(125, 418);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer34, 1_288_413_469);
+} catch {}
+try {
+renderBundleEncoder53.draw(26, 502, 663_042_313, 266_832_898);
+} catch {}
+let pipelineLayout29 = device1.createPipelineLayout({
+  label: '\u{1ffb8}\uf297\u7dc7\u0d86\ua32f\u{1fef4}\u0746\uebd1\u{1f788}',
+  bindGroupLayouts: [bindGroupLayout43],
+});
+let renderBundleEncoder76 = device1.createRenderBundleEncoder({
+  label: '\u1228\u{1f7d9}\u2891\u{1fa3c}\ufa5b\u73cc\u086f\u54ee\u06b4\u6584\u0fb5',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder49.dispatchWorkgroupsIndirect(buffer41, 289992);
+} catch {}
+try {
+renderPassEncoder11.setViewport(536.4, 0.4051, 296.8, 0.5187, 0.7922, 0.9324);
+} catch {}
+try {
+renderPassEncoder33.draw(20, 8, 109_551_416);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(1, bindGroup53);
+} catch {}
+try {
+renderBundleEncoder29.drawIndirect(buffer41, 1268);
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(4, buffer24, 4752);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer53, 1704, new DataView(new ArrayBuffer(22594)), 10002, 1704);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: offscreenCanvas23,
+  origin: { x: 4, y: 52 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 15, y: 18, z: 80},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 5, depthOrArrayLayers: 0});
+} catch {}
+video32.height = 105;
+let computePassEncoder74 = commandEncoder84.beginComputePass({label: '\uc9eb\ua50c\u32cf\uaade'});
+try {
+computePassEncoder49.dispatchWorkgroups(3, 5);
+} catch {}
+try {
+renderPassEncoder40.beginOcclusionQuery(3012);
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: 672.2, g: 309.0, b: -683.4, a: -609.4, });
+} catch {}
+try {
+renderPassEncoder54.setStencilReference(3941);
+} catch {}
+try {
+renderBundleEncoder71.setVertexBuffer(11, buffer24, 648);
+} catch {}
+try {
+buffer47.unmap();
+} catch {}
+let pipelineLayout30 = device1.createPipelineLayout({
+  label: '\u0545\ubdf1\u0173\u027a\u6570\uf157\u06e6\u0bf5\uf52f\ud667',
+  bindGroupLayouts: [bindGroupLayout24, bindGroupLayout18, bindGroupLayout35, bindGroupLayout20, bindGroupLayout30, bindGroupLayout39],
+});
+let renderBundle108 = renderBundleEncoder75.finish({});
+let sampler108 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 13.21,
+  lodMaxClamp: 95.91,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder44.setBindGroup(4, bindGroup51, new Uint32Array(5093), 2586, 0);
+} catch {}
+try {
+renderPassEncoder52.end();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle102, renderBundle94, renderBundle60, renderBundle62, renderBundle99, renderBundle48]);
+} catch {}
+try {
+renderPassEncoder41.draw(37, 114);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(276, 167, 1_779_277_966, 23_839_125, 868_500_809);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer55, 331_760_451);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(6, bindGroup49, []);
+} catch {}
+try {
+renderBundleEncoder52.setIndexBuffer(buffer54, 'uint16');
+} catch {}
+try {
+querySet65.destroy();
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let textureView219 = texture116.createView({
+  label: '\u053e\ud4f1\u615b\u7a7b\u0f1d\u0fc5\u074a\u0617\u02cf\u{1fc4e}\u{1fa35}',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 9,
+  mipLevelCount: 1,
+});
+let externalTexture88 = device1.importExternalTexture({
+  label: '\u0210\u62c8\uc0ba\u{1f799}\u0f65\u7f8b\u0347\u653e\u05f5\u384c',
+  source: videoFrame4,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder50.dispatchWorkgroups(2);
+} catch {}
+try {
+renderPassEncoder33.setStencilReference(842);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer39, 74_306_047);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline157);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexedIndirect(buffer41, 23800);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer54, 'uint16', 15050, 322);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(0, buffer41, 0, 244168);
+} catch {}
+let promise62 = device1.popErrorScope();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: imageBitmap25,
+  origin: { x: 17, y: 10 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 14, y: 2, z: 204},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video35);
+let imageData68 = new ImageData(100, 192);
+let commandEncoder177 = device1.createCommandEncoder();
+let textureView220 = texture131.createView({dimension: '3d', baseMipLevel: 4});
+let renderBundleEncoder77 = device1.createRenderBundleEncoder({
+  label: '\u{1fdfd}\u0e30\u{1fe8d}\uc730\u0ea4\u0c8c',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder40.draw(174, 118, 380_773_274, 178_995_249);
+} catch {}
+try {
+renderBundleEncoder58.drawIndexed(77, 104, 1_213_377_869, 116_816_356, 583_871_292);
+} catch {}
+try {
+renderBundleEncoder56.drawIndirect(buffer41, 180004);
+} catch {}
+try {
+commandEncoder177.copyTextureToBuffer({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 632 */
+  offset: 612,
+  rowsPerImage: 88,
+  buffer: buffer24,
+}, {width: 5, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer24);
+} catch {}
+try {
+commandEncoder177.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture92,
+  mipLevel: 1,
+  origin: {x: 14, y: 0, z: 59},
+  aspect: 'all',
+},
+{width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder177.resolveQuerySet(querySet54, 576, 2073, buffer42, 25600);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer47, 9860, new BigUint64Array(32129), 750, 1684);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 93 */
+{offset: 93, bytesPerRow: 729}, {width: 320, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: videoFrame24,
+  origin: { x: 452, y: 44 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 6, y: 13, z: 18},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule44 = device1.createShaderModule({
+  label: '\uc08d\u{1f764}\ub963\u43f5\u0545\u0aea\uce2a\u5597\u0bdc\u8534\u3202',
+  code: `@group(6) @binding(8384)
+var<storage, read_write> n30: array<u32>;
+@group(3) @binding(5067)
+var<storage, read_write> type22: array<u32>;
+@group(1) @binding(8384)
+var<storage, read_write> global27: array<u32>;
+@group(4) @binding(6764)
+var<storage, read_write> function23: array<u32>;
+@group(4) @binding(3078)
+var<storage, read_write> parameter25: array<u32>;
+@group(0) @binding(6703)
+var<storage, read_write> n31: array<u32>;
+@group(0) @binding(1519)
+var<storage, read_write> function24: array<u32>;
+@group(5) @binding(7160)
+var<storage, read_write> parameter26: array<u32>;
+@group(3) @binding(7457)
+var<storage, read_write> parameter27: array<u32>;
+@group(1) @binding(5282)
+var<storage, read_write> field25: array<u32>;
+
+@compute @workgroup_size(4, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) -> @location(200) vec2<u32> {
+return vec2<u32>();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(5) a1: vec3<f32>, @location(21) a2: u32, @location(23) a3: vec2<i32>, @location(13) a4: vec4<i32>, @location(10) a5: vec4<u32>, @location(7) a6: vec2<u32>, @location(22) a7: vec3<i32>, @location(6) a8: vec2<u32>, @location(2) a9: vec4<u32>, @location(14) a10: vec3<f16>, @location(9) a11: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView221 = texture116.createView({
+  label: '\u0777\u04e5\u2d30\u71f8\uac72\ud67c\u8995\u0e19\u6537\u01db\ub822',
+  baseMipLevel: 9,
+  mipLevelCount: 1,
+  baseArrayLayer: 62,
+  arrayLayerCount: 6,
+});
+try {
+renderPassEncoder46.setBindGroup(4, bindGroup47, []);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle94, renderBundle97, renderBundle58, renderBundle70, renderBundle107]);
+} catch {}
+try {
+renderPassEncoder35.setScissorRect(0, 0, 2, 1);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer35, 352_387_289);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(4, bindGroup25, []);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexedIndirect(buffer41, 80468);
+} catch {}
+try {
+renderBundleEncoder50.drawIndirect(buffer41, 12108);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+commandEncoder177.clearBuffer(buffer24, 4620);
+dissociateBuffer(device1, buffer24);
+} catch {}
+try {
+commandEncoder177.resolveQuerySet(querySet50, 1233, 126, buffer42, 15104);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer8), /* required buffer size: 750 */
+{offset: 750}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+  await promise62;
+} catch {}
+let imageBitmap42 = await createImageBitmap(img20);
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+let renderPassEncoder56 = commandEncoder177.beginRenderPass({
+  label: '\u7e5a\u05aa\u04ef\ue939\u029b\u45e6\u6281\u{1fd5e}\u33b1\u0c89',
+  colorAttachments: [{view: textureView178, depthSlice: 0, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 1054656011,
+});
+let renderBundleEncoder78 = device1.createRenderBundleEncoder({label: '\u439f\u172f\u1b15\u{1fb27}\u{1fd08}', colorFormats: ['rg16uint'], depthReadOnly: true});
+let renderBundle109 = renderBundleEncoder36.finish({});
+try {
+computePassEncoder74.setPipeline(pipeline94);
+} catch {}
+try {
+renderPassEncoder36.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(11, 243, 496_979_032, 87_338_405, 1_364_144_934);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer34, 787_462_745);
+} catch {}
+try {
+renderBundleEncoder74.setPipeline(pipeline139);
+} catch {}
+try {
+device1.queue.submit([commandBuffer23, commandBuffer34, commandBuffer31, commandBuffer27]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: videoFrame31,
+  origin: { x: 62, y: 25 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 39, y: 11, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 34, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let pipeline163 = device1.createRenderPipeline({
+  layout: pipelineLayout25,
+  multisample: {mask: 0x5aa36847},
+  fragment: {
+  module: shaderModule42,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'less', failOp: 'invert', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'increment-wrap'},
+    stencilReadMask: 1153870789,
+    stencilWriteMask: 757162432,
+    depthBias: 366105091,
+  },
+  vertex: {
+    module: shaderModule42,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 2972,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 764, shaderLocation: 18},
+          {format: 'float16x4', offset: 520, shaderLocation: 0},
+          {format: 'sint16x2', offset: 536, shaderLocation: 1},
+          {format: 'uint32', offset: 488, shaderLocation: 13},
+          {format: 'uint32x3', offset: 252, shaderLocation: 7},
+          {format: 'snorm16x2', offset: 104, shaderLocation: 17},
+          {format: 'snorm8x4', offset: 976, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 872, shaderLocation: 20},
+          {format: 'uint32x3', offset: 4, shaderLocation: 22},
+          {format: 'sint32x2', offset: 448, shaderLocation: 4},
+          {format: 'float16x2', offset: 152, shaderLocation: 3},
+          {format: 'uint16x2', offset: 748, shaderLocation: 23},
+          {format: 'float16x2', offset: 316, shaderLocation: 15},
+          {format: 'sint32x3', offset: 336, shaderLocation: 16},
+          {format: 'sint32', offset: 168, shaderLocation: 6},
+          {format: 'uint8x4', offset: 504, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 300, shaderLocation: 12},
+          {format: 'float32x4', offset: 100, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 572, shaderLocation: 19},
+          {format: 'uint8x4', offset: 64, shaderLocation: 21},
+          {format: 'unorm16x2', offset: 308, shaderLocation: 14},
+          {format: 'uint32x4', offset: 68, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 7156,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x4', offset: 248, shaderLocation: 2},
+          {format: 'snorm8x4', offset: 1676, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let canvas43 = document.createElement('canvas');
+let img39 = await imageWithData(242, 127, '#4b80a781', '#e3bf1ec6');
+let textureView222 = texture95.createView({label: '\u42dd\ud05d\u04b4\uf077\u2a59\u4961\u1b04\u930e\u{1f748}\ua014\u07b3'});
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+renderPassEncoder33.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle58, renderBundle105, renderBundle54, renderBundle61, renderBundle108, renderBundle43, renderBundle96, renderBundle49, renderBundle65]);
+} catch {}
+try {
+renderPassEncoder49.setStencilReference(1100);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer55, 953_263_442);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer54, 'uint16', 8732, 3768);
+} catch {}
+try {
+renderBundleEncoder53.draw(280);
+} catch {}
+try {
+renderBundleEncoder52.setIndexBuffer(buffer54, 'uint16', 15482, 498);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline64);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer52, 19956, new Float32Array(11039), 876, 596);
+} catch {}
+let pipeline164 = device1.createRenderPipeline({
+  label: '\u0b1e\u{1f7ae}\u0057',
+  layout: pipelineLayout16,
+  fragment: {
+  module: shaderModule40,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule40,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 6960,
+        attributes: [
+          {format: 'float16x4', offset: 2732, shaderLocation: 10},
+          {format: 'uint8x4', offset: 316, shaderLocation: 16},
+          {format: 'snorm8x4', offset: 684, shaderLocation: 5},
+          {format: 'sint16x2', offset: 128, shaderLocation: 2},
+          {format: 'uint32x3', offset: 948, shaderLocation: 0},
+          {format: 'uint32x4', offset: 1872, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 4148, shaderLocation: 6},
+          {format: 'sint16x2', offset: 500, shaderLocation: 17},
+          {format: 'float16x2', offset: 28, shaderLocation: 7},
+          {format: 'uint32', offset: 628, shaderLocation: 13},
+          {format: 'sint32x4', offset: 4904, shaderLocation: 12},
+          {format: 'uint8x2', offset: 1110, shaderLocation: 19},
+          {format: 'sint16x4', offset: 676, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 458, shaderLocation: 22},
+          {format: 'float32x2', offset: 1320, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 412, shaderLocation: 18},
+          {format: 'snorm8x4', offset: 648, shaderLocation: 4},
+          {format: 'float32x4', offset: 204, shaderLocation: 1},
+          {format: 'float16x2', offset: 2980, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 928,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 272, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 512, shaderLocation: 21},
+          {format: 'float32x3', offset: 44, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 104, shaderLocation: 23},
+        ],
+      },
+      {arrayStride: 4664, stepMode: 'instance', attributes: []},
+      {arrayStride: 148, stepMode: 'vertex', attributes: []},
+      {arrayStride: 6556, attributes: [{format: 'sint8x2', offset: 388, shaderLocation: 11}]},
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: false,
+},
+});
+let externalTexture89 = device1.importExternalTexture({source: video6, colorSpace: 'display-p3'});
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup45, new Uint32Array(7469), 115, 0);
+} catch {}
+try {
+renderPassEncoder26.setViewport(872.4, 0.3275, 246.0, 0.1646, 0.9037, 0.9884);
+} catch {}
+try {
+renderPassEncoder28.drawIndexed(415, 226);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline86);
+} catch {}
+let video42 = await videoWithData();
+let texture144 = device1.createTexture({
+  label: '\u0eae\u5735\u0996',
+  size: [36, 8, 1],
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture90 = device1.importExternalTexture({source: video20, colorSpace: 'display-p3'});
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(5, bindGroup24, []);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer54, 109_557_527);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer54, 'uint32', 2912);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer24);
+} catch {}
+try {
+renderBundleEncoder53.setPipeline(pipeline113);
+} catch {}
+try {
+commandEncoder94.copyBufferToBuffer(buffer32, 30428, buffer49, 25244, 4);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer49);
+} catch {}
+try {
+commandEncoder94.copyBufferToTexture({
+  /* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 74928 */
+  offset: 74928,
+  buffer: buffer29,
+}, {
+  texture: texture133,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder94.clearBuffer(buffer26);
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+commandEncoder94.resolveQuerySet(querySet36, 2433, 118, buffer28, 12032);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture143,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer8), /* required buffer size: 967 */
+{offset: 967, rowsPerImage: 137}, {width: 31, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline165 = device1.createComputePipeline({
+  label: '\u0e38\u6332\u3082\uad91\u0c16\uee3c\u674a\u05da\u0877\u6ca7\u{1fcba}',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule20, entryPoint: 'compute0', constants: {}},
+});
+let video43 = await videoWithData();
+let videoFrame34 = new VideoFrame(canvas12, {timestamp: 0});
+let buffer56 = device1.createBuffer({label: '\u{1fe58}\u02d3\u8b3b\u9cf5', size: 171956, usage: GPUBufferUsage.STORAGE});
+let commandEncoder178 = device1.createCommandEncoder({label: '\u{1f763}\u0c57\u0311\u2d0c\u{1f689}'});
+let renderBundle110 = renderBundleEncoder77.finish();
+try {
+computePassEncoder51.setPipeline(pipeline72);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder54.setBlendConstant({ r: -362.6, g: -986.7, b: -751.8, a: 616.6, });
+} catch {}
+try {
+renderPassEncoder55.setScissorRect(128, 1, 334, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer54, 'uint16', 11266, 305);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(4, buffer24, 0, 430);
+} catch {}
+try {
+device1.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder178.copyBufferToTexture({
+  /* bytesInLastRow: 356 widthInBlocks: 89 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 222504 */
+  offset: 37316,
+  bytesPerRow: 512,
+  rowsPerImage: 319,
+  buffer: buffer29,
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 26, y: 1, z: 82},
+  aspect: 'all',
+}, {width: 89, height: 43, depthOrArrayLayers: 2});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder94.resolveQuerySet(querySet89, 426, 2072, buffer42, 37376);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 7,
+  origin: {x: 15, y: 0, z: 18},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 447_183 */
+{offset: 983, bytesPerRow: 230, rowsPerImage: 194}, {width: 21, height: 0, depthOrArrayLayers: 11});
+} catch {}
+let offscreenCanvas45 = new OffscreenCanvas(158, 60);
+let commandEncoder179 = device1.createCommandEncoder({label: '\u96ec\u{1face}\u062e\u00a3'});
+let commandBuffer35 = commandEncoder179.finish({label: '\ufb00\uead3\u0857\u{1f911}\u0dc2\uf2ae\u{1fb9d}\u{1f958}'});
+let externalTexture91 = device1.importExternalTexture({
+  label: '\u{1feb4}\u0923\ue9e5\u056d\u045c\u0b20\ue29c\u6d1d\u1752\u05ac\u{1ff97}',
+  source: video6,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder41.setStencilReference(3278);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer24, 1_055_548_237);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline139);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(8, buffer24, 2092, 888);
+} catch {}
+try {
+renderBundleEncoder70.setPipeline(pipeline122);
+} catch {}
+try {
+commandEncoder94.copyBufferToBuffer(buffer33, 34544, buffer24, 4216, 716);
+dissociateBuffer(device1, buffer33);
+dissociateBuffer(device1, buffer24);
+} catch {}
+let pipeline166 = device1.createComputePipeline({
+  label: '\u335b\u{1f8b5}\u9dbe\ufd21\u{1fc8f}\uf23a',
+  layout: 'auto',
+  compute: {module: shaderModule40, entryPoint: 'compute0'},
+});
+let textureView223 = texture87.createView({label: '\u557d\ud6ce\ua304\u033a\u78b3\u39cf', dimension: '2d-array', baseMipLevel: 3});
+let computePassEncoder75 = commandEncoder94.beginComputePass({});
+try {
+renderPassEncoder15.setViewport(1046.3, 0.6162, 37.60, 0.00285, 0.7133, 0.7300);
+} catch {}
+try {
+renderPassEncoder41.drawIndexedIndirect(buffer42, 83_390_203);
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer34, 1_341_051_261);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexedIndirect(buffer41, 104616);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(8208, undefined, 0, 3525082839);
+} catch {}
+try {
+commandEncoder178.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11912 */
+  offset: 11912,
+  buffer: buffer29,
+}, {
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 188, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder178.copyTextureToTexture({
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 2941, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+sampler83.label = '\u0aac\u9412\u0684\ue342';
+} catch {}
+let texture145 = device1.createTexture({
+  label: '\ud300\u35b0\u2945\uad7f\u{1f8ff}\ue3c4\u0e13\u{1fc7d}',
+  size: [1134],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint'],
+});
+let textureView224 = texture141.createView({
+  label: '\u9379\u0355\u062f\u02c8\u0aa9\u8e64',
+  dimension: '2d',
+  baseMipLevel: 4,
+  mipLevelCount: 2,
+  baseArrayLayer: 38,
+});
+let renderPassEncoder57 = commandEncoder178.beginRenderPass({
+  label: '\ud2ed\u54ae\u0578\u0beb\u2342\u5f13\u06c3\u65dd',
+  colorAttachments: [{
+  view: textureView133,
+  depthSlice: 2,
+  clearValue: { r: -671.3, g: 31.04, b: -921.6, a: -850.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet55,
+});
+let renderBundleEncoder79 = device1.createRenderBundleEncoder({
+  label: '\ucd06\u67fb\u8584\u6e01\u19f5',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler109 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 32.99,
+  lodMaxClamp: 74.66,
+});
+try {
+renderPassEncoder11.setBindGroup(6, bindGroup33);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer52, 387_836_691);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer26, 649_085_096);
+} catch {}
+try {
+renderBundleEncoder61.setBindGroup(6, bindGroup56);
+} catch {}
+try {
+renderBundleEncoder70.drawIndexed(95, 61);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: img22,
+  origin: { x: 21, y: 18 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 20, y: 1, z: 34},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext36 = offscreenCanvas45.getContext('webgpu');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let img40 = await imageWithData(11, 92, '#4aca2b2c', '#f78cad97');
+try {
+window.someLabel = externalTexture4.label;
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let commandEncoder180 = device1.createCommandEncoder({label: '\u0b7e\u0b9d\u{1f649}\ufdb5\ub12c\ucfc5\u5ec0\u8e89\u0ceb\u0741\u{1f6b8}'});
+let querySet90 = device1.createQuerySet({label: '\u{1f7f6}\u{1f617}\ub2dc\u0a03\u{1fd38}', type: 'occlusion', count: 117});
+let textureView225 = texture68.createView({});
+let externalTexture92 = device1.importExternalTexture({label: '\u02ec\u07f6\u{1f6d5}\u4c4d\u6817\u{1fdd9}\u8526', source: videoFrame14, colorSpace: 'srgb'});
+try {
+renderPassEncoder40.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder33.drawIndexedIndirect(buffer31, 1_008_367_360);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(10, buffer41, 0, 256986);
+} catch {}
+try {
+renderBundleEncoder58.drawIndexedIndirect(buffer41, 87948);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer47, 25996, new BigUint64Array(61966), 10328, 4628);
+} catch {}
+let pipeline167 = await device1.createComputePipelineAsync({
+  label: '\u{1fd5c}\ub513',
+  layout: pipelineLayout25,
+  compute: {module: shaderModule38, entryPoint: 'compute0', constants: {}},
+});
+let canvas44 = document.createElement('canvas');
+let img41 = await imageWithData(236, 166, '#ccbb3121', '#bcc885e4');
+try {
+window.someLabel = externalTexture28.label;
+} catch {}
+let imageBitmap43 = await createImageBitmap(img28);
+let commandEncoder181 = device1.createCommandEncoder({});
+let textureView226 = texture58.createView({label: '\uf465\u5a23\u076f\u376e\ub0c7\u935c'});
+try {
+computePassEncoder46.setPipeline(pipeline107);
+} catch {}
+try {
+renderPassEncoder20.beginOcclusionQuery(1169);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle95, renderBundle67, renderBundle103]);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(33, 2, 7, 0);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer36, 70_246_057);
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer29, 368_016_242);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer54, 'uint16', 11864, 309);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(10, buffer41, 0, 87835);
+} catch {}
+try {
+renderBundleEncoder44.setIndexBuffer(buffer54, 'uint16', 1220, 14359);
+} catch {}
+try {
+commandEncoder181.copyTextureToBuffer({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 628, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 672 widthInBlocks: 168 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 34984 */
+  offset: 34312,
+  buffer: buffer55,
+}, {width: 168, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer55);
+} catch {}
+try {
+canvas44.getContext('webgl2');
+} catch {}
+video39.height = 232;
+try {
+adapter3.label = '\u1fd9\u{1ffd7}\u1ce2\ub516';
+} catch {}
+let gpuCanvasContext37 = canvas43.getContext('webgpu');
+let canvas45 = document.createElement('canvas');
+document.body.prepend(video39);
+let canvas46 = document.createElement('canvas');
+document.body.prepend(img21);
+let video44 = await videoWithData();
+try {
+canvas45.getContext('2d');
+} catch {}
+let commandBuffer36 = commandEncoder180.finish({});
+let textureView227 = texture69.createView({label: '\u0f52\u0b02\u5425', aspect: 'all', mipLevelCount: 2});
+let renderPassEncoder58 = commandEncoder181.beginRenderPass({
+  label: '\u0b17\ue676\u11d9\u0928\u3949\u7774\uc7d2\u16e7',
+  colorAttachments: [{view: textureView226, depthSlice: 95, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet41,
+  maxDrawCount: 509605414,
+});
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+renderPassEncoder30.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle70, renderBundle73, renderBundle105]);
+} catch {}
+try {
+renderPassEncoder49.setStencilReference(1818);
+} catch {}
+try {
+renderPassEncoder11.drawIndirect(buffer39, 790_435_429);
+} catch {}
+try {
+renderBundleEncoder50.draw(321, 218, 2_413_074_223, 54_176_793);
+} catch {}
+try {
+renderBundleEncoder31.drawIndexedIndirect(buffer41, 25580);
+} catch {}
+try {
+renderBundleEncoder74.setVertexBuffer(9, buffer24, 0);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+try {
+canvas46.getContext('webgl');
+} catch {}
+document.body.prepend(canvas20);
+let canvas47 = document.createElement('canvas');
+let img42 = await imageWithData(195, 150, '#c359b182', '#670db355');
+let bindGroupLayout57 = pipeline155.getBindGroupLayout(1);
+let sampler110 = device1.createSampler({
+  label: '\u{1fc35}\u{1f9f2}\u0cf1\u2eb9',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.57,
+  lodMaxClamp: 89.17,
+  compare: 'less-equal',
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder55.beginOcclusionQuery(32);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(470);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(7, buffer24, 0, 2969);
+} catch {}
+try {
+renderBundleEncoder58.drawIndexedIndirect(buffer41, 35972);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: offscreenCanvas29,
+  origin: { x: 400, y: 8 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 2, y: 10, z: 84},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let gpuCanvasContext38 = canvas47.getContext('webgpu');
+let imageBitmap44 = await createImageBitmap(canvas47);
+try {
+window.someLabel = sampler37.label;
+} catch {}
+document.body.prepend(canvas21);
+let img43 = await imageWithData(134, 134, '#2c684e17', '#bac42bfd');
+let bindGroupLayout58 = device1.createBindGroupLayout({
+  label: '\u4bab\u6b5c\u035d\u0477\u75b2\u0860\u{1ffbc}\u0a15',
+  entries: [
+    {
+      binding: 2288,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 14437237, hasDynamicOffset: true },
+    },
+    {binding: 284, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+  ],
+});
+let commandEncoder182 = device1.createCommandEncoder();
+let renderBundle111 = renderBundleEncoder51.finish({});
+try {
+computePassEncoder41.setBindGroup(6, bindGroup33, new Uint32Array(4569), 3980, 0);
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline132);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(4, bindGroup27, new Uint32Array(2192), 428, 0);
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(2, 0, 11, 0);
+} catch {}
+try {
+renderPassEncoder22.setViewport(61.01, 6.124, 4.430, 0.6624, 0.4822, 0.8872);
+} catch {}
+try {
+renderPassEncoder41.drawIndexedIndirect(buffer30, 672_777_297);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexed(141, 212);
+} catch {}
+try {
+renderBundleEncoder50.drawIndirect(buffer41, 64464);
+} catch {}
+try {
+renderBundleEncoder74.setVertexBuffer(3, buffer24);
+} catch {}
+let promise63 = buffer55.mapAsync(GPUMapMode.READ, 0, 207400);
+try {
+device1.queue.writeBuffer(buffer52, 37592, new Int16Array(62331), 27750, 4412);
+} catch {}
+let pipeline168 = await device1.createRenderPipelineAsync({
+  label: '\u{1fb34}\u2ff8\u97ae\uf61f',
+  layout: pipelineLayout23,
+  fragment: {
+  module: shaderModule26,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-wrap', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilReadMask: 1180701377,
+  },
+  vertex: {
+    module: shaderModule26,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4588,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 444, shaderLocation: 9},
+          {format: 'uint16x2', offset: 488, shaderLocation: 4},
+          {format: 'sint32x4', offset: 44, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 562, shaderLocation: 16},
+          {format: 'sint32', offset: 1640, shaderLocation: 19},
+          {format: 'sint16x2', offset: 88, shaderLocation: 3},
+          {format: 'sint32x2', offset: 248, shaderLocation: 2},
+          {format: 'sint32', offset: 1160, shaderLocation: 15},
+          {format: 'sint32x4', offset: 1492, shaderLocation: 8},
+          {format: 'uint8x4', offset: 484, shaderLocation: 6},
+          {format: 'sint32x2', offset: 464, shaderLocation: 18},
+          {format: 'unorm10-10-10-2', offset: 204, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 17},
+          {format: 'uint8x2', offset: 1626, shaderLocation: 5},
+          {format: 'float32x4', offset: 148, shaderLocation: 14},
+          {format: 'uint16x2', offset: 1068, shaderLocation: 23},
+          {format: 'sint32x3', offset: 500, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 92, shaderLocation: 20},
+          {format: 'snorm8x4', offset: 240, shaderLocation: 21},
+          {format: 'unorm8x4', offset: 816, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 148, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 260, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 476, shaderLocation: 22},
+        ],
+      },
+      {arrayStride: 348, attributes: []},
+      {arrayStride: 1768, attributes: [{format: 'uint16x4', offset: 372, shaderLocation: 11}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+try {
+adapter2.label = '\u05e4\uaf7b\u463b\ub1e2\u0c6f\u{1fde0}\u{1fbd4}\u9357\u04d6\u{1fe65}\u{1fe10}';
+} catch {}
+gc();
+try {
+gpuCanvasContext32.unconfigure();
+} catch {}
+video12.width = 190;
+let offscreenCanvas46 = new OffscreenCanvas(394, 773);
+let imageBitmap45 = await createImageBitmap(imageBitmap22);
+try {
+offscreenCanvas46.getContext('2d');
+} catch {}
+try {
+window.someLabel = sampler47.label;
+} catch {}
+let commandEncoder183 = device1.createCommandEncoder({label: '\u4738\ua0ba\u44a2'});
+let querySet91 = device1.createQuerySet({label: '\u975a\u{1f93c}\uf0e3\u69bc\u449b\u0e68\u0152', type: 'occlusion', count: 69});
+let renderPassEncoder59 = commandEncoder182.beginRenderPass({
+  label: '\u{1fa3f}\u4853\uf688\u0e98\u{1f6c9}\u9aaf\u{1f733}\u7986',
+  colorAttachments: [{
+  view: textureView128,
+  depthSlice: 365,
+  clearValue: { r: -934.2, g: -141.6, b: -159.4, a: 110.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet91,
+  maxDrawCount: 783843710,
+});
+let externalTexture93 = device1.importExternalTexture({label: '\u509c\u072c', source: video2});
+try {
+computePassEncoder68.setPipeline(pipeline124);
+} catch {}
+try {
+renderPassEncoder33.drawIndexed(50, 462, 2_757_159_745, 240_365_273, 224_087_664);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(2, buffer41, 254332);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder58.drawIndirect(buffer41, 7324);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline156);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(7, buffer41, 95224, 83789);
+} catch {}
+let promise64 = buffer47.mapAsync(GPUMapMode.READ, 0, 70860);
+try {
+commandEncoder183.insertDebugMarker('\u0f89');
+} catch {}
+let pipeline169 = device1.createComputePipeline({
+  label: '\u04cc\u{1f6f0}\u02e4\u0ab3\u0ef1\u{1fa5a}',
+  layout: pipelineLayout29,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+let pipeline170 = device1.createRenderPipeline({
+  label: '\u0b61\u7e81\u02b8\u074e\u5653\u94aa\uf326\ub7e7\u15d9\u0595\u{1fbaa}',
+  layout: pipelineLayout15,
+  multisample: {count: 4, mask: 0x60e5441},
+  fragment: {module: shaderModule40, entryPoint: 'fragment0', targets: [{format: 'rg16uint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule40,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2276,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 560, shaderLocation: 23},
+          {format: 'float32x2', offset: 740, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 3104, shaderLocation: 2},
+          {format: 'sint32x4', offset: 6820, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 4624, shaderLocation: 20},
+          {format: 'snorm16x4', offset: 2964, shaderLocation: 7},
+          {format: 'float32x3', offset: 5012, shaderLocation: 6},
+          {format: 'uint32x3', offset: 4616, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 4296, shaderLocation: 22},
+          {format: 'uint16x2', offset: 3812, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 3692, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 476, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 18968, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 3940, shaderLocation: 1},
+          {format: 'uint32x2', offset: 872, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 5892, shaderLocation: 18},
+          {format: 'sint32x2', offset: 7444, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 7680, shaderLocation: 4},
+          {format: 'sint16x2', offset: 15316, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 13568,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 1524, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 424, shaderLocation: 9},
+          {format: 'sint32x2', offset: 3060, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 3112,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 168, shaderLocation: 19},
+          {format: 'sint32x4', offset: 384, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+adapter1.label = '\u{1fb64}\u5eeb\uc330\u{1fd78}\u{1fac7}';
+} catch {}
+let commandEncoder184 = device1.createCommandEncoder({label: '\ua1d9\u{1f6b3}\u0ce9'});
+let commandBuffer37 = commandEncoder184.finish({label: '\uc7c2\uffeb\u26d8\u{1fe62}\u{1fd7f}'});
+let texture146 = device1.createTexture({
+  size: [850, 5, 1],
+  mipLevelCount: 7,
+  sampleCount: 1,
+  format: 'astc-5x5-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-5x5-unorm'],
+});
+let textureView228 = texture84.createView({});
+let renderBundle112 = renderBundleEncoder37.finish({label: '\u004e\u0e98\u2526\u072e\u0327\u04da\u113f\uc95c\u68f4'});
+let externalTexture94 = device1.importExternalTexture({label: '\u{1f9b3}\u54d2', source: video29, colorSpace: 'srgb'});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup54);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+renderPassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder51.setScissorRect(799, 0, 195, 1);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder70.drawIndexed(208, 22, 1_644_719_748, 34_110_564, 343_618_508);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder183.clearBuffer(buffer53);
+dissociateBuffer(device1, buffer53);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer27, 2092, new DataView(new ArrayBuffer(50727)), 35077, 6164);
+} catch {}
+let pipeline171 = device1.createComputePipeline({layout: 'auto', compute: {module: shaderModule43, entryPoint: 'compute0'}});
+let pipeline172 = device1.createRenderPipeline({
+  label: '\u6704\u54a6\u0eae\ud2fe\ub36e',
+  layout: pipelineLayout27,
+  fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule20,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 5680, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 20118, shaderLocation: 22},
+          {format: 'uint16x2', offset: 11892, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 13052,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 1300, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 2148, shaderLocation: 21},
+          {format: 'sint16x4', offset: 936, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 2372, shaderLocation: 20},
+          {format: 'unorm10-10-10-2', offset: 168, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 114, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 7616,
+        attributes: [
+          {format: 'uint32x2', offset: 1680, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 1556, shaderLocation: 23},
+          {format: 'uint8x2', offset: 792, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 604, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 4044, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 3660, attributes: []},
+      {
+        arrayStride: 500,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 136, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 96, shaderLocation: 2},
+          {format: 'float32x2', offset: 72, shaderLocation: 18},
+        ],
+      },
+      {arrayStride: 4784, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 680,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm8x4', offset: 120, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+document.body.prepend(canvas15);
+let imageBitmap46 = await createImageBitmap(img36);
+let querySet92 = device1.createQuerySet({type: 'occlusion', count: 179});
+let texture147 = device1.createTexture({
+  label: '\u99b4\u3815\u2d66\u{1ff08}\u9070\u{1f9c3}\u83a6\u025c\u{1fec4}\u68f7\u7199',
+  size: [72, 16, 431],
+  mipLevelCount: 4,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let computePassEncoder76 = commandEncoder183.beginComputePass({label: '\u0e69\ud07d\u89a5\uf636\u{1fcaf}'});
+let renderBundleEncoder80 = device1.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthReadOnly: true});
+let sampler111 = device1.createSampler({
+  label: '\ue0e9\u08f5\u0344\u7978\u44fd\uf471\u0ebf\u0d0d\u{1fc7f}\u9efa\u0d25',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 53.15,
+  lodMaxClamp: 67.81,
+});
+let externalTexture95 = device1.importExternalTexture({label: '\u023f\u8763\u2dec\ub73b\u5aae\ua8c1\u55a4', source: videoFrame8, colorSpace: 'srgb'});
+try {
+computePassEncoder66.setPipeline(pipeline104);
+} catch {}
+try {
+renderPassEncoder33.setViewport(53.92, 13.49, 1.491, 0.06383, 0.8478, 0.8547);
+} catch {}
+try {
+renderPassEncoder11.draw(0, 243, 232_530_728, 320_494_286);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexedIndirect(buffer41, 7404);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(3, buffer24, 0, 4632);
+} catch {}
+let arrayBuffer12 = buffer35.getMappedRange(0, 18556);
+let promise65 = device1.queue.onSubmittedWorkDone();
+let pipeline173 = device1.createComputePipeline({
+  label: '\u067d\u{1fe25}\u0b61\u{1fe83}\u{1fcd4}',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule29, entryPoint: 'compute0', constants: {}},
+});
+let canvas48 = document.createElement('canvas');
+let buffer57 = device1.createBuffer({
+  label: '\u4833\u0430\u{1ffb7}',
+  size: 194474,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundleEncoder81 = device1.createRenderBundleEncoder({
+  label: '\u58e7\u03f8\u7b4b\u140e',
+  colorFormats: ['rg16uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle113 = renderBundleEncoder39.finish();
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+renderPassEncoder15.draw(73, 138, 1_058_552_180, 651_033_734);
+} catch {}
+try {
+renderPassEncoder28.drawIndexed(40, 94);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer57, 175_362_748);
+} catch {}
+try {
+renderBundleEncoder80.setPipeline(pipeline113);
+} catch {}
+try {
+computePassEncoder45.insertDebugMarker('\u0e4f');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: canvas39,
+  origin: { x: 9, y: 4 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 21, y: 13, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter({});
+let offscreenCanvas47 = new OffscreenCanvas(783, 116);
+let gpuCanvasContext39 = offscreenCanvas47.getContext('webgpu');
+let videoFrame35 = new VideoFrame(img29, {timestamp: 0});
+offscreenCanvas37.width = 1984;
+let promise66 = adapter2.requestAdapterInfo();
+let buffer58 = device1.createBuffer({size: 38097, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder185 = device1.createCommandEncoder({label: '\ue82c\u80c0\u3401\u0c1a\u{1ff18}'});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup54);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline72);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup30, new Uint32Array(2923), 1611, 0);
+} catch {}
+try {
+renderPassEncoder59.beginOcclusionQuery(17);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle106, renderBundle48, renderBundle102, renderBundle98, renderBundle70, renderBundle74, renderBundle99]);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(60);
+} catch {}
+try {
+renderPassEncoder28.drawIndexedIndirect(buffer56, 242_840_432);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline87);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexed(412, 182, 1_219_910_155, 402_882_878, 8_070_563);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexedIndirect(buffer41, 96572);
+} catch {}
+try {
+renderBundleEncoder50.drawIndirect(buffer41, 6456);
+} catch {}
+try {
+commandEncoder185.copyTextureToBuffer({
+  texture: texture122,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 236 widthInBlocks: 59 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 54828 */
+  offset: 54592,
+  buffer: buffer27,
+}, {width: 59, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+commandEncoder185.copyTextureToTexture({
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 150, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture116,
+  mipLevel: 10,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: imageData67,
+  origin: { x: 33, y: 10 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 77, y: 3, z: 50},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 11, height: 15, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder186 = device1.createCommandEncoder();
+let sampler112 = device1.createSampler({
+  label: '\uc2ac\u{1f781}\uc5ed\u092b\u{1f6ff}\ue7de',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 12.38,
+});
+try {
+computePassEncoder73.setPipeline(pipeline107);
+} catch {}
+try {
+renderPassEncoder44.end();
+} catch {}
+try {
+renderPassEncoder48.setStencilReference(3183);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline172);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(8, buffer41, 61272, 233737);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexed(92, 24);
+} catch {}
+try {
+querySet59.destroy();
+} catch {}
+try {
+commandEncoder185.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 32464 */
+  offset: 32464,
+  buffer: buffer29,
+}, {
+  texture: texture146,
+  mipLevel: 4,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 25, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder185.copyTextureToBuffer({
+  texture: texture111,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 27264 */
+  offset: 27264,
+  buffer: buffer27,
+}, {width: 4, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+device1.queue.submit([commandBuffer37, commandBuffer36]);
+} catch {}
+let pipeline174 = device1.createRenderPipeline({
+  label: '\u08f6\u4e64\uac55\u{1f9ea}\uc25e\u0643\ufe00',
+  layout: pipelineLayout28,
+  multisample: {mask: 0x501514a3},
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 28644,
+        attributes: [
+          {format: 'sint32', offset: 336, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 1732, shaderLocation: 5},
+          {format: 'float16x4', offset: 1496, shaderLocation: 19},
+          {format: 'snorm8x4', offset: 13892, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 292,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x4', offset: 48, shaderLocation: 15},
+          {format: 'sint16x4', offset: 8, shaderLocation: 20},
+          {format: 'unorm16x4', offset: 28, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 28, shaderLocation: 3},
+          {format: 'sint8x4', offset: 164, shaderLocation: 2},
+          {format: 'float32x2', offset: 32, shaderLocation: 1},
+          {format: 'float32', offset: 0, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 20, shaderLocation: 6},
+          {format: 'uint32x2', offset: 120, shaderLocation: 8},
+          {format: 'snorm8x2', offset: 90, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 6672,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 180, shaderLocation: 22},
+          {format: 'unorm8x4', offset: 1856, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 15924,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x2', offset: 1026, shaderLocation: 7},
+          {format: 'float32x2', offset: 2496, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 10516, attributes: [{format: 'uint8x2', offset: 7820, shaderLocation: 10}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front'},
+});
+let querySet93 = device1.createQuerySet({label: '\u{1f87b}\u82a1\ue577\u9af7\u{1f6f7}\u{1fddc}\ud5f1\u0198', type: 'occlusion', count: 1517});
+let texture148 = device1.createTexture({
+  label: '\u5c35\uf52b\u{1ff4a}\ua1b0\ubd52',
+  size: [96, 5, 7],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16uint'],
+});
+let textureView229 = texture111.createView({label: '\u{1f9b4}\u{1fb89}\ub208', dimension: '2d-array', baseMipLevel: 3});
+let computePassEncoder77 = commandEncoder186.beginComputePass();
+let renderBundle114 = renderBundleEncoder42.finish({label: '\u{1ffe9}\u{1f971}\u0783\u8917\u{1f9f3}'});
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: -434.8, g: -60.26, b: -569.4, a: 706.0, });
+} catch {}
+try {
+renderPassEncoder51.setScissorRect(429, 0, 565, 1);
+} catch {}
+try {
+renderPassEncoder11.draw(161, 42, 221_421_445, 1_104_282_061);
+} catch {}
+try {
+renderBundleEncoder56.drawIndexed(16, 22, 105_441_952, 217_527_435, 545_231_986);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexedIndirect(buffer41, 9844);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer41, 107092);
+} catch {}
+try {
+renderBundleEncoder74.setPipeline(pipeline119);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(9092, undefined, 0, 3217015259);
+} catch {}
+try {
+buffer33.unmap();
+} catch {}
+try {
+commandEncoder185.resolveQuerySet(querySet43, 1023, 547, buffer28, 74240);
+} catch {}
+let commandEncoder187 = device1.createCommandEncoder({label: '\u{1fa6f}\ub6c9\ucffe\udb48\u0e9d\u{1f784}\u018c\ueaae\u{1f90e}\uea20\u{1fb62}'});
+let externalTexture96 = device1.importExternalTexture({label: '\u3f5e\uaf91\u{1f9fa}\u9fc3\u0db2\u06e3\u0f1c', source: video5, colorSpace: 'display-p3'});
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.drawIndirect(buffer26, 438_449_695);
+} catch {}
+try {
+renderBundleEncoder70.drawIndexed(56, 266);
+} catch {}
+try {
+  await buffer58.mapAsync(GPUMapMode.WRITE, 0, 21992);
+} catch {}
+try {
+commandEncoder185.copyBufferToTexture({
+  /* bytesInLastRow: 184 widthInBlocks: 46 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 21380 */
+  offset: 21380,
+  rowsPerImage: 0,
+  buffer: buffer33,
+}, {
+  texture: texture142,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 46, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer33);
+} catch {}
+let pipeline175 = await device1.createComputePipelineAsync({layout: pipelineLayout28, compute: {module: shaderModule26, entryPoint: 'compute0', constants: {}}});
+let commandEncoder188 = device1.createCommandEncoder({label: '\u070a\ue293\u09b8\u0cca'});
+let texture149 = device1.createTexture({
+  label: '\u415c\u1452',
+  size: [300],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint'],
+});
+let textureView230 = texture86.createView({label: '\u81c6\u4e9d\u0a36\u23e9\u{1fa3b}\ub584\u{1fdad}\u0685\u{1f90a}\u1a17', baseMipLevel: 3});
+let computePassEncoder78 = commandEncoder185.beginComputePass({label: '\u0fc9\u8113\u{1f988}'});
+try {
+renderPassEncoder11.beginOcclusionQuery(2476);
+} catch {}
+try {
+renderPassEncoder31.setBlendConstant({ r: -120.7, g: 526.7, b: 837.6, a: 752.7, });
+} catch {}
+try {
+renderPassEncoder33.drawIndexed(28, 11, 450_989_782, 19_258_079, 1_580_952_227);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer54, 'uint16', 5724, 9299);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(9, buffer24, 0);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexed(235, 168, 657_738_334, -1_950_348_863, 123_681_729);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+texture54.destroy();
+} catch {}
+let textureView231 = texture74.createView({label: '\ucfae\u0719\u05fa\uc0ce\u200a\u0e12', baseMipLevel: 0});
+let externalTexture97 = device1.importExternalTexture({
+  label: '\u37f9\u0b56\udf2d\u7659\u2242\ud65f\u3ef0\ud352\u066d\u0218\ub864',
+  source: video25,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder50.dispatchWorkgroups(5, 5, 2);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder49.setViewport(356.5, 15.22, 138.5, 4.728, 0.8537, 0.9053);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline156);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(7, buffer24, 0, 3263);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexed(402);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexedIndirect(buffer41, 17872);
+} catch {}
+try {
+renderBundleEncoder52.drawIndirect(buffer41, 132836);
+} catch {}
+try {
+renderBundleEncoder69.setIndexBuffer(buffer54, 'uint32', 10520);
+} catch {}
+try {
+renderPassEncoder55.insertDebugMarker('\u7294');
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+  await promise64;
+} catch {}
+try {
+canvas48.getContext('webgpu');
+} catch {}
+let bindGroup58 = device1.createBindGroup({
+  label: '\u0acb\u7a49\u{1f6fd}\u4e8a\u4ed9\u0cc3\u8fea\uc7aa\u425f\uc5c6',
+  layout: bindGroupLayout15,
+  entries: [],
+});
+let texture150 = device1.createTexture({
+  label: '\u79ad\u5f31',
+  size: {width: 4536, height: 1, depthOrArrayLayers: 404},
+  mipLevelCount: 2,
+  format: 'r8snorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let sampler113 = device1.createSampler({
+  label: '\u9a06\u{1feee}\ucc16\u06e9\u0f52\u{1f972}\u025c\u0cc1',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 70.11,
+});
+let externalTexture98 = device1.importExternalTexture({source: videoFrame13, colorSpace: 'srgb'});
+try {
+computePassEncoder70.setBindGroup(5, bindGroup43);
+} catch {}
+try {
+computePassEncoder70.setBindGroup(6, bindGroup39, new Uint32Array(3586), 183, 0);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(0, bindGroup56, new Uint32Array(1328), 971, 0);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle58, renderBundle107, renderBundle96, renderBundle113, renderBundle110, renderBundle106, renderBundle69, renderBundle105, renderBundle74, renderBundle103]);
+} catch {}
+try {
+renderPassEncoder33.setStencilReference(3803);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer39, 638_107_536);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer54, 'uint16', 10234, 3728);
+} catch {}
+try {
+renderBundleEncoder56.drawIndirect(buffer41, 8292);
+} catch {}
+try {
+commandEncoder188.resolveQuerySet(querySet44, 142, 2667, buffer40, 68096);
+} catch {}
+let video45 = await videoWithData();
+let buffer59 = device1.createBuffer({label: '\u2e3f\u12c8\uac1b\ueb43', size: 10548, usage: GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let texture151 = device1.createTexture({
+  label: '\u0d13\u05e0\u6485\uee3f\u0d14\uf81b\u0f42\u{1fe14}\u{1f7f6}\u{1fc54}',
+  size: [75],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let textureView232 = texture143.createView({label: '\u0a8c\u06c8\u053b\u{1fe82}\u10c8\u0652\ue4e3\u1c93', mipLevelCount: 1});
+let renderPassEncoder60 = commandEncoder188.beginRenderPass({
+  label: '\u{1fb0e}\uf498\u5951\u09be\uc2a9\u{1f86b}\u1d4d',
+  colorAttachments: [{
+  view: textureView111,
+  depthSlice: 115,
+  clearValue: { r: 653.5, g: -936.9, b: -43.24, a: 563.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet63,
+  maxDrawCount: 1157925314,
+});
+try {
+renderPassEncoder57.setBindGroup(5, bindGroup30);
+} catch {}
+try {
+renderPassEncoder46.beginOcclusionQuery(16);
+} catch {}
+try {
+renderPassEncoder49.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(23, 12, 26, 4);
+} catch {}
+try {
+renderPassEncoder41.draw(176, 31);
+} catch {}
+try {
+renderBundleEncoder78.setIndexBuffer(buffer54, 'uint16', 7308, 2925);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(0, buffer24, 0, 15);
+} catch {}
+try {
+device1.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder187.copyTextureToBuffer({
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 424, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3956 widthInBlocks: 989 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 48496 */
+  offset: 48496,
+  buffer: buffer57,
+}, {width: 989, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer57);
+} catch {}
+try {
+device1.queue.submit([commandBuffer35]);
+} catch {}
+let pipeline176 = await device1.createComputePipelineAsync({
+  label: '\u0a09\u093f\u0763\u079c\u86b0\ub6c9\ua3f4\uf65a\u{1ffd0}\u08a4\u0428',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule23, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let bindGroup59 = device1.createBindGroup({label: '\u{1ff0a}\u03f5\u{1f650}\u{1fd74}\u{1ff3f}', layout: bindGroupLayout36, entries: []});
+let textureView233 = texture61.createView({mipLevelCount: 2, baseArrayLayer: 152, arrayLayerCount: 9});
+let renderPassEncoder61 = commandEncoder187.beginRenderPass({
+  label: '\u{1f923}\u100e\u83c1\u0323\u3c0f\ud256\uadd7\u5fd1',
+  colorAttachments: [{view: textureView102, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet46,
+  maxDrawCount: 1195743609,
+});
+let renderBundleEncoder82 = device1.createRenderBundleEncoder({
+  label: '\u41a3\uf2b9\u9264\u{1fe59}\ub37c\u0b54\u9880\uaf44\u55b4\ub5d8',
+  colorFormats: ['rg16uint'],
+  stencilReadOnly: true,
+});
+let renderBundle115 = renderBundleEncoder37.finish();
+let sampler114 = device1.createSampler({
+  label: '\u{1ff7d}\ufe7f\u{1f63e}\u46ad\u{1fdd0}\u0fa6\u5ae8\u{1fa64}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.47,
+});
+try {
+renderPassEncoder45.beginOcclusionQuery(346);
+} catch {}
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer42, 377_826_430);
+} catch {}
+try {
+renderBundleEncoder70.setPipeline(pipeline86);
+} catch {}
+let arrayBuffer13 = buffer47.getMappedRange(39696, 23760);
+try {
+device1.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 2,
+  origin: {x: 10, y: 0, z: 5},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 322_015 */
+{offset: 31, bytesPerRow: 172, rowsPerImage: 39}, {width: 5, height: 0, depthOrArrayLayers: 49});
+} catch {}
+let video46 = await videoWithData();
+let commandEncoder189 = device1.createCommandEncoder();
+let renderBundle116 = renderBundleEncoder71.finish({label: '\u03fb\u043b\u7e27\uc240\u0ff0\u8c8f'});
+try {
+renderPassEncoder20.setViewport(67.87, 11.47, 3.711, 1.423, 0.4841, 0.6068);
+} catch {}
+try {
+renderPassEncoder41.draw(270);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer39, 97_212_386);
+} catch {}
+try {
+renderBundleEncoder56.drawIndexed(8);
+} catch {}
+try {
+renderBundleEncoder56.drawIndirect(buffer41, 35584);
+} catch {}
+try {
+commandEncoder189.copyBufferToBuffer(buffer38, 323092, buffer53, 7672, 1676);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer53);
+} catch {}
+try {
+commandEncoder189.copyTextureToBuffer({
+  texture: texture78,
+  mipLevel: 2,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 36 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4776 */
+  offset: 4740,
+  rowsPerImage: 93,
+  buffer: buffer27,
+}, {width: 9, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+gpuCanvasContext25.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let texture152 = device1.createTexture({
+  label: '\u162e\ub104\udd29',
+  size: {width: 288, height: 64, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView234 = texture103.createView({
+  label: '\u{1f6a7}\u0340\u{1fa4c}\u{1f646}\u0b2b\u62ec\u0c29\u6990\uf531',
+  dimension: '2d',
+  format: 'astc-5x4-unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 49,
+});
+let renderPassEncoder62 = commandEncoder189.beginRenderPass({
+  colorAttachments: [{
+  view: textureView178,
+  depthSlice: 0,
+  clearValue: { r: -586.5, g: -153.2, b: 327.2, a: 702.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet44,
+  maxDrawCount: 199017690,
+});
+let renderBundle117 = renderBundleEncoder32.finish();
+try {
+computePassEncoder37.setPipeline(pipeline84);
+} catch {}
+try {
+renderPassEncoder23.setBlendConstant({ r: -469.6, g: -866.8, b: 919.0, a: 889.7, });
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer35, 2_057_169_546);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline64);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(11, buffer41, 23352, 226031);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(223, 24);
+} catch {}
+try {
+renderBundleEncoder58.drawIndexedIndirect(buffer41, 202688);
+} catch {}
+try {
+  await promise63;
+} catch {}
+offscreenCanvas40.width = 2943;
+gc();
+offscreenCanvas10.width = 1995;
+let bindGroupLayout59 = device1.createBindGroupLayout({
+  label: '\u3e63\ubbb7\u6088\ue628\u0c69\u9111\u0c52\u5a77\u28ca',
+  entries: [
+    {
+      binding: 7860,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 194163791, hasDynamicOffset: false },
+    },
+    {binding: 7433, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 456,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder190 = device1.createCommandEncoder({label: '\u04f8\u220c\u{1fab1}\u1c7d\u0f2f\u5646\u35ad\u3db9\u{1fbe4}\u01f1'});
+let renderBundleEncoder83 = device1.createRenderBundleEncoder({colorFormats: ['rg16uint'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(6, bindGroup39);
+} catch {}
+try {
+renderPassEncoder40.beginOcclusionQuery(259);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer58, 1_039_458_887);
+} catch {}
+try {
+renderBundleEncoder29.draw(312, 116, 1_640_451_696, 1_517_564_030);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(39, 29, 535_698_152, 231_626_446, 285_847_703);
+} catch {}
+try {
+commandEncoder97.copyTextureToBuffer({
+  texture: texture136,
+  mipLevel: 2,
+  origin: {x: 8, y: 1, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 292 widthInBlocks: 73 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3200 */
+  offset: 3200,
+  bytesPerRow: 512,
+  buffer: buffer26,
+}, {width: 73, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+commandEncoder97.copyTextureToTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 288, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 9, y: 3, z: 78},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 343_044 */
+{offset: 912, bytesPerRow: 628, rowsPerImage: 26}, {width: 125, height: 25, depthOrArrayLayers: 21});
+} catch {}
+let imageBitmap47 = await createImageBitmap(canvas28);
+offscreenCanvas21.height = 537;
+let commandEncoder191 = device1.createCommandEncoder({label: '\uc653\u{1fb5d}\ue6bc'});
+let textureView235 = texture131.createView({baseMipLevel: 2});
+let renderBundle118 = renderBundleEncoder27.finish({label: '\u02f4\ud327'});
+let externalTexture99 = device1.importExternalTexture({source: videoFrame14, colorSpace: 'display-p3'});
+try {
+renderPassEncoder59.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer41, 6900);
+} catch {}
+try {
+renderBundleEncoder61.setVertexBuffer(2, buffer24, 172);
+} catch {}
+try {
+commandEncoder190.copyTextureToTexture({
+  texture: texture140,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 39, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer53, 116, new Float32Array(13743), 4740, 20);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture150,
+  mipLevel: 0,
+  origin: {x: 82, y: 0, z: 48},
+  aspect: 'all',
+}, new ArrayBuffer(2_201_459), /* required buffer size: 2_201_459 */
+{offset: 179, bytesPerRow: 4586, rowsPerImage: 30}, {width: 4322, height: 0, depthOrArrayLayers: 17});
+} catch {}
+let pipeline177 = await device1.createRenderPipelineAsync({
+  label: '\u408a\u47ea\ue3de\u70fe\u{1fe2d}\u0df2\u0295\uce43\u0407',
+  layout: pipelineLayout29,
+  fragment: {
+  module: shaderModule44,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {failOp: 'zero', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 1109534668,
+    stencilWriteMask: 600084451,
+    depthBias: -2144378374,
+    depthBiasSlopeScale: 649.6211058764454,
+    depthBiasClamp: 382.5412327915978,
+  },
+  vertex: {
+    module: shaderModule44,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 10980,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 2386, shaderLocation: 13},
+          {format: 'uint16x2', offset: 1396, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 1916, shaderLocation: 14},
+          {format: 'uint32', offset: 708, shaderLocation: 10},
+          {format: 'sint8x4', offset: 900, shaderLocation: 9},
+          {format: 'sint32x4', offset: 7004, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 292,
+        attributes: [
+          {format: 'uint16x4', offset: 24, shaderLocation: 6},
+          {format: 'float32x2', offset: 52, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 4020,
+        attributes: [
+          {format: 'uint8x2', offset: 1440, shaderLocation: 21},
+          {format: 'sint8x4', offset: 52, shaderLocation: 23},
+        ],
+      },
+      {arrayStride: 1004, stepMode: 'instance', attributes: []},
+      {arrayStride: 30368, stepMode: 'vertex', attributes: []},
+      {arrayStride: 1924, attributes: [{format: 'uint32', offset: 660, shaderLocation: 7}]},
+    ],
+  },
+});
+let renderPassEncoder63 = commandEncoder191.beginRenderPass({
+  label: '\ub4c7\uf6f3',
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 1,
+  clearValue: { r: -858.2, g: 115.7, b: -661.0, a: 674.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup42, new Uint32Array(5516), 4551, 0);
+} catch {}
+try {
+renderPassEncoder61.end();
+} catch {}
+try {
+renderPassEncoder20.draw(75, 121, 61_016_650);
+} catch {}
+try {
+renderPassEncoder19.drawIndexed(373, 324, 1_484_998_055, 15_611_073);
+} catch {}
+try {
+renderPassEncoder28.drawIndexedIndirect(buffer47, 180_232_136);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer39, 155_016_217);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer54, 'uint16', 8470, 696);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline122);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(1, buffer41, 0, 80962);
+} catch {}
+try {
+renderBundleEncoder52.draw(42, 257, 1_241_573_254, 469_763_683);
+} catch {}
+try {
+renderBundleEncoder52.drawIndirect(buffer41, 46344);
+} catch {}
+try {
+renderBundleEncoder80.setVertexBuffer(2, buffer24, 3100, 1641);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+window.someLabel = commandBuffer15.label;
+} catch {}
+let texture153 = gpuCanvasContext31.getCurrentTexture();
+let textureView236 = texture58.createView({label: '\u006c\u0d37\ue2eb\u3966\u0da0\u9cf3\u0f56'});
+let renderPassEncoder64 = commandEncoder97.beginRenderPass({
+  label: '\ud4c2\u{1f9dc}\u5cc6\uaef3\u3370\u0dcb',
+  colorAttachments: [{
+  view: textureView133,
+  depthSlice: 1,
+  clearValue: { r: -885.7, g: -502.2, b: -517.7, a: 790.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet49,
+});
+let renderBundle119 = renderBundleEncoder69.finish({label: '\u035a\u5f84\u{1ff8d}\u03fd\u0e2f\u0ec4\u3981'});
+try {
+renderPassEncoder41.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder37.setBlendConstant({ r: 880.2, g: 989.0, b: -876.4, a: -654.8, });
+} catch {}
+try {
+renderPassEncoder51.setScissorRect(1118, 0, 2, 0);
+} catch {}
+try {
+renderPassEncoder41.drawIndexed(29, 123, 118_370_231, 231_586_346, 400_481_046);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer51, 1_499_063_867);
+} catch {}
+try {
+renderPassEncoder64.setVertexBuffer(6, buffer41);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexedIndirect(buffer41, 13960);
+} catch {}
+try {
+commandEncoder190.clearBuffer(buffer27);
+dissociateBuffer(device1, buffer27);
+} catch {}
+try {
+commandEncoder190.resolveQuerySet(querySet50, 1373, 80, buffer42, 30976);
+} catch {}
+let canvas49 = document.createElement('canvas');
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+gc();
+let bindGroup60 = device1.createBindGroup({label: '\u3202\uade6\u0edb\u{1fc08}\u{1f77b}\u7131\u7f0c', layout: bindGroupLayout36, entries: []});
+let commandEncoder192 = device1.createCommandEncoder({label: '\u{1f906}\u0c01\u2fcc\uaf6f\u{1f898}\u0ed3\u21fe\u{1ffdc}\u591d\u2d77'});
+let querySet94 = device1.createQuerySet({label: '\u02e4\ub52a\ubbad\u0266', type: 'occlusion', count: 3937});
+let computePassEncoder79 = commandEncoder192.beginComputePass({label: '\u{1f932}\u0192\u194d\u5cc2\u0c09\u9af1\u8ef9'});
+try {
+computePassEncoder50.dispatchWorkgroups(5, 2);
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline58);
+} catch {}
+try {
+renderPassEncoder32.setStencilReference(3104);
+} catch {}
+try {
+renderPassEncoder59.setViewport(92.78, 59.01, 129.7, 2.761, 0.05481, 0.07599);
+} catch {}
+try {
+renderPassEncoder41.drawIndexed(818, 37, 528_490_606, 11_762_353, 849_457);
+} catch {}
+try {
+renderPassEncoder11.drawIndexedIndirect(buffer38, 355_702_555);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline119);
+} catch {}
+try {
+renderBundleEncoder50.draw(201);
+} catch {}
+try {
+commandEncoder190.copyBufferToBuffer(buffer38, 154704, buffer53, 4200, 2096);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer53);
+} catch {}
+try {
+commandEncoder190.copyTextureToBuffer({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 184 widthInBlocks: 46 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 57240 */
+  offset: 18912,
+  bytesPerRow: 256,
+  rowsPerImage: 147,
+  buffer: buffer26,
+}, {width: 46, height: 3, depthOrArrayLayers: 2});
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+commandEncoder190.clearBuffer(buffer26);
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+computePassEncoder77.insertDebugMarker('\u2b76');
+} catch {}
+gc();
+let imageBitmap48 = await createImageBitmap(imageBitmap36);
+let commandEncoder193 = device1.createCommandEncoder({label: '\u0786\u0f54\ufc58\u8431\u{1fae7}\u6bb0\u{1fef2}\u8370\u013d'});
+let textureView237 = texture141.createView({baseMipLevel: 2, baseArrayLayer: 0, arrayLayerCount: 55});
+let renderPassEncoder65 = commandEncoder190.beginRenderPass({
+  label: '\u{1f927}\u04ed\u05e1\u7cbe\u4a96',
+  colorAttachments: [{
+  view: textureView193,
+  clearValue: { r: -970.9, g: 319.7, b: 902.6, a: 60.45, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 157560652,
+});
+let renderBundleEncoder84 = device1.createRenderBundleEncoder({
+  label: '\u{1f9b3}\u7c65\u1691\u09ab',
+  colorFormats: ['rg16uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle120 = renderBundleEncoder70.finish();
+try {
+computePassEncoder51.setBindGroup(1, bindGroup54, new Uint32Array(5582), 4293, 0);
+} catch {}
+try {
+computePassEncoder45.dispatchWorkgroups(3, 1);
+} catch {}
+try {
+renderPassEncoder30.setStencilReference(778);
+} catch {}
+try {
+renderPassEncoder33.drawIndexed(150);
+} catch {}
+try {
+renderBundleEncoder58.draw(219, 42, 613_955_684, 154_894_212);
+} catch {}
+try {
+renderBundleEncoder83.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(11, buffer41, 266576, 22720);
+} catch {}
+try {
+texture82.destroy();
+} catch {}
+try {
+  await buffer27.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+commandEncoder193.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 1,
+  origin: {x: 52, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 3, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder193.resolveQuerySet(querySet64, 1221, 461, buffer28, 23552);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer57, 11184, new Int16Array(44214), 30261, 452);
+} catch {}
+let pipeline178 = device1.createRenderPipeline({
+  label: '\udaad\u0f7f',
+  layout: pipelineLayout27,
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilBack: {failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilWriteMask: 3243612113,
+    depthBiasSlopeScale: 530.9623666425375,
+  },
+  vertex: {
+    module: shaderModule43,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 5560,
+        attributes: [
+          {format: 'float32x4', offset: 392, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 248, shaderLocation: 6},
+          {format: 'sint8x2', offset: 784, shaderLocation: 16},
+          {format: 'uint8x2', offset: 532, shaderLocation: 2},
+          {format: 'sint32x3', offset: 152, shaderLocation: 0},
+          {format: 'sint16x4', offset: 376, shaderLocation: 20},
+          {format: 'sint16x2', offset: 1784, shaderLocation: 19},
+          {format: 'uint8x4', offset: 416, shaderLocation: 14},
+          {format: 'sint32', offset: 164, shaderLocation: 8},
+          {format: 'sint32x4', offset: 604, shaderLocation: 22},
+          {format: 'unorm8x2', offset: 2616, shaderLocation: 18},
+          {format: 'sint32x2', offset: 4, shaderLocation: 23},
+        ],
+      },
+      {
+        arrayStride: 5356,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 176, shaderLocation: 4},
+          {format: 'uint16x4', offset: 156, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 684, attributes: []},
+      {arrayStride: 14836, stepMode: 'instance', attributes: []},
+      {arrayStride: 4156, stepMode: 'instance', attributes: []},
+      {arrayStride: 1480, attributes: []},
+      {arrayStride: 3424, attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 3620, stepMode: 'instance', attributes: []},
+      {arrayStride: 4292, attributes: []},
+      {
+        arrayStride: 76,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 0, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: true},
+});
+canvas25.width = 378;
+let img44 = await imageWithData(77, 27, '#6f6a3fc3', '#15dc0e18');
+let commandEncoder194 = device2.createCommandEncoder();
+let querySet95 = device2.createQuerySet({label: '\u{1fad3}\u0e75', type: 'occlusion', count: 2407});
+let computePassEncoder80 = commandEncoder154.beginComputePass({label: '\u01bb\u1f88\u90d4\u6124'});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup50, new Uint32Array(3195), 534, 0);
+} catch {}
+try {
+commandEncoder151.copyTextureToTexture({
+  texture: texture117,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 12},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 9});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 546, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer12), /* required buffer size: 338 */
+{offset: 338, rowsPerImage: 136}, {width: 43, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise67 = device2.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let promise68 = navigator.gpu.requestAdapter();
+let querySet96 = device1.createQuerySet({type: 'occlusion', count: 3781});
+let renderBundleEncoder85 = device1.createRenderBundleEncoder({label: '\u02ba\u5d8c\u7110\uad5f\u3552', colorFormats: ['rg16uint'], stencilReadOnly: true});
+let externalTexture100 = device1.importExternalTexture({source: videoFrame2, colorSpace: 'display-p3'});
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup35, new Uint32Array(7248), 3940, 0);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(1131);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer54, 983_967_218);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(8, buffer41, 29492);
+} catch {}
+try {
+renderBundleEncoder56.drawIndexedIndirect(buffer41, 52272);
+} catch {}
+try {
+renderBundleEncoder80.setVertexBuffer(8, buffer41, 93952);
+} catch {}
+try {
+commandEncoder193.copyBufferToBuffer(buffer38, 314712, buffer34, 150588, 178328);
+dissociateBuffer(device1, buffer38);
+dissociateBuffer(device1, buffer34);
+} catch {}
+try {
+commandEncoder193.copyBufferToTexture({
+  /* bytesInLastRow: 348 widthInBlocks: 87 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9656 */
+  offset: 3676,
+  bytesPerRow: 512,
+  rowsPerImage: 127,
+  buffer: buffer33,
+}, {
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 5},
+  aspect: 'all',
+}, {width: 87, height: 12, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer33);
+} catch {}
+try {
+commandEncoder193.copyTextureToBuffer({
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4192 widthInBlocks: 1048 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4172 */
+  offset: 4172,
+  bytesPerRow: 4352,
+  buffer: buffer52,
+}, {width: 1048, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer52);
+} catch {}
+try {
+commandEncoder193.resolveQuerySet(querySet81, 168, 136, buffer28, 94208);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 1648, new Float32Array(46463), 11291, 28);
+} catch {}
+let pipeline179 = device1.createComputePipeline({
+  label: '\u9a4f\u{1fe05}\uad29\u4b9b',
+  layout: 'auto',
+  compute: {module: shaderModule28, entryPoint: 'compute0'},
+});
+let shaderModule45 = device1.createShaderModule({
+  label: '\u4b0d\uff44\u8eb2\u3354\u01c5\u{1f787}\u{1ff7e}\u0928\u3c8b',
+  code: `@group(2) @binding(6342)
+var<storage, read_write> field26: array<u32>;
+@group(1) @binding(1281)
+var<storage, read_write> local19: array<u32>;
+@group(2) @binding(9122)
+var<storage, read_write> parameter28: array<u32>;
+@group(0) @binding(9122)
+var<storage, read_write> parameter29: array<u32>;
+@group(0) @binding(6342)
+var<storage, read_write> local20: array<u32>;
+
+@compute @workgroup_size(2, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32) -> @location(200) vec4<u32> {
+return vec4<u32>();
+}
+
+struct S47 {
+  @location(11) f0: vec3<u32>,
+  @location(20) f1: vec3<u32>,
+  @location(3) f2: vec3<f16>,
+  @location(0) f3: i32,
+  @location(1) f4: f32,
+  @location(5) f5: vec3<f32>,
+  @location(7) f6: vec4<i32>,
+  @location(14) f7: vec3<f16>,
+  @location(19) f8: vec4<i32>,
+  @location(2) f9: vec3<u32>,
+  @location(6) f10: vec2<u32>,
+  @location(17) f11: u32,
+  @builtin(instance_index) f12: u32,
+  @location(23) f13: vec2<f16>,
+  @location(21) f14: vec3<i32>,
+  @location(18) f15: vec3<f16>,
+  @location(13) f16: vec4<f32>,
+  @location(22) f17: vec2<i32>,
+  @location(4) f18: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3<i32>, @location(8) a1: vec2<i32>, @location(12) a2: vec4<f32>, @location(15) a3: u32, @location(9) a4: vec4<f32>, a5: S47, @location(16) a6: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout60 = device1.createBindGroupLayout({
+  label: '\u0c2f\ufd7d\u0137\u{1fd69}\u0fae\ueffb\u{1f6c8}',
+  entries: [
+    {
+      binding: 6375,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 7822,
+      visibility: 0,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let buffer60 = device1.createBuffer({size: 2336, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder195 = device1.createCommandEncoder();
+let renderPassEncoder66 = commandEncoder195.beginRenderPass({
+  label: '\u0ebf\u1ad1\u7396\u9ae3\u5bf5\u{1f663}\u{1f829}',
+  colorAttachments: [{
+  view: textureView86,
+  depthSlice: 96,
+  clearValue: { r: -147.1, g: -767.7, b: 200.7, a: 550.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet37,
+  maxDrawCount: 931142644,
+});
+try {
+computePassEncoder73.end();
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(273);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline157);
+} catch {}
+try {
+renderBundleEncoder50.draw(91);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexedIndirect(buffer41, 320488);
+} catch {}
+try {
+renderBundleEncoder56.drawIndirect(buffer41, 36508);
+} catch {}
+try {
+renderBundleEncoder66.setVertexBuffer(9, buffer41, 18988, 128028);
+} catch {}
+let pipelineLayout31 = device1.createPipelineLayout({
+  label: '\u9362\u0005\u{1f87e}\u0e57',
+  bindGroupLayouts: [bindGroupLayout22, bindGroupLayout25, bindGroupLayout59, bindGroupLayout40, bindGroupLayout60],
+});
+let buffer61 = device1.createBuffer({
+  label: '\u{1fa5c}\u0e05\uc13a\u{1f9fa}\ubf14\ua232\u0a61\u{1f931}\u3a73\u8779',
+  size: 59,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandBuffer38 = commandEncoder176.finish({label: '\u0155\u803d\ub3a6\u0d79\u36b0\u157b\u9bdb'});
+let textureView238 = texture56.createView({label: '\u50e3\ud8e5\u046e\u{1f86f}\u22bf\u{1f718}', baseMipLevel: 1});
+let renderPassEncoder67 = commandEncoder193.beginRenderPass({
+  label: '\u{1f9bc}\u26ae\u4ede\u0753\u047b',
+  colorAttachments: [{view: textureView128, depthSlice: 157, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet62,
+  maxDrawCount: 396002578,
+});
+try {
+computePassEncoder57.setPipeline(pipeline152);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(4, bindGroup32);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: -391.6, g: -396.7, b: -695.5, a: 256.3, });
+} catch {}
+try {
+renderPassEncoder59.setScissorRect(265, 2, 14, 42);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(3384);
+} catch {}
+try {
+renderPassEncoder28.drawIndirect(buffer36, 1_140_615_024);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(7, buffer24, 0, 2670);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexed(143, 147, 979_525_646, 164_755_399, 396_478_602);
+} catch {}
+try {
+renderBundleEncoder83.setPipeline(pipeline87);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: imageData13,
+  origin: { x: 13, y: 9 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 19, y: 12, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline180 = await device1.createRenderPipelineAsync({
+  label: '\u0856\u0946\ud36a\ubb2f\u{1f8ba}\u0af0\uc51d',
+  layout: pipelineLayout29,
+  fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule27,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 14780,
+        attributes: [
+          {format: 'float32x4', offset: 7748, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 3472, shaderLocation: 10},
+          {format: 'sint16x2', offset: 4296, shaderLocation: 2},
+          {format: 'float16x4', offset: 2156, shaderLocation: 6},
+          {format: 'uint8x2', offset: 346, shaderLocation: 19},
+          {format: 'snorm8x4', offset: 1980, shaderLocation: 16},
+          {format: 'uint16x4', offset: 2432, shaderLocation: 9},
+          {format: 'sint16x4', offset: 796, shaderLocation: 23},
+          {format: 'snorm16x4', offset: 10900, shaderLocation: 14},
+          {format: 'float32x4', offset: 664, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 1136, shaderLocation: 7},
+          {format: 'sint8x4', offset: 864, shaderLocation: 3},
+          {format: 'uint16x4', offset: 16, shaderLocation: 12},
+          {format: 'sint16x2', offset: 7116, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 248,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 84, shaderLocation: 11}],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 6668, shaderLocation: 13},
+          {format: 'sint32x3', offset: 1012, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 4320,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x4', offset: 272, shaderLocation: 20},
+          {format: 'snorm16x4', offset: 1248, shaderLocation: 4},
+          {format: 'float16x4', offset: 2508, shaderLocation: 22},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+gc();
+try {
+adapter5.label = '\ufce2\u{1fb82}\u0264\u07da\u{1fa61}\udc6f\u083c\uabf2\u{1f7f3}';
+} catch {}
+let bindGroup61 = device1.createBindGroup({label: '\u0774\uc995', layout: bindGroupLayout34, entries: []});
+let textureView239 = texture92.createView({label: '\ua30d\ubcd3\u9a04\u6fc4\ue03d\u05cb\u{1fe81}\u7f40\ua210\u5008\ub78a'});
+let renderBundleEncoder86 = device1.createRenderBundleEncoder({label: '\u00c4\u09bd', colorFormats: ['rg16uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder52.setBindGroup(1, bindGroup54, new Uint32Array(1956), 1443, 0);
+} catch {}
+try {
+computePassEncoder50.dispatchWorkgroups(2, 2, 5);
+} catch {}
+try {
+computePassEncoder46.setPipeline(pipeline107);
+} catch {}
+try {
+renderPassEncoder62.end();
+} catch {}
+try {
+renderPassEncoder63.setScissorRect(11, 0, 36, 0);
+} catch {}
+try {
+renderPassEncoder20.draw(123, 46, 213_177_525, 1_475_647_414);
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer24, 580_148_645);
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline172);
+} catch {}
+try {
+renderBundleEncoder56.drawIndexedIndirect(buffer41, 28736);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+renderPassEncoder37.insertDebugMarker('\u0a4c');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer53, 160, new Float32Array(63152), 42625, 92);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture78,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 990 */
+{offset: 990, bytesPerRow: 358}, {width: 19, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas27,
+  origin: { x: 81, y: 10 },
+  flipY: true,
+}, {
+  texture: texture153,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline181 = device1.createComputePipeline({
+  label: '\u{1ff6d}\u28a4\u6d65\u{1fd4a}\u{1f6aa}\u40ac\u{1f8d6}\uaa5d',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule41, entryPoint: 'compute0', constants: {}},
+});
+let video47 = await videoWithData();
+let textureView240 = texture145.createView({label: '\ud361\u0ff1\u02a3\ucd3f'});
+let renderBundle121 = renderBundleEncoder42.finish({label: '\u844a\u{1fe5e}\u6249\u{1f6c7}'});
+let externalTexture101 = device1.importExternalTexture({label: '\u0dba\u08b8\u{1ff11}', source: videoFrame9, colorSpace: 'srgb'});
+try {
+computePassEncoder77.setBindGroup(1, bindGroup61, new Uint32Array(4848), 1953, 0);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(1231);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle61, renderBundle82, renderBundle105, renderBundle117, renderBundle119, renderBundle109, renderBundle119, renderBundle96, renderBundle47, renderBundle101]);
+} catch {}
+try {
+renderPassEncoder45.setBlendConstant({ r: 780.7, g: -411.9, b: 311.3, a: -463.5, });
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer54, 'uint32', 4616, 9537);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(3, buffer41);
+} catch {}
+let arrayBuffer14 = buffer27.getMappedRange(0, 14324);
+try {
+device1.queue.writeBuffer(buffer60, 400, new BigUint64Array(41766), 19060, 4);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer4), /* required buffer size: 315 */
+{offset: 315, bytesPerRow: 1101}, {width: 212, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: video40,
+  origin: { x: 2, y: 4 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 12, y: 7, z: 29},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+gc();
+try {
+  await promise67;
+} catch {}
+let shaderModule46 = device1.createShaderModule({
+  label: '\u{1fbb9}\u0509',
+  code: `@group(0) @binding(346)
+var<storage, read_write> parameter30: array<u32>;
+
+@compute @workgroup_size(8, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S49 {
+  @location(30) f0: f32,
+  @location(66) f1: vec3<u32>,
+  @location(111) f2: vec2<f32>,
+  @location(80) f3: vec4<f32>,
+  @location(68) f4: vec3<f32>,
+  @location(86) f5: vec3<u32>,
+  @location(95) f6: vec3<u32>,
+  @location(49) f7: vec4<f32>,
+  @location(32) f8: i32,
+  @location(85) f9: vec2<u32>,
+  @location(88) f10: f16,
+  @location(37) f11: vec3<f32>,
+  @location(31) f12: vec2<i32>,
+  @location(100) f13: f16,
+  @location(41) f14: vec3<u32>,
+  @builtin(sample_mask) f15: u32,
+  @location(89) f16: i32,
+  @location(38) f17: vec2<i32>,
+  @location(15) f18: vec2<i32>,
+  @location(93) f19: vec3<i32>,
+  @location(23) f20: vec4<u32>,
+  @location(50) f21: vec4<u32>,
+  @location(79) f22: i32,
+  @location(70) f23: vec3<f32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec3<i32>,
+  @location(1) f1: vec4<i32>,
+  @location(3) f2: vec2<i32>,
+  @location(0) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(43) a0: vec4<f32>, @location(58) a1: u32, @location(12) a2: vec2<u32>, @location(27) a3: vec2<i32>, @location(109) a4: i32, @location(76) a5: f32, a6: S49, @location(83) a7: vec3<f16>, @builtin(position) a8: vec4<f32>, @builtin(front_facing) a9: bool, @builtin(sample_index) a10: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S48 {
+  @location(3) f0: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(88) f577: f16,
+  @location(68) f578: vec3<f32>,
+  @location(70) f579: vec3<f32>,
+  @location(85) f580: vec2<u32>,
+  @location(93) f581: vec3<i32>,
+  @location(111) f582: vec2<f32>,
+  @location(43) f583: vec4<f32>,
+  @location(50) f584: vec4<u32>,
+  @location(32) f585: i32,
+  @location(23) f586: vec4<u32>,
+  @location(80) f587: vec4<f32>,
+  @location(38) f588: vec2<i32>,
+  @location(37) f589: vec3<f32>,
+  @location(49) f590: vec4<f32>,
+  @location(109) f591: i32,
+  @location(30) f592: f32,
+  @location(89) f593: i32,
+  @location(27) f594: vec2<i32>,
+  @builtin(position) f595: vec4<f32>,
+  @location(86) f596: vec3<u32>,
+  @location(15) f597: vec2<i32>,
+  @location(100) f598: f16,
+  @location(12) f599: vec2<u32>,
+  @location(58) f600: u32,
+  @location(79) f601: i32,
+  @location(31) f602: vec2<i32>,
+  @location(66) f603: vec3<u32>,
+  @location(83) f604: vec3<f16>,
+  @location(76) f605: f32,
+  @location(95) f606: vec3<u32>,
+  @location(41) f607: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec4<f32>, @location(1) a1: f16, @location(13) a2: vec3<f32>, @location(8) a3: i32, @location(9) a4: u32, @builtin(instance_index) a5: u32, @location(2) a6: vec2<f32>, @builtin(vertex_index) a7: u32, @location(11) a8: vec4<f32>, @location(7) a9: vec4<u32>, @location(19) a10: u32, @location(6) a11: vec2<f16>, @location(4) a12: f16, @location(18) a13: vec2<i32>, @location(20) a14: vec3<i32>, @location(23) a15: vec3<f32>, @location(17) a16: i32, @location(22) a17: u32, @location(15) a18: vec3<i32>, @location(0) a19: vec4<f32>, @location(5) a20: vec3<f16>, @location(12) a21: vec3<f32>, @location(16) a22: vec4<u32>, a23: S48, @location(14) a24: vec3<u32>, @location(10) a25: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout61 = device1.createBindGroupLayout({
+  label: '\ue9c6\u{1f85e}\ub0ce\u05b9\ub60c\u0044\u{1fe48}\u1ad6\u0458\u555a',
+  entries: [
+    {
+      binding: 5531,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let textureView241 = texture54.createView({label: '\u0d53\u0f37\u{1ff6a}', format: 'rg32uint', mipLevelCount: 4});
+let sampler115 = device1.createSampler({
+  label: '\u5a83\u3ae3\u0c7f\u027d\u00e1',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.629,
+  lodMaxClamp: 9.452,
+});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderPassEncoder67.setStencilReference(3981);
+} catch {}
+try {
+renderPassEncoder41.drawIndexedIndirect(buffer54, 288_637_607);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline164);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexedIndirect(buffer41, 51568);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer52, 44988, new Float32Array(53402), 23528, 52);
+} catch {}
+gc();
+let imageBitmap49 = await createImageBitmap(canvas15);
+gc();
+let imageData69 = new ImageData(80, 176);
+try {
+  await promise66;
+} catch {}
+let bindGroup62 = device1.createBindGroup({
+  label: '\u72ce\u03d8\u1e4b\u{1f85a}\uf941\uf016',
+  layout: bindGroupLayout27,
+  entries: [{binding: 8217, resource: {buffer: buffer30, offset: 32832}}],
+});
+let sampler116 = device1.createSampler({
+  label: '\ud784\u34da\u0db2\u0902',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 55.39,
+  lodMaxClamp: 68.81,
+  maxAnisotropy: 1,
+});
+let externalTexture102 = device1.importExternalTexture({label: '\u0bf6\u0dc3\u0e5f\u0d45\ucf62', source: videoFrame14});
+try {
+renderPassEncoder55.setBindGroup(6, bindGroup56);
+} catch {}
+try {
+renderPassEncoder41.beginOcclusionQuery(18);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(0, bindGroup60, []);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer41, 896);
+} catch {}
+try {
+adapter5.label = '\u4b9a\u53c2\ubb43';
+} catch {}
+try {
+canvas49.getContext('webgl');
+} catch {}
+try {
+querySet68.label = '\u0cbf\u09e7\u34e5\u{1f956}\u4d58\u51e0\u2c9a\u9562\uc9c5';
+} catch {}
+let sampler117 = device1.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 1.287,
+  lodMaxClamp: 7.374,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder63.setPipeline(pipeline146);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.setStencilReference(2074);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer24, 186_751_862);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer30, 146_221_397);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(9, buffer41, 203108);
+} catch {}
+try {
+renderBundleEncoder52.drawIndexed(25, 54, 501_039_206, 53_194_959, 530_001_365);
+} catch {}
+gc();
+let adapter7 = await navigator.gpu.requestAdapter({});
+let offscreenCanvas48 = new OffscreenCanvas(331, 147);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+let commandEncoder196 = device1.createCommandEncoder();
+let texture154 = device1.createTexture({
+  label: '\u{1f87f}\u8e97\u0db5\uc337\u{1fdf6}\u520e',
+  size: {width: 4536, height: 1, depthOrArrayLayers: 69},
+  mipLevelCount: 6,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint'],
+});
+let textureView242 = texture84.createView({label: '\uc19f\u960c\u8afc\u{1f840}\u3e84\u{1ff5c}', baseMipLevel: 7, mipLevelCount: 1});
+let renderBundle122 = renderBundleEncoder56.finish({label: '\uf09e\u00f0'});
+try {
+renderPassEncoder58.setBindGroup(1, bindGroup60);
+} catch {}
+try {
+renderPassEncoder40.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer54, 'uint32');
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline64);
+} catch {}
+try {
+renderBundleEncoder52.drawIndirect(buffer41, 103108);
+} catch {}
+let promise69 = device1.popErrorScope();
+video9.width = 43;
+let commandEncoder197 = device1.createCommandEncoder({});
+let textureView243 = texture76.createView({
+  label: '\u07d4\u{1f98c}\uab68\u{1f62e}\ue99f\ud34b',
+  dimension: '3d',
+  format: 'rg16uint',
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder50.dispatchWorkgroups(3, 1, 5);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline90);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer33, 539_556_011);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline119);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(10, buffer24, 0);
+} catch {}
+try {
+renderBundleEncoder82.setBindGroup(5, bindGroup51);
+} catch {}
+try {
+renderBundleEncoder29.drawIndexed(215, 11);
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline156);
+} catch {}
+try {
+commandEncoder197.copyBufferToBuffer(buffer32, 10244, buffer55, 222544, 23028);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer55);
+} catch {}
+try {
+computePassEncoder46.insertDebugMarker('\u00c2');
+} catch {}
+let imageBitmap50 = await createImageBitmap(offscreenCanvas27);
+let gpuCanvasContext40 = offscreenCanvas48.getContext('webgpu');
+try {
+adapter5.label = '\ua23c\uf7ea\u906a\u{1fffd}\u0b3a';
+} catch {}
+let commandEncoder198 = device1.createCommandEncoder({label: '\u000f\u{1ff83}\u49e5\ub854\u2661\ue5e3\udca8\ubd61'});
+let texture155 = device1.createTexture({
+  label: '\ue06f\ufe60\udf1c\u{1f6d7}\u9d33\u007b\u{1fb69}',
+  size: {width: 75},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint', 'rg16uint', 'rg16uint'],
+});
+let textureView244 = texture83.createView({baseArrayLayer: 444, arrayLayerCount: 11});
+try {
+renderPassEncoder51.executeBundles([renderBundle118, renderBundle51, renderBundle62, renderBundle82, renderBundle107]);
+} catch {}
+try {
+renderPassEncoder50.setScissorRect(495, 1, 90, 0);
+} catch {}
+try {
+renderPassEncoder43.setStencilReference(4002);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer58, 384_935_374);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline86);
+} catch {}
+try {
+renderBundleEncoder58.drawIndexedIndirect(buffer41, 6816);
+} catch {}
+try {
+buffer59.unmap();
+} catch {}
+try {
+commandEncoder198.resolveQuerySet(querySet44, 2904, 317, buffer42, 59392);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 4180, new DataView(new ArrayBuffer(29176)), 27673, 80);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture87,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer4), /* required buffer size: 1_408 */
+{offset: 800}, {width: 190, height: 5, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 288, height: 64, depthOrArrayLayers: 422}
+*/
+{
+  source: img15,
+  origin: { x: 8, y: 3 },
+  flipY: false,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 35, y: 9, z: 242},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 11, depthOrArrayLayers: 0});
+} catch {}
+let pipeline182 = device1.createComputePipeline({
+  label: '\u02a6\u{1fc49}\ubbb9\uf90c\uf5a9\u1932\u687a\u{1fb45}',
+  layout: pipelineLayout31,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+let pipeline183 = await device1.createRenderPipelineAsync({
+  label: '\u0cc4\u077d\u7969\ufdaa\uc455\ua33d',
+  layout: pipelineLayout29,
+  fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule27,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 5520, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 10756,
+        attributes: [
+          {format: 'sint16x2', offset: 1472, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 6670, shaderLocation: 13},
+          {format: 'sint32x2', offset: 2176, shaderLocation: 11},
+          {format: 'sint32', offset: 160, shaderLocation: 18},
+          {format: 'unorm8x2', offset: 400, shaderLocation: 20},
+          {format: 'snorm8x4', offset: 2736, shaderLocation: 6},
+          {format: 'unorm10-10-10-2', offset: 556, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 556, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint32', offset: 4416, shaderLocation: 15},
+          {format: 'sint16x2', offset: 1380, shaderLocation: 23},
+          {format: 'snorm16x4', offset: 8380, shaderLocation: 22},
+          {format: 'sint32x4', offset: 328, shaderLocation: 3},
+          {format: 'unorm8x4', offset: 3836, shaderLocation: 16},
+          {format: 'uint8x2', offset: 6008, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 3984, shaderLocation: 10},
+          {format: 'unorm16x2', offset: 13436, shaderLocation: 0},
+          {format: 'float32x4', offset: 2224, shaderLocation: 7},
+          {format: 'uint8x2', offset: 3280, shaderLocation: 19},
+        ],
+      },
+      {arrayStride: 6880, attributes: [{format: 'uint32x3', offset: 548, shaderLocation: 9}]},
+      {arrayStride: 1800, attributes: [{format: 'unorm8x4', offset: 120, shaderLocation: 14}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroupLayout62 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 8187,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 6450,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 1628,
+      visibility: 0,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let bindGroup63 = device1.createBindGroup({label: '\ubb98\ueb46\u{1faaf}', layout: bindGroupLayout38, entries: []});
+let commandEncoder199 = device1.createCommandEncoder({label: '\u6360\u6a5a\u737d\u{1f649}\u4451\u0d91\u0b51\u9c10\u0730'});
+let querySet97 = device1.createQuerySet({type: 'occlusion', count: 1679});
+let renderPassEncoder68 = commandEncoder198.beginRenderPass({
+  label: '\u{1fe01}\u7d1d\ucd03\ud229\u1f5b\ue13f\u733e\u0999',
+  colorAttachments: [{
+  view: textureView102,
+  clearValue: { r: 611.9, g: 535.0, b: -176.8, a: -439.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet74,
+  maxDrawCount: 420526169,
+});
+let renderBundle123 = renderBundleEncoder77.finish();
+try {
+computePassEncoder66.setPipeline(pipeline84);
+} catch {}
+try {
+renderPassEncoder28.drawIndexed(83, 81);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer50, 773_567_689);
+} catch {}
+try {
+renderBundleEncoder29.drawIndirect(buffer41, 8904);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(4, buffer24, 2460, 1830);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture78,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(64)), /* required buffer size: 274 */
+{offset: 274}, {width: 20, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline184 = device1.createComputePipeline({
+  label: '\u{1fdf8}\u3918\u0488\udf3d',
+  layout: pipelineLayout25,
+  compute: {module: shaderModule40, entryPoint: 'compute0', constants: {}},
+});
+let pipeline185 = await device1.createRenderPipelineAsync({
+  label: '\u7865\ubcee\uf879\u9811',
+  layout: pipelineLayout16,
+  multisample: {count: 4, mask: 0x9ed5cd94},
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'replace'},
+    stencilBack: {compare: 'always', failOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 4202441836,
+    stencilWriteMask: 395807475,
+    depthBiasSlopeScale: 129.0202806413277,
+    depthBiasClamp: 646.2385260577166,
+  },
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x4', offset: 4588, shaderLocation: 16},
+          {format: 'sint16x4', offset: 1616, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 624, shaderLocation: 7},
+          {format: 'sint16x4', offset: 8240, shaderLocation: 18},
+          {format: 'unorm10-10-10-2', offset: 9820, shaderLocation: 0},
+          {format: 'uint32x4', offset: 9656, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 6256, shaderLocation: 15},
+          {format: 'uint16x4', offset: 8644, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 20416, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 11396,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 228, shaderLocation: 20},
+          {format: 'uint32x4', offset: 5228, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 720, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 2170, shaderLocation: 5},
+          {format: 'float32', offset: 244, shaderLocation: 11},
+          {format: 'float32x2', offset: 936, shaderLocation: 14},
+          {format: 'uint16x2', offset: 5832, shaderLocation: 2},
+          {format: 'sint8x2', offset: 5684, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 176, shaderLocation: 21},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2416,
+        attributes: [
+          {format: 'uint8x2', offset: 126, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 184, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 5052,
+        attributes: [
+          {format: 'sint32x3', offset: 260, shaderLocation: 23},
+          {format: 'float32x2', offset: 100, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+  await promise65;
+} catch {}
+video31.width = 8;
+let img45 = await imageWithData(137, 144, '#8280abf2', '#304fa623');
+let commandEncoder200 = device1.createCommandEncoder();
+let textureView245 = texture107.createView({label: '\u8339\u{1fe78}\u06e2\u7500\u0f7f\udcf7\u0ffc', arrayLayerCount: 1});
+let renderBundle124 = renderBundleEncoder67.finish();
+let sampler118 = device1.createSampler({
+  label: '\u{1fea7}\u998d\u0f95',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 3.944,
+  lodMaxClamp: 8.157,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder55.executeBundles([renderBundle52, renderBundle47, renderBundle115, renderBundle66, renderBundle123, renderBundle119, renderBundle51, renderBundle66]);
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder50.draw(457, 133, 73_682_880, 899_957_436);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(2, buffer24);
+} catch {}
+try {
+commandEncoder199.copyTextureToBuffer({
+  texture: texture111,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 272 widthInBlocks: 68 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9400 */
+  offset: 9400,
+  bytesPerRow: 768,
+  rowsPerImage: 173,
+  buffer: buffer26,
+}, {width: 68, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+renderBundleEncoder86.insertDebugMarker('\u0530');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData8,
+  origin: { x: 0, y: 15 },
+  flipY: false,
+}, {
+  texture: texture153,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext37.unconfigure();
+} catch {}
+video32.height = 267;
+offscreenCanvas39.width = 2679;
+try {
+renderPassEncoder63.executeBundles([renderBundle99, renderBundle98, renderBundle97, renderBundle54, renderBundle67, renderBundle49, renderBundle70]);
+} catch {}
+try {
+renderPassEncoder60.setStencilReference(2654);
+} catch {}
+try {
+renderPassEncoder11.setViewport(594.0, 0.7867, 459.2, 0.1733, 0.5016, 0.9183);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer37, 1_351_357_441);
+} catch {}
+try {
+renderPassEncoder65.drawIndirect(buffer50, 323_685_343);
+} catch {}
+try {
+renderBundleEncoder58.drawIndirect(buffer41, 1496);
+} catch {}
+try {
+commandEncoder199.copyTextureToBuffer({
+  texture: texture70,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 21536 */
+  offset: 21536,
+  bytesPerRow: 0,
+  buffer: buffer52,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer52);
+} catch {}
+try {
+commandEncoder199.clearBuffer(buffer49);
+dissociateBuffer(device1, buffer49);
+} catch {}
+let imageBitmap51 = await createImageBitmap(offscreenCanvas4);
+let offscreenCanvas49 = new OffscreenCanvas(110, 356);
+let commandBuffer39 = commandEncoder159.finish({label: '\u00ae\u0f58\u{1fcfa}\ude5f\u{1fef5}\ufab1\u{1fd7b}\uec30\u0406\u{1f89a}'});
+let textureView246 = texture123.createView({label: '\u0794\ue421\ud3e3\u5d8a\u2b70\u0a95\uaf9a\u{1f819}\uf199'});
+try {
+computePassEncoder54.setBindGroup(3, bindGroup50);
+} catch {}
+canvas7.width = 4014;
+let bindGroup64 = device1.createBindGroup({
+  label: '\ud259\u2700\u4b50\ued36\u0998\u2a36\u0c93\u0e1f\u6de3',
+  layout: bindGroupLayout38,
+  entries: [],
+});
+let pipelineLayout32 = device1.createPipelineLayout({label: '\u{1ff2a}\ud866\u50c5\u017c\ufde3', bindGroupLayouts: [bindGroupLayout15, bindGroupLayout52]});
+let commandEncoder201 = device1.createCommandEncoder({label: '\uf582\u3e92\u22ce\u9149\u0b9d\u0b39\ue2be\u{1f9bf}\u4873\uceb2'});
+let computePassEncoder81 = commandEncoder197.beginComputePass({label: '\u6dff\u9017'});
+try {
+renderPassEncoder58.setStencilReference(1047);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer41, 96568, 102631);
+} catch {}
+try {
+renderBundleEncoder61.setBindGroup(2, bindGroup58);
+} catch {}
+try {
+renderBundleEncoder58.draw(30, 146, 457_394_146, 181_802_366);
+} catch {}
+let arrayBuffer15 = buffer36.getMappedRange(0, 9956);
+try {
+commandEncoder199.copyTextureToTexture({
+  texture: texture131,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 87},
+  aspect: 'all',
+},
+{
+  texture: texture100,
+  mipLevel: 2,
+  origin: {x: 12, y: 1, z: 1},
+  aspect: 'all',
+},
+{width: 86, height: 1, depthOrArrayLayers: 9});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise70 = device1.createComputePipelineAsync({layout: pipelineLayout25, compute: {module: shaderModule41, entryPoint: 'compute0', constants: {}}});
+let canvas50 = document.createElement('canvas');
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+  await promise69;
+} catch {}
+let canvas51 = document.createElement('canvas');
+try {
+pipeline140.label = '\u902e\ub8ba\u012d';
+} catch {}
+let buffer62 = device1.createBuffer({size: 48599, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder202 = device1.createCommandEncoder({label: '\u09f8\u{1f7e1}\ufdb0\u01ae\u0d31\u06d1'});
+let texture156 = device1.createTexture({
+  label: '\u0910\u0d31\u3b55\u35c7\u0388\u4ed4\u052c\u02d7\u32d2\u1158',
+  size: {width: 150},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let textureView247 = texture77.createView({label: '\u43d6\u9528', dimension: '2d-array', format: 'bgra8unorm-srgb'});
+let externalTexture103 = device1.importExternalTexture({
+  label: '\u{1f7ba}\u{1faa9}\u6ce8\ue4d5\u040f\u{1fbd7}\u{1fa77}\ubd33\u{1f675}\u{1fe38}',
+  source: video46,
+});
+try {
+renderPassEncoder63.executeBundles([renderBundle57, renderBundle61]);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline86);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(8, buffer24);
+} catch {}
+try {
+renderBundleEncoder58.drawIndexedIndirect(buffer41, 23008);
+} catch {}
+try {
+renderBundleEncoder55.setPipeline(pipeline122);
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(6, buffer41, 148668, 13070);
+} catch {}
+try {
+commandEncoder196.copyTextureToBuffer({
+  texture: texture149,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 828 widthInBlocks: 207 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 37508 */
+  offset: 37508,
+  buffer: buffer57,
+}, {width: 207, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer57);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer53, 2488, new Int16Array(16527), 4234, 1672);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture143,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer14), /* required buffer size: 56 */
+{offset: 56}, {width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video13,
+  origin: { x: 0, y: 6 },
+  flipY: false,
+}, {
+  texture: texture153,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline186 = await promise70;
+video39.height = 92;
+gc();
+try {
+adapter1.label = '\u738e\u79dc\u{1fd0b}\ufada\u8434\u{1f651}';
+} catch {}
+canvas0.width = 10;
+let videoFrame36 = new VideoFrame(offscreenCanvas25, {timestamp: 0});
+try {
+commandEncoder60.label = '\u04e0\u7174\u{1fb12}\u0f04\u018c\u0bba';
+} catch {}
+let texture157 = device1.createTexture({
+  label: '\u{1fc6d}\u{1f6b2}\uc49d\u8125\u{1fad5}\u1d1f',
+  size: {width: 36},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder82 = commandEncoder200.beginComputePass({label: '\u0a4d\u{1fc00}\u{1fb68}\u{1fb33}\u{1fab9}\u0d8a\ub0bd\u{1f9e2}\u{1fc56}\u0994\u95bd'});
+let renderBundle125 = renderBundleEncoder81.finish({label: '\u1e26\u{1fc23}'});
+try {
+computePassEncoder72.setBindGroup(6, bindGroup46);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline79);
+} catch {}
+try {
+renderPassEncoder19.draw(59);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(192, 65, 1_196_410_878);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer30, 395_702_331);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline119);
+} catch {}
+try {
+renderBundleEncoder55.draw(198, 387, 214_993_126);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder196.clearBuffer(buffer43, 37588, 185916);
+dissociateBuffer(device1, buffer43);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer57, 100196, new DataView(new ArrayBuffer(357)), 259, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 256, y: 4 },
+  flipY: true,
+}, {
+  texture: texture153,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas38.width = 415;
+let gpuCanvasContext41 = offscreenCanvas49.getContext('webgpu');
+let canvas52 = document.createElement('canvas');
+let pipelineLayout33 = device1.createPipelineLayout({
+  label: '\u2e5d\u2ac2\u231b\u0717\u{1fd8e}\u{1fb7f}\ud6c7\u7f55\ud822',
+  bindGroupLayouts: [bindGroupLayout61, bindGroupLayout24, bindGroupLayout52, bindGroupLayout32, bindGroupLayout15, bindGroupLayout35, bindGroupLayout61],
+});
+let textureView248 = texture64.createView({label: '\u0288\u552b\u{1f87e}\u{1ff4e}'});
+let externalTexture104 = device1.importExternalTexture({label: '\u0960\u97da', source: video14});
+try {
+renderPassEncoder56.executeBundles([renderBundle45, renderBundle118, renderBundle61, renderBundle50, renderBundle76, renderBundle97, renderBundle74]);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(1, buffer24, 140, 4891);
+} catch {}
+try {
+renderBundleEncoder50.drawIndexed(46, 427, 210_665_702);
+} catch {}
+try {
+renderBundleEncoder55.drawIndexedIndirect(buffer41, 98212);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer41, 1104);
+} catch {}
+let promise71 = buffer60.mapAsync(GPUMapMode.READ, 1832, 304);
+try {
+commandEncoder201.copyTextureToBuffer({
+  texture: texture111,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10156 */
+  offset: 10156,
+  buffer: buffer26,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer26);
+} catch {}
+try {
+commandEncoder202.copyTextureToTexture({
+  texture: texture122,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture133,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline187 = device1.createRenderPipeline({
+  label: '\ud20f\u{1f750}\u06be\u0d0b\u394f\u{1f6f0}\u059f\ucba8\u00db\ue8c4\uecbe',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule21,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {failOp: 'zero', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilReadMask: 3389204126,
+    stencilWriteMask: 1417983880,
+    depthBiasClamp: 579.5208311152936,
+  },
+  vertex: {
+    module: shaderModule21,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 6228,
+        attributes: [
+          {format: 'uint32x4', offset: 596, shaderLocation: 19},
+          {format: 'unorm16x4', offset: 508, shaderLocation: 18},
+          {format: 'float32', offset: 1548, shaderLocation: 11},
+          {format: 'uint32x2', offset: 1264, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 10096,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 1780, shaderLocation: 21},
+          {format: 'snorm16x4', offset: 2576, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 6292,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint16x2', offset: 2056, shaderLocation: 5}],
+      },
+      {
+        arrayStride: 4608,
+        attributes: [
+          {format: 'uint16x4', offset: 3240, shaderLocation: 13},
+          {format: 'sint32x2', offset: 740, shaderLocation: 17},
+          {format: 'unorm8x2', offset: 198, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+video38.width = 31;
+let texture158 = device1.createTexture({
+  label: '\ua485\u1fa9',
+  size: [288],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg8uint', 'rg8uint'],
+});
+let textureView249 = texture137.createView({
+  label: '\u4db8\u7c1c\u66a6\u480c\u0a25',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 186,
+  arrayLayerCount: 55,
+});
+let sampler119 = device1.createSampler({
+  label: '\u8a70\ub4e4\u{1f7b2}\u9b9b\u{1ff82}\u0479\u4852\u019e',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.317,
+  lodMaxClamp: 44.81,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder65.setPipeline(pipeline104);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(672, 164, 1_113_030_112, 1_186_935_259);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup53);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(314, 10, 154_208_002, -2_142_731_887, 101_925_296);
+} catch {}
+try {
+renderBundleEncoder58.drawIndirect(buffer41, 67080);
+} catch {}
+try {
+renderBundleEncoder76.setPipeline(pipeline156);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(5, buffer41);
+} catch {}
+try {
+commandEncoder201.copyBufferToBuffer(buffer61, 56, buffer52, 4024, 0);
+dissociateBuffer(device1, buffer61);
+dissociateBuffer(device1, buffer52);
+} catch {}
+try {
+commandEncoder202.copyTextureToTexture({
+  texture: texture70,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 144, height: 32, depthOrArrayLayers: 211}
+*/
+{
+  source: imageBitmap12,
+  origin: { x: 11, y: 5 },
+  flipY: true,
+}, {
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 22, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline188 = await device1.createRenderPipelineAsync({
+  label: '\u02f6\u7bb7\u{1fb39}\u8a07\u{1ff38}',
+  layout: pipelineLayout29,
+  multisample: {mask: 0x3add5060},
+  fragment: {
+  module: shaderModule40,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'replace', passOp: 'replace'},
+    stencilBack: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilReadMask: 1388781045,
+    stencilWriteMask: 2822189627,
+    depthBias: 1652262298,
+    depthBiasSlopeScale: 361.1738793295513,
+  },
+  vertex: {
+    module: shaderModule40,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7492,
+        attributes: [
+          {format: 'unorm16x2', offset: 1608, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 7400, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 436, shaderLocation: 23},
+        ],
+      },
+      {arrayStride: 9680, attributes: [{format: 'uint8x2', offset: 1694, shaderLocation: 0}]},
+      {
+        arrayStride: 19596,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 2064, shaderLocation: 21},
+          {format: 'sint8x2', offset: 10880, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 552, shaderLocation: 5},
+          {format: 'sint32', offset: 2264, shaderLocation: 3},
+          {format: 'sint32x4', offset: 804, shaderLocation: 11},
+          {format: 'sint16x4', offset: 3900, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 1396, shaderLocation: 22},
+          {format: 'unorm8x4', offset: 2792, shaderLocation: 14},
+          {format: 'uint32', offset: 4528, shaderLocation: 13},
+          {format: 'sint8x2', offset: 332, shaderLocation: 2},
+          {format: 'uint16x2', offset: 3412, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 3360, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 800, shaderLocation: 18},
+          {format: 'unorm8x2', offset: 3740, shaderLocation: 4},
+          {format: 'float32x2', offset: 5572, shaderLocation: 20},
+          {format: 'sint32x4', offset: 5580, shaderLocation: 15},
+          {format: 'float32', offset: 9756, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 4692,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 60, shaderLocation: 6}],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 7112, shaderLocation: 19},
+          {format: 'uint32x4', offset: 1532, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+});
+let offscreenCanvas50 = new OffscreenCanvas(384, 253);
+let bindGroupLayout63 = device1.createBindGroupLayout({
+  label: '\u0795\u44fc\u6588\u085b\u0f33\u03a1\u06c6\u88e9\u{1f611}',
+  entries: [
+    {
+      binding: 6392,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 184,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let querySet98 = device1.createQuerySet({label: '\ub2ff\u{1ff61}\u{1fc2d}\ua13e\u{1fc4b}\u9f97\u{1fb65}\uea3f', type: 'occlusion', count: 1616});
+let texture159 = device1.createTexture({size: [2268], dimension: '1d', format: 'rg8uint', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+let renderBundle126 = renderBundleEncoder85.finish({label: '\u{1fd6b}\u{1f81c}\u{1f9de}\u31f1\ua22a\u0261'});
+let sampler120 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.38,
+  lodMaxClamp: 33.18,
+});
+try {
+renderPassEncoder40.end();
+} catch {}
+try {
+renderPassEncoder67.setBlendConstant({ r: -963.6, g: 241.2, b: 413.5, a: -936.7, });
+} catch {}
+try {
+renderPassEncoder59.drawIndexed(185, 610, 405_544_266, 441_209_967, 404_794_361);
+} catch {}
+try {
+  await buffer52.mapAsync(GPUMapMode.READ, 79208, 17708);
+} catch {}
+try {
+commandEncoder201.copyTextureToBuffer({
+  texture: texture79,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9756 */
+  offset: 9756,
+  bytesPerRow: 256,
+  buffer: buffer53,
+}, {width: 22, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer53);
+} catch {}
+try {
+commandEncoder196.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 16, y: 25, z: 13},
+  aspect: 'all',
+},
+{width: 62, height: 13, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder196.resolveQuerySet(querySet68, 618, 289, buffer42, 79616);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer24, 416, new Float32Array(15672), 14173, 252);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap20,
+  origin: { x: 5, y: 39 },
+  flipY: false,
+}, {
+  texture: texture153,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img46 = await imageWithData(50, 66, '#431c952a', '#6e793fdc');
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -1008,11 +1008,11 @@ void RenderBundleEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& gro
     }
 
     m_bindGroups.set(groupIndex, &group);
-    if (group.vertexArgumentBuffer()) {
+    if (auto vertexBindGroupBufferIndex = m_device->vertexBufferIndexForBindGroup(groupIndex); group.vertexArgumentBuffer() && m_vertexBuffers.size() > vertexBindGroupBufferIndex) {
         addResource(m_resources, group.vertexArgumentBuffer(), MTLRenderStageVertex);
-        m_vertexBuffers[m_device->vertexBufferIndexForBindGroup(groupIndex)] = { .buffer = group.vertexArgumentBuffer(), .offset = 0, .dynamicOffsetCount = dynamicOffsetCount, .dynamicOffsets = dynamicOffsets->data(), .size = group.vertexArgumentBuffer().length };
+        m_vertexBuffers[vertexBindGroupBufferIndex] = { .buffer = group.vertexArgumentBuffer(), .offset = 0, .dynamicOffsetCount = dynamicOffsetCount, .dynamicOffsets = dynamicOffsets->data(), .size = group.vertexArgumentBuffer().length };
     }
-    if (group.fragmentArgumentBuffer()) {
+    if (group.fragmentArgumentBuffer() && m_fragmentBuffers.size() > groupIndex) {
         addResource(m_resources, group.fragmentArgumentBuffer(), MTLRenderStageFragment);
         m_fragmentBuffers[groupIndex] = { .buffer = group.fragmentArgumentBuffer(), .offset = 0, .dynamicOffsetCount = dynamicOffsetCount, .dynamicOffsets = dynamicOffsets->data(), .size = group.fragmentArgumentBuffer().length };
     }


### PR DESCRIPTION
#### 12be93dae369f8365c7ae4656f149b8da408d7f3
<pre>
[WebGPU] Crash in RenderBundleEncoder::setBindGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=276279">https://bugs.webkit.org/show_bug.cgi?id=276279</a>
&lt;radar://130758821&gt;

Reviewed by Tadeu Zagallo.

An encoder which becomes invalid will have a zero sized fragment
buffer container, add a check to avoid out of bounds access.

* LayoutTests/fast/webgpu/nocrash/fuzz-276279-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-276279.html: Added.
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::setBindGroup):

Canonical link: <a href="https://commits.webkit.org/280740@main">https://commits.webkit.org/280740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7625bdb70e4294308bf810733db34e06fc8c94dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61020 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7843 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46483 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5550 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49575 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27347 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6885 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6846 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62699 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1311 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53741 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53829 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12713 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1121 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32555 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33640 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34725 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33386 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->