### PR TITLE
RemotePlayback watchAvailability callback can leak the Document object.

### DIFF
--- a/LayoutTests/media/media-source/remoteplayback-availability-callback-does-not-leak-expected.txt
+++ b/LayoutTests/media/media-source/remoteplayback-availability-callback-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that the RemotePlayback.watchAvailability callback does not leak the Document object.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/media-source/remoteplayback-availability-callback-does-not-leak.html
+++ b/LayoutTests/media/media-source/remoteplayback-availability-callback-does-not-leak.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/document-leak-test.js"></script>
+<script>
+
+description("Tests that the RemotePlayback.watchAvailability callback does not leak the Document object.");
+onload = () => runDocumentLeakTest({ frameURL: "./resources/remoteplayback-watch-availability-frame.html", framesToCreate: 20 });
+
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/media/media-source/resources/remoteplayback-watch-availability-frame.html
+++ b/LayoutTests/media/media-source/resources/remoteplayback-watch-availability-frame.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<video id="vid" mute controls></video>
+<script>
+try {
+    vid.remote.watchAvailability(_ => {
+        let d = document;
+        let p = document.createElement("p");
+        p.innerText = "This should not leak the Document.";
+        document.body.appendChild(p);
+    });
+    parent.postMessage("iframeLoaded");
+} catch (error) {
+    parent.postMessage("testFailed");
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/media/media-source/remoteplayback-availability-callback-does-not-leak-expected.txt
+++ b/LayoutTests/platform/glib/media/media-source/remoteplayback-availability-callback-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that the RemotePlayback.watchAvailability callback does not leak the Document object.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL Error loading the initial frameURL.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/resources/document-leak-test.js
+++ b/LayoutTests/resources/document-leak-test.js
@@ -48,6 +48,11 @@ function iframeLeaked()
 
 function iframeSentMessage(message)
 {
+    if (message.data === "testFailed") {
+        testFailed("Error loading the initial frameURL.");
+        return finishJSTest();
+    }
+
     let iframe = iframeForMessage(message);
     let frameDocumentID = internals.documentIdentifier(iframe.contentWindow.document);
     let checkCount = 0;

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
@@ -363,6 +363,11 @@ void RemotePlayback::disconnect()
     });
 }
 
+void RemotePlayback::stop()
+{
+    m_callbackMap.clear();
+}
+
 void RemotePlayback::playbackTargetPickerWasDismissed()
 {
     if (m_promptPromises.isEmpty())

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -92,6 +92,9 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
+    // ActiveDOMObject
+    void stop() final;
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger.get(); }
     const void* logIdentifier() const { return m_logIdentifier; }


### PR DESCRIPTION
#### f288b9088d1b74b980c3b7a8d5add134f7689bdb
<pre>
RemotePlayback watchAvailability callback can leak the Document object.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276344">https://bugs.webkit.org/show_bug.cgi?id=276344</a>
<a href="https://rdar.apple.com/131345363">rdar://131345363</a>

Reviewed by Ryosuke Niwa.

RemotePlayback&apos;s watchAvailibility callback can leak captures, including
the Document object, if cancelWatchAvailability is not called by the web
author. This change will clear all registered callbacks when
ActiveDOMObject::stop is called allowing the callback and captures to be
garbage collected.

* LayoutTests/platform/glib/media/media-source/remoteplayback-availability-callback-does-not-leak-expected.txt: Added.
* LayoutTests/media/media-source/remoteplayback-availability-callback-does-not-leak-expected.txt: Added.
* LayoutTests/media/media-source/remoteplayback-availability-callback-does-not-leak.html:
* LayoutTests/media/media-source/resources/remoteplayback-watch-availability-frame.html:
* LayoutTests/resources/document-leak-test.js:
(iframeSentMessage):
* Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp:
(WebCore::RemotePlayback::stop):
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:

Canonical link: <a href="https://commits.webkit.org/280799@main">https://commits.webkit.org/280799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22dd1dad6d99e4d47e66ae72ea30a152b6baa68b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61247 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8070 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46659 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5728 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27526 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31445 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7085 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7074 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53401 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62927 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53920 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1545 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54030 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12756 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1311 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32782 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33868 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34952 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33613 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->