### PR TITLE
Support WTF::interleave() in makeString()

### DIFF
--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -65,6 +65,8 @@ public:
     void append(LChar);
     void append(char character) { append(byteCast<LChar>(character)); }
 
+    template<typename... StringTypeAdapters> void appendFromAdapters(const StringTypeAdapters&...);
+
     // FIXME: Add a StringTypeAdapter so we can append one string builder to another with variadic append.
     void append(const StringBuilder&);
 
@@ -112,7 +114,6 @@ private:
     WTF_EXPORT_PRIVATE void reifyString() const;
 
     void appendFromAdapters() { /* empty base case */ }
-    template<typename... StringTypeAdapters> void appendFromAdapters(const StringTypeAdapters&...);
     template<typename StringTypeAdapter, typename... StringTypeAdapters> void appendFromAdaptersSlow(const StringTypeAdapter&, const StringTypeAdapters&...);
     template<typename StringTypeAdapter> void appendFromAdapterSlow(const StringTypeAdapter&);
 
@@ -349,6 +350,18 @@ template<> struct IntegerToStringConversionTrait<StringBuilder> {
     static void flush(std::span<const LChar> characters, StringBuilder* builder) { builder->append(characters); }
 };
 
+// Helper functor useful in generic contexts where both makeString() and StringBuilder are being used.
+struct SerializeUsingStringBuilder {
+    StringBuilder& builder;
+
+    using Result = void;
+    template<typename... T> void operator()(T&&... args)
+    {
+        return builder.append(std::forward<T>(args)...);
+    }
+};
+
 } // namespace WTF
 
 using WTF::StringBuilder;
+using WTF::SerializeUsingStringBuilder;

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -478,6 +478,9 @@ public:
     Interleave(const Interleave&) = delete;
     Interleave& operator=(const Interleave&) = delete;
 
