### PR TITLE
[CSS] Fix the parsing of custom property as ambiguous rule

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Rule that looks like a custom property declaration is ignored assert_equals: expected 2 but got 3
-FAIL Rule that looks like an invalid custom property declaration is ignored assert_equals: expected 2 but got 3
+PASS Rule that looks like a custom property declaration is ignored
+PASS Rule that looks like an invalid custom property declaration is ignored
 FAIL Nested rule that looks like a custom property declaration assert_equals: expected "hover { }\n    .b { }" but got "hover { }     .b { }"
-FAIL Nested rule that looks like an invalid custom property declaration assert_equals: expected 1 but got 3
+PASS Nested rule that looks like an invalid custom property declaration
 

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -168,7 +168,8 @@ CSSParserToken CSSTokenizer::whiteSpace(UChar /*cc*/)
 {
     auto startOffset = m_input.offset();
     m_input.advanceUntilNonWhitespace();
-    // FIXME: This does not preserve whitespace type (like tabs).
+    // FIXME: This does not preserve whitespace type (like tabs or newline).
+    // https://bugs.webkit.org/show_bug.cgi?id=276431
     auto whitespaceCount = 1 + (m_input.offset() - startOffset);
     return CSSParserToken(whitespaceCount);
 }


### PR DESCRIPTION
#### 445f89c8ea16f77a134149f21e3aacb400704ade
<pre>
[CSS] Fix the parsing of custom property as ambiguous rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=276302">https://bugs.webkit.org/show_bug.cgi?id=276302</a>
<a href="https://rdar.apple.com/131274469">rdar://131274469</a>

Reviewed by Tim Nguyen.

This patch makes parsing of &quot;something that look like a custom property&quot;
fails with a more useful error recovery : until the end of the declaration
or until the end of the rule.

<a href="https://drafts.csswg.org/css-syntax/#consume-qualified-rule">https://drafts.csswg.org/css-syntax/#consume-qualified-rule</a>

If the first two non-&lt;whitespace-token&gt; values of rule’s prelude are an &lt;ident-token&gt; whose value starts with &quot;--&quot; followed by a &lt;colon-token&gt;, then:
    If nested is true, consume the remnants of a bad declaration from input, with nested set to true, and return nothing.
    If nested is false, consume a block from input, and return nothing.

* LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity-expected.txt:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeQualifiedRule):

Canonical link: <a href="https://commits.webkit.org/281108@main">https://commits.webkit.org/281108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8115d2bc9d8d913b0364f8974a9655b09a4b277

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9170 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47528 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6543 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28378 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8088 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8174 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54314 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64059 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54849 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2648 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54942 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12987 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2216 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33884 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34968 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36052 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->