### PR TITLE
[WPE] WPE Platform: fix handling of view to send touch events under wayland

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
@@ -230,6 +230,7 @@ struct _WPEToplevelWaylandPrivate {
 
     bool hasPointer;
     bool isFocused;
+    bool isUnderTouch;
     GWeakPtr<WPEView> visibleView;
 
     Vector<GRefPtr<WPEMonitor>, 1> monitors;
@@ -812,6 +813,20 @@ WPEView* wpeToplevelWaylandGetVisibleFocusedView(WPEToplevelWayland* toplevel)
 {
     auto* priv = toplevel->priv;
     return priv->isFocused ? toplevel->priv->visibleView.get() : nullptr;
+}
+
+void wpeToplevelWaylandSetIsUnderTouch(WPEToplevelWayland* toplevel, bool isUnderTouch)
+{
+    auto* priv = toplevel->priv;
+    priv->isUnderTouch = isUnderTouch;
+    if (isUnderTouch && !priv->visibleView)
+        priv->visibleView.reset(wpeToplevelWaylandFindVisibleView(toplevel));
+}
+
+WPEView* wpeToplevelWaylandGetVisibleViewUnderTouch(WPEToplevelWayland* toplevel)
+{
+    auto* priv = toplevel->priv;
+    return priv->isUnderTouch ? toplevel->priv->visibleView.get() : nullptr;
 }
 
 void wpeToplevelWaylandViewVisibilityChanged(WPEToplevelWayland* toplevel, WPEView* view)

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWaylandPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWaylandPrivate.h
@@ -33,4 +33,6 @@ void wpeToplevelWaylandSetHasPointer(WPEToplevelWayland*, bool);
 WPEView* wpeToplevelWaylandGetVisibleViewUnderPointer(WPEToplevelWayland*);
 void wpeToplevelWaylandSetIsFocused(WPEToplevelWayland*, bool);
 WPEView* wpeToplevelWaylandGetVisibleFocusedView(WPEToplevelWayland*);
+void wpeToplevelWaylandSetIsUnderTouch(WPEToplevelWayland*, bool);
+WPEView* wpeToplevelWaylandGetVisibleViewUnderTouch(WPEToplevelWayland*);
 void wpeToplevelWaylandViewVisibilityChanged(WPEToplevelWayland*, WPEView*);


### PR DESCRIPTION
#### 2931ba164f1ce2d8f9b0ddc448df90ad17222a68
<pre>
[WPE] WPE Platform: fix handling of view to send touch events under wayland
<a href="https://bugs.webkit.org/show_bug.cgi?id=276423">https://bugs.webkit.org/show_bug.cgi?id=276423</a>

Reviewed by Alejandro G. Castro.

Touch events are only sent to the right WPEView if the current toplevel
has the keyboard focus. We need to track the toplevel currently under
touch the same way we do for pointer and keyboard events.

* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp:
(wpeToplevelWaylandSetIsUnderTouch):
(wpeToplevelWaylandGetVisibleViewUnderTouch):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWaylandPrivate.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp:

Canonical link: <a href="https://commits.webkit.org/280814@main">https://commits.webkit.org/280814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2b1f1ec9167508b4ce587b5a38d6005a87542eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61353 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8176 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8364 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5796 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27600 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31525 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7180 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63035 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1645 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7521 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53995 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49896 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/54112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1391 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8603 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32888 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33974 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35058 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->