### PR TITLE
Digital Credentials: implement digital-credentials-get permission policy

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Policy to use: null, is cross-origin: false, is allowed by policy: true
+PASS Policy to use: null, is cross-origin: true, is allowed by policy: false
+PASS Policy to use: digital-credentials-get, is cross-origin: false, is allowed by policy: true
+PASS Policy to use: digital-credentials-get, is cross-origin: true, is allowed by policy: true
+PASS Policy to use: digital-credentials-get *, is cross-origin: true, is allowed by policy: true
+PASS Policy to use: digital-credentials-get *, is cross-origin: false, is allowed by policy: true
+PASS Policy to use: digital-credentials-get 'none', is cross-origin: true, is allowed by policy: false
+PASS Policy to use: digital-credentials-get 'none', is cross-origin: false, is allowed by policy: false
+PASS Policy to use: digital-credentials-get 'self', is cross-origin: true, is allowed by policy: false
+PASS Policy to use: digital-credentials-get 'self', is cross-origin: false, is allowed by policy: true
+PASS Policy to use: digital-credentials-get https://127.0.0.1:9443, is cross-origin: true, is allowed by policy: true
+PASS Policy to use: digital-credentials-get https://127.0.0.1:9443, is cross-origin: false, is allowed by policy: false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>
+            Test allow attribute with "digital-credentials-get" and
+            CredentialsContainer's .get() method
+        </title>
+        <script src="/common/get-host-info.sub.js"></script>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script>
+            const hostInfo = get_host_info();
+            const iframeDetails = [
+                {
+                    policy: null,
+                    crossOrigin: false,
+                    isAllowed: true,
+                },
+                {
+                    policy: null,
+                    crossOrigin: true,
+                    isAllowed: false,
+                },
+                {
+                    policy: "digital-credentials-get",
+                    crossOrigin: false,
+                    isAllowed: true,
+                },
+                {
+                    policy: "digital-credentials-get",
+                    crossOrigin: true,
+                    isAllowed: true,
+                },
+                {
+                    policy: "digital-credentials-get *",
+                    crossOrigin: true,
+                    isAllowed: true,
+                },
+                {
+                    policy: "digital-credentials-get *",
+                    crossOrigin: false,
+                    isAllowed: true,
+                },
+                {
+                    policy: "digital-credentials-get 'none'",
+                    crossOrigin: true,
+                    isAllowed: false,
+                },
+                {
+                    policy: "digital-credentials-get 'none'",
+                    crossOrigin: false,
+                    isAllowed: false,
+                },
+                {
+                    policy: "digital-credentials-get 'self'",
+                    crossOrigin: true,
+                    isAllowed: false,
+                },
+                {
+                    policy: "digital-credentials-get 'self'",
+                    crossOrigin: false,
+                    isAllowed: true,
+                },
+                {
+                    policy: `digital-credentials-get ${hostInfo.HTTPS_REMOTE_ORIGIN}`,
+                    crossOrigin: true,
+                    isAllowed: true,
+                },
+                {
+                    policy: `digital-credentials-get ${hostInfo.HTTPS_REMOTE_ORIGIN}`,
+                    crossOrigin: false,
+                    isAllowed: false,
+                },
+            ];
+
+            async function loadIframe({ policy, crossOrigin, isAllowed }) {
+                const iframe = document.createElement("iframe");
+                if (policy !== null) {
+                    iframe.allow = policy;
+                }
+
+                iframe.src = new URL(
+                    "/digital-credentials/support/iframe.html",
+                    crossOrigin ? hostInfo.HTTPS_REMOTE_ORIGIN : location.origin
+                ).href;
+                iframe.dataset.isAllowed = isAllowed;
+
+                await new Promise((resolve) => {
+                    iframe.onload = resolve;
+                    document.body.appendChild(iframe);
+                });
+                iframe.focus();
+                return iframe;
+            }
+
+            function runTests() {
+                for (const details of iframeDetails) {
+                    promise_test(async (test) => {
+                        const iframe = await loadIframe(details);
+                        const { isAllowed } = details;
+                        const action = "get";
+                        const options = {
+                            digital: { providers: [] },
+                        };
+                        const { data } = await new Promise((resolve) => {
+                            window.addEventListener("message", resolve, {
+                                once: true,
+                            });
+                            iframe.contentWindow.postMessage({ action, options }, "*");
+                        });
+                        const { name, messsage } = data;
+                        assert_equals(
+                            name,
+                            isAllowed ? "TypeError" : "NotAllowedError",
+                            `${iframe.outerHTML} - ${messsage}`
+                        );
+                        iframe.remove();
+                    }, `Policy to use: ${details.policy}, is cross-origin: ${details.crossOrigin}, is allowed by policy: ${details.isAllowed}`);
+                }
+            }
+        </script>
+    </head>
+    <body onload="runTests()"></body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Permissions-Policy is by default 'self'.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<body></body>
+<script>
+    "use strict";
+    const { HTTPS_REMOTE_ORIGIN } = get_host_info();
+    const same_origin_src =
+        "/permissions-policy/resources/digital-credentials-get.html";
+    const cross_origin_src = new URL(same_origin_src, HTTPS_REMOTE_ORIGIN).href;
+
+    promise_test(async (test) => {
+        await test_driver.bless("use activation");
+        await promise_rejects_js(
+            test,
+            TypeError,
+            navigator.identity.get({ digital: { providers: [] } })
+        );
+
+        await test_feature_availability({
+            feature_description: "Digital Credential API",
+            test,
+            src: same_origin_src,
+            expect_feature_available: expect_feature_available_default,
+            is_promise_test: true,
+        });
+
+        await test_feature_availability({
+            feature_description: "Digital Credential API",
+            test,
+            src: cross_origin_src,
+            expect_feature_available: expect_feature_unavailable_default,
+            feature_name: "digital-credentials-get",
+            is_promise_test: true,
+        });
+    }, "Permissions-Policy is by default 'self'.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub-expected.txt
@@ -1,0 +1,5 @@
+
+
+FAIL Permissions-Policy header digital-credentials-get=() disallows the top-level document. promise_rejects_dom: function "function() { throw e }" threw object "TypeError: At least one provider must be specified." that is not a DOMException NotAllowedError: property "code" is equal to undefined, expected 0
+FAIL Permissions-Policy header digital-credentials-get=() disallows same-origin iframes. assert_false: Digital Credential API expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<body></body>
+<script>
+    "use strict";
+    const { HTTPS_REMOTE_ORIGIN } = get_host_info();
+    const same_origin_src =
+        "/permissions-policy/resources/digital-credentials-get.html";
+    const cross_origin_src = new URL(same_origin_src, HTTPS_REMOTE_ORIGIN).href;
+
+    promise_test(async (test) => {
+        await test_driver.bless("user activation");
+        await promise_rejects_dom(
+            test,
+            "NotAllowedError",
+            navigator.identity.get({ digital: { providers: [] } })
+        );
+    }, "Permissions-Policy header digital-credentials-get=() disallows the top-level document.");
+
+    promise_test(async (test) => {
+        await test_feature_availability({
+            feature_description: "Digital Credential API",
+            test,
+            src: same_origin_src,
+            expect_feature_available: expect_feature_unavailable_default,
+            is_promise_test: true,
+            needs_focus: true,
+        });
+    }, "Permissions-Policy header digital-credentials-get=() disallows same-origin iframes.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: digital-credentials-get=()

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Permissions-Policy header digital-credentials-get=(self) allows the top-level document.
+PASS Permissions-Policy header digital-credentials-get=(self) allows same-origin iframes.
+PASS Permissions-Policy header digital-credentials-get=(self) disallows cross-origin iframes.
+PASS Permissions-Policy header digital-credentials-get=(self) gets overridden by allow attribute.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<body></body>
+<script>
+    "use strict";
+    const { HTTPS_REMOTE_ORIGIN } = get_host_info();
+    const same_origin_src =
+        "/permissions-policy/resources/digital-credentials-get.html";
+    const cross_origin_src = new URL(same_origin_src, HTTPS_REMOTE_ORIGIN).href;
+
+    promise_test(async (test) => {
+        await test_driver.bless("use activation");
+        await promise_rejects_js(
+            test,
+            TypeError,
+            navigator.identity.get({ digital: { providers: [] } })
+        );
+    }, "Permissions-Policy header digital-credentials-get=(self) allows the top-level document.");
+
+    promise_test(async (test) => {
+        await test_feature_availability({
+            feature_description: "Digital Credential API",
+            test,
+            src: same_origin_src,
+            expect_feature_available: expect_feature_available_default,
+            is_promise_test: true,
+            needs_focus: true,
+        });
+    }, "Permissions-Policy header digital-credentials-get=(self) allows same-origin iframes.");
+
+    promise_test(async (test) => {
+        await test_feature_availability({
+            feature_description: "Digital Credential API",
+            test,
+            src: cross_origin_src,
+            expect_feature_available: expect_feature_unavailable_default,
+            is_promise_test: true,
+            needs_focus: true,
+        });
+    }, "Permissions-Policy header digital-credentials-get=(self) disallows cross-origin iframes.");
+
+    promise_test(async (test) => {
+        await test_feature_availability({
+            feature_description: "Digital Credential API",
+            test,
+            src: cross_origin_src,
+            expect_feature_available: expect_feature_available_default,
+            feature_name: "digital-credentials-get",
+            is_promise_test: true,
+            needs_focus: true,
+        });
+    }, "Permissions-Policy header digital-credentials-get=(self) gets overridden by allow attribute.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: digital-credentials-get=(self)

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/override-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/override-permissions-policy.https.sub-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Header-set policy is overridden in cross-origin iframe using allow attribute.
+FAIL Setting digital-credentials-get=(self) disallows the API in same-origin iframes. assert_false: Digital Credential API expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/override-permissions-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/override-permissions-policy.https.sub.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/permissions-policy/resources/permissions-policy.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<body></body>
+<script>
+    "use strict";
+    const { HTTPS_REMOTE_ORIGIN } = get_host_info();
+    const same_origin_src =
+        "/permissions-policy/resources/digital-credentials-get.html";
+    const cross_origin_src = new URL(same_origin_src, HTTPS_REMOTE_ORIGIN).href;
+
+    promise_test(async (test) => {
+        await test_feature_availability({
+            feature_description: "Digital Credential API",
+            test,
+            src: cross_origin_src,
+            expect_feature_available: expect_feature_available_default,
+            feature_name: "digital-credentials-get",
+            is_promise_test: true,
+            needs_focus: true,
+        });
+    }, "Header-set policy is overridden in cross-origin iframe using allow attribute.");
+
+    promise_test(async (test) => {
+        await test_feature_availability({
+            feature_description: "Digital Credential API",
+            test,
+            src: same_origin_src,
+            expect_feature_available: expect_feature_unavailable_default,
+            is_promise_test: true,
+            needs_focus: true,
+        });
+    }, "Setting digital-credentials-get=(self) disallows the API in same-origin iframes.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/override-permissions-policy.https.sub.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/override-permissions-policy.https.sub.html.headers
@@ -1,0 +1,1 @@
+Permissions-Policy: digital-credentials-get=()

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/iframe.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+  // @ts-check
+  /**
+   *
+   * @typedef {import('./dc-types').ActionType} IframeActionType
+   * @typedef {import('./dc-types').AbortType} AbortType
+   * @typedef {import('./dc-types').EventData} EventData
+   * @typedef {import('./dc-types').PostData} PostData
+   */
+
+  /**
+   * @param {MessageEvent<EventData>} event
+   */
+  async function messageListener(event) {
+    /** @type {EventData} */
+    const data = event.data ? { ...event.data } : {};
+    /** @type {PostData} */
+    const abortController = new AbortController();
+    if (data.abort) {
+      if (!data.options) {
+        data.options = {};
+      }
+      data.options.signal = abortController.signal;
+    }
+    let result;
+    try {
+      /** @type {CrendetialManager} */
+      const { identity } = navigator;
+      if (abortController && data.abort === "before") {
+        abortController.abort();
+      }
+      switch (data.action) {
+        case "ping":
+          result = "pong";
+          break;
+        case "create":
+          result = await identity.create(data.options);
+          break;
+        case "get":
+          await test_driver.bless("user activation", null, window);
+          assert_true(navigator.userActivation.isActive, "user activation must be active");
+          result = await identity.get(data.options);
+          break;
+        case "preventSilentAccess":
+          result = await identity.preventSilentAccess();
+          break;
+        default:
+          throw new Error(
+            `Unsupported action in ${window.location}: ${data.action}`
+          );
+      }
+    } catch (error) {
+      result = {
+        constructor: error.constructor.name,
+        name: error.name,
+        message: error.message,
+      };
+    } finally {
+      event.source?.postMessage(result, event.origin);
+    }
+  }
+
+  window.addEventListener("message", messageListener);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/digital-credentials-get.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/digital-credentials-get.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script>
+    const type = "availability-result";
+    async function notify() {
+        if (!navigator.userActivation.isActive) {
+            await test_driver.bless("user activation", null, window);
+        }
+        let enabled = undefined;
+        try {
+            await navigator.identity.get({ digital: { providers: [] } });
+        } catch (e) {
+            switch (e.name) {
+                case "NotAllowedError":
+                    enabled = false;
+                    break;
+                case "TypeError":
+                    enabled = true;
+                    break;
+                default:
+                    throw e;
+            }
+        } finally {
+            window.parent.postMessage({ type, enabled }, "*");
+        }
+    }
+</script>
+<body onload="notify()">
+    <h1>Digital Credentials iframe</h1>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/permissions-policy.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/permissions-policy.js
@@ -30,7 +30,7 @@ function assert_permissions_policy_supported() {
 //    promise. Used by test_feature_availability_with_post_message_result()
 function test_feature_availability(
     feature_descriptionOrObject, test, src, expect_feature_available, feature_name,
-    allowfullscreen, is_promise_test = false) {
+    allowfullscreen, is_promise_test = false, needs_focus = false) {
 
   if (feature_descriptionOrObject && feature_descriptionOrObject instanceof Object) {
     const {
@@ -41,6 +41,7 @@ function test_feature_availability(
       feature_name,
       allowfullscreen,
       is_promise_test,
+      needs_focus,
     } = feature_descriptionOrObject;
     return test_feature_availability(
       feature_description,
@@ -49,7 +50,8 @@ function test_feature_availability(
       expect_feature_available,
       feature_name,
       allowfullscreen,
-      is_promise_test
+      is_promise_test,
+      needs_focus,
     );
   }
 
@@ -84,6 +86,9 @@ function test_feature_availability(
                     window.addEventListener('message', resolve);
                   }).then(expectFeatureAvailable);
   document.body.appendChild(frame);
+  if (needs_focus) {
+    frame.focus();
+  }
   return promise;
 }
 

--- a/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
+++ b/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
@@ -51,6 +51,12 @@ void IdentityCredentialsContainer::get(CredentialRequestOptions&& options, Crede
         return;
 
     RefPtr document = this->document();
+    ASSERT(document);
+    if (!PermissionsPolicy::isFeatureEnabled(PermissionsPolicy::Feature::DigitalCredentialsGetRule, *document, PermissionsPolicy::ShouldReportViolation::No)) {
+        promise.reject(Exception { ExceptionCode::NotAllowedError, "Third-party iframes are not allowed to call .get() unless explicitly allowed via Permissions Policy (digital-credentials-get)"_s });
+        return;
+    }
+
     if (!document->hasFocus()) {
         promise.reject(Exception { ExceptionCode::NotAllowedError, "The document is not focused."_s });
         return;

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -77,6 +77,8 @@ static ASCIILiteral toFeatureNameForLogging(PermissionsPolicy::Feature feature)
 #if ENABLE(WEB_AUTHN)
     case PermissionsPolicy::Feature::PublickeyCredentialsGetRule:
         return "PublickeyCredentialsGet"_s;
+    case PermissionsPolicy::Feature::DigitalCredentialsGetRule:
+        return "DigitalCredentialsGet"_s;
 #endif
 #if ENABLE(WEBXR)
     case PermissionsPolicy::Feature::XRSpatialTracking:
@@ -117,6 +119,7 @@ static std::pair<PermissionsPolicy::Feature, StringView> readFeatureIdentifier(S
 #endif
 #if ENABLE(WEB_AUTHN)
     constexpr auto publickeyCredentialsGetRuleToken { "publickey-credentials-get"_s };
+    constexpr auto digitalCredentialsGetRuleToken { "digital-credentials-get"_s };
 #endif
 #if ENABLE(WEBXR)
     constexpr auto xrSpatialTrackingToken { "xr-spatial-tracking"_s };
@@ -171,6 +174,9 @@ static std::pair<PermissionsPolicy::Feature, StringView> readFeatureIdentifier(S
     } else if (value.startsWith(publickeyCredentialsGetRuleToken)) {
         feature = PermissionsPolicy::Feature::PublickeyCredentialsGetRule;
         remainingValue = value.substring(publickeyCredentialsGetRuleToken.length());
+    } else if (value.startsWith(digitalCredentialsGetRuleToken)) {
+        feature = PermissionsPolicy::Feature::DigitalCredentialsGetRule;
+        remainingValue = value.substring(digitalCredentialsGetRuleToken.length());
 #endif
 #if ENABLE(WEBXR)
     } else if (value.startsWith(xrSpatialTrackingToken)) {
@@ -213,6 +219,7 @@ static ASCIILiteral defaultAllowlistValue(PermissionsPolicy::Feature feature)
 #endif
 #if ENABLE(WEB_AUTHN)
     case PermissionsPolicy::Feature::PublickeyCredentialsGetRule:
+    case PermissionsPolicy::Feature::DigitalCredentialsGetRule:
 #endif
 #if ENABLE(WEBXR)
     case PermissionsPolicy::Feature::XRSpatialTracking:

--- a/Source/WebCore/html/PermissionsPolicy.h
+++ b/Source/WebCore/html/PermissionsPolicy.h
@@ -63,6 +63,7 @@ public:
 #endif
 #if ENABLE(WEB_AUTHN)
         PublickeyCredentialsGetRule,
+        DigitalCredentialsGetRule,
 #endif
 #if ENABLE(WEBXR)
         XRSpatialTracking,

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8320,6 +8320,7 @@ struct WebCore::OwnerPermissionsPolicyData {
 #endif
 #if ENABLE(WEB_AUTHN)
     PublickeyCredentialsGetRule,
+    DigitalCredentialsGetRule,
 #endif
 #if ENABLE(WEBXR)
     XRSpatialTracking,


### PR DESCRIPTION
#### 99992856c4bc1fe9cd0c862a1065517a0a8f8ec2
<pre>
Digital Credentials: implement digital-credentials-get permission policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=275783">https://bugs.webkit.org/show_bug.cgi?id=275783</a>
<a href="https://rdar.apple.com/130821690">rdar://130821690</a>

Reviewed by Matthew Finkel.

Implements the digital-credentials-get permission policy directive.
This directive allows a site to control whether the .get() method
can be used in the Digital Credential API.

Related spec change:
<a href="https://github.com/WICG/digital-credentials/pull/132">https://github.com/WICG/digital-credentials/pull/132</a>

* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/default-permissions-policy.https.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/override-permissions-policy.https.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/override-permissions-policy.https.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/override-permissions-policy.https.sub.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/digital-credentials-get.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/permissions-policy.js:
(test_feature_availability):
* Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp:
(WebCore::IdentityCredentialsContainer::get):
* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::toFeatureNameForLogging):
(WebCore::readFeatureIdentifier):
(WebCore::defaultAllowlistValue):
* Source/WebCore/html/PermissionsPolicy.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/281154@main">https://commits.webkit.org/281154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00126ee61819c3eb8fe823d96395a238ba531e7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62136 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8954 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47369 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6376 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50586 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28220 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7888 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7958 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54118 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63839 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8168 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54690 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54765 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13050 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2047 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33666 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34752 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->