### PR TITLE
[css-anchor-position-1] AnchorPositionedStateMap should be owned by Style::TreeResolver

### DIFF
--- a/Source/WebCore/css/CSSToLengthConversionData.cpp
+++ b/Source/WebCore/css/CSSToLengthConversionData.cpp
@@ -45,6 +45,7 @@ CSSToLengthConversionData::CSSToLengthConversionData(const RenderStyle& style, c
     , m_renderView(builderContext.document->renderView())
     , m_elementForContainerUnitResolution(builderContext.element)
     , m_viewportDependencyDetectionStyle(const_cast<RenderStyle*>(m_style))
+    , m_anchorPositionedStateMap(builderContext.anchorPositionedStateMap)
 {
 }
 

--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -32,8 +32,11 @@
 
 #include "CSSPropertyNames.h"
 #include "Element.h"
+#include "EventTarget.h"
+#include <memory>
 #include <optional>
 #include <wtf/Assertions.h>
+#include <wtf/WeakHashMap.h>
 
 namespace WebCore {
 
@@ -44,7 +47,9 @@ class RenderStyle;
 class RenderView;
 
 namespace Style {
+struct AnchorPositionedElementState;
 struct BuilderContext;
+using AnchorPositionedStateMap = WeakHashMap<Element, std::unique_ptr<AnchorPositionedElementState>, WeakPtrImplWithEventTargetData>;
 };
 
 class CSSToLengthConversionData {
@@ -65,6 +70,7 @@ public:
     CSSPropertyID propertyToCompute() const { return m_propertyToCompute.value_or(CSSPropertyInvalid); }
     const RenderView* renderView() const { return m_renderView; }
     const Element* elementForContainerUnitResolution() const { return m_elementForContainerUnitResolution.get(); }
+    Style::AnchorPositionedStateMap* anchorPositionedStateMap() const { return m_anchorPositionedStateMap; }
 
     const FontCascade& fontCascadeForFontUnits() const;
     int computedLineHeightForFontUnits() const;
@@ -109,6 +115,7 @@ private:
     std::optional<CSSPropertyID> m_propertyToCompute;
     // FIXME: Remove this hack.
     RenderStyle* m_viewportDependencyDetectionStyle { nullptr };
+    Style::AnchorPositionedStateMap* m_anchorPositionedStateMap { nullptr };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -25,20 +25,21 @@
 #include "config.h"
 #include "AnchorPositionEvaluator.h"
 
-#include "Document.h"
-#include "DocumentInlines.h"
-#include "Element.h"
-#include "StyleScope.h"
+#include "StyleBuilderState.h"
 
 namespace WebCore::Style {
 
-Length AnchorPositionEvaluator::resolveAnchorValue(const CSSAnchorValue* anchorValue, const Element* element)
+Length AnchorPositionEvaluator::resolveAnchorValue(const CSSAnchorValue* anchorValue, const BuilderState& builderState)
 {
+    auto* element = builderState.element();
     if (!element)
         return Length(0, LengthType::Fixed);
 
-    auto& anchorPositionedStateMap = element->protectedDocument()->checkedStyleScope()->anchorPositionedStateMap();
-    auto* anchorPositionedElementState = anchorPositionedStateMap.ensure(*element, [&] {
+    auto* anchorPositionedStateMap = builderState.cssToLengthConversionData().anchorPositionedStateMap();
+    if (!anchorPositionedStateMap)
+        return Length(0, LengthType::Fixed);
+
+    auto* anchorPositionedElementState = anchorPositionedStateMap->ensure(*element, [&] {
         return WTF::makeUnique<AnchorPositionedElementState>();
     }).iterator->value.get();
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -35,6 +35,8 @@ class Element;
 
 namespace Style {
 
+class BuilderState;
+
 struct AnchorPositionedElementState {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -49,7 +51,7 @@ using AnchorPositionedStateMap = WeakHashMap<Element, std::unique_ptr<AnchorPosi
 
 class AnchorPositionEvaluator {
 public:
-    static Length resolveAnchorValue(const CSSAnchorValue*, const Element*);
+    static Length resolveAnchorValue(const CSSAnchorValue*, const BuilderState&);
 };
 
 }

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "MatchedDeclarationsCache.h"
 
+#include "AnchorPositionEvaluator.h"
 #include "CSSFontSelector.h"
 #include "Document.h"
 #include "DocumentInlines.h"
@@ -60,7 +61,7 @@ void MatchedDeclarationsCache::deref() const
     m_owner->deref();
 }
 
-bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderStyle& style, const RenderStyle& parentStyle)
+bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderStyle& style, const RenderStyle& parentStyle, const AnchorPositionedStateMap* anchorPositionedStateMap)
 {
     // FIXME: Writing mode and direction properties modify state when applying to document element by calling
     // Document::setWritingMode/DirectionSetOnDocumentElement. We can't skip the applying by caching.
@@ -86,7 +87,7 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderS
     // the relevant anchors that this element will be positioned relative to. Then, the
     // anchor-positioned element will be resolved once again, this time with the anchor
     // information needed to fully resolve the element.
-    if (element.document().styleScope().anchorPositionedStateMap().contains(element))
+    if (anchorPositionedStateMap && anchorPositionedStateMap->contains(element))
         return false;
 
     // Getting computed style after a font environment change but before full style resolution may involve styles with non-current fonts.

--- a/Source/WebCore/style/MatchedDeclarationsCache.h
+++ b/Source/WebCore/style/MatchedDeclarationsCache.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "AnchorPositionEvaluator.h"
 #include "MatchResult.h"
 #include "RenderStyle.h"
 #include "Timer.h"
@@ -42,7 +43,7 @@ public:
     explicit MatchedDeclarationsCache(const Resolver&);
     ~MatchedDeclarationsCache();
 
-    static bool isCacheable(const Element&, const RenderStyle&, const RenderStyle& parentStyle);
+    static bool isCacheable(const Element&, const RenderStyle&, const RenderStyle& parentStyle, const AnchorPositionedStateMap*);
     static unsigned computeHash(const MatchResult&, const StyleCustomPropertyData& inheritedCustomProperties);
 
     struct Entry {

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -266,10 +266,8 @@ inline Length BuilderConverter::convertLength(const BuilderState& builderState, 
     if (primitiveValue.isCalculatedPercentageWithLength())
         return Length(primitiveValue.cssCalcValue()->createCalculationValue(conversionData));
 
-    if (primitiveValue.isAnchor()) {
-        RefPtr anchorPositionedElement = builderState.element();
-        return AnchorPositionEvaluator::resolveAnchorValue(primitiveValue.cssAnchorValue(), anchorPositionedElement.get());
-    }
+    if (primitiveValue.isAnchor())
+        return AnchorPositionEvaluator::resolveAnchorValue(primitiveValue.cssAnchorValue(), builderState);
 
     ASSERT_NOT_REACHED();
     return Length(0, LengthType::Fixed);

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "AnchorPositionEvaluator.h"
 #include "CSSToLengthConversionData.h"
 #include "CSSToStyleMap.h"
 #include "CascadeLevel.h"
@@ -57,6 +58,7 @@ struct BuilderContext {
     const RenderStyle& parentStyle;
     const RenderStyle* rootElementStyle = nullptr;
     RefPtr<const Element> element = nullptr;
+    AnchorPositionedStateMap* anchorPositionedStateMap = nullptr;
 };
 
 class BuilderState {

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "AnchorPositionEvaluator.h"
 #include "CSSSelector.h"
 #include "ElementRuleCollector.h"
 #include "InspectorCSSOMWrappers.h"
@@ -78,6 +79,7 @@ struct ResolutionContext {
     // This needs to be provided during style resolution when up-to-date document element style is not available via DOM.
     const RenderStyle* documentElementStyle { nullptr };
     SelectorMatchingState* selectorMatchingState { nullptr };
+    AnchorPositionedStateMap* anchorPositionedStateMap { nullptr };
     bool isSVGUseTreeRoot { false };
 };
 

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -27,7 +27,6 @@
 
 #pragma once
 
-#include "AnchorPositionEvaluator.h"
 #include "LayoutSize.h"
 #include "StyleScopeOrdinal.h"
 #include "Timer.h"
@@ -160,8 +159,6 @@ public:
     const CSSCounterStyleRegistry& counterStyleRegistry() const { return m_counterStyleRegistry.get(); }
     CSSCounterStyleRegistry& counterStyleRegistry() { return m_counterStyleRegistry.get(); }
 
-    AnchorPositionedStateMap& anchorPositionedStateMap() { return m_anchorPositionedStateMap; }
-
 private:
     Scope& documentScope();
     bool isForUserAgentShadowTree() const;
@@ -256,8 +253,6 @@ private:
 
     // FIXME: These (and some things above) are only relevant for the root scope.
     HashMap<ResolverSharingKey, Ref<Resolver>> m_sharedShadowTreeResolvers;
-
-    AnchorPositionedStateMap m_anchorPositionedStateMap;
 };
 
 HTMLSlotElement* assignedSlotForScopeOrdinal(const Element&, ScopeOrdinal);

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -565,7 +565,8 @@ ResolutionContext TreeResolver::makeResolutionContext()
         &parent().style,
         parentBoxStyle(),
         m_documentElementStyle.get(),
-        &scope().selectorMatchingState
+        &scope().selectorMatchingState,
+        &m_anchorPositionedStateMap
     };
 }
 
@@ -1235,7 +1236,7 @@ std::unique_ptr<Update> TreeResolver::resolve()
 
         // We also need to ensure that style resolution visits any unresolved
         // anchor-positioned elements.
-        for (auto elementAndState : m_document.styleScope().anchorPositionedStateMap()) {
+        for (auto elementAndState : m_anchorPositionedStateMap) {
             if (!elementAndState.value->hasBeenResolved)
                 elementAndState.key.invalidateForResumingAnchorPositionedElementResolution();
         }
@@ -1339,7 +1340,7 @@ auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderSt
     }
 
     // Check if this element is anchor-positioned
-    auto* anchorPositionedElementState = m_document.styleScope().anchorPositionedStateMap().get(element);
+    auto* anchorPositionedElementState = m_anchorPositionedStateMap.get(element);
     if (!anchorPositionedElementState)
         return AnchorPositionedElementAction::None;
 
@@ -1383,7 +1384,7 @@ auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderSt
 // Precondition: containingBlock is nullptr if and only if containingBlock is the initial containing block.
 void TreeResolver::findAnchorsForAnchorPositionedElement(const Element& anchorPositionedElement, const Element* containingBlock)
 {
-    auto* anchorPositionedElementState = m_document.styleScope().anchorPositionedStateMap().get(anchorPositionedElement);
+    auto* anchorPositionedElementState = m_anchorPositionedStateMap.get(anchorPositionedElement);
     ASSERT(anchorPositionedElementState);
 
     // Check if we have already found the anchors for this anchor-positioned element

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -161,6 +161,8 @@ private:
     HashMap<Ref<Element>, std::optional<QueryContainerState>> m_queryContainerStates;
     bool m_hasUnresolvedQueryContainers { false };
 
+    AnchorPositionedStateMap m_anchorPositionedStateMap;
+
     HashSet<Ref<Element>> m_anchorElements;
     HashMap<String, Vector<Ref<Element>>> m_anchorsForAnchorName;
     HashMap<Ref<Element>, Vector<Ref<Element>>> m_unresolvedAnchorPositionedElementsForContainingBlock;


### PR DESCRIPTION
#### 29669213d5e64a43a0d6bfc148179df9a68fc3de
<pre>
[css-anchor-position-1] AnchorPositionedStateMap should be owned by Style::TreeResolver
<a href="https://bugs.webkit.org/show_bug.cgi?id=276448">https://bugs.webkit.org/show_bug.cgi?id=276448</a>
<a href="https://rdar.apple.com/131489149">rdar://131489149</a>

Reviewed by Tim Nguyen.

AnchorPositionedStateMap is solely used by style resolution. Therefore,
we should move it from Style::Scope to Style::TreeResolver. In order
to access this state map for AnchorPositionEvaluator::resolveAnchorValue,
this patch propagates the state map down through various style building
state structs/contexts.

* Source/WebCore/css/CSSToLengthConversionData.cpp:
(WebCore::CSSToLengthConversionData::CSSToLengthConversionData):
* Source/WebCore/css/CSSToLengthConversionData.h:
(WebCore::CSSToLengthConversionData::anchorPositionedStateMap const):
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::resolveAnchorValue):
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::isCacheable):
* Source/WebCore/style/MatchedDeclarationsCache.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertLength):
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::State::State):
(WebCore::Style::Resolver::State::anchorPositionedStateMap const):
(WebCore::Style::Resolver::initializeStateAndStyle):
(WebCore::Style::Resolver::builderContext):
(WebCore::Style::Resolver::applyMatchedProperties):
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::makeResolutionContext):
(WebCore::Style::TreeResolver::resolve):
(WebCore::Style::TreeResolver::updateAnchorPositioningState):
(WebCore::Style::TreeResolver::findAnchorsForAnchorPositionedElement):
* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/280918@main">https://commits.webkit.org/280918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cea63951978bda76f506bf2c93de9643360cc737

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8373 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44892 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46946 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5963 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27772 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31709 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7366 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7377 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63237 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1842 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54171 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1849 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50083 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54306 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12835 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1573 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33085 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34171 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35255 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33916 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->