### PR TITLE
[GStreamer] Move some DMABuf-related code from the player to a new DMABufUtilities file

### DIFF
--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -48,6 +48,7 @@ platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
 platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp @no-unify
 
 platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
+platform/graphics/gstreamer/DMABufUtilities.cpp
 platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp @no-unify
 platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp @no-unify
 platform/graphics/gstreamer/GRefPtrGStreamer.cpp

--- a/Source/WebCore/platform/graphics/gstreamer/DMABufUtilities.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufUtilities.cpp
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (C) 2024 Metrological Group B.V.
+ *  Copyright (C) 2024 Igalia S.L
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "config.h"
+
+#if USE(GSTREAMER) && USE(TEXTURE_MAPPER_DMABUF)
+#include "DMABufUtilities.h"
+
+namespace WebCore {
+
+DMABufDestination::DMABufDestination(struct gbm_bo* bo, uint32_t width, uint32_t height)
+    : bo(bo)
+    , height(height)
+{
+    map = gbm_bo_map(bo, 0, 0, width, height, GBM_BO_TRANSFER_WRITE, &stride, &mapData);
+    if (!map)
+        return;
+
+    isValid = true;
+    data = reinterpret_cast<uint8_t*>(map);
+}
+
+DMABufDestination::~DMABufDestination()
+{
+    if (isValid)
+        gbm_bo_unmap(bo, mapData);
+}
+
+void DMABufDestination::copyPlaneData(GstVideoFrame* sourceVideoFrame, unsigned planeIndex)
+{
+    auto sourceStride = GST_VIDEO_FRAME_PLANE_STRIDE(sourceVideoFrame, planeIndex);
+    auto* planeData = reinterpret_cast<uint8_t*>(GST_VIDEO_FRAME_PLANE_DATA(sourceVideoFrame, planeIndex));
+    for (uint32_t y = 0; y < height; ++y) {
+        auto* destinationData = &data[y * stride];
+        auto* sourceData = &planeData[y * sourceStride];
+        memcpy(destinationData, sourceData, std::min(static_cast<uint32_t>(sourceStride), stride));
+    }
+}
+
+bool fillSwapChainBuffer(const RefPtr<GBMBufferSwapchain::Buffer>& buffer, const GRefPtr<GstSample>& sample)
+{
+    GstMappedFrame sourceFrame(sample, GST_MAP_READ);
+    if (!sourceFrame)
+        return false;
+
+    auto* sourceVideoFrame = sourceFrame.get();
+    for (unsigned i = 0; i < GST_VIDEO_FRAME_N_PLANES(sourceVideoFrame); ++i) {
+        auto& planeData = buffer->planeData(i);
+
+        Locker locker { DMABufDestination::mappingLock() };
+        DMABufDestination destination(planeData.bo, planeData.width, planeData.height);
+        if (destination.isValid)
+            destination.copyPlaneData(sourceVideoFrame, i);
+    }
+    return true;
+}
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER) && USE(TEXTURE_MAPPER_DMABUF)

