### PR TITLE
[webkitpy] Remove WinCairoPort class, --platform=wincairo should be an alias of --platform=win

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -1683,6 +1683,7 @@ sub determinePortName()
         gtk => GTK,
         'jsc-only' => JSCOnly,
         playstation => PlayStation,
+        win => WinCairo,
         wincairo => WinCairo,
         wpe => WPE
     );

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -64,9 +64,12 @@ def platform_options(use_globs=False):
         optparse.make_option('--wpe', action='store_const', dest='platform',
             const=('wpe*' if use_globs else 'wpe'),
             help=('Alias for --platform=wpe')),
+        optparse.make_option('--win', action='store_const', dest='platform',
+            const=('win'),
+            help=('Alias for --platform=win')),
         optparse.make_option('--wincairo', action='store_const', dest='platform',
-            const=('wincairo'),
-            help=('Alias for --platform=wincairo')),
+            const=('win'),
+            help=('Alias for --platform=win')),
         optparse.make_option('--maccatalyst', action='store_const', dest='platform',
             const=('maccatalyst'),
             help=('Alias for --platform=maccatalyst')),
@@ -111,7 +114,7 @@ class PortFactory(object):
         'mac.MacCatalystPort',
         'mac.MacPort',
         'test.TestPort',
-        'win.WinCairoPort',
+        'win.WinPort',
         'wpe.WPEPort',
     )
 
@@ -125,7 +128,7 @@ class PortFactory(object):
         elif platform.is_mac():
             return 'mac'
         elif platform.is_win():
-            return 'wincairo'
+            return 'win'
         raise NotImplementedError('unknown platform: %s' % platform)
 
     def get(self, port_name=None, options=None, **kwargs):
