### PR TITLE
Add getPendingPushMessage IPC to webpushd

### DIFF
--- a/Source/WebKit/Shared/WebPushDaemonConstants.h
+++ b/Source/WebKit/Shared/WebPushDaemonConstants.h
@@ -27,12 +27,17 @@
 
 #ifdef __cplusplus
 
+#include <wtf/Seconds.h>
 #include <wtf/text/ASCIILiteral.h>
 
 namespace WebKit::WebPushD {
 
 // If an origin processes more than this many silent pushes, then it will be unsubscribed from push.
 constexpr unsigned maxSilentPushCount = 3;
+
+// getPendingPushMessage starts a timer with this time interval after returning a push message to the client. If the timer expires, then we increment the subscription's silent push count.
+static constexpr Seconds silentPushTimeoutForProduction { 30_s };
+static constexpr Seconds silentPushTimeoutForTesting { 1_s };
 
 constexpr auto protocolVersionKey = "protocol version"_s;
 constexpr uint64_t protocolVersionValue = 3;

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -94,6 +94,7 @@ private:
     void setPushAndNotificationsEnabledForOrigin(const String& originString, bool, CompletionHandler<void()>&& replySender);
     void injectPushMessageForTesting(PushMessageForTesting&&, CompletionHandler<void(const String&)>&&);
     void injectEncryptedPushMessageForTesting(const String&, CompletionHandler<void(bool)>&&);
+    void getPendingPushMessage(CompletionHandler<void(const std::optional<WebKit::WebPushMessage>&)>&& replySender);
     void getPendingPushMessages(CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender);
     void subscribeToPushService(URL&& scopeURL, const Vector<uint8_t>& applicationServerKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&& replySender);
     void unsubscribeFromPushService(URL&& scopeURL, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&& replySender);
@@ -106,6 +107,7 @@ private:
     void getPushPermissionState(URL&& scopeURL, CompletionHandler<void(const Expected<uint8_t, WebCore::ExceptionData>&)>&&);
     void setHostAppAuditTokenData(const Vector<uint8_t>&);
     void getPushTopicsForTesting(CompletionHandler<void(Vector<String>, Vector<String>)>&&);
+    void didShowNotificationForTesting(URL&& scopeURL, CompletionHandler<void()>&&);
     String bundleIdentifierFromAuditToken(audit_token_t);
     bool hostHasEntitlement(ASCIILiteral);
 

--- a/Source/WebKit/webpushd/PushClientConnection.messages.in
+++ b/Source/WebKit/webpushd/PushClientConnection.messages.in
@@ -24,6 +24,7 @@
 
 messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     SetPushAndNotificationsEnabledForOrigin(String originString, bool enabled) -> ()
+    GetPendingPushMessage() -> (std::optional<WebKit::WebPushMessage> message)
     GetPendingPushMessages() -> (Vector<WebKit::WebPushMessage> messages)
     UpdateConnectionConfiguration(WebKit::WebPushD::WebPushDaemonConnectionConfiguration configuration)
     InjectPushMessageForTesting(WebKit::WebPushD::PushMessageForTesting message) -> (String error)
@@ -37,6 +38,7 @@ messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     RemovePushSubscriptionsForOrigin(WebCore::SecurityOriginData origin) -> (unsigned removed)
     SetPublicTokenForTesting(String token) -> ()
     GetPushTopicsForTesting() -> (Vector<String> enabled, Vector<String> ignored)
+    DidShowNotificationForTesting(URL scopeURL) -> ()
 }
 
 #endif // ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -186,6 +186,11 @@ void PushClientConnection::injectEncryptedPushMessageForTesting(const String& me
     WebPushDaemon::singleton().injectEncryptedPushMessageForTesting(*this, message, WTFMove(replySender));
 }
 
