### PR TITLE
[JSC] Implement Uint8Array.prototype.toHex in SIMD

### DIFF
--- a/JSTests/microbenchmarks/to-hex.js
+++ b/JSTests/microbenchmarks/to-hex.js
@@ -1,0 +1,14 @@
+//@ requireOptions("--useUint8ArrayBase64Methods=1")
+
+function test(buffer)
+{
+    return buffer.toHex();
+}
+noInline(test);
+
+let buffer = new Uint8Array(16 * 1024);
+for (let i = 0; i < buffer.length; ++i)
+    buffer[i] = i & 0xff;
+
+for (let i = 0; i < 1e4; ++i)
+    test(buffer);

--- a/JSTests/stress/uint8array-toHex.js
+++ b/JSTests/stress/uint8array-toHex.js
@@ -15,6 +15,25 @@ shouldBe((new Uint8Array([0, 1])).toHex(), "0001");
 shouldBe((new Uint8Array([254, 255])).toHex(), "feff");
 shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toHex(), "000180feff");
 
+{
+    let expected = ''
+    let buffer = new Uint8Array(16 * 1024);
+    for (let i = 0; i < buffer.length; ++i) {
+        buffer[i] = i & 0xff;
+        expected += (i & 0xff).toString(16).padStart(2, '0');
+    }
+    shouldBe(buffer.toHex(), expected);
+}
+{
+    let expected = ''
+    let buffer = new Uint8Array(15);
+    for (let i = 0; i < buffer.length; ++i) {
+        buffer[i] = i & 0xff;
+        expected += (i & 0xff).toString(16).padStart(2, '0');
+    }
+    shouldBe(buffer.toHex(), expected);
+}
+
 try {
     let uint8array = new Uint8Array;
     $.detachArrayBuffer(uint8array.buffer);

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
@@ -90,16 +90,62 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeToHex, (JSGlobalObject* globalObject
     if (UNLIKELY(isIntegerIndexedObjectOutOfBounds(uint8Array, byteLengthGetter)))
         return throwVMTypeError(globalObject, scope, typedArrayBufferHasBeenDetachedErrorMessage);
 
-    StringBuilder builder;
-    builder.reserveCapacity(uint8Array->length() * 2);
-
     const uint8_t* data = uint8Array->typedVector();
     size_t length = uint8Array->length();
-    for (size_t i = 0; i < length; ++i) {
-        builder.append(radixDigits[data[i] / 16]);
-        builder.append(radixDigits[data[i] % 16]);
+    const auto* end = data + length;
+
+    if (!length)
+        return JSValue::encode(jsEmptyString(vm));
+
+    if ((length * 2) > static_cast<size_t>(StringImpl::MaxLength)) {
+        throwOutOfMemoryError(globalObject, scope, "generated stirng is too long"_s);
+        return { };
     }
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, builder.toString())));
+
+    LChar* buffer = nullptr;
+    auto result = StringImpl::createUninitialized(length * 2, buffer);
+    LChar* bufferEnd = buffer + length * 2;
+    constexpr size_t stride = 8; // Because loading uint8x8_t.
+    if (length >= stride) {
+        auto encodeVector = [&](auto input) {
+            // Hex conversion characters are only 16 characters. This perfectly fits in vqtbl1q_u8's table lookup.
+            // Thus, this function leverages vqtbl1q_u8 to convert vector characters in a bulk manner.
+            //
+            // L => low nibble (4bits)
+            // H => high nibble (4bits)
+            //
+            // original uint8x8_t : LHLHLHLHLHLHLHLH
+            // widen uint16x8_t   : 00LH00LH00LH00LH00LH00LH00LH00LH
+            // high               : LH00LH00LH00LH00LH00LH00LH00LH00
+            // low                : 000L000L000L000L000L000L000L000L
+            // merged             : LH0LLH0LLH0LLH0LLH0LLH0LLH0LLH0L
+            // masked             : 0H0L0H0L0H0L0H0L0H0L0H0L0H0L0H0L
+            constexpr simde_uint8x16_t characters { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+            auto widen = simde_vmovl_u8(input);
+            auto high = simde_vshlq_n_u16(widen, 8);
+            auto low = simde_vshrq_n_u16(widen, 4);
+            auto merged = SIMD::bitOr(high, low);
+            auto masked = SIMD::bitAnd(simde_vreinterpretq_u8_u16(merged), SIMD::splat<uint8_t>(0xf));
+            return simde_vqtbl1q_u8(characters, masked);
+        };
+
+        const auto* cursor = data;
+        auto* output = buffer;
+        for (; cursor + (stride - 1) < end; cursor += stride, output += stride * 2)
+            simde_vst1q_u8(output, encodeVector(simde_vld1_u8(cursor)));
+        if (cursor < end)
+            simde_vst1q_u8(bufferEnd - stride * 2, encodeVector(simde_vld1_u8(end - stride)));
+    } else {
+        const auto* cursor = data;
+        auto* output = buffer;
+        for (; cursor < end; cursor += 1, output += 2) {
+            auto character = *cursor;
+            *output = radixDigits[character / 16];
+            *(output + 1) = radixDigits[character % 16];
+        }
+    }
+
+    return JSValue::encode(jsNontrivialString(vm, WTFMove(result)));
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### d4018f63175c602605145887c61d21ffdbd1a75b
<pre>
[JSC] Implement Uint8Array.prototype.toHex in SIMD
<a href="https://bugs.webkit.org/show_bug.cgi?id=276295">https://bugs.webkit.org/show_bug.cgi?id=276295</a>
<a href="https://rdar.apple.com/problem/131249821">rdar://problem/131249821</a>

Reviewed by Sam Weinig.

toHex function is very simple conversion, thus we can write it in SIMD easily.
In particular, we leverage vqtbl1q_u8 since hex characters are only 16 characters, which fits in vqtbl1q_u8&apos;s table.
The newly written code is 19x faster than the scalar one.

                               ToT                     Patched

    to-hex              259.5243+-0.8852     ^     13.2425+-0.1322        ^ definitely 19.5979x faster

* JSTests/microbenchmarks/to-hex.js: Added.
* JSTests/stress/uint8array-toHex.js:
(255.toHex):
(shouldBe):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/280719@main">https://commits.webkit.org/280719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c860b2cac1fbda41e5ed24115547419f4cbf0b5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57430 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61052 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7875 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8063 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46506 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5572 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59460 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/49603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27370 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/31270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/6909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6878 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/50522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/7180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62731 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/56672 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1343 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1349 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/49632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/1146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78433 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8571 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32587 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/13001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/33672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34757 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33418 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->