### PR TITLE
Avoid temporary string allocations when serializing CSS

### DIFF
--- a/Source/WebCore/css/CSSAnchorValue.cpp
+++ b/Source/WebCore/css/CSSAnchorValue.cpp
@@ -50,14 +50,19 @@ void CSSAnchorValue::collectComputedStyleDependencies(ComputedStyleDependencies&
         m_fallback->collectComputedStyleDependencies(dependencies);
 }
 
-String CSSAnchorValue::customCSSText() const
+void CSSAnchorValue::customCSSText(StringBuilder& builder) const
 {
-    auto element = m_anchorElement ? m_anchorElement->cssText() : String { };
-    auto side = m_anchorSide->cssText();
-    auto fallback = m_fallback ? m_fallback->cssText() : String { };
-    auto optionalSpace = element.isEmpty() ? ""_s : " "_s;
-    auto optionalComma = fallback.isEmpty() ? ""_s : ", "_s;
-    return makeString("anchor("_s, element, optionalSpace, side, optionalComma, fallback, ')');
+    builder.append("anchor("_s);
+    if (m_anchorElement) {
+        m_anchorElement->cssText(builder);
+        builder.append(' ');
+    }
+    m_anchorSide->cssText(builder);
+    if (m_fallback) {
+        builder.append(", "_s);
+        m_fallback->cssText(builder);
+    }
+    builder.append(')');
 }
 
 bool CSSAnchorValue::equals(const CSSAnchorValue& other) const

--- a/Source/WebCore/css/CSSAnchorValue.h
+++ b/Source/WebCore/css/CSSAnchorValue.h
@@ -40,7 +40,8 @@ public:
 
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const;
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSAnchorValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSAspectRatioValue.cpp
+++ b/Source/WebCore/css/CSSAspectRatioValue.cpp
@@ -38,6 +38,11 @@ String CSSAspectRatioValue::customCSSText() const
     return makeString(m_numeratorValue, " / "_s, m_denominatorValue);
 }
 
+void CSSAspectRatioValue::customCSSText(StringBuilder& builder) const
+{
+    builder.append(m_numeratorValue, " / "_s, m_denominatorValue);
+}
+
 bool CSSAspectRatioValue::equals(const CSSAspectRatioValue& other) const
 {
     return m_numeratorValue == other.m_numeratorValue && m_denominatorValue == other.m_denominatorValue;

--- a/Source/WebCore/css/CSSAspectRatioValue.h
+++ b/Source/WebCore/css/CSSAspectRatioValue.h
@@ -40,6 +40,7 @@ public:
     }
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     float numeratorValue() const { return m_numeratorValue; }
     float denominatorValue() const { return m_denominatorValue; }

--- a/Source/WebCore/css/CSSBackgroundRepeatValue.cpp
+++ b/Source/WebCore/css/CSSBackgroundRepeatValue.cpp
@@ -44,17 +44,27 @@ Ref<CSSBackgroundRepeatValue> CSSBackgroundRepeatValue::create(CSSValueID repeat
     return adoptRef(*new CSSBackgroundRepeatValue(repeatXValue, repeatYValue));
 }
 
-String CSSBackgroundRepeatValue::customCSSText() const
+template<typename Maker> decltype(auto) CSSBackgroundRepeatValue::serialize(Maker&& maker) const
 {
     // background-repeat/mask-repeat behave a little like a shorthand, but `repeat no-repeat` is transformed to `repeat-x`.
     if (m_xValue != m_yValue) {
         if (m_xValue == CSSValueRepeat && m_yValue == CSSValueNoRepeat)
-            return nameString(CSSValueRepeatX);
+            return maker(nameString(CSSValueRepeatX));
         if (m_xValue == CSSValueNoRepeat && m_yValue == CSSValueRepeat)
-            return nameString(CSSValueRepeatY);
-        return makeString(nameLiteral(m_xValue), ' ', nameLiteral(m_yValue));
+            return maker(nameString(CSSValueRepeatY));
+        return maker(nameString(m_xValue), ' ', nameString(m_yValue));
     }
-    return nameString(m_xValue);
+    return maker(nameString(m_xValue));
+}
+
+String CSSBackgroundRepeatValue::customCSSText() const
+{
+    return serialize(SerializeUsingMakeString { });
+}
+
+void CSSBackgroundRepeatValue::customCSSText(StringBuilder& builder) const
+{
+    serialize(SerializeUsingStringBuilder { builder });
 }
 
 bool CSSBackgroundRepeatValue::equals(const CSSBackgroundRepeatValue& other) const

--- a/Source/WebCore/css/CSSBackgroundRepeatValue.h
+++ b/Source/WebCore/css/CSSBackgroundRepeatValue.h
@@ -36,6 +36,8 @@ public:
     static Ref<CSSBackgroundRepeatValue> create(CSSValueID repeatXValue, CSSValueID repeatYValue);
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSBackgroundRepeatValue&) const;
 
     CSSValueID xValue() const { return m_xValue; }
@@ -43,6 +45,8 @@ public:
 
 private:
     CSSBackgroundRepeatValue(CSSValueID repeatXValue, CSSValueID repeatYValue);
+
+    template<typename Maker> decltype(auto) serialize(Maker&&) const;
 
     CSSValueID m_xValue;
     CSSValueID m_yValue;

