### PR TITLE
Remove `other` from 'SFrameTransformErrorEventType' interface as per web specification

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -116,8 +116,6 @@ static RTCRtpSFrameTransformErrorEvent::Type errorTypeFromInformation(const RTCR
         return RTCRtpSFrameTransformErrorEvent::Type::Authentication;
     case RTCRtpSFrameTransformer::Error::Syntax:
         return RTCRtpSFrameTransformErrorEvent::Type::Syntax;
-    case RTCRtpSFrameTransformer::Error::Other:
-        return RTCRtpSFrameTransformErrorEvent::Type::Other;
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,7 +36,7 @@ class RTCRtpSFrameTransformErrorEvent final : public Event {
 public:
     virtual ~RTCRtpSFrameTransformErrorEvent();
 
-    enum Type { Authentication, KeyID, Other, Syntax };
+    enum Type { Authentication, KeyID, Syntax };
 
     struct Init : EventInit {
         Type errorType;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,16 +23,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-encoded-transform/#enumdef-sframetransformerroreventtype
+
 enum RTCRtpSFrameTransformErrorEventType {
     "authentication",
     "keyID",
-    "other",
     "syntax"
 };
+
+// https://w3c.github.io/webrtc-encoded-transform/#dictdef-sframetransformerroreventinit
 
 dictionary RTCRtpSFrameTransformErrorEventInit : EventInit {
     required RTCRtpSFrameTransformErrorEventType errorType;
 };
+
+// https://w3c.github.io/webrtc-encoded-transform/#sframetransformerrorevent
 
 [
     Conditional=WEB_RTC,


### PR DESCRIPTION
#### 2124f58f2daec34666ef4d615789384f47576c90
<pre>
Remove `other` from &apos;SFrameTransformErrorEventType&apos; interface as per web specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=276297">https://bugs.webkit.org/show_bug.cgi?id=276297</a>

Reviewed by Brent Fulgham.

This patch aligns WebKit with Web Specification [1]:

[1] <a href="https://w3c.github.io/webrtc-encoded-transform/#enumdef-sframetransformerroreventtype">https://w3c.github.io/webrtc-encoded-transform/#enumdef-sframetransformerroreventtype</a>

As per web specification, the &apos;SFrameTransformErrorEventType&apos; enum
does not have &apos;other&apos;, so this patch removes it.

* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
(WebCore::errorTypeFromInformation):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.idl:

Canonical link: <a href="https://commits.webkit.org/280880@main">https://commits.webkit.org/280880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53954cdd61d4ea3f6ccf040806536552d9b71870

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61351 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8174 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46773 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5794 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27598 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7175 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7178 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63033 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53994 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54111 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12810 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1390 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32886 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33972 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->