### PR TITLE
Crash in WebCore::PlaybackSessionModelMediaElement::exitFullscreen due to null m_mediaElement

### DIFF
--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -59,8 +59,11 @@ PlaybackSessionModelMediaElement::~PlaybackSessionModelMediaElement()
 
 void PlaybackSessionModelMediaElement::setMediaElement(HTMLMediaElement* mediaElement)
 {
-    if (m_mediaElement == mediaElement) {
-        if (m_mediaElement) {
+    RefPtr oldMediaElement = m_mediaElement;
+    RefPtr newMediaElement = mediaElement;
+
+    if (oldMediaElement == newMediaElement) {
+        if (oldMediaElement) {
             for (auto& client : m_clients)
                 client->isPictureInPictureSupportedChanged(isPictureInPictureSupported());
         }
@@ -69,16 +72,16 @@ void PlaybackSessionModelMediaElement::setMediaElement(HTMLMediaElement* mediaEl
 
     auto& events = eventNames();
 
-    if (m_mediaElement && m_isListening) {
+    if (oldMediaElement && m_isListening) {
         for (auto& eventName : observedEventNames())
-            m_mediaElement->removeEventListener(eventName, *this, false);
-        if (auto* audioTracks = m_mediaElement->audioTracks()) {
+            oldMediaElement->removeEventListener(eventName, *this, false);
+        if (auto* audioTracks = oldMediaElement->audioTracks()) {
             audioTracks->removeEventListener(events.addtrackEvent, *this, false);
             audioTracks->removeEventListener(events.changeEvent, *this, false);
             audioTracks->removeEventListener(events.removetrackEvent, *this, false);
         }
 
-        if (auto* textTracks = m_mediaElement->audioTracks()) {
+        if (auto* textTracks = oldMediaElement->audioTracks()) {
             textTracks->removeEventListener(events.addtrackEvent, *this, false);
             textTracks->removeEventListener(events.changeEvent, *this, false);
             textTracks->removeEventListener(events.removetrackEvent, *this, false);
@@ -86,21 +89,21 @@ void PlaybackSessionModelMediaElement::setMediaElement(HTMLMediaElement* mediaEl
     }
     m_isListening = false;
 
-    if (m_mediaElement)
-        m_mediaElement->resetPlaybackSessionState();
+    if (oldMediaElement)
+        oldMediaElement->resetPlaybackSessionState();
 
-    m_mediaElement = mediaElement;
+    m_mediaElement = newMediaElement;
 
-    if (m_mediaElement) {
+    if (newMediaElement) {
         for (auto& eventName : observedEventNames())
-            m_mediaElement->addEventListener(eventName, *this, false);
+            newMediaElement->addEventListener(eventName, *this, false);
 
-        auto& audioTracks = m_mediaElement->ensureAudioTracks();
+        auto& audioTracks = newMediaElement->ensureAudioTracks();
         audioTracks.addEventListener(events.addtrackEvent, *this, false);
         audioTracks.addEventListener(events.changeEvent, *this, false);
         audioTracks.addEventListener(events.removetrackEvent, *this, false);
 
-        auto& textTracks = m_mediaElement->ensureTextTracks();
+        auto& textTracks = newMediaElement->ensureTextTracks();
         textTracks.addEventListener(events.addtrackEvent, *this, false);
         textTracks.addEventListener(events.changeEvent, *this, false);
         textTracks.addEventListener(events.removetrackEvent, *this, false);
@@ -247,79 +250,80 @@ void PlaybackSessionModelMediaElement::removeClient(PlaybackSessionModelClient& 
 
 void PlaybackSessionModelMediaElement::play()
 {
-    if (m_mediaElement)
-        m_mediaElement->play();
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->play();
 }
 
 void PlaybackSessionModelMediaElement::pause()
 {
-    if (m_mediaElement)
-        m_mediaElement->pause();
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->pause();
 }
 
 void PlaybackSessionModelMediaElement::togglePlayState()
 {
-    if (m_mediaElement)
-        m_mediaElement->togglePlayState();
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->togglePlayState();
 }
 
 void PlaybackSessionModelMediaElement::beginScrubbing()
 {
-    if (m_mediaElement)
-        m_mediaElement->beginScrubbing();
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->beginScrubbing();
 }
 
 void PlaybackSessionModelMediaElement::endScrubbing()
 {
-    if (m_mediaElement)
-        m_mediaElement->endScrubbing();
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->endScrubbing();
 }
 
 void PlaybackSessionModelMediaElement::seekToTime(double time, double toleranceBefore, double toleranceAfter)
 {
-    if (m_mediaElement)
-        m_mediaElement->setCurrentTimeWithTolerance(time, toleranceBefore, toleranceAfter);
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->setCurrentTimeWithTolerance(time, toleranceBefore, toleranceAfter);
 }
 
 void PlaybackSessionModelMediaElement::fastSeek(double time)
 {
-    if (m_mediaElement)
-        m_mediaElement->fastSeek(time);
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->fastSeek(time);
 }
 
 void PlaybackSessionModelMediaElement::beginScanningForward()
 {
-    if (m_mediaElement)
-        m_mediaElement->beginScanning(MediaControllerInterface::Forward);
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->beginScanning(MediaControllerInterface::Forward);
 }
 
 void PlaybackSessionModelMediaElement::beginScanningBackward()
 {
-    if (m_mediaElement)
-        m_mediaElement->beginScanning(MediaControllerInterface::Backward);
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->beginScanning(MediaControllerInterface::Backward);
 }
 
 void PlaybackSessionModelMediaElement::endScanning()
 {
-    if (m_mediaElement)
-        m_mediaElement->endScanning();
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->endScanning();
 }
 
 void PlaybackSessionModelMediaElement::setDefaultPlaybackRate(double defaultPlaybackRate)
 {
-    if (m_mediaElement)
-        m_mediaElement->setDefaultPlaybackRate(defaultPlaybackRate);
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->setDefaultPlaybackRate(defaultPlaybackRate);
 }
 
 void PlaybackSessionModelMediaElement::setPlaybackRate(double playbackRate)
 {
-    if (m_mediaElement)
-        m_mediaElement->setPlaybackRate(playbackRate);
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->setPlaybackRate(playbackRate);
 }
 
 void PlaybackSessionModelMediaElement::selectAudioMediaOption(uint64_t selectedAudioIndex)
 {
-    if (!m_mediaElement)
+    RefPtr mediaElement = m_mediaElement;
+    if (!mediaElement)
         return;
 
     for (size_t i = 0, size = m_audioTracksForMenu.size(); i < size; ++i)
@@ -328,7 +332,8 @@ void PlaybackSessionModelMediaElement::selectAudioMediaOption(uint64_t selectedA
 
 void PlaybackSessionModelMediaElement::selectLegibleMediaOption(uint64_t index)
 {
-    if (!m_mediaElement)
+    RefPtr mediaElement = m_mediaElement;
+    if (!mediaElement)
         return;
 
     TextTrack* textTrack;
@@ -337,13 +342,13 @@ void PlaybackSessionModelMediaElement::selectLegibleMediaOption(uint64_t index)
     else
         textTrack = &TextTrack::captionMenuOffItem();
 
-    m_mediaElement->setSelectedTextTrack(textTrack);
+    mediaElement->setSelectedTextTrack(textTrack);
 }
 
 void PlaybackSessionModelMediaElement::togglePictureInPicture()
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    auto* element = dynamicDowncast<HTMLVideoElement>(*m_mediaElement);
+    RefPtr element = dynamicDowncast<HTMLVideoElement>(m_mediaElement);
     ASSERT(element);
     if (!element)
         return;
@@ -358,7 +363,7 @@ void PlaybackSessionModelMediaElement::togglePictureInPicture()
 void PlaybackSessionModelMediaElement::toggleInWindowFullscreen()
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    auto* element = dynamicDowncast<HTMLVideoElement>(*m_mediaElement);
+    RefPtr element = dynamicDowncast<HTMLVideoElement>(m_mediaElement);
     ASSERT(element);
     if (!element)
         return;
@@ -374,7 +379,7 @@ void PlaybackSessionModelMediaElement::toggleInWindowFullscreen()
 
 void PlaybackSessionModelMediaElement::enterFullscreen()
 {
-    RefPtr element = dynamicDowncast<HTMLVideoElement>(*m_mediaElement);
+    RefPtr element = dynamicDowncast<HTMLVideoElement>(m_mediaElement);
     ASSERT(element);
     if (!element)
         return;
@@ -384,7 +389,7 @@ void PlaybackSessionModelMediaElement::enterFullscreen()
 
 void PlaybackSessionModelMediaElement::exitFullscreen()
 {
-    RefPtr element = dynamicDowncast<HTMLVideoElement>(*m_mediaElement);
+    RefPtr element = dynamicDowncast<HTMLVideoElement>(m_mediaElement);
     ASSERT(element);
     if (!element)
         return;
@@ -399,59 +404,60 @@ void PlaybackSessionModelMediaElement::toggleMuted()
 
 void PlaybackSessionModelMediaElement::setMuted(bool muted)
 {
-    if (m_mediaElement)
-        m_mediaElement->setMuted(muted);
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->setMuted(muted);
 }
 
 void PlaybackSessionModelMediaElement::setVolume(double volume)
 {
-    if (m_mediaElement)
-        m_mediaElement->setVolume(volume);
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->setVolume(volume);
 }
 
 void PlaybackSessionModelMediaElement::setPlayingOnSecondScreen(bool value)
 {
-    if (m_mediaElement)
-        m_mediaElement->setPlayingOnSecondScreen(value);
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->setPlayingOnSecondScreen(value);
 }
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
 const String& PlaybackSessionModelMediaElement::spatialTrackingLabel() const
 {
-    if (m_mediaElement)
-        return m_mediaElement->spatialTrackingLabel();
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->spatialTrackingLabel();
     return emptyString();
 }
 
 void PlaybackSessionModelMediaElement::setSpatialTrackingLabel(const String& spatialTrackingLabel)
 {
-    if (m_mediaElement)
-        m_mediaElement->setSpatialTrackingLabel(spatialTrackingLabel);
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->setSpatialTrackingLabel(spatialTrackingLabel);
 }
 #endif
 
 void PlaybackSessionModelMediaElement::sendRemoteCommand(PlatformMediaSession::RemoteControlCommandType command, const PlatformMediaSession::RemoteCommandArgument& argument)
 {
-    if (m_mediaElement)
-        m_mediaElement->mediaSession().didReceiveRemoteControlCommand(command, argument);
+    if (RefPtr mediaElement = m_mediaElement)
+        mediaElement->mediaSession().didReceiveRemoteControlCommand(command, argument);
 }
 
 void PlaybackSessionModelMediaElement::updateMediaSelectionOptions()
 {
-    if (!m_mediaElement)
+    RefPtr mediaElement = m_mediaElement;
+    if (!mediaElement)
         return;
 
-    if (!m_mediaElement->document().page())
+    if (!mediaElement->document().page())
         return;
 
-    auto& captionPreferences = m_mediaElement->document().page()->group().ensureCaptionPreferences();
-    auto* textTracks = m_mediaElement->textTracks();
+    auto& captionPreferences = mediaElement->document().page()->group().ensureCaptionPreferences();
+    auto* textTracks = mediaElement->textTracks();
     if (textTracks && textTracks->length())
         m_legibleTracksForMenu = captionPreferences.sortedTrackListForMenu(textTracks, { TextTrack::Kind::Subtitles, TextTrack::Kind::Captions, TextTrack::Kind::Descriptions });
     else
         m_legibleTracksForMenu.clear();
 
-    auto* audioTracks = m_mediaElement->audioTracks();
+    auto* audioTracks = mediaElement->audioTracks();
     if (audioTracks && audioTracks->length() > 1)
         m_audioTracksForMenu = captionPreferences.sortedTrackListForMenu(audioTracks);
     else
@@ -481,10 +487,11 @@ void PlaybackSessionModelMediaElement::updateMediaSelectionIndices()
 
 double PlaybackSessionModelMediaElement::playbackStartedTime() const
 {
-    if (!m_mediaElement)
+    RefPtr mediaElement = m_mediaElement;
+    if (!mediaElement)
         return 0;
 
-    return m_mediaElement->playbackStartedTime();
+    return mediaElement->playbackStartedTime();
 }
 
 const Vector<AtomString>& PlaybackSessionModelMediaElement::observedEventNames()
@@ -514,65 +521,88 @@ const AtomString&  PlaybackSessionModelMediaElement::eventNameAll()
 
 double PlaybackSessionModelMediaElement::duration() const
 {
-    return m_mediaElement ? m_mediaElement->duration() : 0;
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->duration();
+    return 0;
 }
 
 double PlaybackSessionModelMediaElement::currentTime() const
 {
-    return m_mediaElement ? m_mediaElement->currentTime() : 0;
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->currentTime();
+    return 0;
 }
 
 double PlaybackSessionModelMediaElement::bufferedTime() const
 {
-    return m_mediaElement ? m_mediaElement->maxBufferedTime() : 0;
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->maxBufferedTime();
+    return 0;
 }
 
 bool PlaybackSessionModelMediaElement::isPlaying() const
 {
-    return m_mediaElement ? !m_mediaElement->paused() : false;
+    if (RefPtr mediaElement = m_mediaElement)
+        return !mediaElement->paused();
+    return false;
 }
 
 bool PlaybackSessionModelMediaElement::isStalled() const
 {
-    return m_mediaElement && m_mediaElement->readyState() <= HTMLMediaElement::HAVE_CURRENT_DATA;
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->readyState() <= HTMLMediaElement::HAVE_CURRENT_DATA;
+    return false;
 }
 
 double PlaybackSessionModelMediaElement::defaultPlaybackRate() const
 {
-    return m_mediaElement ? m_mediaElement->defaultPlaybackRate() : 0;
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->defaultPlaybackRate();
+    return 0;
 }
 
 double PlaybackSessionModelMediaElement::playbackRate() const
 {
-    return m_mediaElement ? m_mediaElement->playbackRate() : 0;
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->playbackRate();
+    return 0;
 }
 
 Ref<TimeRanges> PlaybackSessionModelMediaElement::seekableRanges() const
 {
-    return m_mediaElement && m_mediaElement->supportsSeeking() ? m_mediaElement->seekable() : TimeRanges::create();
+    if (RefPtr mediaElement = m_mediaElement; mediaElement && mediaElement->supportsSeeking())
+        return mediaElement->seekable();
+    return TimeRanges::create();
 }
 
 double PlaybackSessionModelMediaElement::seekableTimeRangesLastModifiedTime() const
 {
-    return m_mediaElement ? m_mediaElement->seekableTimeRangesLastModifiedTime() : 0;
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->seekableTimeRangesLastModifiedTime();
+    return 0;
 }
 
 double PlaybackSessionModelMediaElement::liveUpdateInterval() const
 {
-    return m_mediaElement ? m_mediaElement->liveUpdateInterval() : 0;
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->liveUpdateInterval();
+    return 0;
 }
     
 bool PlaybackSessionModelMediaElement::canPlayFastReverse() const
 {
-    return m_mediaElement ? m_mediaElement->minFastReverseRate() < 0.0 : false;
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->minFastReverseRate() < 0.0;
+    return false;
 }
 
 Vector<MediaSelectionOption> PlaybackSessionModelMediaElement::audioMediaSelectionOptions() const
 {
-    if (!m_mediaElement || !m_mediaElement->document().page())
+    RefPtr mediaElement = m_mediaElement;
+    if (!mediaElement || !mediaElement->document().page())
         return { };
 
-    auto& captionPreferences = m_mediaElement->document().page()->group().ensureCaptionPreferences();
+    auto& captionPreferences = mediaElement->document().page()->group().ensureCaptionPreferences();
     return m_audioTracksForMenu.map([&](auto& audioTrack) {
         return captionPreferences.mediaSelectionOptionForTrack(audioTrack.get());
     });
@@ -591,10 +621,11 @@ Vector<MediaSelectionOption> PlaybackSessionModelMediaElement::legibleMediaSelec
 {
     Vector<MediaSelectionOption> legibleOptions;
 
-    if (!m_mediaElement || !m_mediaElement->document().page())
+    RefPtr mediaElement = m_mediaElement;
+    if (!mediaElement || !mediaElement->document().page())
         return { };
 
-    auto& captionPreferences = m_mediaElement->document().page()->group().ensureCaptionPreferences();
+    auto& captionPreferences = mediaElement->document().page()->group().ensureCaptionPreferences();
     return m_legibleTracksForMenu.map([&](auto& track) {
         return captionPreferences.mediaSelectionOptionForTrack(track.get());
     });
@@ -602,7 +633,8 @@ Vector<MediaSelectionOption> PlaybackSessionModelMediaElement::legibleMediaSelec
 
 uint64_t PlaybackSessionModelMediaElement::legibleMediaSelectedIndex() const
 {
-    auto host = m_mediaElement ? m_mediaElement->mediaControlsHost() : nullptr;
+    RefPtr mediaElement = m_mediaElement;
+    auto host = mediaElement ? mediaElement->mediaControlsHost() : nullptr;
     if (!host)
         return std::numeric_limits<uint64_t>::max();
 
@@ -636,15 +668,18 @@ uint64_t PlaybackSessionModelMediaElement::legibleMediaSelectedIndex() const
 
 bool PlaybackSessionModelMediaElement::externalPlaybackEnabled() const
 {
-    return m_mediaElement && m_mediaElement->webkitCurrentPlaybackTargetIsWireless();
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->webkitCurrentPlaybackTargetIsWireless();
+    return false;
 }
 
 PlaybackSessionModel::ExternalPlaybackTargetType PlaybackSessionModelMediaElement::externalPlaybackTargetType() const
 {
-    if (!m_mediaElement || !m_mediaElement->mediaControlsHost())
+    RefPtr mediaElement = m_mediaElement;
+    if (!mediaElement || !mediaElement->mediaControlsHost())
         return ExternalPlaybackTargetType::TargetTypeNone;
 
-    switch (m_mediaElement->mediaControlsHost()->externalDeviceType()) {
+    switch (mediaElement->mediaControlsHost()->externalDeviceType()) {
     default:
         ASSERT_NOT_REACHED();
         return ExternalPlaybackTargetType::TargetTypeNone;
@@ -659,60 +694,73 @@ PlaybackSessionModel::ExternalPlaybackTargetType PlaybackSessionModelMediaElemen
 
 String PlaybackSessionModelMediaElement::externalPlaybackLocalizedDeviceName() const
 {
-    if (m_mediaElement && m_mediaElement->mediaControlsHost())
-        return m_mediaElement->mediaControlsHost()->externalDeviceDisplayName();
+    if (RefPtr mediaElement = m_mediaElement; mediaElement && mediaElement->mediaControlsHost())
+        return mediaElement->mediaControlsHost()->externalDeviceDisplayName();
     return emptyString();
 }
 
 bool PlaybackSessionModelMediaElement::wirelessVideoPlaybackDisabled() const
 {
-    return m_mediaElement && m_mediaElement->mediaSession().wirelessVideoPlaybackDisabled();
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->mediaSession().wirelessVideoPlaybackDisabled();
+    return false;
 }
 
 bool PlaybackSessionModelMediaElement::isMuted() const
 {
-    return m_mediaElement ? m_mediaElement->muted() : false;
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->muted();
+    return false;
 }
 
 double PlaybackSessionModelMediaElement::volume() const
 {
-    return m_mediaElement ? m_mediaElement->volume() : 0;
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->volume();
+    return 0;
 }
 
 bool PlaybackSessionModelMediaElement::isPictureInPictureSupported() const
 {
-    return m_mediaElement ? m_mediaElement->isVideo() : false;
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->isVideo();
+    return false;
 }
 
 bool PlaybackSessionModelMediaElement::isPictureInPictureActive() const
 {
-    if (!m_mediaElement)
+    RefPtr mediaElement = m_mediaElement;
+    if (!mediaElement)
         return false;
 
-    return (m_mediaElement->fullscreenMode() & HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) == HTMLMediaElementEnums::VideoFullscreenModePictureInPicture;
+    return (mediaElement->fullscreenMode() & HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) == HTMLMediaElementEnums::VideoFullscreenModePictureInPicture;
 }
 
 bool PlaybackSessionModelMediaElement::isInWindowFullscreenActive() const
 {
-    if (!m_mediaElement)
+    RefPtr mediaElement = m_mediaElement;
+    if (!mediaElement)
         return false;
 
-    return (m_mediaElement->fullscreenMode() & HTMLMediaElementEnums::VideoFullscreenModeInWindow) == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
+    return (mediaElement->fullscreenMode() & HTMLMediaElementEnums::VideoFullscreenModeInWindow) == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
 }
 
 #if !RELEASE_LOG_DISABLED
 const void* PlaybackSessionModelMediaElement::logIdentifier() const
 {
-    return m_mediaElement ? m_mediaElement->logIdentifier() : nullptr;
+    if (RefPtr mediaElement = m_mediaElement)
+        return mediaElement->logIdentifier();
+    return nullptr;
 }
 
 const Logger* PlaybackSessionModelMediaElement::loggerPtr() const
 {
-    return m_mediaElement ? &m_mediaElement->logger() : nullptr;
+    if (RefPtr mediaElement = m_mediaElement)
+        return &mediaElement->logger();
+    return nullptr;
 }
 #endif
 
+} // namespace WebCore
 
-}
-
-#endif
+#endif // PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))


### PR DESCRIPTION
#### e56299b4f1d9bb84f69ad5cb7ee24fa6fc93eb56
<pre>
Crash in WebCore::PlaybackSessionModelMediaElement::exitFullscreen due to null m_mediaElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=276341">https://bugs.webkit.org/show_bug.cgi?id=276341</a>
<a href="https://rdar.apple.com/131143888">rdar://131143888</a>

Reviewed by Jean-Yves Avenard and Eric Carlson.

Despite an ASSERT(element) in PlaybackSessionModelMediaElement::exitFullscreen, crash reports
indicate that m_mediaElement can be null when exitFullscreen is called. Resolved this by
null-checking m_mediaElement prior to dereferencing it (in exitFullscreen and elsewhere); the debug
assertion is left to help investigate why m_mediaElement is unexpectedly null. While here, updated
PlaybackSessionModelMediaElement to follow our latest smart pointer usage guidelines.

* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::setMediaElement):
(WebCore::PlaybackSessionModelMediaElement::play):
(WebCore::PlaybackSessionModelMediaElement::pause):
(WebCore::PlaybackSessionModelMediaElement::togglePlayState):
(WebCore::PlaybackSessionModelMediaElement::beginScrubbing):
(WebCore::PlaybackSessionModelMediaElement::endScrubbing):
(WebCore::PlaybackSessionModelMediaElement::seekToTime):
(WebCore::PlaybackSessionModelMediaElement::fastSeek):
(WebCore::PlaybackSessionModelMediaElement::beginScanningForward):
(WebCore::PlaybackSessionModelMediaElement::beginScanningBackward):
(WebCore::PlaybackSessionModelMediaElement::endScanning):
(WebCore::PlaybackSessionModelMediaElement::setDefaultPlaybackRate):
(WebCore::PlaybackSessionModelMediaElement::setPlaybackRate):
(WebCore::PlaybackSessionModelMediaElement::selectAudioMediaOption):
(WebCore::PlaybackSessionModelMediaElement::selectLegibleMediaOption):
(WebCore::PlaybackSessionModelMediaElement::togglePictureInPicture):
(WebCore::PlaybackSessionModelMediaElement::toggleInWindowFullscreen):
(WebCore::PlaybackSessionModelMediaElement::enterFullscreen):
(WebCore::PlaybackSessionModelMediaElement::exitFullscreen):
(WebCore::PlaybackSessionModelMediaElement::setMuted):
(WebCore::PlaybackSessionModelMediaElement::setVolume):
(WebCore::PlaybackSessionModelMediaElement::setPlayingOnSecondScreen):
(WebCore::PlaybackSessionModelMediaElement::spatialTrackingLabel const):
(WebCore::PlaybackSessionModelMediaElement::setSpatialTrackingLabel):
(WebCore::PlaybackSessionModelMediaElement::sendRemoteCommand):
(WebCore::PlaybackSessionModelMediaElement::updateMediaSelectionOptions):
(WebCore::PlaybackSessionModelMediaElement::playbackStartedTime const):
(WebCore::PlaybackSessionModelMediaElement::duration const):
(WebCore::PlaybackSessionModelMediaElement::currentTime const):
(WebCore::PlaybackSessionModelMediaElement::bufferedTime const):
(WebCore::PlaybackSessionModelMediaElement::isPlaying const):
(WebCore::PlaybackSessionModelMediaElement::isStalled const):
(WebCore::PlaybackSessionModelMediaElement::defaultPlaybackRate const):
(WebCore::PlaybackSessionModelMediaElement::playbackRate const):
(WebCore::PlaybackSessionModelMediaElement::seekableRanges const):
(WebCore::PlaybackSessionModelMediaElement::seekableTimeRangesLastModifiedTime const):
(WebCore::PlaybackSessionModelMediaElement::liveUpdateInterval const):
(WebCore::PlaybackSessionModelMediaElement::canPlayFastReverse const):
(WebCore::PlaybackSessionModelMediaElement::audioMediaSelectionOptions const):
(WebCore::PlaybackSessionModelMediaElement::legibleMediaSelectionOptions const):
(WebCore::PlaybackSessionModelMediaElement::legibleMediaSelectedIndex const):
(WebCore::PlaybackSessionModelMediaElement::externalPlaybackEnabled const):
(WebCore::PlaybackSessionModelMediaElement::externalPlaybackTargetType const):
(WebCore::PlaybackSessionModelMediaElement::externalPlaybackLocalizedDeviceName const):
(WebCore::PlaybackSessionModelMediaElement::wirelessVideoPlaybackDisabled const):
(WebCore::PlaybackSessionModelMediaElement::isMuted const):
(WebCore::PlaybackSessionModelMediaElement::volume const):
(WebCore::PlaybackSessionModelMediaElement::isPictureInPictureSupported const):
(WebCore::PlaybackSessionModelMediaElement::isPictureInPictureActive const):
(WebCore::PlaybackSessionModelMediaElement::isInWindowFullscreenActive const):
(WebCore::PlaybackSessionModelMediaElement::logIdentifier const):
(WebCore::PlaybackSessionModelMediaElement::loggerPtr const):

Canonical link: <a href="https://commits.webkit.org/280780@main">https://commits.webkit.org/280780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be8a4785e9f04f77175cff23b5e7a9115d63eaff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61185 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46607 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5678 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59593 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34610 "Found 1 new test failure: compositing/reflections/load-video-in-reflection.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27473 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7025 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7011 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62865 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1476 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7389 "layout-tests (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53867 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53969 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12745 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1255 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32720 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33805 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34890 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33551 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->