### PR TITLE
[WPE] WPE Platform: use damage region in DRM platform

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
@@ -168,7 +168,8 @@ std::unique_ptr<Plane> Plane::create(int fd, Type type, drmModePlane* plane, boo
         drmPropertyForName(fd, properties.get(), "SRC_X"),
         drmPropertyForName(fd, properties.get(), "SRC_Y"),
         drmPropertyForName(fd, properties.get(), "SRC_W"),
-        drmPropertyForName(fd, properties.get(), "SRC_H")
+        drmPropertyForName(fd, properties.get(), "SRC_H"),
+        drmPropertyForName(fd, properties.get(), "FB_DAMAGE_CLIPS")
     };
     return makeUnique<Plane>(plane, WTFMove(formats), WTFMove(props));
 }

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
@@ -121,6 +121,7 @@ public:
         Property srcY { 0, 0 };
         Property srcW { 0, 0 };
         Property srcH { 0, 0 };
+        Property fbDamageClips { 0, 0 };
     };
 
     struct Format {


### PR DESCRIPTION
#### ea5a4b0c67b18980a5d3d0ddb04fbcbae34031f3
<pre>
[WPE] WPE Platform: use damage region in DRM platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=276252">https://bugs.webkit.org/show_bug.cgi?id=276252</a>

Reviewed by Alejandro G. Castro.

* Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp:
(WPE::DRM::Plane::create):
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp:
(emptyPlaneProperties):
(primaryPlaneProperties):
(addPlaneProperties):
(wpeViewDRMCommitAtomic):
(buildDamageBlob):
(destroyDamageBlob):
(wpeViewDRMRequestUpdate):
(wpeViewDRMRenderBuffer):

Canonical link: <a href="https://commits.webkit.org/281337@main">https://commits.webkit.org/281337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58f93ba551f12b500038217c01d7cd909759836e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8311 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46892 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5910 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27720 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31651 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7315 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63172 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54113 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1786 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54239 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1516 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8898 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33023 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34109 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35193 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->