### PR TITLE
[WPE] GStreamer hole punch does not render correctly with fixed body position

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -44,6 +44,7 @@ public:
     TextureMapperLayer* backdropLayer { nullptr };
     TextureMapperLayer* replicaLayer { nullptr };
     bool preserves3D { false };
+    Vector<IntRect> holePunchRects;
 };
 
 struct TextureMapperLayer::ComputeTransformData {
@@ -260,7 +261,27 @@ void TextureMapperLayer::paintSelf(TextureMapperPaintOptions& options)
         options.textureMapper.beginClip(transform, m_state.contentsClippingRect);
     }
 
+    bool isHolePunchInPreserve3D = options.preserves3D && contentsLayer->isHolePunchBuffer();
+    if (isHolePunchInPreserve3D) {
+        // If we're in preserve3D mode, then we're painting into an intermediate surface. This means that the
+        // elements are not painted into their final position, as it depends on the offset applied when painting the
+        // intermediate surface. But holepunch buffers need to know the final position in order to position the video
+        // sink and draw the transparent rectangle in the main framebuffer. Options.offset was applied to remove the
+        // offset from the elements that is instead applied to the intermediate surface, so we undo that. That way the
+        // transform shows the final position, and paintToTextureMapper can properly notify the video sink.
+        transform.translate(-options.offset.width(), -options.offset.height());
+    }
+
     contentsLayer->paintToTextureMapper(options.textureMapper, m_state.contentsRect, transform, options.opacity);
+
+    if (isHolePunchInPreserve3D) {
+        // Once the video sink was notified of the position, store the rect in the list of rects that need to be
+        // painted into the main framebuffer and reapply options.offset.
+        // The holepunch rects stored will be painted transparent into the main framebuffer before blending the
+        // intermediate surface.
+        options.holePunchRects.append(enclosingIntRect(transform.mapRect(m_state.contentsRect)));
+        transform.translate(options.offset.width(), options.offset.height());
+    }
 
     if (shouldClip)
         options.textureMapper.endClip();
@@ -831,7 +852,20 @@ void TextureMapperLayer::paintWith3DRenderingContext(TextureMapperPaintOptions& 
                     options.textureMapper.bindSurface(options.surface.get());
                     paintSelfAndChildrenWithReplica(options);
                 }
-                commitSurface(options, *surface, tileRect, options.opacity);
+
+                // Once the subtree is painted into the intermediate surface, we need to blend it into the main framebuffer.
+                tileRect.move(options.offset);
+                options.textureMapper.bindSurface(options.surface.get());
+
+                // There can't be nested preserves3D contexts, so the previous bindSurface always puts us on the
+                // main framebuffer. Draw the holepunch rectangles that we got from the subtree before blending
+                // the intermediate texture.
+                for (auto rect : options.holePunchRects)
+                    options.textureMapper.drawSolidColor(rect, { }, Color::transparentBlack, false);
+                options.holePunchRects.clear();
+
+                // And finally, blend the intermediate surface.
+                options.textureMapper.drawTexture(*surface, tileRect, { }, options.opacity);
             }
         }
     }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayer.h
@@ -46,6 +46,8 @@ public:
 
     void setClient(TextureMapperPlatformLayer::Client* client) { m_client = client; }
 
+    virtual bool isHolePunchBuffer() const { return false; }
+
 protected:
     TextureMapperPlatformLayer::Client* client() { return m_client; }
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
@@ -158,6 +158,14 @@ void TextureMapperPlatformLayerBuffer::paintToTextureMapper(TextureMapper& textu
         });
 }
 
+bool TextureMapperPlatformLayerBuffer::isHolePunchBuffer() const
+{
+    // Holepunch buffers are the only ones that have the ShouldNotBlend flag.
+    // All of the other buffers have to be blended, but holepunch ones need
+    // to overwrite the existent content to render the transparent rectangle.
+    return m_extraFlags.contains(TextureMapperFlags::ShouldNotBlend);
+}
+
 } // namespace WebCore
 
 #endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.h
@@ -70,6 +70,8 @@ public:
 
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
+    bool isHolePunchBuffer() const override;
+
     bool canReuseWithoutReset(const IntSize&, GLint internalFormat);
     BitmapTexture& texture() { return *m_texture; }
 


### PR DESCRIPTION
#### d8014cfad03b9a76013f10d7a54b4760483ae54d
<pre>
[WPE] GStreamer hole punch does not render correctly with fixed body position
<a href="https://bugs.webkit.org/show_bug.cgi?id=274469">https://bugs.webkit.org/show_bug.cgi?id=274469</a>

Reviewed by Carlos Garcia Campos.

When rendering into an intermediate surface due to preserve3D mode, store the
holepunch rectangles that are found in the subtree. Once the rendering is done,
and before blending the intermediate surface into the main framebuffer, draw
the stored holepunch rectangles with transparent, so they pierce the background
content.

* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::paintSelf):
(WebCore::TextureMapperLayer::paintWith3DRenderingContext):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayer.h:
(WebCore::TextureMapperPlatformLayer::isHolePunchBuffer const):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp:
(WebCore::TextureMapperPlatformLayerBuffer::isHolePunchBuffer const):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.h:

Canonical link: <a href="https://commits.webkit.org/280901@main">https://commits.webkit.org/280901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd2a1efb0e71087b793afa7df2620aef7be730cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61604 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8424 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46984 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5997 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27815 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31752 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7409 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7428 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63291 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1893 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7747 "layout-tests (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54209 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54346 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1620 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8648 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33136 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34222 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35306 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33967 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->