### PR TITLE
Fetch padding via a single virtual function call

### DIFF
--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -70,12 +70,8 @@ static inline Layout::BoxGeometry::Edges flexBoxLogicalPadding(const RenderBoxMo
     UNUSED_PARAM(isLeftToRightInlineDirection);
     UNUSED_PARAM(blockFlowDirection);
 
-    auto paddingLeft = renderer.paddingLeft();
-    auto paddingRight = renderer.paddingRight();
-    auto paddingTop = renderer.paddingTop();
-    auto paddingBottom = renderer.paddingBottom();
-
-    return { { paddingLeft, paddingRight }, { paddingTop, paddingBottom } };
+    auto padding = renderer.padding();
+    return { { padding.left(), padding.right() }, { padding.top(), padding.bottom() } };
 }
 
 void FlexLayout::updateFormattingRootGeometryAndInvalidate()

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -270,12 +270,9 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
         RoundedRect border = isBorderFill ? backgroundRoundedRectAdjustedForBleedAvoidance(rect, bleedAvoidance, box, includeLeftEdge, includeRightEdge) : backgroundRoundedRect(rect, box, includeLeftEdge, includeRightEdge);
 
         // Clip to the padding or content boxes as necessary.
-        if (bgLayer.clip() == FillBox::Content) {
-            border = style.getRoundedInnerBorderFor(border.rect(),
-                m_renderer.paddingTop() + m_renderer.borderTop(), m_renderer.paddingBottom() + m_renderer.borderBottom(),
-                m_renderer.paddingLeft() + m_renderer.borderLeft(), m_renderer.paddingRight() + m_renderer.borderRight(),
-                includeLeftEdge, includeRightEdge);
-        } else if (bgLayer.clip() == FillBox::Padding)
+        if (bgLayer.clip() == FillBox::Content)
+            border = m_renderer.roundedContentBoxRect(border.rect(), includeLeftEdge, includeRightEdge);
+        else if (bgLayer.clip() == FillBox::Padding)
             border = style.getRoundedInnerBorderFor(border.rect(), includeLeftEdge, includeRightEdge);
 
         clipRoundedInnerRect(context, pixelSnappedRect, border.pixelSnappedRoundedRectForPainting(deviceScaleFactor));

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -96,20 +96,15 @@ inline LayoutRect RenderBox::contentBoxRect() const
             topScrollbarSpace = horizontalScrollbarHeight;
     }
 
-    auto paddingLeft = this->paddingLeft();
-    auto paddingTop = this->paddingTop();
-
-    auto paddingRight = this->paddingRight();
-    auto paddingBottom = this->paddingBottom();
-
+    auto padding = this->padding();
     auto borderWidths = this->borderWidths();
-    auto location = LayoutPoint { borderWidths.left() + paddingLeft + leftScrollbarSpace, borderWidths.top() + paddingTop + topScrollbarSpace };
+    auto location = LayoutPoint { borderWidths.left() + padding.left() + leftScrollbarSpace, borderWidths.top() + padding.top() + topScrollbarSpace };
 
     auto paddingBoxWidth = std::max(0_lu, width() - borderWidths.left() - borderWidths.right() - verticalScrollbarWidth);
     auto paddingBoxHeight = std::max(0_lu, height() - borderWidths.top() - borderWidths.bottom() - horizontalScrollbarHeight);
 
-    auto width = std::max(0_lu, paddingBoxWidth - paddingLeft - paddingRight - leftScrollbarSpace);
-    auto height = std::max(0_lu, paddingBoxHeight - paddingTop - paddingBottom - topScrollbarSpace);
+    auto width = std::max(0_lu, paddingBoxWidth - padding.left() - padding.right() - leftScrollbarSpace);
+    auto height = std::max(0_lu, paddingBoxHeight - padding.top() - padding.bottom() - topScrollbarSpace);
 
     auto size = LayoutSize { width, height };
 

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -867,6 +867,16 @@ bool RenderBoxModelObject::borderObscuresBackground() const
     return true;
 }
 
