### PR TITLE
AX: Iterating over `WebCore::nextVisuallyDistinctCandidate`s can loop infinitely when starting from a role="img" Position

### DIFF
--- a/LayoutTests/accessibility/mac/role-img-selection-hang.html
+++ b/LayoutTests/accessibility/mac/role-img-selection-hang.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<ul id="list">
+  <li>
+    <a id="link" href="#url">
+      <div id="img" role="img">
+        <span style="position:absolute">X</span>
+        <span>Y</span>
+      </div>
+    </a>
+  </li>
+</ul>
+
+<script>
+var output = "This test ensures we do not cause a main-thread infinite loop when trying to setSelectedTextRange with a range containing a role='img' element.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var link = accessibilityController.accessibleElementById("link");
+    setTimeout(async function() {
+        link.setSelectedTextMarkerRange(link.textMarkerRangeForElement(link));
+        // Wait for the selected range to be set.
+        output += await expectAsync("link.stringForTextMarkerRange(link.selectedTextMarkerRange()) !== null", "true");
+
+        // Exercise a main-thread API (setting a DOM attribute) and wait for the result to be applied, confirming the main-thread isn't hung.
+        document.getElementById("img").setAttribute("aria-label", "foo bar");
+        await waitFor(() => platformTextAlternatives(accessibilityController.accessibleElementById("img")).includes("foo bar"));
+
+        document.getElementById("list").style.display = "none";
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/fast/text/input-fieldset-find-loop-expected.txt
+++ b/LayoutTests/fast/text/input-fieldset-find-loop-expected.txt
@@ -1,0 +1,11 @@
+PASS: Got a match at 6,9 as expected.
+PASS: Got a match at 1,1 as expected.
+PASS: Got a match at 3,3 as expected.
+PASS: Got a match at 12,15 as expected.
+PASS: Got a match at 5,8 as expected.
+PASS: Got a match at 6,9 as expected.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/text/input-fieldset-find-loop.html
+++ b/LayoutTests/fast/text/input-fieldset-find-loop.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="test-content">
+    <div role="img">First foo</div>
+
+    <form>
+      <fieldset>
+        <input type="text" value="foo1">
+        <input type="text" value="foo2">
+      </fieldset>
+    </form>
+
+    Outer foo
+
+    <div role="img">Last foo</div>
+</div>
+
+<script>
+// We should be able to find all instances of "foo", despite the presence of inputs inside a fieldset, and role="img" containers.
+var output = "";
+
+document.body.offsetTop;
+let selection = getSelection();
+selection.empty();
+
+let expectedRange;
+const expectedRanges = [[6, 9], [1, 1], [3, 3], [12, 15], [5, 8], [6, 9]];
+while (expectedRange = expectedRanges.shift()) {
+    testRunner.findString("foo", ["WrapAround"]);
+    const actualRange = [selection.baseOffset, selection.extentOffset];
+    if (expectedRange[0] !== actualRange[0] || expectedRange[1] !== actualRange[1])
+        output += `FAIL: Expected a match at ${expectedRange} but got a match at ${actualRange} instead.\n`;
+    else
+        output += `PASS: Got a match at ${expectedRange} as expected.\n`;
+}
+document.getElementById("test-content").style.display = "none";
+debug(output);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac/accessibility/mac/role-img-selection-hang-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/mac/role-img-selection-hang-expected.txt
@@ -1,0 +1,8 @@
+This test ensures we do not cause a main-thread infinite loop when trying to setSelectedTextRange with a range containing a role='img' element.
+
+PASS: link.stringForTextMarkerRange(link.selectedTextMarkerRange()) !== null === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5353,11 +5353,6 @@ void Element::createUniqueElementData()
         m_elementData = uncheckedDowncast<ShareableElementData>(*m_elementData).makeUniqueCopy();
 }
 
-bool Element::canContainRangeEndPoint() const
-{
-    return !equalLettersIgnoringASCIICase(attributeWithoutSynchronization(roleAttr), "img"_s);
-}
-
 String Element::resolveURLStringIfNeeded(const String& urlString, ResolveURLs resolveURLs, const URL& base) const
 {
     if (resolveURLs == ResolveURLs::No)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -600,7 +600,7 @@ public:
     virtual bool isSliderThumbElement() const { return false; }
     virtual bool isHTMLTablePartElement() const { return false; }
 
-    bool canContainRangeEndPoint() const override;
+    bool canContainRangeEndPoint() const override { return true; }
 
     // Used for disabled form elements; if true, prevents mouse events from being dispatched
     // to event listeners, and prevents DOMActivate events from being sent at all.


### PR DESCRIPTION
#### ade80d35aba6a6719dd3044bcdb78266d1f1b9f8
<pre>
AX: Iterating over `WebCore::nextVisuallyDistinctCandidate`s can loop infinitely when starting from a role=&quot;img&quot; Position
<a href="https://bugs.webkit.org/show_bug.cgi?id=276383">https://bugs.webkit.org/show_bug.cgi?id=276383</a>
<a href="https://rdar.apple.com/131406459">rdar://131406459</a>

Reviewed by NOBODY (OOPS!).

One example of where we do this is in AXObjectCache:

<a href="https://github.com/WebKit/WebKit/blob/b750a5abaa781f9442aa2f3ad68f404362da7bec/Source/WebCore/accessibility/AXObjectCache.cpp#L3336#L3338">https://github.com/WebKit/WebKit/blob/b750a5abaa781f9442aa2f3ad68f404362da7bec/Source/WebCore/accessibility/AXObjectCache.cpp#L3336#L3338</a>

In more detail, given this markup:

&lt;div role=&quot;img&quot;&gt;
    &lt;span style=&quot;position:absolute&quot;&gt;X&lt;/span&gt;
    &lt;span&gt;Y&lt;/span&gt;
&lt;/div&gt;

When we create a VisiblePosition from this Position:

(Position
  (anchor node: #text 0x159003ec0 length=1 &quot;Y&quot;)
  (offset: 0)
  (anchor type: offset in anchor))

We get its `canonicalPosition` in the VisiblePosition constructor, which computes:

(Position
  (anchor node: DIV 0x159003c40)
  (offset: 0)
  (anchor type: before anchor))

This starts iteration for `nextVisuallyDistinctCandidate` back at the beginning of the div, repeating until we get back
to the &quot;Y&quot; position, in turn computing the before-anchor-div position, repeating forever.

This happens because the div is role=&quot;img&quot;, which was special cased to be `Element::canContainRangeEndPoint()` in:

<a href="https://bugs.webkit.org/attachment.cgi?id=229259&amp;action=prettypatch">https://bugs.webkit.org/attachment.cgi?id=229259&amp;action=prettypatch</a> (Find on Page can get stuck in a loop when the search string occurs in an input in a fieldset).

Making it `canContainRangeEndPoint` also makes it `editingIgnoresContent == true`, in turn making it `Position::isCandidate() == true`.

I can no longer reproduce the Find On Page loop bug that this behavior was added to solve, so this patch removes it and
adds a testcase (fast/text/input-fieldset-find-loop.html) confirming there is no loop here. Another testcase
(accessibility/role-img-selection-hang.html) is added to ensure the `nextVisuallyDistinctCandidate` loop is fixed.

Notably, I can also reproduce this hang without any accessibility technology enabled if I make the surrounding body
contenteditable, and add / remove random characters and newlines for a little while (I don&apos;t know any exact sequence off-hand).

* LayoutTests/accessibility/role-img-selection-hang-expected.txt: Added.
* LayoutTests/accessibility/role-img-selection-hang.html: Added.
* LayoutTests/fast/text/input-fieldset-find-loop-expected.txt: Added.
* LayoutTests/fast/text/input-fieldset-find-loop.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::canContainRangeEndPoint const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db4706647d9fac24575088f167721ac68f72ea92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61299 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8122 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46688 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5758 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59707 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34703 "Found 5 new test failures: compositing/layers-inside-overflow-scroll.html compositing/overflow/scroll-ancestor-update.html compositing/reflections/load-video-in-reflection.html compositing/self-painting-layers.html editing/text-iterator/backwards-text-iterator-basic.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27557 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31476 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7126 "Found 3 new test failures: accessibility/mac/object-replacement-with-rendered-children-at-node-start.html editing/text-iterator/backwards-text-iterator-basic.html imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7126 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53431 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7399 "Found 1 new test failure: accessibility/mac/object-replacement-with-rendered-children-at-node-start.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62979 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1591 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7476 "Found 1 new test failure: accessibility/mac/object-replacement-with-rendered-children-at-node-start.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53949 "Found 1 new test failure: editing/text-iterator/backwards-text-iterator-basic.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54064 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1343 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32834 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33920 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->