### PR TITLE
[Writing Tools] Make Table: Mail: Generated table has extra borderlines

### DIFF
--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -224,7 +224,7 @@ bool EditCommandComposition::areRootEditabledElementsConnected()
     return true;
 }
 
-void EditCommandComposition::unapply()
+void EditCommandComposition::unapply(AddToUndoStack addToUndoStack)
 {
     RefPtr document = protectedDocument();
     ASSERT(document);
@@ -251,12 +251,15 @@ void EditCommandComposition::unapply()
 #endif
 
     auto prohibitScrollingForScope = document->view() ? document->view()->prohibitScrollingWhenChangingContentSizeForScope() : nullptr;
-    if (!document->editor().willUnapplyEditing(*this))
+    if (addToUndoStack == AddToUndoStack::Yes && !document->editor().willUnapplyEditing(*this))
         return;
 
     size_t size = m_commands.size();
     for (size_t i = size; i; --i)
         m_commands[i - 1]->doUnapply();
+
+    if (addToUndoStack == AddToUndoStack::No)
+        return;
 
     document->editor().unappliedEditing(*this);
 
@@ -264,6 +267,11 @@ void EditCommandComposition::unapply()
         m_replacedText.postTextStateChangeNotificationForUnapply(document->existingAXObjectCache());
 
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(document->selection().isNone() || document->selection().isConnectedToDocument());
+}
+
+void EditCommandComposition::unapply()
+{
+    this->unapply(AddToUndoStack::Yes);
 }
 
 void EditCommandComposition::reapply()

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -68,9 +68,14 @@ private:
 
 class EditCommandComposition : public UndoStep {
 public:
+    enum class AddToUndoStack : bool {
+        No, Yes
+    };
+
     static Ref<EditCommandComposition> create(Document&, const VisibleSelection& startingSelection, const VisibleSelection& endingSelection, EditAction);
 
     void unapply() override;
+    void unapply(AddToUndoStack);
     void reapply() override;
     EditAction editingAction() const override { return m_editAction; }
     void append(SimpleEditCommand*);

--- a/Source/WebCore/editing/WritingToolsCompositionCommand.h
+++ b/Source/WebCore/editing/WritingToolsCompositionCommand.h
@@ -56,12 +56,16 @@ public:
 
     SimpleRange endingContextRange() const { return m_endingContextRange; }
 
+    // FIXME: Remove this when WritingToolsController no longer needs to support `contextRangeForSessionWithID`.
+    SimpleRange currentContextRange() const { return m_currentContextRange; }
+
 private:
     WritingToolsCompositionCommand(Ref<Document>&&, const SimpleRange&);
 
     void doApply() override { }
 
     SimpleRange m_endingContextRange;
+    SimpleRange m_currentContextRange;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -46,6 +46,8 @@ class Page;
 
 struct SimpleRange;
 
+enum class TextAnimationRunMode : uint8_t;
+
 class WritingToolsController final : public CanMakeWeakPtr<WritingToolsController>, public CanMakeCheckedPtr<WritingToolsController> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(WritingToolsController);
@@ -144,6 +146,8 @@ private:
 
     void replaceContentsOfRangeInSession(ProofreadingState&, const SimpleRange&, const String&);
     void replaceContentsOfRangeInSession(CompositionState&, const SimpleRange&, const AttributedString&, WritingToolsCompositionCommand::State);
+
+    void compositionSessionDidReceiveTextWithReplacementRangeAsync(const WritingTools::Session&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished, TextAnimationRunMode);
 
     void showOriginalCompositionForSession(const WritingTools::Session&);
     void showRewrittenCompositionForSession(const WritingTools::Session&);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -1199,6 +1199,92 @@ TEST(WritingTools, CompositionWithUnderline)
     TestWebKitAPI::Util::run(&finished);
 }
 