+void PushClientConnection::getPendingPushMessage(CompletionHandler<void(const std::optional<WebKit::WebPushMessage>&)>&& replySender)
+{
+    WebPushDaemon::singleton().getPendingPushMessage(*this, WTFMove(replySender));
+}
+
 void PushClientConnection::getPendingPushMessages(CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender)
 {
     WebPushDaemon::singleton().getPendingPushMessages(*this, WTFMove(replySender));
@@ -224,6 +229,11 @@ void PushClientConnection::removePushSubscriptionsForOrigin(WebCore::SecurityOri
 void PushClientConnection::setPublicTokenForTesting(const String& publicToken, CompletionHandler<void()>&& replySender)
 {
     WebPushDaemon::singleton().setPublicTokenForTesting(*this, publicToken, WTFMove(replySender));
+}
+
+void PushClientConnection::didShowNotificationForTesting(URL&& scopeURL, CompletionHandler<void()>&& replySender)
+{
+    WebPushDaemon::singleton().didShowNotificationForTesting(*this, WTFMove(scopeURL), WTFMove(replySender));
 }
 
 void PushClientConnection::getPushPermissionState(URL&&, CompletionHandler<void(const Expected<uint8_t, WebCore::ExceptionData>&)>&& replySender)

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -41,7 +41,9 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/OSObjectPtr.h>
+#include <wtf/StdList.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 
 
@@ -69,7 +71,6 @@ public:
     void connectionAdded(xpc_connection_t);
     void connectionRemoved(xpc_connection_t);
 
-    void setMachServiceName(const String& machServiceName) { m_machServiceName = machServiceName; }
     void startMockPushService();
     void startPushService(const String& incomingPushServiceName, const String& pushDatabasePath);
     void handleIncomingPush(const WebCore::PushSubscriptionSetIdentifier&, WebKit::WebPushMessage&&);
@@ -78,6 +79,7 @@ public:
     void setPushAndNotificationsEnabledForOrigin(PushClientConnection&, const String& originString, bool, CompletionHandler<void()>&& replySender);
     void injectPushMessageForTesting(PushClientConnection&, PushMessageForTesting&&, CompletionHandler<void(const String&)>&&);
     void injectEncryptedPushMessageForTesting(PushClientConnection&, const String&, CompletionHandler<void(bool)>&&);
+    void getPendingPushMessage(PushClientConnection&, CompletionHandler<void(const std::optional<WebKit::WebPushMessage>&)>&& replySender);
     void getPendingPushMessages(PushClientConnection&, CompletionHandler<void(const Vector<WebKit::WebPushMessage>&)>&& replySender);
     void getPushTopicsForTesting(PushClientConnection&, CompletionHandler<void(Vector<String>, Vector<String>)>&&);
     void subscribeToPushService(PushClientConnection&, const URL& scopeURL, const Vector<uint8_t>& applicationServerKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&& replySender);
@@ -87,6 +89,7 @@ public:
     void removeAllPushSubscriptions(PushClientConnection&, CompletionHandler<void(unsigned)>&&);
     void removePushSubscriptionsForOrigin(PushClientConnection&, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
     void setPublicTokenForTesting(PushClientConnection&, const String& publicToken, CompletionHandler<void()>&&);
+    void didShowNotificationForTesting(PushClientConnection&, const URL& scopeURL, CompletionHandler<void()>&& replySender);
 
 private:
     WebPushDaemon();
@@ -100,19 +103,33 @@ private:
     void releaseIncomingPushTransaction();
     void incomingPushTransactionTimerFired();
 
+    Seconds silentPushTimeout() const;
+    void rescheduleSilentPushTimer();
+    void silentPushTimerFired();
+    void didShowNotificationImpl(const WebCore::PushSubscriptionSetIdentifier&, const String& scope);
+
     PushClientConnection* toPushClientConnection(xpc_connection_t);
     HashMap<xpc_connection_t, Ref<PushClientConnection>> m_connectionMap;
 
     std::unique_ptr<PushService> m_pushService;
+    bool m_usingMockPushService { false };
     bool m_pushServiceStarted { false };
     Deque<Function<void()>> m_pendingPushServiceFunctions;
 
-    HashMap<WebCore::PushSubscriptionSetIdentifier, Vector<WebKit::WebPushMessage>> m_pushMessages;
-    HashMap<String, Deque<PushMessageForTesting>> m_testingPushMessages;
-    
+    HashMap<WebCore::PushSubscriptionSetIdentifier, Deque<WebKit::WebPushMessage>> m_pushMessages;
+
     WebCore::Timer m_incomingPushTransactionTimer;
     OSObjectPtr<os_transaction_t> m_incomingPushTransaction;
-    String m_machServiceName;
+
+    struct PotentialSilentPush {
+        WebCore::PushSubscriptionSetIdentifier identifier;
+        String scope;
+        MonotonicTime expirationTime;
+    };
+
+    WebCore::Timer m_silentPushTimer;
+    OSObjectPtr<os_transaction_t> m_silentPushTransaction;
+    StdList<PotentialSilentPush> m_potentialSilentPushes;
 };
 
 } // namespace WebPushD

--- a/Source/WebKit/webpushd/WebPushDaemonMain.mm
+++ b/Source/WebKit/webpushd/WebPushDaemonMain.mm
@@ -155,8 +155,6 @@ int WebPushDaemonMain(int argc, char** argv)
 
         WebKit::startListeningForMachServiceConnections(machServiceName, entitlementName, connectionAdded, connectionRemoved, connectionEventHandler);
 
-        ::WebPushD::WebPushDaemon::singleton().setMachServiceName(String::fromUTF8(machServiceName));
-
         if (useMockPushService)
             ::WebPushD::WebPushDaemon::singleton().startMockPushService();
         else {


### PR DESCRIPTION
#### c48c059497e4001943f243e8046eeae28aea8cbc
<pre>
Add getPendingPushMessage IPC to webpushd
<a href="https://bugs.webkit.org/show_bug.cgi?id=276282">https://bugs.webkit.org/show_bug.cgi?id=276282</a>
<a href="https://rdar.apple.com/131225000">rdar://131225000</a>

Reviewed by Brady Eidson.

Currently clients fetch push messages via the getPendingPushMessages IPC, and we count on them to
call incrementSilentPushCount if the associated service worker doesn&apos;t call
ServiceWorkerRegistration.showNotification as part of handling the push event.

We&apos;d like to eventually remove the incrementSilentPushCount IPC. Instead, this patch introduces a
new getPendingPushMessage IPC which also implicitly starts a 30 second timer waiting for the client
to call showNotification. If the timer expires, then we automatically increment the silent push
count for the push subscription in the daemon.

* Source/WebKit/Shared/WebPushDaemonConstants.h:
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/PushClientConnection.messages.in:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::getPendingPushMessage):
(WebPushD::PushClientConnection::didShowNotificationForTesting):
* Source/WebKit/webpushd/WebPushDaemon.h:
(WebPushD::WebPushDaemon::setMachServiceName): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::startMockPushService):
(WebPushD::WebPushDaemon::injectPushMessageForTesting):
(WebPushD::WebPushDaemon::handleIncomingPush):
(WebPushD::WebPushDaemon::notifyClientPushMessageIsAvailable):
(WebPushD::WebPushDaemon::silentPushTimeout const):
(WebPushD::WebPushDaemon::rescheduleSilentPushTimer):
(WebPushD::WebPushDaemon::silentPushTimerFired):
(WebPushD::WebPushDaemon::didShowNotificationImpl):
(WebPushD::WebPushDaemon::getPendingPushMessage):
(WebPushD::WebPushDaemon::getPendingPushMessages):
(WebPushD::WebPushDaemon::didShowNotificationForTesting):
* Source/WebKit/webpushd/WebPushDaemonMain.mm:
(WebKit::WebPushDaemonMain):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::defaultWebPushDaemonConfiguration):
(TestWebKitAPI::createAndConfigureConnectionToService):
(TestWebKitAPI::TEST(WebPushD, BasicCommunication)):
(TestWebKitAPI::sendConfigurationWithAuditToken): Deleted.

Canonical link: <a href="https://commits.webkit.org/280760@main">https://commits.webkit.org/280760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5df2a73f39482e707895c5a226dc88f57828d2b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46490 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5557 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6892 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6856 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62709 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53748 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1327 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53837 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12721 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1128 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32565 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33650 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34735 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33396 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->