### PR TITLE
Allow WKWebView clients to toggle fullscreen video

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -727,7 +727,7 @@ protected:
 
     bool showPosterFlag() const { return m_showPoster; }
     void setShowPosterFlag(bool);
-    
+
     void setChangingVideoFullscreenMode(bool value) { m_changingVideoFullscreenMode = value; }
     bool isChangingVideoFullscreenMode() const { return m_changingVideoFullscreenMode; }
 

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -41,12 +41,6 @@ class PlaybackSessionModel;
 class PlaybackSessionModelClient;
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PlaybackSessionModel> : std::true_type { };
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PlaybackSessionModelClient> : std::true_type { };
-}
-
 namespace WebCore {
 
 class TimeRanges;
@@ -71,6 +65,12 @@ public:
     virtual ~PlaybackSessionModel() { };
     virtual void addClient(PlaybackSessionModelClient&) = 0;
     virtual void removeClient(PlaybackSessionModelClient&) = 0;
+
+    // CheckedPtr interface
+    virtual uint32_t ptrCount() const = 0;
+    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
+    virtual void incrementPtrCount() const = 0;
+    virtual void decrementPtrCount() const = 0;
 
     virtual void play() = 0;
     virtual void pause() = 0;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -41,13 +41,25 @@ class AudioTrack;
 class HTMLMediaElement;
 class TextTrack;
 
-class PlaybackSessionModelMediaElement final : public PlaybackSessionModel, public EventListener {
+class PlaybackSessionModelMediaElement final
+    : public PlaybackSessionModel
+    , public EventListener
+    , public CanMakeCheckedPtr<PlaybackSessionModelMediaElement> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionModelMediaElement);
 public:
     static Ref<PlaybackSessionModelMediaElement> create()
     {
         return adoptRef(*new PlaybackSessionModelMediaElement());
     }
     WEBCORE_EXPORT virtual ~PlaybackSessionModelMediaElement();
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+
     WEBCORE_EXPORT void setMediaElement(HTMLMediaElement*);
     HTMLMediaElement* mediaElement() const { return m_mediaElement.get(); }
 

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -384,6 +384,7 @@ void PlaybackSessionModelMediaElement::enterFullscreen()
     if (!element)
         return;
 
+    UserGestureIndicator indicator { IsProcessingUserGesture::Yes, &element->document() };
     element->webkitEnterFullscreen();
 }
 
@@ -394,6 +395,7 @@ void PlaybackSessionModelMediaElement::exitFullscreen()
     if (!element)
         return;
 
+    UserGestureIndicator indicator { IsProcessingUserGesture::Yes, &element->document() };
     element->webkitExitFullscreen();
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2835,6 +2835,11 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
 #endif
 }
 
+- (BOOL)_canEnterFullscreen
+{
+    return _page->canEnterFullscreen();
+}
+
 - (BOOL)_isPictureInPictureActive
 {
 #if HAVE(TOUCH_BAR) && ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
@@ -2877,6 +2882,12 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
 #if HAVE(TOUCH_BAR) && ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
     _impl->toggleInWindowFullscreen();
 #endif
+}
+
+- (void)_enterFullscreen
+{
+    if (RefPtr page = _page)
+        page->enterFullscreen();
 }
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -379,11 +379,13 @@ for this property.
 
 @property (nonatomic, readonly) BOOL _canTogglePictureInPicture;
 @property (nonatomic, readonly) BOOL _canToggleInWindow;
+@property (nonatomic, readonly) BOOL _canEnterFullscreen WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 @property (nonatomic, readonly) BOOL _isPictureInPictureActive;
 @property (nonatomic, readonly) BOOL _isInWindowActive;
 - (void)_updateMediaPlaybackControlsManager;
 - (void)_togglePictureInPicture;
 - (void)_toggleInWindow;
+- (void)_enterFullscreen WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 - (void)_stopAllMediaPlayback;
 - (void)_suspendAllMediaPlayback;
 - (void)_resumeAllMediaPlayback;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -133,6 +133,8 @@ public:
 
     void hasActiveNowPlayingSessionChanged(bool) final;
 
