### PR TITLE
[WebXR] Only allow WebXR IPC messages after prompt is confirmed

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -631,6 +631,19 @@ void GPUProcess::requestBitmapImageForCurrentTime(WebCore::ProcessIdentifier pro
 }
 #endif
 
+#if ENABLE(WEBXR)
+std::optional<WebCore::ProcessIdentity> GPUProcess::immersiveModeProcessIdentity() const
+{
+    return m_processIdentity;
+}
+
+void GPUProcess::webXRPromptAccepted(std::optional<WebCore::ProcessIdentity> processIdentity, CompletionHandler<void(bool)>&& completionHandler)
+{
+    m_processIdentity = processIdentity;
+    completionHandler(true);
+}
+#endif
+
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -33,6 +33,7 @@
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/IntDegrees.h>
 #include <WebCore/MediaPlayerIdentifier.h>
+#include <WebCore/ProcessIdentity.h>
 #include <WebCore/ShareableBitmap.h>
 #include <WebCore/Timer.h>
 #include <pal/SessionID.h>
@@ -130,6 +131,9 @@ public:
 #if ENABLE(VIDEO)
     void requestBitmapImageForCurrentTime(WebCore::ProcessIdentifier, WebCore::MediaPlayerIdentifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
 #endif
+#if ENABLE(WEBXR)
+    std::optional<WebCore::ProcessIdentity> immersiveModeProcessIdentity() const;
+#endif
 
 private:
     void lowMemoryHandler(Critical, Synchronous);
@@ -198,11 +202,14 @@ private:
 #if HAVE(POWERLOG_TASK_MODE_QUERY)
     void enablePowerLogging(SandboxExtension::Handle&&);
 #endif
+#if ENABLE(WEBXR)
+    void webXRPromptAccepted(std::optional<WebCore::ProcessIdentity>, CompletionHandler<void(bool)>&&);
+#endif
 
     // Connections to WebProcesses.
     HashMap<WebCore::ProcessIdentifier, Ref<GPUConnectionToWebProcess>> m_webProcessConnections;
     MonotonicTime m_creationTime { MonotonicTime::now() };
-    
+
     GPUProcessPreferences m_preferences;
 
 #if ENABLE(MEDIA_STREAM)
@@ -240,6 +247,9 @@ private:
 #endif
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
     mutable std::unique_ptr<RemoteAudioSessionProxyManager> m_audioSessionManager;
+#endif
+#if ENABLE(WEBXR)
+    std::optional<WebCore::ProcessIdentity> m_processIdentity;
 #endif
 #if ENABLE(VP9) && PLATFORM(COCOA)
     bool m_haveEnabledVP8Decoder { false };

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -86,6 +86,9 @@ messages -> GPUProcess LegacyReceiver {
 #if USE(EXTENSIONKIT)
     ResolveBookmarkDataForCacheDirectory(std::span<const uint8_t> bookmarkData)
 #endif
+#if ENABLE(WEBXR)
+    WebXRPromptAccepted(std::optional<WebCore::ProcessIdentity> processIdentity) -> (bool accepted)
+#endif
 }
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -261,6 +261,16 @@ bool RemoteGraphicsContextGL::webXREnabled() const
     return false;
 }
 
+bool RemoteGraphicsContextGL::webXRPromptAccepted() const
+{
+#if ENABLE(WEBXR) && PLATFORM(COCOA) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+    auto currentAcceptedValue = GPUProcess::singleton().immersiveModeProcessIdentity();
+    return currentAcceptedValue && m_sharedResourceCache->resourceOwner() == *currentAcceptedValue;
+#else
+    return webXREnabled();
+#endif
+}
+
 void RemoteGraphicsContextGL::simulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting event)
 {
     assertIsCurrent(workQueue());

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -29,8 +29,10 @@
 
 #include "Connection.h"
 #include "GPUConnectionToWebProcess.h"
+#include "GPUProcess.h"
 #include "GraphicsContextGLIdentifier.h"
 #include "RemoteRenderingBackend.h"
+#include "RemoteSharedResourceCache.h"
 #include "ScopedWebGLRenderingResourcesRequest.h"
 #include "SharedVideoFrame.h"
 #include "StreamMessageReceiver.h"
@@ -147,6 +149,7 @@ protected:
 private:
     void paintNativeImageToImageBuffer(WebCore::NativeImage&, WebCore::RenderingResourceIdentifier);
     bool webXREnabled() const;
+    bool webXRPromptAccepted() const;
 
 protected:
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -323,19 +323,19 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void GetInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, size_t paramsSize) -> (std::span<const int32_t> params) Synchronous
     void SetDrawingBufferColorSpace(WebCore::DestinationColorSpace arg0)
 #if ENABLE(WEBXR)
