### PR TITLE
Parse "dir" member of the web application manifest

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
@@ -36,6 +36,12 @@
 namespace WebCore {
 
 struct ApplicationManifest {
+    enum class Direction : uint8_t {
+        Auto,
+        LTR, // NOLINT
+        RTL, // NOLINT
+    };
+
     enum class Display : uint8_t {
         Browser,
         MinimalUI,
@@ -63,6 +69,7 @@ struct ApplicationManifest {
     };
 
     String rawJSON;
+    Direction dir;
     String name;
     String shortName;
     String description;

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
@@ -48,6 +48,7 @@ private:
 
     RefPtr<JSON::Object> createJSONObject(const String&);
     URL parseStartURL(const JSON::Object&, const URL&);
+    ApplicationManifest::Direction parseDir(const JSON::Object&);
     ApplicationManifest::Display parseDisplay(const JSON::Object&);
     const std::optional<ScreenOrientationLockType> parseOrientation(const JSON::Object&);
     String parseName(const JSON::Object&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1336,6 +1336,12 @@ enum class WebCore::ScreenOrientationLockType : uint8_t {
 };
 
 #if ENABLE(APPLICATION_MANIFEST)
+[Nested] enum class WebCore::ApplicationManifest::Direction : uint8_t {
+    Auto
+    LTR
+    RTL
+};
+
 [Nested] enum class WebCore::ApplicationManifest::Display : uint8_t {
     Browser
     MinimalUI
@@ -1364,6 +1370,7 @@ enum class WebCore::ScreenOrientationLockType : uint8_t {
 
 struct WebCore::ApplicationManifest {
     String rawJSON
+    WebCore::ApplicationManifest::Direction dir
     String name
     String shortName
     String description

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
@@ -36,6 +36,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, _WKApplicationManifestDirection) {
+    _WKApplicationManifestDirectionAuto,
+    _WKApplicationManifestDirectionLTR,
+    _WKApplicationManifestDirectionRTL,
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 typedef NS_ENUM(NSInteger, _WKApplicationManifestDisplayMode) {
     _WKApplicationManifestDisplayModeBrowser,
     _WKApplicationManifestDisplayModeMinimalUI,
@@ -67,6 +73,7 @@ WK_CLASS_AVAILABLE(macos(10.13.4), ios(11.3))
 - (nullable instancetype)initWithJSONData:(NSData *)jsonData manifestURL:(NSURL *)manifestURL documentURL:(NSURL *)documentURL WK_API_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2));
 
 @property (nonatomic, readonly, nullable, copy) NSString *rawJSON;
+@property (nonatomic, readonly) _WKApplicationManifestDirection dir;
 @property (nonatomic, readonly, nullable, copy) NSString *name;
 @property (nonatomic, readonly, nullable, copy) NSString *shortName;
 @property (nonatomic, readonly, nullable, copy) NSString *applicationDescription;

--- a/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
@@ -36,6 +36,20 @@
 using namespace WebCore;
 
 namespace WebCore {
+static inline std::ostream& operator<<(std::ostream& os, const ApplicationManifest::Direction& direction)
+{
+    using enum ApplicationManifest::Direction;
+
+    switch (direction) {
+    case Auto:
+        return os << "ApplicationManifest::Direction::Auto";
+    case LTR:
+        return os << "ApplicationManifest::Direction::LTR";
+    case RTL:
+        return os << "ApplicationManifest::Direction::RTL";
+    }
+}
+
 static inline std::ostream& operator<<(std::ostream& os, const ApplicationManifest::Display& display)
 {
     switch (display) {
@@ -168,6 +182,11 @@ public:
         auto manifest = parseTopLevelProperty("start_url"_s, rawJSON);
         auto value = manifest.startURL;
         EXPECT_STREQ(expectedValue.string().utf8().data(), value.string().utf8().data());
+    }
+
+    void testDir(const String& rawJSON, ApplicationManifest::Direction expectedValue)
+    {
+        EXPECT_EQ(expectedValue, parseTopLevelProperty("dir"_s, rawJSON).dir);
     }
 
     void testDisplay(const String& rawJSON, ApplicationManifest::Display expectedValue)
@@ -442,6 +461,25 @@ TEST_F(ApplicationManifestParserTest, StartURL)
     m_manifestURL = URL { "https://example.com/dir3/manifest.json"_s };
 
     testStartURL("\"../page2\""_s, "https://example.com/page2"_s);
+}
+
+TEST_F(ApplicationManifestParserTest, Dir)
+{
+    using enum ApplicationManifest::Direction;
+
+    testDir("123"_s, Auto);
+    testDir("null"_s, Auto);
+    testDir("true"_s, Auto);
+    testDir("{ }"_s, Auto);
+    testDir("[ ]"_s, Auto);
+    testDir("\"\""_s, Auto);
+    testDir("\"garbage string\""_s, Auto);
+    testDir("\"\vltr\""_s, Auto);
+
+    testDir("\"auto\""_s, Auto);
+    testDir("\"ltr\""_s, LTR);
+    testDir("\"rtl\""_s, RTL);
+    testDir("\"\t\nLTR \""_s, LTR);
 }
 
 TEST_F(ApplicationManifestParserTest, Display)


### PR DESCRIPTION
#### 1b2b03786fb750eb56bed4e2d64d8477f8552f1e
<pre>
Parse &quot;dir&quot; member of the web application manifest
<a href="https://bugs.webkit.org/show_bug.cgi?id=276409">https://bugs.webkit.org/show_bug.cgi?id=276409</a>
<a href="https://rdar.apple.com/problem/131900106">rdar://problem/131900106</a>

Reviewed by Darin Adler.

Implements the &quot;dir&quot; member to the web application manifest parser per spec:
<a href="https://www.w3.org/TR/appmanifest/#dir-member">https://www.w3.org/TR/appmanifest/#dir-member</a>
Along with the required encorders/decoders and API tests.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseManifest):
(WebCore::ApplicationManifestParser::parseDir):
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifest initWithCoder:]):
(-[_WKApplicationManifest encodeWithCoder:]):
(-[_WKApplicationManifest direction]):
* Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp:
(WebCore::operator&lt;&lt;):
(ApplicationManifestParserTest::testDir):
(TEST_F):

Canonical link: <a href="https://commits.webkit.org/282761@main">https://commits.webkit.org/282761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e39a68944aa87c8c36df7d28ecc1c5f63071f6df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68074 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14660 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51584 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10121 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32203 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36846 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12817 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13533 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58903 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59054 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14174 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6631 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39229 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40308 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->