+    void videoControlsManagerDidChange() override;
+
 protected:
     RetainPtr<WKWebView> webView() const { return m_webView.get(); }
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -327,4 +327,10 @@ void PageClientImplCocoa::hasActiveNowPlayingSessionChanged(bool hasActiveNowPla
     [m_webView didChangeValueForKey:@"_hasActiveNowPlayingSession"];
 }
 
+void PageClientImplCocoa::videoControlsManagerDidChange()
+{
+    [m_webView willChangeValueForKey:@"_canEnterFullscreen"];
+    [m_webView didChangeValueForKey:@"_canEnterFullscreen"];
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -34,6 +34,7 @@
 #include <WebCore/PlaybackSessionModel.h>
 #include <WebCore/TimeRanges.h>
 #include <WebCore/VideoReceiverEndpoint.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
@@ -47,13 +48,24 @@ class WebPageProxy;
 class PlaybackSessionManagerProxy;
 class VideoReceiverEndpointMessage;
 
-class PlaybackSessionModelContext final: public RefCounted<PlaybackSessionModelContext>, public WebCore::PlaybackSessionModel  {
+class PlaybackSessionModelContext final
+    : public RefCounted<PlaybackSessionModelContext>
+    , public WebCore::PlaybackSessionModel
+    , public CanMakeCheckedPtr<PlaybackSessionModelContext> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionModelContext);
 public:
     static Ref<PlaybackSessionModelContext> create(PlaybackSessionManagerProxy& manager, PlaybackSessionContextIdentifier contextId)
     {
         return adoptRef(*new PlaybackSessionModelContext(manager, contextId));
     }
     virtual ~PlaybackSessionModelContext();
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     // PlaybackSessionModel
     void addClient(WebCore::PlaybackSessionModelClient&) final;
@@ -218,6 +230,7 @@ public:
 
     void invalidate();
 
+    bool hasControlsManagerInterface() const { return !!m_controlsManagerContextId; }
     WebCore::PlatformPlaybackSessionInterface* controlsManagerInterface();
     void requestControlledElementID();
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -31,6 +31,7 @@
 #include "MessageReceiver.h"
 #include <WebCore/HTMLMediaElement.h>
 #include <WebCore/HTMLMediaElementEnums.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -39,11 +40,6 @@
 
 namespace WebKit {
 class WebFullScreenManagerProxy;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebKit::WebFullScreenManagerProxy> : std::true_type { };
 }
 
 namespace WebCore {
@@ -79,8 +75,9 @@ public:
     virtual void unlockFullscreenOrientation() { }
 };
 
-class WebFullScreenManagerProxy : public IPC::MessageReceiver {
+class WebFullScreenManagerProxy : public IPC::MessageReceiver, public CanMakeCheckedPtr<WebFullScreenManagerProxy> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebFullScreenManagerProxy);
 public:
     WebFullScreenManagerProxy(WebPageProxy&, WebFullScreenManagerProxyClient&);
     virtual ~WebFullScreenManagerProxy();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -273,6 +273,7 @@
 #if PLATFORM(COCOA)
 #include "InsertTextOptions.h"
 #include "NetworkIssueReporter.h"
+#include "PlaybackSessionInterfaceLMK.h"
 #include "RemoteLayerTreeDrawingAreaProxy.h"
 #include "RemoteLayerTreeScrollingPerformanceData.h"
 #include "UserMediaCaptureManagerProxy.h"
@@ -283,6 +284,9 @@
 #include <WebCore/AttributedString.h>
 #include <WebCore/CoreAudioCaptureDeviceManager.h>
 #include <WebCore/LegacyWebArchive.h>
+#include <WebCore/NullPlaybackSessionInterface.h>
+#include <WebCore/PlaybackSessionInterfaceAVKit.h>
+#include <WebCore/PlaybackSessionInterfaceMac.h>
 #include <WebCore/RunLoopObserver.h>
 #include <WebCore/SystemBattery.h>
 #include <objc/runtime.h>
@@ -7697,6 +7701,30 @@ void WebPageProxy::fullscreenMayReturnToInline()
 }
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
+
+bool WebPageProxy::canEnterFullscreen()
+{
+    if (RefPtr playbackSessionManager = m_playbackSessionManager)
+        return playbackSessionManager->hasControlsManagerInterface();
+    return false;
+}
+
+void WebPageProxy::enterFullscreen()
+{
+    RefPtr playbackSessionManager = m_playbackSessionManager;
+    if (!playbackSessionManager)
+        return;
+
+    RefPtr controlsManagerInterface = playbackSessionManager->controlsManagerInterface();
+    if (!controlsManagerInterface)
+        return;
+
+    CheckedPtr playbackSessionModel = controlsManagerInterface->playbackSessionModel();
+    if (!playbackSessionModel)
+        return;
+
+    playbackSessionModel->enterFullscreen();
+}
 
 void WebPageProxy::didEnterFullscreen(PlaybackSessionContextIdentifier identifier)
 {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2156,6 +2156,9 @@ public:
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
+    bool canEnterFullscreen();
+    void enterFullscreen();
+
     void failedToEnterFullscreen(PlaybackSessionContextIdentifier);
     void didEnterFullscreen(PlaybackSessionContextIdentifier);
     void didExitFullscreen(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -940,6 +940,7 @@ void PageClientImpl::didChangeBackgroundColor()
 
 void PageClientImpl::videoControlsManagerDidChange()
 {
+    PageClientImplCocoa::videoControlsManagerDidChange();
     [webView() _videoControlsManagerDidChange];
 }
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -944,6 +944,7 @@ void PageClientImpl::didHandleAcceptedCandidate()
 
 void PageClientImpl::videoControlsManagerDidChange()
 {
+    PageClientImplCocoa::videoControlsManagerDidChange();
     m_impl->videoControlsManagerDidChange();
 }
 

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -548,13 +548,11 @@ void PlaybackSessionManager::togglePictureInPicture(PlaybackSessionContextIdenti
 
 void PlaybackSessionManager::enterFullscreen(PlaybackSessionContextIdentifier contextId)
 {
-    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).enterFullscreen();
 }
 
 void PlaybackSessionManager::exitFullscreen(PlaybackSessionContextIdentifier contextId)
 {
-    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
     ensureModel(contextId).exitFullscreen();
 }
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -932,6 +932,7 @@
 		A179918B1E1CA24100A505ED /* SharedBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A17991891E1CA24100A505ED /* SharedBufferTest.cpp */; };
 		A17EAC55208305A00084B41B /* find.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = A17EAC542083056E0084B41B /* find.pdf */; };
 		A198D0A22BC64D8E0058BBEB /* NowPlayingMetadataObserver.mm in Sources */ = {isa = PBXBuildFile; fileRef = A198D0A12BC64D8E0058BBEB /* NowPlayingMetadataObserver.mm */; };
