### PR TITLE
MathML <mroot>: clamp RadicalKernBefore/AfterDegree

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/radicals/root-parameters-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/radicals/root-parameters-2-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL RadicalKernBeforeDegree = -1em < 0 assert_approx_equals: should be clamped to 0 expected 0 +/- 1 but got -10
-FAIL RadicalKernBeforeAfterDegree = -5em < -3em = -degree's inline size assert_approx_equals: should be clamped to 3em expected 30 +/- 1 but got 50
+PASS RadicalKernBeforeDegree = -1em < 0
+PASS RadicalKernBeforeAfterDegree = -5em < -3em = -degree's inline size
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout-expected.txt
@@ -76,9 +76,9 @@ PASS mphantom layout is not affected by children with "position: fixed" style
 PASS mroot preferred width calculation is not affected by children with "display: none" style
 PASS mroot layout is not affected by children with "display: none" style
 PASS mroot preferred width calculation is not affected by children with "position: absolute" style
-FAIL mroot layout is not affected by children with "position: absolute" style assert_approx_equals: inline size expected 8.375 +/- 1 but got 0
+FAIL mroot layout is not affected by children with "position: absolute" style assert_approx_equals: inline size expected 13.734375 +/- 1 but got 0
 PASS mroot preferred width calculation is not affected by children with "position: fixed" style
-FAIL mroot layout is not affected by children with "position: fixed" style assert_approx_equals: inline size expected 8.375 +/- 1 but got 0
+FAIL mroot layout is not affected by children with "position: fixed" style assert_approx_equals: inline size expected 13.734375 +/- 1 but got 0
 PASS mrow preferred width calculation is not affected by children with "display: none" style
 PASS mrow layout is not affected by children with "display: none" style
 PASS mrow preferred width calculation is not affected by children with "display: contents" style

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/width-height-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/width-height-001-expected.txt
@@ -21,8 +21,8 @@ FAIL width and height properties on mpadded assert_approx_equals: width expected
 FAIL inline-size and block-size properties on mpadded assert_approx_equals: width expected 600 +/- 1 but got 0
 FAIL width and height properties on mphantom assert_approx_equals: width expected 500 +/- 1 but got 0
 FAIL inline-size and block-size properties on mphantom assert_approx_equals: width expected 600 +/- 1 but got 0
-FAIL width and height properties on mroot assert_approx_equals: width expected 500 +/- 1 but got 8.375
-FAIL inline-size and block-size properties on mroot assert_approx_equals: width expected 600 +/- 1 but got 8.375
+FAIL width and height properties on mroot assert_approx_equals: width expected 500 +/- 1 but got 13.734375
+FAIL inline-size and block-size properties on mroot assert_approx_equals: width expected 600 +/- 1 but got 13.734375
 FAIL width and height properties on mrow assert_approx_equals: width expected 500 +/- 1 but got 0
 FAIL inline-size and block-size properties on mrow assert_approx_equals: width expected 600 +/- 1 but got 0
 PASS width and height properties on ms

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/width-height-001-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/width-height-001-expected.txt
@@ -21,8 +21,8 @@ FAIL width and height properties on mpadded assert_approx_equals: width expected
 FAIL inline-size and block-size properties on mpadded assert_approx_equals: width expected 600 +/- 1 but got 0
 FAIL width and height properties on mphantom assert_approx_equals: width expected 500 +/- 1 but got 0
 FAIL inline-size and block-size properties on mphantom assert_approx_equals: width expected 600 +/- 1 but got 0
-FAIL width and height properties on mroot assert_approx_equals: width expected 500 +/- 1 but got 8.546875
-FAIL inline-size and block-size properties on mroot assert_approx_equals: width expected 600 +/- 1 but got 8.546875
+FAIL width and height properties on mroot assert_approx_equals: width expected 500 +/- 1 but got 17.4375
+FAIL inline-size and block-size properties on mroot assert_approx_equals: width expected 600 +/- 1 but got 17.4375
 FAIL width and height properties on mrow assert_approx_equals: width expected 500 +/- 1 but got 0
 FAIL inline-size and block-size properties on mrow assert_approx_equals: width expected 600 +/- 1 but got 0
 PASS width and height properties on ms