-    [EnabledIf='webXREnabled()'] void CreateExternalImage(uint32_t externalImage, WebCore::GraphicsContextGL::ExternalImageSource arg0, uint32_t internalFormat, int32_t layer) NotStreamEncodable
-    [EnabledIf='webXREnabled()'] void DeleteExternalImage(uint32_t handle)
-    [EnabledIf='webXREnabled()'] void BindExternalImage(uint32_t target, uint32_t arg1)
-    [EnabledIf='webXREnabled()'] void CreateExternalSync(uint32_t externalSync, WebCore::GraphicsContextGL::ExternalSyncSource arg0) NotStreamEncodable
+    [EnabledIf='webXRPromptAccepted()'] void CreateExternalImage(uint32_t externalImage, WebCore::GraphicsContextGL::ExternalImageSource arg0, uint32_t internalFormat, int32_t layer) NotStreamEncodable
+    [EnabledIf='webXRPromptAccepted()'] void DeleteExternalImage(uint32_t handle)
+    [EnabledIf='webXRPromptAccepted()'] void BindExternalImage(uint32_t target, uint32_t arg1)
+    [EnabledIf='webXRPromptAccepted()'] void CreateExternalSync(uint32_t externalSync, WebCore::GraphicsContextGL::ExternalSyncSource arg0) NotStreamEncodable
 #endif
     [EnabledIf='webXREnabled()'] void DeleteExternalSync(uint32_t arg0)
 #if ENABLE(WEBXR)
-    [EnabledIf='webXREnabled()'] void EnableRequiredWebXRExtensions() -> (bool returnValue) Synchronous
-    [EnabledIf='webXREnabled()'] void AddFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const float> horizontalSamplesLeft, std::span<const float> verticalSamples, std::span<const float> horizontalSamplesRight) -> (bool returnValue) Synchronous
-    [EnabledIf='webXREnabled()'] void EnableFoveation(uint32_t arg0)
-    [EnabledIf='webXREnabled()'] void DisableFoveation()
-    [EnabledIf='webXREnabled()'] void FramebufferDiscard(uint32_t target, std::span<const uint32_t> attachments)
-    [EnabledIf='webXREnabled()'] void FramebufferResolveRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
+    [EnabledIf='webXRPromptAccepted()'] void EnableRequiredWebXRExtensions() -> (bool returnValue) Synchronous
+    [EnabledIf='webXRPromptAccepted()'] void AddFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const float> horizontalSamplesLeft, std::span<const float> verticalSamples, std::span<const float> horizontalSamplesRight) -> (bool returnValue) Synchronous
+    [EnabledIf='webXRPromptAccepted()'] void EnableFoveation(uint32_t arg0)
+    [EnabledIf='webXRPromptAccepted()'] void DisableFoveation()
+    [EnabledIf='webXRPromptAccepted()'] void FramebufferDiscard(uint32_t target, std::span<const uint32_t> attachments)
+    [EnabledIf='webXRPromptAccepted()'] void FramebufferResolveRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
 #endif
 }
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -147,6 +147,7 @@ def types_that_must_be_moved():
         'WebCore::GraphicsContextGL::ExternalImageSource',
         'WebCore::GraphicsContextGL::ExternalSyncSource',
         'WebCore::ProcessIdentity',
+        'std::optional<WebCore::ProcessIdentity>',
         'WebKit::ConsumerSharedCARingBufferHandle',
         'WebKit::GPUProcessConnectionParameters',
         'WebKit::ModelProcessConnectionParameters',

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -620,6 +620,14 @@ void GPUProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connect
 #endif
 }
 
+#if ENABLE(WEBXR)
+void GPUProcessProxy::webXRPromptAccepted(std::optional<WebCore::ProcessIdentity> processIdentity, CompletionHandler<void(bool)>&& completion)
+{
+    sendWithAsyncReply(Messages::GPUProcess::WebXRPromptAccepted(WTFMove(processIdentity)), WTFMove(completion));
+}
+#endif
+
+
 void GPUProcessProxy::updateProcessAssertion()
 {
     bool hasAnyForegroundWebProcesses = false;

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -113,6 +113,9 @@ public:
     void enablePowerLogging();
     static bool isPowerLoggingInTaskMode();
 #endif
+#if ENABLE(WEBXR)
+    void webXRPromptAccepted(std::optional<WebCore::ProcessIdentity>, CompletionHandler<void(bool)>&&);
+#endif
 
     void updatePreferences(WebProcessProxy&);
     void updateScreenPropertiesIfNeeded();

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2765,6 +2765,14 @@ TextStream& operator<<(TextStream& ts, const WebProcessProxy& process)
     return ts;
 }
 
+#if ENABLE(WEBXR)
+const WebCore::ProcessIdentity& WebProcessProxy::processIdentity()
+{
+    return m_processIdentity;
+}
+#endif
+
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -516,6 +516,10 @@ public:
     Seconds totalBackgroundTime() const;
     Seconds totalSuspendedTime() const;
 
