### PR TITLE
Resync invoker tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative-expected.txt
@@ -5,16 +5,16 @@ PASS Element includes ParentNode: member names are unique
 PASS Element includes NonDocumentTypeChildNode: member names are unique
 PASS Element includes ChildNode: member names are unique
 PASS Element includes Slottable: member names are unique
-PASS InvokeEvent interface: existence and properties of interface object
-PASS InvokeEvent interface object length
-PASS InvokeEvent interface object name
-PASS InvokeEvent interface: existence and properties of interface prototype object
-PASS InvokeEvent interface: existence and properties of interface prototype object's "constructor" property
-PASS InvokeEvent interface: existence and properties of interface prototype object's @@unscopables property
-PASS InvokeEvent interface: attribute invoker
-PASS InvokeEvent interface: attribute action
-PASS InvokeEvent must be primary interface of new InvokeEvent("invoke")
-PASS Stringification of new InvokeEvent("invoke")
-PASS InvokeEvent interface: new InvokeEvent("invoke") must inherit property "invoker" with the proper type
-PASS InvokeEvent interface: new InvokeEvent("invoke") must inherit property "action" with the proper type
+FAIL CommandEvent interface: existence and properties of interface object assert_own_property: self does not have own property "CommandEvent" expected property "CommandEvent" missing
+FAIL CommandEvent interface object length assert_own_property: self does not have own property "CommandEvent" expected property "CommandEvent" missing
+FAIL CommandEvent interface object name assert_own_property: self does not have own property "CommandEvent" expected property "CommandEvent" missing
+FAIL CommandEvent interface: existence and properties of interface prototype object assert_own_property: self does not have own property "CommandEvent" expected property "CommandEvent" missing
+FAIL CommandEvent interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "CommandEvent" expected property "CommandEvent" missing
+FAIL CommandEvent interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "CommandEvent" expected property "CommandEvent" missing
+FAIL CommandEvent interface: attribute invoker assert_own_property: self does not have own property "CommandEvent" expected property "CommandEvent" missing
+FAIL CommandEvent interface: attribute command assert_own_property: self does not have own property "CommandEvent" expected property "CommandEvent" missing
+FAIL CommandEvent must be primary interface of new CommandEvent("invoke") assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: CommandEvent"
+FAIL Stringification of new CommandEvent("invoke") assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: CommandEvent"
+FAIL CommandEvent interface: new CommandEvent("invoke") must inherit property "invoker" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: CommandEvent"
+FAIL CommandEvent interface: new CommandEvent("invoke") must inherit property "command" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: CommandEvent"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative.html
@@ -10,7 +10,7 @@
 <script>
   idl_test(["invokers.tentative"], ["html", "dom"], (idl_array) => {
     idl_array.add_objects({
-      InvokeEvent: ['new InvokeEvent("invoke")'],
+      CommandEvent: ['new CommandEvent("invoke")'],
     });
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interestelement-interface.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interestelement-interface.tentative.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:keithamus@github.com" />
 <meta name="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com" />
 <link rel="help" href="https://open-ui.org/components/interest-invokers.explainer/" />
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt
@@ -1,15 +1,16 @@
 
 
-PASS invokeTargetElement reflects invokee HTML element
-PASS invokeTargetElement reflects set value
-PASS invokeTargetElement reflects set value across shadow root into light dom
-PASS invokeTargetElement does not reflect set value inside shadowroot
-PASS invokeTargetElement throws error on assignment of non Element
-PASS invokeAction reflects '' when attribute not present
-PASS invokeAction reflects '' when attribute empty, setAttribute version
-PASS invokeAction reflects same casing
-PASS invokeAction reflects '' when attribute empty, IDL version
-PASS invokeAction reflects tostring value
-PASS invokeAction reflects '' when attribute set to []
-PASS invokeAction reflects tostring value 2
+FAIL commandForElement reflects invokee HTML element assert_equals: expected (object) Element node <div id="invokee"></div> but got (undefined) undefined
+FAIL commandForElement reflects set value assert_equals: expected "" but got "invokee"
+FAIL commandForElement reflects set value across shadow root into light dom assert_equals: expected "" but got "invokee"
+FAIL commandForElement does not reflect set value inside shadowroot assert_equals: expected null but got Element node <div></div>
+FAIL commandForElement throws error on assignment of non Element assert_throws_js: commandForElement attribute must be an instance of Element function "function () {
+        invoker.commandForElement = {};
+      }" did not throw
+FAIL command reflects '' when attribute empty, setAttribute version assert_equals: expected (string) "" but got (undefined) undefined
+FAIL command reflects same casing assert_equals: expected "fooBarBaz" but got ""
+PASS command reflects '' when attribute empty, IDL version
+FAIL command reflects tostring value assert_equals: expected "1,2,3" but got ""
+FAIL command reflects '' when attribute set to [] assert_equals: expected (string) "" but got (object) []
+FAIL command reflects tostring value 2 assert_equals: expected (string) "[object Object]" but got (object) object "[object Object]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html
@@ -5,89 +5,84 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<button id="invoker" invoketarget="invokee"></button>
+<button id="invoker" commandfor="invokee" command="test"></button>
 <div id="invokee"></div>
 
 <script>
   test(function () {
-    assert_equals(invoker.invokeTargetElement, invokee);
-  }, "invokeTargetElement reflects invokee HTML element");
+    assert_equals(invoker.commandForElement, invokee);
+  }, "commandForElement reflects invokee HTML element");
 
   test(function () {
     const div = document.body.appendChild(document.createElement("div"));
-    invoker.invokeTargetElement = div;
-    assert_equals(invoker.invokeTargetElement, div);
-    assert_equals(invoker.getAttribute("invoketarget"), "");
-    assert_false(invoker.hasAttribute("invokeaction"));
-  }, "invokeTargetElement reflects set value");
+    invoker.commandForElement = div;
+    assert_equals(invoker.commandForElement, div);
+    assert_equals(invoker.getAttribute("commandfor"), "");
+    assert_equals(invoker.getAttribute("command"), "test");
+  }, "commandForElement reflects set value");
 
   test(function () {
     const host = document.body.appendChild(document.createElement("div"));
     const shadow = host.attachShadow({ mode: "open" });
     const button = shadow.appendChild(document.createElement("button"));
-    button.invokeTargetElement = invokee;
-    assert_equals(button.invokeTargetElement, invokee);
-    assert_equals(invoker.getAttribute("invoketarget"), "");
-    assert_false(invoker.hasAttribute("invokeaction"));
-  }, "invokeTargetElement reflects set value across shadow root into light dom");
+    button.commandForElement = invokee;
+    assert_equals(button.commandForElement, invokee);
+    assert_equals(invoker.getAttribute("commandfor"), "");
+    assert_equals(invoker.getAttribute("command"), "test");
+  }, "commandForElement reflects set value across shadow root into light dom");
 
   test(function () {
     const host = document.body.appendChild(document.createElement("div"));
     const shadow = host.attachShadow({ mode: "open" });
     const div = shadow.appendChild(document.createElement("div"));
-    invoker.invokeTargetElement = div;
-    assert_equals(invoker.invokeTargetElement, null);
-    assert_equals(invoker.getAttribute("invoketarget"), "");
-    assert_false(invoker.hasAttribute("invokeaction"));
-  }, "invokeTargetElement does not reflect set value inside shadowroot");
+    invoker.commandForElement = div;
+    assert_equals(invoker.commandForElement, null);
+    assert_equals(invoker.getAttribute("commandfor"), "");
+    assert_equals(invoker.getAttribute("command"), "test");
+  }, "commandForElement does not reflect set value inside shadowroot");
 
   test(function () {
     assert_throws_js(
       TypeError,
       function () {
-        invoker.invokeTargetElement = {};
+        invoker.commandForElement = {};
       },
-      "invokeTargetElement attribute must be an instance of Element",
+      "commandForElement attribute must be an instance of Element",
     );
-  }, "invokeTargetElement throws error on assignment of non Element");
+  }, "commandForElement throws error on assignment of non Element");
 
   test(function () {
-    assert_false(invoker.hasAttribute("invokeaction"));
-    assert_equals(invoker.invokeAction, "");
-  }, "invokeAction reflects '' when attribute not present");
+    invoker.setAttribute("command", "");
+    assert_equals(invoker.getAttribute("command"), "");
+    assert_equals(invoker.command, "");
+  }, "command reflects '' when attribute empty, setAttribute version");
 
   test(function () {
-    invoker.setAttribute("invokeaction", "");
-    assert_equals(invoker.getAttribute("invokeaction"), "");
-    assert_equals(invoker.invokeAction, "");
-  }, "invokeAction reflects '' when attribute empty, setAttribute version");
+    invoker.command = "fooBarBaz";
+    assert_equals(invoker.getAttribute("command"), "fooBarBaz");
+    assert_equals(invoker.command, "fooBarBaz");
+  }, "command reflects same casing");
 
   test(function () {
-    invoker.invokeAction = "fooBarBaz";
-    assert_equals(invoker.getAttribute("invokeaction"), "fooBarBaz");
-    assert_equals(invoker.invokeAction, "fooBarBaz");
-  }, "invokeAction reflects same casing");
+    invoker.command = "";
+    assert_equals(invoker.getAttribute("command"), "");
+    assert_equals(invoker.command, "");
+  }, "command reflects '' when attribute empty, IDL version");
 
   test(function () {
-    invoker.invokeAction = "";
-    assert_equals(invoker.getAttribute("invokeaction"), "");
-    assert_equals(invoker.invokeAction, "");
-  }, "invokeAction reflects '' when attribute empty, IDL version");
+    invoker.command = [1, 2, 3];
+    assert_equals(invoker.getAttribute("command"), "1,2,3");
+    assert_equals(invoker.command, "1,2,3");
+  }, "command reflects tostring value");
 
   test(function () {
-    invoker.invokeAction = [1, 2, 3];
-    assert_equals(invoker.getAttribute("invokeaction"), "1,2,3");
-    assert_equals(invoker.invokeAction, "1,2,3");
-  }, "invokeAction reflects tostring value");
+    invoker.command = [];
+    assert_equals(invoker.getAttribute("command"), "");
+    assert_equals(invoker.command, "");
+  }, "command reflects '' when attribute set to []");
 
   test(function () {
-    invoker.invokeAction = [];
-    assert_equals(invoker.getAttribute("invokeaction"), "");
-    assert_equals(invoker.invokeAction, "");
-  }, "invokeAction reflects '' when attribute set to []");
-
-  test(function () {
-    invoker.invokeAction = {};
-    assert_equals(invoker.invokeAction, "[object Object]");
-  }, "invokeAction reflects tostring value 2");
+    invoker.command = {};
+    assert_equals(invoker.command, "[object Object]");
+  }, "command reflects tostring value 2");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative-expected.txt
@@ -1,5 +1,5 @@
 
 
-PASS InvokeEvent propagates across shadow boundaries retargeting invoker
-PASS cross shadow InvokeEvent retargets invoker to host element
+FAIL CommandEvent propagates across shadow boundaries retargeting invoker Can't find variable: CommandEvent
+FAIL cross shadow CommandEvent retargets invoker to host element Can't find variable: CommandEvent
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative.html
@@ -25,7 +25,7 @@
     let hostEventTarget = null;
     let hostEventInvoker = null;
     slot.addEventListener(
-      "invoke",
+      "command",
       (e) => {
         childEvent = e;
         childEventTarget = e.target;
@@ -34,7 +34,7 @@
       { once: true },
     );
     host.addEventListener(
-      "invoke",
+      "command",
       (e) => {
         hostEvent = e;
         hostEventTarget = e.target;
@@ -42,13 +42,13 @@
       },
       { once: true },
     );
-    const event = new InvokeEvent("invoke", {
+    const event = new CommandEvent("command", {
       bubbles: true,
       invoker: slot,
       composed: true,
     });
     slot.dispatchEvent(event);
-    assert_true(childEvent instanceof InvokeEvent, "slot saw invoke event");
+    assert_true(childEvent instanceof CommandEvent, "slot saw invoke event");
     assert_equals(
       childEventTarget,
       slot,
@@ -74,7 +74,7 @@
       host,
       "invoker is retargeted to shadowroot host",
     );
-  }, "InvokeEvent propagates across shadow boundaries retargeting invoker");
+  }, "CommandEvent propagates across shadow boundaries retargeting invoker");
 
   test(function (t) {
     const host = document.createElement("div");
@@ -83,12 +83,13 @@
     const shadow = host.attachShadow({ mode: "open" });
     const button = shadow.appendChild(document.createElement("button"));
     const invokee = host.appendChild(document.createElement("div"));
-    button.invokeTargetElement = invokee;
+    button.commandForElement = invokee;
+    button.command = 'test-command';
     let event = null;
     let eventTarget = null;
     let eventInvoker = null;
     invokee.addEventListener(
-      "invoke",
+      "command",
       (e) => {
         event = e;
         eventTarget = e.target;
@@ -97,8 +98,8 @@
       { once: true },
     );
     button.click();
-    assert_true(event instanceof InvokeEvent);
+    assert_true(event instanceof CommandEvent);
     assert_equals(eventTarget, invokee, "target is invokee");
     assert_equals(eventInvoker, host, "invoker is host");
-  }, "cross shadow InvokeEvent retargets invoker to host element");
+  }, "cross shadow CommandEvent retargets invoker to host element");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt
@@ -1,25 +1,42 @@
 
 
-PASS action is a readonly defaulting to ''
-PASS invoker is readonly defaulting to null
-PASS action reflects initialized attribute
-PASS action set to undefined
-PASS action set to null
-PASS action set to false
-PASS action explicitly set to empty string
-PASS action set to true
-PASS action set to a number
-PASS action set to []
-PASS action set to [1, 2, 3]
-PASS action set to an object
-PASS action set to an object with a toString function
-PASS InvokeEventInit properties set value
-PASS InvokeEventInit properties set value 2
-PASS InvokeEventInit properties set value 3
-PASS invoker set to undefined
-PASS invoker set to null
-PASS invoker set to false
-PASS invoker set to true
-PASS invoker set to {}
-PASS invoker set to non-Element EventTarget
+FAIL command is a readonly defaulting to '' Can't find variable: CommandEvent
+FAIL invoker is readonly defaulting to null Can't find variable: CommandEvent
+FAIL command reflects initialized attribute Can't find variable: CommandEvent
+FAIL command set to undefined Can't find variable: CommandEvent
+FAIL command set to null Can't find variable: CommandEvent
+FAIL command set to false Can't find variable: CommandEvent
+FAIL command explicitly set to empty string Can't find variable: CommandEvent
+FAIL command set to true Can't find variable: CommandEvent
+FAIL command set to a number Can't find variable: CommandEvent
+FAIL command set to [] Can't find variable: CommandEvent
+FAIL command set to [1, 2, 3] Can't find variable: CommandEvent
+FAIL command set to an object Can't find variable: CommandEvent
+FAIL command set to an object with a toString function Can't find variable: CommandEvent
+FAIL CommandEventInit properties set value Can't find variable: CommandEvent
+FAIL CommandEventInit properties set value 2 Can't find variable: CommandEvent
+FAIL CommandEventInit properties set value 3 Can't find variable: CommandEvent
+FAIL invoker set to undefined Can't find variable: CommandEvent
+FAIL invoker set to null Can't find variable: CommandEvent
+FAIL invoker set to false assert_throws_js: invoker is not an object function "function () {
+        new CommandEvent("test", { invoker: false });
+      }" threw object "ReferenceError: Can't find variable: CommandEvent" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL invoker set to true assert_throws_js: invoker is not an object function "function () {
+        const event = new CommandEvent("test", { invoker: true });
+      }" threw object "ReferenceError: Can't find variable: CommandEvent" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL invoker set to {} assert_throws_js: invoker is not an object function "function () {
+        const event = new CommandEvent("test", { invoker: {} });
+      }" threw object "ReferenceError: Can't find variable: CommandEvent" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL invoker set to non-Element EventTarget assert_throws_js: invoker is not an Element function "function () {
+        const eventInit = { command: "closed", invoker: new XMLHttpRequest() };
+        const event = new CommandEvent("toggle", eventInit);
+      }" threw object "ReferenceError: Can't find variable: CommandEvent" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html
@@ -14,112 +14,112 @@
 
 <script>
   test(function () {
-    const event = new InvokeEvent("test");
-    assert_equals(event.action, "");
-    assert_readonly(event, "action", "readonly attribute value");
-  }, "action is a readonly defaulting to ''");
+    const event = new CommandEvent("test");
+    assert_equals(event.command, "");
+    assert_readonly(event, "command", "readonly attribute value");
+  }, "command is a readonly defaulting to ''");
 
   test(function () {
-    const event = new InvokeEvent("test");
+    const event = new CommandEvent("test");
     assert_equals(event.invoker, null);
     assert_readonly(event, "invoker", "readonly attribute value");
   }, "invoker is readonly defaulting to null");
 
   test(function () {
-    const event = new InvokeEvent("test", { action: "sAmPle" });
-    assert_equals(event.action, "sAmPle");
-  }, "action reflects initialized attribute");
+    const event = new CommandEvent("test", { command: "sAmPle" });
+    assert_equals(event.command, "sAmPle");
+  }, "command reflects initialized attribute");
 
   test(function () {
-    const event = new InvokeEvent("test", { action: undefined });
-    assert_equals(event.action, "");
-  }, "action set to undefined");
+    const event = new CommandEvent("test", { command: undefined });
+    assert_equals(event.command, "");
+  }, "command set to undefined");
 
   test(function () {
-    const event = new InvokeEvent("test", { action: null });
-    assert_equals(event.action, "null");
-  }, "action set to null");
+    const event = new CommandEvent("test", { command: null });
+    assert_equals(event.command, "null");
+  }, "command set to null");
 
   test(function () {
-    const event = new InvokeEvent("test", { action: false });
-    assert_equals(event.action, "false");
-  }, "action set to false");
+    const event = new CommandEvent("test", { command: false });
+    assert_equals(event.command, "false");
+  }, "command set to false");
 
   test(function () {
-    const event = new InvokeEvent("test", { action: "" });
-    assert_equals(event.action, "");
-  }, "action explicitly set to empty string");
+    const event = new CommandEvent("test", { command: "" });
+    assert_equals(event.command, "");
+  }, "command explicitly set to empty string");
 
   test(function () {
-    const event = new InvokeEvent("test", { action: true });
-    assert_equals(event.action, "true");
-  }, "action set to true");
+    const event = new CommandEvent("test", { command: true });
+    assert_equals(event.command, "true");
+  }, "command set to true");
 
   test(function () {
-    const event = new InvokeEvent("test", { action: 0.5 });
-    assert_equals(event.action, "0.5");
-  }, "action set to a number");
+    const event = new CommandEvent("test", { command: 0.5 });
+    assert_equals(event.command, "0.5");
+  }, "command set to a number");
 
   test(function () {
-    const event = new InvokeEvent("test", { action: [] });
-    assert_equals(event.action, "");
-  }, "action set to []");
+    const event = new CommandEvent("test", { command: [] });
+    assert_equals(event.command, "");
+  }, "command set to []");
 
   test(function () {
-    const event = new InvokeEvent("test", { action: [1, 2, 3] });
-    assert_equals(event.action, "1,2,3");
-  }, "action set to [1, 2, 3]");
+    const event = new CommandEvent("test", { command: [1, 2, 3] });
+    assert_equals(event.command, "1,2,3");
+  }, "command set to [1, 2, 3]");
 
   test(function () {
-    const event = new InvokeEvent("test", { action: { sample: 0.5 } });
-    assert_equals(event.action, "[object Object]");
-  }, "action set to an object");
+    const event = new CommandEvent("test", { command: { sample: 0.5 } });
+    assert_equals(event.command, "[object Object]");
+  }, "command set to an object");
 
   test(function () {
-    const event = new InvokeEvent("test", {
-      action: {
+    const event = new CommandEvent("test", {
+      command: {
         toString() {
           return "sample";
         },
       },
     });
-    assert_equals(event.action, "sample");
-  }, "action set to an object with a toString function");
+    assert_equals(event.command, "sample");
+  }, "command set to an object with a toString function");
 
   test(function () {
-    const eventInit = { action: "sample", invoker: document.body };
-    const event = new InvokeEvent("test", eventInit);
-    assert_equals(event.action, "sample");
+    const eventInit = { command: "sample", invoker: document.body };
+    const event = new CommandEvent("test", eventInit);
+    assert_equals(event.command, "sample");
     assert_equals(event.invoker, document.body);
-  }, "InvokeEventInit properties set value");
+  }, "CommandEventInit properties set value");
 
   test(function () {
     const eventInit = {
-      action: "open",
+      command: "open",
       invoker: document.getElementById("div"),
     };
-    const event = new InvokeEvent("beforetoggle", eventInit);
-    assert_equals(event.action, "open");
+    const event = new CommandEvent("beforetoggle", eventInit);
+    assert_equals(event.command, "open");
     assert_equals(event.invoker, document.getElementById("div"));
-  }, "InvokeEventInit properties set value 2");
+  }, "CommandEventInit properties set value 2");
 
   test(function () {
     const eventInit = {
-      action: "closed",
+      command: "closed",
       invoker: document.getElementById("button"),
     };
-    const event = new InvokeEvent("toggle", eventInit);
-    assert_equals(event.action, "closed");
+    const event = new CommandEvent("toggle", eventInit);
+    assert_equals(event.command, "closed");
     assert_equals(event.invoker, document.getElementById("button"));
-  }, "InvokeEventInit properties set value 3");
+  }, "CommandEventInit properties set value 3");
 
   test(function () {
-    const event = new InvokeEvent("test", { invoker: undefined });
+    const event = new CommandEvent("test", { invoker: undefined });
     assert_equals(event.invoker, null);
   }, "invoker set to undefined");
 
   test(function () {
-    const event = new InvokeEvent("test", { invoker: null });
+    const event = new CommandEvent("test", { invoker: null });
     assert_equals(event.invoker, null);
   }, "invoker set to null");
 
