### PR TITLE
[Navigation] Implement NavigationDestination.getState

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-navigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-navigate-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigate event destination.getState() should be the state given to navigate() assert_not_equals: got disallowed value undefined
+PASS navigate event destination.getState() should be the state given to navigate()
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -630,6 +630,9 @@ bool Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationT
     RefPtr document = window()->protectedDocument();
 
     RefPtr apiMethodTracker = m_ongoingAPIMethodTracker;
+    // FIXME: this should not be needed, we should pass it into FrameLoader.
+    if (apiMethodTracker && apiMethodTracker->serializedState)
+        destination->setStateObject(apiMethodTracker->serializedState.get());
     bool isSameDocument = destination->sameDocument();
     bool isTraversal = navigationType == NavigationNavigationType::Traverse;
     bool canIntercept = documentCanHaveURLRewritten(*document, destination->url()) && (!isTraversal || isSameDocument);
@@ -782,8 +785,9 @@ bool Navigation::dispatchTraversalNavigateEvent(HistoryItem& historyItem)
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-push/replace/reload-navigate-event
 bool Navigation::dispatchPushReplaceReloadNavigateEvent(const URL& url, NavigationNavigationType navigationType, bool isSameDocument, FormState* formState, SerializedScriptValue* classicHistoryAPIState)
 {
-    // FIXME: Set event's classic history API state to classicHistoryAPIState.
     Ref destination = NavigationDestination::create(url, nullptr, isSameDocument);
+    if (classicHistoryAPIState)
+        destination->setStateObject(classicHistoryAPIState);
     return innerDispatchNavigateEvent(navigationType, WTFMove(destination), { }, formState, classicHistoryAPIState);
 }
 

--- a/Source/WebCore/page/NavigationDestination.cpp
+++ b/Source/WebCore/page/NavigationDestination.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "NavigationDestination.h"
 
+#include "JSDOMGlobalObject.h"
+#include "SerializedScriptValue.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
@@ -38,6 +40,14 @@ NavigationDestination::NavigationDestination(const URL& url, RefPtr<NavigationHi
     , m_url(url)
     , m_isSameDocument(isSameDocument)
 {
+}
+
+JSC::JSValue NavigationDestination::getState(JSDOMGlobalObject& globalObject) const
+{
+    if (!m_stateObject)
+        return JSC::jsUndefined();
+
+    return m_stateObject->deserialize(globalObject, &globalObject, SerializationErrorMode::Throwing);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationDestination.h
+++ b/Source/WebCore/page/NavigationDestination.h
@@ -46,7 +46,8 @@ public:
     String id() const { return m_entry ? m_entry->id() : String(); };
     int64_t index() const { return m_entry ? m_entry->index() : -1; };
     bool sameDocument() const { return m_isSameDocument; };
-    const JSC::JSValue& getState() const { return m_state; };
+    JSC::JSValue getState(JSDOMGlobalObject&) const;
+    void setStateObject(SerializedScriptValue* stateObject) { m_stateObject = stateObject; }
 
 private:
     explicit NavigationDestination(const URL&, RefPtr<NavigationHistoryEntry>&&, bool isSameDocument);
@@ -54,7 +55,7 @@ private:
     RefPtr<NavigationHistoryEntry> m_entry;
     URL m_url;
     bool m_isSameDocument;
-    JSC::JSValue m_state;
+    RefPtr<SerializedScriptValue> m_stateObject;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationDestination.idl
+++ b/Source/WebCore/page/NavigationDestination.idl
@@ -8,5 +8,5 @@
   readonly attribute long long index;
   readonly attribute boolean sameDocument;
 
-  any getState();
+  [CallWith=CurrentGlobalObject] any getState();
 };


### PR DESCRIPTION
#### 4876281cfad6c0e881c669a99b48e564b7234f3e
<pre>
[Navigation] Implement NavigationDestination.getState
<a href="https://bugs.webkit.org/show_bug.cgi?id=276320">https://bugs.webkit.org/show_bug.cgi?id=276320</a>

Reviewed by Alex Christensen.

Implement NavigationDestination.getState functionality [1].

Note that state is not set yet in the traversal case and although it
improves behaviour, it is obscured by an unrelated problem that makes
those tests fail before getState is called.

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationhistoryentry-getstate">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationhistoryentry-getstate</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-navigate-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::dispatchPushReplaceReloadNavigateEvent):
* Source/WebCore/page/NavigationDestination.cpp:
(WebCore::NavigationDestination::getState const):
* Source/WebCore/page/NavigationDestination.h:
* Source/WebCore/page/NavigationDestination.idl:

Canonical link: <a href="https://commits.webkit.org/280809@main">https://commits.webkit.org/280809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab79d0df8c24097696d90c321d1b338908062c75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61273 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8096 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46672 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5739 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27539 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7101 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7100 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53413 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62953 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53933 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54042 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12765 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1325 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32808 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33894 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34978 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33639 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->