### PR TITLE
Support border/margin/padding on munderover/munder/mover

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002-expected.txt
@@ -15,8 +15,8 @@ PASS Border properties on mn
 PASS Border properties on mn (rtl)
 PASS Border properties on mo
 PASS Border properties on mo (rtl)
-FAIL Border properties on mover assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on mover (rtl) assert_approx_equals: left border expected 30 +/- 1 but got 0
+PASS Border properties on mover
+PASS Border properties on mover (rtl)
 PASS Border properties on mpadded
 PASS Border properties on mpadded (rtl)
 PASS Border properties on mphantom
@@ -42,10 +42,10 @@ PASS Border properties on mtable
 PASS Border properties on mtable (rtl)
 PASS Border properties on mtext
 PASS Border properties on mtext (rtl)
-FAIL Border properties on munder assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on munder (rtl) assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on munderover assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on munderover (rtl) assert_approx_equals: left border expected 30 +/- 1 but got 0
+PASS Border properties on munder
+PASS Border properties on munder (rtl)
+PASS Border properties on munderover
+PASS Border properties on munderover (rtl)
 PASS Border properties on semantics
 PASS Border properties on semantics (rtl)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
@@ -3,7 +3,7 @@ FAIL Margin properties on the children of menclose assert_approx_equals: preferr
 FAIL Margin properties on the children of merror assert_approx_equals: preferred width expected 49 +/- 1 but got 24
 FAIL Margin properties on the children of mfrac assert_approx_equals: preferred width expected 49 +/- 1 but got 24
 FAIL Margin properties on the children of mmultiscripts assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
-FAIL Margin properties on the children of mover assert_approx_equals: inline size expected 45 +/- 1 but got 20
+FAIL Margin properties on the children of mover assert_approx_equals: preferred width expected 47 +/- 1 but got 22
 FAIL Margin properties on the children of mpadded assert_approx_equals: preferred width expected 47 +/- 1 but got 22
 FAIL Margin properties on the children of mphantom assert_approx_equals: preferred width expected 47 +/- 1 but got 22
 FAIL Margin properties on the children of mroot assert_approx_equals: inline size expected 105.0625 +/- 1 but got 80.0625
@@ -13,8 +13,8 @@ FAIL Margin properties on the children of mstyle assert_approx_equals: preferred
 FAIL Margin properties on the children of msub assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
 FAIL Margin properties on the children of msubsup assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
 FAIL Margin properties on the children of msup assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
-FAIL Margin properties on the children of munder assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of munderover assert_approx_equals: inline size expected 45 +/- 1 but got 20
+FAIL Margin properties on the children of munder assert_approx_equals: preferred width expected 47 +/- 1 but got 22
+FAIL Margin properties on the children of munderover assert_approx_equals: preferred width expected 47 +/- 1 but got 22
 
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
@@ -15,8 +15,8 @@ PASS Padding properties on mn
 PASS Padding properties on mn (rtl)
 PASS Padding properties on mo
 PASS Padding properties on mo (rtl)
