### PR TITLE
requestIdleCallback callback can leak the Document object.

### DIFF
--- a/LayoutTests/requestidlecallback/requestidlecallback-does-not-leak-expected.txt
+++ b/LayoutTests/requestidlecallback/requestidlecallback-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Test that requestIdleCallback does not leak the Document object.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/requestidlecallback/requestidlecallback-does-not-leak.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-does-not-leak.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html><!-- webkit-test-runner [ RequestIdleCallbackEnabled=true ] -->
+<html>
+<body>
+<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/document-leak-test.js"></script>
+<script>
+
+description("Test that requestIdleCallback does not leak the Document object.");
+onload = () => runDocumentLeakTest({ frameURL: "./resources/requestidlecallback-frame.html", framesToCreate: 20 });
+
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/requestidlecallback/resources/requestidlecallback-frame.html
+++ b/LayoutTests/requestidlecallback/resources/requestidlecallback-frame.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+function createParagraph()
+{
+    let d = document;
+    let p = d.createElement("p");
+    p.innerText = "This should not leak the document.";
+    d.body.appendChild(p);
+    window.requestIdleCallback(createParagraph);
+}
+
+requestIdleCallback(createParagraph);
+parent.postMessage("iframeLoaded");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -886,6 +886,9 @@ void Document::commonTeardown()
             resizeObserver->disconnect();
     }
 
+    if (m_idleCallbackController)
+        m_idleCallbackController->removeAllIdleCallbacks();
+
     scriptRunner().clearPendingScripts();
 
     if (RefPtr highlightRegistry = m_highlightRegistry)

--- a/Source/WebCore/dom/IdleCallbackController.cpp
+++ b/Source/WebCore/dom/IdleCallbackController.cpp
@@ -82,6 +82,12 @@ void IdleCallbackController::removeIdleCallback(int signedIdentifier)
     });
 }
 
+void IdleCallbackController::removeAllIdleCallbacks()
+{
+    m_idleRequestCallbacks.clear();
+    m_runnableIdleCallbacks.clear();
+}
+
 void IdleCallbackController::queueTaskToStartIdlePeriod()
 {
     Ref document = *m_document;

--- a/Source/WebCore/dom/IdleCallbackController.h
+++ b/Source/WebCore/dom/IdleCallbackController.h
@@ -53,6 +53,7 @@ public:
 
     int queueIdleCallback(Ref<IdleRequestCallback>&&, Seconds timeout);
     void removeIdleCallback(int);
+    void removeAllIdleCallbacks();
 
     void startIdlePeriod();
     bool isEmpty() const { return m_idleRequestCallbacks.isEmpty() && m_runnableIdleCallbacks.isEmpty(); }


### PR DESCRIPTION
#### 5903684082e88a29c77a731c8de3192d8b26cc2d
<pre>
requestIdleCallback callback can leak the Document object.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276388">https://bugs.webkit.org/show_bug.cgi?id=276388</a>
<a href="https://rdar.apple.com/131409608">rdar://131409608</a>

Reviewed by NOBODY (OOPS!).

If we never run an idle callback we can end up leaking the Document
object. This change adds a step to Document::commonTeardown which will clear any
pending or runnable idle callback requests which will allow the
callbacks to be garbage collected.

* LayoutTests/requestidlecallback/requestidlecallback-does-not-leak-expected.txt: Added.
* LayoutTests/requestidlecallback/requestidlecallback-does-not-leak.html: Added.
* LayoutTests/requestidlecallback/resources/requestidlecallback-frame.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::commonTeardown):
* Source/WebCore/dom/IdleCallbackController.cpp:
(WebCore::IdleCallbackController::removeAllIdleCallbacks):
* Source/WebCore/dom/IdleCallbackController.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5903684082e88a29c77a731c8de3192d8b26cc2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61278 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8101 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46676 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5742 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31460 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7106 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7105 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62958 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53937 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54079 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1327 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32813 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33899 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34983 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33644 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->