+#if ENABLE(WEBXR)
+    const WebCore::ProcessIdentity& processIdentity();
+#endif
+
 private:
     Type type() const final { return Type::WebContent; }
 

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -102,7 +102,7 @@ private:
         SessionEndingFromSystem,
     };
     ImmersiveSessionState m_immersiveSessionState { ImmersiveSessionState::Idle };
-    void setImmersiveSessionState(ImmersiveSessionState);
+    void setImmersiveSessionState(ImmersiveSessionState, CompletionHandler<void(bool)>&&);
     void invalidateImmersiveSessionState(ImmersiveSessionState nextSessionState = ImmersiveSessionState::Idle);
 
     WebPageProxy& m_page;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -361,20 +361,20 @@ public:
     void setDrawingBufferColorSpace(const WebCore::DestinationColorSpace&) final;
 
 #if ENABLE(WEBXR)
-    GCGLExternalImage createExternalImage(WebCore::GraphicsContextGL::ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
-    void deleteExternalImage(GCGLExternalImage handle) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
-    void bindExternalImage(GCGLenum target, GCGLExternalImage) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
-    GCGLExternalSync createExternalSync(WebCore::GraphicsContextGL::ExternalSyncSource&&) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
+    GCGLExternalImage createExternalImage(WebCore::GraphicsContextGL::ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
+    void deleteExternalImage(GCGLExternalImage handle) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
+    void bindExternalImage(GCGLenum target, GCGLExternalImage) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
+    GCGLExternalSync createExternalSync(WebCore::GraphicsContextGL::ExternalSyncSource&&) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
 #endif
-    void deleteExternalSync(GCGLExternalSync) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
+    void deleteExternalSync(GCGLExternalSync) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
 
 #if ENABLE(WEBXR)
-    bool enableRequiredWebXRExtensions() IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
-    bool addFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const GCGLfloat> horizontalSamplesLeft, std::span<const GCGLfloat> verticalSamples, std::span<const GCGLfloat> horizontalSamplesRight) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
-    void enableFoveation(GCGLuint) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
-    void disableFoveation() IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
-    void framebufferDiscard(GCGLenum target, std::span<const GCGLenum> attachments) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
-    void framebufferResolveRenderbuffer(GCGLenum target, GCGLenum attachment, GCGLenum renderbuffertarget, PlatformGLObject arg3) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
+    bool enableRequiredWebXRExtensions() IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
+    bool addFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const GCGLfloat> horizontalSamplesLeft, std::span<const GCGLfloat> verticalSamples, std::span<const GCGLfloat> horizontalSamplesRight) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
+    void enableFoveation(GCGLuint) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
+    void disableFoveation() IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
+    void framebufferDiscard(GCGLenum target, std::span<const GCGLenum> attachments) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
+    void framebufferResolveRenderbuffer(GCGLenum target, GCGLenum attachment, GCGLenum renderbuffertarget, PlatformGLObject arg3) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXRPromptAccepted()') final;
 #endif
     // End of list used by generate-gpup-webgl script.
 


### PR DESCRIPTION
#### 6afb7c249681f62c45b1566827e17a44731e9a97
<pre>
[WebXR] Only allow WebXR IPC messages after prompt is confirmed
<a href="https://bugs.webkit.org/show_bug.cgi?id=276380">https://bugs.webkit.org/show_bug.cgi?id=276380</a>
&lt;radar://128015279&gt;

Reviewed by Dan Glastonbury.

Make WebXR IPC calls no-ops if the prompt hasn&apos;t been accepted.

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::immersiveModeProcessIdentity const):
(WebKit::GPUProcess::webXRPromptAccepted):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
(WebKit::RemoteGraphicsContextGL::webXRPromptAccepted):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(createExternalImage):
(deleteExternalImage):
(bindExternalImage):
(createExternalSync):
(addFoveation):
(enableFoveation):
(disableFoveation):
(framebufferDiscard):
(framebufferResolveRenderbuffer):
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_must_be_moved):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::webXRPromptAccepted):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::processIdentity):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::requestPermissionOnSessionFeatures):
(WebKit::PlatformXRSystem::initializeTrackingAndRendering):
(WebKit::PlatformXRSystem::shutDownTrackingAndRendering):
(WebKit::PlatformXRSystem::didCompleteShutdownTriggeredBySystem):
(WebKit::PlatformXRSystem::setImmersiveSessionState):
(WebKit::PlatformXRSystem::invalidateImmersiveSessionState):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:

Canonical link: <a href="https://commits.webkit.org/281114@main">https://commits.webkit.org/281114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26d3ad9a33d409cfaa7696ea631ff3dff0e56496

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8272 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46851 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5872 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27679 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/57353 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31615 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7276 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63132 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54075 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54598 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13000 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1480 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32984 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34070 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->