@@ -127,7 +127,7 @@
     assert_throws_js(
       TypeError,
       function () {
-        new InvokeEvent("test", { invoker: false });
+        new CommandEvent("test", { invoker: false });
       },
       "invoker is not an object",
     );
@@ -137,7 +137,7 @@
     assert_throws_js(
       TypeError,
       function () {
-        const event = new InvokeEvent("test", { invoker: true });
+        const event = new CommandEvent("test", { invoker: true });
       },
       "invoker is not an object",
     );
@@ -147,7 +147,7 @@
     assert_throws_js(
       TypeError,
       function () {
-        const event = new InvokeEvent("test", { invoker: {} });
+        const event = new CommandEvent("test", { invoker: {} });
       },
       "invoker is not an object",
     );
@@ -157,8 +157,8 @@
     assert_throws_js(
       TypeError,
       function () {
-        const eventInit = { action: "closed", invoker: new XMLHttpRequest() };
-        const event = new InvokeEvent("toggle", eventInit);
+        const eventInit = { command: "closed", invoker: new XMLHttpRequest() };
+        const event = new CommandEvent("toggle", eventInit);
       },
       "invoker is not an Element",
     );

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
@@ -1,33 +1,35 @@
 
 
-PASS event dispatches on click
-PASS setting custom invokeAction property to -foo (must include dash) sets event action
-PASS setting custom invokeaction attribute to -foo (must include dash) sets event action
-PASS setting custom invokeAction property to foo- (must include dash) sets event action
-PASS setting custom invokeaction attribute to foo- (must include dash) sets event action
-PASS setting custom invokeAction property to cAsE-cArRiEs (must include dash) sets event action
-PASS setting custom invokeaction attribute to cAsE-cArRiEs (must include dash) sets event action
-PASS setting custom invokeAction property to - (must include dash) sets event action
-PASS setting custom invokeaction attribute to - (must include dash) sets event action
-PASS setting custom invokeAction property to -a- (must include dash) sets event action
-PASS setting custom invokeaction attribute to -a- (must include dash) sets event action
-PASS setting custom invokeAction property to a-b (must include dash) sets event action
-PASS setting custom invokeaction attribute to a-b (must include dash) sets event action
-PASS setting custom invokeAction property to --- (must include dash) sets event action
-PASS setting custom invokeaction attribute to --- (must include dash) sets event action
-PASS setting custom invokeAction property to show-picker (must include dash) sets event action
-PASS setting custom invokeaction attribute to show-picker (must include dash) sets event action
-PASS setting custom invokeAction property to foo (no dash) did not dispatch an event
-PASS setting custom invokeaction attribute to foo (no dash) did not dispatch an event
-PASS setting custom invokeAction property to foobar (no dash) did not dispatch an event
-PASS setting custom invokeaction attribute to foobar (no dash) did not dispatch an event
-PASS setting custom invokeAction property to foo bar (no dash) did not dispatch an event
-PASS setting custom invokeaction attribute to foo bar (no dash) did not dispatch an event
-PASS setting custom invokeAction property to em—dash (no dash) did not dispatch an event
-PASS setting custom invokeaction attribute to em—dash (no dash) did not dispatch an event
-PASS setting custom invokeAction property to hidedocument (no dash) did not dispatch an event
-PASS setting custom invokeaction attribute to hidedocument (no dash) did not dispatch an event
+FAIL event dispatches on click promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command property to -foo (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command attribute to -foo (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command property to foo- (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command attribute to foo- (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command property to cAsE-cArRiEs (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command attribute to cAsE-cArRiEs (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command property to - (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command attribute to - (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command property to -a- (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command attribute to -a- (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command property to a-b (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command attribute to a-b (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command property to --- (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command attribute to --- (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command property to show-picker (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+FAIL setting custom command attribute to show-picker (must include dash) sets event command promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: CommandEvent"
+PASS setting custom command property to foo (no dash) did not dispatch an event
+PASS setting custom command attribute to foo (no dash) did not dispatch an event
+PASS setting custom command property to foobar (no dash) did not dispatch an event
+PASS setting custom command attribute to foobar (no dash) did not dispatch an event
+PASS setting custom command property to foo bar (no dash) did not dispatch an event
+PASS setting custom command attribute to foo bar (no dash) did not dispatch an event
+PASS setting custom command property to em—dash (no dash) did not dispatch an event
+PASS setting custom command attribute to em—dash (no dash) did not dispatch an event
+PASS setting custom command property to hidedocument (no dash) did not dispatch an event
+PASS setting custom command attribute to hidedocument (no dash) did not dispatch an event
 PASS event does not dispatch if click:preventDefault is called
 PASS event does not dispatch if invoker is disabled
-PASS event dispatches if invokee is non-HTML Element
+PASS event does not dispatch if invoker is form associated without `type`
+FAIL event dispatches if invoker is form associated with `type=button` assert_true: event was not called expected true got false
+FAIL event dispatches if invokee is non-HTML Element assert_equals: expected (object) Element node <svg id="svg-invokee"></svg> but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
@@ -11,79 +11,90 @@
 <script src="resources/invoker-utils.js"></script>
 
 <div id="invokee"></div>
-<button id="invokerbutton" invoketarget="invokee"></button>
+<button id="invokerbutton" commandfor="invokee" command="custom-command"></button>
+<form id="aform"></form>
 
 <script>
+  aform.addEventListener('submit', (e) => (e.preventDefault()));
+
+  function resetState() {
+    invokerbutton.setAttribute("commandfor", "invokee");
+    invokerbutton.setAttribute("command", "custom-command");
+    invokerbutton.removeAttribute("disabled");
+    invokerbutton.removeAttribute("form");
+    invokerbutton.removeAttribute("type");
+  }
+
   promise_test(async function (t) {
     let event = null;
-    invokee.addEventListener("invoke", (e) => (event = e), { once: true });
+    invokee.addEventListener("command", (e) => (event = e), { once: true });
     await clickOn(invokerbutton);
-    assert_true(event instanceof InvokeEvent, "event is InvokeEvent");
-    assert_equals(event.type, "invoke", "type");
+    assert_true(event instanceof CommandEvent, "event is CommandEvent");
+    assert_equals(event.type, "command", "type");
     assert_equals(event.bubbles, false, "bubbles");
     assert_equals(event.composed, true, "composed");
     assert_equals(event.isTrusted, true, "isTrusted");
-    assert_equals(event.action, "", "action");
+    assert_equals(event.command, "custom-command", "command");
     assert_equals(event.target, invokee, "target");
     assert_equals(event.invoker, invokerbutton, "invoker");
   }, "event dispatches on click");
 
   // valid custom invokeactions
   ["-foo", "foo-", "cAsE-cArRiEs", "-", "-a-", "a-b", "---", "show-picker"].forEach(
-    (action) => {
+    (command) => {
       promise_test(async function (t) {
-        t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+        t.add_cleanup(resetState);
         let event = null;
-        invokee.addEventListener("invoke", (e) => (event = e), { once: true });
-        invokerbutton.invokeAction = action;
+        invokee.addEventListener("command", (e) => (event = e), { once: true });
+        invokerbutton.command = command;
         await clickOn(invokerbutton);
-        assert_true(event instanceof InvokeEvent, "event is InvokeEvent");
-        assert_equals(event.type, "invoke", "type");
+        assert_true(event instanceof CommandEvent, "event is CommandEvent");
+        assert_equals(event.type, "command", "type");
         assert_equals(event.bubbles, false, "bubbles");
         assert_equals(event.composed, true, "composed");
         assert_equals(event.isTrusted, true, "isTrusted");
-        assert_equals(event.action, action, "action");
+        assert_equals(event.command, command, "command");
         assert_equals(event.target, invokee, "target");
         assert_equals(event.invoker, invokerbutton, "invoker");
-      }, `setting custom invokeAction property to ${action} (must include dash) sets event action`);
+      }, `setting custom command property to ${command} (must include dash) sets event command`);
 
       promise_test(async function (t) {
-        t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+        t.add_cleanup(resetState);
         let event = null;
-        invokee.addEventListener("invoke", (e) => (event = e), { once: true });
-        invokerbutton.setAttribute("invokeaction", action);
+        invokee.addEventListener("command", (e) => (event = e), { once: true });
+        invokerbutton.setAttribute("command", command);
         await clickOn(invokerbutton);
-        assert_true(event instanceof InvokeEvent, "event is InvokeEvent");
-        assert_equals(event.type, "invoke", "type");
+        assert_true(event instanceof CommandEvent, "event is CommandEvent");
+        assert_equals(event.type, "command", "type");
         assert_equals(event.bubbles, false, "bubbles");
         assert_equals(event.composed, true, "composed");
         assert_equals(event.isTrusted, true, "isTrusted");
-        assert_equals(event.action, action, "action");
+        assert_equals(event.command, command, "command");
         assert_equals(event.target, invokee, "target");
         assert_equals(event.invoker, invokerbutton, "invoker");
-      }, `setting custom invokeaction attribute to ${action} (must include dash) sets event action`);
+      }, `setting custom command attribute to ${command} (must include dash) sets event command`);
     },
   );
 
   // invalid custom invokeactions
-  ["foo", "foobar", "foo bar", "em—dash", "hidedocument"].forEach((action) => {
+  ["foo", "foobar", "foo bar", "em—dash", "hidedocument"].forEach((command) => {
     promise_test(async function (t) {
-      t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+      t.add_cleanup(resetState);
       let event = null;
-      invokee.addEventListener("invoke", (e) => (event = e), { once: true });
-      invokerbutton.invokeAction = action;
+      invokee.addEventListener("command", (e) => (event = e), { once: true });
+      invokerbutton.command = command;
       await clickOn(invokerbutton);
       assert_equals(event, null, "event should not have fired");
-    }, `setting custom invokeAction property to ${action} (no dash) did not dispatch an event`);
+    }, `setting custom command property to ${command} (no dash) did not dispatch an event`);
 
     promise_test(async function (t) {
-      t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
+      t.add_cleanup(resetState);
       let event = null;
-      invokee.addEventListener("invoke", (e) => (event = e), { once: true });
-      invokerbutton.setAttribute("invokeaction", action);
+      invokee.addEventListener("command", (e) => (event = e), { once: true });
+      invokerbutton.setAttribute("command", command);
       await clickOn(invokerbutton);
       assert_equals(event, null, "event should not have fired");
-    }, `setting custom invokeaction attribute to ${action} (no dash) did not dispatch an event`);
+    }, `setting custom command attribute to ${command} (no dash) did not dispatch an event`);
   });
 
   promise_test(async function (t) {
@@ -96,7 +107,7 @@
       { once: true },
     );
     invokee.addEventListener(
-      "invoke",
+      "command",
       (event) => {
         called = true;
       },
@@ -107,52 +118,49 @@
   }, "event does not dispatch if click:preventDefault is called");
 
   promise_test(async function (t) {
-    t.add_cleanup(() => invokerbutton.removeAttribute("disabled"));
+    t.add_cleanup(resetState);
     let called = false;
-    invokee.addEventListener(
-      "invoke",
-      (event) => {
-        called = true;
-      },
-      { once: true },
-    );
+    invokee.addEventListener("command", (e) => (called = true), { once: true });
     invokerbutton.setAttribute("disabled", "");
     await clickOn(invokerbutton);
     assert_false(called, "event was not called");
   }, "event does not dispatch if invoker is disabled");
 
   promise_test(async function (t) {
-    svgInvokee = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    t.add_cleanup(() => {
-      invokerbutton.invokeTargetElement = invokee;
-      svgInvokee.remove();
-    });
-    document.body.append(svgInvokee);
+    t.add_cleanup(resetState);
     let called = false;
+    invokee.addEventListener("command", (e) => (called = true), { once: true });
+    invokerbutton.setAttribute("form", "aform");
+    await clickOn(invokerbutton);
+    assert_false(called, "event was not called");
+  }, "event does not dispatch if invoker is form associated without `type`");
+
+  promise_test(async function (t) {
+    t.add_cleanup(resetState);
+    let called = false;
+    invokee.addEventListener("command", (e) => (called = true), { once: true });
+    invokerbutton.setAttribute("form", "aform");
+    invokerbutton.setAttribute("type", "button");
+    await clickOn(invokerbutton);
+    assert_true(called, "event was not called");
+  }, "event dispatches if invoker is form associated with `type=button`");
+
+  promise_test(async function (t) {
+    svgInvokee = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svgInvokee.setAttribute("id", "svg-invokee");
+    t.add_cleanup(resetState);
+    document.body.append(svgInvokee);
     assert_false(svgInvokee instanceof HTMLElement);
     assert_true(svgInvokee instanceof Element);
-    let eventInvoker = null;
-    svgInvokee.addEventListener(
-      "invoke",
-      (event) => {
-        eventInvoker = event.invoker;
-        eventTarget = event.target;
-        called = true;
-      },
-      { once: true },
-    );
-    invokerbutton.invokeTargetElement = svgInvokee;
+    let event = null;
+    svgInvokee.addEventListener("command", (e) => (event = e), { once: true });
+    invokerbutton.setAttribute("commandfor", "svg-invokee");
+    invokerbutton.setAttribute("command", "custom-command");
+    assert_equals(invokerbutton.commandForElement, svgInvokee);
     await clickOn(invokerbutton);
-    assert_true(called, "event was called");
-    assert_equals(
-      eventInvoker,
-      invokerbutton,
-      "event.invoker is set to right element",
-    );
-    assert_equals(
-      eventTarget,
-      svgInvokee,
-      "event.target is set to right element",
-    );
+    assert_not_equals(event, null, "event was called");
+    assert_true(event instanceof CommandEvent, "event is CommandEvent");
+    assert_equals(event.invoker, invokerbutton, "event.invoker is set to right element");
+    assert_equals(event.target, svgInvokee, "event.target is set to right element");
   }, "event dispatches if invokee is non-HTML Element");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative.html
@@ -12,65 +12,47 @@
 
 <div id="invokee">
   Fullscreen content
-  <button id="invokerbutton" invoketarget="invokee"></button>
+  <button id="invokerbutton" commandfor="invokee"></button>
 </div>
 
 <script>
-  // auto
-
-  promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      if (document.fullscreenElement) await document.exitFullscreen();
-    });
-    assert_false(invokee.matches(":fullscreen"));
-    await clickOn(invokerbutton);
-    assert_false(invokee.matches(":fullscreen"));
-  }, "invoking div with auto action is no-op");
+  async function resetState() {
+    invokerbutton.setAttribute("command", "toggleFullscreen");
+    if (document.fullscreenElement) await document.exitFullscreen();
+  }
 
   // toggleFullscreen
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      if (document.fullscreenElement) await document.exitFullscreen();
-    });
+    t.add_cleanup(resetState);
     assert_false(invokee.matches(":fullscreen"));
-    invokerbutton.setAttribute("invokeaction", "toggleFullscreen");
+    invokerbutton.setAttribute("command", "toggleFullscreen");
     await clickOn(invokerbutton);
     assert_true(invokee.matches(":fullscreen"));
   }, "invoking div with toggleFullscreen action makes div fullscreen");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      if (document.fullscreenElement) await document.exitFullscreen();
-    });
+    t.add_cleanup(resetState);
     assert_false(invokee.matches(":fullscreen"));
