### PR TITLE
WebCodecs Audio and Video Encoder callbacks leak the Document object.

### DIFF
--- a/LayoutTests/http/tests/webcodecs/audio-encoder-callbacks-do-not-leak-expected.txt
+++ b/LayoutTests/http/tests/webcodecs/audio-encoder-callbacks-do-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that AudioEncoder callbacks do not leak the document object.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webcodecs/audio-encoder-callbacks-do-not-leak.html
+++ b/LayoutTests/http/tests/webcodecs/audio-encoder-callbacks-do-not-leak.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/document-leak-test.js"></script>
+</head>
+<body>
+<script>
+    description("Tests that AudioEncoder callbacks do not leak the document object.");
+    onload = () => runDocumentLeakTest({ frameURL: "./resources/audio-encoder-callbacks-frame.html", framesToCreate: 20 });
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webcodecs/resources/audio-encoder-callbacks-frame.html
+++ b/LayoutTests/http/tests/webcodecs/resources/audio-encoder-callbacks-frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+const audioEncoder = new AudioEncoder({
+    output: _ => {},
+    error: _ => {},
+});
+
+onload = () => parent.postMessage("iframeLoaded");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webcodecs/resources/video-encoder-callbacks-frame.html
+++ b/LayoutTests/http/tests/webcodecs/resources/video-encoder-callbacks-frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+const videoEncoder = new VideoEncoder({
+    output: _ => {},
+    error: _ => {},
+});
+
+onload = () => parent.postMessage("iframeLoaded");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webcodecs/video-encoder-callbacks-do-not-leak-expected.txt
+++ b/LayoutTests/http/tests/webcodecs/video-encoder-callbacks-do-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that VideoEncoder callbacks do not leak the document object.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webcodecs/video-encoder-callbacks-do-not-leak.html
+++ b/LayoutTests/http/tests/webcodecs/video-encoder-callbacks-do-not-leak.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/document-leak-test.js"></script>
+</head>
+<body>
+<script>
+    description("Tests that VideoEncoder callbacks do not leak the document object.");
+    onload = () => runDocumentLeakTest({ frameURL: "./resources/video-encoder-callbacks-frame.html", framesToCreate: 20 });
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h
@@ -75,6 +75,8 @@ public:
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
+    WebCodecsEncodedAudioChunkOutputCallback& outputCallbackConcurrently() { return m_output.get(); }
+    WebCodecsErrorCallback& errorCallbackConcurrently() { return m_error.get(); }
 private:
     WebCodecsAudioEncoder(ScriptExecutionContext&, Init&&);
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.idl
@@ -31,6 +31,7 @@
     EnabledBySetting=WebCodecsAudioEnabled,
     Exposed=(Window,DedicatedWorker),
     InterfaceName=AudioEncoder,
