### PR TITLE
Fix error in flexbox alignment overflow calculations.

### DIFF
--- a/LayoutTests/fast/overflow/flexbox-abspos-overflow-expected.html
+++ b/LayoutTests/fast/overflow/flexbox-abspos-overflow-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+
+<html>
+<style>
+#scroller {
+  height: 200px;
+  border: solid black thick;
+  overflow: scroll;
+  position: relative;
+}
+</style>
+
+<div id=scroller>
+  <div style="background: blue; height: 400px; flex: none"></div>
+  <div style="position: absolute; top: -20px; left: -20px; border: solid orange 20px"></div>
+</div>

--- a/LayoutTests/fast/overflow/flexbox-abspos-overflow.html
+++ b/LayoutTests/fast/overflow/flexbox-abspos-overflow.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+<title>Flexbox Start-edge Abspos Overflow</title>
+<link rel="help" href="https://www.w3.org/TR/css-align/#overflow-scroll-position">
+<link rel="help" href="https://www.w3.org/TR/css-overflow/#scrollable">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes/">
+<link rel="author" href="http://fantasai.inkedblade.net/contact" title="Elika J. Etemad">
+<style>
+#scroller {
+  display: flex;
+  flex-flow: column;
+  height: 200px;
+  border: solid black thick;
+  overflow: scroll;
+  position: relative;
+}
+</style>
+
+<div id=scroller>
+  <div style="background: blue; height: 400px; flex: none"></div>
+  <div style="position: absolute; top: -20px; left: -20px; border: solid orange 20px"></div>
+</div>
+
+<script>
+  function test()
+  {
+    // Trigger layout
+    document.body.offsetHeight;
+
+    // Scroll to the top left
+    var s = document.getElementById('scroller');
+    s.scrollTop = -1000;
+    s.scrollLeft = -1000;
+
+    document.body.offsetHeight; // trigger layout
+
+    document.documentElement.removeAttribute("class");
+  };
+  document.addEventListener("TestRendered", function(){ test(); });
+  window.addEventListener("load", function(){ test(); }); // for manual inspection
+</script>

--- a/LayoutTests/fast/overflow/flexbox-multiline-overflow-expected.html
+++ b/LayoutTests/fast/overflow/flexbox-multiline-overflow-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+
+<html>
+<style>
+#scroller {
+  display: flex;
+  flex-flow: row wrap;
+  width: 60px;
+  border: solid black thick;
+  overflow: scroll;
+  justify-content: safe end;
+}
+.child {
+  width: 80%;
+  flex: none;
+  border: solid orange;
+  margin-left: 40%;
+}
+.child:nth-child(2) {
+  width: 120%;
+  margin-left: 0;
+}
+</style>
+
+<div id=scroller>
+  <div class=child>1</div>
+  <div class=child>2</div>
+  <div class=child>3</div>
+</div>
+

--- a/LayoutTests/fast/overflow/flexbox-multiline-overflow.html
+++ b/LayoutTests/fast/overflow/flexbox-multiline-overflow.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+<title>Flexbox Start-edge Abspos Overflow</title>
+<link rel="help" href="https://www.w3.org/TR/css-align/#overflow-scroll-position">
+<link rel="help" href="https://www.w3.org/TR/css-overflow/#scrollable">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes/">
+<link rel="author" href="http://fantasai.inkedblade.net/contact" title="Elika J. Etemad">
+<style>
+#scroller {
+  display: flex;
+  flex-flow: row wrap;
+  width: 60px;
+  border: solid black thick;
+  overflow: scroll;
+  justify-content: end;
+}
+.child {
+  width: 80%;
+  flex: none;
+  border: solid orange;
+}
+.child:nth-child(2) {
+  width: 120%;
+}
+</style>
+
+<div id=scroller>
+  <div class=child>1</div>
+  <div class=child>2</div>
+  <div class=child>3</div>
+</div>
+
+<script>
+  function test()
+  {
+    // Trigger layout
+    document.body.offsetHeight;
+
+    // Scroll to the top left
+    var s = document.getElementById('scroller');
+    s.scrollTop = -1000;
+    s.scrollLeft = -1000;
+
+    document.body.offsetHeight; // trigger layout
+
+    document.documentElement.removeAttribute("class");
+  };
+  document.addEventListener("TestRendered", function(){ test(); });
+  window.addEventListener("load", function(){ test(); }); // for manual inspection
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/negative-overflow-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/negative-overflow-002-expected.txt
@@ -237,11 +237,15 @@ scrollHeight expected 130 but got 120
 FAIL .container 12 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: horizontal-tb; direction: ltr; flex-flow: column-reverse wrap-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollHeight expected 130 but got 120
