### PR TITLE
XMLHttpRequest without credentials fails with CORS error on redirections

### DIFF
--- a/LayoutTests/http/tests/xmlhttprequest/access-control-and-redirects-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/access-control-and-redirects-expected.txt
@@ -30,4 +30,12 @@ PASS: NetworkError:  A network error occurred.
 Testing http://localhost:8000/resources/redirect.py?url=http://localhost:8000/xmlhttprequest/resources/access-control-basic-allow.cgi(async)
 Expecting success: false
 PASS: 0
+Testing resources/redirect-cors.py?access-control-allow-origin=*&url=http://localhost:8000/xmlhttprequest/resources/redirect-cors.py?access-control-allow-origin=*%26url=http://127.0.0.1:8000/xmlhttprequest/resources/access-control-basic-allow-star.cgi (sync)
+Expecting success: true
+PASS: PASS: Cross-domain access allowed.
+
+Testing resources/redirect-cors.py?access-control-allow-origin=*&url=http://localhost:8000/xmlhttprequest/resources/redirect-cors.py?access-control-allow-origin=*%26url=http://127.0.0.1:8000/xmlhttprequest/resources/access-control-basic-allow-star.cgi(async)
+Expecting success: true
+PASS: PASS: Cross-domain access allowed.
+
 

--- a/LayoutTests/http/tests/xmlhttprequest/access-control-and-redirects.html
+++ b/LayoutTests/http/tests/xmlhttprequest/access-control-and-redirects.html
@@ -47,7 +47,8 @@ function runTest(url, expectSyncSuccess, expectAsyncSuccess)
 var tests = [
     ["/resources/redirect.py?url=http://localhost:8000/xmlhttprequest/resources/access-control-basic-allow.cgi", true, true],
     ["http://localhost:8000/resources/redirect.py?url=http://127.0.0.1:8000/xmlhttprequest/resources/access-control-basic-allow.cgi", false, false],
-    ["http://localhost:8000/resources/redirect.py?url=http://localhost:8000/xmlhttprequest/resources/access-control-basic-allow.cgi", false, false]
+    ["http://localhost:8000/resources/redirect.py?url=http://localhost:8000/xmlhttprequest/resources/access-control-basic-allow.cgi", false, false],
+    ["resources/redirect-cors.py?access-control-allow-origin=*&url=http://localhost:8000/xmlhttprequest/resources/redirect-cors.py?access-control-allow-origin=*%26url=http://127.0.0.1:8000/xmlhttprequest/resources/access-control-basic-allow-star.cgi", true, true]
 ]
 
 var currentTest = 0;

--- a/LayoutTests/platform/mac-wk1/http/tests/xmlhttprequest/access-control-and-redirects-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/xmlhttprequest/access-control-and-redirects-expected.txt
@@ -27,4 +27,11 @@ PASS: NetworkError:  A network error occurred.
 Testing http://localhost:8000/resources/redirect.py?url=http://localhost:8000/xmlhttprequest/resources/access-control-basic-allow.cgi(async)
 Expecting success: false
 PASS: 0
+Testing resources/redirect-cors.py?access-control-allow-origin=*&url=http://localhost:8000/xmlhttprequest/resources/redirect-cors.py?access-control-allow-origin=*%26url=http://127.0.0.1:8000/xmlhttprequest/resources/access-control-basic-allow-star.cgi (sync)
+Expecting success: true
+FAIL: NetworkError:  A network error occurred.
+Testing resources/redirect-cors.py?access-control-allow-origin=*&url=http://localhost:8000/xmlhttprequest/resources/redirect-cors.py?access-control-allow-origin=*%26url=http://127.0.0.1:8000/xmlhttprequest/resources/access-control-basic-allow-star.cgi(async)
+Expecting success: true
+PASS: PASS: Cross-domain access allowed.
+
 

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -264,28 +264,30 @@ bool CrossOriginAccessControlCheckDisabler::crossOriginAccessControlCheckEnabled
     return m_accessControlCheckEnabled;
 }
 