+RoundedRect RenderBoxModelObject::roundedContentBoxRect(const LayoutRect& borderBoxRect, bool includeLeftEdge, bool includeRightEdge) const
+{
+    auto borderWidths = this->borderWidths();
+    auto padding = this->padding();
+    return style().getRoundedInnerBorderFor(borderBoxRect,
+        borderWidths.top() + padding.top(), borderWidths.bottom() + padding.bottom(),
+        borderWidths.left() + padding.left(), borderWidths.right() + padding.right(),
+        includeLeftEdge, includeRightEdge);
+}
+
 LayoutUnit RenderBoxModelObject::containingBlockLogicalWidthForContent() const
 {
     if (auto* containingBlock = this->containingBlock())

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -118,6 +118,7 @@ public:
 
     // These functions are used during layout. Table cells and the MathML
     // code override them to include some extra intrinsic padding.
+    virtual inline RectEdges<LayoutUnit> padding() const;
     virtual inline LayoutUnit paddingTop() const;
     virtual inline LayoutUnit paddingBottom() const;
     virtual inline LayoutUnit paddingLeft() const;
@@ -180,6 +181,8 @@ public:
     LayoutUnit horizontalMarginExtent() const { return marginLeft() + marginRight(); }
     LayoutUnit marginLogicalHeight() const { return marginBefore() + marginAfter(); }
     LayoutUnit marginLogicalWidth() const { return marginStart() + marginEnd(); }
+
+    RoundedRect roundedContentBoxRect(const LayoutRect& borderBoxRect, bool includeLeftEdge = true, bool includeRightEdge = true) const;
 
     inline bool hasInlineDirectionBordersPaddingOrMargin() const;
     inline bool hasInlineDirectionBordersOrPadding() const;

--- a/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
+++ b/Source/WebCore/rendering/RenderBoxModelObjectInlines.h
@@ -88,6 +88,16 @@ inline RectEdges<LayoutUnit> RenderBoxModelObject::borderWidths() const
     };
 }
 
+RectEdges<LayoutUnit> RenderBoxModelObject::padding() const
+{
+    return {
+        computedCSSPaddingTop(),
+        computedCSSPaddingRight(),
+        computedCSSPaddingBottom(),
+        computedCSSPaddingLeft()
+    };
+}
+
 inline LayoutUnit RenderBoxModelObject::resolveLengthPercentageUsingContainerLogicalWidth(const Length& value) const
 {
     LayoutUnit containerWidth;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1869,7 +1869,7 @@ void RenderLayerBacking::updateContentsRects()
     m_graphicsLayer->setContentsRect(snapRectToDevicePixelsIfNeeded(contentsBox(), renderer()));
     
     if (CheckedPtr renderReplaced = dynamicDowncast<RenderReplaced>(renderer())) {
-        FloatRoundedRect contentsClippingRect = renderReplaced->roundedContentBoxRect().pixelSnappedRoundedRectForPainting(deviceScaleFactor());
+        FloatRoundedRect contentsClippingRect = renderReplaced->roundedContentBoxRect(renderReplaced->borderBoxRect()).pixelSnappedRoundedRectForPainting(deviceScaleFactor());
         contentsClippingRect.move(contentOffsetInCompositingLayer());
         m_graphicsLayer->setContentsClippingRect(contentsClippingRect);
     }

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -302,8 +302,7 @@ void RenderReplaced::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
         if (!completelyClippedOut) {
             // Push a clip if we have a border radius, since we want to round the foreground content that gets painted.
             paintInfo.context().save();
-            auto pixelSnappedRoundedRect = style().getRoundedInnerBorderFor(paintRect,
-                paddingTop() + borderTop(), paddingBottom() + borderBottom(), paddingLeft() + borderLeft(), paddingRight() + borderRight(), true, true).pixelSnappedRoundedRectForPainting(document().deviceScaleFactor());
+            auto pixelSnappedRoundedRect = roundedContentBoxRect(paintRect).pixelSnappedRoundedRectForPainting(document().deviceScaleFactor());
             BackgroundPainter::clipRoundedInnerRect(paintInfo.context(), paintRect, pixelSnappedRoundedRect);
         }
     }
@@ -525,13 +524,6 @@ double RenderReplaced::computeIntrinsicAspectRatio() const
     FloatSize intrinsicSize;
     computeAspectRatioInformationForRenderBox(embeddedContentBox(), intrinsicSize, intrinsicRatio);
     return intrinsicRatio.aspectRatioDouble();
-}
-
-RoundedRect RenderReplaced::roundedContentBoxRect() const
-{
-    return style().getRoundedInnerBorderFor(borderBoxRect(),
-        borderTop() + paddingTop(), borderBottom() + paddingBottom(),
-        borderLeft() + paddingLeft(), borderRight() + paddingRight());
 }
 
 void RenderReplaced::computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -41,8 +41,6 @@ public:
 
     LayoutSize intrinsicSize() const final;
     
-    RoundedRect roundedContentBoxRect() const;
-    
     bool isContentLikelyVisibleInViewport();
     bool needsPreferredWidthsRecalculation() const override;
 

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -324,6 +324,31 @@ void RenderTableCell::layout()
     setCellWidthChanged(false);
 }
 