--- a/Source/WebCore/css/CSSBasicShapes.h
+++ b/Source/WebCore/css/CSSBasicShapes.h
@@ -60,7 +60,8 @@ public:
     RefPtr<CSSValue> protectedBottomRightRadius() const { return m_bottomRightRadius; }
     RefPtr<CSSValue> protectedBottomLeftRadius() const { return m_bottomLeftRadius; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSInsetShapeValue&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
@@ -117,7 +118,8 @@ public:
     RefPtr<CSSValue> protectedCenterX() const { return m_centerX; }
     RefPtr<CSSValue> protectedCenterY() const { return m_centerY; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSCircleValue&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
@@ -158,7 +160,8 @@ public:
     RefPtr<CSSValue> protectedCenterX() const { return m_centerX; }
     RefPtr<CSSValue> protectedCenterY() const { return m_centerY; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSEllipseValue&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
@@ -197,7 +200,8 @@ public:
 
     WindRule windRule() const { return m_windRule; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSPolygonValue&) const;
 
 private:
@@ -228,7 +232,8 @@ public:
     RefPtr<CSSValue> protectedBottomRightRadius() const { return m_bottomRightRadius; }
     RefPtr<CSSValue> protectedBottomLeftRadius() const { return m_bottomLeftRadius; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSRectShapeValue&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
@@ -296,7 +301,8 @@ public:
     RefPtr<CSSValue> protectedBottomRightRadius() const { return m_bottomRightRadius; }
     RefPtr<CSSValue> protectedBottomLeftRadius() const { return m_bottomLeftRadius; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSXywhValue&) const;
 
 
@@ -350,7 +356,8 @@ public:
     const SVGPathByteStream& pathData() const { return m_pathData; }
     WindRule windRule() const { return m_windRule; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSPathValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSBorderImageSliceValue.cpp
+++ b/Source/WebCore/css/CSSBorderImageSliceValue.cpp
@@ -45,11 +45,11 @@ Ref<CSSBorderImageSliceValue> CSSBorderImageSliceValue::create(Quad slices, bool
     return adoptRef(*new CSSBorderImageSliceValue(WTFMove(slices), fill));
 }
 
-String CSSBorderImageSliceValue::customCSSText() const
+void CSSBorderImageSliceValue::customCSSText(StringBuilder& builder) const
 {
+    m_slices.cssText(builder);
     if (m_fill)
-        return makeString(m_slices.cssText(), " fill"_s);
-    return m_slices.cssText();
+        builder.append(" fill"_s);
 }
 
 bool CSSBorderImageSliceValue::equals(const CSSBorderImageSliceValue& other) const

--- a/Source/WebCore/css/CSSBorderImageSliceValue.h
+++ b/Source/WebCore/css/CSSBorderImageSliceValue.h
@@ -40,7 +40,8 @@ public:
     const Quad& slices() const { return m_slices; }
     bool fill() const { return m_fill; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSBorderImageSliceValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSBorderImageWidthValue.cpp
+++ b/Source/WebCore/css/CSSBorderImageWidthValue.cpp
@@ -44,14 +44,14 @@ Ref<CSSBorderImageWidthValue> CSSBorderImageWidthValue::create(Quad widths, bool
     return adoptRef(*new CSSBorderImageWidthValue(WTFMove(widths), overridesBorderWidths));
 }
 
-String CSSBorderImageWidthValue::customCSSText() const
+void CSSBorderImageWidthValue::customCSSText(StringBuilder& builder) const
 {
     // The border-image-width longhand can't set m_overridesBorderWidths to true, so serialize as empty string.
     // This can only be created by the -webkit-border-image shorthand, which will not serialize as empty string in this case.
     // This is an unconventional relationship between a longhand and a shorthand, which we may want to revise.
     if (m_overridesBorderWidths)
-        return String();
-    return m_widths.cssText();
+        return;
+    m_widths.cssText(builder);
 }
 
 bool CSSBorderImageWidthValue::equals(const CSSBorderImageWidthValue& other) const

--- a/Source/WebCore/css/CSSBorderImageWidthValue.h
+++ b/Source/WebCore/css/CSSBorderImageWidthValue.h
@@ -40,7 +40,8 @@ public:
     const Quad& widths() const { return m_widths; }
     bool overridesBorderWidths() const { return m_overridesBorderWidths; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSBorderImageWidthValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSCanvasValue.cpp
+++ b/Source/WebCore/css/CSSCanvasValue.cpp
@@ -44,6 +44,11 @@ String CSSCanvasValue::customCSSText() const
     return makeString("-webkit-canvas("_s, m_name, ')');
 }
 
+void CSSCanvasValue::customCSSText(StringBuilder& builder) const
+{
+    return builder.append("-webkit-canvas("_s, m_name, ')');
+}
+
 bool CSSCanvasValue::equals(const CSSCanvasValue& other) const
 {
     return m_name == other.m_name;

--- a/Source/WebCore/css/CSSCanvasValue.h
+++ b/Source/WebCore/css/CSSCanvasValue.h
@@ -42,6 +42,8 @@ public:
     ~CSSCanvasValue();
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSCanvasValue&) const;
 
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;

--- a/Source/WebCore/css/CSSContainerRule.cpp
+++ b/Source/WebCore/css/CSSContainerRule.cpp
@@ -49,13 +49,11 @@ const StyleRuleContainer& CSSContainerRule::styleRuleContainer() const
     return downcast<StyleRuleContainer>(groupRule());
 }
 
-String CSSContainerRule::cssText() const
+void CSSContainerRule::cssText(StringBuilder& builder) const
 {
-    StringBuilder builder;
     builder.append("@container "_s);
     CQ::serialize(builder, styleRuleContainer().containerQuery());
     appendCSSTextForItems(builder);
-    return builder.toString();
 }
 
 String CSSContainerRule::conditionText() const
@@ -71,7 +69,7 @@ String CSSContainerRule::containerName() const
 
     auto name = styleRuleContainer().containerQuery().name;
     if (!name.isEmpty())
-        serializeIdentifier(name, builder);
+        serializeIdentifier(builder, name);
 
     return builder.toString();
 }

--- a/Source/WebCore/css/CSSContainerRule.h
+++ b/Source/WebCore/css/CSSContainerRule.h
@@ -35,7 +35,7 @@ class CSSContainerRule final : public CSSConditionRule {
 public:
     static Ref<CSSContainerRule> create(StyleRuleContainer&, CSSStyleSheet* parent);
 
-    String cssText() const final;
+    void cssText(StringBuilder&) const final;
     String conditionText() const final;
     String containerName() const;
     String containerQuery() const;

--- a/Source/WebCore/css/CSSContentDistributionValue.h
+++ b/Source/WebCore/css/CSSContentDistributionValue.h
@@ -40,10 +40,14 @@ public:
     CSSValueID overflow() const { return m_overflow; }
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSContentDistributionValue&) const;
 
 private:
     CSSContentDistributionValue(CSSValueID distribution, CSSValueID position, CSSValueID overflow);
+
+    template<typename Maker> decltype(auto) serialize(Maker&&) const;
 
     CSSValueID m_distribution;
     CSSValueID m_position;

--- a/Source/WebCore/css/CSSCounterStyle.h
+++ b/Source/WebCore/css/CSSCounterStyle.h
@@ -54,7 +54,7 @@ public:
     const CSSCounterStyleDescriptors::Ranges& ranges() const { return m_descriptors.m_ranges; }
     const CSSCounterStyleDescriptors::Pad& pad() const { return m_descriptors.m_pad; }
     const CSSCounterStyleDescriptors::Name& fallbackName() const { return m_descriptors.m_fallbackName; }
-    const Vector<CSSCounterStyleDescriptors::Symbol>& symbols() const { return m_descriptors.m_symbols; }
+    const CSSCounterStyleDescriptors::Symbols& symbols() const { return m_descriptors.m_symbols; }
     const CSSCounterStyleDescriptors::AdditiveSymbols& additiveSymbols() const { return m_descriptors.m_additiveSymbols; }
     CSSCounterStyleDescriptors::SpeakAs speakAs() const { return m_descriptors.m_speakAs; }
     const CSSCounterStyleDescriptors::Name extendsName() const { return m_descriptors.m_extendsName; }
@@ -68,7 +68,7 @@ public:
     void setRanges(const CSSCounterStyleDescriptors::Ranges& ranges) { m_descriptors.m_ranges = ranges; }
     void setPad(const CSSCounterStyleDescriptors::Pad& pad) { m_descriptors.m_pad = pad; }
     void setFallbackName(const CSSCounterStyleDescriptors::Name& fallbackName) { m_descriptors.m_fallbackName = fallbackName; }
-    void setSymbols(const Vector<CSSCounterStyleDescriptors::Symbol>& symbols) { m_descriptors.m_symbols = symbols; }
+    void setSymbols(const CSSCounterStyleDescriptors::Symbols& symbols) { m_descriptors.m_symbols = symbols; }
     void setAdditiveSymbols(const CSSCounterStyleDescriptors::AdditiveSymbols& additiveSymbols) { m_descriptors.m_additiveSymbols = additiveSymbols; }
     void setSpeakAs(CSSCounterStyleDescriptors::SpeakAs speakAs) { m_descriptors.m_speakAs = speakAs; }
     void setFirstSymbolValueForFixedSystem(int firstSymbolValue) { m_descriptors.m_fixedSystemFirstSymbolValue = firstSymbolValue; }

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.h
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.h
@@ -36,17 +36,24 @@ class StyleProperties;
 
 struct CSSCounterStyleDescriptors {
     using Name = AtomString;
-    using Ranges = Vector<std::pair<int, int>>;
+    using Range = std::pair<int, int>;
+    using Ranges = Vector<Range>;
     using SystemData = std::pair<CSSCounterStyleDescriptors::Name, int>;
     // The keywords that can be used as values for the counter-style `system` descriptor.
     // https://www.w3.org/TR/css-counter-styles-3/#counter-style-system
     struct Symbol {
         bool isCustomIdent { false };
         String text;
-        friend bool operator==(const Symbol&, const Symbol&) = default;
+
+        bool hasCSSText() const;
         String cssText() const;
+        void cssText(StringBuilder&) const;
+
+        bool operator==(const Symbol&) const = default;
     };
-    using AdditiveSymbols = Vector<std::pair<Symbol, unsigned>>;
+    using Symbols = Vector<Symbol>;
+    using AdditiveSymbol = std::pair<Symbol, unsigned>;
+    using AdditiveSymbols = Vector<AdditiveSymbol>;
     enum class System : uint8_t {
         Cyclic,
         Numeric,
@@ -74,13 +81,21 @@ struct CSSCounterStyleDescriptors {
     struct Pad {
         unsigned m_padMinimumLength = 0;
         Symbol m_padSymbol;
-        friend bool operator==(const Pad&, const Pad&) = default;
+
+        bool hasCSSText() const;
         String cssText() const;
+        void cssText(StringBuilder&) const;
+
+        bool operator==(const Pad&) const = default;
     };
     struct NegativeSymbols {
         Symbol m_prefix = { false, "-"_s };
         Symbol m_suffix;
-        friend bool operator==(const NegativeSymbols&, const NegativeSymbols&) = default;
+        bool hasCSSText() const;
+        String cssText() const;
+        void cssText(StringBuilder&) const;
+
+        bool operator==(const NegativeSymbols&) const = default;
     };
     enum class ExplicitlySetDescriptors: uint16_t {
         System = 1 << 0,
@@ -95,8 +110,9 @@ struct CSSCounterStyleDescriptors {
         SpeakAs = 1 << 9
     };
 
-    // create() is prefered here rather than a custom constructor, so that the Struct still classifies as an aggregate.
+    // create() is preferred here rather than a custom constructor, so that the struct still classifies as an aggregate.
     static CSSCounterStyleDescriptors create(AtomString name, const StyleProperties&);
+
     bool operator==(const CSSCounterStyleDescriptors& other) const
     {
         // Intentionally doesn't check m_isExtendedResolved.
@@ -115,9 +131,10 @@ struct CSSCounterStyleDescriptors {
             && m_fixedSystemFirstSymbolValue == other.m_fixedSystemFirstSymbolValue
             && m_explicitlySetDescriptors == other.m_explicitlySetDescriptors;
     }
+
     void setExplicitlySetDescriptors(const StyleProperties&);
     bool isValid() const;
-    static bool areSymbolsValidForSystem(System, const Vector<Symbol>&, const AdditiveSymbols&);
+    static bool areSymbolsValidForSystem(System, const Symbols&, const AdditiveSymbols&);
 
     void setName(Name);
     void setSystem(System);
@@ -128,19 +145,48 @@ struct CSSCounterStyleDescriptors {
     void setRanges(Ranges);
     void setPad(Pad);
     void setFallbackName(Name);
-    void setSymbols(Vector<Symbol>);
+    void setSymbols(Symbols);
     void setAdditiveSymbols(AdditiveSymbols);
 
+    bool hasNameCSSText() const;
     String nameCSSText() const;
+    void nameCSSText(StringBuilder&) const;
+
+    bool hasSystemCSSText() const;
     String systemCSSText() const;
+    void systemCSSText(StringBuilder&) const;
+
+    bool hasNegativeCSSText() const;
     String negativeCSSText() const;
+    void negativeCSSText(StringBuilder&) const;
+
+    bool hasPrefixCSSText() const;
     String prefixCSSText() const;
+    void prefixCSSText(StringBuilder&) const;
+
+    bool hasSuffixCSSText() const;
     String suffixCSSText() const;
+    void suffixCSSText(StringBuilder&) const;
+
+    bool hasRangesCSSText() const;
     String rangesCSSText() const;
+    void rangesCSSText(StringBuilder&) const;
+
+    bool hasPadCSSText() const;
     String padCSSText() const;
+    void padCSSText(StringBuilder&) const;
+
+    bool hasFallbackCSSText() const;
     String fallbackCSSText() const;
+    void fallbackCSSText(StringBuilder&) const;
+
+    bool hasSymbolsCSSText() const;
     String symbolsCSSText() const;
+    void symbolsCSSText(StringBuilder&) const;
+
+    bool hasAdditiveSymbolsCSSText() const;
     String additiveSymbolsCSSText() const;
+    void additiveSymbolsCSSText(StringBuilder&) const;
 
     Name m_name;
     System m_system;
@@ -150,7 +196,7 @@ struct CSSCounterStyleDescriptors {
     Ranges m_ranges;
     Pad m_pad;
     Name m_fallbackName;
-    Vector<Symbol> m_symbols;
+    Symbols m_symbols;
     AdditiveSymbols m_additiveSymbols;
     SpeakAs m_speakAs;
     Name m_extendsName;
@@ -164,7 +210,8 @@ CSSCounterStyleDescriptors::AdditiveSymbols additiveSymbolsFromCSSValue(Ref<CSSV
 CSSCounterStyleDescriptors::Pad padFromCSSValue(Ref<CSSValue>);
 CSSCounterStyleDescriptors::NegativeSymbols negativeSymbolsFromCSSValue(Ref<CSSValue>);
 CSSCounterStyleDescriptors::Symbol symbolFromCSSValue(RefPtr<CSSValue>);
-Vector<CSSCounterStyleDescriptors::Symbol> symbolsFromCSSValue(Ref<CSSValue>);
+CSSCounterStyleDescriptors::Symbols symbolsFromCSSValue(Ref<CSSValue>);
 CSSCounterStyleDescriptors::Name fallbackNameFromCSSValue(Ref<CSSValue>);
 CSSCounterStyleDescriptors::SystemData extractSystemDataFromCSSValue(RefPtr<CSSValue>, CSSCounterStyleDescriptors::System);
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCounterStyleRule.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRule.cpp
@@ -114,60 +114,69 @@ CSSCounterStyleRule::CSSCounterStyleRule(StyleRuleCounterStyle& counterStyleRule
 
 CSSCounterStyleRule::~CSSCounterStyleRule() = default;
 
-String CSSCounterStyleRule::cssText() const
+void CSSCounterStyleRule::cssText(StringBuilder& builder) const
 {
-    String systemText = system();
-    const auto systemPrefix = systemText.isEmpty() ? ""_s : " system: "_s;
-    const auto systemSuffix = systemText.isEmpty() ? ""_s : ";"_s;
+    auto& descriptors = this->descriptors();
 
-    String symbolsText = symbols();
-    const auto symbolsPrefix = symbolsText.isEmpty() ? ""_s : " symbols: "_s;
-    const auto symbolsSuffix = symbolsText.isEmpty() ? ""_s : ";"_s;
+    builder.append("@counter-style "_s, name(), " {"_s);
 
-    String additiveSymbolsText = additiveSymbols();
-    const auto additiveSymbolsPrefix = additiveSymbolsText.isEmpty() ? ""_s : " additive-symbols: "_s;
-    const auto additiveSymbolsSuffix = additiveSymbolsText.isEmpty() ? ""_s : ";"_s;
+    if (descriptors.hasSystemCSSText()) {
+        builder.append(" system: "_s);
+        descriptors.systemCSSText(builder);
+        builder.append(';');
+    }
 
-    String negativeText = negative();
-    const auto negativePrefix = negativeText.isEmpty() ? ""_s : " negative: "_s;
-    const auto negativeSuffix = negativeText.isEmpty() ? ""_s : ";"_s;
+    if (descriptors.hasSymbolsCSSText()) {
+        builder.append(" symbols: "_s);
+        descriptors.symbolsCSSText(builder);
+        builder.append(';');
+    }
 
-    String prefixText = prefix();
-    const auto prefixTextPrefix = prefixText.isEmpty() ? ""_s : " prefix: "_s;
-    const auto prefixTextSuffix = prefixText.isEmpty() ? ""_s : ";"_s;
+    if (descriptors.hasAdditiveSymbolsCSSText()) {
+        builder.append(" additive-symbols: "_s);
+        descriptors.additiveSymbolsCSSText(builder);
+        builder.append(';');
+    }
 
-    String suffixText = suffix();
-    const auto suffixTextPrefix = suffixText.isEmpty() ? ""_s : " suffix: "_s;
-    const auto suffixTextSuffix = suffixText.isEmpty() ? ""_s : ";"_s;
+    if (descriptors.hasNegativeCSSText()) {
+        builder.append(" negative: "_s);
+        descriptors.negativeCSSText(builder);
+        builder.append(';');
+    }
 
-    String padText = pad();
-    const auto padPrefix = padText.isEmpty() ? ""_s : " pad: "_s;
-    const auto padSuffix = padText.isEmpty() ? ""_s : ";"_s;
+    if (descriptors.hasPrefixCSSText()) {
+        builder.append(" prefix: "_s);
+        descriptors.prefixCSSText(builder);
+        builder.append(';');
+    }
 
-    String rangeText = range();
-    const auto rangePrefix = rangeText.isEmpty() ? ""_s : " range: "_s;
-    const auto rangeSuffix = rangeText.isEmpty() ? ""_s : ";"_s;
+    if (descriptors.hasSuffixCSSText()) {
+        builder.append(" suffix: "_s);
+        descriptors.suffixCSSText(builder);
+        builder.append(';');
+    }
 
-    String fallbackText = fallback();
-    const auto fallbackPrefix = fallbackText.isEmpty() ? ""_s : " fallback: "_s;
-    const auto fallbackSuffix = fallbackText.isEmpty() ? ""_s : ";"_s;
+    if (descriptors.hasPadCSSText()) {
+        builder.append(" pad: "_s);
+        descriptors.padCSSText(builder);
+        builder.append(';');
+    }
 
-    String speakAsText = speakAs();
-    const auto speakAsPrefix = speakAsText.isEmpty() ? ""_s : " speak-as: "_s;
-    const auto speakAsSuffix = speakAsText.isEmpty() ? ""_s : ";"_s;
+    if (descriptors.hasRangesCSSText()) {
+        builder.append(" range: "_s);
+        descriptors.rangesCSSText(builder);
+        builder.append(';');
+    }
 
-    return makeString("@counter-style "_s, name(), " {"_s,
-        systemPrefix, systemText, systemSuffix,
-        symbolsPrefix, symbolsText, symbolsSuffix,
-        additiveSymbolsPrefix, additiveSymbolsText, additiveSymbolsSuffix,
-        negativePrefix, negativeText, negativeSuffix,
-        prefixTextPrefix, prefixText, prefixTextSuffix,
-        suffixTextPrefix, suffixText, suffixTextSuffix,
-        padPrefix, padText, padSuffix,
-        rangePrefix, rangeText, rangeSuffix,
-        fallbackPrefix, fallbackText, fallbackSuffix,
-        speakAsPrefix, speakAsText, speakAsSuffix,
-    " }"_s);
+    if (descriptors.hasFallbackCSSText()) {
+        builder.append(" fallback: "_s);
+        descriptors.fallbackCSSText(builder);
+        builder.append(';');
+    }
+
+    // FIXME: @counter-style speak-as not supported (rdar://103019111).
+
+    builder.append(" }"_s);
 }
 
 void CSSCounterStyleRule::reattach(StyleRuleBase& rule)

--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -32,6 +32,7 @@
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
+
 class StyleRuleCounterStyle final : public StyleRuleBase {
 public:
     static Ref<StyleRuleCounterStyle> create(const AtomString&, CSSCounterStyleDescriptors&&);
@@ -70,7 +71,7 @@ public:
     static Ref<CSSCounterStyleRule> create(StyleRuleCounterStyle&, CSSStyleSheet*);
     virtual ~CSSCounterStyleRule();
 
-    String cssText() const final;
+    void cssText(StringBuilder&) const final;
     void reattach(StyleRuleBase&) final;
     StyleRuleType styleRuleType() const final { return StyleRuleType::CounterStyle; }
 

--- a/Source/WebCore/css/CSSCounterValue.cpp
+++ b/Source/WebCore/css/CSSCounterValue.cpp
@@ -52,31 +52,49 @@ bool CSSCounterValue::equals(const CSSCounterValue& other) const
     return m_identifier == other.m_identifier && m_separator == other.m_separator && arePointingToEqualData(m_counterStyle, other.m_counterStyle);
 }
 
-String CSSCounterValue::customCSSText() const
+void CSSCounterValue::customCSSText(StringBuilder& builder) const
 {
-    bool isDecimal = m_counterStyle->valueID() == CSSValueDecimal || (m_counterStyle->isCustomIdent() && m_counterStyle->customIdent() == "decimal"_s);
-    auto listStyleSeparator = isDecimal ? ""_s : ", "_s;
-    auto listStyleLiteral = isDecimal ? ""_s : counterStyleCSSText();
     if (m_separator.isEmpty())
-        return makeString("counter("_s, m_identifier, listStyleSeparator, listStyleLiteral, ')');
-    StringBuilder result;
-    result.append("counters("_s, m_identifier, ", "_s);
-    serializeString(m_separator, result);
-    result.append(listStyleSeparator, listStyleLiteral, ')');
-    return result.toString();
+        builder.append("counter("_s, m_identifier);
+    else {
+        builder.append("counters("_s, m_identifier, ", "_s);
+        serializeString(builder, m_separator);
+    }
+
+    bool isDecimal = m_counterStyle->valueID() == CSSValueDecimal || (m_counterStyle->isCustomIdent() && m_counterStyle->customIdent() == "decimal"_s);
+    if (!isDecimal) {
+        builder.append(", "_s);
+        counterStyleCSSText(builder);
+    }
+
+    builder.append(')');
 }
 
 String CSSCounterValue::counterStyleCSSText() const
 {
     if (!m_counterStyle)
         return emptyString();
-
     if (m_counterStyle->isValueID())
         return nameString(m_counterStyle->valueID()).string();
     if (m_counterStyle->isCustomIdent())
         return m_counterStyle->customIdent();
-
     ASSERT_NOT_REACHED();
     return emptyString();
 }
+
+void CSSCounterValue::counterStyleCSSText(StringBuilder& builder) const
+{
+    if (!m_counterStyle)
+        return;
+    if (m_counterStyle->isValueID()) {
+        builder.append(nameString(m_counterStyle->valueID()));
+        return;
+    }
+    if (m_counterStyle->isCustomIdent()) {
+        builder.append(m_counterStyle->customIdent());
+        return;
+    }
+    ASSERT_NOT_REACHED();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCounterValue.h
+++ b/Source/WebCore/css/CSSCounterValue.h
@@ -37,9 +37,12 @@ public:
     const AtomString& identifier() const { return m_identifier; }
     const AtomString& separator() const { return m_separator; }
     RefPtr<CSSValue> counterStyle() const { return m_counterStyle; }
-    String counterStyleCSSText() const;
 
-    String customCSSText() const;
+    String counterStyleCSSText() const;
+    void counterStyleCSSText(StringBuilder&) const;
+
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSCounterValue&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const

--- a/Source/WebCore/css/CSSCrossfadeValue.cpp
+++ b/Source/WebCore/css/CSSCrossfadeValue.cpp
@@ -59,9 +59,15 @@ bool CSSCrossfadeValue::equalInputImages(const CSSCrossfadeValue& other) const
     return compareCSSValue(m_fromValueOrNone, other.m_fromValueOrNone) && compareCSSValue(m_toValueOrNone, other.m_toValueOrNone);
 }
 
-String CSSCrossfadeValue::customCSSText() const
+void CSSCrossfadeValue::customCSSText(StringBuilder& builder) const
 {
-    return makeString(m_isPrefixed ? "-webkit-"_s : ""_s, "cross-fade("_s, m_fromValueOrNone->cssText(), ", "_s, m_toValueOrNone->cssText(), ", "_s, m_percentageValue->cssText(), ')');
+    builder.append(m_isPrefixed ? "-webkit-"_s : ""_s, "cross-fade("_s);
+    m_fromValueOrNone->cssText(builder);
+    builder.append(", "_s);
+    m_toValueOrNone->cssText(builder);
+    builder.append(", "_s);
+    m_percentageValue->cssText(builder);
+    builder.append(')');
 }
 
 RefPtr<StyleImage> CSSCrossfadeValue::createStyleImage(Style::BuilderState& state) const

--- a/Source/WebCore/css/CSSCrossfadeValue.h
+++ b/Source/WebCore/css/CSSCrossfadeValue.h
@@ -46,7 +46,8 @@ public:
     bool equals(const CSSCrossfadeValue&) const;
     bool equalInputImages(const CSSCrossfadeValue&) const;
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool isPrefixed() const { return m_isPrefixed; }
 
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;

--- a/Source/WebCore/css/CSSCursorImageValue.cpp
+++ b/Source/WebCore/css/CSSCursorImageValue.cpp
@@ -59,12 +59,14 @@ CSSCursorImageValue::CSSCursorImageValue(Ref<CSSValue>&& imageValue, const std::
 
 CSSCursorImageValue::~CSSCursorImageValue() = default;
 
-String CSSCursorImageValue::customCSSText() const
+void CSSCursorImageValue::customCSSText(StringBuilder& builder) const
 {
-    auto text = m_imageValue.get().cssText();
+    m_imageValue->cssText(builder);
+
     if (!m_hotSpot)
-        return text;
-    return makeString(text, ' ', m_hotSpot->x(), ' ', m_hotSpot->y());
+        return;
+
+    builder.append(' ', m_hotSpot->x(), ' ', m_hotSpot->y());
 }
 
 bool CSSCursorImageValue::equals(const CSSCursorImageValue& other) const

--- a/Source/WebCore/css/CSSCursorImageValue.h
+++ b/Source/WebCore/css/CSSCursorImageValue.h
@@ -42,7 +42,9 @@ public:
     std::optional<IntPoint> hotSpot() const { return m_hotSpot; }
 
     const URL& imageURL() const { return m_originalURL; }
-    String customCSSText() const;
+
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSCursorImageValue&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -128,6 +128,14 @@ String CSSCustomPropertyValue::customCSSText() const
     return m_cachedCSSText;
 }
 
+void CSSCustomPropertyValue::customCSSText(StringBuilder& builder) const
+{
+    // FIXME: This is implemented in the opposite way from other CSSValue subclasses, which usually
+    // have the non-builder `customCSSText` call the builder one, because for CSSCustomPropertyValue
+    // the css text is being cached. If we ever decide that caching is not needed, we should reverse it.
+    builder.append(customCSSText());
+}
+
 const Vector<CSSParserToken>& CSSCustomPropertyValue::tokens() const
 {
     static NeverDestroyed<Vector<CSSParserToken>> emptyTokens;

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -89,6 +89,7 @@ public:
     }
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     const AtomString& name() const { return m_name; }
     bool isResolved() const { return !std::holds_alternative<Ref<CSSVariableReferenceValue>>(m_value); }

--- a/Source/WebCore/css/CSSFilterImageValue.cpp
+++ b/Source/WebCore/css/CSSFilterImageValue.cpp
@@ -53,9 +53,13 @@ bool CSSFilterImageValue::equalInputImages(const CSSFilterImageValue& other) con
     return compareCSSValue(m_imageValueOrNone, other.m_imageValueOrNone);
 }
 
-String CSSFilterImageValue::customCSSText() const
+void CSSFilterImageValue::customCSSText(StringBuilder& builder) const
 {
-    return makeString("filter("_s, m_imageValueOrNone->cssText(), ", "_s, m_filterValue->cssText(), ')');
+    builder.append("filter("_s);
+    m_imageValueOrNone->cssText(builder);
+    builder.append(", "_s);
+    m_filterValue->cssText(builder);
+    builder.append(')');
 }
 
 RefPtr<StyleImage> CSSFilterImageValue::createStyleImage(Style::BuilderState& state) const

--- a/Source/WebCore/css/CSSFilterImageValue.h
+++ b/Source/WebCore/css/CSSFilterImageValue.h
@@ -49,7 +49,7 @@ public:
     bool equals(const CSSFilterImageValue&) const;
     bool equalInputImages(const CSSFilterImageValue&) const;
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 

--- a/Source/WebCore/css/CSSFontFaceRule.h
+++ b/Source/WebCore/css/CSSFontFaceRule.h
@@ -41,9 +41,11 @@ private:
     CSSFontFaceRule(StyleRuleFontFace&, CSSStyleSheet* parent);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::FontFace; }
-    String cssText() const final;
-    String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
-    String cssTextInternal(const String& declarations) const;
+
+    void cssText(StringBuilder&) const final;
+    void cssTextWithReplacementURLs(StringBuilder&, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
+    template<typename DeclarationsFunctor> void cssTextInternal(StringBuilder&, bool hasDeclarations, DeclarationsFunctor&&) const;
+
     void reattach(StyleRuleBase&) final;
 
     Ref<StyleRuleFontFace> m_fontFaceRule;

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -63,9 +63,11 @@ void CSSFontFaceSrcLocalValue::setSVGFontFaceElement(SVGFontFaceElement& element
     m_element = &element;
 }
 
-String CSSFontFaceSrcLocalValue::customCSSText() const
+void CSSFontFaceSrcLocalValue::customCSSText(StringBuilder& builder) const
 {
-    return makeString("local("_s, serializeString(m_fontFaceName), ')');
+    builder.append("local("_s);
+    serializeString(builder, m_fontFaceName);
+    builder.append(')');
 }
 
 bool CSSFontFaceSrcLocalValue::equals(const CSSFontFaceSrcLocalValue& other) const
@@ -143,29 +145,23 @@ bool CSSFontFaceSrcResourceValue::customMayDependOnBaseURL() const
     return WebCore::mayDependOnBaseURL(m_location);
 }
 
-String CSSFontFaceSrcResourceValue::customCSSText() const
+void CSSFontFaceSrcResourceValue::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder builder;
     if (!m_replacementURLString.isEmpty())
-        builder.append(serializeURL(m_replacementURLString));
+        serializeURL(builder, m_replacementURLString);
     else {
         if (m_shouldUseResolvedURLInCSSText)
-            builder.append(serializeURL(m_location.resolvedURL.string()));
+            serializeURL(builder, m_location.resolvedURL.string());
         else
-            builder.append(serializeURL(m_location.specifiedURLString));
+            serializeURL(builder, m_location.specifiedURLString);
     }
-    if (!m_format.isEmpty())
-        builder.append(" format("_s, serializeString(m_format), ')');
-    if (!m_technologies.isEmpty()) {
-        builder.append(" tech("_s);
-        for (size_t i = 0; i < m_technologies.size(); ++i) {
-            if (i)
-                builder.append(", "_s);
-            builder.append(cssTextFromFontTech(m_technologies[i]));
-        }
+    if (!m_format.isEmpty()) {
+        builder.append(" format("_s);
+        serializeString(builder, m_format);
         builder.append(')');
     }
-    return builder.toString();
+    if (!m_technologies.isEmpty())
+        builder.append(" tech("_s, interleave(m_technologies, cssTextFromFontTech, ", "_s), ')');
 }
 
 bool CSSFontFaceSrcResourceValue::equals(const CSSFontFaceSrcResourceValue& other) const

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -50,7 +50,8 @@ public:
     SVGFontFaceElement* svgFontFaceElement() const;
     void setSVGFontFaceElement(SVGFontFaceElement&);
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSFontFaceSrcLocalValue&) const;
 
 private:
@@ -114,7 +115,8 @@ public:
     bool isEmpty() const { return m_location.specifiedURLString.isEmpty(); }
     std::unique_ptr<FontLoadRequest> fontLoadRequest(ScriptExecutionContext&, bool isInitiatingElementInUserAgentShadowTree);
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
     void customSetReplacementURLForSubresources(const HashMap<String, String>&);
     void customClearReplacementURLForSubresources();

--- a/Source/WebCore/css/CSSFontFeatureValue.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValue.cpp
@@ -38,9 +38,8 @@ CSSFontFeatureValue::CSSFontFeatureValue(FontTag&& tag, int value)
 {
 }
 
-String CSSFontFeatureValue::customCSSText() const
+void CSSFontFeatureValue::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder builder;
     builder.append('"');
     for (char c : m_tag)
         builder.append(c);
@@ -48,7 +47,6 @@ String CSSFontFeatureValue::customCSSText() const
     // Omit the value if it's 1 as 1 is implied by default.
     if (m_value != 1)
         builder.append(' ', m_value);
-    return builder.toString();
 }
 
 bool CSSFontFeatureValue::equals(const CSSFontFeatureValue& other) const

--- a/Source/WebCore/css/CSSFontFeatureValue.h
+++ b/Source/WebCore/css/CSSFontFeatureValue.h
@@ -39,7 +39,8 @@ public:
 
     const FontTag& tag() const { return m_tag; }
     int value() const { return m_value; }
-    String customCSSText() const;
+
+    void customCSSText(StringBuilder&) const;
 
     bool equals(const CSSFontFeatureValue&) const;
 

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
@@ -36,28 +36,21 @@ CSSFontFeatureValuesRule::CSSFontFeatureValuesRule(StyleRuleFontFeatureValues& f
 {
 }
 
-String CSSFontFeatureValuesRule::cssText() const
+void CSSFontFeatureValuesRule::cssText(StringBuilder& builder) const
 {
-    StringBuilder builder;
-    builder.append("@font-feature-values "_s);
-    auto joinFontFamiliesWithSeparator = [&builder] (const auto& elements, ASCIILiteral separator) {
-        bool first = true;
-        for (auto element : elements) {
-            if (!first)
-                builder.append(separator);
-            builder.append(serializeFontFamily(element));
-            first = false;
-        }
-    };
-    joinFontFamiliesWithSeparator(m_fontFeatureValuesRule->fontFamilies(), ", "_s);
-    builder.append(" { "_s);
+    builder.append(
+        "@font-feature-values "_s,
+        interleave(m_fontFeatureValuesRule->fontFamilies(), [](auto& builder, auto& fontFamily) { serializeFontFamily(builder, fontFamily); }, ", "_s),
+        " { "_s
+    );
+
     const auto& value = m_fontFeatureValuesRule->value();
-    
-    auto addVariant = [&builder] (const String& variantName, const auto& tags) {
+
+    auto addVariant = [&builder](const String& variantName, const auto& tags) {
         if (!tags.isEmpty()) {
             builder.append('@', variantName, " { "_s);
             for (auto tag : tags) {
-                serializeIdentifier(tag.key, builder);
+                serializeIdentifier(builder, tag.key);
                 builder.append(':');
                 for (auto integer : tag.value)
                     builder.append(' ', integer);
@@ -77,7 +70,6 @@ String CSSFontFeatureValuesRule::cssText() const
     addVariant("styleset"_s, value->styleset());
     
     builder.append('}');
-    return builder.toString();
 }
 
 void CSSFontFeatureValuesRule::reattach(StyleRuleBase& rule)
@@ -91,13 +83,12 @@ CSSFontFeatureValuesBlockRule::CSSFontFeatureValuesBlockRule(StyleRuleFontFeatur
 {
 }
 
-String CSSFontFeatureValuesBlockRule::cssText() const
+void CSSFontFeatureValuesBlockRule::cssText(StringBuilder&) const
 {
     // This rule is always contained inside a FontFeatureValuesRule,
     // which is the only one we are expected to serialize to CSS.
     // We should never serialize a Block by itself.
     ASSERT_NOT_REACHED();
-    return { };
 }
 
 void CSSFontFeatureValuesBlockRule::reattach(StyleRuleBase& rule)

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.h
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.h
@@ -61,7 +61,7 @@ private:
     CSSFontFeatureValuesRule(StyleRuleFontFeatureValues&, CSSStyleSheet* parent);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::FontFeatureValues; }
-    String cssText() const final;
+    void cssText(StringBuilder&) const final;
     void reattach(StyleRuleBase&) final;
 
     Ref<StyleRuleFontFeatureValues> m_fontFeatureValuesRule;
@@ -76,7 +76,7 @@ private:
     CSSFontFeatureValuesBlockRule(StyleRuleFontFeatureValuesBlock&, CSSStyleSheet* parent);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::FontFeatureValuesBlock; }
-    String cssText() const final;
+    void cssText(StringBuilder&) const final;
     void reattach(StyleRuleBase&) final;
 
     Ref<StyleRuleFontFeatureValuesBlock> m_fontFeatureValuesBlockRule;

--- a/Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.cpp
+++ b/Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.cpp
@@ -30,9 +30,11 @@
 
 namespace WebCore {
 
-String CSSFontPaletteValuesOverrideColorsValue::customCSSText() const
+void CSSFontPaletteValuesOverrideColorsValue::customCSSText(StringBuilder& builder) const
 {
-    return makeString(m_key->cssText(), ' ', m_color->cssText());
+    m_key->cssText(builder);
+    builder.append(' ');
+    m_color->cssText(builder);
 }
 
 bool CSSFontPaletteValuesOverrideColorsValue::equals(const CSSFontPaletteValuesOverrideColorsValue& other) const

--- a/Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.h
+++ b/Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.h
@@ -56,7 +56,7 @@ public:
         return m_color.get();
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     bool equals(const CSSFontPaletteValuesOverrideColorsValue&) const;
 

--- a/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontPaletteValuesRule.cpp
@@ -53,10 +53,10 @@ String CSSFontPaletteValuesRule::name() const
 
 String CSSFontPaletteValuesRule::fontFamily() const
 {
-    auto serialize = [] (auto& family) {
-        return serializeFontFamily(family.string());
+    auto serialize = [](auto& builder, auto& family) {
+        return serializeFontFamily(builder, family.string());
     };
-    return makeStringByJoining(m_fontPaletteValuesRule->fontFamilies().map(serialize).span(), ", "_s);
+    return makeString(interleave(m_fontPaletteValuesRule->fontFamilies(), serialize, ", "_s));
 }
 
 String CSSFontPaletteValuesRule::basePalette() const
@@ -87,9 +87,8 @@ String CSSFontPaletteValuesRule::overrideColors() const
     return result.toString();
 }
 
-String CSSFontPaletteValuesRule::cssText() const
+void CSSFontPaletteValuesRule::cssText(StringBuilder& builder) const
 {
-    StringBuilder builder;
     builder.append("@font-palette-values "_s, name(), " { "_s);
     if (!m_fontPaletteValuesRule->fontFamilies().isEmpty())
         builder.append("font-family: "_s, fontFamily(), "; "_s);
@@ -113,12 +112,12 @@ String CSSFontPaletteValuesRule::cssText() const
         for (size_t i = 0; i < m_fontPaletteValuesRule->overrideColors().size(); ++i) {
             if (i)
                 builder.append(',');
-            builder.append(' ', m_fontPaletteValuesRule->overrideColors()[i].first, ' ', serializationForCSS(m_fontPaletteValuesRule->overrideColors()[i].second));
+            builder.append(' ', m_fontPaletteValuesRule->overrideColors()[i].first, ' ');
+            serializationForCSS(builder, m_fontPaletteValuesRule->overrideColors()[i].second);
         }
         builder.append("; "_s);
     }
     builder.append('}');
-    return builder.toString();
 }
 
 void CSSFontPaletteValuesRule::reattach(StyleRuleBase& rule)

--- a/Source/WebCore/css/CSSFontPaletteValuesRule.h
+++ b/Source/WebCore/css/CSSFontPaletteValuesRule.h
@@ -49,7 +49,7 @@ private:
     CSSFontPaletteValuesRule(StyleRuleFontPaletteValues&, CSSStyleSheet* parent);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::FontPaletteValues; }
-    String cssText() const final;
+    void cssText(StringBuilder&) const final;
     void reattach(StyleRuleBase&) final;
 
     Ref<StyleRuleFontPaletteValues> m_fontPaletteValuesRule;

--- a/Source/WebCore/css/CSSFontStyleRangeValue.cpp
+++ b/Source/WebCore/css/CSSFontStyleRangeValue.cpp
@@ -30,16 +30,16 @@
 
 namespace WebCore {
 
-String CSSFontStyleRangeValue::customCSSText() const
+void CSSFontStyleRangeValue::customCSSText(StringBuilder& builder) const
 {
-    if (!obliqueValues)
-        return fontStyleValue->cssText();
+    if (!obliqueValues) {
+        fontStyleValue->cssText(builder);
+        return;
+    }
 
-    StringBuilder builder;
-    builder.append(fontStyleValue->cssText());
+    fontStyleValue->cssText(builder);
     builder.append(' ');
-    builder.append(obliqueValues->cssText());
-    return builder.toString();
+    obliqueValues->cssText(builder);
 }
 
 bool CSSFontStyleRangeValue::equals(const CSSFontStyleRangeValue& other) const

--- a/Source/WebCore/css/CSSFontStyleRangeValue.h
+++ b/Source/WebCore/css/CSSFontStyleRangeValue.h
@@ -42,7 +42,7 @@ public:
         return adoptRef(*new CSSFontStyleRangeValue(WTFMove(fontStyleValue), WTFMove(obliqueValues)));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     bool equals(const CSSFontStyleRangeValue&) const;
 

--- a/Source/WebCore/css/CSSFontStyleWithAngleValue.cpp
+++ b/Source/WebCore/css/CSSFontStyleWithAngleValue.cpp
@@ -41,9 +41,10 @@ Ref<CSSFontStyleWithAngleValue> CSSFontStyleWithAngleValue::create(Ref<CSSPrimit
     return adoptRef(*new CSSFontStyleWithAngleValue(WTFMove(obliqueAngle)));
 }
 
-String CSSFontStyleWithAngleValue::customCSSText() const
+void CSSFontStyleWithAngleValue::customCSSText(StringBuilder& builder) const
 {
-    return makeString("oblique "_s, m_obliqueAngle->cssText());
+    builder.append("oblique "_s);
+    m_obliqueAngle->cssText(builder);
 }
 
 bool CSSFontStyleWithAngleValue::equals(const CSSFontStyleWithAngleValue& other) const

--- a/Source/WebCore/css/CSSFontStyleWithAngleValue.h
+++ b/Source/WebCore/css/CSSFontStyleWithAngleValue.h
@@ -36,7 +36,8 @@ public:
 
     const CSSPrimitiveValue& obliqueAngle() const { return m_obliqueAngle; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSFontStyleWithAngleValue&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const

--- a/Source/WebCore/css/CSSFontValue.cpp
+++ b/Source/WebCore/css/CSSFontValue.cpp
@@ -27,25 +27,33 @@
 
 namespace WebCore {
 
-String CSSFontValue::customCSSText() const
+void CSSFontValue::customCSSText(StringBuilder& builder) const
 {
-    // font variant weight size / line-height family
-    StringBuilder result;
-    if (style)
-        result.append(style->cssText());
-    if (variant)
-        result.append(result.isEmpty() ? ""_s : " "_s, variant->cssText());
-    if (weight)
-        result.append(result.isEmpty() ? ""_s : " "_s, weight->cssText());
-    if (stretch)
-        result.append(result.isEmpty() ? ""_s : " "_s, stretch->cssText());
-    if (size)
-        result.append(result.isEmpty() ? ""_s : " "_s, size->cssText());
-    if (lineHeight)
-        result.append(size ? " / "_s : result.isEmpty() ? ""_s : " "_s, lineHeight->cssText());
-    if (family)
-        result.append(result.isEmpty() ? ""_s : " "_s, family->cssText());
-    return result.toString();
+    auto initialLengthOfBuilder = builder.length();
+
+    auto append = [&](auto& arg) {
+        if (!arg)
+            return;
+        if (initialLengthOfBuilder != builder.length())
+            builder.append(' ');
+        arg->cssText(builder);
+    };
+
+    append(style);
+    append(variant);
+    append(weight);
+    append(stretch);
+    append(size);
+
+    if (lineHeight) {
+        if (size)
+            builder.append(" / "_s);
+        else if (initialLengthOfBuilder != builder.length())
+            builder.append(' ');
+        lineHeight->cssText(builder);
+    }
+
+    append(family);
 }
 
 bool CSSFontValue::equals(const CSSFontValue& other) const

--- a/Source/WebCore/css/CSSFontValue.h
+++ b/Source/WebCore/css/CSSFontValue.h
@@ -35,7 +35,7 @@ public:
         return adoptRef(*new CSSFontValue);
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     bool equals(const CSSFontValue&) const;
 

--- a/Source/WebCore/css/CSSFontVariantAlternatesValue.cpp
+++ b/Source/WebCore/css/CSSFontVariantAlternatesValue.cpp
@@ -36,13 +36,35 @@ CSSFontVariantAlternatesValue::CSSFontVariantAlternatesValue(FontVariantAlternat
 {
 }
 
-String CSSFontVariantAlternatesValue::customCSSText() const
+void CSSFontVariantAlternatesValue::customCSSText(StringBuilder& builder) const
 {
-    TextStream ts;
-    // For the moment, the stream operator implements the CSS serialization exactly.
-    // If it changes for whatever reason, we should reimplement the CSS serialization here.
-    ts << m_value;
-    return ts.release();
+    if (m_value.isNormal()) {
+        builder.append("normal"_s);
+        return;
+    }
+
+    auto initialLengthOfBuilder = builder.length();
+
+    auto values = m_value.values();
+    auto append = [&]<typename ...Ts>(Ts&& ...args) {
+        // Separate elements with a space.
+        builder.append(initialLengthOfBuilder == builder.length() ? ""_s: " "_s, std::forward<Ts>(args)...);
+    };
+    // FIXME: These strings needs to be escaped.
+    if (!values.stylistic.isNull())
+        append("stylistic("_s, values.stylistic, ')');
+    if (values.historicalForms)
+        append("historical-forms"_s);
+    if (!values.styleset.isEmpty())
+        append("styleset("_s, interleave(values.styleset, ", "_s), ')');
+    if (!values.characterVariant.isEmpty())
+        append("character-variant("_s, interleave(values.characterVariant, ", "_s), ')');
+    if (!values.swash.isNull())
+        append("swash("_s, values.swash, ')');
+    if (!values.ornaments.isNull())
+        append("ornaments("_s, values.ornaments, ')');
+    if (!values.annotation.isNull())
+        append("annotation("_s, values.annotation, ')');
 }
 
 bool CSSFontVariantAlternatesValue::equals(const CSSFontVariantAlternatesValue& other) const

--- a/Source/WebCore/css/CSSFontVariantAlternatesValue.h
+++ b/Source/WebCore/css/CSSFontVariantAlternatesValue.h
@@ -39,7 +39,8 @@ public:
     }
 
     const FontVariantAlternates& value() const { return m_value; }
-    String customCSSText() const;
+
+    void customCSSText(StringBuilder&) const;
 
     bool equals(const CSSFontVariantAlternatesValue&) const;
 

--- a/Source/WebCore/css/CSSFontVariationValue.cpp
+++ b/Source/WebCore/css/CSSFontVariationValue.cpp
@@ -42,6 +42,11 @@ String CSSFontVariationValue::customCSSText() const
     return makeString('"', m_tag[0], m_tag[1], m_tag[2], m_tag[3], "\" "_s, m_value);
 }
 
+void CSSFontVariationValue::customCSSText(StringBuilder& builder) const
+{
+    builder.append('"', m_tag[0], m_tag[1], m_tag[2], m_tag[3], "\" "_s, m_value);
+}
+
 bool CSSFontVariationValue::equals(const CSSFontVariationValue& other) const
 {
     return m_tag == other.m_tag && m_value == other.m_value;

--- a/Source/WebCore/css/CSSFontVariationValue.h
+++ b/Source/WebCore/css/CSSFontVariationValue.h
@@ -39,7 +39,9 @@ public:
 
     const FontTag& tag() const { return m_tag; }
     float value() const { return m_value; }
+
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     bool equals(const CSSFontVariationValue&) const;
 

--- a/Source/WebCore/css/CSSFunctionValue.cpp
+++ b/Source/WebCore/css/CSSFunctionValue.cpp
@@ -99,13 +99,11 @@ Ref<CSSFunctionValue> CSSFunctionValue::create(CSSValueID name, Ref<CSSValue> ar
     return adoptRef(*new CSSFunctionValue(name, WTFMove(argument1), WTFMove(argument2), WTFMove(argument3), WTFMove(argument4)));
 }
 
-String CSSFunctionValue::customCSSText() const
+void CSSFunctionValue::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder result;
-    result.append(nameLiteral(m_name), '(');
-    serializeItems(result);
-    result.append(')');
-    return result.toString();
+    builder.append(nameLiteral(m_name), '(');
+    serializeItems(builder);
+    builder.append(')');
 }
 
 bool CSSFunctionValue::addDerivedHash(Hasher& hasher) const

--- a/Source/WebCore/css/CSSFunctionValue.h
+++ b/Source/WebCore/css/CSSFunctionValue.h
@@ -42,7 +42,8 @@ public:
 
     CSSValueID name() const { return m_name; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSFunctionValue& other) const { return m_name == other.m_name && itemsEqual(other); }
 
 private:

--- a/Source/WebCore/css/CSSGradientValue.h
+++ b/Source/WebCore/css/CSSGradientValue.h
@@ -116,7 +116,8 @@ public:
         return adoptRef(*new CSSLinearGradientValue(WTFMove(data), repeating, colorInterpolationMethod, WTFMove(stops)));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSLinearGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
@@ -193,7 +194,8 @@ public:
         return adoptRef(*new CSSPrefixedLinearGradientValue(WTFMove(data), repeating, colorInterpolationMethod, WTFMove(stops)));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSPrefixedLinearGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
@@ -267,7 +269,8 @@ public:
         return adoptRef(*new CSSDeprecatedLinearGradientValue(WTFMove(data), colorInterpolationMethod, WTFMove(stops)));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSDeprecatedLinearGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
@@ -378,7 +381,8 @@ public:
         return adoptRef(*new CSSRadialGradientValue(WTFMove(data), repeating, colorInterpolationMethod, WTFMove(stops)));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSRadialGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
@@ -552,7 +556,8 @@ public:
         return adoptRef(*new CSSPrefixedRadialGradientValue(WTFMove(data), repeating, colorInterpolationMethod, WTFMove(stops)));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSPrefixedRadialGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
@@ -636,7 +641,8 @@ public:
         return adoptRef(*new CSSDeprecatedRadialGradientValue(WTFMove(data), colorInterpolationMethod, WTFMove(stops)));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSDeprecatedRadialGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 
@@ -735,7 +741,8 @@ public:
         return adoptRef(*new CSSConicGradientValue(WTFMove(data), repeating, colorInterpolationMethod, WTFMove(stops)));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSConicGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 

--- a/Source/WebCore/css/CSSGridAutoRepeatValue.cpp
+++ b/Source/WebCore/css/CSSGridAutoRepeatValue.cpp
@@ -53,13 +53,11 @@ CSSValueID CSSGridAutoRepeatValue::autoRepeatID() const
     return m_isAutoFit ? CSSValueAutoFit : CSSValueAutoFill;
 }
 
-String CSSGridAutoRepeatValue::customCSSText() const
+void CSSGridAutoRepeatValue::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder result;
-    result.append("repeat("_s, nameLiteral(autoRepeatID()), ", "_s);
-    serializeItems(result);
-    result.append(')');
-    return result.toString();
+    builder.append("repeat("_s, nameLiteral(autoRepeatID()), ", "_s);
+    serializeItems(builder);
+    builder.append(')');
 }
 
 bool CSSGridAutoRepeatValue::equals(const CSSGridAutoRepeatValue& other) const

--- a/Source/WebCore/css/CSSGridAutoRepeatValue.h
+++ b/Source/WebCore/css/CSSGridAutoRepeatValue.h
@@ -51,7 +51,8 @@ public:
 
     CSSValueID autoRepeatID() const;
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSGridAutoRepeatValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSGridIntegerRepeatValue.cpp
+++ b/Source/WebCore/css/CSSGridIntegerRepeatValue.cpp
@@ -47,13 +47,11 @@ Ref<CSSGridIntegerRepeatValue> CSSGridIntegerRepeatValue::create(size_t repetiti
     return adoptRef(*new CSSGridIntegerRepeatValue(repetitions, WTFMove(builder)));
 }
 
-String CSSGridIntegerRepeatValue::customCSSText() const
+void CSSGridIntegerRepeatValue::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder result;
-    result.append("repeat("_s, repetitions(), ", "_s);
-    serializeItems(result);
-    result.append(')');
-    return result.toString();
+    builder.append("repeat("_s, m_repetitions, ", "_s);
+    serializeItems(builder);
+    builder.append(')');
 }
 
 bool CSSGridIntegerRepeatValue::equals(const CSSGridIntegerRepeatValue& other) const

--- a/Source/WebCore/css/CSSGridIntegerRepeatValue.h
+++ b/Source/WebCore/css/CSSGridIntegerRepeatValue.h
@@ -48,7 +48,8 @@ public:
 
     size_t repetitions() const { return m_repetitions; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSGridIntegerRepeatValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSGridLineNamesValue.cpp
+++ b/Source/WebCore/css/CSSGridLineNamesValue.cpp
@@ -36,18 +36,9 @@
 
 namespace WebCore {
 
-String CSSGridLineNamesValue::customCSSText() const
+void CSSGridLineNamesValue::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder result;
-    result.append('[');
-    bool first = true;
-    for (auto& name : m_names) {
-        if (!std::exchange(first, false))
-            result.append(' ');
-        serializeIdentifier(name, result);
-    }
-    result.append(']');
-    return result.toString();
+    builder.append('[', interleave(m_names, [](auto& builder, auto& name) { serializeIdentifier(builder, name); }, ' '), ']');
 }
 
 CSSGridLineNamesValue::CSSGridLineNamesValue(std::span<const String> names)

--- a/Source/WebCore/css/CSSGridLineNamesValue.h
+++ b/Source/WebCore/css/CSSGridLineNamesValue.h
@@ -42,7 +42,8 @@ public:
 
     std::span<const String> names() const { return m_names; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSGridLineNamesValue& other) const { return m_names == other.m_names; }
 
 private:

--- a/Source/WebCore/css/CSSGridTemplateAreasValue.cpp
+++ b/Source/WebCore/css/CSSGridTemplateAreasValue.cpp
@@ -55,7 +55,7 @@ Ref<CSSGridTemplateAreasValue> CSSGridTemplateAreasValue::create(NamedGridAreaMa
     return adoptRef(*new CSSGridTemplateAreasValue(WTFMove(map), rowCount, columnCount));
 }
 
-static String stringForPosition(const NamedGridAreaMap& gridAreaMap, size_t row, size_t column)
+static void serializePosition(StringBuilder& builder, const NamedGridAreaMap& gridAreaMap, size_t row, size_t column)
 {
     HashSet<String> candidates;
     for (auto& it : gridAreaMap.map) {
@@ -65,10 +65,13 @@ static String stringForPosition(const NamedGridAreaMap& gridAreaMap, size_t row,
     }
     for (auto& it : gridAreaMap.map) {
         auto& area = it.value;
-        if (column >= area.columns.startLine() && column < area.columns.endLine() && candidates.contains(it.key))
-            return it.key;
+        if (column >= area.columns.startLine() && column < area.columns.endLine() && candidates.contains(it.key)) {
+            builder.append(it.key);
+            return;
+        }
     }
-    return "."_s;
+
+    builder.append('.');;
 }
 
 String CSSGridTemplateAreasValue::stringForRow(size_t row) const
@@ -95,13 +98,12 @@ String CSSGridTemplateAreasValue::stringForRow(size_t row) const
     return builder.toString();
 }
 
-String CSSGridTemplateAreasValue::customCSSText() const
+void CSSGridTemplateAreasValue::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder builder;
     for (size_t row = 0; row < m_rowCount; ++row) {
         builder.append('"');
         for (size_t column = 0; column < m_columnCount; ++column) {
-            builder.append(stringForPosition(m_map, row, column));
+            serializePosition(builder, m_map, row, column);
             if (column != m_columnCount - 1)
                 builder.append(' ');
         }
@@ -109,7 +111,6 @@ String CSSGridTemplateAreasValue::customCSSText() const
         if (row != m_rowCount - 1)
             builder.append(' ');
     }
-    return builder.toString();
 }
 
 bool CSSGridTemplateAreasValue::equals(const CSSGridTemplateAreasValue& other) const

--- a/Source/WebCore/css/CSSGridTemplateAreasValue.h
+++ b/Source/WebCore/css/CSSGridTemplateAreasValue.h
@@ -40,7 +40,7 @@ class CSSGridTemplateAreasValue final : public CSSValue {
 public:
     static Ref<CSSGridTemplateAreasValue> create(NamedGridAreaMap, size_t rowCount, size_t columnCount);
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     const NamedGridAreaMap& gridAreaMap() const { return m_map; }
     size_t rowCount() const { return m_rowCount; }

--- a/Source/WebCore/css/CSSGroupingRule.h
+++ b/Source/WebCore/css/CSSGroupingRule.h
@@ -52,9 +52,8 @@ protected:
 
 private:
     bool isGroupingRule() const final { return true; }
-    void appendCSSTextForItemsInternal(StringBuilder&, StringBuilder&) const;
-    void cssTextForRules(StringBuilder&) const;
-    void cssTextForRulesWithReplacementURLs(StringBuilder&, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const;
+
+    template<typename F> void appendCSSTextForItemsInternal(StringBuilder&, F&&) const;
 
     Ref<StyleRuleGroup> m_groupRule;
     mutable Vector<RefPtr<CSSRule>> m_childRuleCSSOMWrappers;

--- a/Source/WebCore/css/CSSImageSetOptionValue.cpp
+++ b/Source/WebCore/css/CSSImageSetOptionValue.cpp
@@ -77,15 +77,13 @@ bool CSSImageSetOptionValue::equals(const CSSImageSetOptionValue& other) const
     return true;
 }
 
-String CSSImageSetOptionValue::customCSSText() const
+void CSSImageSetOptionValue::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder result;
-    result.append(m_image->cssText());
-    result.append(' ', m_resolution->cssText());
+    m_image->cssText(builder);
+    builder.append(' ');
+    m_resolution->cssText(builder);
     if (!m_mimeType.isNull())
-        result.append(" type(\""_s, m_mimeType, "\")"_s);
-
-    return result.toString();
+        builder.append(" type(\""_s, m_mimeType, "\")"_s);
 }
 
 void CSSImageSetOptionValue::setResolution(Ref<CSSPrimitiveValue>&& resolution)

--- a/Source/WebCore/css/CSSImageSetOptionValue.h
+++ b/Source/WebCore/css/CSSImageSetOptionValue.h
@@ -38,8 +38,9 @@ public:
     static Ref<CSSImageSetOptionValue> create(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&);
     static Ref<CSSImageSetOptionValue> create(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&, String);
 
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSImageSetOptionValue&) const;
-    String customCSSText() const;
 
     Ref<CSSValue> image() const { return m_image; }
 

--- a/Source/WebCore/css/CSSImageSetValue.cpp
+++ b/Source/WebCore/css/CSSImageSetValue.cpp
@@ -46,18 +46,13 @@ CSSImageSetValue::CSSImageSetValue(CSSValueListBuilder builder)
 {
 }
 
-String CSSImageSetValue::customCSSText() const
+void CSSImageSetValue::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder result;
-    result.append("image-set("_s);
-    for (size_t i = 0; i < this->length(); ++i) {
-        if (i > 0)
-            result.append(", "_s);
-        ASSERT(is<CSSImageSetOptionValue>(item(i)));
-        result.append(item(i)->cssText());
-    }
-    result.append(')');
-    return result.toString();
+    builder.append(
+        "image-set("_s,
+        interleave(*this, [](auto& builder, auto& value) { value.cssText(builder); }, ", "_s),
+        ')'
+    );
 }
 
 RefPtr<StyleImage> CSSImageSetValue::createStyleImage(Style::BuilderState& state) const

--- a/Source/WebCore/css/CSSImageSetValue.h
+++ b/Source/WebCore/css/CSSImageSetValue.h
@@ -39,7 +39,8 @@ class CSSImageSetValue final : public CSSValueContainingVector {
 public:
     static Ref<CSSImageSetValue> create(CSSValueListBuilder);
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSImageSetValue& other) const { return itemsEqual(other); }
 
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -161,6 +161,24 @@ String CSSImageValue::customCSSText() const
     return serializeURL(m_location.specifiedURLString);
 }
 
+void CSSImageValue::customCSSText(StringBuilder& builder) const
+{
+    if (m_isInvalid)
+        return;
+
+    if (!m_replacementURLString.isEmpty()) {
+        serializeURL(builder, m_replacementURLString);
+        return;
+    }
+
+    if (m_shouldUseResolvedURLInCSSText) {
+        serializeURL(builder, m_location.resolvedURL.string());
+        return;
+    }
+
+    serializeURL(builder, m_location.specifiedURLString);
+}
+
 Ref<DeprecatedCSSOMValue> CSSImageValue::createDeprecatedCSSOMWrapper(CSSStyleDeclaration& styleDeclaration) const
 {
     // We expose CSSImageValues as URI primitive values in CSSOM to maintain old behavior.

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -57,6 +57,7 @@ public:
     URL reresolvedURL(const Document&) const;
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     Ref<DeprecatedCSSOMValue> createDeprecatedCSSOMWrapper(CSSStyleDeclaration&) const;
 

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -52,12 +52,12 @@ private:
     CSSImportRule(StyleRuleImport&, CSSStyleSheet*);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Import; }
-    String cssText() const final;
-    String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
+    void cssText(StringBuilder&) const final;
+    void cssTextWithReplacementURLs(StringBuilder&, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
     void reattach(StyleRuleBase&) final;
     void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) final;
 
-    String cssTextInternal(const String& urlString) const;
+    void cssTextInternal(StringBuilder&, const String& urlString) const;
     const MQ::MediaQueryList& mediaQueries() const;
     void setMediaQueries(MQ::MediaQueryList&&);
 

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -74,15 +74,16 @@ MutableStyleProperties& StyleRuleKeyframe::mutableProperties()
 
 String StyleRuleKeyframe::keyText() const
 {
-    StringBuilder keyText;
-    for (size_t i = 0; i < m_keys.size(); ++i) {
-        if (i)
-            keyText.append(',');
-        keyText.append(m_keys[i] * 100, '%');
-    }
-    return keyText.toString();
+    StringBuilder builder;
+    keyText(builder);
+    return builder.toString();
 }
-    
+
+void StyleRuleKeyframe::keyText(StringBuilder& builder) const
+{
+    builder.append(interleave(m_keys, [](auto& builder, auto& key) { builder.append(key * 100, '%'); }, ','));
+}
+
 bool StyleRuleKeyframe::setKeyText(const String& keyText)
 {
     ASSERT(!keyText.isNull());
@@ -93,11 +94,18 @@ bool StyleRuleKeyframe::setKeyText(const String& keyText)
     return true;
 }
 
-String StyleRuleKeyframe::cssText() const
+void StyleRuleKeyframe::cssText(StringBuilder& builder) const
 {
-    if (auto declarations = m_properties->asText(); !declarations.isEmpty())
-        return makeString(keyText(), " { "_s, declarations, " }"_s);
-    return makeString(keyText(), " { }"_s);
+    keyText(builder);;
+    builder.append(" { "_s);
+
+    if (m_properties->isEmpty()) {
+        builder.append('}');
+        return;
+    }
+
+    m_properties->asText(builder);
+    builder.append(" }"_s);
 }
 
 CSSKeyframeRule::CSSKeyframeRule(StyleRuleKeyframe& keyframe, CSSKeyframesRule* parent)

--- a/Source/WebCore/css/CSSKeyframeRule.h
+++ b/Source/WebCore/css/CSSKeyframeRule.h
@@ -44,6 +44,7 @@ public:
     Ref<StyleRuleKeyframe> copy() const { RELEASE_ASSERT_NOT_REACHED(); }
 
     String keyText() const;
+    void keyText(StringBuilder&) const;
     bool setKeyText(const String&);
     void setKey(double key)
     {
@@ -57,7 +58,7 @@ public:
     const StyleProperties& properties() const { return m_properties; }
     MutableStyleProperties& mutableProperties();
 
-    String cssText() const;
+    void cssText(StringBuilder&) const;
 
 private:
     explicit StyleRuleKeyframe(Ref<StyleProperties>&&);
@@ -71,7 +72,7 @@ class CSSKeyframeRule final : public CSSRule {
 public:
     virtual ~CSSKeyframeRule();
 
-    String cssText() const final { return m_keyframe->cssText(); }
+    void cssText(StringBuilder& builder) const final { return m_keyframe->cssText(builder); }
     void reattach(StyleRuleBase&) final;
 
     String keyText() const { return m_keyframe->keyText(); }

--- a/Source/WebCore/css/CSSKeyframesRule.cpp
+++ b/Source/WebCore/css/CSSKeyframesRule.cpp
@@ -157,14 +157,15 @@ CSSKeyframeRule* CSSKeyframesRule::findRule(const String& s)
     return i ? item(*i) : nullptr;
 }
 
-String CSSKeyframesRule::cssText() const
+void CSSKeyframesRule::cssText(StringBuilder& builder) const
 {
-    StringBuilder result;
-    result.append("@keyframes "_s, name(), " { \n"_s);
-    for (unsigned i = 0, size = length(); i < size; ++i)
-        result.append("  "_s, m_keyframesRule->keyframes()[i]->cssText(), '\n');
-    result.append('}');
-    return result.toString();
+    builder.append("@keyframes "_s, name(), " { \n"_s);
+    for (unsigned i = 0, size = length(); i < size; ++i) {
+        builder.append("  "_s);
+        m_keyframesRule->keyframes()[i]->cssText(builder);
+        builder.append('\n');
+    }
+    builder.append('}');
 }
 
 unsigned CSSKeyframesRule::length() const

--- a/Source/WebCore/css/CSSKeyframesRule.h
+++ b/Source/WebCore/css/CSSKeyframesRule.h
@@ -72,7 +72,7 @@ public:
     virtual ~CSSKeyframesRule();
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Keyframes; }
-    String cssText() const final;
+    void cssText(StringBuilder&) const final;
     void reattach(StyleRuleBase&) final;
 
     const AtomString& name() const { return m_keyframesRule->name(); }

--- a/Source/WebCore/css/CSSLayerBlockRule.h
+++ b/Source/WebCore/css/CSSLayerBlockRule.h
@@ -42,7 +42,7 @@ class CSSLayerBlockRule final : public CSSGroupingRule {
 public:
     static Ref<CSSLayerBlockRule> create(StyleRuleLayer&, CSSStyleSheet* parent);
 
-    String cssText() const final;
+    void cssText(StringBuilder&) const final;
     String name() const;
 
 private:
@@ -50,7 +50,8 @@ private:
     StyleRuleType styleRuleType() const final { return StyleRuleType::LayerBlock; }
 };
 
-String stringFromCascadeLayerName(const CascadeLayerName&);
+String serializedCascadeLayerName(const CascadeLayerName&);
+void serializedCascadeLayerName(StringBuilder&, const CascadeLayerName&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/css/CSSLayerStatementRule.cpp
+++ b/Source/WebCore/css/CSSLayerStatementRule.cpp
@@ -51,31 +51,16 @@ Ref<CSSLayerStatementRule> CSSLayerStatementRule::create(StyleRuleLayer& rule, C
 
 CSSLayerStatementRule::~CSSLayerStatementRule() = default;
 
-String CSSLayerStatementRule::cssText() const
+void CSSLayerStatementRule::cssText(StringBuilder& builder) const
 {
-    StringBuilder result;
-
-    result.append("@layer "_s);
-
-    auto nameList = this->nameList();
-    for (auto& name : nameList) {
-        result.append(name);
-        if (&name != &nameList.last())
-            result.append(", "_s);
-    }
-    result.append(';');
-
-    return result.toString();
+    builder.append("@layer "_s, interleave(m_layerRule->nameList(), serializedCascadeLayerName, ", "_s), ';');
 }
 
 Vector<String> CSSLayerStatementRule::nameList() const
 {
-    Vector<String> result;
-
-    for (auto& name : m_layerRule.get().nameList())
-        result.append(stringFromCascadeLayerName(name));
-
-    return result;
+    return WTF::map(m_layerRule->nameList(), [](auto& name) {
+        return serializedCascadeLayerName(name);
+    });
 }
 
 void CSSLayerStatementRule::reattach(StyleRuleBase& rule)

--- a/Source/WebCore/css/CSSLayerStatementRule.h
+++ b/Source/WebCore/css/CSSLayerStatementRule.h
@@ -40,7 +40,7 @@ public:
     static Ref<CSSLayerStatementRule> create(StyleRuleLayer&, CSSStyleSheet* parent);
     virtual ~CSSLayerStatementRule();
 
-    String cssText() const final;
+    void cssText(StringBuilder&) const final;
     Vector<String> nameList() const;
 
 private:

--- a/Source/WebCore/css/CSSLineBoxContainValue.cpp
+++ b/Source/WebCore/css/CSSLineBoxContainValue.cpp
@@ -36,24 +36,22 @@ CSSLineBoxContainValue::CSSLineBoxContainValue(OptionSet<LineBoxContain> value)
 {
 }
 
-String CSSLineBoxContainValue::customCSSText() const
+void CSSLineBoxContainValue::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder text;
-    if (m_value.contains(LineBoxContain::Block))
-        text.append("block"_s);
-    if (m_value.contains(LineBoxContain::Inline))
-        text.append(text.isEmpty() ? ""_s : " "_s, "inline"_s);
-    if (m_value.contains(LineBoxContain::Font))
-        text.append(text.isEmpty() ? ""_s : " "_s, "font"_s);
-    if (m_value.contains(LineBoxContain::Glyphs))
-        text.append(text.isEmpty() ? ""_s : " "_s, "glyphs"_s);
-    if (m_value.contains(LineBoxContain::Replaced))
-        text.append(text.isEmpty() ? ""_s : " "_s, "replaced"_s);
-    if (m_value.contains(LineBoxContain::InlineBox))
-        text.append(text.isEmpty() ? ""_s : " "_s, "inline-box"_s);
-    if (m_value.contains(LineBoxContain::InitialLetter))
-        text.append(text.isEmpty() ? ""_s : " "_s, "initial-letter"_s);
-    return text.toString();
+    auto initialLengthOfBuilder = builder.length();
+
+    auto append = [&](LineBoxContain option, ASCIILiteral literal) {
+        if (m_value.contains(option))
+            builder.append(initialLengthOfBuilder != builder.length() ? " "_s : ""_s, literal);
+    };
+
+    append(LineBoxContain::Block, "block"_s);
+    append(LineBoxContain::Inline, "inline"_s);
+    append(LineBoxContain::Font, "font"_s);
+    append(LineBoxContain::Glyphs, "glyphs"_s);
+    append(LineBoxContain::Replaced, "replaced"_s);
+    append(LineBoxContain::InlineBox, "inline-box"_s);
+    append(LineBoxContain::InitialLetter, "initial-letter"_s);
 }
 
 }

--- a/Source/WebCore/css/CSSLineBoxContainValue.h
+++ b/Source/WebCore/css/CSSLineBoxContainValue.h
@@ -51,7 +51,8 @@ public:
         return adoptRef(*new CSSLineBoxContainValue(value));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSLineBoxContainValue& other) const { return m_value == other.m_value; }
     OptionSet<LineBoxContain> value() const { return m_value; }
 

--- a/Source/WebCore/css/CSSMarkup.h
+++ b/Source/WebCore/css/CSSMarkup.h
@@ -29,10 +29,17 @@
 namespace WebCore {
 
 // Common serializing methods. See: http://dev.w3.org/csswg/cssom/#common-serializing-idioms
-void serializeIdentifier(const String& identifier, StringBuilder& appendTo, bool skipStartChecks = false);
-void serializeString(const String&, StringBuilder& appendTo);
+
+void serializeIdentifier(StringBuilder&, const String& identifier, bool skipStartChecks = false);
+String serializeIdentifier(const String& identifier, bool skipStartChecks = false);
+
+void serializeString(StringBuilder&, const String&);
 String serializeString(const String&);
+
+void serializeURL(StringBuilder&, const String&);
 String serializeURL(const String&);
+
+void serializeFontFamily(StringBuilder&, const String&);
 String serializeFontFamily(const String&);
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSMediaRule.cpp
+++ b/Source/WebCore/css/CSSMediaRule.cpp
@@ -52,20 +52,18 @@ void CSSMediaRule::setMediaQueries(MQ::MediaQueryList&& queries)
     downcast<StyleRuleMedia>(groupRule()).setMediaQueries(WTFMove(queries));
 }
 
-String CSSMediaRule::cssText() const
+void CSSMediaRule::cssText(StringBuilder& builder) const
 {
-    StringBuilder builder;
-    builder.append("@media "_s, conditionText());
+    builder.append("@media "_s);
+    MQ::serialize(builder, mediaQueries());
     appendCSSTextForItems(builder);
-    return builder.toString();
 }
 
-String CSSMediaRule::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
+void CSSMediaRule::cssTextWithReplacementURLs(StringBuilder& builder, const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
 {
-    StringBuilder builder;
-    builder.append("@media "_s, conditionText());
+    builder.append("@media "_s);
+    MQ::serialize(builder, mediaQueries());
     appendCSSTextWithReplacementURLsForItems(builder, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
-    return builder.toString();
 }
 
 String CSSMediaRule::conditionText() const

--- a/Source/WebCore/css/CSSMediaRule.h
+++ b/Source/WebCore/css/CSSMediaRule.h
@@ -47,8 +47,8 @@ private:
     CSSMediaRule(StyleRuleMedia&, CSSStyleSheet*);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Media; }
-    String cssText() const final;
-    String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
+    void cssText(StringBuilder&) const final;
+    void cssTextWithReplacementURLs(StringBuilder&, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
     String conditionText() const final;
 
     const MQ::MediaQueryList& mediaQueries() const;

--- a/Source/WebCore/css/CSSNamedImageValue.cpp
+++ b/Source/WebCore/css/CSSNamedImageValue.cpp
@@ -44,6 +44,11 @@ String CSSNamedImageValue::customCSSText() const
     return makeString("-webkit-named-image("_s, m_name, ')');
 }
 
+void CSSNamedImageValue::customCSSText(StringBuilder& builder) const
+{
+    builder.append("-webkit-named-image("_s, m_name, ')');
+}
+
 bool CSSNamedImageValue::equals(const CSSNamedImageValue& other) const
 {
     return m_name == other.m_name;

--- a/Source/WebCore/css/CSSNamedImageValue.h
+++ b/Source/WebCore/css/CSSNamedImageValue.h
@@ -45,6 +45,8 @@ public:
     ~CSSNamedImageValue();
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSNamedImageValue&) const;
 
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;

--- a/Source/WebCore/css/CSSNamespaceRule.cpp
+++ b/Source/WebCore/css/CSSNamespaceRule.cpp
@@ -50,14 +50,14 @@ AtomString CSSNamespaceRule::prefix() const
     return m_namespaceRule->prefix();
 }
 
-String CSSNamespaceRule::cssText() const
+void CSSNamespaceRule::cssText(StringBuilder& builder) const
 {
     auto prefix = this->prefix();
-    StringBuilder result;
-    result.append("@namespace "_s);
-    serializeIdentifier(prefix, result);
-    result.append(prefix.isEmpty() ? ""_s : " "_s, "url("_s, serializeString(namespaceURI()), ");"_s);
-    return result.toString();
+    builder.append("@namespace "_s);
+    serializeIdentifier(builder, prefix);
+    builder.append(prefix.isEmpty() ? ""_s : " "_s, "url("_s);
+    serializeString(builder, namespaceURI());
+    builder.append(");"_s);
 }
 
 void CSSNamespaceRule::reattach(StyleRuleBase&)

--- a/Source/WebCore/css/CSSNamespaceRule.h
+++ b/Source/WebCore/css/CSSNamespaceRule.h
@@ -44,7 +44,7 @@ private:
     CSSNamespaceRule(StyleRuleNamespace&, CSSStyleSheet*);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Namespace; }
-    String cssText() const final;
+    void cssText(StringBuilder&) const final;
     void reattach(StyleRuleBase&) final;
 
     Ref<StyleRuleNamespace> m_namespaceRule;

--- a/Source/WebCore/css/CSSOffsetRotateValue.cpp
+++ b/Source/WebCore/css/CSSOffsetRotateValue.cpp
@@ -30,21 +30,17 @@
 
 namespace WebCore {
 
-String CSSOffsetRotateValue::customCSSText() const
+void CSSOffsetRotateValue::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder builder;
+    auto initialLengthOfBuilder = builder.length();
 
     if (m_modifier)
-        builder.append(m_modifier->cssText());
-
+        m_modifier->cssText(builder);
     if (m_angle) {
-        if (!builder.isEmpty())
+        if (initialLengthOfBuilder != builder.length())
             builder.append(' ');
-
-        builder.append(m_angle->cssText());
+        m_angle->cssText(builder);
     }
-
-    return builder.toString();
 }
 
 bool CSSOffsetRotateValue::isInitialValue() const

--- a/Source/WebCore/css/CSSOffsetRotateValue.h
+++ b/Source/WebCore/css/CSSOffsetRotateValue.h
@@ -37,7 +37,7 @@ public:
         return adoptRef(*new CSSOffsetRotateValue(WTFMove(modifier), WTFMove(angle)));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     CSSPrimitiveValue* modifier() const { return m_modifier.get(); }
     CSSPrimitiveValue* angle() const { return m_angle.get(); }

--- a/Source/WebCore/css/CSSPageRule.cpp
+++ b/Source/WebCore/css/CSSPageRule.cpp
@@ -29,6 +29,7 @@
 #include "Document.h"
 #include "PropertySetCSSStyleDeclaration.h"
 #include "StyleProperties.h"
+#include "StylePropertiesInlines.h"
 #include "StyleRule.h"
 #include <wtf/text/MakeString.h>
 
@@ -76,11 +77,17 @@ void CSSPageRule::setSelectorText(const String& selectorText)
     m_pageRule->wrapperAdoptSelectorList(WTFMove(*selectorList));
 }
 
-String CSSPageRule::cssText() const
+void CSSPageRule::cssText(StringBuilder& builder) const
 {
-    if (auto declarations = m_pageRule->properties().asText(); !declarations.isEmpty())
-        return makeString(selectorText(), " { "_s, declarations, " }"_s);
-    return makeString(selectorText(), " { }"_s);
+    builder.append(selectorText(), " { "_s);
+
+    if (m_pageRule->properties().isEmpty()) {
+        builder.append('}');
+        return;
+    }
+
+    m_pageRule->properties().asText(builder);
+    builder.append(" }"_s);
 }
 
 void CSSPageRule::reattach(StyleRuleBase& rule)

--- a/Source/WebCore/css/CSSPageRule.h
+++ b/Source/WebCore/css/CSSPageRule.h
@@ -45,7 +45,7 @@ private:
     CSSPageRule(StyleRulePage&, CSSStyleSheet*);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Page; }
-    String cssText() const final;
+    void cssText(StringBuilder&) const final;
     void reattach(StyleRuleBase&) final;
 
     Ref<StyleRulePage> m_pageRule;

--- a/Source/WebCore/css/CSSPaintImageValue.cpp
+++ b/Source/WebCore/css/CSSPaintImageValue.cpp
@@ -49,6 +49,12 @@ String CSSPaintImageValue::customCSSText() const
     return makeString("paint("_s, m_name, ')');
 }
 
+void CSSPaintImageValue::customCSSText(StringBuilder& builder) const
+{
+    // FIXME: This should include the arguments too.
+    builder.append("paint("_s, m_name, ')');
+}
+
 RefPtr<StyleImage> CSSPaintImageValue::createStyleImage(Style::BuilderState&) const
 {
     return StylePaintImage::create(m_name, m_arguments);

--- a/Source/WebCore/css/CSSPaintImageValue.h
+++ b/Source/WebCore/css/CSSPaintImageValue.h
@@ -48,8 +48,10 @@ public:
 
     const String& name() const { return m_name; }
 
-    bool equals(const CSSPaintImageValue& other) const { return m_name == other.m_name; }
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
+    bool equals(const CSSPaintImageValue& other) const { return m_name == other.m_name; }
 
     RefPtr<StyleImage> createStyleImage(Style::BuilderState&) const;
 

--- a/Source/WebCore/css/CSSPendingSubstitutionValue.h
+++ b/Source/WebCore/css/CSSPendingSubstitutionValue.h
@@ -48,6 +48,7 @@ public:
 
     bool equals(const CSSPendingSubstitutionValue& other) const { return m_shorthandValue.ptr() == other.m_shorthandValue.ptr(); }
     static String customCSSText() { return emptyString(); }
+    static void customCSSText(StringBuilder&) { }
 
     RefPtr<CSSValue> resolveValue(Style::BuilderState&, CSSPropertyID) const;
 

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -188,6 +188,7 @@ public:
     const CSSAnchorValue* cssAnchorValue() const { return isAnchor() ? m_value.anchor : nullptr; }
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     bool equals(const CSSPrimitiveValue&) const;
 
@@ -235,6 +236,7 @@ private:
     bool addDerivedHash(Hasher&) const;
 
     ALWAYS_INLINE String serializeInternal() const;
+    ALWAYS_INLINE String serializeInternalWithCaching() const;
     NEVER_INLINE String formatNumberValue(ASCIILiteral suffix) const;
     NEVER_INLINE String formatIntegerValue(ASCIILiteral suffix) const;
     static constexpr bool isFontIndependentLength(CSSUnitType);

--- a/Source/WebCore/css/CSSPropertyRule.cpp
+++ b/Source/WebCore/css/CSSPropertyRule.cpp
@@ -70,19 +70,17 @@ String CSSPropertyRule::initialValue() const
     return m_propertyRule->descriptor().initialValue->serialize();
 }
 
-String CSSPropertyRule::cssText() const
+void CSSPropertyRule::cssText(StringBuilder& builder) const
 {
-    StringBuilder builder;
-
     auto& descriptor = m_propertyRule->descriptor();
 
     builder.append("@property "_s);
-    serializeIdentifier(descriptor.name, builder);
+    serializeIdentifier(builder, descriptor.name);
     builder.append(" { "_s);
 
     if (!descriptor.syntax.isNull()) {
         builder.append("syntax: "_s);
-        serializeString(syntax(), builder);
+        serializeString(builder, syntax());
         builder.append("; "_s);
     }
 
@@ -93,8 +91,6 @@ String CSSPropertyRule::cssText() const
         builder.append("initial-value: "_s, initialValue(), "; "_s);
 
     builder.append('}');
-
-    return builder.toString();
 }
 
 void CSSPropertyRule::reattach(StyleRuleBase& rule)

--- a/Source/WebCore/css/CSSPropertyRule.h
+++ b/Source/WebCore/css/CSSPropertyRule.h
@@ -41,7 +41,7 @@ public:
     bool inherits() const;
     String initialValue() const;
 
-    String cssText() const final;
+    void cssText(StringBuilder&) const final;
 
 private:
     CSSPropertyRule(StyleRuleProperty&, CSSStyleSheet*);

--- a/Source/WebCore/css/CSSQuadValue.cpp
+++ b/Source/WebCore/css/CSSQuadValue.cpp
@@ -39,9 +39,9 @@ Ref<CSSQuadValue> CSSQuadValue::create(Quad quad)
     return adoptRef(*new CSSQuadValue(WTFMove(quad)));
 }
 
-String CSSQuadValue::customCSSText() const
+void CSSQuadValue::customCSSText(StringBuilder& builder) const
 {
-    return m_quad.cssText();
+    m_quad.cssText(builder);
 }
 
 bool CSSQuadValue::equals(const CSSQuadValue& other) const

--- a/Source/WebCore/css/CSSQuadValue.h
+++ b/Source/WebCore/css/CSSQuadValue.h
@@ -35,7 +35,8 @@ public:
 
     const Quad& quad() const { return m_quad; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSQuadValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSRayValue.cpp
+++ b/Source/WebCore/css/CSSRayValue.cpp
@@ -30,27 +30,31 @@
 #include "CSSRayValue.h"
 
 #include "CSSPrimitiveValueMappings.h"
-#include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-String CSSRayValue::customCSSText() const
+void CSSRayValue::customCSSText(StringBuilder& builder) const
 {
-    bool isNonDefaultSize = m_size != CSSValueClosestSide;
-    bool hasPosition = m_position;
-    bool hasCustomCoordinateBox = m_coordinateBox != CSSBoxType::BoxMissing;
+    builder.append("ray("_s);
 
-    return makeString(
-        "ray("_s, m_angle->cssText(),
-        isNonDefaultSize ? " "_s : ""_s,
-        isNonDefaultSize ? nameLiteral(m_size) : ""_s,
-        m_isContaining ? " contain"_s : ""_s,
-        hasPosition ? " at "_s : ""_s,
-        hasPosition ? m_position->cssText() : ""_s,
-        ')',
-        hasCustomCoordinateBox ? " "_s : ""_s,
-        hasCustomCoordinateBox ? nameLiteral(toCSSValueID(m_coordinateBox)) : ""_s
-    );
+    m_angle->cssText(builder);
+
+    if (m_size != CSSValueClosestSide)
+        builder.append(' ', nameLiteral(m_size));
+
+    if (m_isContaining)
+        builder.append(" contain"_s);
+
+    if (m_position) {
+        builder.append(" at "_s);
+        m_position->cssText(builder);
+    }
+
+    builder.append(')');
+
+    if (m_coordinateBox != CSSBoxType::BoxMissing)
+        builder.append(' ', nameLiteral(toCSSValueID(m_coordinateBox)));
 }
 
 bool CSSRayValue::equals(const CSSRayValue& other) const

--- a/Source/WebCore/css/CSSRayValue.h
+++ b/Source/WebCore/css/CSSRayValue.h
@@ -48,7 +48,7 @@ public:
         return adoptRef(*new CSSRayValue(WTFMove(angle), size, isContaining, WTFMove(position), coordinateBox));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     Ref<CSSPrimitiveValue> angle() const { return m_angle; }
     CSSValueID size() const { return m_size; }

--- a/Source/WebCore/css/CSSRectValue.cpp
+++ b/Source/WebCore/css/CSSRectValue.cpp
@@ -39,9 +39,9 @@ Ref<CSSRectValue> CSSRectValue::create(Rect rect)
     return adoptRef(*new CSSRectValue(WTFMove(rect)));
 }
 
-String CSSRectValue::customCSSText() const
+void CSSRectValue::customCSSText(StringBuilder& builder) const
 {
-    return m_rect.cssText();
+    m_rect.cssText(builder);
 }
 
 bool CSSRectValue::equals(const CSSRectValue& other) const

--- a/Source/WebCore/css/CSSRectValue.h
+++ b/Source/WebCore/css/CSSRectValue.h
@@ -35,7 +35,8 @@ public:
 
     const Rect& rect() const { return m_rect; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSRectValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSReflectValue.cpp
+++ b/Source/WebCore/css/CSSReflectValue.cpp
@@ -43,11 +43,14 @@ Ref<CSSReflectValue> CSSReflectValue::create(CSSValueID direction, Ref<CSSPrimit
     return adoptRef(*new CSSReflectValue(direction, WTFMove(offset), WTFMove(mask)));
 }
 
-String CSSReflectValue::customCSSText() const
+void CSSReflectValue::customCSSText(StringBuilder& builder) const
 {
-    if (m_mask)
-        return makeString(nameLiteral(m_direction), ' ', m_offset->cssText(), ' ', m_mask->cssText());
-    return makeString(nameLiteral(m_direction), ' ', m_offset->cssText());
+    builder.append(nameLiteral(m_direction), ' ');
+    m_offset->cssText(builder);
+    if (m_mask) {
+        builder.append(' ');
+        m_mask->cssText(builder);
+    }
 }
 
 bool CSSReflectValue::equals(const CSSReflectValue& other) const

--- a/Source/WebCore/css/CSSReflectValue.h
+++ b/Source/WebCore/css/CSSReflectValue.h
@@ -39,7 +39,8 @@ public:
     const CSSPrimitiveValue& offset() const { return m_offset.get(); }
     const CSSValue* mask() const { return m_mask.get(); }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSReflectValue&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const

--- a/Source/WebCore/css/CSSRule.cpp
+++ b/Source/WebCore/css/CSSRule.cpp
@@ -47,6 +47,25 @@ unsigned short CSSRule::typeForCSSOM() const
     return enumToUnderlyingType(styleRuleType());
 }
 
+String CSSRule::cssText() const
+{
+    StringBuilder builder;
+    cssText(builder);
+    return builder.toString();
+}
+
+String CSSRule::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
+{
+    StringBuilder builder;
+    cssTextWithReplacementURLs(builder, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
+    return builder.toString();
+}
+
+void CSSRule::cssTextWithReplacementURLs(StringBuilder& builder, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const
+{
+    return cssText(builder);
+}
+
 ExceptionOr<void> CSSRule::setCssText(const String&)
 {
     return { };

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -43,8 +43,13 @@ public:
 
     virtual StyleRuleType styleRuleType() const = 0;
     virtual bool isGroupingRule() const { return false; }
-    virtual String cssText() const = 0;
-    virtual String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const { return cssText(); }
+
+    WEBCORE_EXPORT String cssText() const;
+    String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const;
+
+    virtual void cssText(StringBuilder&) const = 0;
+    virtual void cssTextWithReplacementURLs(StringBuilder&, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const;
+
     virtual void reattach(StyleRuleBase&) = 0;
 
     void setParentStyleSheet(CSSStyleSheet*);

--- a/Source/WebCore/css/CSSScopeRule.cpp
+++ b/Source/WebCore/css/CSSScopeRule.cpp
@@ -46,18 +46,16 @@ const StyleRuleScope& CSSScopeRule::styleRuleScope() const
     return downcast<StyleRuleScope>(groupRule());
 }
 
-String CSSScopeRule::cssText() const
+void CSSScopeRule::cssText(StringBuilder& builder) const
 {
-    StringBuilder builder;
     builder.append("@scope"_s);
     auto start = this->start();
     if (!start.isEmpty())
         builder.append(" ("_s, start, ')');
     auto end = this->end();
     if (!end.isEmpty())
-        builder.append(" to "_s, '(', end, ')');
+        builder.append(" to ("_s, end, ')');
     appendCSSTextForItems(builder);
-    return builder.toString();
 }
 
 String CSSScopeRule::start() const

--- a/Source/WebCore/css/CSSScopeRule.h
+++ b/Source/WebCore/css/CSSScopeRule.h
@@ -35,7 +35,7 @@ class CSSScopeRule final : public CSSGroupingRule {
 public:
     static Ref<CSSScopeRule> create(StyleRuleScope&, CSSStyleSheet* parent);
 
-    String cssText() const final;
+    void cssText(StringBuilder&) const final;
     String start() const;
     String end() const;
 

--- a/Source/WebCore/css/CSSScrollValue.cpp
+++ b/Source/WebCore/css/CSSScrollValue.cpp
@@ -34,18 +34,19 @@
 
 namespace WebCore {
 
-String CSSScrollValue::customCSSText() const
+void CSSScrollValue::customCSSText(StringBuilder& builder) const
 {
     auto hasScroller = m_scroller && m_scroller->valueID() != CSSValueNearest;
     auto hasAxis = m_axis && m_axis->valueID() != CSSValueBlock;
 
-    return makeString(
-        "scroll("_s,
-        hasScroller ? m_scroller->cssText() : ""_s,
-        hasScroller && hasAxis ? " "_s : ""_s,
-        hasAxis ? m_axis->cssText() : ""_s,
-        ")"_s
-    );
+    builder.append("scroll("_s);
+    if (hasScroller)
+        m_scroller->cssText(builder);
+    if (hasScroller && hasAxis)
+        builder.append(' ');
+    if (hasAxis)
+        m_axis->cssText(builder);
+    builder.append(')');
 }
 
 bool CSSScrollValue::equals(const CSSScrollValue& other) const

--- a/Source/WebCore/css/CSSScrollValue.h
+++ b/Source/WebCore/css/CSSScrollValue.h
@@ -47,7 +47,7 @@ public:
         return adoptRef(*new CSSScrollValue(WTFMove(scroller), WTFMove(axis)));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     RefPtr<CSSValue> scroller() const { return m_scroller; }
     RefPtr<CSSValue> axis() const { return m_axis; }

--- a/Source/WebCore/css/CSSShadowValue.cpp
+++ b/Source/WebCore/css/CSSShadowValue.cpp
@@ -37,39 +37,24 @@ CSSShadowValue::CSSShadowValue(RefPtr<CSSPrimitiveValue>&& x, RefPtr<CSSPrimitiv
 {
 }
 
-String CSSShadowValue::customCSSText() const
+void CSSShadowValue::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder text;
+    auto initialLengthOfBuilder = builder.length();
 
-    if (color)
-        text.append(color->cssText());
-    if (x) {
-        if (!text.isEmpty())
-            text.append(' ');
-        text.append(x->cssText());
-    }
-    if (y) {
-        if (!text.isEmpty())
-            text.append(' ');
-        text.append(y->cssText());
-    }
-    if (blur) {
-        if (!text.isEmpty())
-            text.append(' ');
-        text.append(blur->cssText());
-    }
-    if (spread) {
-        if (!text.isEmpty())
-            text.append(' ');
-        text.append(spread->cssText());
-    }
-    if (style) {
-        if (!text.isEmpty())
-            text.append(' ');
-        text.append(style->cssText());
-    }
+    auto append = [&](auto& arg) {
+        if (!arg)
+            return;
+        if (initialLengthOfBuilder != builder.length())
+            builder.append(' ');
+        arg->cssText(builder);
+    };
 
-    return text.toString();
+    append(color);
+    append(x);
+    append(y);
+    append(blur);
+    append(spread);
+    append(style);
 }
 
 bool CSSShadowValue::equals(const CSSShadowValue& other) const

--- a/Source/WebCore/css/CSSShadowValue.h
+++ b/Source/WebCore/css/CSSShadowValue.h
@@ -40,7 +40,7 @@ public:
         return adoptRef(*new CSSShadowValue(WTFMove(x), WTFMove(y), WTFMove(blur), WTFMove(spread), WTFMove(style), WTFMove(color)));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     bool equals(const CSSShadowValue&) const;
 

--- a/Source/WebCore/css/CSSStartingStyleRule.cpp
+++ b/Source/WebCore/css/CSSStartingStyleRule.cpp
@@ -35,12 +35,10 @@ CSSStartingStyleRule::CSSStartingStyleRule(StyleRuleStartingStyle& rule, CSSStyl
 {
 }
 
-String CSSStartingStyleRule::cssText() const
+void CSSStartingStyleRule::cssText(StringBuilder& builder) const
 {
-    StringBuilder builder;
     builder.append("@starting-style"_s);
     appendCSSTextForItems(builder);
-    return builder.toString();
 }
 
 }

--- a/Source/WebCore/css/CSSStartingStyleRule.h
+++ b/Source/WebCore/css/CSSStartingStyleRule.h
@@ -38,7 +38,7 @@ public:
         return adoptRef(*new CSSStartingStyleRule(rule, parent));
     }
 
-    String cssText() const final;
+    void cssText(StringBuilder&) const final;
 
 private:
     CSSStartingStyleRule(StyleRuleStartingStyle&, CSSStyleSheet*);

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -62,16 +62,16 @@ private:
     CSSStyleRule(StyleRuleWithNesting&, CSSStyleSheet*);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Style; }
-    String cssText() const final;
-    String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
-    String cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const;
+    void cssText(StringBuilder&) const final;
+    void cssTextWithReplacementURLs(StringBuilder&, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
     void reattach(StyleRuleBase&) final;
     void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) final;
 
+    template<typename F> void cssTextForRules(StringBuilder&, F&&) const;
+    template<typename DeclarationsFunctor, typename RulesFunctor> void cssTextInternal(StringBuilder&, bool hasDeclarations, DeclarationsFunctor&&, bool hasRules, RulesFunctor&&) const;
+
     String generateSelectorText() const;
     Vector<Ref<StyleRuleBase>> nestedRules() const;
-    void cssTextForRules(StringBuilder& rules) const;
-    void cssTextForRulesWithReplacementURLs(StringBuilder& rules, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const;
 
     Ref<StyleRule> m_styleRule;
     Ref<DeclaredStylePropertyMap> m_styleMap;

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -490,23 +490,28 @@ String CSSStyleSheet::debugDescription() const
 
 String CSSStyleSheet::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet)
 {
+    StringBuilder builder;
+    cssTextWithReplacementURLs(builder, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
+    return builder.toString();
+}
+
+void CSSStyleSheet::cssTextWithReplacementURLs(StringBuilder& builder, const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet)
+{
     auto ruleList = cssRulesSkippingAccessCheck();
     if (!ruleList)
-        return { };
+        return;
 
-    StringBuilder result;
+    auto initialLengthOfBuilder = builder.length();
+
     for (unsigned index = 0; index < ruleList->length(); ++index) {
         auto rule = ruleList->item(index);
         if (!rule)
             continue;
 
-        auto ruleText = rule->cssTextWithReplacementURLs(replacementURLStrings, replacementURLStringsForCSSStyleSheet);
-        if (!result.isEmpty() && !ruleText.isEmpty())
-            result.append(' ');
-
-        result.append(ruleText);
+        if (initialLengthOfBuilder != builder.length())
+            builder.append(' ');
+        rule->cssTextWithReplacementURLs(builder, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
     }
-    return result.toString();
 }
 
 // https://w3c.github.io/csswg-drafts/cssom-1/#dom-cssstylesheet-replace

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -161,6 +161,7 @@ public:
 
     String debugDescription() const final;
     String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&);
+    void cssTextWithReplacementURLs(StringBuilder&, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&);
     void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&);
 
     bool isDetached() const;

--- a/Source/WebCore/css/CSSSubgridValue.cpp
+++ b/Source/WebCore/css/CSSSubgridValue.cpp
@@ -35,16 +35,6 @@
 
 namespace WebCore {
 
-String CSSSubgridValue::customCSSText() const
-{
-    if (!length())
-        return "subgrid"_s;
-    StringBuilder result;
-    result.append("subgrid "_s);
-    serializeItems(result);
-    return result.toString();
-}
-
 CSSSubgridValue::CSSSubgridValue(CSSValueListBuilder builder)
     : CSSValueContainingVector(SubgridClass, SpaceSeparator, WTFMove(builder))
 {
@@ -53,6 +43,17 @@ CSSSubgridValue::CSSSubgridValue(CSSValueListBuilder builder)
 Ref<CSSSubgridValue> CSSSubgridValue::create(CSSValueListBuilder builder)
 {
     return adoptRef(*new CSSSubgridValue(WTFMove(builder)));
+}
+
+void CSSSubgridValue::customCSSText(StringBuilder& builder) const
+{
+    if (!length()) {
+        builder.append("subgrid"_s);
+        return;
+    }
+
+    builder.append("subgrid "_s);
+    serializeItems(builder);
 }
 
 }

--- a/Source/WebCore/css/CSSSubgridValue.h
+++ b/Source/WebCore/css/CSSSubgridValue.h
@@ -38,7 +38,8 @@ class CSSSubgridValue final : public CSSValueContainingVector {
 public:
     static Ref<CSSSubgridValue> create(CSSValueListBuilder);
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSSubgridValue& other) const { return itemsEqual(other); }
 
 private:

--- a/Source/WebCore/css/CSSSupportsRule.cpp
+++ b/Source/WebCore/css/CSSSupportsRule.cpp
@@ -48,20 +48,16 @@ Ref<CSSSupportsRule> CSSSupportsRule::create(StyleRuleSupports& rule, CSSStyleSh
     return adoptRef(*new CSSSupportsRule(rule, parent));
 }
 
-String CSSSupportsRule::cssText() const
+void CSSSupportsRule::cssText(StringBuilder& builder) const
 {
-    StringBuilder builder;
     builder.append("@supports "_s, conditionText());
     appendCSSTextForItems(builder);
-    return builder.toString();
 }
 
-String CSSSupportsRule::cssTextWithReplacementURLs(const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
+void CSSSupportsRule::cssTextWithReplacementURLs(StringBuilder& builder, const HashMap<String, String>& replacementURLStrings, const HashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
 {
-    StringBuilder builder;
     builder.append("@supports "_s, conditionText());
     appendCSSTextWithReplacementURLsForItems(builder, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
-    return builder.toString();
 }
 
 String CSSSupportsRule::conditionText() const

--- a/Source/WebCore/css/CSSSupportsRule.h
+++ b/Source/WebCore/css/CSSSupportsRule.h
@@ -40,8 +40,8 @@ class CSSSupportsRule final : public CSSConditionRule {
 public:
     static Ref<CSSSupportsRule> create(StyleRuleSupports&, CSSStyleSheet* parent);
 
-    String cssText() const final;
-    String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
+    void cssText(StringBuilder&) const final;
+    void cssTextWithReplacementURLs(StringBuilder&, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const final;
     String conditionText() const final;
 
 private:

--- a/Source/WebCore/css/CSSTimingFunctionValue.h
+++ b/Source/WebCore/css/CSSTimingFunctionValue.h
@@ -39,7 +39,7 @@ public:
 
     const Vector<LinearTimingFunction::Point>& points() const { return m_points; }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     bool equals(const CSSLinearTimingFunctionValue&) const;
 
@@ -62,6 +62,7 @@ public:
     }
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     double x1() const { return m_x1; }
     double y1() const { return m_y1; }
@@ -97,6 +98,7 @@ public:
     std::optional<StepsTimingFunction::StepPosition> stepPosition() const { return m_stepPosition; }
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     bool equals(const CSSStepsTimingFunctionValue&) const;
 
@@ -125,6 +127,7 @@ public:
     double initialVelocity() const { return m_initialVelocity; }
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     bool equals(const CSSSpringTimingFunctionValue&) const;
 

--- a/Source/WebCore/css/CSSTransformListValue.h
+++ b/Source/WebCore/css/CSSTransformListValue.h
@@ -40,7 +40,7 @@ public:
     static Ref<CSSTransformListValue> create(CSSValueListBuilder);
     static Ref<CSSTransformListValue> create(Ref<CSSValue>);
 
-    String customCSSText() const { return serializeItems(); }
+    void customCSSText(StringBuilder& builder) const { serializeItems(builder); }
     bool equals(const CSSTransformListValue& other) const { return itemsEqual(other); }
 
 private:

--- a/Source/WebCore/css/CSSUnicodeRangeValue.cpp
+++ b/Source/WebCore/css/CSSUnicodeRangeValue.cpp
@@ -39,6 +39,16 @@ String CSSUnicodeRangeValue::customCSSText() const
     return makeString("U+"_s, hex(m_from, Lowercase), '-', hex(m_to, Lowercase));
 }
 
+void CSSUnicodeRangeValue::customCSSText(StringBuilder& builder) const
+{
+    if (m_from == m_to) {
+        builder.append("U+"_s, hex(m_from, Lowercase));
+        return;
+    }
+
+    builder.append("U+"_s, hex(m_from, Lowercase), '-', hex(m_to, Lowercase));
+}
+
 bool CSSUnicodeRangeValue::equals(const CSSUnicodeRangeValue& other) const
 {
     return m_from == other.m_from && m_to == other.m_to;

--- a/Source/WebCore/css/CSSUnicodeRangeValue.h
+++ b/Source/WebCore/css/CSSUnicodeRangeValue.h
@@ -41,6 +41,7 @@ public:
     char32_t to() const { return m_to; }
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     bool equals(const CSSUnicodeRangeValue&) const;
 

--- a/Source/WebCore/css/CSSUnknownRule.h
+++ b/Source/WebCore/css/CSSUnknownRule.h
@@ -34,7 +34,7 @@ public:
 
     virtual ~CSSUnknownRule() = default;
 
-    String cssText() const final { return String(); }
+    void cssText(StringBuilder&) const final { }
     void reattach(StyleRuleBase&) final { }
 
 private:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -70,6 +70,7 @@ public:
     bool hasAtLeastOneRef() const { return m_refCount; }
 
     String cssText() const;
+    void cssText(StringBuilder&) const;
 
     bool isAnchorValue() const { return m_classType == AnchorClass; }
     bool isAspectRatioValue() const { return m_classType == AspectRatioClass; }

--- a/Source/WebCore/css/CSSValueList.cpp
+++ b/Source/WebCore/css/CSSValueList.cpp
@@ -218,19 +218,12 @@ CSSValueListBuilder CSSValueContainingVector::copyValues() const
 
 void CSSValueContainingVector::serializeItems(StringBuilder& builder) const
 {
-    builder.append(interleave(*this, [](auto& value) { return value.cssText(); }, separatorCSSText()));
+    builder.append(interleave(*this, [](auto& builder, auto& value) { value.cssText(builder); }, separatorCSSText()));
 }
 
-String CSSValueContainingVector::serializeItems() const
+void CSSValueList::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder result;
-    serializeItems(result);
-    return result.toString();
-}
-
-String CSSValueList::customCSSText() const
-{
-    return serializeItems();
+    serializeItems(builder);
 }
 
 bool CSSValueContainingVector::itemsEqual(const CSSValueContainingVector& other) const

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -57,7 +57,6 @@ public:
     bool hasValue(CSSValueID) const;
 
     void serializeItems(StringBuilder&) const;
-    String serializeItems() const;
 
     bool itemsEqual(const CSSValueContainingVector&) const;
     bool containsSingleEqualItem(const CSSValue&) const;
@@ -116,7 +115,8 @@ public:
     static Ref<CSSValueList> createSlashSeparated(Ref<CSSValue>); // FIXME: Upgrade callers to not use a list at all.
     static Ref<CSSValueList> createSlashSeparated(Ref<CSSValue>, Ref<CSSValue>);
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSValueList&) const;
 
 private:

--- a/Source/WebCore/css/CSSValuePair.cpp
+++ b/Source/WebCore/css/CSSValuePair.cpp
@@ -63,11 +63,21 @@ bool CSSValuePair::canBeCoalesced() const
 
 String CSSValuePair::customCSSText() const
 {
-    String first = m_first->cssText();
-    String second = m_second->cssText();
-    if (m_coalesceIdenticalValues && first == second)
+    auto first = m_first->cssText();
+    if (canBeCoalesced())
         return first;
-    return makeString(first, separatorCSSText(), second);
+    return makeString(first, separatorCSSText(), m_second->cssText());
+}
+
+void CSSValuePair::customCSSText(StringBuilder& builder) const
+{
+    m_first->cssText(builder);
+
+    if (canBeCoalesced())
+        return;
+
+    builder.append(separatorCSSText());
+    m_second->cssText(builder);
 }
 
 bool CSSValuePair::equals(const CSSValuePair& other) const

--- a/Source/WebCore/css/CSSValuePair.h
+++ b/Source/WebCore/css/CSSValuePair.h
@@ -42,6 +42,8 @@ public:
     Ref<CSSValue> protectedSecond() const { return m_second; }
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSValuePair&) const;
     bool canBeCoalesced() const;
 

--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -86,4 +86,9 @@ String CSSVariableData::serialize() const
     return tokenRange().serialize(CSSParserToken::SerializationMode::CustomProperty);
 }
 
+void CSSVariableData::serialize(StringBuilder& builder) const
+{
+    tokenRange().serialize(builder, CSSParserToken::SerializationMode::CustomProperty);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSVariableData.h
+++ b/Source/WebCore/css/CSSVariableData.h
@@ -49,9 +49,10 @@ public:
 
     const Vector<CSSParserToken>& tokens() const { return m_tokens; }
 
-    bool operator==(const CSSVariableData& other) const;
+    bool operator==(const CSSVariableData&) const;
 
     String serialize() const;
+    void serialize(StringBuilder&) const;
 
 private:
     CSSVariableData(const CSSParserTokenRange&, const CSSParserContext&);

--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -73,6 +73,11 @@ String CSSVariableReferenceValue::customCSSText() const
     return m_stringValue;
 }
 
+void CSSVariableReferenceValue::customCSSText(StringBuilder& builder) const
+{
+    m_data->serialize(builder);
+}
+
 const CSSParserContext& CSSVariableReferenceValue::context() const
 {
     return m_data->context();

--- a/Source/WebCore/css/CSSVariableReferenceValue.h
+++ b/Source/WebCore/css/CSSVariableReferenceValue.h
@@ -53,7 +53,9 @@ public:
     static Ref<CSSVariableReferenceValue> create(Ref<CSSVariableData>&&);
 
     bool equals(const CSSVariableReferenceValue&) const;
+
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     RefPtr<CSSVariableData> resolveVariableReferences(Style::BuilderState&) const;
     const CSSParserContext& context() const;

--- a/Source/WebCore/css/CSSViewValue.cpp
+++ b/Source/WebCore/css/CSSViewValue.cpp
@@ -30,25 +30,32 @@
 #include "CSSViewValue.h"
 
 #include "CSSPrimitiveValueMappings.h"
-#include <wtf/text/MakeString.h>
+#include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-String CSSViewValue::customCSSText() const
+void CSSViewValue::customCSSText(StringBuilder& builder) const
 {
     auto hasAxis = m_axis && m_axis->valueID() != CSSValueBlock;
     auto hasEndInset = m_endInset && m_endInset != m_startInset;
     auto hasStartInset = (m_startInset && m_startInset->valueID() != CSSValueAuto) || (m_startInset && m_startInset->valueID() == CSSValueAuto && hasEndInset);
 
-    return makeString(
-        "view("_s,
-        hasAxis ? m_axis->cssText() : ""_s,
-        hasAxis && hasStartInset ? " "_s : ""_s,
-        hasStartInset ? m_startInset->cssText() : ""_s,
-        hasStartInset && hasEndInset ? " "_s : ""_s,
-        hasEndInset ? m_endInset->cssText() : ""_s,
-        ")"_s
-    );
+    builder.append("view("_s);
+    if (hasAxis) {
+        m_axis->cssText(builder);
+        if (hasStartInset)
+            builder.append(' ');
+    }
+
+    if (hasStartInset) {
+        m_startInset->cssText(builder);
+        if (hasEndInset)
+            builder.append(' ');
+    }
+    if (hasEndInset)
+        m_endInset->cssText(builder);
+
+    builder.append(')');
 }
 
 bool CSSViewValue::equals(const CSSViewValue& other) const

--- a/Source/WebCore/css/CSSViewValue.h
+++ b/Source/WebCore/css/CSSViewValue.h
@@ -47,7 +47,7 @@ public:
         return adoptRef(*new CSSViewValue(WTFMove(axis), WTFMove(startInset), WTFMove(endInset)));
     }
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     RefPtr<CSSValue> axis() const { return m_axis; }
     RefPtr<CSSValue> startInset() const { return m_startInset; }

--- a/Source/WebCore/css/DOMCSSNamespace.cpp
+++ b/Source/WebCore/css/DOMCSSNamespace.cpp
@@ -83,9 +83,7 @@ bool DOMCSSNamespace::supports(Document& document, const String& conditionText)
 
 String DOMCSSNamespace::escape(const String& ident)
 {
-    StringBuilder builder;
-    serializeIdentifier(ident, builder);
-    return builder.toString();
+    return serializeIdentifier(ident);
 }
 
 HighlightRegistry& DOMCSSNamespace::highlights(Document& document)

--- a/Source/WebCore/css/DeprecatedCSSOMValueList.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMValueList.cpp
@@ -26,19 +26,15 @@
 #include "config.h"
 #include "DeprecatedCSSOMValueList.h"
 
-#include <wtf/text/StringBuilder.h>
+#include <wtf/text/MakeString.h>
 
 namespace WebCore {
 
 String DeprecatedCSSOMValueList::cssText() const
 {
     // FIXME: Clearly wrong for cases like CSSSubgridValue. Change to call cssText on m_value instead.
-    auto prefix = ""_s;
     auto separator = CSSValueList::separatorCSSText(static_cast<CSSValueList::ValueSeparator>(m_valueSeparator));
-    StringBuilder result;
-    for (auto& value : m_values)
-        result.append(std::exchange(prefix, separator), value.get().cssText());
-    return result.toString();
+    return makeString(interleave(m_values, [](auto& value) { return value->cssText(); }, separator));
 }
 
 }

--- a/Source/WebCore/css/Quad.h
+++ b/Source/WebCore/css/Quad.h
@@ -39,6 +39,36 @@ public:
         return serialize(top().cssText(), right().cssText(), bottom().cssText(), left().cssText());
     }
 
+    void cssText(StringBuilder& builder) const
+    {
+        if (!left().equals(right())) {
+            top().cssText(builder);
+            builder.append(' ');
+            right().cssText(builder);
+            builder.append(' ');
+            bottom().cssText(builder);
+            builder.append(' ');
+            left().cssText(builder);
+            return;
+        }
+        if (!bottom().equals(top())) {
+            top().cssText(builder);
+            builder.append(' ');
+            right().cssText(builder);
+            builder.append(' ');
+            bottom().cssText(builder);
+            return;
+        }
+        if (!right().equals(top())) {
+            top().cssText(builder);
+            builder.append(' ');
+            right().cssText(builder);
+            return;
+        }
+
+        top().cssText(builder);
+    }
+
     static String serialize(const String& top, const String& right, const String& bottom, const String& left)
     {
         if (left != right)

--- a/Source/WebCore/css/Rect.h
+++ b/Source/WebCore/css/Rect.h
@@ -33,11 +33,23 @@ public:
 
     String cssText() const
     {
-        return generateCSSString(top().cssText(), right().cssText(), bottom().cssText(), left().cssText());
+        return serialize(top().cssText(), right().cssText(), bottom().cssText(), left().cssText());
     }
 
-private:
-    static String generateCSSString(const String& top, const String& right, const String& bottom, const String& left)
+    void cssText(StringBuilder& builder) const
+    {
+        builder.append("rect("_s);
+        top().cssText(builder);
+        builder.append(", "_s);
+        right().cssText(builder);
+        builder.append(", "_s);
+        bottom().cssText(builder);
+        builder.append(", "_s);
+        left().cssText(builder);
+        builder.append(')');
+    }
+
+    static String serialize(const String& top, const String& right, const String& bottom, const String& left)
     {
         return makeString("rect("_s, top, ", "_s, right, ", "_s, bottom, ", "_s, left, ')');
     }

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -1183,13 +1183,15 @@ String ShorthandSerializer::serializeGridTemplate() const
         if (!result.isEmpty())
             result.append(' ');
         if (auto lineNames = dynamicDowncast<CSSGridLineNamesValue>(currentValue))
-            result.append(lineNames->customCSSText());
+            lineNames->customCSSText(result);
         else {
             result.append('"', areasValue->stringForRow(row), '"');
             if (!isValidTrackSize(currentValue))
                 return String();
-            if (!isValueID(currentValue, CSSValueAuto))
-                result.append(' ', currentValue.cssText());
+            if (!isValueID(currentValue, CSSValueAuto)) {
+                result.append(' ');
+                currentValue.cssText(result);
+            }
             row++;
         }
     }
@@ -1296,9 +1298,21 @@ String serializeShorthandValue(const StyleProperties& properties, CSSPropertyID 
     return ShorthandSerializer(properties, shorthand).serialize();
 }
 
+void serializeShorthandValue(StringBuilder& builder, const StyleProperties& properties, CSSPropertyID shorthand)
+{
+    // FIXME: Pass the builder to ShorthandSerializer to avoid intermediate object allocations.
+    builder.append(serializeShorthandValue(properties, shorthand));
+}
+
 String serializeShorthandValue(const ComputedStyleExtractor& extractor, CSSPropertyID shorthand)
 {
     return ShorthandSerializer(extractor, shorthand).serialize();
+}
+
+void serializeShorthandValue(StringBuilder& builder, const ComputedStyleExtractor& extractor, CSSPropertyID shorthand)
+{
+    // FIXME: Pass the builder to ShorthandSerializer to avoid intermediate object allocations.
+    builder.append(serializeShorthandValue(extractor, shorthand));
 }
 
 }

--- a/Source/WebCore/css/ShorthandSerializer.h
+++ b/Source/WebCore/css/ShorthandSerializer.h
@@ -34,6 +34,8 @@ class StyleProperties;
 enum CSSPropertyID : uint16_t;
 
 String serializeShorthandValue(const ComputedStyleExtractor&, CSSPropertyID);
+void serializeShorthandValue(StringBuilder&, const ComputedStyleExtractor&, CSSPropertyID);
 String serializeShorthandValue(const StyleProperties&, CSSPropertyID);
+void serializeShorthandValue(StringBuilder&, const StyleProperties&, CSSPropertyID);
 
 }

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -60,6 +60,13 @@ Ref<ImmutableStyleProperties> StyleProperties::immutableCopyIfNeeded() const
 
 String serializeLonghandValue(CSSPropertyID property, const CSSValue& value)
 {
+    StringBuilder builder;
+    serializeLonghandValue(builder, property, value);
+    return builder.toString();
+}
+
+void serializeLonghandValue(StringBuilder& builder, CSSPropertyID property, const CSSValue& value)
+{
     switch (property) {
     case CSSPropertyFillOpacity:
     case CSSPropertyFloodOpacity:
@@ -68,24 +75,30 @@ String serializeLonghandValue(CSSPropertyID property, const CSSValue& value)
     case CSSPropertyStrokeOpacity:
         // FIXME: Handle this when creating the CSSValue for opacity, to be consistent with other CSS value serialization quirks.
         // Opacity percentage values serialize as a fraction in the range 0-1, not "%".
-        if (auto* primitive = dynamicDowncast<CSSPrimitiveValue>(value); primitive && primitive->isPercentage())
-            return makeString(primitive->doubleValue() / 100);
+        if (auto* primitive = dynamicDowncast<CSSPrimitiveValue>(value); primitive && primitive->isPercentage()) {
+            builder.append(primitive->doubleValue() / 100);
+            return;
+        }
         break;
     default:
         break;
     }
+
     // Longhands set by mask and background shorthands can have comma-separated lists with implicit initial values in them.
     // We need to serialize those lists with the actual values, not as "initial".
     // Doing this for all CSSValueList with comma separators is better than checking the property is one of those longhands.
     // Serializing this way is harmless for other properties; those won't have any implicit initial values.
     if (auto* list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::CommaSeparator) {
-        StringBuilder result;
-        auto separator = ""_s;
-        for (auto& individualValue : *list)
-            result.append(std::exchange(separator, ", "_s), serializeLonghandValue(property, individualValue));
-        return result.toString();
+        builder.append(interleave(*list, [&](auto& builder, auto& individualValue) { serializeLonghandValue(builder, property, individualValue); }, ", "_s));
+        return;
     }
-    return value.isImplicitInitialValue() ? initialValueTextForLonghand(property) : value.cssText();
+
+    if (value.isImplicitInitialValue()) {
+        builder.append(initialValueTextForLonghand(property));
+        return;
+    }
+
+    value.cssText(builder);
 }
 
 inline String StyleProperties::serializeLonghandValue(CSSPropertyID propertyID) const
@@ -93,9 +106,19 @@ inline String StyleProperties::serializeLonghandValue(CSSPropertyID propertyID) 
     return WebCore::serializeLonghandValue(propertyID, getPropertyCSSValue(propertyID).get());
 }
 
+inline void StyleProperties::serializeLonghandValue(StringBuilder& builder, CSSPropertyID propertyID) const
+{
+    WebCore::serializeLonghandValue(builder, propertyID, getPropertyCSSValue(propertyID).get());
+}
+
 inline String StyleProperties::serializeShorthandValue(CSSPropertyID propertyID) const
 {
     return WebCore::serializeShorthandValue(*this, propertyID);
+}
+
+inline void StyleProperties::serializeShorthandValue(StringBuilder& builder, CSSPropertyID propertyID) const
+{
+    WebCore::serializeShorthandValue(builder, *this, propertyID);
 }
 
 String StyleProperties::getPropertyValue(CSSPropertyID propertyID) const
@@ -190,12 +213,16 @@ bool StyleProperties::isPropertyImplicit(CSSPropertyID propertyID) const
 
 String StyleProperties::asText() const
 {
-    return asTextInternal().toString();
+    StringBuilder builder;
+    asText(builder);
+    return builder.toString();
 }
 
 AtomString StyleProperties::asTextAtom() const
 {
-    return asTextInternal().toAtomString();
+    StringBuilder builder;
+    asText(builder);
+    return builder.toAtomString();
 }
 
 static constexpr bool canUseShorthandForLonghand(CSSPropertyID shorthandID, CSSPropertyID longhandID)
@@ -268,10 +295,8 @@ static constexpr bool canUseShorthandForLonghand(CSSPropertyID shorthandID, CSSP
     }
 }
 
-StringBuilder StyleProperties::asTextInternal() const
+void StyleProperties::asText(StringBuilder& result) const
 {
-    StringBuilder result;
-
     constexpr unsigned shorthandPropertyCount = lastShorthandProperty - firstShorthandProperty + 1;
     std::bitset<shorthandPropertyCount> shorthandPropertyUsed;
     std::bitset<shorthandPropertyCount> shorthandPropertyAppeared;
@@ -331,7 +356,6 @@ StringBuilder StyleProperties::asTextInternal() const
     }
 
     ASSERT(!numDecls ^ !result.isEmpty());
-    return result;
 }
 
 bool StyleProperties::hasCSSOMWrapper() const