-    invokerbutton.setAttribute("invokeaction", "toggleFullscreen");
+    invokerbutton.setAttribute("command", "toggleFullscreen");
     invokerbutton.click();
     assert_false(invokee.matches(":fullscreen"));
   }, "invoking div with toggleFullscreen action (without user activation) is a no-op");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      if (document.fullscreenElement) await document.exitFullscreen();
-    });
-    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+    t.add_cleanup(resetState);
+    invokee.addEventListener("command", (e) => e.preventDefault(), {
       once: true,
     });
     assert_false(invokee.matches(":fullscreen"));
-    invokerbutton.setAttribute("invokeaction", "toggleFullscreen");
+    invokerbutton.setAttribute("command", "toggleFullscreen");
     await clickOn(invokerbutton);
     assert_false(invokee.matches(":fullscreen"));
   }, "invoking div with toggleFullscreen action and preventDefault is a no-op");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      if (document.fullscreenElement) await document.exitFullscreen();
-    });
-    invokerbutton.setAttribute("invokeaction", "toggleFullscreen");
+    t.add_cleanup(resetState);
+    invokerbutton.setAttribute("command", "toggleFullscreen");
     await test_driver.bless('go fullscreen');
     await invokee.requestFullscreen();
     assert_true(invokee.matches(":fullscreen"));
@@ -79,11 +61,8 @@
   }, "invoking fullscreen div with toggleFullscreen action exits fullscreen");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      if (document.fullscreenElement) await document.exitFullscreen();
-    });
-    invokerbutton.setAttribute("invokeaction", "tOgGlEFullscreen");
+    t.add_cleanup(resetState);
+    invokerbutton.setAttribute("command", "tOgGlEFullscreen");
     await test_driver.bless('go fullscreen');
     await invokee.requestFullscreen();
     assert_true(invokee.matches(":fullscreen"));
@@ -94,36 +73,27 @@
   // requestFullscreen
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      if (document.fullscreenElement) await document.exitFullscreen();
-    });
+    t.add_cleanup(resetState);
     assert_false(invokee.matches(":fullscreen"));
-    invokerbutton.setAttribute("invokeaction", "requestFullscreen");
+    invokerbutton.setAttribute("command", "requestFullscreen");
     await clickOn(invokerbutton);
     assert_true(invokee.matches(":fullscreen"));
   }, "invoking div with requestFullscreen action makes div fullscreen");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      if (document.fullscreenElement) await document.exitFullscreen();
-    });
-    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+    t.add_cleanup(resetState);
+    invokee.addEventListener("command", (e) => e.preventDefault(), {
       once: true,
     });
     assert_false(invokee.matches(":fullscreen"));
-    invokerbutton.setAttribute("invokeaction", "requestFullscreen");
+    invokerbutton.setAttribute("command", "requestFullscreen");
     await clickOn(invokerbutton);
     assert_false(invokee.matches(":fullscreen"));
   }, "invoking div with requestFullscreen action and preventDefault is a no-op");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      if (document.fullscreenElement) await document.exitFullscreen();
-    });
-    invokerbutton.setAttribute("invokeaction", "requestFullscreen");
+    t.add_cleanup(resetState);
+    invokerbutton.setAttribute("command", "requestFullscreen");
     await test_driver.bless('go fullscreen');
     await invokee.requestFullscreen();
     assert_true(invokee.matches(":fullscreen"));
@@ -134,22 +104,16 @@
   // exitFullscreen
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      if (document.fullscreenElement) await document.exitFullscreen();
-    });
+    t.add_cleanup(resetState);
     assert_false(invokee.matches(":fullscreen"));
-    invokerbutton.setAttribute("invokeaction", "exitFullscreen");
+    invokerbutton.setAttribute("command", "exitFullscreen");
     await clickOn(invokerbutton);
     assert_false(invokee.matches(":fullscreen"));
   }, "invoking div with exitFullscreen action is a no-op");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      if (document.fullscreenElement) await document.exitFullscreen();
-    });
-    invokerbutton.setAttribute("invokeaction", "exitFullscreen");
+    t.add_cleanup(resetState);
+    invokerbutton.setAttribute("command", "exitFullscreen");
     await test_driver.bless('go fullscreen');
     await invokee.requestFullscreen();
     assert_true(invokee.matches(":fullscreen"));
@@ -158,14 +122,11 @@
   }, "invoking fullscreen div with exitFullscreen action exits fullscreen");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      if (document.fullscreenElement) await document.exitFullscreen();
-    });
-    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+    t.add_cleanup(resetState);
+    invokee.addEventListener("command", (e) => e.preventDefault(), {
       once: true,
     });
-    invokerbutton.setAttribute("invokeaction", "exitFullscreen");
+    invokerbutton.setAttribute("command", "exitFullscreen");
     await test_driver.bless('go fullscreen');
     await invokee.requestFullscreen();
     assert_true(invokee.matches(":fullscreen"));

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-behavior.tentative.html
@@ -11,38 +11,22 @@
 <script src="resources/invoker-utils.js"></script>
 
 <audio controls id="invokee" src="/media/sound_5.mp3"></audio>
-<button id="invokerbutton" invoketarget="invokee"></button>
+<button id="invokerbutton" commandfor="invokee" command="mute"></button>
 
 <script>
