### PR TITLE
Do not dispatch fetch event if its client is already cancelled

### DIFF
--- a/LayoutTests/http/wpt/service-workers/navigation-iframe-cancel.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/navigation-iframe-cancel.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Cancel frame loads with navigation preloads
+

--- a/LayoutTests/http/wpt/service-workers/navigation-iframe-cancel.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigation-iframe-cancel.https.html
@@ -1,0 +1,45 @@
+<html>
+<head>
+<title>Service Worker Fetch Event</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+async function registerServiceWorker(scope)
+{
+    var registration = await navigator.serviceWorker.register("navigation-iframe-site-worker.js", { scope : scope });
+    var activeWorker = registration.active;
+    if (!activeWorker) {
+        activeWorker = registration.installing;
+        registration = await new Promise(resolve => {
+            activeWorker.addEventListener('statechange', () => {
+                if (activeWorker.state === "activated")
+                  resolve(registration);
+            });
+        });
+    }
+    if (registration.navigationPreload)
+        await registration.navigationPreload.enable();
+    return registration;
+}
+
+promise_test(async (test) => {
+     const scope = "resources/";
+     await registerServiceWorker(scope);
+
+    let frames = [];
+    for (let i = 0; i < 20; ++i) {
+         const frame = document.createElement('iframe');
+         frame.src = "./resources/" + i;
+         document.body.appendChild(frame);
+         frames.push(frame);
+    }
+    await new Promise(resolve => setTimeout(resolve, 0));
+    for (let i = 19; i >= 0; --i) {
+         frames[i].remove();
+    }
+}, "Cancel frame loads with navigation preloads");
+</script>
+</body>
+</html>

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.h
@@ -55,11 +55,24 @@ public:
     virtual void didFail(const ResourceError&) = 0;
     virtual void didFinish(const NetworkLoadMetrics&) = 0;
     virtual void didNotHandle() = 0;
-    virtual void cancel() = 0;
     virtual void setCancelledCallback(Function<void()>&&) = 0;
     virtual void usePreload() = 0;
     virtual void contextIsStopping() = 0;
+
+    void cancel();
+    bool isCancelled() const { return m_isCancelled; }
+
+private:
+    virtual void doCancel() = 0;
+    bool m_isCancelled { false };
 };
+
+inline void Client::cancel()
+{
+    ASSERT(!m_isCancelled);
+    m_isCancelled = true;
+    doCancel();
+}
 
 void dispatchFetchEvent(Ref<Client>&&, ServiceWorkerGlobalScope&, ResourceRequest&&, String&& referrer, FetchOptions&&, SWServerConnectionIdentifier, FetchIdentifier, bool isServiceWorkerNavigationPreloadEnabled, String&& clientIdentifier, String&& resultingClientIdentifier);
 };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -142,6 +142,11 @@ void ServiceWorkerThread::queueTaskToFireFetchEvent(Ref<ServiceWorkerFetch::Clie
 {
     Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
     serviceWorkerGlobalScope->eventLoop().queueTask(TaskSource::DOMManipulation, [serviceWorkerGlobalScope, client = WTFMove(client), request = WTFMove(request), referrer = WTFMove(referrer), options = WTFMove(options), connectionIdentifier, fetchIdentifier, isServiceWorkerNavigationPreloadEnabled, clientIdentifier = WTFMove(clientIdentifier), resultingClientIdentifier = WTFMove(resultingClientIdentifier)]() mutable {
+        if (client->isCancelled()) {
+            RELEASE_LOG_INFO(ServiceWorker, "Skipping fetch event dispatching since client cancelled it");
+            return;
+        }
+
         ServiceWorkerFetch::dispatchFetchEvent(WTFMove(client), serviceWorkerGlobalScope, WTFMove(request), WTFMove(referrer), WTFMove(options), connectionIdentifier, fetchIdentifier, isServiceWorkerNavigationPreloadEnabled, WTFMove(clientIdentifier), WTFMove(resultingClientIdentifier));
     });
 }

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
@@ -242,7 +242,7 @@ void WebServiceWorkerFetchTaskClient::didNotHandleInternal()
     cleanup();
 }
 
-void WebServiceWorkerFetchTaskClient::cancel()
+void WebServiceWorkerFetchTaskClient::doCancel()
 {
     Locker lock(m_connectionLock);
 

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
@@ -58,7 +58,7 @@ private:
     void didFail(const WebCore::ResourceError&) final;
     void didFinish(const WebCore::NetworkLoadMetrics&) final;
     void didNotHandle() final;
-    void cancel() final;
+    void doCancel() final;
     void setCancelledCallback(Function<void()>&&) final;
     void usePreload() final;
     void contextIsStopping() final;


### PR DESCRIPTION
#### 5d14f119e11e9b20df828804d9c76cac7517fad8
<pre>
Do not dispatch fetch event if its client is already cancelled
<a href="https://bugs.webkit.org/show_bug.cgi?id=276417">https://bugs.webkit.org/show_bug.cgi?id=276417</a>
<a href="https://rdar.apple.com/131072280">rdar://131072280</a>

Reviewed by Chris Dumez.

We are adding a fetch task and cancelling it when receiving IPC messages.
We are then queuing a task on the event loop to dispatch the fetch event.
If the cancel message happens before the dispatch of the fetch event, we are no longer dispatching the event since it is unnecessary.
To do so, we update the ServiceWorkerFetch::Client class to add a isCancelled getter and use it before dispatching the event.

* LayoutTests/http/wpt/service-workers/navigation-iframe-cancel.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/navigation-iframe-cancel.https.html: Added.
* Source/WebCore/workers/service/context/ServiceWorkerFetch.h:
(WebCore::ServiceWorkerFetch::Client::isCancelled const):
(WebCore::ServiceWorkerFetch::Client::cancel):
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::queueTaskToFireFetchEvent):
* Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp:
(WebKit::WebServiceWorkerFetchTaskClient::doCancel):
(WebKit::WebServiceWorkerFetchTaskClient::cancel): Deleted.
* Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h:

Canonical link: <a href="https://commits.webkit.org/280819@main">https://commits.webkit.org/280819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32668d5c39d1922d9b960e39029ce85ec7c63154

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8180 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46778 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5800 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27603 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7181 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7184 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63039 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1649 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7525 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53998 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49900 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54115 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1395 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32892 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33978 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35062 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->