### PR TITLE
Define the deriveBits length parameter as optional

### DIFF
--- a/LayoutTests/crypto/subtle/derive-bits-malformed-parameters-expected.txt
+++ b/LayoutTests/crypto/subtle/derive-bits-malformed-parameters-expected.txt
@@ -5,7 +5,6 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS crypto.subtle.deriveBits() rejected promise  with TypeError: Not enough arguments.
 PASS crypto.subtle.deriveBits(1) rejected promise  with TypeError: Not enough arguments.
-PASS crypto.subtle.deriveBits(1, 2) rejected promise  with TypeError: Not enough arguments.
 PASS crypto.subtle.deriveBits({ name:"ECDH", public:wrongKey }, wrongKey, 128) rejected promise  with InvalidAccessError: CryptoKey doesn't match AlgorithmIdentifier.
 PASS crypto.subtle.deriveBits({ name:"ECDH", public:wrongKey }, wrongKey, 128) rejected promise  with InvalidAccessError: CryptoKey doesn't support bits derivation.
 PASS successfullyParsed is true

--- a/LayoutTests/crypto/subtle/derive-bits-malformed-parameters.html
+++ b/LayoutTests/crypto/subtle/derive-bits-malformed-parameters.html
@@ -32,7 +32,6 @@ var jwkKey = {
 // Not enough arguments.
 shouldReject('crypto.subtle.deriveBits()');
 shouldReject('crypto.subtle.deriveBits(1)');
-shouldReject('crypto.subtle.deriveBits(1, 2)');
 
 crypto.subtle.importKey("raw", rawKey, hmacImportParams, extractable, ["sign", "verify"]).then(function(result) {
     wrongKey = result;

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any-expected.txt
@@ -4,20 +4,20 @@ PASS HKDF derivation with 256 as 'length' parameter
 PASS HKDF derivation with 0 as 'length' parameter
 PASS HKDF derivation with null as 'length' parameter
 PASS HKDF derivation with undefined as 'length' parameter
-FAIL HKDF derivation with omitted as 'length' parameter assert_equals: deriveBits correctly threw OperationError: Not enough arguments expected "OperationError" but got "TypeError"
+PASS HKDF derivation with omitted as 'length' parameter
 PASS PBKDF2 derivation with 256 as 'length' parameter
 PASS PBKDF2 derivation with 0 as 'length' parameter
 PASS PBKDF2 derivation with null as 'length' parameter
 PASS PBKDF2 derivation with undefined as 'length' parameter
-FAIL PBKDF2 derivation with omitted as 'length' parameter assert_equals: deriveBits correctly threw OperationError: Not enough arguments expected "OperationError" but got "TypeError"
+PASS PBKDF2 derivation with omitted as 'length' parameter
 PASS ECDH derivation with 256 as 'length' parameter
 FAIL ECDH derivation with 0 as 'length' parameter assert_array_equals: Derived bits do not match the expected result. lengths differ, expected array object "" length 0, got object "87,31,26,232,151,28,227,35,250,17,131,137,203,95,65,196,59,61,181,161" length 32
 PASS ECDH derivation with null as 'length' parameter
 PASS ECDH derivation with undefined as 'length' parameter
-FAIL ECDH derivation with omitted as 'length' parameter promise_test: Unhandled rejection with value: object "TypeError: Not enough arguments"
+PASS ECDH derivation with omitted as 'length' parameter
 PASS X25519 derivation with 256 as 'length' parameter
 FAIL X25519 derivation with 0 as 'length' parameter assert_array_equals: Derived bits do not match the expected result. lengths differ, expected array object "" length 0, got object "63,245,136,2,149,247,97,118,8,143,137,228,61,254,190,126,161,149,0,8" length 32
 PASS X25519 derivation with null as 'length' parameter
 PASS X25519 derivation with undefined as 'length' parameter
-FAIL X25519 derivation with omitted as 'length' parameter promise_test: Unhandled rejection with value: object "TypeError: Not enough arguments"
+PASS X25519 derivation with omitted as 'length' parameter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.worker-expected.txt
@@ -4,20 +4,20 @@ PASS HKDF derivation with 256 as 'length' parameter
 PASS HKDF derivation with 0 as 'length' parameter
 PASS HKDF derivation with null as 'length' parameter
 PASS HKDF derivation with undefined as 'length' parameter
-FAIL HKDF derivation with omitted as 'length' parameter assert_equals: deriveBits correctly threw OperationError: Not enough arguments expected "OperationError" but got "TypeError"
+PASS HKDF derivation with omitted as 'length' parameter
 PASS PBKDF2 derivation with 256 as 'length' parameter
 PASS PBKDF2 derivation with 0 as 'length' parameter
 PASS PBKDF2 derivation with null as 'length' parameter
 PASS PBKDF2 derivation with undefined as 'length' parameter
-FAIL PBKDF2 derivation with omitted as 'length' parameter assert_equals: deriveBits correctly threw OperationError: Not enough arguments expected "OperationError" but got "TypeError"
+PASS PBKDF2 derivation with omitted as 'length' parameter
 PASS ECDH derivation with 256 as 'length' parameter
 FAIL ECDH derivation with 0 as 'length' parameter assert_array_equals: Derived bits do not match the expected result. lengths differ, expected array object "" length 0, got object "87,31,26,232,151,28,227,35,250,17,131,137,203,95,65,196,59,61,181,161" length 32
 PASS ECDH derivation with null as 'length' parameter
 PASS ECDH derivation with undefined as 'length' parameter
-FAIL ECDH derivation with omitted as 'length' parameter promise_test: Unhandled rejection with value: object "TypeError: Not enough arguments"
+PASS ECDH derivation with omitted as 'length' parameter
 PASS X25519 derivation with 256 as 'length' parameter
 FAIL X25519 derivation with 0 as 'length' parameter assert_array_equals: Derived bits do not match the expected result. lengths differ, expected array object "" length 0, got object "63,245,136,2,149,247,97,118,8,143,137,228,61,254,190,126,161,149,0,8" length 32
 PASS X25519 derivation with null as 'length' parameter
 PASS X25519 derivation with undefined as 'length' parameter
-FAIL X25519 derivation with omitted as 'length' parameter promise_test: Unhandled rejection with value: object "TypeError: Not enough arguments"
+PASS X25519 derivation with omitted as 'length' parameter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/idlharness.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/idlharness.https.any-expected.txt
@@ -49,7 +49,7 @@ PASS SubtleCrypto interface: operation verify(AlgorithmIdentifier, CryptoKey, Bu
 PASS SubtleCrypto interface: operation digest(AlgorithmIdentifier, BufferSource)
 PASS SubtleCrypto interface: operation generateKey(AlgorithmIdentifier, boolean, sequence<KeyUsage>)
 PASS SubtleCrypto interface: operation deriveKey(AlgorithmIdentifier, CryptoKey, AlgorithmIdentifier, boolean, sequence<KeyUsage>)
-PASS SubtleCrypto interface: operation deriveBits(AlgorithmIdentifier, CryptoKey, unsigned long)
+PASS SubtleCrypto interface: operation deriveBits(AlgorithmIdentifier, CryptoKey, optional unsigned long?)
 PASS SubtleCrypto interface: operation importKey(KeyFormat, (BufferSource or JsonWebKey), AlgorithmIdentifier, boolean, sequence<KeyUsage>)
 PASS SubtleCrypto interface: operation exportKey(KeyFormat, CryptoKey)
 PASS SubtleCrypto interface: operation wrapKey(KeyFormat, CryptoKey, CryptoKey, AlgorithmIdentifier)
@@ -70,8 +70,8 @@ PASS SubtleCrypto interface: crypto.subtle must inherit property "generateKey(Al
 PASS SubtleCrypto interface: calling generateKey(AlgorithmIdentifier, boolean, sequence<KeyUsage>) on crypto.subtle with too few arguments must throw TypeError
 PASS SubtleCrypto interface: crypto.subtle must inherit property "deriveKey(AlgorithmIdentifier, CryptoKey, AlgorithmIdentifier, boolean, sequence<KeyUsage>)" with the proper type
 PASS SubtleCrypto interface: calling deriveKey(AlgorithmIdentifier, CryptoKey, AlgorithmIdentifier, boolean, sequence<KeyUsage>) on crypto.subtle with too few arguments must throw TypeError
-PASS SubtleCrypto interface: crypto.subtle must inherit property "deriveBits(AlgorithmIdentifier, CryptoKey, unsigned long)" with the proper type
-PASS SubtleCrypto interface: calling deriveBits(AlgorithmIdentifier, CryptoKey, unsigned long) on crypto.subtle with too few arguments must throw TypeError
+PASS SubtleCrypto interface: crypto.subtle must inherit property "deriveBits(AlgorithmIdentifier, CryptoKey, optional unsigned long?)" with the proper type
+PASS SubtleCrypto interface: calling deriveBits(AlgorithmIdentifier, CryptoKey, optional unsigned long?) on crypto.subtle with too few arguments must throw TypeError
 PASS SubtleCrypto interface: crypto.subtle must inherit property "importKey(KeyFormat, (BufferSource or JsonWebKey), AlgorithmIdentifier, boolean, sequence<KeyUsage>)" with the proper type
 PASS SubtleCrypto interface: calling importKey(KeyFormat, (BufferSource or JsonWebKey), AlgorithmIdentifier, boolean, sequence<KeyUsage>) on crypto.subtle with too few arguments must throw TypeError
 PASS SubtleCrypto interface: crypto.subtle must inherit property "exportKey(KeyFormat, CryptoKey)" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/idlharness.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/idlharness.https.any.worker-expected.txt
@@ -49,7 +49,7 @@ PASS SubtleCrypto interface: operation verify(AlgorithmIdentifier, CryptoKey, Bu
 PASS SubtleCrypto interface: operation digest(AlgorithmIdentifier, BufferSource)
 PASS SubtleCrypto interface: operation generateKey(AlgorithmIdentifier, boolean, sequence<KeyUsage>)
 PASS SubtleCrypto interface: operation deriveKey(AlgorithmIdentifier, CryptoKey, AlgorithmIdentifier, boolean, sequence<KeyUsage>)
-PASS SubtleCrypto interface: operation deriveBits(AlgorithmIdentifier, CryptoKey, unsigned long)
+PASS SubtleCrypto interface: operation deriveBits(AlgorithmIdentifier, CryptoKey, optional unsigned long?)
 PASS SubtleCrypto interface: operation importKey(KeyFormat, (BufferSource or JsonWebKey), AlgorithmIdentifier, boolean, sequence<KeyUsage>)
 PASS SubtleCrypto interface: operation exportKey(KeyFormat, CryptoKey)
 PASS SubtleCrypto interface: operation wrapKey(KeyFormat, CryptoKey, CryptoKey, AlgorithmIdentifier)
@@ -70,8 +70,8 @@ PASS SubtleCrypto interface: crypto.subtle must inherit property "generateKey(Al
 PASS SubtleCrypto interface: calling generateKey(AlgorithmIdentifier, boolean, sequence<KeyUsage>) on crypto.subtle with too few arguments must throw TypeError
 PASS SubtleCrypto interface: crypto.subtle must inherit property "deriveKey(AlgorithmIdentifier, CryptoKey, AlgorithmIdentifier, boolean, sequence<KeyUsage>)" with the proper type
 PASS SubtleCrypto interface: calling deriveKey(AlgorithmIdentifier, CryptoKey, AlgorithmIdentifier, boolean, sequence<KeyUsage>) on crypto.subtle with too few arguments must throw TypeError
-PASS SubtleCrypto interface: crypto.subtle must inherit property "deriveBits(AlgorithmIdentifier, CryptoKey, unsigned long)" with the proper type
-PASS SubtleCrypto interface: calling deriveBits(AlgorithmIdentifier, CryptoKey, unsigned long) on crypto.subtle with too few arguments must throw TypeError
+PASS SubtleCrypto interface: crypto.subtle must inherit property "deriveBits(AlgorithmIdentifier, CryptoKey, optional unsigned long?)" with the proper type
+PASS SubtleCrypto interface: calling deriveBits(AlgorithmIdentifier, CryptoKey, optional unsigned long?) on crypto.subtle with too few arguments must throw TypeError
 PASS SubtleCrypto interface: crypto.subtle must inherit property "importKey(KeyFormat, (BufferSource or JsonWebKey), AlgorithmIdentifier, boolean, sequence<KeyUsage>)" with the proper type
 PASS SubtleCrypto interface: calling importKey(KeyFormat, (BufferSource or JsonWebKey), AlgorithmIdentifier, boolean, sequence<KeyUsage>) on crypto.subtle with too few arguments must throw TypeError
 PASS SubtleCrypto interface: crypto.subtle must inherit property "exportKey(KeyFormat, CryptoKey)" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/WebCryptoAPI.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/WebCryptoAPI.idl
@@ -68,7 +68,7 @@ interface SubtleCrypto {
                          sequence<KeyUsage> keyUsages );
   Promise<ArrayBuffer> deriveBits(AlgorithmIdentifier algorithm,
                           CryptoKey baseKey,
-                          unsigned long length);
+                          optional unsigned long? length = null);
 
   Promise<CryptoKey> importKey(KeyFormat format,
                          (BufferSource or JsonWebKey) keyData,

--- a/Source/WebCore/crypto/CryptoAlgorithm.cpp
+++ b/Source/WebCore/crypto/CryptoAlgorithm.cpp
@@ -60,7 +60,7 @@ void CryptoAlgorithm::generateKey(const CryptoAlgorithmParameters&, bool, Crypto
     exceptionCallback(ExceptionCode::NotSupportedError);
 }
 
-void CryptoAlgorithm::deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t, VectorCallback&&, ExceptionCallback&& exceptionCallback, ScriptExecutionContext&, WorkQueue&)
+void CryptoAlgorithm::deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t>, VectorCallback&&, ExceptionCallback&& exceptionCallback, ScriptExecutionContext&, WorkQueue&)
 {
     exceptionCallback(ExceptionCode::NotSupportedError);
 }

--- a/Source/WebCore/crypto/CryptoAlgorithm.h
+++ b/Source/WebCore/crypto/CryptoAlgorithm.h
@@ -68,7 +68,7 @@ public:
     virtual void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
     virtual void digest(Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
     virtual void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&);
-    virtual void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
+    virtual void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=169262
     virtual void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit);
     virtual void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit);

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -936,7 +936,7 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
         promise->reject(result.releaseException().code(), "Cannot get key length from derivedKeyType"_s);
         return;
     }