@@ -446,7 +470,16 @@ String StyleProperties::PropertyReference::cssName() const
 
 String StyleProperties::PropertyReference::cssText() const
 {
-    return makeString(cssName(), ": "_s, WebCore::serializeLonghandValue(id(), *m_value), isImportant() ? " !important;"_s : ";"_s);
+    StringBuilder builder;
+    cssText(builder);
+    return builder.toString();
+}
+
+void StyleProperties::PropertyReference::cssText(StringBuilder& builder) const
+{
+    builder.append(cssName(), ": "_s);
+    WebCore::serializeLonghandValue(builder, id(), *m_value);
+    builder.append(isImportant() ? " !important;"_s : ";"_s);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -57,6 +57,7 @@ public:
 
         String cssName() const;
         String cssText() const;
+        void cssText(StringBuilder&) const;
 
         const CSSValue* value() const { return m_value; }
         // FIXME: We should try to remove this mutable overload.
@@ -123,6 +124,7 @@ public:
 
     Ref<MutableStyleProperties> copyProperties(std::span<const CSSPropertyID>) const;
     
+    void asText(StringBuilder&) const;
     String asText() const;
     AtomString asTextAtom() const;
 
@@ -154,13 +156,16 @@ protected:
     unsigned m_arraySize : 28 { 0 };
 
 private:
-    StringBuilder asTextInternal() const;
     String serializeLonghandValue(CSSPropertyID) const;
+    void serializeLonghandValue(StringBuilder&, CSSPropertyID) const;
     String serializeShorthandValue(CSSPropertyID) const;
+    void serializeShorthandValue(StringBuilder&, CSSPropertyID) const;
 };
 
 String serializeLonghandValue(CSSPropertyID, const CSSValue&);