+#if PLATFORM(MAC)
+static RetainPtr<NSAttributedString> makeTableAttributedString(NSArray<NSArray<NSString *> *> *rawTable)
+{
+    if (!rawTable.count)
+        return nil;
+
+    RetainPtr textTable = adoptNS([[NSTextTable alloc] init]);
+    [textTable setNumberOfColumns:rawTable.firstObject.count];
+
+    RetainPtr result = adoptNS([[NSMutableAttributedString alloc] init]);
+
+    for (NSUInteger row = 0; row < rawTable.count; row++) {
+        for (NSUInteger column = 0; column < rawTable[row].count; column++) {
+            RetainPtr textTableBlock = adoptNS([[NSTextTableBlock alloc] initWithTable:textTable.get() startingRow:row rowSpan:1 startingColumn:column columnSpan:1]);
+
+            RetainPtr paragraphStyle = adoptNS([[NSMutableParagraphStyle alloc] init]);
+            [paragraphStyle setTextBlocks:@[ textTableBlock.get() ]];
+
+            RetainPtr attributedString = adoptNS([[NSAttributedString alloc] initWithString:[rawTable[row][column] stringByAppendingString:@"\n"] attributes:@{
+                NSParagraphStyleAttributeName : paragraphStyle.get()
+            }]);
+
+            [result appendAttributedString:attributedString.get()];
+        }
+    }
+
+    return result;
+}
+
+TEST(WritingTools, CompositionWithTable)
+{
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@""
+        "<body contenteditable>"
+        "   <div>Task Name, Start Date, End Date, Status</div>"
+        "   <div>Task A, 2024-01-01, 2024-01-10, In Progress</div>"
+        "   <div>Task B, 2024-01-05, 2024-01-15, Completed</div>"
+        "</body>"
+    ]);
+
+    [webView focusDocumentBodyAndSelectAll];
+
+    __block bool finished = false;
+    [[webView writingToolsDelegate] willBeginWritingToolsSession:session.get() requestContexts:^(NSArray<WTContext *> *contexts) {
+        [[webView writingToolsDelegate] writingToolsSession:session.get() didReceiveAction:WTActionCompositionRestart];
+
+        RetainPtr attributedText = makeTableAttributedString(@[
+            @[ @"Task Name", @"Start Date", @"End Date", @"Status" ],
+            @[ @"Task A", @"2024-01-01", @"2024-01-10", @"In Progress" ],
+            @[ @"Task B", @"2024-01-05", @"2024-01-15", @"Completed" ],
+        ]);
+
+        // Invoke `didReceiveText` multiple times to ensure multiple tables are *not* created.
+
+        [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 27) inContext:contexts.firstObject finished:NO];
+        TestWebKitAPI::Util::runFor(0.1_s);
+
+        [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 27) inContext:contexts.firstObject finished:YES];
+        TestWebKitAPI::Util::runFor(0.1_s);
+
+        EXPECT_EQ([webView stringByEvaluatingJavaScript:@"document.getElementsByTagName('table').length"].intValue, 1);
+        EXPECT_EQ([webView stringByEvaluatingJavaScript:@"document.getElementsByTagName('tr').length"].intValue, 3);
+        EXPECT_EQ([webView stringByEvaluatingJavaScript:@"document.getElementsByTagName('td').length"].intValue, 12);
+
+        [[webView writingToolsDelegate] writingToolsSession:session.get() didReceiveAction:WTActionShowOriginal];
+
+        EXPECT_EQ([webView stringByEvaluatingJavaScript:@"document.getElementsByTagName('table').length"].intValue, 0);
+        EXPECT_EQ([webView stringByEvaluatingJavaScript:@"document.getElementsByTagName('tr').length"].intValue, 0);
+        EXPECT_EQ([webView stringByEvaluatingJavaScript:@"document.getElementsByTagName('td').length"].intValue, 0);
+
+        [[webView writingToolsDelegate] writingToolsSession:session.get() didReceiveAction:WTActionShowRewritten];
+
+        EXPECT_EQ([webView stringByEvaluatingJavaScript:@"document.getElementsByTagName('table').length"].intValue, 1);
+        EXPECT_EQ([webView stringByEvaluatingJavaScript:@"document.getElementsByTagName('tr').length"].intValue, 3);
+        EXPECT_EQ([webView stringByEvaluatingJavaScript:@"document.getElementsByTagName('td').length"].intValue, 12);
+
+        [[webView writingToolsDelegate] didEndWritingToolsSession:session.get() accepted:YES];
+
+        finished = true;
+    }];
+
+    TestWebKitAPI::Util::run(&finished);
+}
+#endif
+
 TEST(WritingTools, CompositionWithList)
 {
     auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);


### PR DESCRIPTION
#### 292bb3d0d677c5d7d39dde27b8b141d54f779b35
<pre>
[Writing Tools] Make Table: Mail: Generated table has extra borderlines
<a href="https://bugs.webkit.org/show_bug.cgi?id=276315">https://bugs.webkit.org/show_bug.cgi?id=276315</a>
<a href="https://rdar.apple.com/129926389">rdar://129926389</a>

Reviewed by Aditya Keerthi.

When `didReceiveText` is invoked multiple times when replacing text with a table, multiple table
elements were being created. This is because when the controller tries to re-create the context range
after the first table, it is unable to do so since selections cannot encompass a table or list element.

Fix by not trying to re-create the context range at all; instead, just undo the previous replacements,
and then the context range will always just be the original range for the current composition.

To facilitate this, add a &apos;silent&apos; option when undo-ing a composition edit command so that a command can
be undone without adding it to the undo stack or emitting any type of event.

Additionally, since the TextAnimationController currently relies on being able to get the current range using
the session identifier, add a new property to the Writing Tools command to give this information.

* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::EditCommandComposition::unapply):
* Source/WebCore/editing/CompositeEditCommand.h:
* Source/WebCore/editing/WritingToolsCompositionCommand.cpp:
(WebCore::WritingToolsCompositionCommand::WritingToolsCompositionCommand):
(WebCore::WritingToolsCompositionCommand::replaceContentsOfRangeWithFragment):
* Source/WebCore/editing/WritingToolsCompositionCommand.h:
(WebCore::WritingToolsCompositionCommand::currentContextRange const):
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange):
(WebCore::WritingToolsController::contextRangeForSessionWithID const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(makeTableAttributedString):
(TEST(WritingTools, CompositionWithTable)):
(TEST(WritingTools, SmartReplyWithInsertedSpace)):

Canonical link: <a href="https://commits.webkit.org/281780@main">https://commits.webkit.org/281780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8c257f205f22ab7a7390d7d923d2bcf8b6711a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64909 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11524 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11799 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7989 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63011 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/37542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/52824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30110 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10042 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10437 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66640 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4921 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56652 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52783 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4075 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/37225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->