### PR TITLE
REGRESSION (278000@main): Adobe Acrobat signature shows a broken line

### DIFF
--- a/LayoutTests/fast/canvas/canvas-strokePath-round-lineCap-expected.html
+++ b/LayoutTests/fast/canvas/canvas-strokePath-round-lineCap-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <script>
+    async function doLoad() {
+      var canvas = document.createElement('canvas');
+      document.body.appendChild(canvas);
+      var ctx = canvas.getContext('2d');
+
+      canvas.width = 200;
+      canvas.height = 200;
+      ctx.lineWidth = 29.04;
+      ctx.lineCap = "round";
+
+      ctx.clearRect(0, 0, 200, 200);
+
+      ctx.strokeStyle = "#f00";
+      ctx.beginPath();
+      ctx.moveTo(50, 50);
+      ctx.lineTo(100, 150);
+      ctx.stroke();
+
+      ctx.strokeStyle = "#0f0";
+      ctx.beginPath();
+      ctx.moveTo(100, 150);
+      ctx.bezierCurveTo(150, 100, 150, 100, 150, 50);
+      ctx.stroke();
+    }
+  </script>
+</head>
+
+<body onload="doLoad()">
+</body>
+
+</html>

--- a/LayoutTests/fast/canvas/canvas-strokePath-round-lineCap.html
+++ b/LayoutTests/fast/canvas/canvas-strokePath-round-lineCap.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <script>
+    async function doLoad() {
+      if (window.testRunner) {
+        testRunner.waitUntilDone();
+        if (testRunner.dontForceRepaint)
+          testRunner.dontForceRepaint();
+      }
+
+      var canvas = document.createElement('canvas');
+      document.body.appendChild(canvas);
+      var ctx = canvas.getContext('2d');
+
+      canvas.width = 200;
+      canvas.height = 200;
+      ctx.lineWidth = 29.04;
+      ctx.lineCap = "round";
+
+      ctx.clearRect(0, 0, 200, 200);
+
+      // Paint the whole cleared canvas.
+      await new Promise(requestAnimationFrame);
+      await new Promise(requestAnimationFrame);
+
+      // After this, repaints should be restricted to the new stroke bounds.
+
+      ctx.strokeStyle = "#f00";
+      ctx.beginPath();
+      ctx.moveTo(50, 50);
+      ctx.lineTo(100, 150);
+      ctx.stroke();
+
+      ctx.strokeStyle = "#0f0";
+      ctx.beginPath();
+      ctx.moveTo(100, 150);
+      ctx.bezierCurveTo(150, 100, 150, 100, 150, 50);
+      ctx.stroke();
+
+      await new Promise(requestAnimationFrame);
+      await new Promise(requestAnimationFrame);
+
+      if (window.testRunner) {
+        testRunner.notifyDone();
+      }
+    }
+  </script>
+</head>
+
+<body onload="doLoad()">
+</body>
+
+</html>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1223,7 +1223,7 @@ void CanvasRenderingContext2DBase::strokeInternal(const Path& path)
         c->strokePath(path);
 
     didDraw(repaintEntireCanvas, [&]() {
-        return targetSwitcher ? targetSwitcher->expandedBounds() : path.fastBoundingRect();
+        return targetSwitcher ? targetSwitcher->expandedBounds() : inflatedStrokeRect(path.fastBoundingRect());
     });
 }
 


### PR DESCRIPTION
#### 53cb4c04965122ec3b8cb8da242c5d9c9ba302a7
<pre>
REGRESSION (278000@main): Adobe Acrobat signature shows a broken line
<a href="https://bugs.webkit.org/show_bug.cgi?id=276471">https://bugs.webkit.org/show_bug.cgi?id=276471</a>
<a href="https://rdar.apple.com/131084323">rdar://131084323</a>

Reviewed by Simon Fraser.

278000@main removed the inflateStrokeRect code in
CanvasRenderingContext2DBase::strokeInternal(), which caused
stroke corners to be visually clipped off.

Fixing by re-adding the missing inflatedStrokeRect.

* LayoutTests/fast/canvas/canvas-strokePath-round-lineCap-expected.html: Added.
* LayoutTests/fast/canvas/canvas-strokePath-round-lineCap.html: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::strokeInternal):

Canonical link: <a href="https://commits.webkit.org/280905@main">https://commits.webkit.org/280905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/990ac2a432e689db19d18c0cf4375e2b9ff716ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8433 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60116 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46993 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6006 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31760 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7418 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7437 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63301 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7755 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54217 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54356 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12826 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1629 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33145 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34231 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35315 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->