### PR TITLE
[Cocoa] Recognize a second entitlement to allow non-Lockdown Mode processes to launch

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -463,7 +463,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 {
 #if PLATFORM(IOS_FAMILY)
     // On iOS, the web browser entitlement is required to disable Lockdown mode.
-    if (!enabled && !WTF::processHasEntitlement("com.apple.developer.web-browser"_s))
+    if (!enabled && !WTF::processHasEntitlement("com.apple.developer.web-browser"_s) && !WTF::processHasEntitlement("com.apple.private.allow-ldm-exempt-webview"_s))
         [NSException raise:NSInternalInconsistencyException format:@"The 'com.apple.developer.web-browser' restricted entitlement is required to disable Lockdown mode"];
 #endif
 
@@ -560,7 +560,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 #if ENABLE(LOCKDOWN_MODE_API)
 #if PLATFORM(IOS_FAMILY)
     // On iOS, the web browser entitlement is required to disable lockdown mode.
-    if (!lockdownModeEnabled && !WTF::processHasEntitlement("com.apple.developer.web-browser"_s))
+    if (!lockdownModeEnabled && !WTF::processHasEntitlement("com.apple.developer.web-browser"_s) && !WTF::processHasEntitlement("com.apple.private.allow-ldm-exempt-webview"_s))
         [NSException raise:NSInternalInconsistencyException format:@"The 'com.apple.developer.web-browser' restricted entitlement is required to disable lockdown mode"];
 #endif
 


### PR DESCRIPTION
#### ee77044edb549dc49236ff5a21aea503cd87331a
<pre>
[Cocoa] Recognize a second entitlement to allow non-Lockdown Mode processes to launch
<a href="https://bugs.webkit.org/show_bug.cgi?id=276338">https://bugs.webkit.org/show_bug.cgi?id=276338</a>
&lt;<a href="https://rdar.apple.com/127464996">rdar://127464996</a>&gt;

Reviewed by Per Arne Vollan.

Applications using `WKWebView` that have the `com.apple.developer.web-browser` entitlement can request that a particular page be loaded outside of Lockdown Mode. This allows users to bypass LDM on sites that don&apos;t work well under that restricted set of features.

We would like to permit some system processes to launch a plain WKWebView in lockdown mode because of similar compatibility issues. We do not want to use the `web-browser` entitlement, since we do not want the other powerful features that entitlement grants.

We are adding a managed entitlement to support this restricted use case: `com.apple.private.allow-ldm-exempt-webview`

This patch recognizes this new entitlement as an alternative to `com.apple.developer.web-browser` for this specific case.

* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setCaptivePortalModeEnabled:]):
(-[WKWebpagePreferences setLockdownModeEnabled:]):

Canonical link: <a href="https://commits.webkit.org/280761@main">https://commits.webkit.org/280761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/427c3b8b1da3e05b456f68c76a6c89c5a45a73d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61130 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7953 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46568 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5633 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59538 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34566 "Found 3 new test failures: compositing/overflow/overflow-compositing-descendant.html compositing/reflections/load-video-in-reflection.html http/wpt/service-workers/fetch-service-worker-preload-cache.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27431 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31349 "Found 1 new test failure: imported/w3c/web-platform-tests/websockets/basic-auth.any.html?wss (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6956 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53313 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62809 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1421 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7343 "Found 1 new test failure: webaudio/Panner/PannerNode-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53827 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53922 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12723 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1213 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32665 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33750 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33496 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->