### PR TITLE
http/tests/xmlhttprequest/gzip-content-type.html gives a different output depending on Apache version

### DIFF
--- a/LayoutTests/http/conf/apache2.4-darwin-httpd.conf
+++ b/LayoutTests/http/conf/apache2.4-darwin-httpd.conf
@@ -33,12 +33,16 @@ LoadModule negotiation_module libexec/apache2/mod_negotiation.so
 LoadModule actions_module libexec/apache2/mod_actions.so
 LoadModule alias_module libexec/apache2/mod_alias.so
 LoadModule rewrite_module libexec/apache2/mod_rewrite.so
+LoadModule setenvif_module libexec/apache2/mod_setenvif.so
 
 <IfModule !mpm_prefork_module>
 	LoadModule mpm_prefork_module libexec/apache2/mod_mpm_prefork.so
 </IfModule>
 
 ServerName 127.0.0.1
+
+# Allow python CGI scripts to set the `Content-Length` header.
+SetEnvIf Request_URI "\.py$" ap_trust_cgilike_cl
 
 <Directory />
     Options Indexes FollowSymLinks MultiViews ExecCGI Includes


### PR DESCRIPTION
#### e2cefb9ce6aa390c827015ad65ab440ac2745bbc
<pre>
http/tests/xmlhttprequest/gzip-content-type.html gives a different output depending on Apache version
<a href="https://bugs.webkit.org/show_bug.cgi?id=276406">https://bugs.webkit.org/show_bug.cgi?id=276406</a>
<a href="https://rdar.apple.com/131423730">rdar://131423730</a>

Reviewed by Brady Eidson and Aakash Jain.

Some of out bots recently got an updated Apache version. When this happened, 2 XHR tests dealing with
gzip-compressed responses have had a different output. In particular, the `Content-Length` HTTP header
is no longer present on the response.

Set the `ap_trust_cgilike_cl` Apache environment variable to allow CGI scripts to set the
`Content-Length` HTTP header again, for backward compatibility:
- <a href="https://httpd.apache.org/docs/current/env.html">https://httpd.apache.org/docs/current/env.html</a>

* LayoutTests/http/conf/apache2.4-darwin-httpd.conf:

Canonical link: <a href="https://commits.webkit.org/280834@main">https://commits.webkit.org/280834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33ce694ca6e3a610a0d2674cc3d7dceb3c1d458c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61369 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8192 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46787 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5813 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27612 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31544 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7194 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7196 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53496 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63051 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7537 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54010 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54128 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1408 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8614 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32904 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33990 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35074 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33735 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->