### PR TITLE
WKWebView _loadAndDecodeImage's maximum size parameter crops the image instead of scaling it

### DIFF
--- a/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
@@ -136,6 +136,16 @@ std::optional<DestinationColorSpace> DestinationColorSpace::asRGB() const
 #endif
 }
 
+bool DestinationColorSpace::supportsOutput() const
+{
+#if USE(CG)
+    return CGColorSpaceSupportsOutput(platformColorSpace());
+#else
+    notImplemented();
+    return true;
+#endif
+}
+
 TextStream& operator<<(TextStream& ts, const DestinationColorSpace& colorSpace)
 {
     if (colorSpace == DestinationColorSpace::SRGB())

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.h
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.h
@@ -51,6 +51,8 @@ public:
 
     WEBCORE_EXPORT std::optional<DestinationColorSpace> asRGB() const;
 
+    WEBCORE_EXPORT bool supportsOutput() const;
+
 private:
     PlatformColorSpace m_platformColorSpace;
 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm
@@ -45,6 +45,9 @@ TEST(WebKit, LoadAndDecodeImage)
     auto pngData = [&] {
         return contentsToVector([[NSBundle mainBundle] URLForResource:@"icon" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]);
     };
+    auto untaggedPNGData = [&] {
+        return contentsToVector([[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]);
+    };
     auto gifData = [&] {
         return contentsToVector([[NSBundle mainBundle] URLForResource:@"apple" withExtension:@"gif" subdirectory:@"TestWebKitAPI.resources"]);
     };
@@ -52,6 +55,7 @@ TEST(WebKit, LoadAndDecodeImage)
     HTTPServer server {
         { "/terminate"_s, { HTTPResponse::Behavior::TerminateConnectionAfterReceivingResponse } },
         { "/test_png"_s, { pngData() } },
+        { "/test_untagged_png"_s, { untaggedPNGData() } },
         { "/test_gif"_s, { gifData() } },
         { "/redirect"_s, { 302, { { "Location"_s, "/test_png"_s } }, "redirecting..."_s } },
         { "/not_image"_s, { "this is not an image"_s } }
@@ -75,6 +79,14 @@ TEST(WebKit, LoadAndDecodeImage)
         return makeUnexpected(error);
     };
 
+    auto colorSpaceForImage = [&] (Util::PlatformImage *image) -> RetainPtr<CGColorSpaceRef> {
+        return CGImageGetColorSpace(Util::convertToCGImage(image).get());
+    };
+
+    auto colorSpaceDescriptionForImage = [&] (Util::PlatformImage *image) -> NSString * {
+        return (__bridge NSString *)adoptCF(CFCopyDescription(colorSpaceForImage(image).get())).autorelease();
+    };
+
     auto result1 = imageOrError("/terminate"_s);
     EXPECT_WK_STREQ(result1.error().get().domain, NSURLErrorDomain);
     EXPECT_EQ(result1.error().get().code, NSURLErrorNetworkConnectionLost);
@@ -90,14 +102,24 @@ TEST(WebKit, LoadAndDecodeImage)
     auto result4 = imageOrError("/test_png"_s, CGSizeMake(100, 100));
     EXPECT_EQ(result4->get().size.height, 80);
     EXPECT_EQ(result4->get().size.width, 100);
+    EXPECT_TRUE([colorSpaceDescriptionForImage(result4->get()) containsString:@"Calibrated RGB"]);
 
-    auto result5 = imageOrError("/test_gif"_s);
-    EXPECT_EQ(result5->get().size.height, 64);
-    EXPECT_EQ(result5->get().size.width, 52);
+    auto result5 = imageOrError("/test_png"_s, CGSizeMake(1000, 1000));
+    EXPECT_EQ(result5->get().size.height, 174);
+    EXPECT_EQ(result5->get().size.width, 215);
 
-    auto result6 = imageOrError("/redirect"_s);
-    EXPECT_EQ(result2->get().size.height, 174);
-    EXPECT_EQ(result2->get().size.width, 215);
+    auto result6 = imageOrError("/test_gif"_s);
+    EXPECT_EQ(result6->get().size.height, 64);
+    EXPECT_EQ(result6->get().size.width, 52);
+
+    auto result7 = imageOrError("/redirect"_s);
+    EXPECT_EQ(result7->get().size.height, 174);
+    EXPECT_EQ(result7->get().size.width, 215);
+
+    auto result8 = imageOrError("/test_untagged_png"_s, CGSizeMake(100, 100));
+    EXPECT_EQ(result8->get().size.height, 100);
+    EXPECT_EQ(result8->get().size.width, 100);
+    EXPECT_TRUE([colorSpaceDescriptionForImage(result8->get()) containsString:@"sRGB"]);
 
     HTTPServer tlsServer { {
         { "/"_s, { pngData() } },


### PR DESCRIPTION
#### 7ca87096bd024ce32d7bfe87e86883db12a145fa
<pre>
WKWebView _loadAndDecodeImage&apos;s maximum size parameter crops the image instead of scaling it
<a href="https://bugs.webkit.org/show_bug.cgi?id=276384">https://bugs.webkit.org/show_bug.cgi?id=276384</a>
<a href="https://rdar.apple.com/131406675">rdar://131406675</a>

Reviewed by Simon Fraser.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadAndDecodeImage):
The _loadAndDecodeImage method has an optional parameter allowing clients to
choose a maximum size for the image to be scaled into. However, the implementation
crops the image into the maximum size, instead of scaling into it. Also, it
currently scales images *up* to fit in the maximum size, instead of leaving
smaller images alone.

Fix both of these issues.

Also, drive-by add a fallback to an sRGB destination in cases where the decoded
image has a colorspace that it is not possible for us to draw into.

Canonical link: <a href="https://commits.webkit.org/280823@main">https://commits.webkit.org/280823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cc0289b0e9b5e69747041fff66215aa901c5be5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61312 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8135 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46697 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5766 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49848 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7139 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7139 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62993 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53959 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54073 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12775 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1355 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32847 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33933 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->