### PR TITLE
[CSS] Add debugDescription() to StyleRule

### DIFF
--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -36,6 +36,7 @@
 #include <wtf/RefPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/UniqueArray.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -89,6 +90,8 @@ public:
 
     WEBCORE_EXPORT void operator delete(StyleRuleBase*, std::destroying_delete_t);
 
+    String debugDescription() const;
+
 protected:
     explicit StyleRuleBase(StyleRuleType, bool hasDocumentSecurityOrigin = false);
     StyleRuleBase(const StyleRuleBase&);
@@ -140,6 +143,7 @@ public:
     static unsigned averageSizeInBytes();
     void setProperties(Ref<StyleProperties>&&);
 
+    String debugDescription() const;
 protected:
     StyleRule(Ref<StyleProperties>&&, bool hasDocumentSecurityOrigin, CSSSelectorList&&);
     StyleRule(const StyleRule&);
@@ -171,6 +175,7 @@ public:
     const CSSSelectorList& originalSelectorList() const { return m_originalSelectorList; }
     void wrapperAdoptOriginalSelectorList(CSSSelectorList&&);
 
+    String debugDescription() const;
 protected:
     StyleRuleWithNesting(const StyleRuleWithNesting&);
 
@@ -294,6 +299,7 @@ public:
     friend class CSSGroupingRule;
     friend class CSSStyleSheet;
 
+    String debugDescription() const;
 protected:
     StyleRuleGroup(StyleRuleType, Vector<Ref<StyleRuleBase>>&&);
     StyleRuleGroup(const StyleRuleGroup&);
@@ -310,6 +316,7 @@ public:
     const MQ::MediaQueryList& mediaQueries() const { return m_mediaQueries; }
     void setMediaQueries(MQ::MediaQueryList&& queries) { m_mediaQueries = WTFMove(queries); }
 
+    String debugDescription() const;
 private:
     StyleRuleMedia(MQ::MediaQueryList&&, Vector<Ref<StyleRuleBase>>&&);
     StyleRuleMedia(const StyleRuleMedia&);
@@ -495,6 +502,8 @@ inline CompiledSelector& StyleRule::compiledSelectorForListIndex(unsigned index)
 }
 
 #endif
+
+WTF::TextStream& operator<<(WTF::TextStream&, const StyleRuleBase&);
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### e2a1cb2a0ea2fc891747aca06dc39a09e2934b8c
<pre>
[CSS] Add debugDescription() to StyleRule
<a href="https://bugs.webkit.org/show_bug.cgi?id=276303">https://bugs.webkit.org/show_bug.cgi?id=276303</a>

Reviewed by Sammy Gill.

* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::debugDescription const):
(WebCore::StyleRuleWithNesting::debugDescription const):
(WebCore::StyleRuleGroup::debugDescription const):
(WebCore::StyleRuleMedia::debugDescription const):
(WebCore::StyleRuleBase::debugDescription const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/css/StyleRule.h:

Canonical link: <a href="https://commits.webkit.org/280744@main">https://commits.webkit.org/280744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e4bc00060f1cef6da75b8b5bf70e7a0d4c4a8d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61060 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46513 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5578 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27377 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6914 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6886 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62739 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7278 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53771 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53861 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12715 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1151 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32595 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33680 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34765 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33426 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->