### PR TITLE
[LinearMediaPlayer] Blank video frames seen before docking and after undocking

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -105,6 +105,11 @@ enum class MediaPlayerPitchCorrectionAlgorithm : uint8_t {
     BestForSpeech,
 };
 
+enum class MediaPlayerNeedsRenderingModeChanged : bool {
+    No,
+    Yes,
+};
+
 class MediaPlayerEnums {
 public:
     using NetworkState = MediaPlayerNetworkState;
@@ -117,6 +122,7 @@ public:
     using MediaEngineIdentifier = MediaPlayerMediaEngineIdentifier;
     using WirelessPlaybackTargetType = MediaPlayerWirelessPlaybackTargetType;
     using PitchCorrectionAlgorithm = MediaPlayerPitchCorrectionAlgorithm;
+    using NeedsRenderingModeChanged = MediaPlayerNeedsRenderingModeChanged;
 
     enum {
         VideoFullscreenModeNone = 0,

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -63,7 +63,6 @@ class VideoLayerManagerObjC;
 class VideoTrackPrivate;
 class WebCoreDecompressionSession;
 
-
 class MediaPlayerPrivateMediaSourceAVFObjC
     : public CanMakeWeakPtr<MediaPlayerPrivateMediaSourceAVFObjC>
     , public RefCounted<MediaPlayerPrivateMediaSourceAVFObjC>
@@ -285,12 +284,12 @@ private:
     void ensureLayer();
     void destroyLayer();
     void ensureDecompressionSession();
-    void destroyDecompressionSession();
+    MediaPlayerEnums::NeedsRenderingModeChanged destroyDecompressionSession();
     void ensureVideoRenderer();
     void destroyVideoRenderer();
 
     bool shouldEnsureLayerOrVideoRenderer() const;
-    void ensureLayerOrVideoRenderer();
+    void ensureLayerOrVideoRenderer(MediaPlayerEnums::NeedsRenderingModeChanged);
     void destroyLayerOrVideoRenderer();
     void configureLayerOrVideoRenderer(WebSampleBufferVideoRendering *);
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -234,11 +234,11 @@ private:
     void ensureLayer();
     void destroyLayer();
     void ensureDecompressionSession();
-    void destroyDecompressionSession();
+    MediaPlayerEnums::NeedsRenderingModeChanged destroyDecompressionSession();
     void ensureVideoRenderer();
     void destroyVideoRenderer();
 
-    void ensureLayerOrVideoRenderer();
+    void ensureLayerOrVideoRenderer(MediaPlayerEnums::NeedsRenderingModeChanged);
     void destroyLayerOrVideoRenderer();
     void configureLayerOrVideoRenderer(WebSampleBufferVideoRendering *);
 

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -201,8 +201,11 @@ LMPlayableViewController *VideoPresentationInterfaceLMK::playableViewController(
 
 void VideoPresentationInterfaceLMK::ensurePlayableViewController()
 {
-    if (!m_playerViewController)
-        m_playerViewController = [linearMediaPlayer() makeViewController];
+    if (m_playerViewController)
+        return;
+
+    m_playerViewController = [linearMediaPlayer() makeViewController];
+    [m_playerViewController view].alpha = 0;
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### d5fddb160c2739f7d90e5a4b9b5ed1d6e30d69eb
<pre>
[LinearMediaPlayer] Blank video frames seen before docking and after undocking
<a href="https://bugs.webkit.org/show_bug.cgi?id=276453">https://bugs.webkit.org/show_bug.cgi?id=276453</a>
<a href="https://rdar.apple.com/130425275">rdar://130425275</a>

Reviewed by Jer Noble.

Two issues resulted in blank frames briefly appearing in an &lt;video&gt; element in element fullscreen:

1. Just prior to docking, an LMPlayableViewController is presented that obscures the web view.
Since this VC&apos;s presentationMode is immediately changed to `.fullscreenFromInline` which hides the
web view&apos;s scene and presents a new fullscreen scene, we should hide the view controller while it&apos;s
in `.inline` mode (by setting its root view&apos;s alpha to 0).

2. Right after undocking, when committing the staged AVSampleBufferDisplayLayer, MediaPlayerPrivate
would call renderingModeChanged(), which calls Element::invalidateStyleAndLayerComposition(). This
results in the &lt;video&gt; element briefly rendering a black frame. To avoid this, changed
MediaPlayerPrivate to call renderingModeChanged() as soon as the AVSampleBufferDisplayLayer is
staged, while the LinearMediaKit scene is still occluding the web view.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/MediaPlayerEnums.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateDisplayLayerAndDecompressionSession):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyDecompressionSession):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayerOrVideoRenderer):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::updateDisplayLayerAndDecompressionSession):
(WebCore::MediaPlayerPrivateWebM::destroyDecompressionSession):
(WebCore::MediaPlayerPrivateWebM::ensureLayerOrVideoRenderer):
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::ensurePlayableViewController):

Canonical link: <a href="https://commits.webkit.org/280848@main">https://commits.webkit.org/280848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e74ffdd9f98715f5caaf9a30aff4b2bcb5b5d5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61452 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8275 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46858 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5876 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27686 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7271 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7279 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53566 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63135 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54079 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54201 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12792 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1483 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32987 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34073 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35157 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->