### PR TITLE
Race condition in report-processor between fetching `tests` and `test_metrics` tables

### DIFF
--- a/Websites/perf.webkit.org/public/include/report-processor.php
+++ b/Websites/perf.webkit.org/public/include/report-processor.php
@@ -218,6 +218,8 @@ class ReportProcessor {
         $metric_rows = $this->db->fetch_table('test_metrics');
         foreach ($metric_rows as &$metric) {
             $test = &$test_by_id[$metric['metric_test']];
+            if (is_null($test['metrics']))
+                continue;
             $metrics_by_name = &array_ensure_item_has_array($test['metrics'], $metric['metric_name']);
             $metrics_by_name[$metric['metric_aggregator']] = $metric['metric_id'];
         }


### PR DESCRIPTION
#### 99bbc3cc4b9e93b97035efcbd980245652de5223
<pre>
Race condition in report-processor between fetching `tests` and `test_metrics` tables
<a href="https://rdar.apple.com/131324950">rdar://131324950</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=276330">https://bugs.webkit.org/show_bug.cgi?id=276330</a>

Reviewed by Ryosuke Niwa.

The race condition is caused by `tests` and `test_metrics` not being fetched atomically.
New `tests` and `test_metrics` entries can be inserted by another concurrent call after `tests` table
fetch but before `test_metrics` fetch. `test_metrics` can refer to a new test and cause null reference
in the array key by test id.
The fix is to ignore new `test_metrics` based on following observation:
    1. `ReportProcessor-&gt;fetch_tests` builds `ReportProcessor-&gt;tests` variable which is only used by
       `ReportProcessor-&gt;recursively_ensure_tests`.
    2. `ReportProcessor-&gt;recursively_ensure_tests` handles missing tests / metrics by fetching them
       from database.

* Websites/perf.webkit.org/public/include/report-processor.php: Add a null check on `$test[&apos;metrics&apos;]`.

Canonical link: <a href="https://commits.webkit.org/280784@main">https://commits.webkit.org/280784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94a54db9c8e28740a61b58db7f59cd7205e35e66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61220 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8043 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46639 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5710 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27505 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31423 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7046 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62900 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7425 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53898 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49781 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54006 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12743 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1288 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32755 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33841 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34925 "Failed to checkout and rebase branch from PR 30582") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->