### PR TITLE
Speedometer 3: getBoundingClientRect spends time updating layer positions that it doesn't use.

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2760,9 +2760,9 @@ auto Document::updateLayout(OptionSet<LayoutOptions> layoutOptions, const Elemen
                 } else
                     context = nullptr;
             }
-            if (frameView->layoutContext().isLayoutPending() || renderView()->needsLayout()) {
+            if (frameView->layoutContext().needsLayout()) {
                 ContentVisibilityForceLayoutScope scope(*renderView(), context);
-                frameView->layoutContext().layout();
+                frameView->layoutContext().layout(layoutOptions.contains(LayoutOptions::CanDeferUpdateLayerPositions));
                 result = UpdateLayoutResult::ChangesDone;
             }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -369,6 +369,11 @@ enum class LayoutOptions : uint8_t {
     ContentVisibilityForceLayout = 1 << 2,
     UpdateCompositingLayers = 1 << 3,
     DoNotLayoutAncestorDocuments = 1 << 4,
+    // Doesn't call RenderLayer::recursiveUpdateLayerPositionsAfterLayout if
+    // possible. The caller should use a LocalFrameView::AutoPreventLayerAccess
+    // for the scope that layout is expected to be flushed to stop any access to
+    // the stale RenderLayers.
+    CanDeferUpdateLayerPositions = 1 << 5
 };
 
 enum class HttpEquivPolicy : uint8_t {

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1906,7 +1906,8 @@ std::optional<std::pair<CheckedPtr<RenderObject>, FloatRect>> Element::boundingA
 FloatRect Element::boundingClientRect()
 {
     Ref document = this->document();
-    document->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    document->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout , LayoutOptions::CanDeferUpdateLayerPositions }, this);
+    LocalFrameView::AutoPreventLayerAccess preventAccess(*document->view());
     auto pair = boundingAbsoluteRectWithoutLayout();
     if (!pair)
         return { };

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -31,6 +31,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
 #include "RenderLayer.h"
+#include "RenderLayerInlines.h"
 #include "RenderObject.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -48,6 +48,7 @@
 #include "Page.h"
 #include "PageGroup.h"
 #include "RenderLayer.h"
+#include "RenderLayerInlines.h"
 #include "RenderVideo.h"
 #include "RenderView.h"
 #include "Settings.h"

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -129,6 +129,9 @@ public:
     CheckedRef<const LocalFrameViewLayoutContext> checkedLayoutContext() const;
     CheckedRef<LocalFrameViewLayoutContext> checkedLayoutContext();
 
+    bool hasPendingUpdateLayerPositions() const;
+    void flushUpdateLayerPositions();
+
     WEBCORE_EXPORT bool didFirstLayout() const;
 
     WEBCORE_EXPORT bool needsLayout() const;
@@ -279,6 +282,7 @@ public:
     void cancelScheduledScrolls();
     void scrollToFocusedElementImmediatelyIfNeeded();
     void updateLayerPositionsAfterScrolling() final;
+    void updateLayerPositionsAfterOverflowScroll(RenderLayer&);
     void updateCompositingLayersAfterScrolling() final;
     static WEBCORE_EXPORT bool scrollRectToVisible(const LayoutRect& absoluteRect, const RenderObject&, bool insideFixed, const ScrollRectToVisibleOptions&);
 
@@ -726,6 +730,33 @@ public:
 
     FrameIdentifier rootFrameID() const final;
 
+#if ASSERT_ENABLED
+    struct AutoPreventLayerAccess {
+        AutoPreventLayerAccess(LocalFrameView& view)
+            : frameView(view)
+            , oldPreventLayerAccess(view.layerAccessPrevented())
+        {
+            view.setLayerAcessPrevented(true);
+        }
+
+        ~AutoPreventLayerAccess()
+        {
+            frameView->setLayerAcessPrevented(oldPreventLayerAccess);
+        }
+
+    private:
+        CheckedPtr<LocalFrameView> frameView;
+        bool oldPreventLayerAccess { false };
+    };
+
+    void setLayerAcessPrevented(bool prevented) { m_layerAccessPrevented = prevented; }
+    bool layerAccessPrevented() const { return m_layerAccessPrevented; }
+#else
+    struct AutoPreventLayerAccess {
+        AutoPreventLayerAccess(LocalFrameView&) { }
+    };
+#endif
+
 private:
     explicit LocalFrameView(LocalFrame&);
 
@@ -890,7 +921,7 @@ private:
     RenderElement* viewportRenderer() const;
     
     void willDoLayout(SingleThreadWeakPtr<RenderElement> layoutRoot);
-    void didLayout(SingleThreadWeakPtr<RenderElement> layoutRoot, bool didRunSimplifiedLayout);
+    void didLayout(SingleThreadWeakPtr<RenderElement> layoutRoot, bool didRunSimplifiedLayout, bool canDeferUpdateLayerPositions);
 
     FloatSize calculateSizeForCSSViewportUnitsOverride(std::optional<OverrideViewportSize>) const;
 
@@ -994,6 +1025,26 @@ private:
     std::unique_ptr<ScrollableAreaSet> m_scrollableAreasForAnimatedScroll;
     std::unique_ptr<SingleThreadWeakHashSet<RenderLayerModelObject>> m_viewportConstrainedObjects;
 
+    struct UpdateLayerPositions {
+        bool merge(const UpdateLayerPositions& other)
+        {
+            // FIXME: If one is an ancestor of the other we can also probably combine them.
+            if (layoutRoot != other.layoutRoot)
+                return false;
+
+            needsFullRepaint |= other.needsFullRepaint;
+            if (!other.didRunSimplifiedLayout)
+                didRunSimplifiedLayout = false;
+            return true;
+        }
+
+        SingleThreadWeakPtr<RenderElement> layoutRoot;
+        RenderElement::LayoutIdentifier layoutIdentifier : 12 { 0 };
+        bool needsFullRepaint { false };
+        bool didRunSimplifiedLayout { true };
+    };
+    std::optional<UpdateLayerPositions> m_pendingUpdateLayerPositions;
+
     OptionSet<LayoutMilestone> m_milestonesPendingPaint;
 
     static const unsigned visualCharacterThreshold = 200;
@@ -1052,6 +1103,9 @@ private:
     bool m_inUpdateEmbeddedObjects { false };
     bool m_scheduledToScrollToAnchor { false };
     bool m_updateCompositingLayersIsPending { false };
+#if ASSERT_ENABLED
+    bool m_layerAccessPrevented { false };
+#endif
 };
 
 inline void LocalFrameView::incrementVisuallyNonEmptyPixelCount(const IntSize& size)

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -141,13 +141,13 @@ UpdateScrollInfoAfterLayoutTransaction& LocalFrameViewLayoutContext::updateScrol
     return *m_updateScrollInfoAfterLayoutTransaction;
 }
 