+    JSCustomMarkFunction
 ] interface WebCodecsAudioEncoder : EventTarget {
     [CallWith=CurrentScriptExecutionContext] constructor(WebCodecsAudioEncoderInit init);
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.h
@@ -43,6 +43,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(WebCodecsEncodedAudioChunk&, const WebCodecsEncodedAudioChunkMetadata&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.idl
@@ -24,7 +24,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_CODECS,
-    IsStrongCallback
-] callback WebCodecsEncodedAudioChunkOutputCallback = undefined (WebCodecsEncodedAudioChunk chunk, optional WebCodecsEncodedAudioChunkMetadata metadata = {});
+[ Conditional=WEB_CODECS ] callback WebCodecsEncodedAudioChunkOutputCallback = undefined (WebCodecsEncodedAudioChunk chunk, optional WebCodecsEncodedAudioChunkMetadata metadata = {});

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h
@@ -42,6 +42,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(WebCodecsEncodedVideoChunk&, const WebCodecsEncodedVideoChunkMetadata&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.idl
@@ -23,7 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_CODECS,
-    IsStrongCallback
-] callback WebCodecsEncodedVideoChunkOutputCallback = undefined (WebCodecsEncodedVideoChunk chunk, optional WebCodecsEncodedVideoChunkMetadata metadata = {});
+[ Conditional=WEB_CODECS ] callback WebCodecsEncodedVideoChunkOutputCallback = undefined (WebCodecsEncodedVideoChunk chunk, optional WebCodecsEncodedVideoChunkMetadata metadata = {});

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -74,6 +74,9 @@ public:
     void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
+    WebCodecsEncodedVideoChunkOutputCallback& outputCallbackConcurrently() { return m_output.get(); }
+    WebCodecsErrorCallback& errorCallbackConcurrently() { return m_error.get(); }
+
 private:
     WebCodecsVideoEncoder(ScriptExecutionContext&, Init&&);
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.idl
@@ -30,6 +30,7 @@
     EnabledBySetting=WebCodecsVideoEnabled,
     Exposed=(Window,DedicatedWorker),
     InterfaceName=VideoEncoder,
+    JSCustomMarkFunction
 ] interface WebCodecsVideoEncoder : EventTarget {
     [CallWith=CurrentScriptExecutionContext] constructor(WebCodecsVideoEncoderInit init);
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -730,6 +730,8 @@ bindings/js/JSCSSTransformComponentCustom.cpp
 bindings/js/JSUndoItemCustom.cpp
 bindings/js/JSWebAnimationCustom.cpp
 bindings/js/JSWebCodecsVideoDecoderCustom.cpp
+bindings/js/JSWebCodecsAudioEncoderCustom.cpp
+bindings/js/JSWebCodecsVideoEncoderCustom.cpp
 bindings/js/JSWebGL2RenderingContextCustom.cpp
 bindings/js/JSWebGLRenderingContextCustom.cpp
 bindings/js/JSWebXRSessionCustom.cpp

--- a/Source/WebCore/bindings/js/JSWebCodecsAudioEncoderCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebCodecsAudioEncoderCustom.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEB_CODECS)
+#include "JSWebCodecsAudioEncoder.h"
+
+#include "WebCodecsEncodedAudioChunkOutputCallback.h"
+#include "WebCodecsErrorCallback.h"
+
+#include <JavaScriptCore/JSCInlines.h>
+
+namespace WebCore {
+
+template <typename Visitor>
+void JSWebCodecsAudioEncoder::visitAdditionalChildren(Visitor& visitor)
+{
+    wrapped().outputCallbackConcurrently().visitJSFunction(visitor);
+    wrapped().errorCallbackConcurrently().visitJSFunction(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWebCodecsAudioEncoder);
+
+}
+
+#endif

--- a/Source/WebCore/bindings/js/JSWebCodecsVideoEncoderCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebCodecsVideoEncoderCustom.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEB_CODECS)
+#include "JSWebCodecsVideoEncoder.h"
+
+#include "WebCodecsEncodedVideoChunkOutputCallback.h"
+#include "WebCodecsErrorCallback.h"
+
+#include <JavaScriptCore/JSCInlines.h>
+
+namespace WebCore {
+
+template <typename Visitor>
+void JSWebCodecsVideoEncoder::visitAdditionalChildren(Visitor& visitor)
+{
+    wrapped().outputCallbackConcurrently().visitJSFunction(visitor);
+    wrapped().errorCallbackConcurrently().visitJSFunction(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWebCodecsVideoEncoder);
+
+}
+
+#endif


### PR DESCRIPTION
#### a0a1e48bd8e0d0a54f2981fce20c2be70186906f
<pre>
WebCodecs Audio and Video Encoder callbacks leak the Document object.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276332">https://bugs.webkit.org/show_bug.cgi?id=276332</a>
<a href="https://rdar.apple.com/131327288">rdar://131327288</a>

Reviewed by Ryosuke Niwa.

Similar to the Audio and Video Decoder objects WebCodecs encoders store
refs to their Strong callbacks which leak the Document. This change
makes the output callbacks of the encoders Weak and keeps them alive via
the owning encoder wrappers visitAdditionalChildren.

* LayoutTests/http/tests/webcodecs/audio-encoder-callbacks-do-not-leak-expected.txt: Added.
* LayoutTests/http/tests/webcodecs/audio-encoder-callbacks-do-not-leak.html: Added.
* LayoutTests/http/tests/webcodecs/resources/audio-encoder-callbacks-frame.html: Added.
* LayoutTests/http/tests/webcodecs/resources/video-encoder-callbacks-frame.html: Added.
* LayoutTests/http/tests/webcodecs/video-encoder-callbacks-do-not-leak-expected.txt: Added.
* LayoutTests/http/tests/webcodecs/video-encoder-callbacks-do-not-leak.html: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.h:
(WebCore::WebCodecsAudioEncoder::outputCallbackConcurrently):
(WebCore::WebCodecsAudioEncoder::errorCallbackConcurrently):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.idl:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.h:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.idl:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.idl:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
(WebCore::WebCodecsVideoEncoder::outputCallbackConcurrently):
(WebCore::WebCodecsVideoEncoder::errorCallbackConcurrently):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSWebCodecsAudioEncoderCustom.cpp: Added.
(WebCore::JSWebCodecsAudioEncoder::visitAdditionalChildren):
* Source/WebCore/bindings/js/JSWebCodecsVideoEncoderCustom.cpp: Added.
(WebCore::JSWebCodecsVideoEncoder::visitAdditionalChildren):

Canonical link: <a href="https://commits.webkit.org/280762@main">https://commits.webkit.org/280762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c9f5703140e24fb0e254342f8e30d9d04c553f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61116 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7939 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46560 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5627 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27423 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31339 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6968 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6942 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53306 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62795 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53822 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53917 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12724 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1203 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32651 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33736 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->