-  // auto
-
-  promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
-    assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "");
-    await clickOn(invokerbutton);
-    await new Promise((resolve) => {
-      requestAnimationFrame(resolve);
-    });
-    assert_true(invokee.paused);
-  }, "invoking audio with auto action is no-op");
+  function resetState() {
+    invokerbutton.setAttribute("command", "mute");
+    invokee.pause();
+    invokee.currentTime = 0;
+    invokee.muted = false;
+  }
 
   // playpause
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
+    t.add_cleanup(resetState);
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "playpause");
+    invokerbutton.setAttribute("command", "playpause");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -51,14 +35,9 @@
   }, "invoking audio with playpause action makes audio play");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
+    t.add_cleanup(resetState);
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "playpause");
+    invokerbutton.setAttribute("command", "playpause");
     invokerbutton.click();
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -67,17 +46,12 @@
   }, "invoking audio with playpause action (without user activation) is a no-op");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
-    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+    t.add_cleanup(resetState);
+    invokee.addEventListener("command", (e) => e.preventDefault(), {
       once: true,
     });
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "playpause");
+    invokerbutton.setAttribute("command", "playpause");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -86,16 +60,11 @@
   }, "invoking audio with playpause action and preventDefault is a no-op");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
+    t.add_cleanup(resetState);
     await test_driver.bless("play audio");
     invokee.play();
     assert_false(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "playpause");
+    invokerbutton.setAttribute("command", "playpause");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -106,14 +75,9 @@
   // play
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
+    t.add_cleanup(resetState);
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "play");
+    invokerbutton.setAttribute("command", "play");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -122,14 +86,9 @@
   }, "invoking audio with play action makes audio play");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
+    t.add_cleanup(resetState);
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "play");
+    invokerbutton.setAttribute("command", "play");
     invokerbutton.click();
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -138,17 +97,12 @@
   }, "invoking audio with play action (without user activation) is a no-op");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
-    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+    t.add_cleanup(resetState);
+    invokee.addEventListener("command", (e) => e.preventDefault(), {
       once: true,
     });
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "play");
+    invokerbutton.setAttribute("command", "play");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -157,16 +111,11 @@
   }, "invoking audio with play action and preventDefault is a no-op");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
+    t.add_cleanup(resetState);
     await test_driver.bless("play audio");
     invokee.play();
     assert_false(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "play");
+    invokerbutton.setAttribute("command", "play");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -177,14 +126,9 @@
   // pause
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
+    t.add_cleanup(resetState);
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "pause");
+    invokerbutton.setAttribute("command", "pause");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -193,17 +137,12 @@
   }, "invoking audio with pause action is a no-op");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
-    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+    t.add_cleanup(resetState);
+    invokee.addEventListener("command", (e) => e.preventDefault(), {
       once: true,
     });
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "pause");
+    invokerbutton.setAttribute("command", "pause");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -212,16 +151,11 @@
   }, "invoking audio with pause action and preventDefault is a no-op");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
+    t.add_cleanup(resetState);
     await test_driver.bless("play audio");
     invokee.play();
     assert_false(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "pause");
+    invokerbutton.setAttribute("command", "pause");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -232,14 +166,9 @@
   // mute
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
+    t.add_cleanup(resetState);
     assert_false(invokee.muted);
-    invokerbutton.setAttribute("invokeaction", "toggleMuted");
+    invokerbutton.setAttribute("command", "toggleMuted");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -248,17 +177,12 @@
   }, "invoking audio with toggleMuted action mutes it");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
-    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+    t.add_cleanup(resetState);
+    invokee.addEventListener("command", (e) => e.preventDefault(), {
       once: true,
     });
     assert_false(invokee.muted);
-    invokerbutton.setAttribute("invokeaction", "toggleMuted");
+    invokerbutton.setAttribute("command", "toggleMuted");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -267,15 +191,10 @@
   }, "invoking audio with toggleMuted action and preventDefault is a no-op");
 
   promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
+    t.add_cleanup(resetState);
     invokee.muted = true;
     assert_true(invokee.muted);
-    invokerbutton.setAttribute("invokeaction", "toggleMuted");
+    invokerbutton.setAttribute("command", "toggleMuted");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-invalid-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-invalid-behavior.tentative-expected.txt
@@ -1,5 +1,6 @@
 
 
+PASS invoking (as ) on audio does nothing
 PASS invoking (as foo-bar) on audio does nothing
 PASS invoking (as showpopover) on audio does nothing
 PASS invoking (as showmodal) on audio does nothing

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-invalid-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-invalid-behavior.tentative.html
@@ -11,11 +11,12 @@
 <script src="resources/invoker-utils.js"></script>
 
 <audio controls id="invokee" src="/media/sound_5.mp3"></audio>
-<button id="invokerbutton" invoketarget="invokee"></button>
+<button id="invokerbutton" commandfor="invokee"></button>
 
 <script>
   // invalid actions on audio
   [
+    "",
     "foo-bar",
     "showpopover",
     "showmodal",
@@ -24,8 +25,8 @@
     "close",
   ].forEach((action) => {
     promise_test(async function (t) {
-      t.add_cleanup(() => invokerbutton.removeAttribute("invokeaction"));
-      invokerbutton.setAttribute("invokeaction", action);
+      t.add_cleanup(() => invokerbutton.removeAttribute("command"));
+      invokerbutton.setAttribute("command", action);
       assert_true(invokee.paused);
       assert_false(invokee.muted);
       await clickOn(invokerbutton);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative.html
@@ -11,95 +11,83 @@
 <script src="resources/invoker-utils.js"></script>
 
 <details id="invokee">Details Contents</details>
-<button id="invokerbutton" invoketarget="invokee"></button>
+<button id="invokerbutton" commandfor="invokee" command="open"></button>
 
 <script>
   function resetState() {
-    invokerbutton.removeAttribute("invokeaction");
+    invokerbutton.removeAttribute("command");
     invokee.removeAttribute("open");
   }
 
   // Open actions
   [
-    null,
-    "",
     "toggle",
     "open",
     /* test case sensitivity */
     "tOgGlE",
     "oPeN",
-  ].forEach((action) => {
+  ].forEach((command) => {
     promise_test(
       async function (t) {
         t.add_cleanup(resetState);
-        if (action !== null) invokerbutton.invokeAction = action;
+        invokerbutton.command = command;
         assert_false(invokee.matches("[open]"));
         await clickOn(invokerbutton);
         assert_true(invokee.matches("[open]"));
       },
-      `invoking (as ${
-        action === null ? "auto" : action || "explicit empty"
-      }) closed details opens`,
+      `invoking (as ${command}) closed details opens`,
     );
 
     promise_test(
       async function (t) {
         t.add_cleanup(resetState);
-        if (action !== null) invokerbutton.invokeAction = action;
+        invokerbutton.command = command;
         assert_false(invokee.matches("[open]"));
-        invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+        invokee.addEventListener("command", (e) => e.preventDefault(), {
           once: true,
         });
         await clickOn(invokerbutton);
         t.add_cleanup(() => invokee.removeAttribute("open"));
         assert_false(invokee.matches("[open]"));
       },
-      `invoking (as ${
-        action === null ? "auto" : action || "explicit empty"
-      }) closed details with preventDefault does not open`,
+      `invoking (as ${command}) closed details with preventDefault does not open`,
     );
   });
 
   // Close actions
   [
-    null,
-    "",
     "toggle",
     "close",
     /* test case sensitivity */
     "tOgGlE",
     "cLoSe",
-  ].forEach((action) => {
+  ].forEach((command) => {
     promise_test(
       async function (t) {
         t.add_cleanup(resetState);
-        if (action !== null) invokerbutton.invokeAction = action;
+        invokerbutton.command = command;
         invokee.setAttribute("open", "");
         assert_true(invokee.matches("[open]"));
         await clickOn(invokerbutton);
         assert_false(invokee.matches("[open]"));
       },
-      `invoking (as ${
-        action === null ? "auto" : action || "explicit empty"
-      }) open details closes`,
+      `invoking (as ${command}) open details closes`,
     );
 
     promise_test(
       async function (t) {
         t.add_cleanup(resetState);
-        if (action !== null) invokerbutton.invokeAction = action;
+        invokerbutton.command = command;
         invokee.setAttribute("open", "");
-        invokerbutton.setAttribute("invokeaction", "toggle");
-        invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+        invokerbutton.setAttribute("command", "toggle");
+        invokee.addEventListener("command", (e) => e.preventDefault(), {
           once: true,
         });
         assert_true(invokee.matches("[open]"));
         await clickOn(invokerbutton);
         assert_true(invokee.matches("[open]"));
       },
-      `invoking (as ${
-        action === null ? "auto" : action || "explicit empty"
-      }) open details with prevent default closes`,
+      `invoking (as ${command}) open details with prevent default closes`,
     );
   });
 
@@ -107,9 +95,9 @@
 
   promise_test(async function (t) {
     t.add_cleanup(resetState);
-    invokerbutton.invokeAction = "toggle";
+    invokerbutton.command = "toggle";
     invokee.addEventListener(
-      "invoke",
+      "command",
       (e) => {
         invokee.setAttribute("open", "");
       },
@@ -126,20 +114,20 @@
 
   promise_test(async function (t) {
     t.add_cleanup(resetState);
-    invokerbutton.invokeAction = "open";
+    invokerbutton.command = "open";
     invokee.setAttribute("open", "");
     assert_true(invokee.matches("[open]"));
     await clickOn(invokerbutton);
     assert_true(invokee.matches("[open]"));
-  }, "invoking open details with open action is noop");
+  }, "invoking open details with open command is noop");
 
   // close
 
   promise_test(async function (t) {
     t.add_cleanup(resetState);
-    invokerbutton.invokeAction = "close";
+    invokerbutton.command = "close";
     assert_false(invokee.matches("[open]"));
     await clickOn(invokerbutton);
     assert_false(invokee.matches("[open]"));
-  }, "invoking closed details with close action is noop");
+  }, "invoking closed details with close command is noop");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-invalid-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-invalid-behavior.tentative-expected.txt
@@ -1,5 +1,7 @@
 
 
+PASS invoking (as ) on details does nothing
+PASS invoking (as ) on open details does nothing
 PASS invoking (as foo-bar) on details does nothing
 PASS invoking (as foo-bar) on open details does nothing
 PASS invoking (as showpopover) on details does nothing

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-invalid-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-invalid-behavior.tentative.html
@@ -11,16 +11,17 @@
 <script src="resources/invoker-utils.js"></script>
 
 <details id="invokee">Details Contents</details>
-<button id="invokerbutton" invoketarget="invokee"></button>
+<button id="invokerbutton" commandfor="invokee" command="open"></button>
 
 <script>
   function resetState() {
-    invokerbutton.removeAttribute("invokeaction");
+    invokerbutton.removeAttribute("command");
     invokee.removeAttribute("open");
   }
 
   // invalid actions on details
   [
+    "",
     "foo-bar",
     "showpopover",
     "showmodal",
@@ -28,22 +29,22 @@
     "hidepopover",
     "hide",
     "toggleopen",
-  ].forEach((action) => {
+  ].forEach((command) => {
     promise_test(async function (t) {
       t.add_cleanup(resetState);
-      invokerbutton.invokeAction = action;
+      invokerbutton.command = command;
       assert_false(invokee.matches("[open]"));
       await clickOn(invokerbutton);
       assert_false(invokee.matches("[open]"));
-    }, `invoking (as ${action}) on details does nothing`);
+    }, `invoking (as ${command}) on details does nothing`);
 
     promise_test(async function (t) {
       t.add_cleanup(resetState);
-      invokerbutton.invokeAction = action;
+      invokerbutton.command = command;
       invokee.setAttribute("open", "");
       assert_true(invokee.matches("[open]"));
       await clickOn(invokerbutton);
       assert_true(invokee.matches("[open]"));
-    }, `invoking (as ${action}) on open details does nothing`);
+    }, `invoking (as ${command}) on open details does nothing`);
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative-expected.txt
@@ -1,86 +1,49 @@
 
 
-PASS invoking (with invokeaction property as auto) closed dialog opens as modal
-PASS invoking (with invokeaction property as auto) closed dialog with preventDefault is noop
-PASS invoking (with invokeaction property as auto) while changing action still opens as modal
-PASS invoking (with invokeaction attribute as auto) closed dialog opens as modal
-PASS invoking (with invokeaction attribute as auto) closed dialog with preventDefault is noop
-PASS invoking (with invokeaction attribute as auto) while changing action still opens as modal
-PASS invoking (with invokeaction property as explicit empty) closed dialog opens as modal
-PASS invoking (with invokeaction property as explicit empty) closed dialog with preventDefault is noop
-PASS invoking (with invokeaction property as explicit empty) while changing action still opens as modal
-PASS invoking (with invokeaction attribute as explicit empty) closed dialog opens as modal
-PASS invoking (with invokeaction attribute as explicit empty) closed dialog with preventDefault is noop
-PASS invoking (with invokeaction attribute as explicit empty) while changing action still opens as modal
-PASS invoking (with invokeaction property as showmodal) closed dialog opens as modal
-PASS invoking (with invokeaction property as showmodal) closed dialog with preventDefault is noop
-PASS invoking (with invokeaction property as showmodal) while changing action still opens as modal
-PASS invoking (with invokeaction attribute as showmodal) closed dialog opens as modal
-PASS invoking (with invokeaction attribute as showmodal) closed dialog with preventDefault is noop
-PASS invoking (with invokeaction attribute as showmodal) while changing action still opens as modal
-PASS invoking (with invokeaction property as sHoWmOdAl) closed dialog opens as modal
-PASS invoking (with invokeaction property as sHoWmOdAl) closed dialog with preventDefault is noop
-PASS invoking (with invokeaction property as sHoWmOdAl) while changing action still opens as modal
-PASS invoking (with invokeaction attribute as sHoWmOdAl) closed dialog opens as modal
-PASS invoking (with invokeaction attribute as sHoWmOdAl) closed dialog with preventDefault is noop
-PASS invoking (with invokeaction attribute as sHoWmOdAl) while changing action still opens as modal
-PASS invoking to close (with invokeaction property as auto) open dialog closes
-PASS invoking to close (with invokeaction property as auto) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction property as auto) open modal dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction property as auto) open dialog while changing action still closes
-PASS invoking to close (with invokeaction property as auto) open modal dialog while changing action still closes
-PASS invoking to close (with invokeaction attribute as auto) open dialog closes
-PASS invoking to close (with invokeaction attribute as auto) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction attribute as auto) open modal dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction attribute as auto) open dialog while changing action still closes
-PASS invoking to close (with invokeaction attribute as auto) open modal dialog while changing action still closes
-PASS invoking to close (with invokeaction property as explicit empty) open dialog closes
-PASS invoking to close (with invokeaction property as explicit empty) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction property as explicit empty) open modal dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction property as explicit empty) open dialog while changing action still closes
-PASS invoking to close (with invokeaction property as explicit empty) open modal dialog while changing action still closes
-PASS invoking to close (with invokeaction attribute as explicit empty) open dialog closes
-PASS invoking to close (with invokeaction attribute as explicit empty) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction attribute as explicit empty) open modal dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction attribute as explicit empty) open dialog while changing action still closes
-PASS invoking to close (with invokeaction attribute as explicit empty) open modal dialog while changing action still closes
-PASS invoking to close (with invokeaction property as close) open dialog closes
-PASS invoking to close (with invokeaction property as close) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction property as close) open modal dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction property as close) open dialog while changing action still closes
-PASS invoking to close (with invokeaction property as close) open modal dialog while changing action still closes
-PASS invoking to close (with invokeaction attribute as close) open dialog closes
-PASS invoking to close (with invokeaction attribute as close) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction attribute as close) open modal dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction attribute as close) open dialog while changing action still closes
-PASS invoking to close (with invokeaction attribute as close) open modal dialog while changing action still closes
-PASS invoking to close (with invokeaction property as cLoSe) open dialog closes
-PASS invoking to close (with invokeaction property as cLoSe) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction property as cLoSe) open modal dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction property as cLoSe) open dialog while changing action still closes
-PASS invoking to close (with invokeaction property as cLoSe) open modal dialog while changing action still closes
-PASS invoking to close (with invokeaction attribute as cLoSe) open dialog closes
-PASS invoking to close (with invokeaction attribute as cLoSe) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction attribute as cLoSe) open modal dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction attribute as cLoSe) open dialog while changing action still closes
-PASS invoking to close (with invokeaction attribute as cLoSe) open modal dialog while changing action still closes
+FAIL invoking (with command property as showmodal) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with command property as showmodal) closed dialog with preventDefault is noop
+FAIL invoking (with command property as showmodal) while changing command still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking (with command attribute as showmodal) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with command attribute as showmodal) closed dialog with preventDefault is noop
+FAIL invoking (with command attribute as showmodal) while changing command still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking (with command property as sHoWmOdAl) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with command property as sHoWmOdAl) closed dialog with preventDefault is noop
+FAIL invoking (with command property as sHoWmOdAl) while changing command still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking (with command attribute as sHoWmOdAl) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with command attribute as sHoWmOdAl) closed dialog with preventDefault is noop
+FAIL invoking (with command attribute as sHoWmOdAl) while changing command still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking to close (with command property as close) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with command property as close) open dialog with preventDefault is no-op
+PASS invoking to close (with command property as close) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with command property as close) open dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command property as close) open modal dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command attribute as close) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with command attribute as close) open dialog with preventDefault is no-op
+PASS invoking to close (with command attribute as close) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with command attribute as close) open dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command attribute as close) open modal dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command property as cLoSe) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with command property as cLoSe) open dialog with preventDefault is no-op
+PASS invoking to close (with command property as cLoSe) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with command property as cLoSe) open dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command property as cLoSe) open modal dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command attribute as cLoSe) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with command attribute as cLoSe) open dialog with preventDefault is no-op
+PASS invoking to close (with command attribute as cLoSe) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with command attribute as cLoSe) open dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command attribute as cLoSe) open modal dialog while changing command still closes assert_false: invokee.open expected false got true
 PASS invoking (as showmodal) open dialog is noop
