### PR TITLE
WebCodecs AudioDecoder callbacks leak the Document object

### DIFF
--- a/LayoutTests/http/tests/webcodecs/audio-decoder-callbacks-do-not-leak-expected.txt
+++ b/LayoutTests/http/tests/webcodecs/audio-decoder-callbacks-do-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that AudioDecoder callbacks do not leak the document object.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webcodecs/audio-decoder-callbacks-do-not-leak.html
+++ b/LayoutTests/http/tests/webcodecs/audio-decoder-callbacks-do-not-leak.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/document-leak-test.js"></script>
+</head>
+<body>
+<script>
+    description("Tests that AudioDecoder callbacks do not leak the document object.");
+    onload = () => runDocumentLeakTest({ frameURL: "./resources/audio-decoder-callbacks-frame.html", framesToCreate: 20 });
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webcodecs/resources/audio-decoder-callbacks-frame.html
+++ b/LayoutTests/http/tests/webcodecs/resources/audio-decoder-callbacks-frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+const audioDecoder = new AudioDecoder({
+    output: _ => {},
+    error: _ => {},
+});
+
+onload = () => parent.postMessage("iframeLoaded");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webcodecs/video-decoder-callbacks-do-not-leak-expected.txt
+++ b/LayoutTests/http/tests/webcodecs/video-decoder-callbacks-do-not-leak-expected.txt
@@ -1,4 +1,4 @@
-Tests that VideoDecoder error callback does not leak the document object.
+Tests that VideoDecoder callbacks do not leak the document object.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 

--- a/LayoutTests/http/tests/webcodecs/video-decoder-callbacks-do-not-leak.html
+++ b/LayoutTests/http/tests/webcodecs/video-decoder-callbacks-do-not-leak.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <script>
-    description("Tests that VideoDecoder error callback does not leak the document object.");
+    description("Tests that VideoDecoder callbacks do not leak the document object.");
     onload = () => runDocumentLeakTest({ frameURL: "./resources/video-decoder-callbacks-frame.html", framesToCreate: 20 });
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h
@@ -42,6 +42,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(WebCodecsAudioData&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.idl
@@ -24,7 +24,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_CODECS,
-    IsStrongCallback
-] callback WebCodecsAudioDataOutputCallback = undefined(WebCodecsAudioData output);
+[ Conditional=WEB_CODECS ] callback WebCodecsAudioDataOutputCallback = undefined(WebCodecsAudioData output);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h
@@ -75,6 +75,9 @@ public:
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
+    WebCodecsAudioDataOutputCallback& outputCallbackConcurrently() { return m_output.get(); }
+    WebCodecsErrorCallback& errorCallbackConcurrently() { return m_error.get(); }
+
 private:
     WebCodecsAudioDecoder(ScriptExecutionContext&, Init&&);
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.idl
@@ -31,6 +31,7 @@
     EnabledBySetting=WebCodecsAudioEnabled,
     Exposed=(Window,DedicatedWorker),
     InterfaceName=AudioDecoder,
+    JSCustomMarkFunction
 ] interface WebCodecsAudioDecoder : EventTarget {
     [CallWith=CurrentScriptExecutionContext] constructor(WebCodecsAudioDecoderInit init);
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -729,6 +729,7 @@ bindings/js/JSCSSStyleValueCustom.cpp
 bindings/js/JSCSSTransformComponentCustom.cpp
 bindings/js/JSUndoItemCustom.cpp
 bindings/js/JSWebAnimationCustom.cpp
+bindings/js/JSWebCodecsAudioDecoderCustom.cpp
 bindings/js/JSWebCodecsVideoDecoderCustom.cpp
 bindings/js/JSWebCodecsAudioEncoderCustom.cpp
 bindings/js/JSWebCodecsVideoEncoderCustom.cpp

--- a/Source/WebCore/bindings/js/JSWebCodecsAudioDecoderCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebCodecsAudioDecoderCustom.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEB_CODECS)
+#include "JSWebCodecsAudioDecoder.h"
+
+#include "WebCodecsAudioDataOutputCallback.h"
+#include "WebCodecsErrorCallback.h"
+
+#include <JavaScriptCore/JSCInlines.h>
+
+namespace WebCore {
+
+template <typename Visitor>
+void JSWebCodecsAudioDecoder::visitAdditionalChildren(Visitor& visitor)
+{
+    wrapped().outputCallbackConcurrently().visitJSFunction(visitor);
+    wrapped().errorCallbackConcurrently().visitJSFunction(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWebCodecsAudioDecoder);
+
+}
+
+#endif


### PR DESCRIPTION
#### 8c66f1def4e54f5a404425465ad45c6471e99297
<pre>
WebCodecs AudioDecoder callbacks leak the Document object
<a href="https://bugs.webkit.org/show_bug.cgi?id=276322">https://bugs.webkit.org/show_bug.cgi?id=276322</a>
<a href="https://rdar.apple.com/131315241">rdar://131315241</a>

Reviewed by Youenn Fablet.

This is similar to VideoDecoder&apos;s callbacks leaking the Document object
via holding references to the callback object but not ever releasing the
references (280738@main). To fix the leak, we make the callback Weak and
keep it alive via visitAdditionalChildren during the marking phase.

* LayoutTests/http/tests/webcodecs/audio-decoder-callbacks-do-not-leak-expected.txt: Added.
* LayoutTests/http/tests/webcodecs/audio-decoder-callbacks-do-not-leak.html: Copied from LayoutTests/http/tests/webcodecs/video-decoder-callbacks-do-not-leak.html.
* LayoutTests/http/tests/webcodecs/resources/audio-decoder-callbacks-frame.html: Added.
* LayoutTests/http/tests/webcodecs/video-decoder-callbacks-do-not-leak-expected.txt:
* LayoutTests/http/tests/webcodecs/video-decoder-callbacks-do-not-leak.html: Fixed a typo in the description of the test.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.idl:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.h:
(WebCore::WebCodecsAudioDecoder::outputCallbackConcurrently):
(WebCore::WebCodecsAudioDecoder::errorCallbackConcurrently):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSWebCodecsAudioDecoderCustom.cpp: Added.
(WebCore::JSWebCodecsAudioDecoder::visitAdditionalChildren):

Canonical link: <a href="https://commits.webkit.org/280783@main">https://commits.webkit.org/280783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18ae7fde0ae16f8bb8b57f7361154ff6d3eb1514

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61231 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8242 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5720 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27516 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31432 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/7072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7057 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62911 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1523 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49793 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/54024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12749 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1299 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33852 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/34936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->