### PR TITLE
AXObjectCache::characterOffsetFromVisiblePosition can iterate infinitely when moving through role="img" container

### DIFF
--- a/LayoutTests/accessibility/mac/role-img-selection-hang-expected.txt
+++ b/LayoutTests/accessibility/mac/role-img-selection-hang-expected.txt
@@ -1,0 +1,7 @@
+This test ensures we do not cause a main-thread infinite loop when trying to setSelectedTextRange with a range containing a role='img' element.
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/role-img-selection-hang.html
+++ b/LayoutTests/accessibility/mac/role-img-selection-hang.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<ul id="list">
+  <li>
+    <a id="link" href="#url">
+      <div id="img" role="img">
+        <span style="position:absolute">X</span>
+        <span>Y</span>
+      </div>
+    </a>
+  </li>
+</ul>
+
+<script>
+var output = "This test ensures we do not cause a main-thread infinite loop when trying to setSelectedTextRange with a range containing a role='img' element.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var link = accessibilityController.accessibleElementById("link");
+    setTimeout(async function() {
+        link.setSelectedTextMarkerRange(link.textMarkerRangeForElement(link));
+
+        // Exercise a main-thread API (setting a DOM attribute) and wait for the result to be applied, confirming the main-thread isn't hung.
+        document.getElementById("img").setAttribute("aria-label", "foo bar");
+        await waitFor(() => platformTextAlternatives(accessibilityController.accessibleElementById("img")).includes("foo bar"));
+
+        document.getElementById("list").style.display = "none";
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
#### c223637aad47dceef3291a95636ceb9fc10ee1ab
<pre>
AXObjectCache::characterOffsetFromVisiblePosition can iterate infinitely when moving through role=&quot;img&quot; container
<a href="https://bugs.webkit.org/show_bug.cgi?id=276464">https://bugs.webkit.org/show_bug.cgi?id=276464</a>
<a href="https://rdar.apple.com/problem/131502510">rdar://problem/131502510</a>

Reviewed by Ryosuke Niwa.

Given this markup:

&lt;div role=&quot;img&quot;&gt;
    &lt;span style=&quot;position:absolute&quot;&gt;X&lt;/span&gt;
    &lt;span&gt;Y&lt;/span&gt;
&lt;/div&gt;

When we create a VisiblePosition from this Position:

(Position
  (anchor node: #text 0x159003ec0 length=1 &quot;Y&quot;)
  (offset: 0)
  (anchor type: offset in anchor))

We get its `canonicalPosition` in the VisiblePosition constructor, which computes:

(Position
  (anchor node: DIV 0x159003c40)
  (offset: 0)
  (anchor type: before anchor))

This starts iteration for `nextVisuallyDistinctCandidate` back at the beginning of the div, repeating until we get back
to the &quot;Y&quot; position, in turn computing the before-anchor-div position, repeating forever.

This happens because the div is role=&quot;img&quot;, which was special cased to be `Element::canContainRangeEndPoint()` in:

<a href="https://bugs.webkit.org/attachment.cgi?id=229259&amp">https://bugs.webkit.org/attachment.cgi?id=229259&amp</a>;action=prettypatch (Find on Page can get stuck in a loop when the search string occurs in an input in a fieldset).

Making it `canContainRangeEndPoint` also makes it `editingIgnoresContent == true`, in turn making it `Position::isCandidate() == true`.

I tried to solve the core editing bug in <a href="https://github.com/WebKit/WebKit/pull/30614">https://github.com/WebKit/WebKit/pull/30614</a>, but my approach (removing this
special role=&quot;img&quot; logic in Element::canContainRangeEndPoint()) caused other undesirable effects (more details in
<a href="https://github.com/WebKit/WebKit/pull/30614#issuecomment-2221064954)">https://github.com/WebKit/WebKit/pull/30614#issuecomment-2221064954)</a>, so some other fix is needed (tracked by
<a href="https://bugs.webkit.org/show_bug.cgi?id=276460).">https://bugs.webkit.org/show_bug.cgi?id=276460).</a>

For now, this commit works around this foundational bug by changing `AXObjectCache::characterOffsetFromVisiblePosition`
to detect we&apos;ve moved back to the start position, and breaking to prevent an infinite loop.

* LayoutTests/accessibility/mac/role-img-selection-hang-expected.txt: Added.
* LayoutTests/accessibility/mac/role-img-selection-hang.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::characterOffsetFromVisiblePosition):

Canonical link: <a href="https://commits.webkit.org/280847@main">https://commits.webkit.org/280847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abf18c25900e9ff55897f78aded406255c2b6213

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8264 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8452 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46846 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5866 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27674 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7261 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7268 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63124 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54067 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54186 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12789 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1473 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32976 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34062 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35146 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->