-PASS invoking (as showmodal) open modal, while changing action still a no-op
-PASS invoking (as showmodal) closed popover dialog opens as modal
+PASS invoking (as showmodal) open modal, while changing command still a no-op
+FAIL invoking (as showmodal) closed popover dialog opens as modal assert_true: invokee.open expected true got false
 PASS invoking (as close) already closed dialog is noop
 PASS invoking (as showmodal) dialog as open popover=manual is noop
 PASS invoking (as showmodal) dialog as open popover=auto is noop
 PASS invoking (as close) dialog as open popover=manual is noop
 PASS invoking (as close) dialog as open popover=auto is noop
-PASS invoking (as explicit empty) dialog as open popover=manual is noop
-PASS invoking (as explicit empty) dialog as open popover=auto is noop
 PASS invoking (as showmodal) dialog that is removed is noop
 PASS invoking (as showmodal) dialog from a detached invoker
 PASS invoking (as showmodal) detached dialog from a detached invoker
 PASS invoking (as close) dialog that is removed is noop
 PASS invoking (as close) dialog from a detached invoker
 PASS invoking (as close) detached dialog from a detached invoker
-PASS invoking (as explicit empty) dialog that is removed is noop
-PASS invoking (as explicit empty) dialog from a detached invoker
-PASS invoking (as explicit empty) detached dialog from a detached invoker
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative.html
@@ -11,43 +11,39 @@
 <script src="resources/invoker-utils.js"></script>
 
 <dialog id="invokee">
-  <button id="containedinvoker" invoketarget="invokee"></button>
+  <button id="containedinvoker" commandfor="invokee" command="close"></button>
 </dialog>
-<button id="invokerbutton" invoketarget="invokee"></button>
+<button id="invokerbutton" commandfor="invokee" command="showmodal"></button>
 
 <script>
   function resetState() {
     invokee.close();
     try { invokee.hidePopover(); } catch {}
     invokee.removeAttribute("popover");
-    invokerbutton.removeAttribute("invokeaction");
-    containedinvoker.removeAttribute("invokeaction");
+    invokerbutton.setAttribute("command", "showmodal");
+    containedinvoker.setAttribute("command", "close");
   }
 
   // opening a dialog
 
