### PR TITLE
[GStreamer] Move gstStructureGet<T> definition to cpp file

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1010,6 +1010,36 @@ static ASCIILiteral webrtcStatsTypeName(int value)
 }
 #endif
 
+template<typename T>
+std::optional<T> gstStructureGet(const GstStructure* structure, ASCIILiteral key)
+{
+    T value;
+    if constexpr(std::is_same_v<T, int>) {
+        if (gst_structure_get_int(structure, key.characters(), &value))
+            return value;
+    } else if constexpr(std::is_same_v<T, int64_t>) {
+        if (gst_structure_get_int64(structure, key.characters(), &value))
+            return value;
+    } else if constexpr(std::is_same_v<T, unsigned>) {
+        if (gst_structure_get_uint(structure, key.characters(), &value))
+            return value;
+    } else if constexpr(std::is_same_v<T, uint64_t>) {
+        if (gst_structure_get_uint64(structure, key.characters(), &value))
+            return value;
+    } else if constexpr(std::is_same_v<T, double>) {
+        if (gst_structure_get_double(structure, key.characters(), &value))
+            return value;
+    } else
+        static_assert(!std::is_same_v<T, T>, "type not implemented for gstStructureGet");
+    return std::nullopt;
+}
+
+template std::optional<int> gstStructureGet(const GstStructure*, ASCIILiteral key);
+template std::optional<int64_t> gstStructureGet(const GstStructure*, ASCIILiteral key);
+template std::optional<unsigned> gstStructureGet(const GstStructure*, ASCIILiteral key);
+template std::optional<uint64_t> gstStructureGet(const GstStructure*, ASCIILiteral key);
+template std::optional<double> gstStructureGet(const GstStructure*, ASCIILiteral key);
+
 static RefPtr<JSON::Value> gstStructureToJSON(const GstStructure*);
 
 static std::optional<RefPtr<JSON::Value>> gstStructureValueToJSON(const GValue* value)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -273,29 +273,7 @@ GstElement* makeGStreamerElement(const char* factoryName, const char* name);
 GstElement* makeGStreamerBin(const char* description, bool ghostUnlinkedPads);
 
 template<typename T>
-inline std::optional<T> gstStructureGet(const GstStructure* structure, ASCIILiteral key)
-{
-    static_assert(std::is_same_v<T, int> || std::is_same_v<T, int64_t> || std::is_same_v<T, unsigned> || std::is_same_v<T, uint64_t> || std::is_same_v<T, double>);
-
-    T value;
-    if constexpr(std::is_same_v<T, int>) {
-        if (UNLIKELY(gst_structure_get_int(structure, key.characters(), &value)))
-            return value;
-    } else if constexpr(std::is_same_v<T, int64_t>) {
-        if (UNLIKELY(gst_structure_get_int64(structure, key.characters(), &value)))
-            return value;
-    } else if constexpr(std::is_same_v<T, unsigned>) {
-        if (UNLIKELY(gst_structure_get_uint(structure, key.characters(), &value)))
-            return value;
-    } else if constexpr(std::is_same_v<T, uint64_t>) {
-        if (UNLIKELY(gst_structure_get_uint64(structure, key.characters(), &value)))
-            return value;
-    } else if constexpr(std::is_same_v<T, double>) {
-        if (UNLIKELY(gst_structure_get_double(structure, key.characters(), &value)))
-            return value;
-    }
-    return std::nullopt;
-}
+std::optional<T> gstStructureGet(const GstStructure*, ASCIILiteral key);
 
 String gstStructureToJSONString(const GstStructure*);
 


### PR DESCRIPTION
#### 3f2972a007a277a88260b3a433e500fdf9d62e6e
<pre>
[GStreamer] Move gstStructureGet&lt;T&gt; definition to cpp file
<a href="https://bugs.webkit.org/show_bug.cgi?id=276484">https://bugs.webkit.org/show_bug.cgi?id=276484</a>

Reviewed by Xabier Rodriguez-Calvar and Philippe Normand.

Move gstStructureGet&lt;T&gt;&apos;s definition to the cpp file, because it improves
recompilation times when adding new types.

Driving by, since the function isn&apos;t inlined anymore, we don&apos;t hit
the miscompilation bug with Clang 18 bug fixed by 280669@main anymore, so
we can remove the workaround with UNLIKELY.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::gstStructureGet):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::gstStructureGet): Deleted.

Canonical link: <a href="https://commits.webkit.org/280859@main">https://commits.webkit.org/280859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb7ff05361b936bab6a11301f8c5de53aed744b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61494 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8317 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8505 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5916 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50018 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/27724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31657 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/7312 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7321 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63178 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7651 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54246 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12799 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1522 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33029 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34115 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35199 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33860 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->