### PR TITLE
Scroll corner paints in a visibility:hidden subtree

### DIFF
--- a/LayoutTests/compositing/animation/hidden-animated-layer-should-not-have-scrollbars-expected.html
+++ b/LayoutTests/compositing/animation/hidden-animated-layer-should-not-have-scrollbars-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE HTML>
+<!-- nothing -->

--- a/LayoutTests/compositing/animation/hidden-animated-layer-should-not-have-scrollbars.html
+++ b/LayoutTests/compositing/animation/hidden-animated-layer-should-not-have-scrollbars.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<style>
+@keyframes boring {
+  0% { transform: translateZ(0px); }
+  100% { transform: translateZ(0px); }
+}
+#scroller {
+  width: 100px;
+  height: 100px;
+  overflow: scroll;
+  animation: boring 5s infinite;
+  visibility: hidden;
+}
+#scrolled {
+  width: 10px;
+  height: 10px;
+  position: relative;
+  background: blue;
+  visibility: hidden;
+  top: 300px;
+}
+</style>
+<div id="scroller">
+  <div id="scrolled"></div>
+</div>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1219,7 +1219,7 @@ void RenderLayer::recursiveUpdateLayerPositionsAfterScroll(OptionSet<UpdateLayer
     // If we have no visible content and no visible descendants, there is no point recomputing
     // our rectangles as they will be empty. If our visibility changes, we are expected to
     // recompute all our positions anyway.
-    if (!m_hasVisibleDescendant && !m_hasVisibleContent)
+    if (subtreeIsInvisible())
         return;
 
     bool positionChanged = updateLayerPosition();
@@ -5030,7 +5030,7 @@ LayoutRect RenderLayer::calculateLayerBounds(const RenderLayer* ancestorLayer, c
         return LayoutRect();
 
     // FIXME: This could be improved to do a check like hasVisibleNonCompositingDescendantLayers() (bug 92580).
-    if ((flags & ExcludeHiddenDescendants) && this != ancestorLayer && !hasVisibleContent() && !hasVisibleDescendant())
+    if ((flags & ExcludeHiddenDescendants) && this != ancestorLayer && subtreeIsInvisible())
         return LayoutRect();
 
     if (isRenderViewLayer()) {

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1175,6 +1175,8 @@ private:
 
     inline bool hasNonOpacityTransparency() const;
 
+    bool subtreeIsInvisible() const { return !hasVisibleContent() && !hasVisibleDescendant(); }
+
     void updatePagination();
 
     void setHasCompositingDescendant(bool b)  { m_hasCompositingDescendant = b; }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2328,6 +2328,13 @@ bool RenderLayerBacking::requiresScrollCornerLayer() const
 
 bool RenderLayerBacking::updateOverflowControlsLayers(bool needsHorizontalScrollbarLayer, bool needsVerticalScrollbarLayer, bool needsScrollCornerLayer)
 {
+    // If the subtree is invisible, we don't actually need scrollbar layers.
+    if (m_owningLayer.subtreeIsInvisible()) {
+        needsHorizontalScrollbarLayer = false;
+        needsVerticalScrollbarLayer = false;
+        needsScrollCornerLayer = false;
+    }
+
     auto createOrDestroyLayer = [&](RefPtr<GraphicsLayer>& layer, bool needLayer, bool drawsContent, ASCIILiteral layerName) {
         if (needLayer == !!layer)
             return false;


### PR DESCRIPTION
<pre>
Scroll corner paints in a visibility:hidden subtree
<a href="https://bugs.webkit.org/show_bug.cgi?id=276107">https://bugs.webkit.org/show_bug.cgi?id=276107</a>
rdar://problem/131351554

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/5d8a13843d41c418d040d3e1c16d37593c091628">https://chromium.googlesource.com/chromium/blink/+/5d8a13843d41c418d040d3e1c16d37593c091628</a>

This patch fixes an issue where WebKit was painting scrollbar
corner while it has 'hidden' visibility in subtree.

This only reproduces when the user has 'always on' scrollbar
turned on.

This also adds 'helper' function and then leverages it throughout
call sites.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::recursiveUpdateLayerPositionsAfterScroll): Use `subtreeIsInvisible` helper
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h: Introduce `subtreeIsInvisible` helper function
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateOverflowControlsLayers): Use `subtreeIsInvisible` helper
* LayoutTests/compositing/animation/hidden-animated-layer-should-not-have-scrollbars.html: Add Test Case
* LayoutTests/compositing/animation/hidden-animated-layer-should-not-have-scrollbars-expected.html: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94a0e525dabd22522010689c626c2f90e1e89cb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61206 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8029 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46626 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5696 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27492 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7046 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7032 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53362 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62886 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53886 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53992 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1273 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32741 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33826 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->