--- a/Source/WebCore/platform/graphics/gstreamer/DMABufUtilities.h
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufUtilities.h
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (C) 2024 Metrological Group B.V.
+ *  Copyright (C) 2024 Igalia S.L
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#pragma once
+
+#if USE(GSTREAMER) && USE(TEXTURE_MAPPER_DMABUF)
+
+#include "DMABufColorSpace.h"
+#include "DMABufFormat.h"
+#include "GBMBufferSwapchain.h"
+#include "GStreamerCommon.h"
+
+#include <gbm.h>
+#include <gst/video/video.h>
+#include <wtf/Lock.h>
+
+namespace WebCore {
+
+// GStreamer's gst_video_format_to_fourcc() doesn't cover RGB-like formats, so we
+// provide the appropriate FourCC values for those through this function.
+inline uint32_t dmaBufFourccValue(GstVideoFormat format)
+{
+    switch (format) {
+    case GST_VIDEO_FORMAT_RGBx:
+        return uint32_t(DMABufFormat::FourCC::XBGR8888);
+    case GST_VIDEO_FORMAT_BGRx:
+        return uint32_t(DMABufFormat::FourCC::XRGB8888);
+    case GST_VIDEO_FORMAT_xRGB:
+        return uint32_t(DMABufFormat::FourCC::BGRX8888);
+    case GST_VIDEO_FORMAT_xBGR:
+        return uint32_t(DMABufFormat::FourCC::RGBX8888);
+    case GST_VIDEO_FORMAT_RGBA:
+        return uint32_t(DMABufFormat::FourCC::ABGR8888);
+    case GST_VIDEO_FORMAT_BGRA:
+        return uint32_t(DMABufFormat::FourCC::ARGB8888);
+    case GST_VIDEO_FORMAT_ARGB:
+        return uint32_t(DMABufFormat::FourCC::BGRA8888);
+    case GST_VIDEO_FORMAT_ABGR:
+        return uint32_t(DMABufFormat::FourCC::RGBA8888);
+    case GST_VIDEO_FORMAT_P010_10LE:
+    case GST_VIDEO_FORMAT_P010_10BE:
+        return uint32_t(DMABufFormat::FourCC::P010);
+    case GST_VIDEO_FORMAT_P016_LE:
+    case GST_VIDEO_FORMAT_P016_BE:
+        return uint32_t(DMABufFormat::FourCC::P016);
+    default:
+        break;
+    }
+
+    return gst_video_format_to_fourcc(format);
+}
+
+inline DMABufColorSpace dmaBufColorSpaceForColorimetry(const GstVideoColorimetry* cinfo)
+{
+    if (gst_video_colorimetry_matches(cinfo, GST_VIDEO_COLORIMETRY_SRGB))
+        return DMABufColorSpace::SRGB;
+    if (gst_video_colorimetry_matches(cinfo, GST_VIDEO_COLORIMETRY_BT601))
+        return DMABufColorSpace::BT601;
+    if (gst_video_colorimetry_matches(cinfo, GST_VIDEO_COLORIMETRY_BT709))
+        return DMABufColorSpace::BT709;
+    if (gst_video_colorimetry_matches(cinfo, GST_VIDEO_COLORIMETRY_BT2020))
+        return DMABufColorSpace::BT2020;
+    if (gst_video_colorimetry_matches(cinfo, GST_VIDEO_COLORIMETRY_SMPTE240M))
+        return DMABufColorSpace::SMPTE240M;
+    return DMABufColorSpace::Invalid;
+}
+
+// Destination helper struct, maps the gbm_bo object into CPU-memory space and copies from the accompanying Source.
+struct DMABufDestination {
+    static Lock& mappingLock()
+    {
+        static Lock s_mappingLock;
+        return s_mappingLock;
+    }
+
+    DMABufDestination(struct gbm_bo*, uint32_t width, uint32_t height);
+    ~DMABufDestination();
+
+    void copyPlaneData(GstVideoFrame*, unsigned planeIndex);
+
+    bool isValid { false };
+    struct gbm_bo* bo { nullptr };
+    void* map { nullptr };
+    void* mapData { nullptr };
+    uint8_t* data { nullptr };
+    uint32_t height { 0 };
+    uint32_t stride { 0 };
+};
+
+bool fillSwapChainBuffer(const RefPtr<GBMBufferSwapchain::Buffer>&, const GRefPtr<GstSample>&);
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER) && USE(TEXTURE_MAPPER_DMABUF)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -121,12 +121,10 @@
 #endif // USE(TEXTURE_MAPPER)
 
 #if USE(TEXTURE_MAPPER_DMABUF)
-#include "DMABufFormat.h"
-#include "DMABufObject.h"
+#include "DMABufUtilities.h"
 #include "DMABufVideoSinkGStreamer.h"
 #include "GBMBufferSwapchain.h"
 #include "TextureMapperPlatformLayerProxyDMABuf.h"
