### PR TITLE
Clicking and dragging  video viewer drags a layer on top of the other

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -214,11 +214,11 @@ class MediaController
             this.togglePlayback();
             event.preventDefault();
             event.stopPropagation();
-        }
-        else if (event.type === "keyup" && this.isFullscreen && event.key === " ") {
+        } else if (event.type === "keyup" && this.isFullscreen && event.key === " ") {
             event.preventDefault();
             event.stopPropagation();
-        }
+        } else if (event.type === "dragstart" && this.isFullscreen)
+            event.preventDefault();
 
         if (event.currentTarget === this.media) {
             if (event.type === "play")
@@ -352,6 +352,11 @@ class MediaController
         this._supportingObjects = this._supportingObjectClasses().map(SupportClass => new SupportClass(this), this);
 
         this.controls.shouldUseSingleBarLayout = this.controls instanceof InlineMediaControls && this.isYouTubeEmbedWithTitle;
+
+        if (this.controls instanceof MacOSFullscreenMediaControls)
+            window.addEventListener("dragstart", this, true);
+        else
+            window.removeEventListener("dragstart", this, true);
 
         if (this.host && this.host.inWindowFullscreen) {
             this._stopPropagationOnClickEvents();


### PR DESCRIPTION
#### 8a053f41c96e04f9c7747d6fad34251896c44542
<pre>
Clicking and dragging  video viewer drags a layer on top of the other
<a href="https://bugs.webkit.org/show_bug.cgi?id=276400">https://bugs.webkit.org/show_bug.cgi?id=276400</a>
<a href="https://rdar.apple.com/127512495">rdar://127512495</a>

Reviewed by Jer Noble and Antoine Quint.

On YouTube.com, clicking and dragging on a video in Video Viewer causes elements on
the page behind the video to come to the forefront. This is because YouTube gives
a draggable=true attribute to the parent div of the video element.

To fix this, now when we enter fullscreen on macOS, we add a dragstart event listener
to the window, which calls preventDefault() when the dragstart event occurs. We
remove this event listener when we enter inline.

* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype.handleEvent):
(MediaController.prototype._updateControlsIfNeeded):

Canonical link: <a href="https://commits.webkit.org/280838@main">https://commits.webkit.org/280838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02266006d71b4d9567d26b04a95635b14085714e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61377 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8200 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46794 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5816 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49912 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27619 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7205 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7204 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53503 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63059 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54013 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54131 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1412 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8616 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32912 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33998 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35082 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->