+void serializeLonghandValue(StringBuilder&, CSSPropertyID, const CSSValue&);
 inline String serializeLonghandValue(CSSPropertyID, const CSSValue*);
+inline void serializeLonghandValue(StringBuilder&, CSSPropertyID, const CSSValue*);
 inline CSSValueID longhandValueID(CSSPropertyID, const CSSValue&);
 inline std::optional<CSSValueID> longhandValueID(CSSPropertyID, const CSSValue*);
 

--- a/Source/WebCore/css/StylePropertiesInlines.h
+++ b/Source/WebCore/css/StylePropertiesInlines.h
@@ -99,6 +99,12 @@ inline String serializeLonghandValue(CSSPropertyID property, const CSSValue* val
     return value ? serializeLonghandValue(property, *value) : String();
 }
 
+inline void serializeLonghandValue(StringBuilder& builder, CSSPropertyID property, const CSSValue* value)
+{
+    if (value)
+        serializeLonghandValue(builder, property, *value);
+}
+
 inline CSSValueID longhandValueID(CSSPropertyID property, const CSSValue& value)
 {
     return value.isImplicitInitialValue() ? initialValueIDForLonghand(property) : valueID(value);

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -1170,11 +1170,11 @@ void CSSCalcOperationNode::buildCSSTextRecursive(const CSSCalcExpressionNode& no
 {
     // If root is a numeric value, or a non-math function, serialize root per the normal rules for it and return the result.
     if (auto* valueNode = dynamicDowncast<CSSCalcPrimitiveValueNode>(node)) {
-        builder.append(valueNode->customCSSText());
+        valueNode->customCSSText(builder);
         return;
     }
     if (auto* symbolNode = dynamicDowncast<CSSCalcSymbolNode>(node)) {
-        builder.append(symbolNode->customCSSText());
+        symbolNode->customCSSText(builder);
         return;
     }
 

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
@@ -56,6 +56,11 @@ String CSSCalcPrimitiveValueNode::customCSSText() const
     return protectedValue()->cssText();
 }
 
+void CSSCalcPrimitiveValueNode::customCSSText(StringBuilder& result) const
+{
+    protectedValue()->cssText(result);
+}
+
 CSSUnitType CSSCalcPrimitiveValueNode::primitiveType() const
 {
     return protectedValue()->primitiveType();

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
@@ -42,6 +42,7 @@ public:
     static RefPtr<CSSCalcPrimitiveValueNode> create(double value, CSSUnitType);
 
     String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
     CSSUnitType primitiveType() const final;
 

--- a/Source/WebCore/css/calc/CSSCalcSymbolNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcSymbolNode.cpp
@@ -47,9 +47,14 @@ CSSCalcSymbolNode::CSSCalcSymbolNode(CSSValueID symbol, CSSUnitType unitType)
 {
 }
 
-String CSSCalcSymbolNode::customCSSText() const
+ASCIILiteral CSSCalcSymbolNode::customCSSText() const
 {
     return nameLiteralForSerialization(m_symbol);
+}
+
+void CSSCalcSymbolNode::customCSSText(StringBuilder& builder) const
+{
+    builder.append(customCSSText());
 }
 
 bool CSSCalcSymbolNode::isResolvable() const

--- a/Source/WebCore/css/calc/CSSCalcSymbolNode.h
+++ b/Source/WebCore/css/calc/CSSCalcSymbolNode.h
@@ -35,7 +35,8 @@ class CSSCalcSymbolNode final : public CSSCalcExpressionNode {
 public:
     static Ref<CSSCalcSymbolNode> create(CSSValueID, CSSUnitType);
 
-    String customCSSText() const;
+    ASCIILiteral customCSSText() const;
+    void customCSSText(StringBuilder&) const;
 
 private:
     CSSCalcSymbolNode(CSSValueID, CSSUnitType);

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -326,11 +326,9 @@ void CSSCalcValue::collectComputedStyleDependencies(ComputedStyleDependencies& d
     protectedExpressionNode()->collectComputedStyleDependencies(dependencies);
 }
 
-String CSSCalcValue::customCSSText() const
+void CSSCalcValue::customCSSText(StringBuilder& builder) const
 {
-    StringBuilder builder;
     CSSCalcOperationNode::buildCSSText(protectedExpressionNode().get(), builder);
-    return builder.toString();
 }
 
 bool CSSCalcValue::equals(const CSSCalcValue& other) const

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -68,9 +68,10 @@ public:
 
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const;
 
-    String customCSSText() const;
+    void customCSSText(StringBuilder&) const;
+
     bool equals(const CSSCalcValue&) const;
-    
+
     static bool isCalcFunction(CSSValueID);
 
     void dump(TextStream&) const;

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -635,26 +635,26 @@ void CSSParserToken::serialize(StringBuilder& builder, const CSSParserToken* nex
 
     switch (type()) {
     case IdentToken:
-        serializeIdentifier(value().toString(), builder);
+        serializeIdentifier(builder, value().toString());
         appendCommentIfNeeded({ IdentToken, FunctionToken, UrlToken, BadUrlToken, NumberToken, PercentageToken, DimensionToken, CDCToken, LeftParenthesisToken }, '-');
         break;
     case FunctionToken:
-        serializeIdentifier(value().toString(), builder);
+        serializeIdentifier(builder, value().toString());
         builder.append('(');
         break;
     case AtKeywordToken:
         builder.append('@');
-        serializeIdentifier(value().toString(), builder);
+        serializeIdentifier(builder, value().toString());
         appendCommentIfNeeded({ IdentToken, FunctionToken, UrlToken, BadUrlToken, NumberToken, PercentageToken, DimensionToken, CDCToken }, '-');
         break;
     case HashToken:
         builder.append('#');
-        serializeIdentifier(value().toString(), builder, (getHashTokenType() == HashTokenUnrestricted));
+        serializeIdentifier(builder, value().toString(), (getHashTokenType() == HashTokenUnrestricted));
         appendCommentIfNeeded({ IdentToken, FunctionToken, UrlToken, BadUrlToken, NumberToken, PercentageToken, DimensionToken, CDCToken }, '-');
         break;
     case UrlToken:
         builder.append("url("_s);
-        serializeIdentifier(value().toString(), builder);
+        serializeIdentifier(builder, value().toString());
         builder.append(')');
         break;
     case DelimiterToken:
@@ -713,12 +713,12 @@ void CSSParserToken::serialize(StringBuilder& builder, const CSSParserToken* nex
             builder.append(originalText());
         else {
             builder.append(numericValue());
-            serializeIdentifier(unitString().toString(), builder);
+            serializeIdentifier(builder, unitString().toString());
         }
         appendCommentIfNeeded({ IdentToken, FunctionToken, UrlToken, BadUrlToken, NumberToken, PercentageToken, DimensionToken, CDCToken }, '-');
         break;
     case StringToken:
-        serializeString(value().toString(), builder);
+        serializeString(builder, value().toString());
         break;
 
     case IncludeMatchToken:

--- a/Source/WebCore/css/parser/CSSParserTokenRange.cpp
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.cpp
@@ -123,9 +123,14 @@ const CSSParserToken& CSSParserTokenRange::consumeLast()
 String CSSParserTokenRange::serialize(CSSParserToken::SerializationMode mode) const
 {
     StringBuilder builder;
+    serialize(builder, mode);
+    return builder.toString();
+}
+
+void CSSParserTokenRange::serialize(StringBuilder& builder, CSSParserToken::SerializationMode mode) const
+{
     for (const CSSParserToken* it = m_first; it < m_last; ++it)
         it->serialize(builder, it + 1 == m_last ? nullptr : it + 1, mode);
-    return builder.toString();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -97,6 +97,7 @@ public:
     CSSParserTokenRange consumeAll() { return { std::exchange(m_first, m_last), m_last }; }
 
     String serialize(CSSParserToken::SerializationMode = CSSParserToken::SerializationMode::Normal) const;
+    void serialize(StringBuilder&, CSSParserToken::SerializationMode = CSSParserToken::SerializationMode::Normal) const;
 
     const CSSParserToken* begin() const { return m_first; }
     std::span<const CSSParserToken> span() const { return std::span { begin(), size() }; }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.cpp
@@ -38,7 +38,7 @@ bool unevaluatedCalcEqual(const Ref<CSSCalcValue>& a, const Ref<CSSCalcValue>& b
 
 void unevaluatedCalcSerialization(StringBuilder& builder, const Ref<CSSCalcValue>& calc)
 {
-    builder.append(calc->customCSSText());
+    calc->customCSSText(builder);
 }
 
 AngleRaw evaluateCalc(const UnevaluatedCalc<AngleRaw>& calc, const CSSCalcSymbolTable& symbolTable)

--- a/Source/WebCore/css/query/ContainerQuery.cpp
+++ b/Source/WebCore/css/query/ContainerQuery.cpp
@@ -54,7 +54,7 @@ void serialize(StringBuilder& builder, const ContainerQuery& query)
 {
     auto name = query.name;
     if (!name.isEmpty()) {
-        serializeIdentifier(name, builder);
+        serializeIdentifier(builder, name);
         builder.append(' ');
     }
 

--- a/Source/WebCore/css/query/MediaQueryParser.cpp
+++ b/Source/WebCore/css/query/MediaQueryParser.cpp
@@ -206,7 +206,7 @@ void serialize(StringBuilder& builder, const MediaQuery& query)
     }
 
     if (!query.mediaType.isEmpty() && (!query.condition || query.prefix || query.mediaType != allAtom())) {
-        serializeIdentifier(query.mediaType, builder);
+        serializeIdentifier(builder, query.mediaType);
         if (query.condition)
             builder.append(" and "_s);
     }

--- a/Source/WebCore/css/typedom/CSSKeywordValue.cpp
+++ b/Source/WebCore/css/typedom/CSSKeywordValue.cpp
@@ -71,7 +71,7 @@ ExceptionOr<void> CSSKeywordValue::setValue(const String& value)
 void CSSKeywordValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments>) const
 {
     // https://drafts.css-houdini.org/css-typed-om/#keywordvalue-serialization
-    serializeIdentifier(m_value, builder);
+    serializeIdentifier(builder, m_value);
 }
 
 RefPtr<CSSValue> CSSKeywordValue::toCSSValue() const

--- a/Source/WebCore/css/typedom/CSSStyleImageValue.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleImageValue.cpp
@@ -46,7 +46,7 @@ CSSStyleImageValue::CSSStyleImageValue(Ref<CSSImageValue>&& cssValue, Document* 
 
 void CSSStyleImageValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments>) const
 {
-    builder.append(m_cssValue->cssText());
+    m_cssValue->cssText(builder);
 }
 
 Document* CSSStyleImageValue::document() const

--- a/Source/WebCore/css/typedom/CSSStyleValue.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValue.cpp
@@ -90,7 +90,7 @@ String CSSStyleValue::toString() const
 void CSSStyleValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments>) const
 {
     if (m_propertyValue)
-        builder.append(m_propertyValue->cssText());
+        m_propertyValue->cssText(builder);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -230,7 +230,7 @@ bool MarkupAccumulator::appendContentsForNode(StringBuilder& result, const Node&
     if (!cssStyleSheet)
         return false;
 
-    result.append(cssStyleSheet->cssTextWithReplacementURLs(m_urlReplacementData->replacementURLStrings, m_urlReplacementData->replacementURLStringsForCSSStyleSheet));
+    cssStyleSheet->cssTextWithReplacementURLs(result, m_urlReplacementData->replacementURLStrings, m_urlReplacementData->replacementURLStringsForCSSStyleSheet);
     return true;
 }
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -668,18 +668,13 @@ String HTMLImageElement::completeURLsInAttributeValue(const URL& base, const Att
                 return attribute.value();
         }
 
-        StringBuilder result;
-        for (const auto& candidate : imageCandidates) {
-            if (&candidate != &imageCandidates[0])
-                result.append(", "_s);
-            result.append(resolveURLStringIfNeeded(candidate.string.toString(), resolveURLs, base));
+        return makeString(interleave(imageCandidates, [&](auto& builder, auto& candidate) {
+            builder.append(resolveURLStringIfNeeded(candidate.string.toString(), resolveURLs, base));
             if (candidate.density != UninitializedDescriptor)
-                result.append(' ', candidate.density, 'x');
+                builder.append(' ', candidate.density, 'x');
             if (candidate.resourceWidth != UninitializedDescriptor)
-                result.append(' ', candidate.resourceWidth, 'w');
-        }
-
-        return result.toString();
+                builder.append(' ', candidate.resourceWidth, 'w');
+        }, ", "_s));
     }
 
     return HTMLElement::completeURLsInAttributeValue(base, attribute, resolveURLs);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -344,23 +344,23 @@ String CanvasRenderingContext2DBase::State::fontString() const
     if (!font.realized())
         return DefaultFont;
 
-    StringBuilder serializedFont;
+    StringBuilder builder;
     const auto& font = this->font.fontDescription();
 
     auto italic = font.italic() ? "italic "_s : ""_s;
     auto smallCaps = font.variantCaps() == FontVariantCaps::Small ? "small-caps "_s : ""_s;
-    serializedFont.append(italic, smallCaps, font.computedSize(), "px"_s);
+    builder.append(italic, smallCaps, font.computedSize(), "px"_s);
 
     for (unsigned i = 0; i < font.familyCount(); ++i) {
         StringView family = font.familyAt(i);
         if (family.startsWith("-webkit-"_s))
             family = family.substring(8);
 
-        auto separator = i ? ", "_s : " "_s;
-        serializedFont.append(separator, serializeFontFamily(family.toString()));
+        builder.append(i ? ", "_s : " "_s);
+        serializeFontFamily(builder, family.toString());
     }
 
-    return serializedFont.toString();
+    return builder.toString();
 }
 
 CanvasLineCap CanvasRenderingContext2DBase::State::canvasLineCap() const

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -154,15 +154,15 @@ static Ref<JSON::ArrayOf<Inspector::Protocol::Animation::Keyframe>> buildObjectF
             for (auto property : properties) {
                 --count;
                 WTF::switchOn(property,
-                    [&] (CSSPropertyID cssPropertyId) {
+                    [&](CSSPropertyID cssPropertyId) {
                         stylePayloadBuilder.append(nameString(cssPropertyId), ": "_s);
                         if (auto value = computedStyleExtractor.valueForPropertyInStyle(style, cssPropertyId, renderer))
-                            stylePayloadBuilder.append(value->cssText());
+                            value->cssText(stylePayloadBuilder);
                     },
-                    [&] (const AtomString& customProperty) {
+                    [&](const AtomString& customProperty) {
                         stylePayloadBuilder.append(customProperty, ": "_s);
                         if (auto value = computedStyleExtractor.customPropertyValue(customProperty))
-                            stylePayloadBuilder.append(value->cssText());
+                            value->cssText(stylePayloadBuilder);
                     }
                 );
                 stylePayloadBuilder.append(';');

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -239,14 +239,14 @@ void PageSerializer::serializeFrame(LocalFrame* frame)
 
 void PageSerializer::serializeCSSStyleSheet(CSSStyleSheet* styleSheet, const URL& url)
 {
-    StringBuilder cssText;
+    StringBuilder builder;
     for (unsigned i = 0; i < styleSheet->length(); ++i) {
         CSSRule* rule = styleSheet->item(i);
-        String itemText = rule->cssText();
-        if (!itemText.isEmpty()) {
-            cssText.append(itemText);
+        auto lengthOfBuilderBefore = builder.length();
+        rule->cssText(builder);
+        if (lengthOfBuilderBefore != builder.length()) {
             if (i < styleSheet->length() - 1)
-                cssText.append("\n\n"_s);
+                builder.append("\n\n"_s);
         }
         Document* document = styleSheet->ownerDocument();
         // Some rules have resources associated with them that we need to retrieve.
@@ -266,7 +266,7 @@ void PageSerializer::serializeCSSStyleSheet(CSSStyleSheet* styleSheet, const URL
         // FIXME: We should check whether a charset has been specified and if none was found add one.
         PAL::TextEncoding textEncoding(styleSheet->contents().charset());
         ASSERT(textEncoding.isValid());
-        m_resources.append({ url, cssContentTypeAtom(), SharedBuffer::create(textEncoding.encode(cssText.toString(), PAL::UnencodableHandling::Entities)) });
+        m_resources.append({ url, cssContentTypeAtom(), SharedBuffer::create(textEncoding.encode(builder.toString(), PAL::UnencodableHandling::Entities)) });
         m_resourceURLs.add(url);
     }
 }

--- a/Source/WebCore/platform/graphics/ColorSerialization.h
+++ b/Source/WebCore/platform/graphics/ColorSerialization.h
@@ -37,9 +37,13 @@ enum class ColorSpace : uint8_t;
 // serializationForRenderTreeAsText returns the color serialized for DumpRenderTree, #RRGGBB, #RRGGBBAA or the CSS serialization.
 
 WEBCORE_EXPORT String serializationForCSS(const Color&);
+void serializationForCSS(StringBuilder&, const Color&);
 WEBCORE_EXPORT String serializationForHTML(const Color&);
+void serializationForHTML(StringBuilder&, const Color&);
 WEBCORE_EXPORT String serializationForRenderTreeAsText(const Color&);
+void serializationForRenderTreeAsText(StringBuilder&, const Color&);
 
 ASCIILiteral serialization(ColorSpace);
+void serialization(StringBuilder&, ColorSpace);
 
 }

--- a/Source/WebCore/svg/SVGPathParser.cpp
+++ b/Source/WebCore/svg/SVGPathParser.cpp
@@ -50,10 +50,18 @@ bool SVGPathParser::parseToByteStream(SVGPathSource& source, SVGPathByteStream& 
 
 bool SVGPathParser::parseToString(SVGPathSource& source, String& result, PathParsingMode mode, bool checkForInitialMoveTo)
 {
-    SVGPathStringBuilder builder;
-    SVGPathParser parser(builder, source, mode);
+    StringBuilder stringBuilder;
+    bool ok = parseToString(source, stringBuilder, mode, checkForInitialMoveTo);
+    result = stringBuilder.toString();
+    return ok;
+}
+
+bool SVGPathParser::parseToString(SVGPathSource& source, StringBuilder& stringBuilder, PathParsingMode mode, bool checkForInitialMoveTo)
+{
+    SVGPathStringBuilder pathBuilder { stringBuilder };
+    SVGPathParser parser(pathBuilder, source, mode);
     bool ok = parser.parsePathData(checkForInitialMoveTo);
-    result = builder.result();
+    pathBuilder.finalize();
     return ok;
 }
 

--- a/Source/WebCore/svg/SVGPathParser.h
+++ b/Source/WebCore/svg/SVGPathParser.h
@@ -38,6 +38,7 @@ public:
 
     static bool parseToByteStream(SVGPathSource&, SVGPathByteStream&, PathParsingMode = NormalizedParsing, bool checkForInitialMoveTo = true);
     static bool parseToString(SVGPathSource&, String& result, PathParsingMode = NormalizedParsing, bool checkForInitialMoveTo = true);
+    static bool parseToString(SVGPathSource&, StringBuilder&, PathParsingMode = NormalizedParsing, bool checkForInitialMoveTo = true);
 
 private:
     SVGPathParser(SVGPathConsumer&, SVGPathSource&, PathParsingMode);

--- a/Source/WebCore/svg/SVGPathStringBuilder.cpp
+++ b/Source/WebCore/svg/SVGPathStringBuilder.cpp
@@ -25,19 +25,27 @@
 
 namespace WebCore {
 
-SVGPathStringBuilder::SVGPathStringBuilder() = default;
+SVGPathStringBuilder::SVGPathStringBuilder(StringBuilder& stringBuilder)
+    : m_stringBuilder { stringBuilder }
+{
+}
 
 SVGPathStringBuilder::~SVGPathStringBuilder() = default;
 
 String SVGPathStringBuilder::result()
 {
+    finalize();
+    return m_stringBuilder.toString();
+}
+
+void SVGPathStringBuilder::finalize()
+{
     unsigned size = m_stringBuilder.length();
     if (!size)
-        return String();
+        return;
 
     // Remove trailing space.
     m_stringBuilder.shrink(size - 1);
-    return m_stringBuilder.toString();
 }
 
 void SVGPathStringBuilder::incrementPathSegmentCount()

--- a/Source/WebCore/svg/SVGPathStringBuilder.h
+++ b/Source/WebCore/svg/SVGPathStringBuilder.h
@@ -27,10 +27,11 @@ namespace WebCore {
 
 class SVGPathStringBuilder final : public SVGPathConsumer {
 public:
-    WEBCORE_EXPORT SVGPathStringBuilder();
+    WEBCORE_EXPORT SVGPathStringBuilder(StringBuilder&);
     WEBCORE_EXPORT virtual ~SVGPathStringBuilder();
 
     WEBCORE_EXPORT String result();
+    void finalize();
 
     void incrementPathSegmentCount() final;
     bool continueConsuming() final;
@@ -50,7 +51,7 @@ public:
     void arcTo(float, float, float, bool largeArcFlag, bool sweepFlag, const FloatPoint&, PathCoordinateMode) final;
 
 private:
-    StringBuilder m_stringBuilder;
+    StringBuilder& m_stringBuilder;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGPathUtilities.cpp
+++ b/Source/WebCore/svg/SVGPathUtilities.cpp
@@ -126,6 +126,15 @@ bool buildStringFromByteStream(const SVGPathByteStream& stream, String& result, 
     return SVGPathParser::parseToString(source, result, parsingMode, checkForInitialMoveTo);
 }
 
+bool buildStringFromByteStream(const SVGPathByteStream& stream, StringBuilder& builder, PathParsingMode parsingMode, bool checkForInitialMoveTo)
+{
+    if (stream.isEmpty())
+        return true;
+
+    SVGPathByteStreamSource source(stream);
+    return SVGPathParser::parseToString(source, builder, parsingMode, checkForInitialMoveTo);
+}
+
 bool buildSVGPathByteStreamFromString(StringView d, SVGPathByteStream& result, PathParsingMode parsingMode)
 {
     result.clear();

--- a/Source/WebCore/svg/SVGPathUtilities.h
+++ b/Source/WebCore/svg/SVGPathUtilities.h
@@ -44,6 +44,7 @@ bool buildSVGPathByteStreamFromString(StringView, SVGPathByteStream&, PathParsin
 
 // SVGPathByteStream -> String
 bool buildStringFromByteStream(const SVGPathByteStream&, String&, PathParsingMode, bool checkForInitialMoveTo = true);
+bool buildStringFromByteStream(const SVGPathByteStream&, StringBuilder&, PathParsingMode, bool checkForInitialMoveTo = true);
 
 // SVGPathByteStream -> SVGPathSegList
 bool buildSVGPathSegListFromByteStream(const SVGPathByteStream&, SVGPathSegList&, PathParsingMode);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5455,28 +5455,29 @@ ExceptionOr<String> Internals::pathStringWithShrinkWrappedRects(const Vector<dou
     for (unsigned i = 0; i < rectComponents.size(); i += 4)
         rects.append(FloatRect(rectComponents[i], rectComponents[i + 1], rectComponents[i + 2], rectComponents[i + 3]));
 
-    SVGPathStringBuilder builder;
-    PathUtilities::pathWithShrinkWrappedRects(rects, radius).applyElements([&builder](const PathElement& element) {
+    StringBuilder builder;
+    SVGPathStringBuilder pathBuilder { builder };
+    PathUtilities::pathWithShrinkWrappedRects(rects, radius).applyElements([&pathBuilder](const PathElement& element) {
         switch (element.type) {
         case PathElement::Type::MoveToPoint:
-            builder.moveTo(element.points[0], false, AbsoluteCoordinates);
+            pathBuilder.moveTo(element.points[0], false, AbsoluteCoordinates);
             return;
         case PathElement::Type::AddLineToPoint:
-            builder.lineTo(element.points[0], AbsoluteCoordinates);
+            pathBuilder.lineTo(element.points[0], AbsoluteCoordinates);
             return;
         case PathElement::Type::AddQuadCurveToPoint:
-            builder.curveToQuadratic(element.points[0], element.points[1], AbsoluteCoordinates);
+            pathBuilder.curveToQuadratic(element.points[0], element.points[1], AbsoluteCoordinates);
             return;
         case PathElement::Type::AddCurveToPoint:
-            builder.curveToCubic(element.points[0], element.points[1], element.points[2], AbsoluteCoordinates);
+            pathBuilder.curveToCubic(element.points[0], element.points[1], element.points[2], AbsoluteCoordinates);
             return;
         case PathElement::Type::CloseSubpath:
-            builder.closePath();
+            pathBuilder.closePath();
             return;
         }
         ASSERT_NOT_REACHED();
     });
-    return builder.result();
+    return builder.toString();
 }
 
 void Internals::systemBeep()


### PR DESCRIPTION
#### 23e4ef26e7c26f02676a845473585baf81961a84
<pre>
Avoid temporary string allocations when serializing CSS
<a href="https://bugs.webkit.org/show_bug.cgi?id=276318">https://bugs.webkit.org/show_bug.cgi?id=276318</a>

Reviewed by NOBODY (OOPS!).

When serializing CSS rules and values, the serialization often
requires the concatenation of multiple items. To avoid unnecessary
temporary string construction overloads of the `cssText`/`customCSSText`
functions that take a `StringBuilder` can be used to allow writing
the result directly into the final location.

CSS rule subclasses now must implement the `cssText` method that
takes a `StringBuilder` rather than one that returns a `String`. The
latter is implemented only for the base class, and calls to the
former. Additionally, CSS rule subclasses may implement the
`cssTextWithReplacementURLs() method that takes a `StringBuilder`
if they serialize URLs. Again, the version that returns a `String`
is implemented in the base class by calling the `StringBuilder` one.

CSS value subclasses now must implement a `customCSSText` method that
takes a `StringBuilder`, but, unlike rules, they can also implement
an overload that returns a `String` if the implementation would be
more efficient for callers that only want its value. Any subclass
that doesn&apos;t implement the version returning a `String` will instead
have have their `StringBuilder` version called from the base class.

Additional work is still needed avoid temporary allocations for
shorthand and selector serialization.

* Source/WebCore/css/CSSAnchorValue.cpp:
* Source/WebCore/css/CSSAnchorValue.h:
* Source/WebCore/css/CSSAspectRatioValue.cpp:
* Source/WebCore/css/CSSAspectRatioValue.h:
* Source/WebCore/css/CSSBackgroundRepeatValue.cpp:
* Source/WebCore/css/CSSBackgroundRepeatValue.h:
* Source/WebCore/css/CSSBasicShapes.cpp:
* Source/WebCore/css/CSSBasicShapes.h:
* Source/WebCore/css/CSSBorderImageSliceValue.cpp:
* Source/WebCore/css/CSSBorderImageSliceValue.h:
* Source/WebCore/css/CSSBorderImageWidthValue.cpp:
* Source/WebCore/css/CSSBorderImageWidthValue.h:
* Source/WebCore/css/CSSCanvasValue.cpp:
* Source/WebCore/css/CSSCanvasValue.h:
* Source/WebCore/css/CSSContainerRule.cpp:
* Source/WebCore/css/CSSContainerRule.h:
* Source/WebCore/css/CSSContentDistributionValue.cpp:
* Source/WebCore/css/CSSContentDistributionValue.h:
* Source/WebCore/css/CSSCounterStyle.h:
* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
* Source/WebCore/css/CSSCounterStyleDescriptors.h:
* Source/WebCore/css/CSSCounterStyleRule.cpp:
* Source/WebCore/css/CSSCounterStyleRule.h:
* Source/WebCore/css/CSSCounterValue.cpp:
* Source/WebCore/css/CSSCounterValue.h:
* Source/WebCore/css/CSSCrossfadeValue.cpp:
* Source/WebCore/css/CSSCrossfadeValue.h:
* Source/WebCore/css/CSSCursorImageValue.cpp:
* Source/WebCore/css/CSSCursorImageValue.h:
* Source/WebCore/css/CSSCustomPropertyValue.cpp:
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/CSSFilterImageValue.cpp:
* Source/WebCore/css/CSSFilterImageValue.h:
* Source/WebCore/css/CSSFontFaceRule.cpp:
* Source/WebCore/css/CSSFontFaceRule.h:
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
* Source/WebCore/css/CSSFontFaceSrcValue.h:
* Source/WebCore/css/CSSFontFeatureValue.cpp:
* Source/WebCore/css/CSSFontFeatureValue.h:
* Source/WebCore/css/CSSFontFeatureValuesRule.cpp:
* Source/WebCore/css/CSSFontFeatureValuesRule.h:
* Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.cpp:
* Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.h:
* Source/WebCore/css/CSSFontPaletteValuesRule.cpp:
* Source/WebCore/css/CSSFontPaletteValuesRule.h:
* Source/WebCore/css/CSSFontStyleRangeValue.cpp:
* Source/WebCore/css/CSSFontStyleRangeValue.h:
* Source/WebCore/css/CSSFontStyleWithAngleValue.cpp:
* Source/WebCore/css/CSSFontStyleWithAngleValue.h:
* Source/WebCore/css/CSSFontValue.cpp:
* Source/WebCore/css/CSSFontValue.h:
* Source/WebCore/css/CSSFontVariantAlternatesValue.cpp:
* Source/WebCore/css/CSSFontVariantAlternatesValue.h:
* Source/WebCore/css/CSSFontVariationValue.cpp:
* Source/WebCore/css/CSSFontVariationValue.h:
* Source/WebCore/css/CSSFunctionValue.cpp:
* Source/WebCore/css/CSSFunctionValue.h:
* Source/WebCore/css/CSSGradientValue.cpp:
* Source/WebCore/css/CSSGradientValue.h:
* Source/WebCore/css/CSSGridAutoRepeatValue.cpp:
* Source/WebCore/css/CSSGridAutoRepeatValue.h:
* Source/WebCore/css/CSSGridIntegerRepeatValue.cpp:
* Source/WebCore/css/CSSGridIntegerRepeatValue.h:
* Source/WebCore/css/CSSGridLineNamesValue.cpp:
* Source/WebCore/css/CSSGridLineNamesValue.h:
* Source/WebCore/css/CSSGridTemplateAreasValue.cpp:
* Source/WebCore/css/CSSGridTemplateAreasValue.h:
* Source/WebCore/css/CSSGroupingRule.cpp:
* Source/WebCore/css/CSSGroupingRule.h:
* Source/WebCore/css/CSSImageSetOptionValue.cpp:
* Source/WebCore/css/CSSImageSetOptionValue.h:
* Source/WebCore/css/CSSImageSetValue.cpp:
* Source/WebCore/css/CSSImageSetValue.h:
* Source/WebCore/css/CSSImageValue.cpp:
* Source/WebCore/css/CSSImageValue.h:
* Source/WebCore/css/CSSImportRule.cpp:
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSKeyframeRule.cpp:
* Source/WebCore/css/CSSKeyframeRule.h:
* Source/WebCore/css/CSSKeyframesRule.cpp:
* Source/WebCore/css/CSSKeyframesRule.h:
* Source/WebCore/css/CSSLayerBlockRule.cpp:
* Source/WebCore/css/CSSLayerBlockRule.h:
* Source/WebCore/css/CSSLayerStatementRule.cpp:
* Source/WebCore/css/CSSLayerStatementRule.h:
* Source/WebCore/css/CSSLineBoxContainValue.cpp:
* Source/WebCore/css/CSSLineBoxContainValue.h:
* Source/WebCore/css/CSSMarkup.cpp:
* Source/WebCore/css/CSSMarkup.h:
* Source/WebCore/css/CSSMediaRule.cpp:
* Source/WebCore/css/CSSMediaRule.h:
* Source/WebCore/css/CSSNamedImageValue.cpp:
* Source/WebCore/css/CSSNamedImageValue.h:
* Source/WebCore/css/CSSNamespaceRule.cpp:
* Source/WebCore/css/CSSNamespaceRule.h:
* Source/WebCore/css/CSSOffsetRotateValue.cpp:
* Source/WebCore/css/CSSOffsetRotateValue.h:
* Source/WebCore/css/CSSPageRule.cpp:
* Source/WebCore/css/CSSPageRule.h:
* Source/WebCore/css/CSSPaintImageValue.cpp:
* Source/WebCore/css/CSSPaintImageValue.h:
* Source/WebCore/css/CSSPendingSubstitutionValue.h:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSPropertyRule.cpp:
* Source/WebCore/css/CSSPropertyRule.h:
* Source/WebCore/css/CSSQuadValue.cpp:
* Source/WebCore/css/CSSQuadValue.h:
* Source/WebCore/css/CSSRayValue.cpp:
* Source/WebCore/css/CSSRayValue.h:
* Source/WebCore/css/CSSRectValue.cpp:
* Source/WebCore/css/CSSRectValue.h:
* Source/WebCore/css/CSSReflectValue.cpp:
* Source/WebCore/css/CSSReflectValue.h:
* Source/WebCore/css/CSSRule.cpp:
* Source/WebCore/css/CSSRule.h:
* Source/WebCore/css/CSSScopeRule.cpp:
* Source/WebCore/css/CSSScopeRule.h:
* Source/WebCore/css/CSSScrollValue.cpp:
* Source/WebCore/css/CSSScrollValue.h:
* Source/WebCore/css/CSSSelector.cpp:
* Source/WebCore/css/CSSShadowValue.cpp:
* Source/WebCore/css/CSSShadowValue.h:
* Source/WebCore/css/CSSStartingStyleRule.cpp:
* Source/WebCore/css/CSSStartingStyleRule.h:
* Source/WebCore/css/CSSStyleRule.cpp:
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/CSSSubgridValue.cpp:
* Source/WebCore/css/CSSSubgridValue.h:
* Source/WebCore/css/CSSSupportsRule.cpp:
* Source/WebCore/css/CSSSupportsRule.h:
* Source/WebCore/css/CSSTimingFunctionValue.cpp:
* Source/WebCore/css/CSSTimingFunctionValue.h:
* Source/WebCore/css/CSSTransformListValue.h:
* Source/WebCore/css/CSSUnicodeRangeValue.cpp:
* Source/WebCore/css/CSSUnicodeRangeValue.h:
* Source/WebCore/css/CSSUnknownRule.h:
* Source/WebCore/css/CSSValue.cpp:
* Source/WebCore/css/CSSValue.h:
* Source/WebCore/css/CSSValueList.cpp:
* Source/WebCore/css/CSSValueList.h:
* Source/WebCore/css/CSSValuePair.cpp:
* Source/WebCore/css/CSSValuePair.h:
* Source/WebCore/css/CSSVariableData.cpp:
* Source/WebCore/css/CSSVariableData.h:
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
* Source/WebCore/css/CSSVariableReferenceValue.h:
* Source/WebCore/css/CSSViewValue.cpp:
* Source/WebCore/css/CSSViewValue.h:
* Source/WebCore/css/DOMCSSNamespace.cpp:
* Source/WebCore/css/DeprecatedCSSOMValueList.cpp:
* Source/WebCore/css/Quad.h:
* Source/WebCore/css/Rect.h:
* Source/WebCore/css/ShorthandSerializer.cpp:
* Source/WebCore/css/ShorthandSerializer.h:
* Source/WebCore/css/StyleProperties.cpp:
* Source/WebCore/css/StyleProperties.h:
* Source/WebCore/css/StylePropertiesInlines.h:
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp:
* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h:
* Source/WebCore/css/calc/CSSCalcSymbolNode.cpp:
* Source/WebCore/css/calc/CSSCalcSymbolNode.h:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
* Source/WebCore/css/calc/CSSCalcValue.h:
* Source/WebCore/css/parser/CSSParserToken.cpp:
* Source/WebCore/css/parser/CSSParserTokenRange.cpp:
* Source/WebCore/css/parser/CSSParserTokenRange.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.cpp:
* Source/WebCore/css/query/ContainerQuery.cpp:
* Source/WebCore/css/query/GenericMediaQuerySerialization.cpp:
* Source/WebCore/css/query/MediaQueryParser.cpp:
* Source/WebCore/css/typedom/CSSKeywordValue.cpp:
* Source/WebCore/css/typedom/CSSStyleImageValue.cpp:
* Source/WebCore/css/typedom/CSSStyleValue.cpp:
* Source/WebCore/editing/MarkupAccumulator.cpp:
* Source/WebCore/html/HTMLImageElement.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
* Source/WebCore/page/PageSerializer.cpp:
* Source/WebCore/platform/graphics/ColorSerialization.cpp:
* Source/WebCore/platform/graphics/ColorSerialization.h:
* Source/WebCore/svg/SVGPathParser.cpp:
* Source/WebCore/svg/SVGPathParser.h:
* Source/WebCore/svg/SVGPathStringBuilder.cpp:
* Source/WebCore/svg/SVGPathStringBuilder.h:
* Source/WebCore/svg/SVGPathUtilities.cpp:
* Source/WebCore/svg/SVGPathUtilities.h:
* Source/WebCore/testing/Internals.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23e4ef26e7c26f02676a845473585baf81961a84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57595 "15 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61217 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8040 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8228 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46637 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-shapes/shape-outside/values/shape-outside-inset-009.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5709 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27503 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31420 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-shapes/shape-outside/values/shape-outside-inset-009.html imported/w3c/web-platform-tests/websockets/basic-auth.any.html?wss (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7059 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7043 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62897 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1509 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7423 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-shapes/shape-outside/values/shape-outside-inset-009.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53900 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-shapes/shape-outside/values/shape-outside-inset-009.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54008 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1286 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32752 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33838 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34922 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33583 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->