-void LocalFrameViewLayoutContext::layout()
+void LocalFrameViewLayoutContext::layout(bool canDeferUpdateLayerPositions)
 {
     LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " LocalFrameViewLayoutContext::layout() with size " << view().layoutSize());
 
     Ref protectedView(view());
 
-    performLayout();
+    performLayout(canDeferUpdateLayerPositions);
 
     if (view().hasOneRef())
         return;
@@ -159,14 +159,14 @@ void LocalFrameViewLayoutContext::layout()
         if (!needsLayout())
             break;
 
-        performLayout();
+        performLayout(canDeferUpdateLayerPositions);
 
         if (view().hasOneRef())
             return;
     }
 }
 
-void LocalFrameViewLayoutContext::performLayout()
+void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPositions)
 {
     Ref frame = this->frame();
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!document()->inRenderTreeUpdate());
@@ -269,14 +269,14 @@ void LocalFrameViewLayoutContext::performLayout()
         if (m_needsFullRepaint)
             renderView()->repaintRootContents();
         ASSERT(!layoutRoot->needsLayout());
-        protectedView()->didLayout(layoutRoot, isSimplifiedLayout);
-        runOrScheduleAsynchronousTasks();
+        protectedView()->didLayout(layoutRoot, isSimplifiedLayout, canDeferUpdateLayerPositions);
+        runOrScheduleAsynchronousTasks(canDeferUpdateLayerPositions);
     }
     InspectorInstrumentation::didLayout(frame, *layoutRoot);
     DebugPageOverlays::didLayout(frame);
 }
 
-void LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks()
+void LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks(bool canDeferUpdateLayerPositions)
 {
     if (m_postLayoutTaskTimer.isActive())
         return;
@@ -295,10 +295,10 @@ void LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks()
     }
 
     runPostLayoutTasks();
-    if (needsLayout()) {
+    if (needsLayoutInternal()) {
         // If runPostLayoutTasks() made us layout again, let's defer the tasks until after we return.
         m_postLayoutTaskTimer.startOneShot(0_s);
-        layout();
+        layout(canDeferUpdateLayerPositions);
     }
 }
 
