### PR TITLE
Support padding/border/margin on RenderMathMLToken

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1828,6 +1828,7 @@ imported/w3c/web-platform-tests/mathml/relations/css-styling/floats/floating-ins
 imported/w3c/web-platform-tests/mathml/relations/css-styling/mathvariant-basic-transforms-with-default-font.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/mathvariant-double-struck-font-style-font-weight.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/mi-fontstyle-fontweight.html [ ImageOnlyFailure ]
+webkit.org/b/276413 imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/width-height-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/relations/css-styling/width-height-003.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -8056,6 +8056,7 @@
         "web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-001-ref.html",
         "web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-002-ref.html",
         "web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-003-ref.html",
+        "web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004-ref.html",
         "web-platform-tests/mathml/relations/css-styling/presentational-hints-001-ref.html",
         "web-platform-tests/mathml/relations/css-styling/presentational-hints-002-ref.html",
         "web-platform-tests/mathml/relations/css-styling/transform-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Padding/border/margin on an mi with italic mathvariant (reference)</title>
+<style>
+  @font-face {
+    font-family: TestFont;
+    src: url("/fonts/math/mathvariant-italic.woff");
+  }
+  math  {
+    font-family: TestFont;
+    font-size: 300px;
+  }
+</style>
+<body>
+  <p>This test passes if you see the text <code>1d434</code> in cyan on a blue
+    background, surrounded by a 10px padding, surrounded by a 10px
+    yellow dashed border, itself surrounded by a 10px pink margin.</p>
+  <div style="background: pink; position: absolute; left: 10px; top: 4em;">
+    <math>
+      <mtext style="background: blue; border: 10px dashed yellow; padding: 10px; margin: 10px; color: cyan;">&#x1D434;</mtext>
+    </math>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Padding/border/margin on an mi with italic mathvariant (reference)</title>
+<style>
+  @font-face {
+    font-family: TestFont;
+    src: url("/fonts/math/mathvariant-italic.woff");
+  }
+  math  {
+    font-family: TestFont;
+    font-size: 300px;
+  }
+</style>
+<body>
+  <p>This test passes if you see the text <code>1d434</code> in cyan on a blue
+    background, surrounded by a 10px padding, surrounded by a 10px
+    yellow dashed border, itself surrounded by a 10px pink margin.</p>
+  <div style="background: pink; position: absolute; left: 10px; top: 4em;">
+    <math>
+      <mtext style="background: blue; border: 10px dashed yellow; padding: 10px; margin: 10px; color: cyan;">&#x1D434;</mtext>
+    </math>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Padding/border/margin on an mi with italic mathvariant</title>
+<link rel="help" href="https://w3c.github.io/mathml-core/#layout-algorithms">
+<link rel="help" href="https://w3c.github.io/mathml-core/#css-styling">
+<link rel="help" href="https://w3c.github.io/mathml-core/#the-mathvariant-attribute">
+<link rel="help" href="https://w3c.github.io/mathml-core/#new-text-transform-values">
+<link rel="help" href="https://w3c.github.io/mathml-core/#italic-mappings">
+<link rel="match" href="padding-border-margin-004-ref.html"/>
+<meta name="assert" content="Verify visual rendering of padding/border/margin on an mi with italic mathvariant.">
+<style>
+  @font-face {
+    font-family: TestFont;
+    src: url("/fonts/math/mathvariant-italic.woff");
+  }
+  math  {
+    font-family: TestFont;
+    font-size: 300px;
+  }
+</style>
+<body>
+  <p>This test passes if you see the text <code>1d434</code> in cyan on a blue
+    background, surrounded by a 10px padding, surrounded by a 10px
+    yellow dashed border, itself surrounded by a 10px pink margin.</p>
+  <div style="background: pink; position: absolute; left: 10px; top: 4em;">
+    <math>
+      <mi style="background: blue; border: 10px dashed yellow; padding: 10px; margin: 10px; color: cyan;">&#x41;</mi>
+    </math>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/w3c-import.log
@@ -30,3 +30,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-003-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-003-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-003.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/padding-border-margin-004.html


### PR DESCRIPTION
#### 7099dcb8c935e105be857d6f565c42358065a5fb
<pre>
Support padding/border/margin on RenderMathMLToken
<a href="https://bugs.webkit.org/show_bug.cgi?id=276317">https://bugs.webkit.org/show_bug.cgi?id=276317</a>

Reviewed by Rob Buis.

This patch imports the WPT reftest from [1] and implements
padding/border/margin for RenderMathMLToken when a mathVariantGlyph is
used. That improves the rendering of the test but is not enough to
make it pass [2].

[1] <a href="https://github.com/web-platform-tests/wpt/commit/8d6df04645f8106a474da0e187e132d0923adf7c">https://github.com/web-platform-tests/wpt/commit/8d6df04645f8106a474da0e187e132d0923adf7c</a>
[2] <a href="https://bugs.webkit.org/show_bug.cgi?id=276413">https://bugs.webkit.org/show_bug.cgi?id=276413</a>

Canonical link: <a href="https://commits.webkit.org/280851@main">https://commits.webkit.org/280851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0af25a22f6c243f8c10a3b608a700b1a3c5673b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8282 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46863 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5881 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27691 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7277 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7286 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53571 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63142 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54085 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49995 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54207 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12791 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1489 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32994 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34080 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35164 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33825 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->