-PASS .container 13
-PASS .container 14
+FAIL .container 13 assert_equals:
+<div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: row;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
+scrollWidth expected 370 but got 360
+FAIL .container 14 assert_equals:
+<div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
+scrollWidth expected 130 but got 120
 FAIL .container 15 assert_equals:
 <div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: wrap-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollHeight expected 370 but got 360
+scrollWidth expected 130 but got 120
 PASS .container 16
 PASS .container 17
 FAIL .container 18 assert_equals:
@@ -250,14 +254,16 @@ scrollHeight expected 370 but got 360
 FAIL .container 19 assert_equals:
 <div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: column;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollWidth expected 130 but got 120
-PASS .container 20
+FAIL .container 20 assert_equals:
+<div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: column wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
+scrollWidth expected 370 but got 360
 PASS .container 21
 FAIL .container 22 assert_equals:
 <div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: column-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollWidth expected 130 but got 120
 FAIL .container 23 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: column-reverse wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollHeight expected 130 but got 120
+scrollWidth expected 370 but got 360
 FAIL .container 24 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: column-reverse wrap-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollHeight expected 130 but got 120
@@ -285,10 +291,10 @@ FAIL .container 36 assert_equals:
 scrollWidth expected 130 but got 120
 FAIL .container 37 assert_equals:
 <div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: vertical-rl; direction: rtl; flex-flow: row;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollHeight expected 370 but got 360
+scrollHeight expected 370 but got 345
 FAIL .container 38 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-rl; direction: rtl; flex-flow: wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollHeight expected 130 but got 120
+scrollHeight expected 130 but got 105
 FAIL .container 39 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-rl; direction: rtl; flex-flow: wrap-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollWidth expected 370 but got 360
@@ -300,7 +306,9 @@ scrollWidth expected 370 but got 360
 FAIL .container 43 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-rl; direction: rtl; flex-flow: column;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollHeight expected 130 but got 120
-PASS .container 44
+FAIL .container 44 assert_equals:
+<div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: vertical-rl; direction: rtl; flex-flow: column wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
+scrollHeight expected 370 but got 360
 PASS .container 45
 FAIL .container 46 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-rl; direction: rtl; flex-flow: column-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
@@ -335,10 +343,10 @@ FAIL .container 60 assert_equals:
 scrollWidth expected 130 but got 120
 FAIL .container 61 assert_equals:
 <div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: vertical-lr; direction: rtl; flex-flow: row;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollHeight expected 370 but got 360
+scrollHeight expected 370 but got 345
 FAIL .container 62 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-lr; direction: rtl; flex-flow: wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollHeight expected 130 but got 120
+scrollHeight expected 130 but got 105
 FAIL .container 63 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-lr; direction: rtl; flex-flow: wrap-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollWidth expected 370 but got 360
@@ -350,7 +358,9 @@ scrollWidth expected 370 but got 360
 FAIL .container 67 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-lr; direction: rtl; flex-flow: column;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollHeight expected 130 but got 120
-PASS .container 68
+FAIL .container 68 assert_equals:
+<div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: vertical-lr; direction: rtl; flex-flow: column wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
+scrollHeight expected 370 but got 360
 PASS .container 69
 FAIL .container 70 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-lr; direction: rtl; flex-flow: column-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-flexbox/negative-overflow-002-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-flexbox/negative-overflow-002-expected.txt
@@ -239,13 +239,13 @@ FAIL .container 12 assert_equals:
 scrollHeight expected 130 but got 120
 FAIL .container 13 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: row;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollWidth expected 370 but got 360
+scrollWidth expected 370 but got 345
 FAIL .container 14 assert_equals:
 <div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollWidth expected 130 but got 120
+scrollWidth expected 130 but got 105
 FAIL .container 15 assert_equals:
 <div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: wrap-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollWidth expected 130 but got 120
+scrollWidth expected 130 but got 105
 PASS .container 16
 PASS .container 17
 FAIL .container 18 assert_equals:
@@ -256,14 +256,14 @@ FAIL .container 19 assert_equals:
 scrollWidth expected 130 but got 105
 FAIL .container 20 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: column wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollWidth expected 370 but got 360
+scrollWidth expected 370 but got 345
 PASS .container 21
 FAIL .container 22 assert_equals:
 <div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: column-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollWidth expected 130 but got 105
 FAIL .container 23 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: column-reverse wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollWidth expected 370 but got 360
+scrollWidth expected 370 but got 345
 FAIL .container 24 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: horizontal-tb; direction: rtl; flex-flow: column-reverse wrap-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollHeight expected 130 but got 120
