### PR TITLE
Crash in WebKit::RemoteLayerBackingStore::needsDisplay due to owner() being null.

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -130,6 +130,7 @@ public:
 
     // Returns true if we need to encode the buffer.
     bool layerWillBeDisplayed();
+    bool layerWillBeDisplayedWithRenderingSuppression();
     bool needsDisplay() const;
 
     bool performDelegatedLayerDisplay();

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -231,6 +231,17 @@ bool RemoteLayerBackingStore::layerWillBeDisplayed()
     return collection->backingStoreWillBeDisplayed(*this);
 }
 
+bool RemoteLayerBackingStore::layerWillBeDisplayedWithRenderingSuppression()
+{
+    auto* collection = backingStoreCollection();
+    if (!collection) {
+        ASSERT_NOT_REACHED();
+        return false;
+    }
+
+    return collection->backingStoreWillBeDisplayedWithRenderingSuppression(*this);
+}
+
 void RemoteLayerBackingStore::setNeedsDisplay(const IntRect rect)
 {
     m_dirtyRegion.unite(intersection(layerBounds(), rect));

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -76,6 +76,7 @@ public:
 
     // Return value indicates whether the backing store needs to be included in the transaction.
     bool backingStoreWillBeDisplayed(RemoteLayerBackingStore&);
+    bool backingStoreWillBeDisplayedWithRenderingSuppression(RemoteLayerBackingStore&);
     void backingStoreBecameUnreachable(RemoteLayerBackingStore&);
 
     virtual void prepareBackingStoresForDisplay(RemoteLayerTreeTransaction&);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -210,6 +210,18 @@ bool RemoteLayerBackingStoreCollection::backingStoreWillBeDisplayed(RemoteLayerB
     return true;
 }
 
+bool RemoteLayerBackingStoreCollection::backingStoreWillBeDisplayedWithRenderingSuppression(RemoteLayerBackingStore& backingStore)
+{
+    ASSERT(m_inLayerFlush);
+    m_reachableBackingStoreInLatestFlush.add(backingStore);
+
+    auto backingStoreIter = m_unparentedBackingStore.find(backingStore);
+    bool wasUnparented = backingStoreIter != m_unparentedBackingStore.end();
+
+    ASSERT_UNUSED(wasUnparented, !wasUnparented);
+    return false;
+}
+
 void RemoteLayerBackingStoreCollection::purgeFrontBufferForTesting(RemoteLayerBackingStore& backingStore)
 {
     if (auto* remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(&backingStore)) {

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -71,7 +71,7 @@ public:
     PlatformLayer* platformLayer() const override { return nullptr; }
 
     void recursiveBuildTransaction(RemoteLayerTreeContext&, RemoteLayerTreeTransaction&);
-    void recursiveMarkWillBeDisplayed();
+    void recursiveMarkWillBeDisplayedWithRenderingSuppresion();
 
     void setNeedsDisplayInRect(const WebCore::FloatRect& dirtyRect) override;
     void setNeedsDisplay() override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -190,15 +190,15 @@ void PlatformCALayerRemote::updateClonedLayerProperties(PlatformCALayerRemote& c
     clone.updateCustomAppearance(customAppearance());
 }
 
-void PlatformCALayerRemote::recursiveMarkWillBeDisplayed()
+void PlatformCALayerRemote::recursiveMarkWillBeDisplayedWithRenderingSuppresion()
 {
     if (m_properties.backingStoreOrProperties.store && m_properties.backingStoreAttached)
-        m_properties.backingStoreOrProperties.store->layerWillBeDisplayed();
+        m_properties.backingStoreOrProperties.store->layerWillBeDisplayedWithRenderingSuppression();
 
     for (size_t i = 0; i < m_children.size(); ++i) {
         PlatformCALayerRemote& child = downcast<PlatformCALayerRemote>(*m_children[i]);
         ASSERT(child.superlayer() == this);
-        child.recursiveMarkWillBeDisplayed();
+        child.recursiveMarkWillBeDisplayedWithRenderingSuppresion();
     }
 }
 
@@ -211,7 +211,7 @@ void PlatformCALayerRemote::recursiveBuildTransaction(RemoteLayerTreeContext& co
         // Rendering is suppressed, so don't include any mutations from this subtree
         // in the transaction. We do still mark all existing layers as will be displayed though,
         // to prevent the previous contents from being discarded.
-        recursiveMarkWillBeDisplayed();
+        recursiveMarkWillBeDisplayedWithRenderingSuppresion();
         return;
     }
 


### PR DESCRIPTION
#### 69f43e22401674b905bb6762846ce2f1814146be
<pre>
Crash in WebKit::RemoteLayerBackingStore::needsDisplay due to owner() being null.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276352">https://bugs.webkit.org/show_bug.cgi?id=276352</a>
&lt;<a href="https://rdar.apple.com/131107394">rdar://131107394</a>&gt;

Reviewed by Dan Glastonbury.

When a layer subtree has rendering suppression, we just want add its backing store
to m_reachableBackingStoreInLatestFlush to stop it from being purged.

It is entirely possible for the owner() (the GraphicsLayer) to have gone away, and
we want to continue to display the old content until suppression ends.

The existing code for RemoteLayerBackingStoreCollection::backingStoreWillBeDisplayed
checked for invalidation via needsDisplay(), which then crashed if the owner had gone
away.

This adds a new alternative that doesn&apos;t check for invalidation, with very explicit
rendering suppression naming.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::layerWillBeDisplayedWithRenderingSuppression):
(WebKit::RemoteLayerBackingStore::needsDisplay const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::backingStoreWillBeDisplayedWithRenderingSuppression):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::recursiveMarkWillBeDisplayedWithRenderingSuppresion):
(WebKit::PlatformCALayerRemote::recursiveBuildTransaction):
(WebKit::PlatformCALayerRemote::recursiveMarkWillBeDisplayed): Deleted.

Canonical link: <a href="https://commits.webkit.org/280874@main">https://commits.webkit.org/280874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d469ad2a3ba22584a4e82e4e936a02e7f31f119

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61533 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8356 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8544 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5947 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59941 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/50054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/27758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/31694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7360 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/7617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63220 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7687 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1832 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/50065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/54289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/1557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8633 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33068 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34154 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35238 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->