### PR TITLE
[GTK][WPE] Do not pass invalid damage areas to the UI process

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -1148,8 +1148,11 @@ void TextureMapperLayer::recordDamage(const FloatRect& rect, const Transformatio
     // Some layers are drawn on an intermediate surface and have this offset applied to convert to the
     // intermediate surface coordinates. In order to translate back to actual coordinates,
     // we have to undo it.
-    if (!options.offset.isZero())
-        transformedRect.move(-options.offset);
+    transformedRect.move(-options.offset);
+    auto clipBounds = options.textureMapper.clipBounds();
+    clipBounds.move(-options.offset);
+    transformedRect.intersect(clipBounds);
+
     m_visitor->recordDamage(transformedRect);
 }
 

--- a/Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in
+++ b/Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in
@@ -24,5 +24,5 @@ messages -> AcceleratedBackingStoreDMABuf NotRefCounted {
     DidCreateBuffer(uint64_t id, WebCore::IntSize size, uint32_t format, Vector<UnixFileDescriptor> fds, Vector<uint32_t> offsets, Vector<uint32_t> strides, uint64_t modifier, WebKit::DMABufRendererBufferFormat::Usage usage)
     DidCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle handle)
     DidDestroyBuffer(uint64_t id)
-    Frame(uint64_t id, std::optional<WebCore::Region> damage)
+    Frame(uint64_t id, WebCore::Region damage)
 }

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -80,7 +80,7 @@ private:
     void didCreateBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage);
     void didCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle&&);
     void didDestroyBuffer(uint64_t id);
-    void frame(uint64_t id, std::optional<WebCore::Region>&&);
+    void frame(uint64_t id, WebCore::Region&&);
     void frameDone();
     void ensureGLContext();
     bool prepareForRendering();
@@ -110,7 +110,7 @@ private:
         };
 
         virtual Type type() const = 0;
-        virtual void didUpdateContents(Buffer*, const std::optional<WebCore::Region>&) = 0;
+        virtual void didUpdateContents(Buffer*, const WebCore::Region&) = 0;
 #if USE(GTK4)
         virtual GdkTexture* texture() const { return nullptr; }
 #else
@@ -145,7 +145,7 @@ private:
         BufferDMABuf(uint64_t id, const WebCore::IntSize&, float deviceScaleFactor, DMABufRendererBufferFormat::Usage, Vector<WTF::UnixFileDescriptor>&&, GRefPtr<GdkDmabufTextureBuilder>&&);
 
         Buffer::Type type() const override { return Buffer::Type::DmaBuf; }
-        void didUpdateContents(Buffer*, const std::optional<WebCore::Region>&) override;
+        void didUpdateContents(Buffer*, const WebCore::Region&) override;
         GdkTexture* texture() const override { return m_texture.get(); }
         RendererBufferFormat format() const override;
 
@@ -164,7 +164,7 @@ private:
         BufferEGLImage(uint64_t id, const WebCore::IntSize&, float deviceScaleFactor, DMABufRendererBufferFormat::Usage, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, uint64_t modifier, EGLImage);
 
         Buffer::Type type() const override { return Buffer::Type::EglImage; }
-        void didUpdateContents(Buffer*, const std::optional<WebCore::Region>&) override;
+        void didUpdateContents(Buffer*, const WebCore::Region&) override;
 #if USE(GTK4)
         GdkTexture* texture() const override { return m_texture.get(); }
 #else
@@ -193,7 +193,7 @@ private:
         BufferGBM(uint64_t id, const WebCore::IntSize&, float deviceScaleFactor, DMABufRendererBufferFormat::Usage, WTF::UnixFileDescriptor&&, struct gbm_bo*);
 
         Buffer::Type type() const override { return Buffer::Type::Gbm; }
-        void didUpdateContents(Buffer*, const std::optional<WebCore::Region>&) override;
+        void didUpdateContents(Buffer*, const WebCore::Region&) override;
         cairo_surface_t* surface() const override { return m_surface.get(); }
         RendererBufferFormat format() const override;
 
@@ -212,7 +212,7 @@ private:
         BufferSHM(uint64_t id, RefPtr<WebCore::ShareableBitmap>&&, float deviceScaleFactor);
 
         Buffer::Type type() const override { return Buffer::Type::SharedMemory; }
-        void didUpdateContents(Buffer*, const std::optional<WebCore::Region>&) override;
+        void didUpdateContents(Buffer*, const WebCore::Region&) override;
         cairo_surface_t* surface() const override { return m_surface.get(); }
         RendererBufferFormat format() const override;
 
@@ -244,7 +244,7 @@ private:
     Renderer m_renderer;
     RefPtr<Buffer> m_pendingBuffer;
     RefPtr<Buffer> m_committedBuffer;
-    std::optional<WebCore::Region> m_pendingDamageRegion;
+    WebCore::Region m_pendingDamageRegion;
     HashMap<uint64_t, RefPtr<Buffer>> m_buffers;
 };
 

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
@@ -68,7 +68,7 @@ private:
     void didCreateBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage);
     void didCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle&&);
     void didDestroyBuffer(uint64_t id);
