### PR TITLE
H265 WebRTC negotiation sometimes fails

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/api/video_codecs/h265_profile_tier_level.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/api/video_codecs/h265_profile_tier_level.cc
@@ -274,6 +274,12 @@ absl::optional<H265ProfileTierLevel> ParseSdpForH265ProfileTierLevel(
 
 bool H265IsSameProfileTierLevel(const CodecParameterMap& params1,
                                 const CodecParameterMap& params2) {
+#if WEBRTC_WEBKIT_BUILD
+  // FIXME: https://bugs.webkit.org/show_bug.cgi?id=276486.
+  // Populate encoder and decoder factories to properly support negotiation.
+  if (!params1.size() || !params2.size())
+      return true;
+#endif
   const absl::optional<H265ProfileTierLevel> ptl1 =
       ParseSdpForH265ProfileTierLevel(params1);
   const absl::optional<H265ProfileTierLevel> ptl2 =


### PR DESCRIPTION
#### 7aac03437a367d8e7b059235ea0e734d041534ba
<pre>
H265 WebRTC negotiation sometimes fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=276369">https://bugs.webkit.org/show_bug.cgi?id=276369</a>
<a href="https://rdar.apple.com/131388275">rdar://131388275</a>

Reviewed by Eric Carlson.

After the resync to M126, libwebrtc is now matching HEVC codec profiles.
We revert to the past behavior by disabling the precise checks if one of the codec has no parameter.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276486">https://bugs.webkit.org/show_bug.cgi?id=276486</a> will handle the population of the decoder/encoder factories to handle the proper negotiation.

* Source/ThirdParty/libwebrtc/Source/webrtc/api/video_codecs/h265_profile_tier_level.cc:

Canonical link: <a href="https://commits.webkit.org/280863@main">https://commits.webkit.org/280863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/568d6a52d8b75cbcad43c2a7dd9b0d9639590d17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61501 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8324 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8512 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5922 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27730 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7319 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7328 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63186 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1793 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50036 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/54252 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12800 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1529 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33036 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34122 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35206 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->