-    size_t length = result.releaseReturnValue();
+    std::optional<size_t> length = result.releaseReturnValue();
 
     auto importAlgorithm = CryptoAlgorithmRegistry::singleton().create(importParams->identifier);
     auto algorithm = CryptoAlgorithmRegistry::singleton().create(params->identifier);
@@ -972,7 +972,7 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
     algorithm->deriveBits(*params, baseKey, length, WTFMove(callback), WTFMove(exceptionCallback), *scriptExecutionContext(), m_workQueue);
 }
 
-void SubtleCrypto::deriveBits(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& baseKey, unsigned length, Ref<DeferredPromise>&& promise)
+void SubtleCrypto::deriveBits(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& baseKey, std::optional<unsigned> length, Ref<DeferredPromise>&& promise)
 {
     auto paramsOrException = normalizeCryptoAlgorithmParameters(state, WTFMove(algorithmIdentifier), Operations::DeriveBits);
     if (paramsOrException.hasException()) {

--- a/Source/WebCore/crypto/SubtleCrypto.h
+++ b/Source/WebCore/crypto/SubtleCrypto.h
@@ -68,7 +68,7 @@ public:
     void digest(JSC::JSGlobalObject&, AlgorithmIdentifier&&, BufferSource&& data, Ref<DeferredPromise>&&);
     void generateKey(JSC::JSGlobalObject&, AlgorithmIdentifier&&, bool extractable, Vector<CryptoKeyUsage>&& keyUsages, Ref<DeferredPromise>&&);
     void deriveKey(JSC::JSGlobalObject&, AlgorithmIdentifier&&, CryptoKey& baseKey, AlgorithmIdentifier&& derivedKeyType, bool extractable, Vector<CryptoKeyUsage>&&, Ref<DeferredPromise>&&);
-    void deriveBits(JSC::JSGlobalObject&, AlgorithmIdentifier&&, CryptoKey& baseKey, unsigned length, Ref<DeferredPromise>&&);
+    void deriveBits(JSC::JSGlobalObject&, AlgorithmIdentifier&&, CryptoKey& baseKey, std::optional<unsigned> length, Ref<DeferredPromise>&&);
     void importKey(JSC::JSGlobalObject&, KeyFormat, KeyDataVariant&&, AlgorithmIdentifier&&, bool extractable, Vector<CryptoKeyUsage>&&, Ref<DeferredPromise>&&);
     void exportKey(KeyFormat, CryptoKey&, Ref<DeferredPromise>&&);
     void wrapKey(JSC::JSGlobalObject&, KeyFormat, CryptoKey&, CryptoKey& wrappingKey, AlgorithmIdentifier&& wrapAlgorithm, Ref<DeferredPromise>&&);

--- a/Source/WebCore/crypto/SubtleCrypto.idl
+++ b/Source/WebCore/crypto/SubtleCrypto.idl
@@ -39,7 +39,7 @@ typedef (object or DOMString) AlgorithmIdentifier;
     [CallWith=CurrentGlobalObject] Promise<any> digest(AlgorithmIdentifier algorithm, BufferSource data);
     [CallWith=CurrentGlobalObject] Promise<any> generateKey(AlgorithmIdentifier algorithm, boolean extractable, sequence<CryptoKeyUsage> keyUsages);
     [CallWith=CurrentGlobalObject] Promise<any> deriveKey(AlgorithmIdentifier algorithm, CryptoKey baseKey, AlgorithmIdentifier derivedKeyType, boolean extractable, sequence<CryptoKeyUsage> keyUsages);
-    [CallWith=CurrentGlobalObject] Promise<ArrayBuffer> deriveBits(AlgorithmIdentifier algorithm, CryptoKey baseKey, unsigned long length);
+    [CallWith=CurrentGlobalObject] Promise<ArrayBuffer> deriveBits(AlgorithmIdentifier algorithm, CryptoKey baseKey, optional unsigned long? length = null);
     [CallWith=CurrentGlobalObject] Promise<CryptoKey> importKey(KeyFormat format, (BufferSource or JsonWebKey) keyData, AlgorithmIdentifier algorithm, boolean extractable, sequence<CryptoKeyUsage> keyUsages);
     Promise<any> exportKey(KeyFormat format, CryptoKey key);
     [CallWith=CurrentGlobalObject] Promise<any> wrapKey(KeyFormat format, CryptoKey key, CryptoKey wrappingKey, AlgorithmIdentifier wrapAlgorithm);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
@@ -66,7 +66,7 @@ void CryptoAlgorithmECDH::generateKey(const CryptoAlgorithmParameters& parameter
     callback(WTFMove(pair));
 }
 
-void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
     auto& ecParameters = downcast<CryptoAlgorithmEcdhKeyDeriveParams>(parameters);
 
@@ -90,16 +90,16 @@ void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters
         return;
     }
 
-    auto unifiedCallback = [callback = WTFMove(callback), exceptionCallback = WTFMove(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey, size_t length) mutable {
+    auto unifiedCallback = [callback = WTFMove(callback), exceptionCallback = WTFMove(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey, std::optional<size_t> length) mutable {
         if (!derivedKey) {
             exceptionCallback(ExceptionCode::OperationError);
             return;
         }
-        if (!length) {
+        if (!length || !(*length)) {
             callback(WTFMove(*derivedKey));
             return;
         }
-        auto lengthInBytes = std::ceil(length / 8.);
+        auto lengthInBytes = std::ceil(*length / 8.);
         if (lengthInBytes > (*derivedKey).size()) {
             exceptionCallback(ExceptionCode::OperationError);
             return;

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.h
@@ -45,7 +45,7 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit) final;
 };

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
@@ -44,9 +44,9 @@ CryptoAlgorithmIdentifier CryptoAlgorithmHKDF::identifier() const
     return s_identifier;
 }
 
-void CryptoAlgorithmHKDF::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmHKDF::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    if (!length || length % 8) {
+    if (!length || !(*length) || *length % 8) {
         exceptionCallback(ExceptionCode::OperationError);
         return;
     }
@@ -54,7 +54,7 @@ void CryptoAlgorithmHKDF::deriveBits(const CryptoAlgorithmParameters& parameters
     UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
         [parameters = crossThreadCopy(downcast<CryptoAlgorithmHkdfParams>(parameters)), baseKey = WTFMove(baseKey), length, useCryptoKit] {
-            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length, useCryptoKit);
+            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), *length, useCryptoKit);
         });
 }
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h
@@ -42,7 +42,7 @@ private:
     CryptoAlgorithmHKDF() = default;
     CryptoAlgorithmIdentifier identifier() const final;
 
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp
@@ -43,16 +43,16 @@ CryptoAlgorithmIdentifier CryptoAlgorithmPBKDF2::identifier() const
     return s_identifier;
 }
 