+		A1AD382F2C3DA40B003499BE /* FullscreenLifecycle.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1AD38272C3D9FAF003499BE /* FullscreenLifecycle.mm */; };
 		A1C142C224AA7B2E00444207 /* ContextMenuMouseEvents.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1C142C124AA7B2E00444207 /* ContextMenuMouseEvents.mm */; };
 		A1C4FB731BACD1CA003742D0 /* pages.pages in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1C4FB721BACD1B7003742D0 /* pages.pages */; };
 		A1C7D7D32AB817A90055AD62 /* LoggerCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1C7D7D22AB817A90055AD62 /* LoggerCocoa.mm */; };
@@ -3177,6 +3178,7 @@
 		A18AA8CC1C3FA218009B2B97 /* ContentFiltering.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContentFiltering.h; sourceTree = "<group>"; };
 		A198D0A12BC64D8E0058BBEB /* NowPlayingMetadataObserver.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NowPlayingMetadataObserver.mm; sourceTree = "<group>"; };
 		A1A4FE5D18DD3DB700B5EA8A /* Download.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Download.mm; sourceTree = "<group>"; };
+		A1AD38272C3D9FAF003499BE /* FullscreenLifecycle.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenLifecycle.mm; sourceTree = "<group>"; };
 		A1C142C124AA7B2E00444207 /* ContextMenuMouseEvents.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ContextMenuMouseEvents.mm; sourceTree = "<group>"; };
 		A1C4FB6C1BACCE50003742D0 /* QuickLook.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = QuickLook.mm; sourceTree = "<group>"; };
 		A1C4FB721BACD1B7003742D0 /* pages.pages */ = {isa = PBXFileReference; lastKnownFileType = file; name = pages.pages; path = ios/pages.pages; sourceTree = SOURCE_ROOT; };