@@ -291,10 +291,10 @@ FAIL .container 36 assert_equals:
 scrollWidth expected 130 but got 120
 FAIL .container 37 assert_equals:
 <div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: vertical-rl; direction: rtl; flex-flow: row;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollHeight expected 370 but got 360
+scrollHeight expected 370 but got 345
 FAIL .container 38 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-rl; direction: rtl; flex-flow: wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollHeight expected 130 but got 120
+scrollHeight expected 130 but got 105
 FAIL .container 39 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-rl; direction: rtl; flex-flow: wrap-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollWidth expected 370 but got 360
@@ -306,7 +306,9 @@ scrollWidth expected 370 but got 360
 FAIL .container 43 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-rl; direction: rtl; flex-flow: column;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollHeight expected 130 but got 120
-PASS .container 44
+FAIL .container 44 assert_equals:
+<div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: vertical-rl; direction: rtl; flex-flow: column wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
+scrollHeight expected 370 but got 360
 PASS .container 45
 FAIL .container 46 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-rl; direction: rtl; flex-flow: column-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
@@ -341,10 +343,10 @@ FAIL .container 60 assert_equals:
 scrollWidth expected 130 but got 120
 FAIL .container 61 assert_equals:
 <div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: vertical-lr; direction: rtl; flex-flow: row;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollHeight expected 370 but got 360
+scrollHeight expected 370 but got 345
 FAIL .container 62 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-lr; direction: rtl; flex-flow: wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
-scrollHeight expected 130 but got 120
+scrollHeight expected 130 but got 105
 FAIL .container 63 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-lr; direction: rtl; flex-flow: wrap-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollWidth expected 370 but got 360
@@ -356,7 +358,9 @@ scrollWidth expected 370 but got 360
 FAIL .container 67 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-lr; direction: rtl; flex-flow: column;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
 scrollHeight expected 130 but got 120
-PASS .container 68
+FAIL .container 68 assert_equals:
+<div class="container" data-expected-scroll-width="130" data-expected-scroll-height="370" style="writing-mode: vertical-lr; direction: rtl; flex-flow: column wrap;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>
+scrollHeight expected 370 but got 360
 PASS .container 69
 FAIL .container 70 assert_equals:
 <div class="container" data-expected-scroll-width="370" data-expected-scroll-height="130" style="writing-mode: vertical-lr; direction: rtl; flex-flow: column-reverse;"><div class="item">1</div><div class="item">2</div><div class="item">3</div></div>

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -441,6 +441,7 @@ void RenderFlexibleBox::layoutBlock(bool relayoutChildren, LayoutUnit)
 
         m_numberOfInFlowChildrenOnFirstLine = { };
         m_numberOfInFlowChildrenOnLastLine = { };
+        m_justifyContentStartOverflow = 0;
 
         beginUpdateScrollInfoAfterLayoutTransaction();
 
@@ -2188,7 +2189,7 @@ bool RenderFlexibleBox::childHasPercentHeightDescendants(const RenderBox& render
     return false;
 }
 
-static LayoutUnit contentAlignmentStartOverflow(LayoutUnit availableFreeSpace, ContentPosition position, ContentDistribution distribution, OverflowAlignment safety)
+static LayoutUnit contentAlignmentStartOverflow(LayoutUnit availableFreeSpace, ContentPosition position, ContentDistribution distribution, OverflowAlignment safety, bool isReverse)
 {
     if (availableFreeSpace >= 0 || safety == OverflowAlignment::Safe)
         return 0_lu;
@@ -2202,17 +2203,19 @@ static LayoutUnit contentAlignmentStartOverflow(LayoutUnit availableFreeSpace, C
     case ContentPosition::Baseline:
     case ContentPosition::LastBaseline:
         return 0_lu;
+    case ContentPosition::FlexStart:
+        return isReverse ? -availableFreeSpace : 0_lu;
     case ContentPosition::Center:
         return -availableFreeSpace / 2;
     case ContentPosition::End:
-    case ContentPosition::FlexEnd:
-    case ContentPosition::FlexStart:
         return -availableFreeSpace;
+    case ContentPosition::FlexEnd:
+        return isReverse ? 0_lu : -availableFreeSpace;
     default:
         ASSERT((distribution == ContentDistribution::Default && position == ContentPosition::Normal) // Normal alignment.
             || distribution == ContentDistribution::Stretch
             || distribution == ContentDistribution::SpaceBetween);
-        return -availableFreeSpace;
+        return isReverse ? -availableFreeSpace : 0_lu;
     }
 }
 
