### PR TITLE
[JSC] Disallow yield/await expressions in class field initializers

### DIFF
--- a/JSTests/stress/yield-await-class-field-initializer-expr.js
+++ b/JSTests/stress/yield-await-class-field-initializer-expr.js
@@ -1,0 +1,89 @@
+// Tests for 'yield' and 'await' inside class field initializers, where the class is declared inside
+// async and generator functions.
+const verbose = false;
+
+const wrappers = ['none', 'generator', 'async'];
+const fieldModifiers = ['', 'static'];
+const fieldInitExprs = ['yield', 'yield 42', 'await', 'await 3'];
+
+function genTestCases() {
+    let cases = [];
+    for (const wrapper of wrappers) {
+        for (const fieldModifier of fieldModifiers) {
+            for (const fieldInitExpr of fieldInitExprs) {
+                cases.push({ wrapper, fieldModifier, fieldInitExpr });
+            }
+        }
+    }
+    return cases;
+}
+
+function genTestScript(c) {
+    let tabs = 0;
+    let script = "";
+
+    function append(line) {
+        for (t = 0; t < tabs; t++)
+            script += '  ';
+        script += line + '\n';
+    }
+
+    switch (c.wrapper) {
+        case 'generator':
+            append('function * g() {');
+            break;
+        case 'async':
+            append('async function f() {');
+            break;
+        case 'none':
+            break;
+    }
+    tabs++;
+    append('class C {');
+    tabs++;
+    append(`${c.fieldModifier} f = ${c.fieldInitExpr};`);
+    tabs--;
+    append('}');
+    tabs--;
+    if (c.wrapper !== 'none') append('}');
+    return script;
+}
+
+function expected(c, result, error) {
+    if (c.fieldInitExpr === 'await') {
+        // 'await' will parse as an identifier.
+        if (c.wrapper === 'none' && c.fieldModifier === 'static') {
+            // In this case, 'await' as identifier produces a ReferenceError.
+            return result === null && error instanceof ReferenceError;
+        }
+        // In these cases, 'await' as identifier has value 'undefined').
+        return result === undefined && error === null;
+    }
+    // All other cases should result in a SyntaxError.
+    return result === null && error instanceof SyntaxError;
+}
+
+cases = genTestCases();
+
+for (const c of cases) {
+    let script = genTestScript(c);
+    let result = null;
+    let error = null;
+    try {
+        result = eval(script);
+    } catch (e) {
+        error = e;
+    }
+
+    if (verbose || !expected(c, result, error)) {
+        print(`Case: ${c.wrapper}:${c.fieldModifier}:${c.fieldInitExpr}`);
+        print(`Script:\n${script}`);
+        if (result != null) {
+            print("Result: " + result);
+        } else if (error != null) {
+            print("Error: " + error);
+        } else {
+            print("Expecting either result or error!")
+        }
+    }
+}

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -4326,6 +4326,9 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseYieldExpress
     // http://ecma-international.org/ecma-262/6.0/#sec-generator-function-definitions-static-semantics-early-errors
     failIfTrue(m_parserState.functionParsePhase == FunctionParsePhase::Parameters, "Cannot use yield expression within parameters");
 
+    // https://github.com/tc39/ecma262/issues/3333
+    failIfTrue(m_parserState.isParsingClassFieldInitializer, "Cannot use yield expression inside class field initializer expression");
+
     JSTokenLocation location(tokenLocation());
     JSTextPosition divotStart = tokenStartPosition();
     ASSERT(match(YIELD));
@@ -4352,6 +4355,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseAwaitExpress
     ASSERT(currentScope()->isAsyncFunction() || isModuleParseMode(sourceParseMode()));
     ASSERT(isAsyncFunctionParseMode(sourceParseMode()) || isModuleParseMode(sourceParseMode()));
     ASSERT(m_parserState.functionParsePhase != FunctionParsePhase::Parameters);
+    ASSERT(!m_parserState.isParsingClassFieldInitializer);
     JSTokenLocation location(tokenLocation());
     JSTextPosition divotStart = tokenStartPosition();
     next();
@@ -5086,7 +5090,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePrimaryExpre
         semanticFailIfTrue(currentScope()->isStaticBlock(), "The 'await' keyword is disallowed in the IdentifierReference position within static block");
         if (m_parserState.functionParsePhase == FunctionParsePhase::Parameters)
             semanticFailIfFalse(m_parserState.allowAwait, "Cannot use 'await' within a parameter default expression");
-        else if (currentFunctionScope()->isAsyncFunctionBoundary() || isModuleParseMode(sourceParseMode()))
+        else if (!m_parserState.isParsingClassFieldInitializer && (currentFunctionScope()->isAsyncFunctionBoundary() || isModuleParseMode(sourceParseMode())))
             return parseAwaitExpression(context);
 
         goto identifierExpression;
@@ -5583,7 +5587,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseUnaryExpress
     bool hasPrefixUpdateOp = false;
     unsigned lastOperator = 0;
 
-    if (UNLIKELY(match(AWAIT) && (currentFunctionScope()->isAsyncFunctionBoundary() || isModuleParseMode(sourceParseMode())))) {
+    if (UNLIKELY(match(AWAIT) && !m_parserState.isParsingClassFieldInitializer && (currentFunctionScope()->isAsyncFunctionBoundary() || isModuleParseMode(sourceParseMode())))) {
         semanticFailIfTrue(currentScope()->isStaticBlock(), "Cannot use 'await' within static block");
         return parseAwaitExpression(context);
     }


### PR DESCRIPTION
#### 36f50aab423c74d3b9b941e41a49b7ca2d581668
<pre>
[JSC] Disallow yield/await expressions in class field initializers
<a href="https://bugs.webkit.org/show_bug.cgi?id=276438">https://bugs.webkit.org/show_bug.cgi?id=276438</a>
<a href="https://rdar.apple.com/119044881">rdar://119044881</a>

Reviewed by Yusuke Suzuki.

The language spec doesn&apos;t explictly disallow yield and await expressions
in class field initializers, however it implicitly does given that
the expression is effectively evaluated as if it&apos;s inside a method.
Additionally, the consensus seems to be that these expressions
should not be allowed, see:

<a href="https://github.com/tc39/ecma262/issues/3333">https://github.com/tc39/ecma262/issues/3333</a>

The yield and await expressions are now handled differently, but
similar to how they are each handled in other contexts. This also
seems to be the least disruptive way to handle existing scripts,
as well as consistent with other engines:

yield: raise syntax error
await: parse as an identifier

Also adding a new test that generates and verifies scripts containing
a class with a field initializer containing yield and await, where the
class is either not nested or nested inside generator or async functions
to verify the behavior of various combinations.

* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseYieldExpression):
(JSC::Parser&lt;LexerType&gt;::parseAwaitExpression):
(JSC::Parser&lt;LexerType&gt;::parsePrimaryExpression):
(JSC::Parser&lt;LexerType&gt;::parseUnaryExpression):

Canonical link: <a href="https://commits.webkit.org/280837@main">https://commits.webkit.org/280837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/474897182e2a50211d23d96527ab6fb0b56f70ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61398 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8221 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46811 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5834 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27640 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7222 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7225 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50868 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53526 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63081 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57018 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54032 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54148 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1433 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78779 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8615 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32933 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13067 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->