+    Interleave(Interleave&&) = default;
+    Interleave& operator=(Interleave&&) = default;
+
     template<typename Accumulator> void writeUsing(Accumulator& accumulator) const
     {
         auto begin = std::begin(container);

--- a/Source/WebCore/Modules/fetch/FetchHeaders.cpp
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.cpp
@@ -212,13 +212,7 @@ ExceptionOr<String> FetchHeaders::get(const String& name) const
     if (equalIgnoringASCIICase(name, "set-cookie"_s)) {
         if (m_setCookieValues.isEmpty())
             return String();
-        StringBuilder builder;
-        for (const auto& value : m_setCookieValues) {
-            if (!builder.isEmpty())
-                builder.append(", "_s);
-            builder.append(value);
-        }
-        return builder.toString();
+        return makeString(interleave(m_setCookieValues, ", "_s));
     }
     return m_headers.get(name);
 }

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
@@ -320,19 +320,10 @@ String IDBKeyData::loggingString() const
     switch (type()) {
     case IndexedDB::KeyType::Invalid:
         return "<invalid>"_s;
-    case IndexedDB::KeyType::Array: {
-        StringBuilder builder;
-        builder.append("<array> - { "_s);
-        auto& array = std::get<Vector<IDBKeyData>>(m_value);
-        for (size_t i = 0; i < array.size(); ++i) {
-            builder.append(array[i].loggingString());
-            if (i < array.size() - 1)
-                builder.append(", "_s);
-        }
-        builder.append(" }"_s);
-        result = builder.toString();
+    case IndexedDB::KeyType::Array:
+        result = makeString("<array> - { "_s, interleave(std::get<Vector<IDBKeyData>>(m_value), [](auto& builder, auto& item) { builder.append(item.loggingString()); }, ", "_s), " }"_s);
         break;
-    }
+
     case IndexedDB::KeyType::Binary: {
         StringBuilder builder;
         builder.append("<binary> - "_s);

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
@@ -63,11 +63,7 @@ const String WebSocketExtensionDispatcher::createHeaderValue() const
     if (!numProcessors)
         return String();
 
-    StringBuilder builder;
-    builder.append(m_processors[0]->handshakeString());
-    for (size_t i = 1; i < numProcessors; ++i)
-        builder.append(", "_s, m_processors[i]->handshakeString());
-    return builder.toString();
+    return makeString(interleave(m_processors, [](auto& processor) { return processor->handshakeString(); }, ", "_s));
 }
 
 void WebSocketExtensionDispatcher::appendAcceptedExtension(const String& extensionToken, HashMap<String, String>& extensionParameters)

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -658,14 +658,7 @@ TextStream& operator<<(TextStream& stream, AXObjectCache& axObjectCache)
 #if ENABLE(AX_THREAD_TEXT_APIS)
 static void streamTextRuns(TextStream& stream, const AXTextRuns& runs)
 {
-    StringBuilder result;
-    for (size_t i = 0; i < runs.size(); i++) {
-        result.append(makeString(runs[i].lineIndex, ":|", runs[i].text, "|(len: ", runs[i].text.length(), ")"));
-        if (i != runs.size() - 1)
-            result.append(", ");
-    }
-
-    stream.dumpProperty("textRuns", result);
+    stream.dumpProperty("textRuns", makeString(interleave(runs, [](auto& builder, auto& run) { builder.append(run.lineIndex, ":|"_s, run.text, "|(len: "_s, run.text.length(), ')'); }, ", "_s)));
 }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 

--- a/Source/WebCore/accessibility/AXTextRun.cpp
+++ b/Source/WebCore/accessibility/AXTextRun.cpp
@@ -27,19 +27,14 @@
 #include "AXTextRun.h"
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
+
+#include <wtf/text/MakeString.h>
+
 namespace WebCore {
 
 String AXTextRuns::debugDescription() const
 {
-    StringBuilder result;
-    result.append('[');
-    for (unsigned i = 0; i < runs.size(); i++) {
-        result.append(runs[i].debugDescription(containingBlock));
-        if (i != runs.size() - 1)
-            result.append(", ");
-    }
-    result.append(']');
-    return result.toString();
+    return makeString('[', interleave(runs, [&](auto& run) { return run.debugDescription(containingBlock); }, ", "_s), ']');
 }
 
 size_t AXTextRuns::indexForOffset(unsigned textOffset) const

--- a/Tools/TestWebKitAPI/Tests/WTF/MoveOnly.h
+++ b/Tools/TestWebKitAPI/Tests/WTF/MoveOnly.h
@@ -28,6 +28,7 @@
 
 #include <wtf/HashFunctions.h>
 #include <wtf/HashTraits.h>
+#include <wtf/text/StringConcatenateNumbers.h>
 
 class MoveOnly {
 public:
@@ -97,6 +98,25 @@ template<> struct DefaultHash<MoveOnly> {
     static constexpr bool safeToCompareToEmptyOrDeleted = true;
     static constexpr bool hasHashInValue = true; // This is not correct, but for debugging of RobinHoodHashSet.
 };
+
+template<> class StringTypeAdapter<MoveOnly, void> {
+public:
+    StringTypeAdapter(const MoveOnly& moveOnly)
+        : m_moveOnly { moveOnly }
+    {
+    }
+
+    unsigned length() const { return StringTypeAdapter<unsigned>(m_moveOnly.value()).length(); }
+    bool is8Bit() const { return StringTypeAdapter<unsigned>(m_moveOnly.value()).is8Bit(); }
+    template<typename CharacterType> void writeTo(CharacterType* destination) const
+    {
+        StringTypeAdapter<unsigned>(m_moveOnly.value()).writeTo(destination);
+    }
+
+private:
+    const MoveOnly& m_moveOnly;
+};
+
 } // namespace WTF
 
 #endif // MoveOnly_h

--- a/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
@@ -38,28 +38,6 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/unicode/CharacterNames.h>
 
-namespace WTF {
-
-template<> class StringTypeAdapter<MoveOnly, void> {
-public:
-    StringTypeAdapter(const MoveOnly& moveOnly)
-        : m_moveOnly { moveOnly }
-    {
-    }
-
-    unsigned length() const { return StringTypeAdapter<unsigned>(m_moveOnly.value()).length(); }
-    bool is8Bit() const { return StringTypeAdapter<unsigned>(m_moveOnly.value()).is8Bit(); }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const
-    {
-        StringTypeAdapter<unsigned>(m_moveOnly.value()).writeTo(destination);
-    }
-
-private:
-    const MoveOnly& m_moveOnly;
-};
-
-} // namespace WTF
-
 namespace TestWebKitAPI {
 
 static String builderContent(const StringBuilder& builder)

--- a/Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include "MoveOnly.h"
 #include "Test.h"
 #include <cstddef>
 #include <cstdint>
@@ -213,6 +214,86 @@ TEST(WTF, StringConcatenate_Tuple)
     EXPECT_STREQ("hello 42 world", makeString(std::make_tuple(helloCodepoints), ' ', unsigned(42), ' ', "world"_s).utf8().data());
     EXPECT_STREQ("hello 42 world", makeString(std::make_tuple(helloCodepoints, ' ', unsigned(42)), ' ', "world"_s).utf8().data());
     EXPECT_STREQ("hello 42 world", makeString(std::make_tuple(helloCodepoints, ' ', unsigned(42), ' ', "world"_s)).utf8().data());
+}
+
+TEST(WTF, StringConcatenate_Interleave)
+{
+    std::array strings { "a"_s, "b"_s, "c"_s };
+
+    {
+        auto result = makeString('[', interleave(strings, [](auto& builder, auto& s) { builder.append(s); }, ", "_s), ']');
+
+        EXPECT_EQ(String("[a, b, c]"_s), result);
+    }
+
+    {
+        auto result = makeString('[', interleave(strings, [](auto& s) { return s; }, ", "_s), ']');
+
+        EXPECT_EQ(String("[a, b, c]"_s), result);
+    }
+
+    {
+        auto result = makeString('[', interleave(strings, ", "_s), ']');
+
+        EXPECT_EQ(String("[a, b, c]"_s), result);
+    }
+}
+
+struct A { int value; };
+struct B { int value; };
+
+[[maybe_unused]] static void serializeOverloadBuilder(StringBuilder& builder, const A& a)
+{
+    builder.append(a.value);
+}
+
+[[maybe_unused]] static void serializeOverloadBuilder(StringBuilder& builder, const B& b)
+{
+    builder.append(b.value);
+}
+
+[[maybe_unused]] static int serializeOverloadReturn(const A& a)
+{
+    return a.value;
+}
+
+[[maybe_unused]] static int serializeOverloadReturn(const B& b)
+{
+    return b.value;
+}
+
+TEST(WTF, StringConcatenate_InterleaveOverload)
+{
+    std::array as { A { 1 }, A { 2 }, A { 3 } };
+
+    {
+        auto result = makeString('[', interleave(as, serializeOverloadBuilder, ", "_s), ']');
+
+        EXPECT_EQ(String("[1, 2, 3]"_s), result);
+    }
+}
+
+TEST(WTF, StringConcatenate_InterleaveNoCopies)
+{
+    std::array values { MoveOnly { 1 }, MoveOnly { 2 }, MoveOnly { 3 } };
+
+    {
+        auto result = makeString('[', interleave(values, [](auto& builder, auto& moveOnly) { builder.append(moveOnly.value()); }, ", "_s), ']');
+
+        EXPECT_EQ(String("[1, 2, 3]"_s), result);
+    }
+
+    {
+        auto result = makeString('[', interleave(values, [](auto& moveOnly) { return moveOnly.value(); }, ", "_s), ']');
+
+        EXPECT_EQ(String("[1, 2, 3]"_s), result);
+    }
+
+    {
+        auto result = makeString('[', interleave(values, ", "_s), ']');
+
+        EXPECT_EQ(String("[1, 2, 3]"_s), result);
+    }
 }
 
 }


### PR DESCRIPTION
#### f4463967d4ce5f170b4fe47c856bea59c6f69de8
<pre>
Support WTF::interleave() in makeString()
<a href="https://bugs.webkit.org/show_bug.cgi?id=276285">https://bugs.webkit.org/show_bug.cgi?id=276285</a>

Reviewed by Darin Adler.

Added support for WTF::interleave() to makeString() by introducing support
for a &quot;slow&quot; path to makeString() that uses a StringBuilder rather than a
precise allocation.

* Source/WTF/wtf/text/MakeString.h:
    - Add slow path support, delegating to StringBuilder.

* Source/WTF/wtf/text/StringBuilder.h:
    - Expose appendFromAdapters() so that makeString() can directly
      invoke it after adapter construction.

* Source/WTF/wtf/text/StringConcatenate.h:
    - Add move constructor/assignment operator for interleave for
      cases where it is forwarded.

* Source/WebCore/Modules/fetch/FetchHeaders.cpp:
* Source/WebCore/Modules/indexeddb/IDBKeyData.cpp:
* Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp:
* Source/WebCore/accessibility/AXLogger.cpp:
* Source/WebCore/accessibility/AXTextRun.cpp:
    - Adopt interleave in a few places to ensure it works.

* Tools/TestWebKitAPI/Tests/WTF/StringConcatenate.cpp:
(TestWebKitAPI::TEST(WTF, StringConcatenate_Interleave)):
(TestWebKitAPI::serializeOverloadBuilder):
(TestWebKitAPI::serializeOverloadReturn):
(TestWebKitAPI::TEST(WTF, StringConcatenate_InterleaveOverload)):
(TestWebKitAPI::TEST(WTF, StringConcatenate_InterleaveNoCopies)):
    - Add tests for the various forms of interleave.

Canonical link: <a href="https://commits.webkit.org/280721@main">https://commits.webkit.org/280721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d55d1503b3609a178a1ffdc5857a2bdba15dd39e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57428 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61050 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7873 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46504 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5571 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59458 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34491 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27368 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31272 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6907 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6876 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50520 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62729 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/56670 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53761 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53850 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12691 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1145 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78431 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32585 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12999 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33670 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->