### PR TITLE
Need a short description (OOPS!).

### DIFF
--- a/JSTests/stress/yield-await-class-field-initializer-expr.js
+++ b/JSTests/stress/yield-await-class-field-initializer-expr.js
@@ -1,0 +1,89 @@
+// Tests for 'yield' and 'await' inside class field initializers, where the class is declared inside
+// async and generator functions.
+const verbose = false;
+
+const wrappers = ['none', 'generator', 'async'];
+const fieldModifiers = ['', 'static'];
+const fieldInitExprs = ['yield', 'yield 42', 'await', 'await 3'];
+
+function genTestCases() {
+    let cases = [];
+    for (const wrapper of wrappers) {
+        for (const fieldModifier of fieldModifiers) {
+            for (const fieldInitExpr of fieldInitExprs) {
+                cases.push({ wrapper, fieldModifier, fieldInitExpr });
+            }
+        }
+    }
+    return cases;
+}
+
+function genTestScript(c) {
+    let tabs = 0;
+    let script = "";
+
+    function append(line) {
+        for (t = 0; t < tabs; t++)
+            script += '  ';
+        script += line + '\n';
+    }
+
+    switch (c.wrapper) {
+        case 'generator':
+            append('function * g() {');
+            break;
+        case 'async':
+            append('async function f() {');
+            break;
+        case 'none':
+            break;
+    }
+    tabs++;
+    append('class C {');
+    tabs++;
+    append(`${c.fieldModifier} f = ${c.fieldInitExpr};`);
+    tabs--;
+    append('}');
+    tabs--;
+    if (c.wrapper !== 'none') append('}');
+    return script;
+}
+
+function expected(c, result, error) {
+    if (c.fieldInitExpr === 'await') {
+        // 'await' will parse as an identifier.
+        if (c.wrapper === 'none' && c.fieldModifier === 'static') {
+            // In this case, 'await' produces a ReferenceError.
+            return result === null && error !== null;
+        }
+        // In these cases, 'await' identifier has value 'undefined').
+        return result === undefined && error === null;
+    }
+    // All other cases should result in a SyntaxError.
+    return result === null && error !== null;
+}
+
+cases = genTestCases();
+
+for (const c of cases) {
+    let script = genTestScript(c);
+    let result = null;
+    let error = null;
+    try {
+        result = eval(script);
+    } catch (e) {
+        error = e;
+    }
+
+    if (verbose || !expected(c, result, error)) {
+        print(`Case: ${c.wrapper}:${c.fieldModifier}:${c.fieldInitExpr}`);
+        print(`Script:\n${script}`);
+        if (result != null) {
+            print("Result: " + result);
+        } else if (error != null) {
+            print("Error: " + error);
+        } else {
+            print("Expecting either result or error!")
+        }
+    }
+}

--- a/JSTests/stress/yield-await-class-field-initializer-expr.js
+++ b/JSTests/stress/yield-await-class-field-initializer-expr.js
@@ -53,14 +53,14 @@ function expected(c, result, error) {
     if (c.fieldInitExpr === 'await') {
         // 'await' will parse as an identifier.
         if (c.wrapper === 'none' && c.fieldModifier === 'static') {
-            // In this case, 'await' produces a ReferenceError.
-            return result === null && error !== null;
+            // In this case, 'await' as identifier produces a ReferenceError.
+            return result === null && error instanceof ReferenceError;
         }
-        // In these cases, 'await' identifier has value 'undefined').
+        // In these cases, 'await' as identifier has value 'undefined').
         return result === undefined && error === null;
     }
     // All other cases should result in a SyntaxError.
-    return result === null && error !== null;
+    return result === null && error instanceof SyntaxError;
 }
 
 cases = genTestCases();

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -4355,6 +4355,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseAwaitExpress
     ASSERT(currentScope()->isAsyncFunction() || isModuleParseMode(sourceParseMode()));
     ASSERT(isAsyncFunctionParseMode(sourceParseMode()) || isModuleParseMode(sourceParseMode()));
     ASSERT(m_parserState.functionParsePhase != FunctionParsePhase::Parameters);
+    ASSERT(!m_parserState.isParsingClassFieldInitializer);
     JSTokenLocation location(tokenLocation());
     JSTextPosition divotStart = tokenStartPosition();
     next();
@@ -5089,7 +5090,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePrimaryExpre
         semanticFailIfTrue(currentScope()->isStaticBlock(), "The 'await' keyword is disallowed in the IdentifierReference position within static block");
         if (m_parserState.functionParsePhase == FunctionParsePhase::Parameters)
             semanticFailIfFalse(m_parserState.allowAwait, "Cannot use 'await' within a parameter default expression");
-        else if ((currentFunctionScope()->isAsyncFunctionBoundary() || isModuleParseMode(sourceParseMode())) && !m_parserState.isParsingClassFieldInitializer)
+        else if (!m_parserState.isParsingClassFieldInitializer && (currentFunctionScope()->isAsyncFunctionBoundary() || isModuleParseMode(sourceParseMode())))
             return parseAwaitExpression(context);
 
         goto identifierExpression;
@@ -5586,7 +5587,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseUnaryExpress
     bool hasPrefixUpdateOp = false;
     unsigned lastOperator = 0;
 
-    if (UNLIKELY(match(AWAIT) && (currentFunctionScope()->isAsyncFunctionBoundary() || isModuleParseMode(sourceParseMode())) && !m_parserState.isParsingClassFieldInitializer)) {
+    if (UNLIKELY(match(AWAIT) && !m_parserState.isParsingClassFieldInitializer && (currentFunctionScope()->isAsyncFunctionBoundary() || isModuleParseMode(sourceParseMode())))) {
         semanticFailIfTrue(currentScope()->isStaticBlock(), "Cannot use 'await' within static block");
         return parseAwaitExpression(context);
     }


### PR DESCRIPTION
#### 96d22fb4138f0adc4f36d11108d5dc19a64dfc66
<pre>
Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* JSTests/stress/yield-await-class-field-initializer-expr.js:
(expected):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseAwaitExpression):
(JSC::Parser&lt;LexerType&gt;::parsePrimaryExpression):
(JSC::Parser&lt;LexerType&gt;::parseUnaryExpression):
</pre>
----------------------------------------------------------------------
#### 7c635babbd943018498beba28745d3484dcc7e3e
<pre>
Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* JSTests/stress/yield-await-class-field-initializer-expr.js: Added.
(genTestCases):
(genTestScript.append):
(genTestScript):
(const.c.of.cases.catch):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseYieldExpression):
(JSC::Parser&lt;LexerType&gt;::parseUnaryExpression):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96d22fb4138f0adc4f36d11108d5dc19a64dfc66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61382 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8205 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46798 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5821 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34783 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/49915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/27631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31553 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/7208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7209 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/50852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/7478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63065 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57002 "Found 1 new JSC stress test failure: stress/scoped-arguments-table-should-be-tolerant-for-oom.js.bytecode-cache (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1674 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7549 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1680 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/49926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/54136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1417 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78763 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/32917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13060 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34003 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->