### PR TITLE
Clicking and dragging  video viewer in the page menu drag a layer on top of the other.

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -353,16 +353,25 @@ class MediaController
 
         this.controls.shouldUseSingleBarLayout = this.controls instanceof InlineMediaControls && this.isYouTubeEmbedWithTitle;
 
-        if (this.host && this.host.inWindowFullscreen) {
-            this._stopPropagationOnClickEvents();
-            if (!this.host.supportsSeeking)
-                this.controls.timeControl.scrubber.disabled = true;
-
-            if (!this.host.supportsRewind)
-                this.controls.rewindButton.dropped = true;
-        }
+        this._updateControlsForInWindowFullscreenIfNeeded();
 
         this._updateControlsAvailability();
+    }
+
+    _updateControlsForInWindowFullscreenIfNeeded()
+    {
+        if (!this.host || !this.host.inWindowFullscreen)
+            return;
+
+        this.media.parentNode.setAttribute("draggable", "false");
+
+        this._stopPropagationOnClickEvents();
+
+        if (!this.host.supportsSeeking)
+            this.controls.timeControl.scrubber.disabled = true;
+
+        if (!this.host.supportsRewind)
+            this.controls.rewindButton.dropped = true;
     }
 
     _stopPropagationOnClickEvents()


### PR DESCRIPTION
#### 37cdf7449ebce078026129b71c9bc6186464ff36
<pre>
Clicking and dragging  video viewer in the page menu drag a layer on top of the other.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276328">https://bugs.webkit.org/show_bug.cgi?id=276328</a>
<a href="https://rdar.apple.com/127512495">rdar://127512495</a>

Reviewed by NOBODY (OOPS!).

On YouTube.com, clicking and dragging on a video in Video Viewer causes elements on
the page behind the video to come to the forefront. This is because YouTube gives
a draggable=true attribute to the parent div of the video element.

To fix this, this patch sets the media&apos;s parent node&apos;s draggable attribute to false.
This patch also places the in-window fullscreen specific logic into a separate method
in the MediaController class called _updateControlsForInWindowFullscreenIfNeeded().

* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype._updateControlsIfNeeded):
(MediaController.prototype._updateControlsForInWindowFullscreenIfNeeded):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37cdf7449ebce078026129b71c9bc6186464ff36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61113 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7936 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46555 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5625 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59521 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34552 "Found 3 new test failures: compositing/geometry/video-opacity-overlay.html compositing/reflections/load-video-in-reflection.html compositing/self-painting-layers.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27419 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31335 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6966 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6939 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53303 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62792 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53816 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49688 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53910 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1198 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32648 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33733 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33479 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->