### PR TITLE
[iOS 18] Undo voice command in Mail compose view does not fully undo dictated text

### DIFF
--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -2275,6 +2275,11 @@ void Editor::setComposition(const String& text, SetCompositionMode mode)
     }
 }
 
+void Editor::closeTyping()
+{
+    TypingCommand::closeTyping(m_document);
+}
+
 RenderInline* Editor::writingSuggestionRenderer() const
 {
     return m_writingSuggestionRenderer.get();

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -624,6 +624,8 @@ public:
     RenderInline* writingSuggestionRenderer() const;
     void setWritingSuggestionRenderer(RenderInline&);
 
+    WEBCORE_EXPORT void closeTyping();
+
 private:
     Document& document() const { return m_document.get(); }
     Ref<Document> protectedDocument() const { return m_document.get(); }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -14300,6 +14300,12 @@ void WebPageProxy::setAllowsLayoutViewportHeightExpansion(bool value)
     pageClient().scheduleVisibleContentRectUpdate();
 }
 
+void WebPageProxy::closeCurrentTypingCommand()
+{
+    if (hasRunningProcess())
+        send(Messages::WebPage::CloseCurrentTypingCommand());
+}
+
 } // namespace WebKit
 
 #undef WEBPAGEPROXY_RELEASE_LOG

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2483,6 +2483,8 @@ public:
     void updateActivityState();
     void dispatchActivityStateChange();
 
+    void closeCurrentTypingCommand();
+
 private:
     void getWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -129,18 +129,53 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 
 @end
 
-@interface WKQuirkyNSUndoManager : NSUndoManager
+@interface WKNSUndoManager : NSUndoManager
 @property (readonly, weak) WKContentView *contentView;
 @end
 
-@implementation WKQuirkyNSUndoManager
+@implementation WKNSUndoManager {
+    BOOL _isRegisteringUndoCommand;
+}
+
 - (instancetype)initWithContentView:(WKContentView *)contentView
 {
     if (!(self = [super init]))
         return nil;
+
+    _isRegisteringUndoCommand = NO;
     _contentView = contentView;
     return self;
 }
+
+- (void)beginUndoGrouping
+{
+    if (!_isRegisteringUndoCommand)
+        [_contentView _closeCurrentTypingCommand];
+
+    [super beginUndoGrouping];
+}
+
+- (void)registerUndoWithTarget:(id)target selector:(SEL)selector object:(id)object
+{
+    SetForScope registrationScope { _isRegisteringUndoCommand, YES };
+
+    [super registerUndoWithTarget:target selector:selector object:object];
+}
+
+- (void)registerUndoWithTarget:(id)target handler:(void (^)(id))undoHandler
+{
+    SetForScope registrationScope { _isRegisteringUndoCommand, YES };
+
+    [super registerUndoWithTarget:target handler:undoHandler];
+}
+
+@end
+
+@interface WKNSKeyEventSimulatorUndoManager : WKNSUndoManager
+
+@end
+
+@implementation WKNSKeyEventSimulatorUndoManager
 
 - (BOOL)canUndo 
 {
@@ -202,8 +237,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     WebCore::HistoricalVelocityData _historicalKinematicData;
 
-    RetainPtr<NSUndoManager> _undoManager;
-    RetainPtr<WKQuirkyNSUndoManager> _quirkyUndoManager;
+    RetainPtr<WKNSUndoManager> _undoManager;
+    RetainPtr<WKNSKeyEventSimulatorUndoManager> _undoManagerForSimulatingKeyEvents;
 
     Lock _pendingBackgroundPrintFormattersLock;
     RetainPtr<NSMutableSet> _pendingBackgroundPrintFormatters;
@@ -729,12 +764,12 @@ static WebCore::FloatBoxExtent floatBoxExtent(UIEdgeInsets insets)
 - (NSUndoManager *)undoManagerForWebView
 {
     if (self.focusedElementInformation.shouldSynthesizeKeyEventsForEditing && self.hasHiddenContentEditable) {
-        if (!_quirkyUndoManager)
-            _quirkyUndoManager = adoptNS([[WKQuirkyNSUndoManager alloc] initWithContentView:self]);
-        return _quirkyUndoManager.get();
+        if (!_undoManagerForSimulatingKeyEvents)
+            _undoManagerForSimulatingKeyEvents = adoptNS([[WKNSKeyEventSimulatorUndoManager alloc] initWithContentView:self]);
+        return _undoManagerForSimulatingKeyEvents.get();
     }
     if (!_undoManager)
-        _undoManager = adoptNS([[NSUndoManager alloc] init]);
+        _undoManager = adoptNS([[WKNSUndoManager alloc] initWithContentView:self]);
     return _undoManager.get();
 }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -901,6 +901,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)cancelTextRecognitionForVideoInElementFullscreen;
 
 - (BOOL)_tryToHandlePressesEvent:(UIPressesEvent *)event;
+- (void)_closeCurrentTypingCommand;
 
 @property (nonatomic, readonly) BOOL shouldUseAsyncInteractions;
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -13255,6 +13255,14 @@ inline static NSString *extendSelectionCommand(UITextLayoutDirection direction)
 
 #endif
 
