### PR TITLE
Improve divide-by-zero workaround in 'AutoTableLayout'

### DIFF
--- a/LayoutTests/fast/table/auto-layout-close-to-max-width-expected.txt
+++ b/LayoutTests/fast/table/auto-layout-close-to-max-width-expected.txt
@@ -1,0 +1,5 @@
+PASS document.getElementById("onlyTable").offsetWidth is 999999
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/table/auto-layout-close-to-max-width.html
+++ b/LayoutTests/fast/table/auto-layout-close-to-max-width.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<style>
+#outer {
+    width: 2000000px;
+}
+
+table {
+    border-collapse: collapse;
+}
+</style>
+<div id='outer'>
+<table id='onlyTable' width='999999px;'>
+  <tr>
+    <td>
+      <div></div>
+    </td>
+  </tr>
+</table>
+</div>
+<script>
+    shouldEvaluateTo('document.getElementById("onlyTable").offsetWidth', 999999);
+</script>

--- a/LayoutTests/fast/table/auto-layout-width-percentage-exceed-hundred-expected.txt
+++ b/LayoutTests/fast/table/auto-layout-width-percentage-exceed-hundred-expected.txt
@@ -1,0 +1,5 @@
+PASS document.getElementById("onlyTable").offsetWidth is 1000000
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/table/auto-layout-width-percentage-exceed-hundred.html
+++ b/LayoutTests/fast/table/auto-layout-width-percentage-exceed-hundred.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<style>
+#outer {
+    width: 2000000px;
+}
+
+table {
+    border-collapse: collapse;
+}</style>
+<div id='outer'>
+<table id='onlyTable'>
+  <tr>
+    <td width='100%'>
+      <div></div>
+    </td>
+    <td width='60%'>
+      <div width='10px;'></div>
+    </td>
+  </tr>
+</table>
+</div>
+<script>
+    shouldEvaluateTo('document.getElementById("onlyTable").offsetWidth', 1000000);
+</script>


### PR DESCRIPTION
#### a483bb0422b22c36ab850dd25c0868155962de5a
<pre>
Improve divide-by-zero workaround in `AutoTableLayout`

<a href="https://bugs.webkit.org/show_bug.cgi?id=276283">https://bugs.webkit.org/show_bug.cgi?id=276283</a>
<a href="https://rdar.apple.com/131669385">rdar://131669385</a>

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/6c84d2ae7c82ce83fb9ce9c3124917933d4c863c">https://chromium.googlesource.com/chromium/src.git/+/6c84d2ae7c82ce83fb9ce9c3124917933d4c863c</a>

In some situations, table percentage widths exceed 100%, causing
division by zero. The previous code would divide by an arbitrarily
small number to avoid division by zero and get an arbitrary high
value. Since FF/Edge always set to a max width (which is still
unspecified), we now also set to a max width (maxTableWidth).

* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::computeIntrinsicLogicalWidths):
* LayoutTests/fast/table/auto-layout-close-to-max-width.html: Add Test Case
* LayoutTests/fast/table/auto-layout-close-to-max-width-expected.txt: Add Test Case Expectation
* LayoutTests/fast/table/auto-layout-width-percentage-exceed-hundred.html: Add Test Case
* LayoutTests/fast/table/auto-layout-width-percentage-exceed-hundred-expected.txt: Add Test Case Expectation
</pre>