### PR TITLE
[GStreamer][WebRTC] Incoming video track handling improvements

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2110,7 +2110,7 @@ webkit.org/b/187064 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-get
 
 webrtc/video-av1.html [ Skip ]
 
-webkit.org/b/269285 webrtc/h265.html [ Pass Timeout Failure ]
+webkit.org/b/269285 webrtc/h265.html [ Failure ]
 
 # Too slow with filtering implemented in WebKit. Should be done directly by GstWebRTC.
 webrtc/datachannel/filter-ice-candidate.html [ Skip ]

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
@@ -59,6 +59,10 @@ private:
     void stopProducingData() final;
     const RealtimeMediaSourceCapabilities& capabilities() final;
 
+    void configureAppSink(GstElement*);
+    void configureFakeVideoSink(GstElement*);
+    void handleDownstreamEvent(GstElement*, GRefPtr<GstEvent>&&);
+
     virtual void dispatchSample(GRefPtr<GstSample>&&) { }
 
     void unregisterClientLocked(int);


### PR DESCRIPTION
#### aed57210e6b345f50f0292484ad08e1d88c7415c
<pre>
[GStreamer][WebRTC] Incoming video track handling improvements
<a href="https://bugs.webkit.org/show_bug.cgi?id=276419">https://bugs.webkit.org/show_bug.cgi?id=276419</a>

Reviewed by Xabier Rodriguez-Calvar.

The h265.html test now consistently fails, due to bug #269285. Before this patch it was consistently
timing out, due to a caps negotiation issue triggered when the MediaStreamTrack was disabled. The
framerate not being set on the black video frames triggered variable framerate code paths, messing
up downstream elements.

After fixing the framerate issue, another bug surfaced, the buffers coming from the RealtimeIncoming
source had no video meta information, leading to glupload failing to handle frames and raising
errors. By using fakevideosink instead of appsink in the WebRTC pipeline for incoming video tracks
that are decoded the tee element will perform no allocation query shenanigans and the decoder will
correctly attach video metas to buffers.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp:
(WebCore::RealtimeIncomingSourceGStreamer::configureAppSink):
(WebCore::RealtimeIncomingSourceGStreamer::configureFakeVideoSink):
(WebCore::RealtimeIncomingSourceGStreamer::handleDownstreamEvent):
(WebCore::RealtimeIncomingSourceGStreamer::registerClient):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/280855@main">https://commits.webkit.org/280855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e7f6d3dea647f8b5949c60c16b01507e8b21da5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61470 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46872 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5894 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27700 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7288 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7297 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63153 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1762 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7627 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54218 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12794 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/simulcast/getStats.https.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1497 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8624 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33005 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34091 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35175 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->