-    void frame(uint64_t bufferID, const std::optional<WebCore::Region>&);
+    void frame(uint64_t bufferID, WebCore::Region&&);
     void frameDone();
     void bufferRendered();
     void bufferReleased(WPEBuffer*);

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
@@ -62,7 +62,7 @@ public:
     virtual void willDestroyGLContext() { }
     virtual void finalize() { }
     virtual void willRenderFrame() { }
-    virtual void didRenderFrame(const std::optional<WebCore::Region>&) { }
+    virtual void didRenderFrame(WebCore::Region&&) { }
 
     virtual void didCreateCompositingRunLoop(WTF::RunLoop&) { }
     virtual void willDestroyCompositingRunLoop() { }
@@ -74,6 +74,7 @@ public:
     virtual void visibilityDidChange(bool) { }
     virtual bool backgroundColorDidChange();
 
+    const WebCore::IntSize& size() const { return m_size; }
     void clearIfNeeded();
 
 protected:

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -601,7 +601,7 @@ void AcceleratedSurfaceDMABuf::willRenderFrame()
         WTFLogAlways("AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer");
 }
 
-void AcceleratedSurfaceDMABuf::didRenderFrame(const std::optional<WebCore::Region>& damage)
+void AcceleratedSurfaceDMABuf::didRenderFrame(WebCore::Region&& damage)
 {
     if (!m_target)
         return;
@@ -612,7 +612,7 @@ void AcceleratedSurfaceDMABuf::didRenderFrame(const std::optional<WebCore::Regio
         glFlush();
 
     m_target->didRenderFrame();
-    WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStoreDMABuf::Frame(m_target->id(), damage), m_id);
+    WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStoreDMABuf::Frame(m_target->id(), WTFMove(damage)), m_id);
 }
 
 void AcceleratedSurfaceDMABuf::releaseBuffer(uint64_t targetID)

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -73,7 +73,7 @@ private:
     void didCreateGLContext() override;
     void willDestroyGLContext() override;
     void willRenderFrame() override;
-    void didRenderFrame(const std::optional<WebCore::Region>&) override;
+    void didRenderFrame(WebCore::Region&&) override;
 
     void didCreateCompositingRunLoop(WTF::RunLoop&) override;
     void willDestroyCompositingRunLoop() override;

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
@@ -106,7 +106,7 @@ void AcceleratedSurfaceLibWPE::willRenderFrame()
     wpe_renderer_backend_egl_target_frame_will_render(m_backend);
 }
 
-void AcceleratedSurfaceLibWPE::didRenderFrame(const std::optional<WebCore::Region>&)
+void AcceleratedSurfaceLibWPE::didRenderFrame(WebCore::Region&&)
 {
     ASSERT(m_backend);
     wpe_renderer_backend_egl_target_frame_rendered(m_backend);

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
@@ -56,7 +56,7 @@ public:
     void initialize() override;
     void finalize() override;
     void willRenderFrame() override;
-    void didRenderFrame(const std::optional<WebCore::Region>&) override;
+    void didRenderFrame(WebCore::Region&&) override;
 
 private:
     AcceleratedSurfaceLibWPE(WebPage&, Client&);


### PR DESCRIPTION
#### e0016a645813288b296357e1b8e24f3a081d7d72
<pre>
[GTK][WPE] Do not pass invalid damage areas to the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=276480">https://bugs.webkit.org/show_bug.cgi?id=276480</a>

Reviewed by Alejandro G. Castro.

This is not a problem under wayland because the compositor always
handles the case of the area being empty or bigger than the buffer. In
DRM the request fails with invalid argument if the area passed is not
valid. We can make sure the damage areas we generate in the web process
are always valid. We should also avoid passing a damage region
containing the whole buffer.

This patch clips the damage rectangles to make sure they are not bigger
than the buffer size. It also handles the case of empty regions, we
don&apos;t really need to use an optional because an empty damage region
means damaging the whole buffer.

* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::recordDamage):
* Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::BufferDMABuf::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::BufferEGLImage::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::BufferGBM::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::BufferSHM::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::frame):
(WebKit::AcceleratedBackingStoreDMABuf::update):
(WebKit::AcceleratedBackingStoreDMABuf::prepareForRendering):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::frame):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h:
(WebKit::AcceleratedSurface::didRenderFrame):
(WebKit::AcceleratedSurface::size const):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp:
(WebKit::AcceleratedSurfaceLibWPE::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h:

Canonical link: <a href="https://commits.webkit.org/281236@main">https://commits.webkit.org/281236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a06469c760ef0f5923b0fbf39e9f5120bcb2e200

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61487 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8310 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46891 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5909 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27719 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31653 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7305 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7314 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63171 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7645 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54120 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50023 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54237 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1517 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8844 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33022 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34108 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35192 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->