### PR TITLE
Create PermissionsPolicy from Document

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1165,6 +1165,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     history/CachedPage.h
     history/HistoryItem.h
 
+    html/Allowlist.h
     html/AttachmentAssociatedElement.h
     html/Autocapitalize.h
     html/AutocapitalizeTypes.h
@@ -1277,6 +1278,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/MediaElementSession.h
     html/MediaError.h
     html/OffscreenCanvas.h
+    html/OwnerPermissionsPolicyData.h
     html/PDFDocument.h
     html/PermissionsPolicy.h
     html/PluginDocument.h

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10716,7 +10716,7 @@ PermissionsPolicy Document::permissionsPolicy() const
     // because Document may not be set on Frame yet, and it would affect the computation
     // of PermissionsPolicy.
     if (!m_permissionsPolicy)
-        m_permissionsPolicy = makeUnique<PermissionsPolicy>(ownerElement(), securityOrigin().data());
+        m_permissionsPolicy = makeUnique<PermissionsPolicy>(*this);
 
     return *m_permissionsPolicy;
 }

--- a/Source/WebCore/html/Allowlist.h
+++ b/Source/WebCore/html/Allowlist.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "SecurityOriginData.h"
+
+namespace WebCore {
+
+// https://w3c.github.io/webappsec-permissions-policy/#allowlists
+class Allowlist {
+public:
+    Allowlist() = default;
+    struct AllowAllOrigins { };
+    Allowlist(AllowAllOrigins allow)
+        : m_origins(allow)
+    {
+    }
+    explicit Allowlist(const SecurityOriginData& origin)
+        : m_origins(HashSet<SecurityOriginData> { origin })
+    {
+    }
+    explicit Allowlist(HashSet<SecurityOriginData>&& origins)
+        : m_origins(WTFMove(origins))
+    {
+    }
+
+    using OriginsVariant = std::variant<HashSet<SecurityOriginData>, AllowAllOrigins>;
+    explicit Allowlist(OriginsVariant&& origins)
+        : m_origins(WTFMove(origins))
+    {
+    }
+    const OriginsVariant& origins() const { return m_origins; }
+
+    // This is simplified version of https://w3c.github.io/webappsec-permissions-policy/#matches.
+    bool matches(const SecurityOriginData& origin) const
+    {
+        return std::visit(WTF::makeVisitor([&origin](const HashSet<SecurityOriginData>& origins) -> bool {
+            return origins.contains(origin);
+        }, [&] (const auto&) {
+            return true;
+        }), m_origins);
+    }
+
+private:
+    OriginsVariant m_origins;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/html/OwnerPermissionsPolicyData.h
+++ b/Source/WebCore/html/OwnerPermissionsPolicyData.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "PermissionsPolicy.h"
+
+namespace WebCore {
+
+struct OwnerPermissionsPolicyData {
+    using PolicyDirective = PermissionsPolicy::PolicyDirective;
+    OwnerPermissionsPolicyData(SecurityOriginData&& documentOrigin, PermissionsPolicy&& documentPolicy, PolicyDirective&& containerPolicy)
+        : documentOrigin(WTFMove(documentOrigin))
+        , documentPolicy(WTFMove(documentPolicy))
+        , containerPolicy(WTFMove(containerPolicy))
+    {
+    }
+
+    SecurityOriginData documentOrigin;
+    PermissionsPolicy documentPolicy;
+    PolicyDirective containerPolicy;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -30,6 +30,7 @@
 #include "AdjustViewSizeOrNot.h"
 #include "Document.h"
 #include "Frame.h"
+#include "OwnerPermissionsPolicyData.h"
 #include "ScrollTypes.h"
 #include "UserScriptTypes.h"
 #include <wtf/CheckedRef.h>
@@ -319,6 +320,9 @@ public:
     String customNavigatorPlatform() const final;
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const final;
 
+    void setOwnerPermissionsPolicy(OwnerPermissionsPolicyData&& policy) { m_ownerPermisssionsPolicy = WTFMove(policy); }
+    std::optional<OwnerPermissionsPolicyData> ownerPermissionsPolicy() const { return m_ownerPermisssionsPolicy; }
+
 protected:
     void frameWasDisconnectedFromOwner() const final;
 
@@ -389,6 +393,7 @@ private:
     const WeakRef<const LocalFrame> m_rootFrame;
     UniqueRef<EventHandler> m_eventHandler;
     HashSet<RegistrableDomain> m_storageAccessExceptionDomains;
+    std::optional<OwnerPermissionsPolicyData> m_ownerPermisssionsPolicy;
 };
 
 inline LocalFrameView* LocalFrame::view() const


### PR DESCRIPTION
#### b4bb6216f8304dd9e2bab2648aad261546d4dad5
<pre>
Create PermissionsPolicy from Document
<a href="https://bugs.webkit.org/show_bug.cgi?id=276353">https://bugs.webkit.org/show_bug.cgi?id=276353</a>
<a href="https://rdar.apple.com/131357201">rdar://131357201</a>

Reviewed by Youenn Fablet.

This patch makes a few changes that will help add support for permissions policy with site isolation:
1. Replace BitSet with HashSet for InheritedPolicy in PermissionsPolicy, so that we could use strongly typed enum for
getting and setting, which makes the code easier to understand and it is more safe to use it in IPC later. (We will
need to pass the policy between UI process and web processes).
2. Introduce OwnerPermissionsPolicyData struct, which contains information that Document needs from its owner element to
compute permissions policy. With site isolation, Document may not have access to owner element, so we need to store the
information elsewhere. In this patch, we store it in LocalFrame.
3. Allow PermissionsPolicy to be created from Document, and PermissionsPolicy can decide whether to construct object
from owner element or owner policy.
4. Split Allowlist from PermissionsPolicy so that it&apos;s easier to add IPC serialization format for it later.

The owner policy of LocalFrame is not set yet, so there is no behavior change.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::permissionsPolicy const):
* Source/WebCore/html/Allowlist.h: Added.
(WebCore::Allowlist::Allowlist):
(WebCore::Allowlist::origins const):
(WebCore::Allowlist::matches const):
* Source/WebCore/html/OwnerPermissionsPolicyData.h: Added.
(WebCore::OwnerPermissionsPolicyData::OwnerPermissionsPolicyData):
* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::forEachFeature):
(WebCore::parseAllowlist):
(WebCore::PermissionsPolicy::processPermissionsPolicyAttribute):
(WebCore::featureValueForOrigin):
(WebCore::PermissionsPolicy::computeInheritedPolicyValueInContainer const):
(WebCore::PermissionsPolicy::inheritedPolicyValueForFeature const):
(WebCore::PermissionsPolicy::PermissionsPolicy):
(WebCore::PermissionsPolicy::Allowlist::matches const): Deleted.
(WebCore::index): Deleted.
* Source/WebCore/html/PermissionsPolicy.h:
(WebCore::PermissionsPolicy::PermissionsPolicy):
(WebCore::PermissionsPolicy::inheritedPolicy const):
(): Deleted.
(WebCore::PermissionsPolicy::Allowlist::Allowlist): Deleted.
* Source/WebCore/page/LocalFrame.h:

Canonical link: <a href="https://commits.webkit.org/280791@main">https://commits.webkit.org/280791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b0909f5a208f4f351f9a387151a76e5d32c1f7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61224 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8047 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46647 "Passed tests") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5718 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27514 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7068 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7050 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53386 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62904 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53905 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54013 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12748 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1294 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32759 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33845 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34929 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->