### PR TITLE
Lower B3 Div/Mod variants to C calls on ARMv7

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -85,6 +85,15 @@ public:
     }
     
 private:
+    template <class Fn>
+    void replaceWithBinaryCall(Fn &&function)
+    {
+        Value* functionAddress = m_insertionSet.insert<ConstPtrValue>(m_index, m_origin, tagCFunction<OperationPtrTag>(function));
+        Value* result = m_insertionSet.insert<CCallValue>(m_index, m_value->type(), m_origin, Effects::none(), functionAddress, m_value->child(0), m_value->child(1));
+        m_value->replaceWithIdentity(result);
+        m_changed = true;
+    }
+
     void processCurrentBlock()
     {
         for (m_index = 0; m_index < m_block->size(); ++m_index) {
@@ -148,6 +157,11 @@ private:
                     Value* result = m_insertionSet.insert<Value>(m_index, DoubleToFloat, m_origin, doubleMod);
                     m_value->replaceWithIdentity(result);
                     m_changed = true;
+                } else if constexpr (isARM_THUMB2()) {
+                    if (m_value->type() == Int64)
+                        replaceWithBinaryCall(Math::i64_rem_s);
+                    else
+                        replaceWithBinaryCall(Math::i32_rem_s);
                 } else if (isARM64()) {
                     Value* divResult = m_insertionSet.insert<Value>(m_index, chill(Div), m_origin, m_value->child(0), m_value->child(1));
                     Value* multipliedBack = m_insertionSet.insert<Value>(m_index, Mul, m_origin, divResult, m_value->child(1));
@@ -159,6 +173,13 @@ private:
             }
 
             case UMod: {
+                if constexpr (isARM_THUMB2()) {
+                    if (m_value->child(0)->type() == Int64)
+                        replaceWithBinaryCall(Math::i64_rem_u);
+                    else
+                        replaceWithBinaryCall(Math::i32_rem_u);
+                    break;
+                }
                 if (isARM64()) {
                     Value* divResult = m_insertionSet.insert<Value>(m_index, UDiv, m_origin, m_value->child(0), m_value->child(1));
                     Value* multipliedBack = m_insertionSet.insert<Value>(m_index, Mul, m_origin, divResult, m_value->child(1));
@@ -169,6 +190,15 @@ private:
                 break;
             }
 
+            case UDiv: {
+                if constexpr (!isARM_THUMB2())
+                    break;
+                if (m_value->type() == Int64)
+                    replaceWithBinaryCall(Math::i64_div_u);
+                else
+                    replaceWithBinaryCall(Math::i32_div_u);
+                break;
+            }
             case FMax:
             case FMin: {
                 if (isX86()) {
@@ -237,6 +267,15 @@ private:
             case Div: {
                 if (m_value->isChill())
                     makeDivisionChill(Div);
+                else if (isARM_THUMB2()) {
+                    BasicBlock* before = m_blockInsertionSet.splitForward(m_block, m_index);
+                    before->replaceLastWithNew<Value>(m_proc, Nop, m_origin);
+                    Value* result = callDivModHelper(before, Div, m_value->child(0), m_value->child(1));
+                    before->appendNew<Value>(m_proc, Jump, m_origin);
+                    before->setSuccessors(FrequentedBlock(m_block));
+                    m_value->replaceWithIdentity(result);
+                    m_changed = true;
+                }
                 break;
             }
 
@@ -537,6 +576,24 @@ private:
         m_changed = true;
     }
 
+    Value* callDivModHelper(BasicBlock *block, Opcode nonChillOpcode, Value* num, Value* den)
+    {
+        Type type = num->type();
+        Value* functionAddress;
+        if (nonChillOpcode == Div) {
+            if (m_value->type() == Int64)
+                functionAddress = block->appendNew<ConstPtrValue>(m_proc, m_origin, tagCFunction<OperationPtrTag>(Math::i64_div_s));
+            else
+                functionAddress = block->appendNew<ConstPtrValue>(m_proc, m_origin, tagCFunction<OperationPtrTag>(Math::i32_div_s));
+        } else {
+            if (m_value->type() == Int64)
+                functionAddress = block->appendNew<ConstPtrValue>(m_proc, m_origin, tagCFunction<OperationPtrTag>(Math::i64_rem_s));
+            else
+                functionAddress = block->appendNew<ConstPtrValue>(m_proc, m_origin, tagCFunction<OperationPtrTag>(Math::i32_rem_s));
+        }
+        return block->appendNew<CCallValue>(m_proc, type, m_origin, Effects::none(), functionAddress, num, den);
+    }
+
     void makeDivisionChill(Opcode nonChillOpcode)
     {
         ASSERT(nonChillOpcode == Div || nonChillOpcode == Mod);
@@ -583,9 +640,14 @@ private:
             FrequentedBlock(normalDivCase, FrequencyClass::Normal),
             FrequentedBlock(shadyDenCase, FrequencyClass::Rare));
 
+        Value* innerResult;
+        if constexpr (isARM_THUMB2())
+            innerResult = callDivModHelper(normalDivCase, nonChillOpcode, num, den);
+        else
+            innerResult = normalDivCase->appendNew<Value>(m_proc, nonChillOpcode, m_origin, num, den);
         UpsilonValue* normalResult = normalDivCase->appendNew<UpsilonValue>(
             m_proc, m_origin,
-            normalDivCase->appendNew<Value>(m_proc, nonChillOpcode, m_origin, num, den));
+            innerResult);
         normalDivCase->appendNew<Value>(m_proc, Jump, m_origin);
         normalDivCase->setSuccessors(FrequentedBlock(m_block));
 


### PR DESCRIPTION
#### 593256e8937fe2529229c9aaea610cf7ded4fddb
<pre>
Lower B3 Div/Mod variants to C calls on ARMv7
<a href="https://bugs.webkit.org/show_bug.cgi?id=276424">https://bugs.webkit.org/show_bug.cgi?id=276424</a>

Reviewed by Yusuke Suzuki.

Lower Div/Mod/UDiv/UMod to C helpers. This is always a good idea for
Int64 arguments; for Int32, we do the same, but could switch to using
ARM instructions. We&apos;d need to add machinery to specify that they&apos;re
available though.

* Source/JavaScriptCore/b3/B3LowerMacros.cpp:

Canonical link: <a href="https://commits.webkit.org/281005@main">https://commits.webkit.org/281005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/168087906966a6d81488e61dd66db09301111f3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8771 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8966 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47253 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6264 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28094 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7730 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7775 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51418 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53999 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63656 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57569 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54570 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54635 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12892 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1911 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79329 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33483 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13193 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34569 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35653 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->