-void CryptoAlgorithmPBKDF2::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmPBKDF2::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
-    if (!length || length % 8) {
+    if (!length || !(*length) || *length % 8) {
         exceptionCallback(ExceptionCode::OperationError);
         return;
     }
 
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
         [parameters = crossThreadCopy(downcast<CryptoAlgorithmPbkdf2Params>(parameters)), baseKey = WTFMove(baseKey), length] {
-            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), length);
+            return platformDeriveBits(parameters, downcast<CryptoKeyRaw>(baseKey.get()), *length);
         });
 }
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.h
@@ -42,7 +42,7 @@ private:
     CryptoAlgorithmPBKDF2() = default;
     CryptoAlgorithmIdentifier identifier() const final;
 
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
@@ -63,7 +63,7 @@ std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const C
 }
 #endif
 
-void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
 {
     if (baseKey->type() != CryptoKey::Type::Private) {
         exceptionCallback(ExceptionCode::InvalidAccessError);
@@ -86,16 +86,16 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
         return;
     }
 
-    auto unifiedCallback = [callback = WTFMove(callback), exceptionCallback = WTFMove(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey, size_t length) mutable {
+    auto unifiedCallback = [callback = WTFMove(callback), exceptionCallback = WTFMove(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey, std::optional<size_t> length) mutable {
         if (!derivedKey) {
             exceptionCallback(ExceptionCode::OperationError);
             return;
         }
-        if (!length) {
+        if (!length || !(*length)) {
             callback(WTFMove(*derivedKey));
             return;
         }
-        auto lengthInBytes = std::ceil(length / 8.);
+        auto lengthInBytes = std::ceil(*length / 8.);
         if (lengthInBytes > (*derivedKey).size()) {
             exceptionCallback(ExceptionCode::OperationError);
             return;

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h
@@ -36,7 +36,7 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void generateKey(const CryptoAlgorithmParameters& , bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& , ExceptionCallback&& , ScriptExecutionContext&);
-    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, std::optional<size_t> length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit) final;
     void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit) final;
 


### PR DESCRIPTION
#### 9586d3db576cdc891e0c33934825534cd3a7766a
<pre>
Define the deriveBits length parameter as optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=276394">https://bugs.webkit.org/show_bug.cgi?id=276394</a>

Reviewed by Youenn Fablet and Nitin Mahendru.

The PR#345 [1] to the WebCryptoAPI spec defines now the &apos;length&apos;
parameter as optional, defaulting to &apos;null&apos;. This change tries to
solve a long-standing interoperability issue in the deriveBits
operation.

This patch implements the required changes in the IDL so that the
&apos;length&apos; parameter is declared as optional, with &apos;null&apos; as default
value when omitted. The affected algorithms (ECDH, HKDF, PBKDF2
and X25519) are adapted to the parameter&apos;s new type.

The PR#43400 [2] defined tests for the new behavior of the afected
algorithms, which they all pass now.

[1] <a href="https://github.com/w3c/webcrypto/pull/345">https://github.com/w3c/webcrypto/pull/345</a>
[2] <a href="https://github.com/web-platform-tests/wpt/pull/43400">https://github.com/web-platform-tests/wpt/pull/43400</a>

* LayoutTests/crypto/subtle/derive-bits-malformed-parameters-expected.txt:
* LayoutTests/crypto/subtle/derive-bits-malformed-parameters.html:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/idlharness.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/idlharness.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/interfaces/WebCryptoAPI.idl:
* Source/WebCore/crypto/CryptoAlgorithm.cpp:
(WebCore::CryptoAlgorithm::deriveBits):
* Source/WebCore/crypto/CryptoAlgorithm.h:
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::SubtleCrypto::deriveKey):
(WebCore::SubtleCrypto::deriveBits):
* Source/WebCore/crypto/SubtleCrypto.h:
* Source/WebCore/crypto/SubtleCrypto.idl:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp:
(WebCore::CryptoAlgorithmECDH::deriveBits):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp:
(WebCore::CryptoAlgorithmHKDF::deriveBits):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp:
(WebCore::CryptoAlgorithmPBKDF2::deriveBits):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp:
(WebCore::CryptoAlgorithmX25519::deriveBits):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h:

Canonical link: <a href="https://commits.webkit.org/281240@main">https://commits.webkit.org/281240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5db83231921d4586762df546da77140f902be29b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63083 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9580 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48074 "") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6848 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28901 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32712 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8459 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8584 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64807 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8683 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51196 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/55526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2568 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34296 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35379 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36465 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35124 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->