### PR TITLE
REGRESSION (visionOS 2): Yahoo and AOL login pages flicker when adding a new Mail account

### DIFF
--- a/Source/WebCore/platform/ios/LocalCurrentTraitCollection.h
+++ b/Source/WebCore/platform/ios/LocalCurrentTraitCollection.h
@@ -48,6 +48,8 @@ private:
     RetainPtr<UITraitCollection> m_savedTraitCollection;
 };
 
+WEBCORE_EXPORT UITraitCollection *traitCollectionWithAdjustedIdiomForSystemColors(UITraitCollection *);
+
 }
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -67,6 +67,7 @@
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/GraphicsContextCG.h>
 #import <WebCore/IOSurfacePool.h>
+#import <WebCore/LocalCurrentTraitCollection.h>
 #import <WebCore/MIMETypeRegistry.h>
 #import <WebCore/RuntimeApplicationChecks.h>
 #import <WebCore/UserInterfaceLayoutDirection.h>
@@ -647,7 +648,7 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
         return WebCore::Color::transparentBlack;
 
     WebCore::Color color;
-    [webView.traitCollection performAsCurrentTraitCollection:[&]() {
+    [WebCore::traitCollectionWithAdjustedIdiomForSystemColors(webView.traitCollection) performAsCurrentTraitCollection:[&] {
         color = baseScrollViewBackgroundColor(webView, allowPageBackgroundColorOverride);
 
         if (!color.isValid() && webView->_contentView)


### PR DESCRIPTION
#### c8c3aac34000d459e3d3a3408a891f934d8ed262
<pre>
REGRESSION (visionOS 2): Yahoo and AOL login pages flicker when adding a new Mail account
<a href="https://bugs.webkit.org/show_bug.cgi?id=276387">https://bugs.webkit.org/show_bug.cgi?id=276387</a>
<a href="https://rdar.apple.com/129308652">rdar://129308652</a>

Reviewed by Aditya Keerthi.

On visionOS 2, after (what are probably) the changes in either <a href="https://rdar.apple.com/117186193">rdar://117186193</a> or <a href="https://rdar.apple.com/117807846">rdar://117807846</a>,
the following logic:

```
auto userInterfaceStyleTrait = [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight];
auto backgroundLevelTrait = [UITraitCollection traitCollectionWithUserInterfaceLevel:UIUserInterfaceLevelBase];
auto combinedTrait = [UITraitCollection traitCollectionWithTraitsFromCollections:@[ originalTrait.get(), userInterfaceStyleTrait, backgroundLevelTrait ]];
```

...no longer yields a `combinedTrait` that has a user interface idiom of `vision`, in the case
where `originalTrait` had a user interface of `vision`. Instead, the idiom reverts to `unspecified`,
which breaks downstream logic that attempts to override the user interface idiom in visionOS to be
equal to `pad`.

Subsequently, this causes `+[UIColor systemBackgroundColor]` to return transparent black instead of
white in `RenderThemeIOS::cssValueToSystemColorMap()`, which ultimately causes the page background
to be (incorrectly) transparent in `SLYahooAuthService`, leading to a flash as the page loads.

Interestingly...

(1) `+traitCollectionWithTraitsFromCollections:` is deprecated anyways, in favor of
    `-traitCollectionByModifyingTraits:` or `+traitCollectionWithTraits:`.

(2) `-traitCollectionByModifyingTraits:` doesn&apos;t have the same issue, and adopting it fixes the bug.

With that in mind, we can address the regression by moving from the deprecated API to one of the
replacements (`-traitCollectionByModifyingTraits:`).

* Source/WebCore/platform/ios/LocalCurrentTraitCollection.h:
* Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm:

Adopt `-traitCollectionByModifyingTraits:`.

(WebCore::traitCollectionWithAdjustedIdiomForSystemColors):

Rename this from `adjustedTraitCollection` to `traitCollectionWithAdjustedIdiomForSystemColors` to
make the intent more obvious. Also, export it for use in the client layer.

(WebCore::LocalCurrentTraitCollection::LocalCurrentTraitCollection):
(WebCore::adjustedTraitCollection): Deleted.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(scrollViewBackgroundColor):

Also add a missing idiom adjustment here, when determining the scroll view background color. This
ensures that `+systemBackgroundColor` is white to match the iPad idiom here as well.

Canonical link: <a href="https://commits.webkit.org/280802@main">https://commits.webkit.org/280802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/156ea0545ec52f58bbdbdc59249bdb604c34f5a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61300 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46687 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/5756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27556 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7128 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7127 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62980 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1592 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53948 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1598 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49849 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54058 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12758 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1344 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33921 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->