### PR TITLE
Unreviewed, reverting 280317@main (c6894f128e9b)

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c
@@ -84,8 +84,7 @@ pas_bitfit_variant_selection pas_bitfit_heap_select_variant(size_t requested_obj
             continue;
 
         if (verbose)
-            pas_log("max object size = %zu min align = %zu\n",
-                    page_config.base.max_object_size, pas_page_base_config_min_align(page_config.base));
+            pas_log("max object size = %zu\n", page_config.base.max_object_size);
 
         PAS_ASSERT(
             page_config.base.max_object_size

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
@@ -1492,10 +1492,6 @@ pas_segregated_heap_ensure_size_directory_for_size(
     
     result = pas_segregated_heap_size_directory_for_index(heap, index, cached_index, config);
 
-    if (verbose && result) {
-        pas_log("Found result = %p, object_size = %u, min_index = %u\n",
-                result, result->object_size, pas_segregated_size_directory_min_index(result));
-    }
     PAS_ASSERT(
         !result
         || pas_is_aligned(result->object_size, pas_segregated_size_directory_alignment(result))
@@ -1709,17 +1705,9 @@ pas_segregated_heap_ensure_size_directory_for_size(
                 candidate = directory;
         }
 
-        if (verbose && candidate) {
-            pas_log("Found candidate = %p, object_size = %u, min_index = %u\n",
-                    candidate, candidate->object_size, pas_segregated_size_directory_min_index(candidate));
-        }
         /* Figure out the best case scenario if we did create a page directory for this size. */
         best_bytes_dirtied_per_object = PAS_INFINITY;
         best_page_config = NULL;
-
-        if (verbose)
-            pas_log("max_segregated_object_size = %u\n", heap->runtime_config->max_segregated_object_size);
-
         if (object_size <= heap->runtime_config->max_segregated_object_size) {
             for (PAS_EACH_SEGREGATED_PAGE_CONFIG_VARIANT_DESCENDING(variant)) {
                 const pas_segregated_page_config* page_config_ptr;
@@ -1778,8 +1766,6 @@ pas_segregated_heap_ensure_size_directory_for_size(
                 pas_bitfit_heap_select_variant(object_size, config, heap->runtime_config).object_size;
             PAS_ASSERT(!is_utility);
         }
-        if (verbose)
-            pas_log("best_bytes_dirtied_per_object = %f, best_page_config = %p\n", best_bytes_dirtied_per_object, best_page_config);
 
         if (candidate && pas_segregated_size_directory_alignment(candidate) >= alignment) {
             double bytes_dirtied_per_object_by_candidate;
@@ -1798,11 +1784,6 @@ pas_segregated_heap_ensure_size_directory_for_size(
             } else
                 bytes_dirtied_per_object_by_candidate = candidate->object_size;
 
-            if (verbose) {
-                pas_log("bytes_dirtied_per_object_by_candidate = %f, candidate page_config_kind = %s\n",
-                        bytes_dirtied_per_object_by_candidate,
-                        pas_segregated_page_config_kind_get_string(candidate->base.page_config_kind));
-            }
             if (best_bytes_dirtied_per_object * PAS_SIZE_CLASS_PROGRESSION
                 > bytes_dirtied_per_object_by_candidate)
                 result = candidate;
@@ -1813,13 +1794,12 @@ pas_segregated_heap_ensure_size_directory_for_size(
         else {
             pas_compact_atomic_segregated_size_directory_ptr* head;
             pas_segregated_size_directory* basic_size_directory_and_head;
-            size_t ideal_object_size;
 
             if (verbose)
                 pas_log("About to compute ideal object size; object_size = %zu\n", object_size);
 
             if (best_page_config) {
-                ideal_object_size = compute_ideal_object_size(
+                object_size = compute_ideal_object_size(
                     heap,
                     PAS_MAX(object_size,
                             pas_segregated_page_config_min_align(*best_page_config)),
@@ -1829,27 +1809,8 @@ pas_segregated_heap_ensure_size_directory_for_size(
                 
                 /* best_bytes_dirtied_per_object has the right object size computed by the bitfit heap,
                    so just reuse that. */
-                ideal_object_size = (size_t)best_bytes_dirtied_per_object;
+                object_size = (size_t)best_bytes_dirtied_per_object;
             }
-            if (candidate) {
-                size_t ideal_object_index;
-                size_t candidate_min_index;
-
-                ideal_object_index = pas_segregated_heap_index_for_size(ideal_object_size, *config);
-                candidate_min_index = pas_segregated_size_directory_min_index(candidate);
-                if (ideal_object_index < candidate_min_index)
-                    object_size = ideal_object_size;
-                else {
-                    /* Unusual, but the ideal size may be beyond the min_index for the next largest directory.
-                       This can happen, e.g. after the runtime_config has been switched to bitfit only. */
-                    PAS_ASSERT(object_size <= pas_segregated_heap_size_for_index(candidate_min_index - 1, *config));
-                    object_size = pas_segregated_heap_size_for_index(candidate_min_index - 1, *config);
-
-                    if (verbose)
-                        pas_log("Capped object size at next begin_index; object_size = %zu\n", object_size);
-                }
-            } else
-                object_size = ideal_object_size;
 
             if (verbose)
                 pas_log("Did compute ideal object size; object_size = %zu\n", object_size);
@@ -1877,7 +1838,7 @@ pas_segregated_heap_ensure_size_directory_for_size(
                at offset=112 with no gaps, so as to not create internal fragmentation. Had we executed the code
                below, we would have given the 256-size directory alignment=256, and so we would be forced to
                allocate at offset=256, creating a gap of 144 bytes. Yuck!
-               
+
                On the other hand, not executing this code creates this weird situation where if we had once upon
                a time allocated 256 bytes with no particular alignment, and later memaligned 256 bytes with
                256-byte alignment, then we would create a second directory, and the old directory's memory will
@@ -2086,9 +2047,6 @@ pas_segregated_heap_ensure_size_directory_for_size(
                 PAS_ASSERT(begin_index);
                 PAS_ASSERT((pas_segregated_heap_medium_directory_index)begin_index == begin_index);
                 next_tuple->begin_index = (pas_segregated_heap_medium_directory_index)begin_index;
-
-                if (verbose)
-                    pas_log("Updated next_tuple->begin_index = %zu\n", begin_index);
             } else {
                 pas_segregated_heap_medium_directory_tuple* medium_directories;
                 pas_segregated_heap_medium_directory_tuple* medium_directory;
@@ -2097,10 +2055,6 @@ pas_segregated_heap_ensure_size_directory_for_size(
                     &rare_data->medium_directories);
                 
                 if (next_tuple) {
-                    if (verbose) {
-                        pas_log("next_tuple->begin_index = %u, end_index = %u\n",
-                                next_tuple->begin_index, next_tuple->end_index);
-                    }
                     /* Whatever we find has to have a larger object size than what we picked because
                        otherwise we should have just returned that.
                

--- a/Source/bmalloc/libpas/src/test/BmallocTests.cpp
+++ b/Source/bmalloc/libpas/src/test/BmallocTests.cpp
@@ -25,7 +25,6 @@
 
 #include "TestHarness.h"
 #include "bmalloc_heap.h"
-#include "bmalloc_heap_config.h"
 
 #include <cstdlib>
 
@@ -46,29 +45,10 @@ void testBmallocDeallocate()
     bmalloc_deallocate(mem);
 }
 
-void testBmallocForceBitfitAfterAlloc()
-{
-    void* mem0 = bmalloc_try_allocate(28616, pas_non_compact_allocation_mode);
-    CHECK(mem0);
-
-    void* mem1 = bmalloc_try_allocate(20768, pas_non_compact_allocation_mode);
-    CHECK(mem1);
-
-    // Simulate entering mini mode by forcing bitfit only.
-    bmalloc_intrinsic_runtime_config.base.max_segregated_object_size = 0;
-    bmalloc_intrinsic_runtime_config.base.max_bitfit_object_size = UINT_MAX;
-    bmalloc_primitive_runtime_config.base.max_segregated_object_size = 0;
-    bmalloc_primitive_runtime_config.base.max_bitfit_object_size = UINT_MAX;
-
-    void* mem2 = bmalloc_try_allocate(20648, pas_non_compact_allocation_mode);
-    CHECK(mem2);
-}
-
 } // anonymous namespace
 
 void addBmallocTests()
 {
     ADD_TEST(testBmallocAllocate());
     ADD_TEST(testBmallocDeallocate());
-    ADD_TEST(testBmallocForceBitfitAfterAlloc());
 }


### PR DESCRIPTION
#### 0c94d8cc6f1a7d386f656539ae4afb3db7f28519
<pre>
Unreviewed, reverting 280317@main (c6894f128e9b)
<a href="https://bugs.webkit.org/show_bug.cgi?id=276430">https://bugs.webkit.org/show_bug.cgi?id=276430</a>
<a href="https://rdar.apple.com/131470729">rdar://131470729</a>

PAS_ASSERT at pas_segregated_size_directory_enable_exclusive_views + 2032

Reverted change:

    [libpas] pas_segregated_heap_ensure_size_directory_for_size/check_medium_directories assert fail due to creating overlapping directories
    <a href="https://bugs.webkit.org/show_bug.cgi?id=275820">https://bugs.webkit.org/show_bug.cgi?id=275820</a>
    <a href="https://rdar.apple.com/129774839">rdar://129774839</a>
    280317@main (c6894f128e9b)

Canonical link: <a href="https://commits.webkit.org/280826@main">https://commits.webkit.org/280826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24ba6c64108b24a024ed316f9e9c051482f4ed71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61375 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8198 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8386 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46792 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/5814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59783 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/49906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27617 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/31546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/7199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7202 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50845 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/7469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63057 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/56995 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1667 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1673 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/49917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/54130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1410 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78756 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8607 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/13057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33996 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->