-#include <gbm.h>
 #include <gst/allocators/gstdmabuf.h>
 #endif // USE(TEXTURE_MAPPER_DMABUF)
 
@@ -3410,54 +3408,6 @@ void MediaPlayerPrivateGStreamer::pushTextureToCompositor()
 #endif // USE(TEXTURE_MAPPER)
 
 #if USE(TEXTURE_MAPPER_DMABUF)
-// GStreamer's gst_video_format_to_fourcc() doesn't cover RGB-like formats, so we
-// provide the appropriate FourCC values for those through this funcion.
-static uint32_t fourccValue(GstVideoFormat format)
-{
-    switch (format) {
-    case GST_VIDEO_FORMAT_RGBx:
-        return uint32_t(DMABufFormat::FourCC::XBGR8888);
-    case GST_VIDEO_FORMAT_BGRx:
-        return uint32_t(DMABufFormat::FourCC::XRGB8888);
-    case GST_VIDEO_FORMAT_xRGB:
-        return uint32_t(DMABufFormat::FourCC::BGRX8888);
-    case GST_VIDEO_FORMAT_xBGR:
-        return uint32_t(DMABufFormat::FourCC::RGBX8888);
-    case GST_VIDEO_FORMAT_RGBA:
-        return uint32_t(DMABufFormat::FourCC::ABGR8888);
-    case GST_VIDEO_FORMAT_BGRA:
-        return uint32_t(DMABufFormat::FourCC::ARGB8888);
-    case GST_VIDEO_FORMAT_ARGB:
-        return uint32_t(DMABufFormat::FourCC::BGRA8888);
-    case GST_VIDEO_FORMAT_ABGR:
-        return uint32_t(DMABufFormat::FourCC::RGBA8888);
-    case GST_VIDEO_FORMAT_P010_10LE:
-    case GST_VIDEO_FORMAT_P010_10BE:
-        return uint32_t(DMABufFormat::FourCC::P010);
-    case GST_VIDEO_FORMAT_P016_LE:
-    case GST_VIDEO_FORMAT_P016_BE:
-        return uint32_t(DMABufFormat::FourCC::P016);
-    default:
-        break;
-    }
-
-    return gst_video_format_to_fourcc(format);
-}
-
-static DMABufColorSpace colorSpaceForColorimetry(const GstVideoColorimetry* cinfo)
-{
-    if (gst_video_colorimetry_matches(cinfo, GST_VIDEO_COLORIMETRY_SRGB))
-        return DMABufColorSpace::SRGB;
-    if (gst_video_colorimetry_matches(cinfo, GST_VIDEO_COLORIMETRY_BT601))
-        return DMABufColorSpace::BT601;
-    if (gst_video_colorimetry_matches(cinfo, GST_VIDEO_COLORIMETRY_BT709))
-        return DMABufColorSpace::BT709;
-    if (gst_video_colorimetry_matches(cinfo, GST_VIDEO_COLORIMETRY_BT2020))
-        return DMABufColorSpace::BT2020;
-    if (gst_video_colorimetry_matches(cinfo, GST_VIDEO_COLORIMETRY_SMPTE240M))
-        return DMABufColorSpace::SMPTE240M;
-    return DMABufColorSpace::Invalid;
-}
 
 struct DMABufMemoryQuarkData {
     DMABufReleaseFlag releaseFlag;
@@ -3543,10 +3493,10 @@ void MediaPlayerPrivateGStreamer::pushDMABufToCompositor()
                     fourcc = drmInfo.drm_fourcc;
 #endif
                 if (!fourcc)
-                    fourcc = fourccValue(GST_VIDEO_INFO_FORMAT(&videoInfo));
+                    fourcc = dmaBufFourccValue(GST_VIDEO_INFO_FORMAT(&videoInfo));
 
                 object.format = DMABufFormat::create(fourcc);
-                object.colorSpace = colorSpaceForColorimetry(&GST_VIDEO_INFO_COLORIMETRY(&videoInfo));
+                object.colorSpace = dmaBufColorSpaceForColorimetry(&GST_VIDEO_INFO_COLORIMETRY(&videoInfo));
 
                 if (m_videoSize.isEmpty()) {
                     object.width = GST_VIDEO_INFO_WIDTH(&videoInfo);
@@ -3606,16 +3556,19 @@ void MediaPlayerPrivateGStreamer::pushDMABufToCompositor()
 
     // If the decoder is exporting raw memory, we have to use the swapchain to allocate appropriate buffers
     // and copy over the data for each plane. For that to work, linear-storage buffer is required.
+
+    auto fourcc = dmaBufFourccValue(GST_VIDEO_INFO_FORMAT(&videoInfo));
+    if (fourcc == uint32_t(DMABufFormat::FourCC::Invalid)) {
+        GST_ERROR_OBJECT(pipeline(), "Invalid DMABuf fourcc for GStreamer video format %s", gst_video_format_to_string(GST_VIDEO_INFO_FORMAT(&videoInfo)));
+        return;
+    }
+
     GBMBufferSwapchain::BufferDescription bufferDescription {
-        .format = DMABufFormat::create(fourccValue(GST_VIDEO_INFO_FORMAT(&videoInfo))),
+        .format = DMABufFormat::create(fourcc),
         .width = static_cast<uint32_t>GST_VIDEO_INFO_WIDTH(&videoInfo),
         .height = static_cast<uint32_t>GST_VIDEO_INFO_HEIGHT(&videoInfo),
         .flags = GBMBufferSwapchain::BufferDescription::LinearStorage,
     };
-    if (bufferDescription.format.fourcc == DMABufFormat::FourCC::Invalid) {
-        GST_ERROR_OBJECT(pipeline(), "Invalid DMABuf fourcc for GStreamer video format %s", gst_video_format_to_string(GST_VIDEO_INFO_FORMAT(&videoInfo)));
-        return;
-    }
 
     auto swapchainBuffer = m_swapchain->getBuffer(bufferDescription);
     if (!swapchainBuffer) {
@@ -3623,65 +3576,8 @@ void MediaPlayerPrivateGStreamer::pushDMABufToCompositor()
         return;
     }
 
-    // Destination helper struct, maps the gbm_bo object into CPU-memory space and copies from the accompanying Source in fill().
-    struct Destination {
-        static Lock& mappingLock()
-        {
-            static Lock s_mappingLock;
-            return s_mappingLock;
-        }
-
-        Destination(struct gbm_bo* bo, uint32_t width, uint32_t height)
-            : bo(bo)
-            , height(height)
-        {
-            map = gbm_bo_map(bo, 0, 0, width, height, GBM_BO_TRANSFER_WRITE, &stride, &mapData);
-            if (!map)
-                return;
-
-            valid = true;
-            data = reinterpret_cast<uint8_t*>(map);
-        }
-
-        ~Destination()
-        {
-            if (valid)
-                gbm_bo_unmap(bo, mapData);
-        }
-
-        void copyPlaneData(GstVideoFrame* sourceVideoFrame, unsigned planeIndex)
-        {
-            auto sourceStride = GST_VIDEO_FRAME_PLANE_STRIDE(sourceVideoFrame, planeIndex);
-            auto* planeData = reinterpret_cast<uint8_t*>(GST_VIDEO_FRAME_PLANE_DATA(sourceVideoFrame, planeIndex));
-            for (uint32_t y = 0; y < height; ++y) {
-                auto* destinationData = &data[y * stride];
-                auto* sourceData = &planeData[y * sourceStride];
-                memcpy(destinationData, sourceData, std::min(static_cast<uint32_t>(sourceStride), stride));
-            }
-        }
-
-        bool valid { false };
-        struct gbm_bo* bo { nullptr };
-        void* map { nullptr };
-        void* mapData { nullptr };
-        uint8_t* data { nullptr };
-        uint32_t height { 0 };
-        uint32_t stride { 0 };
-    };
-
-    GstMappedFrame sourceFrame(m_sample, GST_MAP_READ);
-    if (!sourceFrame)
+    if (!fillSwapChainBuffer(swapchainBuffer, m_sample))
         return;
-
-    auto* sourceVideoFrame = sourceFrame.get();
-    for (unsigned i = 0; i < GST_VIDEO_FRAME_N_PLANES(sourceVideoFrame); ++i) {
-        auto& planeData = swapchainBuffer->planeData(i);
-
-        Locker locker { Destination::mappingLock() };
-        Destination destination(planeData.bo, planeData.width, planeData.height);
-        if (destination.valid)
-            destination.copyPlaneData(sourceVideoFrame, i);
-    }
 
     // The updated buffer is pushed into the composition stage. The DMABufObject handle uses the swapchain address as the handle base.
     // When the buffer is pushed for the first time, the lambda will be invoked to retrieve a more complete DMABufObject for the
@@ -3691,7 +3587,7 @@ void MediaPlayerPrivateGStreamer::pushDMABufToCompositor()
         DMABufObject(reinterpret_cast<uintptr_t>(m_swapchain.get()) + swapchainBuffer->handle()),
         [&](auto&& initialObject) {
             auto object = swapchainBuffer->createDMABufObject(initialObject.handle);
-            object.colorSpace = colorSpaceForColorimetry(&GST_VIDEO_INFO_COLORIMETRY(&videoInfo));
+            object.colorSpace = dmaBufColorSpaceForColorimetry(&GST_VIDEO_INFO_COLORIMETRY(&videoInfo));
             return object;
         }, textureMapperFlags);
     m_hasFirstVideoSampleBeenRendered = true;

--- a/Source/WebCore/platform/network/DataURLDecoder.cpp
+++ b/Source/WebCore/platform/network/DataURLDecoder.cpp
@@ -31,6 +31,7 @@
 #include <pal/text/DecodeEscapeSequences.h>
 #include <pal/text/TextEncoding.h>
 #include <wtf/MainThread.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
 #include <wtf/URL.h>
 #include <wtf/WorkQueue.h>


### PR DESCRIPTION
#### ef8296de8bc58c4434fb79656f78a76cea852ca3
<pre>
[GStreamer] Move some DMABuf-related code from the player to a new DMABufUtilities file
<a href="https://bugs.webkit.org/show_bug.cgi?id=276481">https://bugs.webkit.org/show_bug.cgi?id=276481</a>

Reviewed by Xabier Rodriguez-Calvar.

Refactoring aiming to reduce a bit the size of MediaPlayerPrivateGStreamer::pushDMABufToCompositor()
and improve readability.

* Source/WebCore/platform/SourcesGStreamer.txt:
* Source/WebCore/platform/graphics/gstreamer/DMABufUtilities.cpp: Added.
(WebCore::DMABufDestination::DMABufDestination):
(WebCore::DMABufDestination::~DMABufDestination):
(WebCore::DMABufDestination::copyPlaneData):
(WebCore::fillSwapChainBuffer):
* Source/WebCore/platform/graphics/gstreamer/DMABufUtilities.h: Added.
(WebCore::dmaBufFourccValue):
(WebCore::dmaBufColorSpaceForColorimetry):
(WebCore::DMABufDestination::mappingLock):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::pushDMABufToCompositor):
(WebCore::fourccValue): Deleted.
(WebCore::colorSpaceForColorimetry): Deleted.

Canonical link: <a href="https://commits.webkit.org/280906@main">https://commits.webkit.org/280906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31ac88193b5ca44e7e783203b46c91afa1bdaa91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61616 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8436 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46995 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6008 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27826 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31763 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7421 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7440 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63304 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54220 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54359 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12827 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1632 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33148 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34234 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35318 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33979 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->