+RectEdges<LayoutUnit> RenderTableCell::padding() const
+{
+    auto top = computedCSSPaddingTop();
+    auto right = computedCSSPaddingRight();
+    auto bottom = computedCSSPaddingBottom();
+    auto left = computedCSSPaddingLeft();
+
+    if (isHorizontalWritingMode()) {
+        bool isTopToBottom = style().blockFlowDirection() == BlockFlowDirection::TopToBottom;
+        top += isTopToBottom ? intrinsicPaddingBefore() : intrinsicPaddingAfter();
+        bottom += isTopToBottom ? intrinsicPaddingAfter() : intrinsicPaddingBefore();
+    } else {
+        bool isLeftToRight = style().blockFlowDirection() == BlockFlowDirection::LeftToRight;
+        left += isLeftToRight ? intrinsicPaddingBefore() : intrinsicPaddingAfter();
+        right += isLeftToRight ? intrinsicPaddingAfter() : intrinsicPaddingBefore();
+    }
+
+    return {
+        top,
+        right,
+        bottom,
+        left
+    };
+}
+
 LayoutUnit RenderTableCell::paddingTop() const
 {
     LayoutUnit result = computedCSSPaddingTop();

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -94,6 +94,7 @@ public:
     LayoutUnit intrinsicPaddingBefore() const { return m_intrinsicPaddingBefore; }
     LayoutUnit intrinsicPaddingAfter() const { return m_intrinsicPaddingAfter; }
 
+    RectEdges<LayoutUnit> padding() const override;
     LayoutUnit paddingTop() const override;
     LayoutUnit paddingBottom() const override;
     LayoutUnit paddingLeft() const override;

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -327,8 +327,7 @@ void RenderWidget::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 
         // Push a clip if we have a border radius, since we want to round the foreground content that gets painted.
         paintInfo.context().save();
-        FloatRoundedRect roundedInnerRect = FloatRoundedRect(style().getRoundedInnerBorderFor(borderRect,
-            paddingTop() + borderTop(), paddingBottom() + borderBottom(), paddingLeft() + borderLeft(), paddingRight() + borderRight(), true, true));
+        auto roundedInnerRect = FloatRoundedRect(roundedContentBoxRect(borderRect));
         BackgroundPainter::clipRoundedInnerRect(paintInfo.context(), borderRect, roundedInnerRect);
     }
 

--- a/Source/WebCore/rendering/shapes/BoxShape.cpp
+++ b/Source/WebCore/rendering/shapes/BoxShape.cpp
@@ -80,9 +80,7 @@ RoundedRect computeRoundedRectForBoxShape(CSSBoxType box, const RenderBox& rende
     // fill-box compute to content-box for HTML elements.
     case CSSBoxType::FillBox:
     case CSSBoxType::ContentBox:
-        return style.getRoundedInnerBorderFor(renderer.borderBoxRect(),
-            renderer.paddingTop() + renderer.borderTop(), renderer.paddingBottom() + renderer.borderBottom(),
-            renderer.paddingLeft() + renderer.borderLeft(), renderer.paddingRight() + renderer.borderRight());
+        return renderer.roundedContentBoxRect(renderer.borderBoxRect());
     // stroke-box, view-box compute to border-box for HTML elements.
     case CSSBoxType::BorderBox:
     case CSSBoxType::StrokeBox:


### PR DESCRIPTION
#### 2ea416db59ab6baf93c482ed01d3ee8d14a66247
<pre>
Fetch padding via a single virtual function call
<a href="https://bugs.webkit.org/show_bug.cgi?id=276335">https://bugs.webkit.org/show_bug.cgi?id=276335</a>
<a href="https://rdar.apple.com/131329205">rdar://131329205</a>

Reviewed by Alan Baradlay.

As we did for borderWidths in 277679@main, fix code that makes 4 virtual functions calls
for padding edges to use a single call that returns a RectEdges&lt;&gt;.

A common call pattern was via `getRoundedInnerBorderFor()`, which can be refactored to
move `RenderReplaced::roundedContentBoxRect()` down to `RenderBoxModelObject`, with
the caller passing the rectangle.

This slightly reduces the time under `RenderBox::contentBoxRect()` in benchmarks.

* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
(WebCore::LayoutIntegration::flexBoxLogicalPadding):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer):
* Source/WebCore/rendering/RenderBoxInlines.h:
(WebCore::RenderBox::contentBoxRect const):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::roundedContentBoxRect const):
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderBoxModelObjectInlines.h:
(WebCore::RenderBoxModelObject::padding const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateContentsRects):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/RenderReplaced.h:
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::padding const):
* Source/WebCore/rendering/RenderTableCell.h:
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::paint):
* Source/WebCore/rendering/shapes/BoxShape.cpp:
(WebCore::computeRoundedRectForBoxShape):

Canonical link: <a href="https://commits.webkit.org/280759@main">https://commits.webkit.org/280759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64c0fb2377506c4dfe6a1d8a0c182e490cf0b81a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61124 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7947 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46567 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5634 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27430 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31347 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.html?wss (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6978 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6950 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62803 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1415 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7339 "layout-tests (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53825 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53920 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12722 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1211 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32659 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33744 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34829 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->