### PR TITLE
[JSC] RegExp quantifier should allow 2^53 - 1

### DIFF
--- a/JSTests/stress/regexp-max-quantifier.js
+++ b/JSTests/stress/regexp-max-quantifier.js
@@ -1,0 +1,85 @@
+function assert(a) {
+    if (!a)
+        throw new Error();
+}
+
+function shouldThrow(expectedError, func, message) {
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!error)
+        throw new Error("Not thrown");
+    if (!(error instanceof expectedError))
+        throw new Error(`Expected "${expectedError.name}" but got "${error.name}"`);
+    if (error.message !== message)
+        throw new Error(`Expected message "${message}" but got "${error.message}"`);
+}
+
+{
+    // Number.MAX_SAFE_INTEGER
+    var re1 = new RegExp("b{9007199254740991}", "u");
+    assert(!re1.test(""));
+
+    var re2 = new RegExp("b{9007199254740991,}?");
+    assert(!re2.test("a"));
+
+    var re3 = new RegExp("b{9007199254740991,9007199254740991}");
+    assert(!re3.test("b"));
+}
+
+{
+    // Number.MAX_SAFE_INTEGER + 1
+    var re1 = new RegExp("b{9007199254740992}", "u");
+    assert(!re1.test(""));
+
+    var re2 = new RegExp("b{9007199254740992,}?");
+    assert(!re2.test("a"));
+
+    var re3 = new RegExp("b{9007199254740992,9007199254740992}");
+    assert(!re3.test("b"));
+}
+
+{
+    // UINT64_MAX - 1
+    var re1 = new RegExp("b{18446744073709551614}", "u");
+    assert(!re1.test(""));
+
+    var re2 = new RegExp("b{18446744073709551614,}?");
+    assert(!re2.test("a"));
+
+    var re3 = new RegExp("b{18446744073709551614,18446744073709551614}");
+    assert(!re3.test("b"));
+}
+
+{
+    // UINT64_MAX
+    shouldThrow(SyntaxError, () => {
+        eval(`new RegExp("b{18446744073709551615}", "u")`);
+    }, "Invalid regular expression: number too large in {} quantifier");
+
+    shouldThrow(SyntaxError, () => {
+        eval(`new RegExp("b{18446744073709551615,}?")`);
+    }, "Invalid regular expression: number too large in {} quantifier");
+
+    shouldThrow(SyntaxError, () => {
+        eval(`new RegExp("b{18446744073709551615,18446744073709551615}")`);
+    }, "Invalid regular expression: number too large in {} quantifier");
+}
+
+{
+    // UINT64_MAX + 1
+    shouldThrow(SyntaxError, () => {
+        eval(`new RegExp("b{18446744073709551616}", "u")`);
+    }, "Invalid regular expression: number too large in {} quantifier");
+
+    shouldThrow(SyntaxError, () => {
+        eval(`new RegExp("b{18446744073709551616,}?")`);
+    }, "Invalid regular expression: number too large in {} quantifier");
+
+    shouldThrow(SyntaxError, () => {
+        eval(`new RegExp("b{18446744073709551616,18446744073709551616}")`);
+    }, "Invalid regular expression: number too large in {} quantifier");
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -118,9 +118,6 @@ test/built-ins/RegExp/prototype/Symbol.replace/get-flags-err.js:
 test/built-ins/RegExp/prototype/Symbol.replace/get-unicode-error.js:
   default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
-test/built-ins/RegExp/quantifier-integer-limit.js:
-  default: 'SyntaxError: Invalid regular expression: number too large in {} quantifier'
-  strict mode: 'SyntaxError: Invalid regular expression: number too large in {} quantifier'
 test/built-ins/Temporal/Duration/compare/argument-duration-out-of-range.js:
   default: 'Test262Error: string with days > max is out of range (first argument) Expected a RangeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: string with days > max is out of range (first argument) Expected a RangeError to be thrown but no exception was thrown at all'

--- a/LayoutTests/fast/regex/overflow-expected.txt
+++ b/LayoutTests/fast/regex/overflow-expected.txt
@@ -6,8 +6,8 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS regexp1.exec('') is null
 PASS regexp2.exec('') is null
 PASS regexp3.exec(s3) is null
-PASS function f() { /[^a$]{4294967295}/ } threw exception SyntaxError: Invalid regular expression: number too large in {} quantifier.
-PASS new RegExp('((?=$))??(?:\\1){34359738368,}') threw exception SyntaxError: Invalid regular expression: number too large in {} quantifier.
+PASS function f() { /[^a$]{18446744073709551615}/ } threw exception SyntaxError: Invalid regular expression: number too large in {} quantifier.
+PASS new RegExp('((?=$))??(?:\\1){1180591620717411303423,}') threw exception SyntaxError: Invalid regular expression: number too large in {} quantifier.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/regex/script-tests/overflow.js
+++ b/LayoutTests/fast/regex/script-tests/overflow.js
@@ -10,6 +10,6 @@ var s3 = "&{6}u4a64YfQP{C}u88c4u5772Qu8693{4294967167}u85f2u7f3fs((uf202){4})u5b
 var regexp3 = new RegExp(s3, "");
 shouldBe("regexp3.exec(s3)", 'null');
 
-shouldThrow("function f() { /[^a$]{4294967295}/ }", '"SyntaxError: Invalid regular expression: number too large in {} quantifier"');
+shouldThrow("function f() { /[^a$]{18446744073709551615}/ }", '"SyntaxError: Invalid regular expression: number too large in {} quantifier"');
 
-shouldThrow("new RegExp('((?=$))??(?:\\\\1){34359738368,}')", '"SyntaxError: Invalid regular expression: number too large in {} quantifier"');
+shouldThrow("new RegExp('((?=$))??(?:\\\\1){1180591620717411303423,}')", '"SyntaxError: Invalid regular expression: number too large in {} quantifier"');

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -43,6 +43,7 @@ namespace JSC { namespace Yarr {
 #define YarrStackSpaceForDotStarEnclosure 1
 
 static constexpr unsigned quantifyInfinite = UINT_MAX;
+static constexpr uint64_t quantifyInfinite64 = std::numeric_limits<uint64_t>::max();
 static constexpr unsigned offsetNoMatch = std::numeric_limits<unsigned>::max();
 
 // The below limit restricts the number of "recursive" match calls in order to


### PR DESCRIPTION
#### 712efd266cc921ce8e8e431e709f5cc8944eb7de
<pre>
[JSC] RegExp quantifier should allow 2^53 - 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=276306">https://bugs.webkit.org/show_bug.cgi?id=276306</a>

Reviewed by Yusuke Suzuki.

According to the spec[1][2] and the test[3], the range quantifier (/a{n,m}/) allows values for n and
m up to 2^53 - 1. However, the current JSC does not allow numbers larger than UINT_MAX, so it throws
a SyntaxError:

```
// Number.MAX_SAFE_INTEGER
new RegExp(&quot;a{9007199254740991}&quot;, &quot;u&quot;);
// SyntaxError: Invalid regular expression: number too large in {} quantifier
```

This patch changes the handling of range quantifiers from unsigned to uint64_t, allowing numbers up
to 2^53 - 1 to be parsed. But since JSC string is &lt;= INT32_MAX, we will never see a string larger
than that. Therefore, it casts from uint64_t to unsigned before passing to the parseQuantifier.

[1]: <a href="https://tc39.es/ecma262/#prod-QuantifierPrefix">https://tc39.es/ecma262/#prod-QuantifierPrefix</a>
[2]: <a href="https://tc39.es/ecma262/#prod-DecimalDigits">https://tc39.es/ecma262/#prod-DecimalDigits</a>
[3]: <a href="https://github.com/tc39/test262/blob/3a7a72aef5009eb22117231d40f9a5a66a9a595a/test/built-ins/RegExp/quantifier-integer-limit.js">https://github.com/tc39/test262/blob/3a7a72aef5009eb22117231d40f9a5a66a9a595a/test/built-ins/RegExp/quantifier-integer-limit.js</a>

* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::parseQuantifier):
(JSC::Yarr::Parser::parseTokens):
(JSC::Yarr::Parser::consumeNumber64):

Canonical link: <a href="https://commits.webkit.org/280953@main">https://commits.webkit.org/280953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d729a4b639cf4b0b51133f7e0d35b1f83062148

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61467 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8290 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46871 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5890 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27699 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7284 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7294 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50937 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63150 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57087 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1759 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54095 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54221 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1496 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78848 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8673 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33002 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13082 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34088 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35172 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->