@@ -331,6 +331,11 @@ void LocalFrameViewLayoutContext::reset()
 }
 
 bool LocalFrameViewLayoutContext::needsLayout() const
+{
+    return needsLayoutInternal() || protectedView()->hasPendingUpdateLayerPositions();
+}
+
+bool LocalFrameViewLayoutContext::needsLayoutInternal() const
 {
     // This can return true in cases where the document does not have a body yet.
     // Document::shouldScheduleLayout takes care of preventing us from scheduling

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -66,7 +66,7 @@ public:
     LocalFrameViewLayoutContext(LocalFrameView&);
     ~LocalFrameViewLayoutContext();
 
-    WEBCORE_EXPORT void layout();
+    WEBCORE_EXPORT void layout(bool canDeferUpdateLayerPositions = false);
     bool needsLayout() const;
 
     // We rely on the side-effects of layout, like compositing updates, to update state in various subsystems
@@ -143,13 +143,15 @@ private:
     friend class LayoutStateDisabler;
     friend class SubtreeLayoutStateMaintainer;
 
-    void performLayout();
+    bool needsLayoutInternal() const;
+
+    void performLayout(bool canDeferUpdateLayerPositions);
     bool canPerformLayout() const;
     bool isLayoutSchedulingEnabled() const { return m_layoutSchedulingIsEnabled; }
 
     void layoutTimerFired();
     void runPostLayoutTasks();
-    void runOrScheduleAsynchronousTasks();
+    void runOrScheduleAsynchronousTasks(bool canDeferUpdateLayerPositions);
     bool inAsynchronousTasks() const { return m_inAsynchronousTasks; }
 
     void setSubtreeLayoutRoot(RenderElement&);

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1098,9 +1098,9 @@ void RenderElement::willBeRemovedFromTree()
     RenderObject::willBeRemovedFromTree();
 }
 
-bool RenderElement::didVisitDuringLastLayout() const
+bool RenderElement::didVisitSinceLayout(LayoutIdentifier identifier) const
 {
-    return layoutIdentifier() == view().frameView().layoutContext().layoutIdentifier();
+    return layoutIdentifier() >= identifier;
 }
 
 inline void RenderElement::clearSubtreeLayoutRootIfNeeded() const

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -306,7 +306,7 @@ public:
     using LayoutIdentifier = unsigned;
     void setLayoutIdentifier(LayoutIdentifier layoutIdentifier) { m_layoutIdentifier = layoutIdentifier; }
     LayoutIdentifier layoutIdentifier() const { return m_layoutIdentifier; }