@@ -133,6 +136,8 @@ class PortFactory(object):
         port_name is None, this routine attempts to guess at the most
         appropriate port on this platform."""
         port_name = port_name or self._default_port()
+        if port_name == 'wincairo':
+            port_name = 'win'
 
         classes = []
         for port_class in self.PORT_CLASSES:
@@ -171,7 +176,7 @@ class PortFactory(object):
             'mac-sonoma-wk2',
             'mac-ventura-wk1',
             'mac-ventura-wk2',
-            'wincairo-win10',
+            'win-win10',
             'wpe',
         ]
         return fnmatch.filter(all_port_names, platform)

--- a/Tools/Scripts/webkitpy/port/factory_unittest.py
+++ b/Tools/Scripts/webkitpy/port/factory_unittest.py
@@ -60,11 +60,16 @@ class FactoryTest(unittest.TestCase):
         self.assert_port(port_name=None,  os_name='mac', os_version=Version.from_name('Lion'), cls=mac.MacPort)
 
     def test_win(self):
-        self.assert_port(port_name='wincairo-win10', cls=win.WinCairoPort)
-        self.assert_port(port_name='wincairo-win10-wk2', cls=win.WinCairoPort)
-        self.assert_port(port_name='wincairo', os_name='win', os_version=Version.from_name('Win10'), cls=win.WinCairoPort)
-        self.assert_port(port_name=None, os_name='win', os_version=Version.from_name('Win10'), cls=win.WinCairoPort)
-        self.assert_port(port_name=None, os_name='win', os_version=Version.from_name('Win10'), options=self.webkit_options, cls=win.WinCairoPort)
+        self.assert_port(port_name='win', os_name='win', os_version=Version.from_name('Win10'), cls=win.WinPort)
+        self.assert_port(port_name='win-win10', cls=win.WinPort)
+        self.assert_port(port_name='win-win10-wk2', cls=win.WinPort)
+        self.assert_port(port_name=None, os_name='win', os_version=Version.from_name('Win10'), cls=win.WinPort)
+        self.assert_port(port_name=None, os_name='win', os_version=Version.from_name('Win10'), options=self.webkit_options, cls=win.WinPort)
+
+    def test_wincairo(self):
+        self.assert_port(port_name='wincairo', os_name='win', os_version=Version.from_name('Win10'), cls=win.WinPort)
+        self.assert_port(port_name='wincairo-win10', cls=win.WinPort)
+        self.assert_port(port_name='wincairo-win10-wk2', cls=win.WinPort)
 
     def test_gtk(self):
         self.assert_port(port_name='gtk', cls=gtk.GtkPort)

--- a/Tools/Scripts/webkitpy/port/win.py
+++ b/Tools/Scripts/webkitpy/port/win.py
@@ -476,16 +476,19 @@ class WinPort(ApplePort):
 
         wk_version = 'wk2' if self.get_option('webkit_test_runner') else 'wk1'
 
+        # FIXME: LayoutTests/platform/wincairo directory should be renamed to LayoutTests/platform/win
+        port_name_for_test = 'wincairo'
+
         for version in versions:
             version_name = to_name(version)
             if not version_name:
                 continue
-            name = self.port_name + '-' + normalize(version_name)
+            name = port_name_for_test + '-' + normalize(version_name)
             paths.append(name + '-' + wk_version)
             paths.append(name)
 
-        paths.append(self.port_name + '-' + wk_version)
-        paths.append(self.port_name)
+        paths.append(port_name_for_test + '-' + wk_version)
+        paths.append(port_name_for_test)
         if self.get_option('webkit_test_runner'):
             paths.append('wk2')
         paths.extend(self.get_option("additional_platform_directory", []))
@@ -494,9 +497,5 @@ class WinPort(ApplePort):
 
     def configuration_for_upload(self, host=None):
         configuration = super(WinPort, self).configuration_for_upload(host=host)
-        configuration['platform'] = self.port_name
+        configuration['platform'] = 'wincairo'
         return configuration
-
-
-class WinCairoPort(WinPort):
-    port_name = "wincairo"

--- a/Tools/Scripts/webkitpy/port/win_unittest.py
+++ b/Tools/Scripts/webkitpy/port/win_unittest.py
@@ -35,7 +35,7 @@ from webkitpy.common.system.executive_mock import MockExecutive
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.common.version_name_map import PUBLIC_TABLE, VersionNameMap
 from webkitpy.port import port_testcase
-from webkitpy.port.win import WinCairoPort
+from webkitpy.port.win import WinPort
 from webkitpy.tool.mocktool import MockOptions
 
 
@@ -43,7 +43,7 @@ class WinPortTest(port_testcase.PortTestCase):
     os_name = 'win'
     os_version = Version.from_name('XP')
     port_name = 'win-xp'
-    port_maker = WinCairoPort
+    port_maker = WinPort
 
     def _assert_search_path(self, expected_search_paths, version, use_webkit2=False):
         port = self.make_port(port_name='win', os_version=version, options=MockOptions(webkit_test_runner=use_webkit2))
@@ -56,13 +56,13 @@ class WinPortTest(port_testcase.PortTestCase):
         self._assert_search_path(['wincairo-vista-wk1', 'wincairo-vista', 'wincairo-7sp0-wk1', 'wincairo-7sp0', 'wincairo-8-wk1', 'wincairo-8', 'wincairo-8.1-wk1', 'wincairo-8.1', 'wincairo-win10-wk1', 'wincairo-win10', 'wincairo-wk1', 'wincairo'], Version.from_name('Vista'))
         self._assert_search_path(['wincairo-7sp0-wk1', 'wincairo-7sp0', 'wincairo-8-wk1', 'wincairo-8', 'wincairo-8.1-wk1', 'wincairo-8.1', 'wincairo-win10-wk1', 'wincairo-win10', 'wincairo-wk1', 'wincairo'], Version.from_name('7sp0'))
 
-        self._assert_search_path(['wincairo-win10-wk2', 'wincairo-win10', 'wincairo-wk2', 'wincairo', 'wk2'], Version.from_name('XP'), use_webkit2=True)
-        self._assert_search_path(['wincairo-win10-wk2', 'wincairo-win10', 'wincairo-wk2', 'wincairo', 'wk2'], Version.from_name('Vista'), use_webkit2=True)
-        self._assert_search_path(['wincairo-win10-wk2', 'wincairo-win10', 'wincairo-wk2', 'wincairo', 'wk2'], Version.from_name('7sp0'), use_webkit2=True)
+        self._assert_search_path(['wincairo-xp-wk2', 'wincairo-xp', 'wincairo-vista-wk2', 'wincairo-vista', 'wincairo-7sp0-wk2', 'wincairo-7sp0', 'wincairo-8-wk2', 'wincairo-8', 'wincairo-8.1-wk2', 'wincairo-8.1', 'wincairo-win10-wk2', 'wincairo-win10', 'wincairo-wk2', 'wincairo', 'wk2'], Version.from_name('XP'), use_webkit2=True)
+        self._assert_search_path(['wincairo-vista-wk2', 'wincairo-vista', 'wincairo-7sp0-wk2', 'wincairo-7sp0', 'wincairo-8-wk2', 'wincairo-8', 'wincairo-8.1-wk2', 'wincairo-8.1', 'wincairo-win10-wk2', 'wincairo-win10', 'wincairo-wk2', 'wincairo', 'wk2'], Version.from_name('Vista'), use_webkit2=True)
+        self._assert_search_path(['wincairo-7sp0-wk2', 'wincairo-7sp0', 'wincairo-8-wk2', 'wincairo-8', 'wincairo-8.1-wk2', 'wincairo-8.1', 'wincairo-win10-wk2', 'wincairo-win10', 'wincairo-wk2', 'wincairo', 'wk2'], Version.from_name('7sp0'), use_webkit2=True)
 
     def _assert_version(self, port_name, expected_version):
         host = MockSystemHost(os_name='win', os_version=expected_version)
-        port = WinCairoPort(host, port_name=port_name)
+        port = WinPort(host, port_name=port_name)
         self.assertEqual(port.version_name(), VersionNameMap.map().to_name(expected_version, platform='win', table=PUBLIC_TABLE))
 
     def test_versions(self):


### PR DESCRIPTION
#### c8fc8c9e214ac645769900a3f1315b3c9976cd34
<pre>
[webkitpy] Remove WinCairoPort class, --platform=wincairo should be an alias of --platform=win
<a href="https://bugs.webkit.org/show_bug.cgi?id=276469">https://bugs.webkit.org/show_bug.cgi?id=276469</a>

Reviewed by Don Olmstead.

For renaming wincairo port to win port, all scripts should accept both
--platform=win and --platform=wincairo during the transition period.
This change modified webkitpy as the first step.

Other scripts also need changes. And, LayoutTests/platform/wincairo
directory should be renamed to LayoutTests/platform/win.

* Tools/Scripts/webkitdirs.pm:
(determinePortName):
* Tools/Scripts/webkitpy/port/factory.py:
(platform_options):
(PortFactory):
(PortFactory._default_port):
(PortFactory.get):
(PortFactory.all_port_names):
* Tools/Scripts/webkitpy/port/factory_unittest.py:
(FactoryTest.test_win):
(FactoryTest):
(FactoryTest.test_wincairo):
* Tools/Scripts/webkitpy/port/win.py:
(WinPort._search_paths):
(WinPort.configuration_for_upload):
* Tools/Scripts/webkitpy/port/win_unittest.py:
(WinPortTest):
(WinPortTest.test_baseline_search_path):
(WinPortTest._assert_version):

Canonical link: <a href="https://commits.webkit.org/280875@main">https://commits.webkit.org/280875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af13ca96d5c6e807cf391190d8947a1f27556590

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57916 "Failed to checkout and rebase branch from PR 30678") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10392 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/61538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8361 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60044 "Failed to checkout and rebase branch from PR 30678") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8549 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/61538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/5955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59946 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/50062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/61538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/57442 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/31696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/7356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7365 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51008 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/7625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63225 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57158 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1830 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1837 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/50073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/54294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/1563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78919 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8635 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33073 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/13093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/34159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35243 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/33904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->