-Expected<void, String> passesAccessControlCheck(const ResourceResponse& response, StoredCredentialsPolicy storedCredentialsPolicy, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler* checkDisabler)
+Expected<void, String> passesAccessControlCheck(const ResourceResponse& response, FetchOptionsCredentials fetchOptionsCredentials, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler* checkDisabler)
 {
-    // A wildcard Access-Control-Allow-Origin can not be used if credentials are to be sent,
-    // even with Access-Control-Allow-Credentials set to true.
     const String& accessControlOriginString = response.httpHeaderField(HTTPHeaderName::AccessControlAllowOrigin);
-    bool starAllowed = storedCredentialsPolicy == StoredCredentialsPolicy::DoNotUse;
-    if (!starAllowed)
-        starAllowed = checkDisabler && !checkDisabler->crossOriginAccessControlCheckEnabled();
-    if (accessControlOriginString == "*"_s && starAllowed)
-        return { };
-
-    String securityOriginString = securityOrigin.toString();
-    if (accessControlOriginString != securityOriginString) {
-        if (accessControlOriginString == "*"_s)
+    const String securityOriginString = securityOrigin.toString();
+    if (accessControlOriginString == "*"_s) {
+        if (checkDisabler && !checkDisabler->crossOriginAccessControlCheckEnabled())
+            return { };
+        // A wildcard Access-Control-Allow-Origin can not be used if credentials are to be sent,
+        // even with Access-Control-Allow-Credentials set to true.
+        // https://fetch.spec.whatwg.org/#cors-protocol-and-credentials.
+        if (fetchOptionsCredentials == FetchOptionsCredentials::Include)
             return makeUnexpected("Cannot use wildcard in Access-Control-Allow-Origin when credentials flag is true."_s);
+    } else if (accessControlOriginString != securityOriginString) {
+        // Multiple origins are not allowed in the allow origin header.
+        // https://fetch.spec.whatwg.org/#http-access-control-allow-origin.
         if (accessControlOriginString.find(',') != notFound)
             return makeUnexpected("Access-Control-Allow-Origin cannot contain more than one origin."_s);
+
         return makeUnexpected(makeString("Origin "_s, securityOriginString, " is not allowed by Access-Control-Allow-Origin."_s, " Status code: "_s, response.httpStatusCode()));
     }
 
-    if (storedCredentialsPolicy == StoredCredentialsPolicy::Use) {
+    if (fetchOptionsCredentials == FetchOptionsCredentials::Include) {
         const String& accessControlCredentialsString = response.httpHeaderField(HTTPHeaderName::AccessControlAllowCredentials);
+        // https://fetch.spec.whatwg.org/#http-access-control-allow-credentials.
         if (accessControlCredentialsString != "true"_s)
             return makeUnexpected("Credentials flag is true, but Access-Control-Allow-Credentials is not \"true\"."_s);
     }
@@ -293,12 +295,12 @@ Expected<void, String> passesAccessControlCheck(const ResourceResponse& response
     return { };
 }
 
-Expected<void, String> validatePreflightResponse(PAL::SessionID sessionID, const ResourceRequest& request, const ResourceResponse& response, StoredCredentialsPolicy storedCredentialsPolicy, const SecurityOrigin& topOrigin, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler* checkDisabler)
+Expected<void, String> validatePreflightResponse(PAL::SessionID sessionID, const ResourceRequest& request, const ResourceResponse& response, FetchOptionsCredentials fetchOptionsCredentials, StoredCredentialsPolicy storedCredentialsPolicy, const SecurityOrigin& topOrigin, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler* checkDisabler)
 {
     if (!response.isSuccessful())
         return makeUnexpected(makeString("Preflight response is not successful. Status code: "_s, response.httpStatusCode()));
 
-    auto accessControlCheckResult = passesAccessControlCheck(response, storedCredentialsPolicy, securityOrigin, checkDisabler);
+    auto accessControlCheckResult = passesAccessControlCheck(response, fetchOptionsCredentials, securityOrigin, checkDisabler);
     if (!accessControlCheckResult)
         return accessControlCheckResult;
 

--- a/Source/WebCore/loader/CrossOriginAccessControl.h
+++ b/Source/WebCore/loader/CrossOriginAccessControl.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "FetchOptionsCredentials.h"
 #include "HTTPHeaderNames.h"
 #include "ReferrerPolicy.h"
 #include "ResourceResponse.h"
@@ -87,8 +88,8 @@ private:
     bool m_accessControlCheckEnabled { true };
 };
 
-WEBCORE_EXPORT Expected<void, String> passesAccessControlCheck(const ResourceResponse&, StoredCredentialsPolicy, const SecurityOrigin&, const CrossOriginAccessControlCheckDisabler*);
-WEBCORE_EXPORT Expected<void, String> validatePreflightResponse(PAL::SessionID, const ResourceRequest&, const ResourceResponse&, StoredCredentialsPolicy, const SecurityOrigin& topOrigin, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler*);
+WEBCORE_EXPORT Expected<void, String> passesAccessControlCheck(const ResourceResponse&, FetchOptionsCredentials, const SecurityOrigin&, const CrossOriginAccessControlCheckDisabler*);
+WEBCORE_EXPORT Expected<void, String> validatePreflightResponse(PAL::SessionID, const ResourceRequest&, const ResourceResponse&, FetchOptionsCredentials, StoredCredentialsPolicy, const SecurityOrigin& topOrigin, const SecurityOrigin& securityOrigin, const CrossOriginAccessControlCheckDisabler*);
 
 enum class ForNavigation : bool { No, Yes };
 WEBCORE_EXPORT std::optional<ResourceError> validateCrossOriginResourcePolicy(CrossOriginEmbedderPolicyValue, const SecurityOrigin&, const URL&, const ResourceResponse&, ForNavigation, const OriginAccessPatterns&);

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -76,7 +76,7 @@ void CrossOriginPreflightChecker::validatePreflightResponse(DocumentThreadableLo
         return;
     }
 
-    auto result = WebCore::validatePreflightResponse(page->sessionID(), request, response, loader.options().storedCredentialsPolicy, loader.topOrigin(), loader.securityOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
+    auto result = WebCore::validatePreflightResponse(page->sessionID(), request, response, loader.options().credentials, loader.options().storedCredentialsPolicy, loader.topOrigin(), loader.securityOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
     if (!result) {
         loader.document().addConsoleMessage(MessageSource::Security, MessageLevel::Error, result.error());
         loader.preflightFailure(identifier, ResourceError(errorDomainWebKitInternal, 0, request.url(), result.error(), ResourceError::Type::AccessControl));

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -673,7 +673,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
             else {
                 ASSERT(m_options.mode == FetchOptions::Mode::Cors);
                 response.setTainting(ResourceResponse::Tainting::Cors);
-                auto accessControlCheckResult = passesAccessControlCheck(response, m_options.storedCredentialsPolicy, protectedSecurityOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
+                auto accessControlCheckResult = passesAccessControlCheck(response, m_options.credentials, protectedSecurityOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
                 if (!accessControlCheckResult) {
                     logErrorAndFail(ResourceError(errorDomainWebKitInternal, 0, response.url(), accessControlCheckResult.error(), ResourceError::Type::AccessControl));
                     return;

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -657,7 +657,7 @@ Expected<void, String> SubresourceLoader::checkResponseCrossOriginAccessControl(
 
     ASSERT(m_origin);
 
-    return passesAccessControlCheck(response, options().credentials == FetchOptions::Credentials::Include ? StoredCredentialsPolicy::Use : StoredCredentialsPolicy::DoNotUse, *protectedOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
+    return passesAccessControlCheck(response, options().credentials, *protectedOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
 }
 
 RefPtr<SecurityOrigin> SubresourceLoader::protectedOrigin() const
@@ -687,7 +687,7 @@ Expected<void, String> SubresourceLoader::checkRedirectionCrossOriginAccessContr
 
         ASSERT(m_origin);
         if (crossOriginFlag) {
-            auto accessControlCheckResult = passesAccessControlCheck(redirectResponse, options().storedCredentialsPolicy, *protectedOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
+            auto accessControlCheckResult = passesAccessControlCheck(redirectResponse, options().credentials, *protectedOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
             if (!accessControlCheckResult)
                 return accessControlCheckResult;
         }

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -294,7 +294,7 @@ void CachedResource::loadFrom(const CachedResource& resource)
 
     if (isCrossOrigin() && m_options.mode == FetchOptions::Mode::Cors) {
         ASSERT(m_origin);
-        auto accessControlCheckResult = WebCore::passesAccessControlCheck(resource.response(), m_options.storedCredentialsPolicy, *m_origin, &CrossOriginAccessControlCheckDisabler::singleton());
+        auto accessControlCheckResult = WebCore::passesAccessControlCheck(resource.response(), m_options.credentials, *m_origin, &CrossOriginAccessControlCheckDisabler::singleton());
         if (!accessControlCheckResult) {
             setResourceError(ResourceError(String(), 0, url(), accessControlCheckResult.error(), ResourceError::Type::AccessControl));
             return;

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
@@ -153,7 +153,7 @@ void NetworkCORSPreflightChecker::didCompleteWithError(const WebCore::ResourceEr
 
     CORS_CHECKER_RELEASE_LOG("didComplete http_status_code=%d", m_response.httpStatusCode());
 
-    auto result = validatePreflightResponse(m_parameters.sessionID, m_parameters.originalRequest, m_response, m_parameters.storedCredentialsPolicy, m_parameters.topOrigin, m_parameters.sourceOrigin, m_networkResourceLoader.get());
+    auto result = validatePreflightResponse(m_parameters.sessionID, m_parameters.originalRequest, m_response, m_parameters.fetchOptionsCredentials, m_parameters.storedCredentialsPolicy, m_parameters.topOrigin, m_parameters.sourceOrigin, m_networkResourceLoader.get());
     if (!result) {
         CORS_CHECKER_RELEASE_LOG("didComplete, AccessControl error: %s", result.error().utf8().data());
         m_completionCallback(ResourceError { errorDomainWebKitInternal, 0, m_parameters.originalRequest.url(), result.error(), ResourceError::Type::AccessControl });

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
@@ -61,6 +61,7 @@ public:
         String userAgent;
         PAL::SessionID sessionID;
         Markable<WebPageProxyIdentifier> webPageProxyID;
+        WebCore::FetchOptionsCredentials fetchOptionsCredentials;
         WebCore::StoredCredentialsPolicy storedCredentialsPolicy;
         bool allowPrivacyProxy { true };
         OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections;

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -259,7 +259,7 @@ ResourceError NetworkLoadChecker::validateResponse(const ResourceRequest& reques
         return { };
     }
 
-    auto result = passesAccessControlCheck(response, m_storedCredentialsPolicy, *origin(), m_networkResourceLoader.get());
+    auto result = passesAccessControlCheck(response, m_options.credentials, *origin(), m_networkResourceLoader.get());
     if (!result)
         return ResourceError { String { }, 0, m_url, WTFMove(result.error()), ResourceError::Type::AccessControl };
 
@@ -485,6 +485,7 @@ void NetworkLoadChecker::checkCORSRequestWithPreflight(ResourceRequest&& request
         request.httpUserAgent(),
         m_sessionID,
         m_webPageProxyID,
+        m_options.credentials,
         m_storedCredentialsPolicy,
         m_allowPrivacyProxy,
         m_advancedPrivacyProtections,


### PR DESCRIPTION
#### 038d5090b7ca645aad8d11fb925558ad8cc87fd1
<pre>
XMLHttpRequest without credentials fails with CORS error on redirections
<a href="https://bugs.webkit.org/show_bug.cgi?id=276364">https://bugs.webkit.org/show_bug.cgi?id=276364</a>

Reviewed by NOBODY (OOPS!).

XMLHTTPRequest without credentials to the same-origin, which redirects to a cross-origin and
then back to the same-origin with Access-Control-Allow-Origin=*, fails with error CORS policy:
"Cannot use wildcard in Access-Control-Allow-Origin when credentials flag is true."

This change fixes the problem. It allows to make a cross-origin XMLHTTPRequest without credentials to
different origin with response Access-Control-Allow-Origin=*. The specification:
https://fetch.spec.whatwg.org/#cors-protocol-and-credentials says that only if credentials mode is "include",
then `Access-Control-Allow-Origin` cannot be `*`.

Added test case which tests this case.

* LayoutTests/http/tests/xmlhttprequest/access-control-and-redirects-expected.txt:
* LayoutTests/http/tests/xmlhttprequest/access-control-and-redirects.html:
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::passesAccessControlCheck):
(WebCore::validatePreflightResponse):
* Source/WebCore/loader/CrossOriginAccessControl.h:
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::validatePreflightResponse):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::loadRequest):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::checkResponseCrossOriginAccessControl):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85244c40c1d6ce58a2b5eab19b9c1e404b59fe2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/78417 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/57463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/31799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/83078 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/29682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/80550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/66614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/5744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/61508 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/19326 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/81484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/51422 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/69119 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/41721 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/48769 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/25334 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/28019 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69865 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/25522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/84444 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/5783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/4032 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/69637 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/5944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/67424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68892 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12914 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/11275 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/5729 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/8642 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/5719 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/9152 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/7505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->