### PR TITLE
MediaSession artwork only uses the first item in the artwork array

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaMetadata.h
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.h
@@ -96,10 +96,19 @@ public:
 #endif
 
 private:
+    struct Pair {
+        float score;
+        String src;
+    };
+
     MediaMetadata();
     void setArtworkImage(Image*);
     void metadataUpdated();
     void refreshArtworkImage();
+    void tryNextArtworkImage(uint32_t, Vector<Pair>&&);
+
+    static constexpr int s_minimumSize = 128;
+    static constexpr int s_idealSize = 512;
 
     WeakPtr<MediaSession> m_session;
     MediaSessionMetadata m_metadata;


### PR DESCRIPTION
#### cbbcae6e1ae3ca3c2b11a499fa133b07746e2820
<pre>
MediaSession artwork only uses the first item in the artwork array
<a href="https://bugs.webkit.org/show_bug.cgi?id=276351">https://bugs.webkit.org/show_bug.cgi?id=276351</a>
<a href="https://rdar.apple.com/81160539">rdar://81160539</a>

Reviewed by Youenn Fablet.

If `sizes` metadata artwork attribute is provided we will use them to determine the &quot;best&quot;
image to select. We do so by giving each resolution a score between 0 and 1. We aim to download
an image that is 512x512 with an aspect ratio of 1.
If the `sizes` attribute contains invalid content or if not provided, we will iterate through
all the available images and download them. We will then either select the one with the highest
score, or the first one found with a resolution greater than 512 pixels.

Test will be added once <a href="https://bugs.webkit.org/show_bug.cgi?id=276133">https://bugs.webkit.org/show_bug.cgi?id=276133</a> lands as it adds some
internal APIs to check which URL was selected with Now Playing.
For now, manually tested.

* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::MediaMetadata::imageDimensionsScore const):
(WebCore::MediaMetadata::refreshArtworkImage):
(WebCore::MediaMetadata::tryNextArtworkImage):
* Source/WebCore/Modules/mediasession/MediaMetadata.h:

Canonical link: <a href="https://commits.webkit.org/280804@main">https://commits.webkit.org/280804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/515c5077ab9951a4ae1ab8feeb801164d9a058b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61314 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8137 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46746 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5767 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27568 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7141 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7141 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62995 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53961 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54076 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12757 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1357 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33935 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->