### PR TITLE
Implement B3 Sub/Mul of Int64 values on 32-bits

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerInt64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerInt64.cpp
@@ -461,7 +461,8 @@ private:
             return;
         }
         case Add:
-        case Sub: {
+        case Sub:
+        case Mul: {
             if (m_value->type() != Int64)
                 return;
             auto left = getMapping(m_value->child(0));

--- a/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
@@ -3215,6 +3215,14 @@ private:
             Value* left = m_value->child(0);
             Value* right = m_value->child(1);
 
+            if (m_value->type() == Int64 && isValidForm(Sub64, Arg::Tmp, Arg::Tmp, Arg::Tmp, Arg::Tmp, Arg::Tmp, Arg::Tmp)) {
+                auto leftArg = someArg(left);
+                auto rightArg = someArg(right);
+                auto result = someArg(m_value);
+                append(Sub64, leftArg.tmpHi(), leftArg.tmpLo(), rightArg.tmpHi(), rightArg.tmpLo(), result.tmpHi(), result.tmpLo());
+                return;
+            }
+
             auto tryAppendMultiplySub = [&] () -> bool {
                 if (imm(right) && !m_valueToTmp[right])
                     return false;
@@ -3315,6 +3323,19 @@ private:
             Value* left = m_value->child(0);
             Value* right = m_value->child(1);
 
+            if ((left->type() == Int64) && (right->type() == Int64)) {
+                Tmp tmpHiLo = tmpForType(Int32);
+                Tmp tmpLoHi = tmpForType(Int32);
+                auto argLeft = someArg(left);
+                auto argRight = someArg(right);
+                auto result = someArg(m_value);
+                append(Air::Mul32, argLeft.tmpHi(), argRight.tmpLo(), tmpHiLo);
+                append(Air::Mul32, argLeft.tmpLo(), argRight.tmpHi(), tmpLoHi);
+                append(Air::UMull32, argLeft.tmpLo(), argRight.tmpLo(), result.tmpHi(), result.tmpLo());
+                append(Air::Add32, tmpHiLo, result.tmpHi());
+                append(Air::Add32, tmpLoHi, result.tmpHi());
+                return;
+            }
             auto tryAppendMultiplyWithExtend = [&] () -> bool {
                 auto tryAirOpcode = [&] () -> Air::Opcode {
                     if (m_value->type() != Int64)


### PR DESCRIPTION
#### a0d948c191f504a1e62387400dc69e7d0b24ca32
<pre>
Implement B3 Sub/Mul of Int64 values on 32-bits
<a href="https://bugs.webkit.org/show_bug.cgi?id=276482">https://bugs.webkit.org/show_bug.cgi?id=276482</a>

Reviewed by Yusuke Suzuki.

Implement both Sub and Mul of Int64 values in B3LowerToAir32_64.cpp.

We cannot easily lower Sub on Int64s in B3LowerInt64 since the
performant implementation requires two subtractions, the latter using
the carry bit produced by the former. Similar to Add, make use of the
already available Sub64 form.

A performant implementation of Mul on Int64 on ARMv7 needs to make use
of the UMull air form (taking 2 32-bit values and producing one 64-bit
output). Technically we could define a B3 op for that just on
ARMv7, but this feels more straightforward. Mul is the last arithmetic
that should need special handling in B3LowerToAir32_64 (as opposed to
being lowered in B3LowerInt64).

* Source/JavaScriptCore/b3/B3LowerInt64.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp:

Canonical link: <a href="https://commits.webkit.org/280964@main">https://commits.webkit.org/280964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/001488f7d940328ddd925650e93baaef1c2cfc2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61490 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8313 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46893 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5912 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27721 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31656 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7308 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7317 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50960 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63174 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57110 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1782 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7648 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54114 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50026 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54243 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12864 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1519 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78871 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33025 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13089 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34111 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35195 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->