-  [null, "", "showmodal", /* test case sensitivity */ "sHoWmOdAl"].forEach(
-    (action) => {
+  ["showmodal", /* test case sensitivity */ "sHoWmOdAl"].forEach(
+    (command) => {
       ["property", "attribute"].forEach((setType) => {
         promise_test(
           async function (t) {
             t.add_cleanup(resetState);
             assert_false(invokee.open, "invokee.open");
             assert_false(invokee.matches(":modal"), "invokee :modal");
-            if (typeof action === "string") {
-              if (setType === "property") {
-                invokerbutton.invokeaction = action;
-              } else {
-                invokerbutton.setAttribute("invokeaction", action);
-              }
+            if (setType === "property") {
+              invokerbutton.command = command;
+            } else {
+              invokerbutton.setAttribute("command", command);
             }
             await clickOn(invokerbutton);
             assert_true(invokee.open, "invokee.open");
             assert_true(invokee.matches(":modal"), "invokee :modal");
           },
-          `invoking (with invokeaction ${setType} as ${
-            action == null ? "auto" : action || "explicit empty"
-          }) closed dialog opens as modal`,
+          `invoking (with command ${setType} as ${command}) closed dialog opens as modal`,
         );
 
         promise_test(
@@ -55,23 +51,19 @@
             t.add_cleanup(resetState);
             assert_false(invokee.open, "invokee.open");
             assert_false(invokee.matches(":modal"), "invokee :modal");
-            invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+            invokee.addEventListener("command", (e) => e.preventDefault(), {
               once: true,
             });
-            if (typeof action === "string") {
-              if (setType === "property") {
-                invokerbutton.invokeaction = action;
-              } else {
-                invokerbutton.setAttribute("invokeaction", action);
-              }
+            if (setType === "property") {
+              invokerbutton.command = command;
+            } else {
+              invokerbutton.setAttribute("command", command);
             }
             await clickOn(invokerbutton);
             assert_false(invokee.open, "invokee.open");
             assert_false(invokee.matches(":modal"), "invokee :modal");
           },
-          `invoking (with invokeaction ${setType} as ${
-            action == null ? "auto" : action || "explicit empty"
-          }) closed dialog with preventDefault is noop`,
+          `invoking (with command ${setType} as ${command}) closed dialog with preventDefault is noop`,
         );
 
         promise_test(
@@ -80,26 +72,22 @@
             assert_false(invokee.open, "invokee.open");
             assert_false(invokee.matches(":modal"), "invokee :modal");
             invokee.addEventListener(
-              "invoke",
+              "command",
               (e) => {
-                invokerbutton.setAttribute("invokeaction", "close");
+                invokerbutton.setAttribute("command", "close");
               },
               { once: true },
             );
-            if (typeof action === "string") {
-              if (setType === "property") {
-                invokerbutton.invokeaction = action;
-              } else {
-                invokerbutton.setAttribute("invokeaction", action);
-              }
+            if (setType === "property") {
+              invokerbutton.command = command;
+            } else {
+              invokerbutton.setAttribute("command", command);
             }
             await clickOn(invokerbutton);
             assert_true(invokee.open, "invokee.open");
             assert_true(invokee.matches(":modal"), "invokee :modal");
           },
-          `invoking (with invokeaction ${setType} as ${
-            action == null ? "auto" : action || "explicit empty"
-          }) while changing action still opens as modal`,
+          `invoking (with command ${setType} as ${command}) while changing command still opens as modal`,
         );
       });
     },
@@ -107,7 +95,7 @@
 
   // closing an already open dialog
 
-  [null, "", "close", /* test case sensitivity */ "cLoSe"].forEach((action) => {
+  ["close", /* test case sensitivity */ "cLoSe"].forEach((command) => {
     ["property", "attribute"].forEach((setType) => {
       promise_test(
         async function (t) {
@@ -115,20 +103,16 @@
           invokee.show();
           assert_true(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
-          if (typeof action === "string") {
-            if (setType === "property") {
-              containedinvoker.invokeaction = action;
-            } else {
-              containedinvoker.setAttribute("invokeaction", action);
-            }
+          if (setType === "property") {
+            containedinvoker.command = command;
+          } else {
+            containedinvoker.setAttribute("command", command);
           }
           await clickOn(containedinvoker);
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
-        `invoking to close (with invokeaction ${setType} as ${
-          action == null ? "auto" : action || "explicit empty"
-        }) open dialog closes`,
+        `invoking to close (with command ${setType} as ${command}) open dialog closes`,
       );
 
       promise_test(
@@ -137,23 +121,21 @@
           invokee.show();
           assert_true(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
-          if (typeof action === "string") {
+          if (typeof command === "string") {
             if (setType === "property") {
-              containedinvoker.invokeaction = action;
+              containedinvoker.command = command;
             } else {
-              containedinvoker.setAttribute("invokeaction", action);
+              containedinvoker.setAttribute("command", command);
             }
           }
-          invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+          invokee.addEventListener("command", (e) => e.preventDefault(), {
             once: true,
           });
           await clickOn(containedinvoker);
           assert_true(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
-        `invoking to close (with invokeaction ${setType} as ${
-          action == null ? "auto" : action || "explicit empty"
-        }) open dialog with preventDefault is no-op`,
+        `invoking to close (with command ${setType} as ${command}) open dialog with preventDefault is no-op`,
       );
 
       promise_test(
@@ -162,23 +144,19 @@
           invokee.showModal();
           assert_true(invokee.open, "invokee.open");
           assert_true(invokee.matches(":modal"), "invokee :modal");
-          if (typeof action === "string") {
-            if (setType === "property") {
-              containedinvoker.invokeaction = action;
-            } else {
-              containedinvoker.setAttribute("invokeaction", action);
-            }
+          if (setType === "property") {
+            containedinvoker.command = command;
+          } else {
+            containedinvoker.setAttribute("command", command);
           }
-          invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+          invokee.addEventListener("command", (e) => e.preventDefault(), {
             once: true,
           });
           await clickOn(containedinvoker);
           assert_true(invokee.open, "invokee.open");
           assert_true(invokee.matches(":modal"), "invokee :modal");
         },
-        `invoking to close (with invokeaction ${setType} as ${
-          action == null ? "auto" : action || "explicit empty"
-        }) open modal dialog with preventDefault is no-op`,
+        `invoking to close (with command ${setType} as ${command}) open modal dialog with preventDefault is no-op`,
       );
 
       promise_test(
@@ -187,17 +165,15 @@
           invokee.show();
           assert_true(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
-          if (typeof action === "string") {
-            if (setType === "property") {
-              containedinvoker.invokeaction = action;
-            } else {
-              containedinvoker.setAttribute("invokeaction", action);
-            }
+          if (setType === "property") {
+            containedinvoker.command = command;
+          } else {
+            containedinvoker.setAttribute("command", command);
           }
           invokee.addEventListener(
-            "invoke",
+            "command",
             (e) => {
-              containedinvoker.setAttribute("invokeaction", "show");
+              containedinvoker.setAttribute("command", "show");
             },
             { once: true },
           );
@@ -205,9 +181,7 @@
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
-        `invoking to close (with invokeaction ${setType} as ${
-          action == null ? "auto" : action || "explicit empty"
-        }) open dialog while changing action still closes`,
+        `invoking to close (with command ${setType} as ${command}) open dialog while changing command still closes`,
       );
 
       promise_test(
@@ -216,17 +190,15 @@
           invokee.showModal();
           assert_true(invokee.open, "invokee.open");
           assert_true(invokee.matches(":modal"), "invokee :modal");
-          if (typeof action === "string") {
-            if (setType === "property") {
-              containedinvoker.invokeaction = action;
-            } else {
-              containedinvoker.setAttribute("invokeaction", action);
-            }
+          if (setType === "property") {
+            containedinvoker.command = command;
+          } else {
+            containedinvoker.setAttribute("command", command);
           }
           invokee.addEventListener(
-            "invoke",
+            "command",
             (e) => {
-              containedinvoker.setAttribute("invokeaction", "show");
+              containedinvoker.setAttribute("command", "show");
             },
             { once: true },
           );
@@ -234,9 +206,7 @@
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
-        `invoking to close (with invokeaction ${setType} as ${
-          action == null ? "auto" : action || "explicit empty"
-        }) open modal dialog while changing action still closes`,
+        `invoking to close (with command ${setType} as ${command}) open modal dialog while changing command still closes`,
       );
     });
   });
@@ -245,7 +215,7 @@
 
   promise_test(async function (t) {
     t.add_cleanup(resetState);
-    containedinvoker.setAttribute("invokeaction", "showModal");
+    containedinvoker.setAttribute("command", "showModal");
     invokee.show();
     assert_true(invokee.open, "invokee.open");
     assert_false(invokee.matches(":modal"), "invokee :modal");
@@ -256,25 +226,25 @@
 
   promise_test(async function (t) {
     t.add_cleanup(resetState);
-    containedinvoker.setAttribute("invokeaction", "showmodal");
+    containedinvoker.setAttribute("command", "showmodal");
     invokee.showModal();
     assert_true(invokee.open, "invokee.open");
     assert_true(invokee.matches(":modal"), "invokee :modal");
     invokee.addEventListener(
-      "invoke",
+      "command",
       (e) => {
-        containedinvoker.setAttribute("invokeaction", "close");
+        containedinvoker.setAttribute("command", "close");
       },
       { once: true },
     );
     await clickOn(invokerbutton);
     assert_true(invokee.open, "invokee.open");
     assert_true(invokee.matches(":modal"), "invokee :modal");
-  }, "invoking (as showmodal) open modal, while changing action still a no-op");
+  }, "invoking (as showmodal) open modal, while changing command still a no-op");
 
   promise_test(async function (t) {
     t.add_cleanup(resetState);
-    invokerbutton.setAttribute("invokeaction", "showmodal");
+    invokerbutton.setAttribute("command", "showmodal");
     assert_false(invokee.open, "invokee.open");
     assert_false(invokee.matches(":modal"), "invokee :modal");
     invokee.setAttribute("popover", "auto");
@@ -287,7 +257,7 @@
 
   promise_test(async function (t) {
     t.add_cleanup(resetState);
-    invokerbutton.setAttribute("invokeaction", "close");
+    invokerbutton.setAttribute("command", "close");
     assert_false(invokee.open, "invokee.open");
     assert_false(invokee.matches(":modal"), "invokee :modal");
     await clickOn(containedinvoker);
@@ -296,21 +266,21 @@
   }, "invoking (as close) already closed dialog is noop");
 
   // Open Popovers using Dialog actions
-  ["showmodal", "close", ""].forEach((action) => {
+  ["showmodal", "close"].forEach((command) => {
     ["manual", "auto"].forEach((popoverState) => {
       promise_test(
         async function (t) {
           t.add_cleanup(resetState);
           invokee.setAttribute("popover", popoverState);
           invokee.showPopover();
-          containedinvoker.setAttribute("invokeaction", action);
+          containedinvoker.setAttribute("command", command);
           assert_true(
             invokee.matches(":popover-open"),
             "invokee :popover-open",
           );
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
-          invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+          invokee.addEventListener("command", (e) => e.preventDefault(), {
             once: true,
           });
           await clickOn(containedinvoker);
@@ -321,15 +291,13 @@
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
-        `invoking (as ${
-          action || "explicit empty"
-        }) dialog as open popover=${popoverState} is noop`,
+        `invoking (as ${command}) dialog as open popover=${popoverState} is noop`,
       );
     });
   });
 
   // Elements being disconnected during invoke steps
-  ["showmodal", "close", ""].forEach((action) => {
+  ["showmodal", "close"].forEach((command) => {
     promise_test(
       async function (t) {
         t.add_cleanup(() => {
@@ -337,11 +305,11 @@
           resetState();
         });
         const invokee = document.querySelector("#invokee");
-        invokerbutton.setAttribute("invokeaction", action);
+        invokerbutton.setAttribute("command", command);
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
         invokee.addEventListener(
-          "invoke",
+          "command",
           (e) => {
             invokee.remove();
           },
@@ -353,42 +321,36 @@
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
       },
-      `invoking (as ${
-        action || "explicit empty"
-      }) dialog that is removed is noop`,
+      `invoking (as ${command}) dialog that is removed is noop`,
     );
 
     promise_test(
       async function (t) {
         const invokerbutton = document.createElement("button");
-        invokerbutton.invokeTargetElement = invokee;
-        invokerbutton.setAttribute("invokeaction", action);
+        invokerbutton.commandForElement = invokee;
+        invokerbutton.setAttribute("command", command);
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
         await clickOn(invokerbutton);
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
       },
-      `invoking (as ${
-        action || "explicit empty"
-      }) dialog from a detached invoker`,
+      `invoking (as ${command}) dialog from a detached invoker`,
     );
 
     promise_test(
       async function (t) {
         const invokerbutton = document.createElement("button");
         const invokee = document.createElement("dialog");
-        invokerbutton.invokeTargetElement = invokee;
-        invokerbutton.setAttribute("invokeaction", action);
+        invokerbutton.commandForElementt = invokee;
+        invokerbutton.setAttribute("command", command);
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
         await clickOn(invokerbutton);
         assert_false(invokee.open, "invokee.open");
         assert_false(invokee.matches(":modal"), "invokee :modal");
       },
-      `invoking (as ${
-        action || "explicit empty"
-      }) detached dialog from a detached invoker`,
+      `invoking (as ${command}) detached dialog from a detached invoker`,
     );
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-invalid-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-invalid-behavior.tentative-expected.txt
@@ -1,5 +1,9 @@
 
 
+PASS invoking (as ) on dialog does nothing
+PASS invoking (as ) on open dialog does nothing
+PASS invoking (as ) on open modal dialog does nothing
+PASS invoking (as ) on open modal while changing the attributer does nothing
 PASS invoking (as foo) on dialog does nothing
 PASS invoking (as foo) on open dialog does nothing
 PASS invoking (as foo) on open modal dialog does nothing
@@ -32,6 +36,4 @@ PASS invoking (as showmodal) dialog as open popover=manual is noop
 PASS invoking (as showmodal) dialog as open popover=auto is noop
 PASS invoking (as close) dialog as open popover=manual is noop
 PASS invoking (as close) dialog as open popover=auto is noop
-PASS invoking (as explicit empty) dialog as open popover=manual is noop
-PASS invoking (as explicit empty) dialog as open popover=auto is noop
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-invalid-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-invalid-behavior.tentative.html
@@ -11,21 +11,22 @@
 <script src="resources/invoker-utils.js"></script>
 
 <dialog id="invokee">
-  <button id="containedinvoker" invoketarget="invokee"></button>
+  <button id="containedinvoker" commandfor="invokee" command="close"></button>
 </dialog>
-<button id="invokerbutton" invoketarget="invokee"></button>
+<button id="invokerbutton" commandfor="invokee" command="showmodal"></button>
 
 <script>
   function resetState() {
     invokee.close();
     try { invokee.hidePopover(); } catch {}
     invokee.removeAttribute("popover");
-    invokerbutton.removeAttribute("invokeaction");
-    containedinvoker.removeAttribute("invokeaction");
+    invokerbutton.removeAttribute("command");
+    containedinvoker.removeAttribute("command");
   }
 
   // invalid
   [
+    "",
     "foo",
     "foo-bar",
     "auto",
@@ -36,7 +37,7 @@
   ].forEach((action) => {
     promise_test(async function (t) {
       t.add_cleanup(resetState);
-      invokerbutton.setAttribute("invokeaction", action);
+      invokerbutton.setAttribute("command", action);
       assert_false(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
       await clickOn(invokerbutton);
@@ -46,7 +47,7 @@
 
     promise_test(async function (t) {
       t.add_cleanup(resetState);
-      containedinvoker.setAttribute("invokeaction", action);
+      containedinvoker.setAttribute("command", action);
       invokee.show();
       assert_true(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
@@ -57,7 +58,7 @@
 
     promise_test(async function (t) {
       t.add_cleanup(resetState);
-      containedinvoker.setAttribute("invokeaction", action);
+      containedinvoker.setAttribute("command", action);
       invokee.showModal();
       assert_true(invokee.open, "invokee.open");
       assert_true(invokee.matches(":modal"), "invokee :modal");
@@ -68,14 +69,14 @@
 
     promise_test(async function (t) {
       t.add_cleanup(resetState);
-      containedinvoker.setAttribute("invokeaction", action);
+      containedinvoker.setAttribute("command", action);
       invokee.showModal();
       assert_true(invokee.open, "invokee.open");
       assert_true(invokee.matches(":modal"), "invokee :modal");
       invokee.addEventListener(
-        "invoke",
+        "command",
         (e) => {
-          containedinvoker.setAttribute("invokeaction", "");
+          containedinvoker.setAttribute("command", "");
         },
         { once: true },
       );
@@ -86,21 +87,21 @@
   });
 
   // Open Popovers using Dialog actions
-  ["showmodal", "close", ""].forEach((action) => {
+  ["showmodal", "close"].forEach((action) => {
     ["manual", "auto"].forEach((popoverState) => {
       promise_test(
         async function (t) {
           t.add_cleanup(resetState);
           invokee.setAttribute("popover", popoverState);
           invokee.showPopover();
-          containedinvoker.setAttribute("invokeaction", action);
+          containedinvoker.setAttribute("command", action);
           assert_true(
             invokee.matches(":popover-open"),
             "invokee :popover-open",
           );
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
-          invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+          invokee.addEventListener("command", (e) => e.preventDefault(), {
             once: true,
           });
           await clickOn(containedinvoker);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
@@ -1,36 +1,30 @@
 
 
-PASS changing invokeaction attribute inside invokeevent doesn't impact the invocation
-PASS invoking (as auto) closed popover opens
-PASS invoking (as auto) closed popover with preventDefault does not open
-PASS invoking (as explicit empty) closed popover opens
-PASS invoking (as explicit empty) closed popover with preventDefault does not open
-PASS invoking (as togglepopover) closed popover opens
+FAIL changing command attribute inside invokeevent doesn't impact the invocation assert_true: expected true got false
+FAIL invoking (as togglepopover) closed popover opens assert_true: expected true got false
 PASS invoking (as togglepopover) closed popover with preventDefault does not open
-PASS invoking (as showpopover) closed popover opens
+FAIL invoking (as showpopover) closed popover opens assert_true: expected true got false
 PASS invoking (as showpopover) closed popover with preventDefault does not open
-PASS invoking (as tOgGlEpOpOvEr) closed popover opens
+FAIL invoking (as tOgGlEpOpOvEr) closed popover opens assert_true: expected true got false
 PASS invoking (as tOgGlEpOpOvEr) closed popover with preventDefault does not open
-PASS invoking (as sHoWpOpOvEr) closed popover opens
+FAIL invoking (as sHoWpOpOvEr) closed popover opens assert_true: expected true got false
 PASS invoking (as sHoWpOpOvEr) closed popover with preventDefault does not open
-PASS invoking (as auto) open popover closes
-PASS invoking (as auto) from within open popover closes
-PASS invoking (as auto) open popover with preventDefault does not close
-PASS invoking (as explicit empty) open popover closes
-PASS invoking (as explicit empty) from within open popover closes
-PASS invoking (as explicit empty) open popover with preventDefault does not close
 PASS invoking (as togglepopover) open popover closes
-PASS invoking (as togglepopover) from within open popover closes
-PASS invoking (as togglepopover) open popover with preventDefault does not close
+FAIL invoking (as togglepopover) open popover with preventDefault does not close assert_true: expected true got false
+FAIL invoking (as togglepopover) from within open popover closes assert_false: expected false got true
+PASS invoking (as togglepopover) from within open popover with preventDefault does not close
 PASS invoking (as hidepopover) open popover closes
-PASS invoking (as hidepopover) from within open popover closes
-PASS invoking (as hidepopover) open popover with preventDefault does not close
+FAIL invoking (as hidepopover) open popover with preventDefault does not close assert_true: expected true got false
+FAIL invoking (as hidepopover) from within open popover closes assert_false: expected false got true
+PASS invoking (as hidepopover) from within open popover with preventDefault does not close
 PASS invoking (as tOgGlEpOpOvEr) open popover closes
-PASS invoking (as tOgGlEpOpOvEr) from within open popover closes
-PASS invoking (as tOgGlEpOpOvEr) open popover with preventDefault does not close
+FAIL invoking (as tOgGlEpOpOvEr) open popover with preventDefault does not close assert_true: expected true got false
+FAIL invoking (as tOgGlEpOpOvEr) from within open popover closes assert_false: expected false got true
+PASS invoking (as tOgGlEpOpOvEr) from within open popover with preventDefault does not close
 PASS invoking (as hIdEpOpOvEr) open popover closes
-PASS invoking (as hIdEpOpOvEr) from within open popover closes
-PASS invoking (as hIdEpOpOvEr) open popover with preventDefault does not close
-PASS invoking (as showpopover) open popover is noop
+FAIL invoking (as hIdEpOpOvEr) open popover with preventDefault does not close assert_true: expected true got false
+FAIL invoking (as hIdEpOpOvEr) from within open popover closes assert_false: expected false got true
+PASS invoking (as hIdEpOpOvEr) from within open popover with preventDefault does not close
+FAIL invoking (as showpopover) open popover is noop assert_true: expected true got false
 PASS invoking (as hidepopover) closed popover is noop
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html
@@ -11,135 +11,133 @@
 <script src="resources/invoker-utils.js"></script>
 
 <div id="invokee" popover>
-  <button id="containedinvoker" invoketarget="invokee"></button>
+  <button id="containedinvoker" commandfor="invokee" command="hidepopover"></button>
 </div>
-<button id="invokerbutton" invoketarget="invokee"></button>
+<button id="invokerbutton" commandfor="invokee" command="togglepopover"></button>
 
 <script>
-  // auto
-
-  promise_test(async function (t) {
-    assert_false(invokee.matches(":popover-open"));
-    invokee.addEventListener("invoke", (e) => { invokerbutton.setAttribute('invokeaction', 'hidepopover'); }, {
-      once: true,
-    });
-    await clickOn(invokerbutton);
-    t.add_cleanup(() => {
-      invokee.hidePopover();
-      invokerbutton.removeAttribute("invokeaction");
-    });
-    assert_true(invokee.matches(":popover-open"));
-  }, "changing invokeaction attribute inside invokeevent doesn't impact the invocation");
-
   function resetState() {
-    invokerbutton.removeAttribute("invokeaction");
-    containedinvoker.removeAttribute("invokeaction");
+    invokerbutton.setAttribute("commandfor", "invokee");
+    invokerbutton.setAttribute("command", "togglepopover");
+    containedinvoker.setAttribute("commandfor", "invokee");
+    containedinvoker.setAttribute("command", "closepopover");
     try {
       invokee.hidePopover();
     } catch {}
     invokee.setAttribute("popover", "");
   }
 
+  promise_test(async function (t) {
+    assert_false(invokee.matches(":popover-open"));
+    invokee.addEventListener("command", (e) => { invokerbutton.setAttribute('command', 'hidepopover'); }, {
+      once: true,
+    });
+    await clickOn(invokerbutton);
+    t.add_cleanup(resetState);
+    assert_true(invokee.matches(":popover-open"));
+  }, "changing command attribute inside invokeevent doesn't impact the invocation");
+
   // Open actions
   [
-    null,
-    "",
     "togglepopover",
     "showpopover",
     /* test case sensitivity */
     "tOgGlEpOpOvEr",
     "sHoWpOpOvEr",
-  ].forEach((action) => {
+  ].forEach((command) => {
     promise_test(
       async function (t) {
         t.add_cleanup(resetState);
-        if (action !== null) invokerbutton.invokeAction = action;
+        invokerbutton.command = command;
         assert_false(invokee.matches(":popover-open"));
         await clickOn(invokerbutton);
         assert_true(invokee.matches(":popover-open"));
       },
-      `invoking (as ${
-        action === null ? "auto" : action || "explicit empty"
-      }) closed popover opens`,
+      `invoking (as ${command}) closed popover opens`,
     );
 
     promise_test(
       async function (t) {
         t.add_cleanup(resetState);
-        if (action !== null) invokerbutton.invokeAction = action;
+        invokerbutton.command = command;
         assert_false(invokee.matches(":popover-open"));
-        invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+        invokee.addEventListener("command", (e) => e.preventDefault(), {
           once: true,
         });
         await clickOn(invokerbutton);
         assert_false(invokee.matches(":popover-open"));
       },
-      `invoking (as ${
-        action === null ? "auto" : action || "explicit empty"
-      }) closed popover with preventDefault does not open`,
+      `invoking (as ${command}) closed popover with preventDefault does not open`,
     );
   });
 
   // Close actions
   [
-    null,
-    "",
     "togglepopover",
     "hidepopover",
     /* test case sensitivity */
     "tOgGlEpOpOvEr",
     "hIdEpOpOvEr",
-  ].forEach((action) => {
+  ].forEach((command) => {
     promise_test(
       async function (t) {
         t.add_cleanup(resetState);
-        if (action !== null) invokerbutton.invokeAction = action;
+        invokerbutton.command = command;
         invokee.showPopover();
         assert_true(invokee.matches(":popover-open"));
         await clickOn(invokerbutton);
         assert_false(invokee.matches(":popover-open"));
       },
-      `invoking (as ${
-        action === null ? "auto" : action || "explicit empty"
-      }) open popover closes`,
+      `invoking (as ${command}) open popover closes`,
     );
 
     promise_test(
       async function (t) {
         t.add_cleanup(resetState);
-        if (action !== null) containedinvoker.invokeAction = action;
+        invokerbutton.command = command;
+        invokee.showPopover();
+        assert_true(invokee.matches(":popover-open"));
+        invokee.addEventListener("command", (e) => e.preventDefault(), {
+          once: true,
+        });
+        await clickOn(invokerbutton);
+        assert_true(invokee.matches(":popover-open"));
+      },
+      `invoking (as ${command}) open popover with preventDefault does not close`,
+    );
+
+    promise_test(
+      async function (t) {
+        t.add_cleanup(resetState);
+        containedinvoker.command = command;
         invokee.showPopover();
         assert_true(invokee.matches(":popover-open"));
         await clickOn(containedinvoker);
         assert_false(invokee.matches(":popover-open"));
       },
-      `invoking (as ${
-        action === null ? "auto" : action || "explicit empty"
-      }) from within open popover closes`,
+      `invoking (as ${command}) from within open popover closes`,
     );
 
     promise_test(
       async function (t) {
         t.add_cleanup(resetState);
-        if (action !== null) invcontainedinvokervokeaction = action;
+        containedinvoker.command = command;
         invokee.showPopover();
-        invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+        invokee.addEventListener("command", (e) => e.preventDefault(), {
           once: true,
         });
         assert_true(invokee.matches(":popover-open"));
         await clickOn(containedinvoker);
         assert_true(invokee.matches(":popover-open"));
       },
-      `invoking (as ${
-        action === null ? "auto" : action || "explicit empty"
-      }) open popover with preventDefault does not close`,
+      `invoking (as ${command}) from within open popover with preventDefault does not close`,
     );
   });
 
   // showpopover specific
   promise_test(async function (t) {
     t.add_cleanup(resetState);
-    invokerbutton.setAttribute("invokeaction", "showpopover");
+    invokerbutton.setAttribute("command", "showpopover");
     invokee.showPopover();
     assert_true(invokee.matches(":popover-open"));
     await clickOn(invokerbutton);
@@ -149,7 +147,7 @@
   // hidepopover specific
   promise_test(async function (t) {
     t.add_cleanup(resetState);
-    invokerbutton.setAttribute("invokeaction", "hidepopover");
+    invokerbutton.setAttribute("command", "hidepopover");
     assert_false(invokee.matches(":popover-open"));
     await clickOn(invokerbutton);
     assert_false(invokee.matches(":popover-open"));

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-invalid-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-invalid-behavior.tentative-expected.txt
@@ -1,13 +1,17 @@
 
 
+PASS invoking (as null) on popover does nothing
+FAIL invoking (as null) on open popover does nothing assert_true: expected true got false
+PASS invoking (as ) on popover does nothing
+FAIL invoking (as ) on open popover does nothing assert_true: expected true got false
 PASS invoking (as foo-bar) on popover does nothing
-PASS invoking (as foo-bar) on open popover does nothing
+FAIL invoking (as foo-bar) on open popover does nothing assert_true: expected true got false
 PASS invoking (as showmodal) on popover does nothing
-PASS invoking (as showmodal) on open popover does nothing
+FAIL invoking (as showmodal) on open popover does nothing assert_true: expected true got false
 PASS invoking (as showpicker) on popover does nothing
-PASS invoking (as showpicker) on open popover does nothing
+FAIL invoking (as showpicker) on open popover does nothing assert_true: expected true got false
 PASS invoking (as open) on popover does nothing
-PASS invoking (as open) on open popover does nothing
+FAIL invoking (as open) on open popover does nothing assert_true: expected true got false
 PASS invoking (as close) on popover does nothing
-PASS invoking (as close) on open popover does nothing
+FAIL invoking (as close) on open popover does nothing assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-invalid-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-invalid-behavior.tentative.html
@@ -11,14 +11,14 @@
 <script src="resources/invoker-utils.js"></script>
 
 <div id="invokee" popover>
-  <button id="containedinvoker" invoketarget="invokee"></button>
+  <button id="containedinvoker" commandfor="invokee"></button>
 </div>
-<button id="invokerbutton" invoketarget="invokee"></button>
+<button id="invokerbutton" commandfor="invokee"></button>
 
 <script>
   function resetState() {
-    invokerbutton.removeAttribute("invokeaction");
-    containedinvoker.removeAttribute("invokeaction");
+    invokerbutton.removeAttribute("command");
+    containedinvoker.removeAttribute("command");
     try {
       invokee.hidePopover();
     } catch {}
@@ -26,22 +26,22 @@
   }
 
   // invalid actions on showpopover
-  ["foo-bar", "showmodal", "showpicker", "open", "close"].forEach((action) => {
+  [null, "", "foo-bar", "showmodal", "showpicker", "open", "close"].forEach((command) => {
     promise_test(async function (t) {
       t.add_cleanup(resetState);
-      invokerbutton.invokeAction = action;
+      invokerbutton.command = command;
       assert_false(invokee.matches(":popover-open"));
       await clickOn(invokerbutton);
       assert_false(invokee.matches(":popover-open"));
-    }, `invoking (as ${action}) on popover does nothing`);
+    }, `invoking (as ${command}) on popover does nothing`);
 
     promise_test(async function (t) {
       t.add_cleanup(resetState);
-      invokerbutton.invokeAction = action;
+      invokerbutton.command = command;
       invokee.showPopover();
       assert_true(invokee.matches(":popover-open"));
       await clickOn(invokerbutton);
       assert_true(invokee.matches(":popover-open"));
-    }, `invoking (as ${action}) on open popover does nothing`);
+    }, `invoking (as ${command}) on open popover does nothing`);
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-video-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-video-behavior.tentative.html
@@ -11,38 +11,20 @@
 <script src="resources/invoker-utils.js"></script>
 
 <video controls id="invokee" src="/media/movie_5.mp4"></video>
-<button id="invokerbutton" invoketarget="invokee"></button>
+<button id="invokerbutton" commandfor="invokee"></button>
 
 <script>
-  // auto
-
-  promise_test(async function (t) {
-    t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
-      invokee.pause();
-      invokee.currentTime = 0;
-      invokee.muted = false;
-    });
-    assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "");
-    await clickOn(invokerbutton);
-    await new Promise((resolve) => {
-      requestAnimationFrame(resolve);
-    });
-    assert_true(invokee.paused);
-  }, "invoking video with auto action is no-op");
-
   // playpause
 
   promise_test(async function (t) {
     t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
+      invokerbutton.removeAttribute("command");
       invokee.pause();
       invokee.currentTime = 0;
       invokee.muted = false;
     });
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "playpause");
+    invokerbutton.setAttribute("command", "playpause");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -52,16 +34,16 @@
 
   promise_test(async function (t) {
     t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
+      invokerbutton.removeAttribute("command");
       invokee.pause();
       invokee.currentTime = 0;
       invokee.muted = false;
     });
-    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+    invokee.addEventListener("command", (e) => e.preventDefault(), {
       once: true,
     });
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "playpause");
+    invokerbutton.setAttribute("command", "playpause");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -71,7 +53,7 @@
 
   promise_test(async function (t) {
     t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
+      invokerbutton.removeAttribute("command");
       invokee.pause();
       invokee.currentTime = 0;
       invokee.muted = false;
@@ -79,7 +61,7 @@
     await test_driver.bless("play video");
     invokee.play();
     assert_false(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "playpause");
+    invokerbutton.setAttribute("command", "playpause");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -91,13 +73,13 @@
 
   promise_test(async function (t) {
     t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
+      invokerbutton.removeAttribute("command");
       invokee.pause();
       invokee.currentTime = 0;
       invokee.muted = false;
     });
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "play");
+    invokerbutton.setAttribute("command", "play");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -107,16 +89,16 @@
 
   promise_test(async function (t) {
     t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
+      invokerbutton.removeAttribute("command");
       invokee.pause();
       invokee.currentTime = 0;
       invokee.muted = false;
     });
-    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+    invokee.addEventListener("command", (e) => e.preventDefault(), {
       once: true,
     });
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "play");
+    invokerbutton.setAttribute("command", "play");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -126,7 +108,7 @@
 
   promise_test(async function (t) {
     t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
+      invokerbutton.removeAttribute("command");
       invokee.pause();
       invokee.currentTime = 0;
       invokee.muted = false;
@@ -134,7 +116,7 @@
     await test_driver.bless("play video");
     invokee.play();
     assert_false(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "play");
+    invokerbutton.setAttribute("command", "play");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -146,13 +128,13 @@
 
   promise_test(async function (t) {
     t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
+      invokerbutton.removeAttribute("command");
       invokee.pause();
       invokee.currentTime = 0;
       invokee.muted = false;
     });
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "pause");
+    invokerbutton.setAttribute("command", "pause");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -162,16 +144,16 @@
 
   promise_test(async function (t) {
     t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
+      invokerbutton.removeAttribute("command");
       invokee.pause();
       invokee.currentTime = 0;
       invokee.muted = false;
     });
-    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+    invokee.addEventListener("command", (e) => e.preventDefault(), {
       once: true,
     });
     assert_true(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "pause");
+    invokerbutton.setAttribute("command", "pause");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -181,7 +163,7 @@
 
   promise_test(async function (t) {
     t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
+      invokerbutton.removeAttribute("command");
       invokee.pause();
       invokee.currentTime = 0;
       invokee.muted = false;
@@ -189,7 +171,7 @@
     await test_driver.bless("play video");
     invokee.play();
     assert_false(invokee.paused);
-    invokerbutton.setAttribute("invokeaction", "pause");
+    invokerbutton.setAttribute("command", "pause");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -201,13 +183,13 @@
 
   promise_test(async function (t) {
     t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
+      invokerbutton.removeAttribute("command");
       invokee.pause();
       invokee.currentTime = 0;
       invokee.muted = false;
     });
     assert_false(invokee.muted);
-    invokerbutton.setAttribute("invokeaction", "toggleMuted");
+    invokerbutton.setAttribute("command", "toggleMuted");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -217,16 +199,16 @@
 
   promise_test(async function (t) {
     t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
+      invokerbutton.removeAttribute("command");
       invokee.pause();
       invokee.currentTime = 0;
       invokee.muted = false;
     });
-    invokee.addEventListener("invoke", (e) => e.preventDefault(), {
+    invokee.addEventListener("command", (e) => e.preventDefault(), {
       once: true,
     });
     assert_false(invokee.muted);
-    invokerbutton.setAttribute("invokeaction", "toggleMuted");
+    invokerbutton.setAttribute("command", "toggleMuted");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -236,14 +218,14 @@
 
   promise_test(async function (t) {
     t.add_cleanup(async () => {
-      invokerbutton.removeAttribute("invokeaction");
+      invokerbutton.removeAttribute("command");
       invokee.pause();
       invokee.currentTime = 0;
       invokee.muted = false;
     });
     invokee.muted = true;
     assert_true(invokee.muted);
-    invokerbutton.setAttribute("invokeaction", "toggleMuted");
+    invokerbutton.setAttribute("command", "toggleMuted");
     await clickOn(invokerbutton);
     await new Promise((resolve) => {
       requestAnimationFrame(resolve);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/resources/invoker-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/resources/invoker-utils.js
@@ -14,3 +14,14 @@ async function clickOn(element) {
       .send();
   await waitForRender();
 }
+async function hoverOver(element) {
+  await waitForRender();
+  let rect = element.getBoundingClientRect();
+  let actions = new test_driver.Actions();
+  // FIXME: Switch to pointerMove(0, 0, {origin: element}) once
+  // https://github.com/web-platform-tests/wpt/issues/41257 is fixed.
+  await actions
+      .pointerMove(Math.round(rect.x + rect.width / 2), Math.round(rect.y + rect.height / 2), {})
+      .send();
+  await waitForRender();
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log
@@ -16,6 +16,13 @@ None
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interestelement-interface.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interestevent-dispatch-shadow.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interestevent-interface.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interesttarget-anchor-event-dispatch.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interesttarget-area-event-dispatch.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interesttarget-button-event-dispatch.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interesttarget-on-popover-behavior.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interesttarget-svg-a-event-dispatch.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html
@@ -28,6 +35,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-invalid-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-invalid-behavior.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-input-number.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-invalid-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-video-behavior.tentative.html

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/invokers.tentative.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/invokers.tentative.idl
@@ -1,15 +1,15 @@
 interface mixin InvokerElement {
-  [CEReactions,Reflect=invoketarget] attribute Element? invokeTargetElement;
-  [CEReactions,Reflect=invokeaction] attribute DOMString invokeAction;
+  [CEReactions,Reflect=invoketarget] attribute Element? commandForElement;
+  [CEReactions,Reflect=invokeaction] attribute DOMString command;
 };
 
-interface InvokeEvent : Event {
-    constructor(DOMString type, optional InvokeEventInit eventInitDict = {});
+interface CommandEvent : Event {
+    constructor(DOMString type, optional CommandEventInit eventInitDict = {});
     readonly attribute Element? invoker;
-    readonly attribute DOMString action;
+    readonly attribute DOMString command;
 };
 
-dictionary InvokeEventInit : EventInit {
+dictionary CommandEventInit : EventInit {
     Element? invoker = null;
-    DOMString action = "";
+    DOMString command = "";
 };

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative-expected.txt
@@ -1,86 +1,49 @@
 
 
-FAIL invoking (with invokeaction property as auto) closed dialog opens as modal assert_true: invokee.open expected true got false
-PASS invoking (with invokeaction property as auto) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction property as auto) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction attribute as auto) closed dialog opens as modal assert_true: invokee.open expected true got false
-PASS invoking (with invokeaction attribute as auto) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction attribute as auto) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction property as explicit empty) closed dialog opens as modal assert_true: invokee.open expected true got false
-PASS invoking (with invokeaction property as explicit empty) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction property as explicit empty) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction attribute as explicit empty) closed dialog opens as modal assert_true: invokee.open expected true got false
-PASS invoking (with invokeaction attribute as explicit empty) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction attribute as explicit empty) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction property as showmodal) closed dialog opens as modal assert_true: invokee.open expected true got false
-PASS invoking (with invokeaction property as showmodal) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction property as showmodal) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction attribute as showmodal) closed dialog opens as modal assert_true: invokee.open expected true got false
-PASS invoking (with invokeaction attribute as showmodal) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction attribute as showmodal) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction property as sHoWmOdAl) closed dialog opens as modal assert_true: invokee.open expected true got false
-PASS invoking (with invokeaction property as sHoWmOdAl) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction property as sHoWmOdAl) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking (with invokeaction attribute as sHoWmOdAl) closed dialog opens as modal assert_true: invokee.open expected true got false
-PASS invoking (with invokeaction attribute as sHoWmOdAl) closed dialog with preventDefault is noop
-FAIL invoking (with invokeaction attribute as sHoWmOdAl) while changing action still opens as modal assert_true: invokee.open expected true got false
-FAIL invoking to close (with invokeaction property as auto) open dialog closes assert_false: invokee.open expected false got true
-PASS invoking to close (with invokeaction property as auto) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction property as auto) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction property as auto) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as auto) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as auto) open dialog closes assert_false: invokee.open expected false got true
-PASS invoking to close (with invokeaction attribute as auto) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction attribute as auto) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction attribute as auto) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as auto) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as explicit empty) open dialog closes assert_false: invokee.open expected false got true
-PASS invoking to close (with invokeaction property as explicit empty) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction property as explicit empty) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction property as explicit empty) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as explicit empty) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as explicit empty) open dialog closes assert_false: invokee.open expected false got true
-PASS invoking to close (with invokeaction attribute as explicit empty) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction attribute as explicit empty) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction attribute as explicit empty) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as explicit empty) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as close) open dialog closes assert_false: invokee.open expected false got true
-PASS invoking to close (with invokeaction property as close) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction property as close) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction property as close) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as close) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as close) open dialog closes assert_false: invokee.open expected false got true
-PASS invoking to close (with invokeaction attribute as close) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction attribute as close) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction attribute as close) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as close) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as cLoSe) open dialog closes assert_false: invokee.open expected false got true
-PASS invoking to close (with invokeaction property as cLoSe) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction property as cLoSe) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction property as cLoSe) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction property as cLoSe) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as cLoSe) open dialog closes assert_false: invokee.open expected false got true
-PASS invoking to close (with invokeaction attribute as cLoSe) open dialog with preventDefault is no-op
-PASS invoking to close (with invokeaction attribute as cLoSe) open modal dialog with preventDefault is no-op
-FAIL invoking to close (with invokeaction attribute as cLoSe) open dialog while changing action still closes assert_false: invokee.open expected false got true
-FAIL invoking to close (with invokeaction attribute as cLoSe) open modal dialog while changing action still closes assert_false: invokee.open expected false got true
+FAIL invoking (with command property as showmodal) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with command property as showmodal) closed dialog with preventDefault is noop
+FAIL invoking (with command property as showmodal) while changing command still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking (with command attribute as showmodal) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with command attribute as showmodal) closed dialog with preventDefault is noop
+FAIL invoking (with command attribute as showmodal) while changing command still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking (with command property as sHoWmOdAl) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with command property as sHoWmOdAl) closed dialog with preventDefault is noop
+FAIL invoking (with command property as sHoWmOdAl) while changing command still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking (with command attribute as sHoWmOdAl) closed dialog opens as modal assert_true: invokee.open expected true got false
+PASS invoking (with command attribute as sHoWmOdAl) closed dialog with preventDefault is noop
+FAIL invoking (with command attribute as sHoWmOdAl) while changing command still opens as modal assert_true: invokee.open expected true got false
+FAIL invoking to close (with command property as close) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with command property as close) open dialog with preventDefault is no-op
+PASS invoking to close (with command property as close) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with command property as close) open dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command property as close) open modal dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command attribute as close) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with command attribute as close) open dialog with preventDefault is no-op
+PASS invoking to close (with command attribute as close) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with command attribute as close) open dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command attribute as close) open modal dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command property as cLoSe) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with command property as cLoSe) open dialog with preventDefault is no-op
+PASS invoking to close (with command property as cLoSe) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with command property as cLoSe) open dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command property as cLoSe) open modal dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command attribute as cLoSe) open dialog closes assert_false: invokee.open expected false got true
+PASS invoking to close (with command attribute as cLoSe) open dialog with preventDefault is no-op
+PASS invoking to close (with command attribute as cLoSe) open modal dialog with preventDefault is no-op
+FAIL invoking to close (with command attribute as cLoSe) open dialog while changing command still closes assert_false: invokee.open expected false got true
+FAIL invoking to close (with command attribute as cLoSe) open modal dialog while changing command still closes assert_false: invokee.open expected false got true
 PASS invoking (as showmodal) open dialog is noop