@@ -2224,13 +2227,13 @@ void RenderFlexibleBox::layoutAndPlaceChildren(LayoutUnit& crossAxisOffset, Flex
     if (style().flexDirection() == FlexDirection::RowReverse)
         mainAxisOffset += isHorizontalFlow() ? verticalScrollbarWidth() : horizontalScrollbarHeight();
 
-    m_justifyContentStartOverflow = 0;
     if (availableFreeSpace < 0) {
         ContentPosition position = style().resolvedJustifyContentPosition(contentAlignmentNormalBehavior());
         ContentDistribution distribution = style().resolvedJustifyContentDistribution(contentAlignmentNormalBehavior());
         OverflowAlignment safety = style().justifyContent().overflow();
         position = resolveLeftRightAlignment(position, style(), isColumnOrRowReverse());
-        m_justifyContentStartOverflow = contentAlignmentStartOverflow(availableFreeSpace, position, distribution, safety);
+        LayoutUnit overflow = contentAlignmentStartOverflow(availableFreeSpace, position, distribution, safety, isColumnOrRowReverse());
+        m_justifyContentStartOverflow = std::max(m_justifyContentStartOverflow, overflow);
     }
 
     LayoutUnit totalMainExtent = mainAxisExtent();
@@ -2418,8 +2421,9 @@ void RenderFlexibleBox::alignFlexLines(FlexLineStates& lineStates, LayoutUnit ga
     ContentPosition position = style().resolvedAlignContentPosition(contentAlignmentNormalBehavior());
     ContentDistribution distribution = style().resolvedAlignContentDistribution(contentAlignmentNormalBehavior());
     OverflowAlignment safety = style().alignContent().overflow();
+    bool isWrapReverse = style().flexWrap() == FlexWrap::Reverse;
 
-    if (position == ContentPosition::FlexStart && !gapBetweenLines && safety != OverflowAlignment::Safe)
+    if (position == ContentPosition::FlexStart && !gapBetweenLines && safety != OverflowAlignment::Safe && !isWrapReverse)
         return;
 
     size_t numLines = lineStates.size();
@@ -2427,8 +2431,8 @@ void RenderFlexibleBox::alignFlexLines(FlexLineStates& lineStates, LayoutUnit ga
     for (size_t i = 0; i < numLines; ++i)
         availableCrossAxisSpace -= lineStates[i].crossAxisExtent;
 
-    m_alignContentStartOverflow = contentAlignmentStartOverflow(availableCrossAxisSpace, position, distribution, safety);
-    LayoutUnit lineOffset = initialAlignContentOffset(availableCrossAxisSpace, position, distribution, safety, numLines, style().flexWrap() == FlexWrap::Reverse);
+    m_alignContentStartOverflow = contentAlignmentStartOverflow(availableCrossAxisSpace, position, distribution, safety, isWrapReverse);
+    LayoutUnit lineOffset = initialAlignContentOffset(availableCrossAxisSpace, position, distribution, safety, numLines, isWrapReverse);
     for (unsigned lineNumber = 0; lineNumber < numLines; ++lineNumber) {
         LineState& lineState = lineStates[lineNumber];
         lineState.crossAxisOffset += lineOffset;


### PR DESCRIPTION
#### efacbbdcc42539c57f1fe9c5dcf40251ce703eef
<pre>
Fix error in flexbox alignment overflow calculations.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276382">https://bugs.webkit.org/show_bug.cgi?id=276382</a>
<a href="https://rdar.apple.com/131201271">rdar://131201271</a>

Reviewed by Alan Baradlay.

This patch fixes the logic in contentAlignmentStartOverflow correctly
clamp overflow, by handling reversed flows properly rather than returning
an overly-large value in some cases. It also fixes the error where we only
account for the last flex line.

* LayoutTests/fast/overflow/flexbox-abspos-overflow-expected.html: Added.
* LayoutTests/fast/overflow/flexbox-abspos-overflow.html: Added.
* LayoutTests/fast/overflow/flexbox-multiline-overflow-expected.html: Added.
* LayoutTests/fast/overflow/flexbox-multiline-overflow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/negative-overflow-002-expected.txt: Partial revert of 273737@main
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-flexbox/negative-overflow-002-expected.txt: Partial revert of 273737@main
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::layoutBlock): Shift reset for m_justifyContentStartOverflow out of the flex line loop.
(WebCore::contentAlignmentStartOverflow): Fix logic to correctly account for reversing.
(WebCore::RenderFlexibleBox::layoutAndPlaceChildren): Update call to pass reversing parameter.
(WebCore::RenderFlexibleBox::alignFlexLines): Update call to pass reversing parameter, and fix multiline handling.

Canonical link: <a href="https://commits.webkit.org/280812@main">https://commits.webkit.org/280812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/886570b3208202f3b4248fceb45337608944fb07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61322 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8145 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46750 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5772 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27575 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7149 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7149 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63003 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53970 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54083 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12768 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1365 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32857 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33943 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35027 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->