--- a/LayoutTests/platform/glib/mathml/presentation/roots-expected.txt
+++ b/LayoutTests/platform/glib/mathml/presentation/roots-expected.txt
@@ -87,9 +87,9 @@ layer at (0,0) size 800x546
       RenderBlock {p} at (0,152) size 784x20
         RenderText {#text} at (0,0) size 173x17
           text run at (0,0) width 173: "cube root (should be blue): "
-        RenderMathMLMath {math} at (173,1) size 22x18 [color=#0000FF]
-          RenderMathMLRoot {mroot} at (0,0) size 22x18
-            RenderMathMLToken {mn} at (13,2) size 9x12
+        RenderMathMLMath {math} at (173,1) size 26x18 [color=#0000FF]
+          RenderMathMLRoot {mroot} at (0,0) size 26x18
+            RenderMathMLToken {mn} at (17,2) size 9x12
               RenderBlock (anonymous) at (0,0) size 8x11
                 RenderText {#text} at (0,-46) size 8x106
                   text run at (0,-46) width 8: "2"
@@ -285,9 +285,9 @@ layer at (0,0) size 800x546
       RenderBlock {p} at (0,384) size 784x58
         RenderText {#text} at (0,21) size 110x17
           text run at (0,21) width 110: "Imbricated roots: "
-        RenderMathMLMath {math} at (110,0) size 353x57
-          RenderMathMLRoot {mroot} at (0,0) size 353x57
-            RenderMathMLRow {mrow} at (17,2) size 336x55
+        RenderMathMLMath {math} at (110,0) size 380x57
+          RenderMathMLRoot {mroot} at (0,0) size 380x57
+            RenderMathMLRow {mrow} at (21,2) size 359x55
               RenderMathMLToken {mn} at (0,22) size 8x11
                 RenderBlock (anonymous) at (0,0) size 8x11
                   RenderText {#text} at (0,-46) size 8x106
@@ -296,8 +296,8 @@ layer at (0,0) size 800x546
                 RenderBlock (anonymous) at (3,0) size 13x12
                   RenderText {#text} at (0,-47) size 12x106
                     text run at (0,-47) width 12: "+"
-              RenderMathMLRoot {mroot} at (27,0) size 308x55
-                RenderMathMLRow {mrow} at (17,2) size 291x53
+              RenderMathMLRoot {mroot} at (27,0) size 331x55
+                RenderMathMLRow {mrow} at (21,2) size 310x53
                   RenderMathMLToken {mn} at (0,20) size 8x11
                     RenderBlock (anonymous) at (0,0) size 8x11
                       RenderText {#text} at (0,-46) size 8x106
@@ -306,8 +306,8 @@ layer at (0,0) size 800x546
                     RenderBlock (anonymous) at (3,0) size 13x12
                       RenderText {#text} at (0,-47) size 12x106
                         text run at (0,-47) width 12: "+"
-                  RenderMathMLRoot {mroot} at (27,0) size 263x53
-                    RenderMathMLRow {mrow} at (17,2) size 246x51
+                  RenderMathMLRoot {mroot} at (27,0) size 283x53
+                    RenderMathMLRow {mrow} at (21,2) size 262x51
                       RenderMathMLToken {mn} at (0,18) size 8x12
                         RenderBlock (anonymous) at (0,0) size 8x12
                           RenderText {#text} at (0,-46) size 8x106
@@ -316,8 +316,8 @@ layer at (0,0) size 800x546
                         RenderBlock (anonymous) at (3,0) size 13x12
                           RenderText {#text} at (0,-47) size 12x106
                             text run at (0,-47) width 12: "+"
-                      RenderMathMLRoot {mroot} at (27,0) size 219x51
-                        RenderMathMLRow {mrow} at (17,2) size 202x49
+                      RenderMathMLRoot {mroot} at (27,0) size 234x51
+                        RenderMathMLRow {mrow} at (21,2) size 213x49
                           RenderMathMLToken {mn} at (0,16) size 8x11
                             RenderBlock (anonymous) at (0,0) size 8x11
                               RenderText {#text} at (0,-46) size 8x106
@@ -326,8 +326,8 @@ layer at (0,0) size 800x546
                             RenderBlock (anonymous) at (3,0) size 13x12
                               RenderText {#text} at (0,-47) size 12x106
                                 text run at (0,-47) width 12: "+"
-                          RenderMathMLRoot {mroot} at (27,0) size 174x49
-                            RenderMathMLRow {mrow} at (16,2) size 158x41
+                          RenderMathMLRoot {mroot} at (27,0) size 186x49
+                            RenderMathMLRow {mrow} at (20,2) size 166x41
                               RenderMathMLToken {mn} at (0,14) size 8x12
                                 RenderBlock (anonymous) at (0,0) size 8x12
                                   RenderText {#text} at (0,-46) size 8x106
@@ -336,8 +336,8 @@ layer at (0,0) size 800x546
                                 RenderBlock (anonymous) at (3,0) size 13x12
                                   RenderText {#text} at (0,-47) size 12x106
                                     text run at (0,-47) width 12: "+"
-                              RenderMathMLRoot {mroot} at (27,0) size 130x41
-                                RenderMathMLRow {mrow} at (16,2) size 114x31
+                              RenderMathMLRoot {mroot} at (27,0) size 138x41
+                                RenderMathMLRow {mrow} at (20,2) size 118x31
                                   RenderMathMLToken {mn} at (0,12) size 8x12
                                     RenderBlock (anonymous) at (0,0) size 8x12
                                       RenderText {#text} at (0,-46) size 8x106
@@ -346,8 +346,8 @@ layer at (0,0) size 800x546
                                     RenderBlock (anonymous) at (3,0) size 13x12
                                       RenderText {#text} at (0,-47) size 12x106
                                         text run at (0,-47) width 12: "+"
-                                  RenderMathMLRoot {mroot} at (27,0) size 87x31
-                                    RenderMathMLRow {mrow} at (16,2) size 71x26
+                                  RenderMathMLRoot {mroot} at (27,0) size 91x31
+                                    RenderMathMLRow {mrow} at (20,2) size 71x26
                                       RenderMathMLToken {mn} at (0,10) size 8x12
                                         RenderBlock (anonymous) at (0,0) size 8x12
                                           RenderText {#text} at (0,-46) size 8x106
@@ -411,68 +411,68 @@ layer at (0,0) size 800x546
       RenderBlock {p} at (0,457) size 784x58
         RenderText {#text} at (0,21) size 73x17
           text run at (0,21) width 73: "RTL roots: "
-        RenderMathMLMath {math} at (72,0) size 353x57
-          RenderMathMLRoot {mroot} at (0,0) size 353x57
-            RenderMathMLRow {mrow} at (0,2) size 335x55
-              RenderMathMLToken {mn} at (326,22) size 9x11
+        RenderMathMLMath {math} at (72,0) size 380x57
+          RenderMathMLRoot {mroot} at (0,0) size 380x57
+            RenderMathMLRow {mrow} at (0,2) size 358x55
+              RenderMathMLToken {mn} at (349,22) size 9x11
                 RenderBlock (anonymous) at (0,0) size 8x11
                   RenderText {#text} at (0,-46) size 8x106
                     text run at (0,-46) width 8: "1"
-              RenderMathMLOperator {mo} at (307,23) size 20x12
+              RenderMathMLOperator {mo} at (330,23) size 20x12
                 RenderBlock (anonymous) at (3,0) size 13x12
                   RenderText {#text} at (0,-47) size 12x106
                     text run at (0,-47) width 12 RTL: "+"
-              RenderMathMLRoot {mroot} at (0,0) size 308x55
-                RenderMathMLRow {mrow} at (0,2) size 290x53
-                  RenderMathMLToken {mn} at (281,20) size 9x11
+              RenderMathMLRoot {mroot} at (0,0) size 331x55
+                RenderMathMLRow {mrow} at (0,2) size 310x53
+                  RenderMathMLToken {mn} at (301,20) size 9x11
                     RenderBlock (anonymous) at (0,0) size 8x11
                       RenderText {#text} at (0,-46) size 8x106
                         text run at (0,-46) width 8: "2"
-                  RenderMathMLOperator {mo} at (262,21) size 20x12
+                  RenderMathMLOperator {mo} at (282,21) size 20x12
                     RenderBlock (anonymous) at (3,0) size 13x12
                       RenderText {#text} at (0,-47) size 12x106
                         text run at (0,-47) width 12 RTL: "+"
-                  RenderMathMLRoot {mroot} at (0,0) size 263x53
-                    RenderMathMLRow {mrow} at (0,2) size 246x51
-                      RenderMathMLToken {mn} at (237,18) size 9x12
+                  RenderMathMLRoot {mroot} at (0,0) size 283x53
+                    RenderMathMLRow {mrow} at (0,2) size 261x51
+                      RenderMathMLToken {mn} at (252,18) size 9x12
                         RenderBlock (anonymous) at (0,0) size 8x12
                           RenderText {#text} at (0,-46) size 8x106
                             text run at (0,-46) width 8: "3"
-                      RenderMathMLOperator {mo} at (218,19) size 20x12
+                      RenderMathMLOperator {mo} at (233,19) size 20x12
                         RenderBlock (anonymous) at (3,0) size 13x12
                           RenderText {#text} at (0,-47) size 12x106
                             text run at (0,-47) width 12 RTL: "+"
-                      RenderMathMLRoot {mroot} at (0,0) size 219x51
-                        RenderMathMLRow {mrow} at (0,2) size 201x49
-                          RenderMathMLToken {mn} at (192,16) size 9x11
+                      RenderMathMLRoot {mroot} at (0,0) size 234x51
+                        RenderMathMLRow {mrow} at (0,2) size 213x49
+                          RenderMathMLToken {mn} at (204,16) size 9x11
                             RenderBlock (anonymous) at (0,0) size 8x11
                               RenderText {#text} at (0,-46) size 8x106
                                 text run at (0,-46) width 8: "4"
-                          RenderMathMLOperator {mo} at (173,17) size 20x12
+                          RenderMathMLOperator {mo} at (185,17) size 20x12
                             RenderBlock (anonymous) at (3,0) size 13x12
                               RenderText {#text} at (0,-47) size 12x106
                                 text run at (0,-47) width 12 RTL: "+"
-                          RenderMathMLRoot {mroot} at (0,0) size 174x49
-                            RenderMathMLRow {mrow} at (0,2) size 157x41
-                              RenderMathMLToken {mn} at (148,14) size 9x12
+                          RenderMathMLRoot {mroot} at (0,0) size 186x49
+                            RenderMathMLRow {mrow} at (0,2) size 165x41
+                              RenderMathMLToken {mn} at (156,14) size 9x12
                                 RenderBlock (anonymous) at (0,0) size 8x12
                                   RenderText {#text} at (0,-46) size 8x106
                                     text run at (0,-46) width 8: "5"
-                              RenderMathMLOperator {mo} at (129,15) size 20x12
+                              RenderMathMLOperator {mo} at (137,15) size 20x12
                                 RenderBlock (anonymous) at (3,0) size 13x12
                                   RenderText {#text} at (0,-47) size 12x106
                                     text run at (0,-47) width 12 RTL: "+"
-                              RenderMathMLRoot {mroot} at (0,0) size 130x41
-                                RenderMathMLRow {mrow} at (0,2) size 114x31
-                                  RenderMathMLToken {mn} at (105,12) size 9x12
+                              RenderMathMLRoot {mroot} at (0,0) size 138x41
+                                RenderMathMLRow {mrow} at (0,2) size 118x31
+                                  RenderMathMLToken {mn} at (109,12) size 9x12
                                     RenderBlock (anonymous) at (0,0) size 8x12
                                       RenderText {#text} at (0,-46) size 8x106
                                         text run at (0,-46) width 8: "6"
-                                  RenderMathMLOperator {mo} at (86,13) size 20x12
+                                  RenderMathMLOperator {mo} at (90,13) size 20x12
                                     RenderBlock (anonymous) at (3,0) size 13x12
                                       RenderText {#text} at (0,-47) size 12x106
                                         text run at (0,-47) width 12 RTL: "+"
-                                  RenderMathMLRoot {mroot} at (0,0) size 87x31
+                                  RenderMathMLRoot {mroot} at (0,0) size 91x31
                                     RenderMathMLRow {mrow} at (0,2) size 70x26
                                       RenderMathMLToken {mn} at (61,10) size 9x12
                                         RenderBlock (anonymous) at (0,0) size 8x12
@@ -505,31 +505,31 @@ layer at (0,0) size 800x546
                                             RenderBlock (anonymous) at (0,0) size 4x4
                                               RenderText {#text} at (0,-28) size 4x60
                                                 text run at (0,-28) width 4: "z"
-                                    RenderMathMLToken {mn} at (76,5) size 6x8
+                                    RenderMathMLToken {mn} at (80,5) size 6x8
                                       RenderBlock (anonymous) at (0,0) size 5x7
                                         RenderText {#text} at (0,-26) size 5x60
                                           text run at (0,-26) width 5: "9"
-                                RenderMathMLToken {mn} at (120,9) size 6x8
+                                RenderMathMLToken {mn} at (128,9) size 6x8
                                   RenderBlock (anonymous) at (0,0) size 5x7
                                     RenderText {#text} at (0,-26) size 5x60
                                       text run at (0,-26) width 5: "8"
-                            RenderMathMLToken {mn} at (164,11) size 6x9
+                            RenderMathMLToken {mn} at (175,11) size 6x9
                               RenderBlock (anonymous) at (0,0) size 5x8
                                 RenderText {#text} at (0,-25) size 5x60
                                   text run at (0,-25) width 5: "7"
-                        RenderMathMLToken {mn} at (208,13) size 6x8
+                        RenderMathMLToken {mn} at (224,13) size 6x8
                           RenderBlock (anonymous) at (0,0) size 5x7
                             RenderText {#text} at (0,-26) size 5x60
                               text run at (0,-26) width 5: "6"
-                    RenderMathMLToken {mn} at (253,14) size 6x8
+                    RenderMathMLToken {mn} at (272,14) size 6x8
                       RenderBlock (anonymous) at (0,0) size 5x7
                         RenderText {#text} at (0,-26) size 5x60
                           text run at (0,-26) width 5: "5"
-                RenderMathMLToken {mn} at (297,15) size 6x8
+                RenderMathMLToken {mn} at (321,15) size 6x8
                   RenderBlock (anonymous) at (0,0) size 5x7
                     RenderText {#text} at (0,-25) size 5x60
                       text run at (0,-25) width 5: "4"
-            RenderMathMLToken {mn} at (342,16) size 6x8
+            RenderMathMLToken {mn} at (369,16) size 6x8
               RenderBlock (anonymous) at (0,0) size 5x7
                 RenderText {#text} at (0,-26) size 5x60
                   text run at (0,-26) width 5: "3"

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout-expected.txt
@@ -76,9 +76,9 @@ PASS mphantom layout is not affected by children with "position: fixed" style
 PASS mroot preferred width calculation is not affected by children with "display: none" style
 PASS mroot layout is not affected by children with "display: none" style
 PASS mroot preferred width calculation is not affected by children with "position: absolute" style
-FAIL mroot layout is not affected by children with "position: absolute" style assert_approx_equals: inline size expected 8.546875 +/- 1 but got 0
+FAIL mroot layout is not affected by children with "position: absolute" style assert_approx_equals: inline size expected 17.4375 +/- 1 but got 0
 PASS mroot preferred width calculation is not affected by children with "position: fixed" style
-FAIL mroot layout is not affected by children with "position: fixed" style assert_approx_equals: inline size expected 8.546875 +/- 1 but got 0
+FAIL mroot layout is not affected by children with "position: fixed" style assert_approx_equals: inline size expected 17.4375 +/- 1 but got 0
 PASS mrow preferred width calculation is not affected by children with "display: none" style
 PASS mrow layout is not affected by children with "display: none" style
 PASS mrow preferred width calculation is not affected by children with "display: contents" style

--- a/LayoutTests/platform/ios/mathml/presentation/roots-expected.txt
+++ b/LayoutTests/platform/ios/mathml/presentation/roots-expected.txt
@@ -87,9 +87,9 @@ layer at (0,0) size 800x604
       RenderBlock {p} at (0,166) size 784x21
         RenderText {#text} at (0,0) size 177x19
           text run at (0,0) width 177: "cube root (should be blue): "
-        RenderMathMLMath {math} at (176,0) size 22x21 [color=#0000FF]
-          RenderMathMLRoot {mroot} at (0,0) size 21x21
-            RenderMathMLToken {mn} at (12,3) size 9x12
+        RenderMathMLMath {math} at (176,0) size 23x21 [color=#0000FF]
+          RenderMathMLRoot {mroot} at (0,0) size 22x21
+            RenderMathMLToken {mn} at (13,3) size 9x12
               RenderBlock (anonymous) at (0,0) size 8x11
                 RenderText {#text} at (0,-2) size 8x17
                   text run at (0,-2) width 8: "2"
@@ -285,9 +285,9 @@ layer at (0,0) size 800x604
       RenderBlock {p} at (0,424) size 784x67
         RenderText {#text} at (0,35) size 114x19
           text run at (0,35) width 114: "Imbricated roots: "
-        RenderMathMLMath {math} at (113,0) size 364x66
-          RenderMathMLRoot {mroot} at (0,0) size 363x66
-            RenderMathMLRow {mrow} at (19,3) size 344x63
+        RenderMathMLMath {math} at (113,0) size 370x66
+          RenderMathMLRoot {mroot} at (0,0) size 369x66
+            RenderMathMLRow {mrow} at (20,3) size 349x63
               RenderMathMLToken {mn} at (0,35) size 8x11
                 RenderBlock (anonymous) at (0,0) size 8x11
                   RenderText {#text} at (0,-2) size 8x17
@@ -296,8 +296,8 @@ layer at (0,0) size 800x604
                 RenderBlock (anonymous) at (3,0) size 13x10
                   RenderText {#text} at (0,-4) size 12x17
                     text run at (0,-4) width 12: "+"
-              RenderMathMLRoot {mroot} at (26,0) size 318x63
-                RenderMathMLRow {mrow} at (19,3) size 298x60
+              RenderMathMLRoot {mroot} at (26,0) size 323x63
+                RenderMathMLRow {mrow} at (20,3) size 302x60
                   RenderMathMLToken {mn} at (0,31) size 8x11
                     RenderBlock (anonymous) at (0,0) size 8x11
                       RenderText {#text} at (0,-2) size 8x17
@@ -306,8 +306,8 @@ layer at (0,0) size 800x604
                     RenderBlock (anonymous) at (3,0) size 13x10
                       RenderText {#text} at (0,-4) size 12x17
                         text run at (0,-4) width 12: "+"
-                  RenderMathMLRoot {mroot} at (26,0) size 272x59
-                    RenderMathMLRow {mrow} at (19,3) size 252x56
+                  RenderMathMLRoot {mroot} at (26,0) size 276x59
+                    RenderMathMLRow {mrow} at (20,3) size 255x56
                       RenderMathMLToken {mn} at (0,27) size 8x12
                         RenderBlock (anonymous) at (0,0) size 8x12
                           RenderText {#text} at (0,-2) size 8x17
@@ -316,8 +316,8 @@ layer at (0,0) size 800x604
                         RenderBlock (anonymous) at (3,0) size 13x10
                           RenderText {#text} at (0,-4) size 12x17
                             text run at (0,-4) width 12: "+"
-                      RenderMathMLRoot {mroot} at (26,0) size 225x55
-                        RenderMathMLRow {mrow} at (19,3) size 206x52
+                      RenderMathMLRoot {mroot} at (26,0) size 229x55
+                        RenderMathMLRow {mrow} at (20,3) size 208x52
                           RenderMathMLToken {mn} at (0,23) size 8x11
                             RenderBlock (anonymous) at (0,0) size 8x11
                               RenderText {#text} at (0,-2) size 8x17
@@ -326,8 +326,8 @@ layer at (0,0) size 800x604
                             RenderBlock (anonymous) at (3,0) size 13x10
                               RenderText {#text} at (0,-4) size 12x17
                                 text run at (0,-4) width 12: "+"
-                          RenderMathMLRoot {mroot} at (26,0) size 179x52
-                            RenderMathMLRow {mrow} at (19,3) size 160x49
+                          RenderMathMLRoot {mroot} at (26,0) size 182x52
+                            RenderMathMLRow {mrow} at (20,3) size 162x49
                               RenderMathMLToken {mn} at (0,19) size 8x12
                                 RenderBlock (anonymous) at (0,0) size 8x12
                                   RenderText {#text} at (0,-2) size 8x17
@@ -336,8 +336,8 @@ layer at (0,0) size 800x604
                                 RenderBlock (anonymous) at (3,0) size 13x10
                                   RenderText {#text} at (0,-4) size 12x17
                                     text run at (0,-4) width 12: "+"
-                              RenderMathMLRoot {mroot} at (26,0) size 133x48
-                                RenderMathMLRow {mrow} at (18,3) size 115x40
+                              RenderMathMLRoot {mroot} at (26,0) size 135x48
+                                RenderMathMLRow {mrow} at (19,3) size 116x40
                                   RenderMathMLToken {mn} at (0,15) size 8x12
                                     RenderBlock (anonymous) at (0,0) size 8x12
                                       RenderText {#text} at (0,-2) size 8x17
@@ -346,8 +346,8 @@ layer at (0,0) size 800x604
                                     RenderBlock (anonymous) at (3,0) size 13x10
                                       RenderText {#text} at (0,-4) size 12x17
                                         text run at (0,-4) width 12: "+"
-                                  RenderMathMLRoot {mroot} at (26,0) size 88x40
-                                    RenderMathMLRow {mrow} at (18,3) size 69x29
+                                  RenderMathMLRoot {mroot} at (26,0) size 89x40
+                                    RenderMathMLRow {mrow} at (19,3) size 69x29
                                       RenderMathMLToken {mn} at (0,11) size 8x12
                                         RenderBlock (anonymous) at (0,0) size 8x12
                                           RenderText {#text} at (0,-2) size 8x17
@@ -411,68 +411,68 @@ layer at (0,0) size 800x604
       RenderBlock {p} at (0,506) size 784x66
         RenderText {#text} at (0,35) size 74x19
           text run at (0,35) width 74: "RTL roots: "
-        RenderMathMLMath {math} at (73,0) size 363x66
-          RenderMathMLRoot {mroot} at (0,0) size 363x66
-            RenderMathMLRow {mrow} at (0,3) size 344x63
-              RenderMathMLToken {mn} at (335,35) size 9x11
+        RenderMathMLMath {math} at (73,0) size 369x66
+          RenderMathMLRoot {mroot} at (0,0) size 369x66
+            RenderMathMLRow {mrow} at (0,3) size 349x63
+              RenderMathMLToken {mn} at (340,35) size 9x11
                 RenderBlock (anonymous) at (0,0) size 8x11
                   RenderText {#text} at (0,-2) size 8x17
                     text run at (0,-2) width 8: "1"
-              RenderMathMLOperator {mo} at (316,37) size 20x10
+              RenderMathMLOperator {mo} at (321,37) size 20x10
                 RenderBlock (anonymous) at (3,0) size 13x10
                   RenderText {#text} at (0,-4) size 12x17
                     text run at (0,-4) width 12 RTL: "+"
-              RenderMathMLRoot {mroot} at (0,0) size 317x63
-                RenderMathMLRow {mrow} at (0,3) size 298x60
-                  RenderMathMLToken {mn} at (289,31) size 9x11
+              RenderMathMLRoot {mroot} at (0,0) size 322x63
+                RenderMathMLRow {mrow} at (0,3) size 302x60
+                  RenderMathMLToken {mn} at (293,31) size 9x11
                     RenderBlock (anonymous) at (0,0) size 8x11
                       RenderText {#text} at (0,-2) size 8x17
                         text run at (0,-2) width 8: "2"
-                  RenderMathMLOperator {mo} at (270,33) size 20x10
+                  RenderMathMLOperator {mo} at (274,33) size 20x10
                     RenderBlock (anonymous) at (3,0) size 13x10
                       RenderText {#text} at (0,-4) size 12x17
                         text run at (0,-4) width 12 RTL: "+"
-                  RenderMathMLRoot {mroot} at (0,0) size 271x59
-                    RenderMathMLRow {mrow} at (0,3) size 251x56
-                      RenderMathMLToken {mn} at (243,27) size 8x12
+                  RenderMathMLRoot {mroot} at (0,0) size 275x59
+                    RenderMathMLRow {mrow} at (0,3) size 255x56
+                      RenderMathMLToken {mn} at (246,27) size 9x12
                         RenderBlock (anonymous) at (0,0) size 8x12
                           RenderText {#text} at (0,-2) size 8x17
                             text run at (0,-2) width 8: "3"
-                      RenderMathMLOperator {mo} at (224,29) size 20x10
+                      RenderMathMLOperator {mo} at (227,29) size 20x10
                         RenderBlock (anonymous) at (3,0) size 13x10
                           RenderText {#text} at (0,-4) size 12x17
                             text run at (0,-4) width 12 RTL: "+"
-                      RenderMathMLRoot {mroot} at (0,0) size 225x55
-                        RenderMathMLRow {mrow} at (0,3) size 205x52
-                          RenderMathMLToken {mn} at (196,23) size 9x11
+                      RenderMathMLRoot {mroot} at (0,0) size 228x55
+                        RenderMathMLRow {mrow} at (0,3) size 208x52
+                          RenderMathMLToken {mn} at (199,23) size 9x11
                             RenderBlock (anonymous) at (0,0) size 8x11
                               RenderText {#text} at (0,-2) size 8x17
                                 text run at (0,-2) width 8: "4"
-                          RenderMathMLOperator {mo} at (178,25) size 19x10
+                          RenderMathMLOperator {mo} at (181,25) size 19x10
                             RenderBlock (anonymous) at (3,0) size 13x10
                               RenderText {#text} at (0,-4) size 12x17
                                 text run at (0,-4) width 12 RTL: "+"
-                          RenderMathMLRoot {mroot} at (0,0) size 179x52
-                            RenderMathMLRow {mrow} at (0,3) size 159x49
-                              RenderMathMLToken {mn} at (150,19) size 9x12
+                          RenderMathMLRoot {mroot} at (0,0) size 182x52
+                            RenderMathMLRow {mrow} at (0,3) size 161x49
+                              RenderMathMLToken {mn} at (152,19) size 9x12
                                 RenderBlock (anonymous) at (0,0) size 8x12
                                   RenderText {#text} at (0,-2) size 8x17
                                     text run at (0,-2) width 8: "5"
-                              RenderMathMLOperator {mo} at (132,21) size 19x10
+                              RenderMathMLOperator {mo} at (134,21) size 19x10
                                 RenderBlock (anonymous) at (3,0) size 13x10
                                   RenderText {#text} at (0,-4) size 12x17
                                     text run at (0,-4) width 12 RTL: "+"
-                              RenderMathMLRoot {mroot} at (0,0) size 133x48
-                                RenderMathMLRow {mrow} at (0,3) size 114x40
-                                  RenderMathMLToken {mn} at (105,15) size 9x12
+                              RenderMathMLRoot {mroot} at (0,0) size 135x48
+                                RenderMathMLRow {mrow} at (0,3) size 115x40
+                                  RenderMathMLToken {mn} at (106,15) size 9x12
                                     RenderBlock (anonymous) at (0,0) size 8x12
                                       RenderText {#text} at (0,-2) size 8x17
                                         text run at (0,-2) width 8: "6"
-                                  RenderMathMLOperator {mo} at (86,17) size 20x10
+                                  RenderMathMLOperator {mo} at (87,17) size 20x10
                                     RenderBlock (anonymous) at (3,0) size 13x10
                                       RenderText {#text} at (0,-4) size 12x17
                                         text run at (0,-4) width 12 RTL: "+"
-                                  RenderMathMLRoot {mroot} at (0,0) size 87x40
+                                  RenderMathMLRoot {mroot} at (0,0) size 88x40
                                     RenderMathMLRow {mrow} at (0,3) size 68x29
                                       RenderMathMLToken {mn} at (59,11) size 9x12
                                         RenderBlock (anonymous) at (0,0) size 8x12
@@ -505,31 +505,31 @@ layer at (0,0) size 800x604
                                             RenderBlock (anonymous) at (0,0) size 5x5
                                               RenderText {#text} at (0,-2) size 5x10
                                                 text run at (0,-2) width 5: "z"
-                                    RenderMathMLToken {mn} at (81,11) size 5x8
+                                    RenderMathMLToken {mn} at (82,11) size 5x8
                                       RenderBlock (anonymous) at (0,0) size 5x7
                                         RenderText {#text} at (0,-1) size 5x10
                                           text run at (0,-1) width 5: "9"
-                                RenderMathMLToken {mn} at (126,15) size 6x8
+                                RenderMathMLToken {mn} at (128,15) size 6x8
                                   RenderBlock (anonymous) at (0,0) size 5x7
                                     RenderText {#text} at (0,-1) size 5x10
                                       text run at (0,-1) width 5: "8"
-                            RenderMathMLToken {mn} at (172,16) size 6x8
+                            RenderMathMLToken {mn} at (175,16) size 5x8
                               RenderBlock (anonymous) at (0,0) size 5x7
                                 RenderText {#text} at (0,-1) size 5x10
                                   text run at (0,-1) width 5: "7"
-                        RenderMathMLToken {mn} at (218,18) size 6x8
+                        RenderMathMLToken {mn} at (222,18) size 5x8
                           RenderBlock (anonymous) at (0,0) size 5x7
                             RenderText {#text} at (0,-1) size 5x10
                               text run at (0,-1) width 5: "6"
-                    RenderMathMLToken {mn} at (265,20) size 5x8
+                    RenderMathMLToken {mn} at (269,20) size 5x8
                       RenderBlock (anonymous) at (0,0) size 5x7
                         RenderText {#text} at (0,-1) size 5x10
                           text run at (0,-1) width 5: "5"
-                RenderMathMLToken {mn} at (311,22) size 5x7
+                RenderMathMLToken {mn} at (316,22) size 5x7
                   RenderBlock (anonymous) at (0,0) size 5x6
                     RenderText {#text} at (0,-1) size 5x10
                       text run at (0,-1) width 5: "4"
-            RenderMathMLToken {mn} at (357,23) size 5x8
+            RenderMathMLToken {mn} at (363,23) size 5x8
               RenderBlock (anonymous) at (0,0) size 5x7
                 RenderText {#text} at (0,-1) size 5x10
                   text run at (0,-1) width 5: "3"

--- a/LayoutTests/platform/mac/mathml/presentation/roots-expected.txt
+++ b/LayoutTests/platform/mac/mathml/presentation/roots-expected.txt
@@ -87,9 +87,9 @@ layer at (0,0) size 800x603
       RenderBlock {p} at (0,165) size 784x21
         RenderText {#text} at (0,1) size 177x18
           text run at (0,1) width 177: "cube root (should be blue): "
-        RenderMathMLMath {math} at (176,0) size 22x21 [color=#0000FF]
-          RenderMathMLRoot {mroot} at (0,0) size 21x21
-            RenderMathMLToken {mn} at (12,3) size 9x12
+        RenderMathMLMath {math} at (176,0) size 23x21 [color=#0000FF]
+          RenderMathMLRoot {mroot} at (0,0) size 22x21
+            RenderMathMLToken {mn} at (13,3) size 9x12
               RenderBlock (anonymous) at (0,0) size 8x11
                 RenderText {#text} at (0,-1) size 8x16
                   text run at (0,-1) width 8: "2"
@@ -285,9 +285,9 @@ layer at (0,0) size 800x603
       RenderBlock {p} at (0,423) size 784x67
         RenderText {#text} at (0,36) size 114x18
           text run at (0,36) width 114: "Imbricated roots: "
-        RenderMathMLMath {math} at (113,0) size 364x66
-          RenderMathMLRoot {mroot} at (0,0) size 363x66
-            RenderMathMLRow {mrow} at (19,3) size 344x63
+        RenderMathMLMath {math} at (113,0) size 370x66
+          RenderMathMLRoot {mroot} at (0,0) size 369x66
+            RenderMathMLRow {mrow} at (20,3) size 349x63
               RenderMathMLToken {mn} at (0,35) size 8x11
                 RenderBlock (anonymous) at (0,0) size 8x11
                   RenderText {#text} at (0,-1) size 8x16
@@ -296,8 +296,8 @@ layer at (0,0) size 800x603
                 RenderBlock (anonymous) at (3,0) size 13x10
                   RenderText {#text} at (0,-3) size 12x16
                     text run at (0,-3) width 12: "+"
-              RenderMathMLRoot {mroot} at (26,0) size 318x63
-                RenderMathMLRow {mrow} at (19,3) size 298x60
+              RenderMathMLRoot {mroot} at (26,0) size 323x63
+                RenderMathMLRow {mrow} at (20,3) size 302x60
                   RenderMathMLToken {mn} at (0,31) size 8x11
                     RenderBlock (anonymous) at (0,0) size 8x11
                       RenderText {#text} at (0,-1) size 8x16
@@ -306,8 +306,8 @@ layer at (0,0) size 800x603
                     RenderBlock (anonymous) at (3,0) size 13x10
                       RenderText {#text} at (0,-3) size 12x16
                         text run at (0,-3) width 12: "+"
-                  RenderMathMLRoot {mroot} at (26,0) size 272x59
-                    RenderMathMLRow {mrow} at (19,3) size 252x56
+                  RenderMathMLRoot {mroot} at (26,0) size 276x59
+                    RenderMathMLRow {mrow} at (20,3) size 255x56
                       RenderMathMLToken {mn} at (0,27) size 8x12
                         RenderBlock (anonymous) at (0,0) size 8x12
                           RenderText {#text} at (0,-1) size 8x16
@@ -316,8 +316,8 @@ layer at (0,0) size 800x603
                         RenderBlock (anonymous) at (3,0) size 13x10
                           RenderText {#text} at (0,-3) size 12x16
                             text run at (0,-3) width 12: "+"
-                      RenderMathMLRoot {mroot} at (26,0) size 225x55
-                        RenderMathMLRow {mrow} at (19,3) size 206x52
+                      RenderMathMLRoot {mroot} at (26,0) size 229x55
+                        RenderMathMLRow {mrow} at (20,3) size 208x52
                           RenderMathMLToken {mn} at (0,23) size 8x11
                             RenderBlock (anonymous) at (0,0) size 8x11
                               RenderText {#text} at (0,-1) size 8x16
@@ -326,8 +326,8 @@ layer at (0,0) size 800x603
                             RenderBlock (anonymous) at (3,0) size 13x10
                               RenderText {#text} at (0,-3) size 12x16
                                 text run at (0,-3) width 12: "+"
-                          RenderMathMLRoot {mroot} at (26,0) size 179x52
-                            RenderMathMLRow {mrow} at (19,3) size 160x49
+                          RenderMathMLRoot {mroot} at (26,0) size 182x52
+                            RenderMathMLRow {mrow} at (20,3) size 162x49
                               RenderMathMLToken {mn} at (0,19) size 8x12
                                 RenderBlock (anonymous) at (0,0) size 8x12
                                   RenderText {#text} at (0,-1) size 8x16
@@ -336,8 +336,8 @@ layer at (0,0) size 800x603
                                 RenderBlock (anonymous) at (3,0) size 13x10
                                   RenderText {#text} at (0,-3) size 12x16
                                     text run at (0,-3) width 12: "+"
-                              RenderMathMLRoot {mroot} at (26,0) size 133x48
-                                RenderMathMLRow {mrow} at (18,3) size 115x40
+                              RenderMathMLRoot {mroot} at (26,0) size 135x48
+                                RenderMathMLRow {mrow} at (19,3) size 116x40
                                   RenderMathMLToken {mn} at (0,15) size 8x12
                                     RenderBlock (anonymous) at (0,0) size 8x12
                                       RenderText {#text} at (0,-1) size 8x16
@@ -346,8 +346,8 @@ layer at (0,0) size 800x603
                                     RenderBlock (anonymous) at (3,0) size 13x10
                                       RenderText {#text} at (0,-3) size 12x16
                                         text run at (0,-3) width 12: "+"
-                                  RenderMathMLRoot {mroot} at (26,0) size 88x40
-                                    RenderMathMLRow {mrow} at (18,3) size 69x29
+                                  RenderMathMLRoot {mroot} at (26,0) size 89x40
+                                    RenderMathMLRow {mrow} at (19,3) size 69x29
                                       RenderMathMLToken {mn} at (0,11) size 8x12
                                         RenderBlock (anonymous) at (0,0) size 8x12
                                           RenderText {#text} at (0,-1) size 8x16
@@ -411,68 +411,68 @@ layer at (0,0) size 800x603
       RenderBlock {p} at (0,505) size 784x66
         RenderText {#text} at (0,36) size 74x18
           text run at (0,36) width 74: "RTL roots: "
-        RenderMathMLMath {math} at (73,0) size 363x66
-          RenderMathMLRoot {mroot} at (0,0) size 363x66
-            RenderMathMLRow {mrow} at (0,3) size 344x63
-              RenderMathMLToken {mn} at (335,35) size 9x11
+        RenderMathMLMath {math} at (73,0) size 370x66
+          RenderMathMLRoot {mroot} at (0,0) size 369x66
+            RenderMathMLRow {mrow} at (0,3) size 349x63
+              RenderMathMLToken {mn} at (340,35) size 9x11
                 RenderBlock (anonymous) at (0,0) size 8x11
                   RenderText {#text} at (0,-1) size 8x16
                     text run at (0,-1) width 8: "1"
-              RenderMathMLOperator {mo} at (316,37) size 20x10
+              RenderMathMLOperator {mo} at (321,37) size 20x10
                 RenderBlock (anonymous) at (3,0) size 13x10
                   RenderText {#text} at (0,-3) size 12x16
                     text run at (0,-3) width 12 RTL: "+"
-              RenderMathMLRoot {mroot} at (0,0) size 317x63
-                RenderMathMLRow {mrow} at (0,3) size 298x60
-                  RenderMathMLToken {mn} at (289,31) size 9x11
+              RenderMathMLRoot {mroot} at (0,0) size 322x63
+                RenderMathMLRow {mrow} at (0,3) size 302x60
+                  RenderMathMLToken {mn} at (293,31) size 9x11
                     RenderBlock (anonymous) at (0,0) size 8x11
                       RenderText {#text} at (0,-1) size 8x16
                         text run at (0,-1) width 8: "2"
-                  RenderMathMLOperator {mo} at (270,33) size 20x10
+                  RenderMathMLOperator {mo} at (274,33) size 20x10
                     RenderBlock (anonymous) at (3,0) size 13x10
                       RenderText {#text} at (0,-3) size 12x16
                         text run at (0,-3) width 12 RTL: "+"
-                  RenderMathMLRoot {mroot} at (0,0) size 271x59
-                    RenderMathMLRow {mrow} at (0,3) size 251x56
-                      RenderMathMLToken {mn} at (243,27) size 8x12
+                  RenderMathMLRoot {mroot} at (0,0) size 275x59
+                    RenderMathMLRow {mrow} at (0,3) size 255x56
+                      RenderMathMLToken {mn} at (246,27) size 9x12
                         RenderBlock (anonymous) at (0,0) size 8x12
                           RenderText {#text} at (0,-1) size 8x16
                             text run at (0,-1) width 8: "3"
-                      RenderMathMLOperator {mo} at (224,29) size 20x10
+                      RenderMathMLOperator {mo} at (227,29) size 20x10
                         RenderBlock (anonymous) at (3,0) size 13x10
                           RenderText {#text} at (0,-3) size 12x16
                             text run at (0,-3) width 12 RTL: "+"
-                      RenderMathMLRoot {mroot} at (0,0) size 225x55
-                        RenderMathMLRow {mrow} at (0,3) size 205x52
-                          RenderMathMLToken {mn} at (196,23) size 9x11
+                      RenderMathMLRoot {mroot} at (0,0) size 228x55
+                        RenderMathMLRow {mrow} at (0,3) size 208x52
+                          RenderMathMLToken {mn} at (199,23) size 9x11
                             RenderBlock (anonymous) at (0,0) size 8x11
                               RenderText {#text} at (0,-1) size 8x16
                                 text run at (0,-1) width 8: "4"
-                          RenderMathMLOperator {mo} at (178,25) size 19x10
+                          RenderMathMLOperator {mo} at (181,25) size 19x10
                             RenderBlock (anonymous) at (3,0) size 13x10
                               RenderText {#text} at (0,-3) size 12x16
                                 text run at (0,-3) width 12 RTL: "+"
-                          RenderMathMLRoot {mroot} at (0,0) size 179x52
-                            RenderMathMLRow {mrow} at (0,3) size 159x49
-                              RenderMathMLToken {mn} at (150,19) size 9x12
+                          RenderMathMLRoot {mroot} at (0,0) size 182x52
+                            RenderMathMLRow {mrow} at (0,3) size 161x49
+                              RenderMathMLToken {mn} at (152,19) size 9x12
                                 RenderBlock (anonymous) at (0,0) size 8x12
                                   RenderText {#text} at (0,-1) size 8x16
                                     text run at (0,-1) width 8: "5"
-                              RenderMathMLOperator {mo} at (132,21) size 19x10
+                              RenderMathMLOperator {mo} at (134,21) size 19x10
                                 RenderBlock (anonymous) at (3,0) size 13x10
                                   RenderText {#text} at (0,-3) size 12x16
                                     text run at (0,-3) width 12 RTL: "+"
-                              RenderMathMLRoot {mroot} at (0,0) size 133x48
-                                RenderMathMLRow {mrow} at (0,3) size 114x40
-                                  RenderMathMLToken {mn} at (105,15) size 9x12
+                              RenderMathMLRoot {mroot} at (0,0) size 135x48
+                                RenderMathMLRow {mrow} at (0,3) size 115x40
+                                  RenderMathMLToken {mn} at (106,15) size 9x12
                                     RenderBlock (anonymous) at (0,0) size 8x12
                                       RenderText {#text} at (0,-1) size 8x16
                                         text run at (0,-1) width 8: "6"
-                                  RenderMathMLOperator {mo} at (86,17) size 20x10
+                                  RenderMathMLOperator {mo} at (87,17) size 20x10
                                     RenderBlock (anonymous) at (3,0) size 13x10
                                       RenderText {#text} at (0,-3) size 12x16
                                         text run at (0,-3) width 12 RTL: "+"
-                                  RenderMathMLRoot {mroot} at (0,0) size 87x40
+                                  RenderMathMLRoot {mroot} at (0,0) size 88x40
                                     RenderMathMLRow {mrow} at (0,3) size 68x29
                                       RenderMathMLToken {mn} at (59,11) size 9x12
                                         RenderBlock (anonymous) at (0,0) size 8x12
@@ -505,31 +505,31 @@ layer at (0,0) size 800x603
                                             RenderBlock (anonymous) at (0,0) size 5x5
                                               RenderText {#text} at (0,-2) size 5x9
                                                 text run at (0,-2) width 5: "z"
-                                    RenderMathMLToken {mn} at (81,11) size 5x8
+                                    RenderMathMLToken {mn} at (82,11) size 5x8
                                       RenderBlock (anonymous) at (0,0) size 5x7
                                         RenderText {#text} at (0,-1) size 5x9
                                           text run at (0,-1) width 5: "9"
-                                RenderMathMLToken {mn} at (126,15) size 6x8
+                                RenderMathMLToken {mn} at (128,15) size 6x8
                                   RenderBlock (anonymous) at (0,0) size 5x7
                                     RenderText {#text} at (0,-1) size 5x9
                                       text run at (0,-1) width 5: "8"
-                            RenderMathMLToken {mn} at (172,16) size 6x8
+                            RenderMathMLToken {mn} at (175,16) size 5x8
                               RenderBlock (anonymous) at (0,0) size 5x7
                                 RenderText {#text} at (0,-1) size 5x9
                                   text run at (0,-1) width 5: "7"
-                        RenderMathMLToken {mn} at (218,18) size 6x8
+                        RenderMathMLToken {mn} at (222,18) size 5x8
                           RenderBlock (anonymous) at (0,0) size 5x7
                             RenderText {#text} at (0,-1) size 5x9
                               text run at (0,-1) width 5: "6"
-                    RenderMathMLToken {mn} at (265,20) size 5x8
+                    RenderMathMLToken {mn} at (269,20) size 5x8
                       RenderBlock (anonymous) at (0,0) size 5x7
                         RenderText {#text} at (0,-1) size 5x9
                           text run at (0,-1) width 5: "5"
-                RenderMathMLToken {mn} at (311,22) size 5x7
+                RenderMathMLToken {mn} at (316,22) size 5x7
                   RenderBlock (anonymous) at (0,0) size 5x6
                     RenderText {#text} at (0,-1) size 5x9
                       text run at (0,-1) width 5: "4"
-            RenderMathMLToken {mn} at (357,23) size 5x8
+            RenderMathMLToken {mn} at (363,23) size 5x8
               RenderBlock (anonymous) at (0,0) size 5x7
                 RenderText {#text} at (0,-1) size 5x9
                   text run at (0,-1) width 5: "3"

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
@@ -65,7 +65,7 @@ private:
         LayoutUnit kernBeforeDegree;
         LayoutUnit kernAfterDegree;
     };
-    HorizontalParameters horizontalParameters();
+    HorizontalParameters horizontalParameters(LayoutUnit indexWidth);
     struct VerticalParameters {
         LayoutUnit verticalGap;
         LayoutUnit ruleThickness;


### PR DESCRIPTION
#### 07c9448d9a71ea3d6fe2c858bb96ae66fb54a664
<pre>
MathML &lt;mroot&gt;: clamp RadicalKernBefore/AfterDegree
<a href="https://bugs.webkit.org/show_bug.cgi?id=276427">https://bugs.webkit.org/show_bug.cgi?id=276427</a>

Reviewed by Rob Buis.

Implements the clamping described in MathML Core.
See <a href="https://w3c.github.io/mathml-core/#root-with-index">https://w3c.github.io/mathml-core/#root-with-index</a>

* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/radic3als/root-parameters-2-expected.txt: This test passes.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout-expected.txt: tweak the failure message.
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/width-height-001-expected.txt: ditto.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/width-height-001-expected.txt: ditto.
* LayoutTests/platform/glib/mathml/presentation/roots-expected.txt: update render tree expectation.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mathml/relations/css-styling/not-participating-to-parent-layout-expected.txt: tweak the failure message.
* LayoutTests/platform/ios/mathml/presentation/roots-expected.txt: update render tree expectation.
* LayoutTests/platform/mac/mathml/presentation/roots-expected.txt: update render tree expectation.
* Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp:
(WebCore::RenderMathMLRoot::horizontalParameters): add a indexWidth parameter and perform the clamping fromt the spec.
(WebCore::RenderMathMLRoot::computePreferredLogicalWidths): pass the preferred width of the index to the helper.
(WebCore::RenderMathMLRoot::layoutBlock): pass the width of the index to the helper.
(WebCore::RenderMathMLRoot::paint): ditto.
* Source/WebCore/rendering/mathml/RenderMathMLRoot.h: add indexWidth parameter too.

Canonical link: <a href="https://commits.webkit.org/280902@main">https://commits.webkit.org/280902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/775bbb5011d4812ddfcb94a8e047783179a1ef31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61614 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8434 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46994 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6007 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50124 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27825 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31761 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7419 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7438 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63302 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1903 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54218 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54357 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12825 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1630 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33146 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35316 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->