-PASS invoking (as showmodal) open modal, while changing action still a no-op
+PASS invoking (as showmodal) open modal, while changing command still a no-op
 FAIL invoking (as showmodal) closed popover dialog opens as modal assert_true: invokee.open expected true got false
 PASS invoking (as close) already closed dialog is noop
 PASS invoking (as showmodal) dialog as open popover=manual is noop
 PASS invoking (as showmodal) dialog as open popover=auto is noop
 PASS invoking (as close) dialog as open popover=manual is noop
 PASS invoking (as close) dialog as open popover=auto is noop
-PASS invoking (as explicit empty) dialog as open popover=manual is noop
-PASS invoking (as explicit empty) dialog as open popover=auto is noop
 PASS invoking (as showmodal) dialog that is removed is noop
 PASS invoking (as showmodal) dialog from a detached invoker
 PASS invoking (as showmodal) detached dialog from a detached invoker
 PASS invoking (as close) dialog that is removed is noop
 PASS invoking (as close) dialog from a detached invoker
 PASS invoking (as close) detached dialog from a detached invoker
-PASS invoking (as explicit empty) dialog that is removed is noop
-PASS invoking (as explicit empty) dialog from a detached invoker
-PASS invoking (as explicit empty) detached dialog from a detached invoker
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt
@@ -1,10 +1,6 @@
 
 
-FAIL changing invokeaction attribute inside invokeevent doesn't impact the invocation assert_true: expected true got false
-FAIL invoking (as auto) closed popover opens assert_true: expected true got false
-PASS invoking (as auto) closed popover with preventDefault does not open
-FAIL invoking (as explicit empty) closed popover opens assert_true: expected true got false
-PASS invoking (as explicit empty) closed popover with preventDefault does not open
+FAIL changing command attribute inside invokeevent doesn't impact the invocation assert_true: expected true got false
 FAIL invoking (as togglepopover) closed popover opens assert_true: expected true got false
 PASS invoking (as togglepopover) closed popover with preventDefault does not open
 FAIL invoking (as showpopover) closed popover opens assert_true: expected true got false