@@ -4148,6 +4150,7 @@
 				CDCF78A7244A2EDB00480311 /* FullscreenAlert.mm */,
 				CD78E11A1DB7EA360014A2DE /* FullscreenDelegate.mm */,
 				3F1B52681D3D7129008D60C4 /* FullscreenLayoutConstraints.mm */,
+				A1AD38272C3D9FAF003499BE /* FullscreenLifecycle.mm */,
 				CDDC7C6825FFF6D000224278 /* FullscreenRemoveNodeBeforeEnter.mm */,
 				F4BDA42E27F8BF2F00F9647D /* FullscreenVideoTextRecognition.mm */,
 				631EFFF51E7B5E8D00D2EBB8 /* Geolocation.mm */,
@@ -6664,6 +6667,7 @@
 				7CCE7EF71A411AE600447C4C /* FrameMIMETypePNG.cpp in Sources */,
 				CDB213BD24EF522800FDE301 /* FullscreenFocus.mm in Sources */,
 				E55999F72B476C2F00A3719F /* FullscreenLayoutParameters.mm in Sources */,
+				A1AD382F2C3DA40B003499BE /* FullscreenLifecycle.mm in Sources */,
 				CDE77D2525A6591C00D4115E /* FullscreenPointerLeave.mm in Sources */,
 				CDBFCC451A9FF45300A7B691 /* FullscreenZoomInitialFrame.mm in Sources */,
 				83DB79691EF63B3C00BFA5E5 /* Function.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLifecycle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLifecycle.mm
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(MAC)
+
+#import "PlatformUtilities.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WebKit.h>
+
+static NSString * const canEnterFullscreenKeyPath = @"_canEnterFullscreen";
+static NSString * const fullscreenStateKeyPath = @"fullscreenState";
+static bool canEnterFullscreenChanged;
+static bool fullscreenStateChanged;
+
+@interface FullscreenLifecycleObserver : NSObject
+@end
+
+@implementation FullscreenLifecycleObserver
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *, id> *)change context:(void *)context
+{
+    ASSERT([object isKindOfClass:WKWebView.class]);
+    if ([keyPath isEqualToString:canEnterFullscreenKeyPath])
+        canEnterFullscreenChanged = true;
+    else if ([keyPath isEqualToString:fullscreenStateKeyPath])
+        fullscreenStateChanged = true;
+    else
+        ASSERT_NOT_REACHED();
+}
+
+@end
+
+TEST(Fullscreen, Lifecycle)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
+    [configuration preferences].elementFullscreenEnabled = YES;
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
+    ASSERT_FALSE([webView _canEnterFullscreen]);
+    ASSERT_EQ([webView fullscreenState], WKFullscreenStateNotInFullscreen);
+
+    auto observer = adoptNS([[FullscreenLifecycleObserver alloc] init]);
+    [webView addObserver:observer.get() forKeyPath:canEnterFullscreenKeyPath options:NSKeyValueObservingOptionNew context:nil];
+    [webView addObserver:observer.get() forKeyPath:fullscreenStateKeyPath options:NSKeyValueObservingOptionNew context:nil];
+
+    [webView loadTestPageNamed:@"large-video-test-now-playing"];
+    [webView waitForMessage:@"playing"];
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return [webView _canEnterFullscreen];
+    });
+    ASSERT_TRUE([webView _canEnterFullscreen]);
+    ASSERT_TRUE(canEnterFullscreenChanged);
+
+    [webView _enterFullscreen];
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return [webView fullscreenState] == WKFullscreenStateInFullscreen;
+    });
+    ASSERT_EQ([webView fullscreenState], WKFullscreenStateInFullscreen);
+    ASSERT_TRUE(fullscreenStateChanged);
+
+    fullscreenStateChanged = false;
+    [webView closeAllMediaPresentationsWithCompletionHandler:^{ }];
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return [webView fullscreenState] == WKFullscreenStateNotInFullscreen;
+    });
+    ASSERT_EQ([webView fullscreenState], WKFullscreenStateNotInFullscreen);
+    ASSERT_TRUE(fullscreenStateChanged);
+
+    canEnterFullscreenChanged = false;
+    [webView synchronouslyLoadHTMLString:@"<body></body>"];
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return ![webView _canEnterFullscreen];
+    });
+    ASSERT_FALSE([webView _canEnterFullscreen]);
+    ASSERT_TRUE(canEnterFullscreenChanged);
+}
+
+#endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSpatialTrackingLabels.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSpatialTrackingLabels.mm
@@ -46,13 +46,9 @@ TEST(WKWebView, DefaultSTSLabel)
     };
 
     auto testDefaultSTSLabelEventually = [&](auto test) {
-        int tries = 0;
-        do {
-            if (test(getDefaultSTSLabel()))
-                break;
-
-            TestWebKitAPI::Util::runFor(0.1_s);
-        } while (++tries <= 100);
+        TestWebKitAPI::Util::waitFor([&] {
+            return test(getDefaultSTSLabel());
+        });
     };
 
     testDefaultSTSLabelEventually([](auto* label) { return ![label isEqualToString:@""]; });

--- a/Tools/TestWebKitAPI/Tests/mac/InWindowFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/InWindowFullscreen.mm
@@ -41,17 +41,6 @@ static RetainPtr<TestWKWebView> createInWindowFullscreenWebView()
     return webView;
 }
 
-template <typename Callable>
-static void testEventually(Callable&& c)
-{
-    int tries = 0;
-    do {
-        if (c())
-            break;
-        TestWebKitAPI::Util::runFor(0.1_s);
-    } while (++tries <= 100);
-}
-
 TEST(InWindowFullscreen, EmptyDocument)
 {
     auto webView = createInWindowFullscreenWebView();
@@ -73,7 +62,7 @@ TEST(InWindowFullscreen, CanToggleAfterPlaybackStarts)
     TestWebKitAPI::Util::run(&isPlaying);
 
     [webView _updateMediaPlaybackControlsManager];
-    testEventually([&] {
+    TestWebKitAPI::Util::waitFor([&] {
         [webView _updateMediaPlaybackControlsManager];
         return [webView _canToggleInWindow];
     });
@@ -92,20 +81,20 @@ TEST(InWindowFullscreen, ToggleChangesIsActive)
     [webView objectByEvaluatingJavaScriptWithUserGesture:@"go()"];
     TestWebKitAPI::Util::run(&isPlaying);
 
-    testEventually([&] {
+    TestWebKitAPI::Util::waitFor([&] {
         [webView _updateMediaPlaybackControlsManager];
         return [webView _canToggleInWindow];
     });
     EXPECT_TRUE([webView _canToggleInWindow]);
 
     [webView _toggleInWindow];
-    testEventually([&] {
+    TestWebKitAPI::Util::waitFor([&] {
         return [webView _isInWindowActive];
     });
     EXPECT_TRUE([webView _isInWindowActive]);
 
     [webView _toggleInWindow];
-    testEventually([&] {
+    TestWebKitAPI::Util::waitFor([&] {
         return ![webView _isInWindowActive];
     });
     EXPECT_FALSE([webView _isInWindowActive]);
@@ -123,7 +112,7 @@ TEST(InWindowFullscreen, ToggleChangesIsActiveWithoutUserGesture)
     [webView objectByEvaluatingJavaScriptWithUserGesture:@"go()"];
     TestWebKitAPI::Util::run(&isPlaying);
 
-    testEventually([&] {
+    TestWebKitAPI::Util::waitFor([&] {
         [webView _updateMediaPlaybackControlsManager];
         return [webView _canToggleInWindow];
     });
@@ -132,10 +121,10 @@ TEST(InWindowFullscreen, ToggleChangesIsActiveWithoutUserGesture)
     [webView objectByEvaluatingJavaScriptWithUserGesture:@"internals.consumeTransientActivation()"];
 
     [webView _toggleInWindow];
-    testEventually([&] {
+    TestWebKitAPI::Util::waitFor([&] {
         return [webView _isInWindowActive];
     });
     EXPECT_TRUE([webView _isInWindowActive]);
 }
 
-}
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Utilities.h
+++ b/Tools/TestWebKitAPI/Utilities.h
@@ -44,4 +44,16 @@ void runFor(Seconds duration);
 // Runs a platform runloop `count` number of spins.
 void spinRunLoop(uint64_t count = 1);
 
+// Waits for 'c' to return true by repeatedly running the platform runloop for 100ms, up to 'maxTries'.
+template <typename Callable>
+void waitFor(Callable&& c, size_t maxTries = 100)
+{
+    size_t tries = 0;
+    do {
+        if (c())
+            break;
+        TestWebKitAPI::Util::runFor(0.1_s);
+    } while (++tries <= maxTries);
 }
+
+} // namespace TestWebKitAPI::Util


### PR DESCRIPTION
#### ad94373263a77c433dc04da03a3029c58962182b
<pre>
Allow WKWebView clients to toggle fullscreen video
<a href="https://bugs.webkit.org/show_bug.cgi?id=276376">https://bugs.webkit.org/show_bug.cgi?id=276376</a>
<a href="https://rdar.apple.com/131394306">rdar://131394306</a>

Reviewed by Jer Noble.

Added APIs to WKWebViewPrivate.h that allow clients to (a) determine whether they can enter
fullscreen video (-_canEnterFullscreen), and (b) enter fullscreen programatically (-_enterFullscreen).
-_canEnterFullscreen is key-value observable.

While here, made it possible to create a CheckedPtr to PlaybackSessionModel and
WebFullScreenManagerProxy and fixed a bug with how PlaybackSessionManager::(enter|exit)Fullscreen
created UserGestureIndicators.

Added an API test.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::enterFullscreen):
(WebCore::PlaybackSessionModelMediaElement::exitFullscreen):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _canEnterFullscreen]):
(-[WKWebView _enterFullscreen]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::videoControlsManagerDidChange):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
(WebKit::PlaybackSessionManagerProxy::hasControlsManagerInterface const):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::canEnterFullscreen):
(WebKit::WebPageProxy::enterFullscreen):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::videoControlsManagerDidChange):
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::videoControlsManagerDidChange):
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::enterFullscreen):
(WebKit::PlaybackSessionManager::exitFullscreen):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLifecycle.mm: Added.
(-[FullscreenLifecycleObserver observeValueForKeyPath:ofObject:change:context:]):
(TEST(Fullscreen, Lifecycle)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSpatialTrackingLabels.mm:
(TEST(WKWebView, DefaultSTSLabel)):
* Tools/TestWebKitAPI/Tests/mac/InWindowFullscreen.mm:
(TestWebKitAPI::TEST(InWindowFullscreen, CanToggleAfterPlaybackStarts)):
(TestWebKitAPI::TEST(InWindowFullscreen, ToggleChangesIsActive)):
(TestWebKitAPI::TEST(InWindowFullscreen, ToggleChangesIsActiveWithoutUserGesture)):
(TestWebKitAPI::testEventually): Deleted.
* Tools/TestWebKitAPI/Utilities.h:
(TestWebKitAPI::Util::waitFor):

Canonical link: <a href="https://commits.webkit.org/280839@main">https://commits.webkit.org/280839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/760f81c11a80b7ef9826357aa4ea1d8ed2d6d82d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61388 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46803 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27628 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7212 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7215 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63071 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1680 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7555 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54022 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49930 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54140 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12783 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1424 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32923 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35093 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33754 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->