-    bool didVisitDuringLastLayout() const;
+    bool didVisitSinceLayout(LayoutIdentifier) const;
 
 protected:
     RenderElement(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -445,13 +445,13 @@ public:
     RenderLayer* reflectionLayer() const;
     bool isReflectionLayer(const RenderLayer&) const;
 
-    const LayoutPoint& location() const { return m_topLeft; }
+    inline const LayoutPoint& location() const;
     void setLocation(const LayoutPoint& p) { m_topLeft = p; }
 
-    const IntSize& size() const { return m_layerSize; }
+    inline const IntSize& size() const;
     void setSize(const IntSize& size) { m_layerSize = size; } // Only public for RenderTreeAsText.
 
-    LayoutRect rect() const { return LayoutRect(location(), size()); }
+    inline LayoutRect rect() const;
 
     IntSize visibleSize() const;
 
@@ -500,7 +500,7 @@ public:
 
     void updateLayerPositionsAfterStyleChange();
     enum class CanUseSimplifiedRepaintPass : uint8_t { No, Yes };
-    void updateLayerPositionsAfterLayout(bool isRelayoutingSubtree, bool didFullRepaint, CanUseSimplifiedRepaintPass);
+    void updateLayerPositionsAfterLayout(RenderElement::LayoutIdentifier, bool isRelayoutingSubtree, bool didFullRepaint, CanUseSimplifiedRepaintPass);
     void updateLayerPositionsAfterOverflowScroll();
     void updateLayerPositionsAfterDocumentScroll();
 
@@ -999,7 +999,7 @@ private:
     // Returns true if the position changed.
     bool updateLayerPosition(OptionSet<UpdateLayerPositionsFlag>* = nullptr);
 
-    void recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFlag>, CanUseSimplifiedRepaintPass = CanUseSimplifiedRepaintPass::No);
+    void recursiveUpdateLayerPositions(RenderElement::LayoutIdentifier, OptionSet<UpdateLayerPositionsFlag>, CanUseSimplifiedRepaintPass = CanUseSimplifiedRepaintPass::No);
 
     enum UpdateLayerPositionsAfterScrollFlag {
         IsOverflowScroll                        = 1 << 0,

--- a/Source/WebCore/rendering/RenderLayerInlines.h
+++ b/Source/WebCore/rendering/RenderLayerInlines.h
@@ -23,6 +23,8 @@
 #include "RenderLayer.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGResourceClipper.h"
+#include "RenderView.h"
+#include "SVGGraphicsElement.h"
 
 namespace WebCore {
 
@@ -72,6 +74,23 @@ inline bool RenderLayer::hasNonOpacityTransparency() const
 inline RenderSVGHiddenContainer* RenderLayer::enclosingSVGHiddenOrResourceContainer() const
 {
     return m_enclosingSVGHiddenOrResourceContainer.get();
+}
+
+inline const LayoutPoint& RenderLayer::location() const
+{
+    ASSERT(!renderer().view().frameView().layerAccessPrevented());
+    return m_topLeft;
+}
+
+inline const IntSize& RenderLayer::size() const
+{
+    ASSERT(!renderer().view().frameView().layerAccessPrevented());
+    return m_layerSize;
+}
+
+inline LayoutRect RenderLayer::rect() const
+{
+    return LayoutRect(location(), size());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -361,9 +361,7 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
     // We don't update compositing layers, because we need to do a deep update from the compositing ancestor.
     if (!view.frameView().layoutContext().isInRenderTreeLayout()) {
         // If we're in the middle of layout, we'll just update layers once layout has finished.
-        m_layer.updateLayerPositionsAfterOverflowScroll();
-
-        view.frameView().scheduleUpdateWidgetPositions();
+        view.frameView().updateLayerPositionsAfterOverflowScroll(m_layer);
 
         if (!m_updatingMarqueePosition) {
             // Avoid updating compositing layers if, higher on the stack, we're already updating layer


### PR DESCRIPTION
#### 9eb6ffd6f2c93fe5f650e207e402cff5370dce3e
<pre>
Speedometer 3: getBoundingClientRect spends time updating layer positions that it doesn&apos;t use.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276393">https://bugs.webkit.org/show_bug.cgi?id=276393</a>
&lt;<a href="https://rdar.apple.com/131418297">rdar://131418297</a>&gt;

Reviewed by Simon Fraser.

Adds a new option to Document::updateLayout for callers to request that updateLayerPositions
be deferred, and uses it for getBoundingClientRect.

Adds an assertion to RenderLayer::position/size() to make sure no code tries to access
layers positions while in this new state.
The assert only covers the scope of getBoundingClientRect, since arbtirary other code
can run next and might try to access the unflushed layer. This shouldn&apos;t be a new concern
though, since `needsLayout` will be true, and the other code should already be flushing layout
if it needs to access layer positions.

LocalFrameView::needsLayout now returns true if there&apos;s actual layout, or a pending layer
flush, so that we flush the layers next time to we try to layout.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateLayout):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::boundingClientRect):
* Source/WebCore/dom/MouseRelatedEvent.cpp:
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::topContentInsetDidChange):
(WebCore::LocalFrameView::hasPendingUpdateLayerPositions const):
(WebCore::LocalFrameView::flushUpdateLayerPositions):
(WebCore::LocalFrameView::didLayout):
(WebCore::LocalFrameView::updateLayerPositionsAfterScrolling):
(WebCore::LocalFrameView::updateLayerPositionsAfterOverflowScroll):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::layout):
(WebCore::LocalFrameViewLayoutContext::performLayout):
(WebCore::LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks):
(WebCore::LocalFrameViewLayoutContext::needsLayout const):
(WebCore::LocalFrameViewLayoutContext::needsLayoutInternal const):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::didVisitSinceLayout const):
(WebCore::RenderElement::didVisitDuringLastLayout const): Deleted.
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateLayerPositionsAfterStyleChange):
(WebCore::RenderLayer::updateLayerPositionsAfterLayout):
(WebCore::RenderLayer::recursiveUpdateLayerPositions):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerInlines.h:
(WebCore::RenderLayer::location const):
(WebCore::RenderLayer::size const):
(WebCore::RenderLayer::rect const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollTo):

Canonical link: <a href="https://commits.webkit.org/281227@main">https://commits.webkit.org/281227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b9e887a5b0709ee45b5181c8768a33ee8fc711c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63049 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9860 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6877 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51228 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/28880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32735 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8489 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8635 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54692 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8769 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64742 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3116 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3127 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51231 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/55490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13115 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2602 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/34347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/36516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->