@@ -13,24 +9,22 @@ FAIL invoking (as tOgGlEpOpOvEr) closed popover opens assert_true: expected true
 PASS invoking (as tOgGlEpOpOvEr) closed popover with preventDefault does not open
 FAIL invoking (as sHoWpOpOvEr) closed popover opens assert_true: expected true got false
 PASS invoking (as sHoWpOpOvEr) closed popover with preventDefault does not open
-FAIL invoking (as auto) open popover closes assert_false: expected false got true
-FAIL invoking (as auto) from within open popover closes assert_false: expected false got true
-PASS invoking (as auto) open popover with preventDefault does not close
-FAIL invoking (as explicit empty) open popover closes assert_false: expected false got true
-FAIL invoking (as explicit empty) from within open popover closes assert_false: expected false got true
-PASS invoking (as explicit empty) open popover with preventDefault does not close
 FAIL invoking (as togglepopover) open popover closes assert_false: expected false got true
-FAIL invoking (as togglepopover) from within open popover closes assert_false: expected false got true
 PASS invoking (as togglepopover) open popover with preventDefault does not close
+FAIL invoking (as togglepopover) from within open popover closes assert_false: expected false got true
+PASS invoking (as togglepopover) from within open popover with preventDefault does not close
 FAIL invoking (as hidepopover) open popover closes assert_false: expected false got true
-FAIL invoking (as hidepopover) from within open popover closes assert_false: expected false got true
 PASS invoking (as hidepopover) open popover with preventDefault does not close
+FAIL invoking (as hidepopover) from within open popover closes assert_false: expected false got true
+PASS invoking (as hidepopover) from within open popover with preventDefault does not close
 FAIL invoking (as tOgGlEpOpOvEr) open popover closes assert_false: expected false got true
-FAIL invoking (as tOgGlEpOpOvEr) from within open popover closes assert_false: expected false got true
 PASS invoking (as tOgGlEpOpOvEr) open popover with preventDefault does not close
+FAIL invoking (as tOgGlEpOpOvEr) from within open popover closes assert_false: expected false got true
+PASS invoking (as tOgGlEpOpOvEr) from within open popover with preventDefault does not close
 FAIL invoking (as hIdEpOpOvEr) open popover closes assert_false: expected false got true
-FAIL invoking (as hIdEpOpOvEr) from within open popover closes assert_false: expected false got true
 PASS invoking (as hIdEpOpOvEr) open popover with preventDefault does not close
+FAIL invoking (as hIdEpOpOvEr) from within open popover closes assert_false: expected false got true
+PASS invoking (as hIdEpOpOvEr) from within open popover with preventDefault does not close
 PASS invoking (as showpopover) open popover is noop
 PASS invoking (as hidepopover) closed popover is noop
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-invalid-behavior.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-invalid-behavior.tentative-expected.txt
@@ -1,0 +1,17 @@
+
+
+PASS invoking (as null) on popover does nothing
+PASS invoking (as null) on open popover does nothing
+PASS invoking (as ) on popover does nothing
+PASS invoking (as ) on open popover does nothing
+PASS invoking (as foo-bar) on popover does nothing
+PASS invoking (as foo-bar) on open popover does nothing
+PASS invoking (as showmodal) on popover does nothing
+PASS invoking (as showmodal) on open popover does nothing
+PASS invoking (as showpicker) on popover does nothing
+PASS invoking (as showpicker) on open popover does nothing
+PASS invoking (as open) on popover does nothing
+PASS invoking (as open) on open popover does nothing
+PASS invoking (as close) on popover does nothing
+PASS invoking (as close) on open popover does nothing
+


### PR DESCRIPTION
#### b991be1f9b7558b319dd45fee954109f66c22b99
<pre>
Resync invoker tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=276447">https://bugs.webkit.org/show_bug.cgi?id=276447</a>

Reviewed by Ryan Reno.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/5c042c8a1ee8b94ef624448f25d134d1d44f0843">https://github.com/web-platform-tests/wpt/commit/5c042c8a1ee8b94ef624448f25d134d1d44f0843</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/interestelement-interface.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-fullscreen-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-invalid-behavior.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-audio-invalid-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-invalid-behavior.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-details-invalid-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-invalid-behavior.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-invalid-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-invalid-behavior.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-invalid-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-video-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/resources/invoker-utils.js:
(async hoverOver):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/interfaces/invokers.tentative.idl:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-invalid-behavior.tentative-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-invalid-behavior.tentative-expected.txt.

Canonical link: <a href="https://commits.webkit.org/280943@main">https://commits.webkit.org/280943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2430c6b228acaea409758d483746a0210d4b469

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61708 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8528 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47057 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6072 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27891 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7506 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7532 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63409 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54311 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2004 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50222 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54430 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12846 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1708 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33240 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34326 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35410 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34071 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->