+- (void)_closeCurrentTypingCommand
+{
+    if (!_page)
+        return;
+
+    _page->closeCurrentTypingCommand();
+}
+
 @end
 
 @implementation WKContentView (WKTesting)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5549,6 +5549,16 @@ void WebPage::didRemoveEditCommand(WebUndoStepID commandID)
     removeWebEditCommand(commandID);
 }
 
+void WebPage::closeCurrentTypingCommand()
+{
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
+    if (RefPtr document = frame->document())
+        document->editor().closeTyping();
+}
+
 void WebPage::setActivePopupMenu(WebPopupMenu* menu)
 {
     m_activePopupMenu = menu;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -597,6 +597,8 @@ public:
     void removeWebEditCommand(WebUndoStepID);
     bool isInRedo() const { return m_isInRedo; }
 
+    void closeCurrentTypingCommand();
+
     void setActivePopupMenu(WebPopupMenu*);
 
     inline void setHiddenPageDOMTimerThrottlingIncreaseLimit(Seconds);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -815,4 +815,6 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     StartPlayingPredominantVideo() -> (bool success)
 #endif
+
+    CloseCurrentTypingCommand()
 }


### PR DESCRIPTION
#### 90ab262c20a7ad6601d72961b4fd7a2d745b8f41
<pre>
[iOS 18] Undo voice command in Mail compose view does not fully undo dictated text
<a href="https://bugs.webkit.org/show_bug.cgi?id=276300">https://bugs.webkit.org/show_bug.cgi?id=276300</a>
<a href="https://rdar.apple.com/126653644">rdar://126653644</a>

Reviewed by Abrar Rahman Protyasha.

In iOS 18, dictation recognizes the phrase &quot;Undo&quot; while dictating text, and reverts the most
recently inserted dictation phrase. However, in the following scenario:

1. Type &quot;Hello&quot;
2. Begin dictation and say &quot;world&quot;
3. Say &quot;Undo&quot;

...the resulting text will sometimes end up being `&quot;Hello wo&quot;` or `&quot;Hello wor&quot;`. To understand why,
we first need to understand how dictation-triggered undo works — when phrases are dictated,
`UIDictationController` begins a new undo group by calling `-[NSUndoManager beginUndoGrouping]` on
the editing responder (`WKContentView`). As the user continues speaking, the &quot;hypothesis text&quot; is
updated, which repeatedly uses `-insertText:` and `-adjustSelectionByRange:completionHandler:` to
replace the dictated text. When the user says &quot;Undo&quot;, the dictation controller then undoes this
entire group.

The issue is that when the dictation controller first calls `-insertText:` after beginning the undo
group, this inserted text is added to the last open typing command (after the user types `&quot;Hello&quot;`)
instead of being a part of the newly established group that encapsulates all of the edit commands
triggered by dictation. As such, when the undo group is undone, we end up with `&quot;Hello&quot;` along with
the first piece of text, with which the dictation controller called `-insertText:`.

To fix this, we detect when any WebKit client (or the system, in this case dictation code) tells the
`WKContentView`&apos;s undo manager to `-beginUndoGrouping`, and close the current typing command to
ensure that edit commands triggered in the new undo group aren&apos;t merged into the previous typing
command before the undo group.

Test: KeyboardInputTests.NewUndoGroupClosesPreviousTypingCommand

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::closeTyping):
* Source/WebCore/editing/Editor.h:

Add a helper command to close the typing command if needed.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::closeCurrentTypingCommand):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKNSUndoManager initWithContentView:]):
(-[WKNSUndoManager beginUndoGrouping]):
(-[WKNSUndoManager registerUndoWithTarget:selector:object:]):
(-[WKNSUndoManager registerUndoWithTarget:handler:]):

Add a helper class that overrides `-beginUndoGrouping` and tells the webpage to close the current
typing command when a new undo group starts. Note that we avoid this codepath when a new command is
being registered, so that we don&apos;t prematurely close typing commands while typing.

(-[WKContentView undoManagerForWebView]):
(-[WKQuirkyNSUndoManager initWithContentView:]): Deleted.
(-[WKQuirkyNSUndoManager canUndo]): Deleted.
(-[WKQuirkyNSUndoManager canRedo]): Deleted.
(-[WKQuirkyNSUndoManager undo]): Deleted.
(-[WKQuirkyNSUndoManager redo]): Deleted.

Rename this helper class to `WKNSKeyEventSimulatorUndoManager` to better reflect its purpose, and
make it subclass `WKNSUndoManager`.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _closeCurrentTypingCommand]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::closeCurrentTypingCommand):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::TEST(KeyboardInputTests, NewUndoGroupClosesPreviousTypingCommand)):

Add a new API test to exercise the change by inserting text within an undo group, bookended using
`-(begin|end)UndoGrouping`.

Canonical link: <a href="https://commits.webkit.org/280737@main">https://commits.webkit.org/280737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ce8fb18468ec3d8c10026d8034582bc618cb2cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57474 "Failed to checkout and rebase branch from PR 30552") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9949 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/61096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/7919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59602 "Failed to checkout and rebase branch from PR 30552") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8107 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/61096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/7919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59504 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/49645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/61096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/31311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/6947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6922 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/7220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62775 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1387 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1394 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/49670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/1183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8576 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32631 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/33716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->