-FAIL Padding properties on mover assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mover (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on mover
+PASS Padding properties on mover
 PASS Padding properties on mpadded
 PASS Padding properties on mpadded (rtl)
 PASS Padding properties on mphantom
@@ -42,10 +42,10 @@ PASS Padding properties on mtable
 PASS Padding properties on mtable (rtl)
 PASS Padding properties on mtext
 PASS Padding properties on mtext (rtl)
-FAIL Padding properties on munder assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on munder (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on munderover assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on munderover (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on munder
+PASS Padding properties on munder (rtl)
+PASS Padding properties on munderover
+PASS Padding properties on munderover (rtl)
 PASS Padding properties on semantics
 PASS Padding properties on semantics (rtl)
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/border-002-expected.txt
@@ -15,8 +15,8 @@ PASS Border properties on mn
 PASS Border properties on mn (rtl)
 PASS Border properties on mo
 PASS Border properties on mo (rtl)
-FAIL Border properties on mover assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on mover (rtl) assert_approx_equals: left border expected 30 +/- 1 but got 0
+PASS Border properties on mover
+PASS Border properties on mover (rtl)
 PASS Border properties on mpadded
 PASS Border properties on mpadded (rtl)
 PASS Border properties on mphantom
@@ -42,10 +42,10 @@ PASS Border properties on mtable
 PASS Border properties on mtable (rtl)
 PASS Border properties on mtext
 PASS Border properties on mtext (rtl)
-FAIL Border properties on munder assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on munder (rtl) assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on munderover assert_approx_equals: left border expected 30 +/- 1 but got 0
-FAIL Border properties on munderover (rtl) assert_approx_equals: left border expected 30 +/- 1 but got 0
+PASS Border properties on munder
+PASS Border properties on munder (rtl)
+PASS Border properties on munderover
+PASS Border properties on munderover (rtl)
 PASS Border properties on semantics
 PASS Border properties on semantics (rtl)
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
@@ -3,7 +3,7 @@ FAIL Margin properties on the children of menclose assert_approx_equals: preferr
 FAIL Margin properties on the children of merror assert_approx_equals: preferred width expected 49 +/- 1 but got 24
 FAIL Margin properties on the children of mfrac assert_approx_equals: preferred width expected 49 +/- 1 but got 24
 FAIL Margin properties on the children of mmultiscripts assert_approx_equals: inline size expected 90.890625 +/- 1 but got 40.890625
-FAIL Margin properties on the children of mover assert_approx_equals: inline size expected 45 +/- 1 but got 20
+FAIL Margin properties on the children of mover assert_approx_equals: preferred width expected 47 +/- 1 but got 22
 FAIL Margin properties on the children of mpadded assert_approx_equals: preferred width expected 47 +/- 1 but got 22
 FAIL Margin properties on the children of mphantom assert_approx_equals: preferred width expected 47 +/- 1 but got 22
 FAIL Margin properties on the children of mroot assert_approx_equals: inline size expected 102.546875 +/- 1 but got 77.546875
@@ -13,8 +13,8 @@ FAIL Margin properties on the children of mstyle assert_approx_equals: preferred
 FAIL Margin properties on the children of msub assert_approx_equals: inline size expected 90.890625 +/- 1 but got 40.890625
 FAIL Margin properties on the children of msubsup assert_approx_equals: inline size expected 90.890625 +/- 1 but got 40.890625
 FAIL Margin properties on the children of msup assert_approx_equals: inline size expected 90.890625 +/- 1 but got 40.890625
-FAIL Margin properties on the children of munder assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of munderover assert_approx_equals: inline size expected 45 +/- 1 but got 20
+FAIL Margin properties on the children of munder assert_approx_equals: preferred width expected 47 +/- 1 but got 22
+FAIL Margin properties on the children of munderover assert_approx_equals: preferred width expected 47 +/- 1 but got 22
 
 
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
@@ -15,8 +15,8 @@ PASS Padding properties on mn
 PASS Padding properties on mn (rtl)
 PASS Padding properties on mo
 PASS Padding properties on mo (rtl)
-FAIL Padding properties on mover assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mover (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on mover
+PASS Padding properties on mover (rtl)
 PASS Padding properties on mpadded
 PASS Padding properties on mpadded (rtl)
 PASS Padding properties on mphantom
@@ -42,10 +42,10 @@ PASS Padding properties on mtable
 PASS Padding properties on mtable (rtl)
 PASS Padding properties on mtext
 PASS Padding properties on mtext (rtl)
-FAIL Padding properties on munder assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on munder (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on munderover assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on munderover (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on munder
+PASS Padding properties on munder (rtl)
+PASS Padding properties on munderover
+PASS Padding properties on munderover (rtl)
 PASS Padding properties on semantics
 PASS Padding properties on semantics (rtl)
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
@@ -15,8 +15,8 @@ PASS Padding properties on mn
 PASS Padding properties on mn (rtl)
 PASS Padding properties on mo
 PASS Padding properties on mo (rtl)
-FAIL Padding properties on mover assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mover (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on mover
+PASS Padding properties on mover (rtl)
 PASS Padding properties on mpadded
 PASS Padding properties on mpadded (rtl)
 PASS Padding properties on mphantom
@@ -42,10 +42,10 @@ PASS Padding properties on mtable
 PASS Padding properties on mtable (rtl)
 PASS Padding properties on mtext
 PASS Padding properties on mtext (rtl)
-FAIL Padding properties on munder assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on munder (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on munderover assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on munderover (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on munder
+PASS Padding properties on munder (rtl)
+PASS Padding properties on munderover
+PASS Padding properties on munderover (rtl)
 PASS Padding properties on semantics
 PASS Padding properties on semantics (rtl)
 

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-002-expected.txt
@@ -15,8 +15,8 @@ PASS Padding properties on mn
 PASS Padding properties on mn (rtl)
 PASS Padding properties on mo
 PASS Padding properties on mo (rtl)
-FAIL Padding properties on mover assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on mover (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on mover
+PASS Padding properties on mover (rtl)
 PASS Padding properties on mpadded
 PASS Padding properties on mpadded (rtl)
 PASS Padding properties on mphantom
@@ -42,10 +42,10 @@ PASS Padding properties on mtable
 PASS Padding properties on mtable (rtl)
 PASS Padding properties on mtext
 PASS Padding properties on mtext (rtl)
-FAIL Padding properties on munder assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on munder (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on munderover assert_approx_equals: left padding expected 30 +/- 1 but got 0
-FAIL Padding properties on munderover (rtl) assert_approx_equals: left padding expected 30 +/- 1 but got 0
+PASS Padding properties on munder
+PASS Padding properties on munder (rtl)
+PASS Padding properties on munderover
+PASS Padding properties on munderover (rtl)
 PASS Padding properties on semantics
 PASS Padding properties on semantics (rtl)
 


### PR DESCRIPTION
#### c7a68fb07eb2a5d105c51c17277629bd11173f61
<pre>
Support border/margin/padding on munderover/munder/mover
<a href="https://bugs.webkit.org/show_bug.cgi?id=276307">https://bugs.webkit.org/show_bug.cgi?id=276307</a>

Reviewed by Rob Buis.

This implements support for border/margin/padding on the munder, mover
and munderover elements according to the rules from MathML Core:

- When handling boxes of children during math layout, we consider *margin*
  boxes. `recomputeLogicalWidth()` is already called during the layout
  of children to set the inline margins (this does not seem enough for
  preferred width calculations though, but will be considered in
  follow-up patches). This patchs adds a call to call
  `computeAndSetBlockDirectionMargins()` on each child in order to set
  their block margins.

- Current math layout is modified so that padding/border are added around
  the current layout in order to obtain the border box.

Canonical link: <a href="https://commits.webkit.org/280746@main">https://commits.webkit.org/280746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4848ae1e52c7452c8809f00020bc02a1e982ae1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61099 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7922 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46542 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5611 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27406 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6949 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6925 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62778 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53802 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53897 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12711 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1186 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32634 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33719 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34804 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->