### PR TITLE
[GTK] Remove GTK 3 comment from GTK 4 web view background color docs

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
@@ -434,41 +434,6 @@ GtkWidget* webkit_web_view_new_with_user_content_manager(WebKitUserContentManage
 }
 #endif
 
-/**
- * webkit_web_view_set_background_color:
- * @web_view: a #WebKitWebView
- * @rgba: a #GdkRGBA
- *
- * Sets the color that will be used to draw the @web_view background.
- *
- * Sets the color that will be used to draw the @web_view background before
- * the actual contents are rendered. Note that if the web page loaded in @web_view
- * specifies a background color, it will take precedence over the @rgba color.
- * By default the @web_view background color is opaque white.
- * Note that the parent window must have a RGBA visual and
- * #GtkWidget:app-paintable property set to %TRUE for backgrounds colors to work.
- *
- * ```c
- * static void browser_window_set_background_color (BrowserWindow *window,
- *                                                  const GdkRGBA *rgba)
- * {
- *     WebKitWebView *web_view;
- *     GdkScreen *screen = gtk_window_get_screen (GTK_WINDOW (window));
- *     GdkVisual *rgba_visual = gdk_screen_get_rgba_visual (screen);
- *
- *     if (!rgba_visual)
- *          return;
- *
- *     gtk_widget_set_visual (GTK_WIDGET (window), rgba_visual);
- *     gtk_widget_set_app_paintable (GTK_WIDGET (window), TRUE);
- *
- *     web_view = browser_window_get_web_view (window);
- *     webkit_web_view_set_background_color (web_view, rgba);
- * }
- * ```
- *
- * Since: 2.8
- */
 void webkit_web_view_set_background_color(WebKitWebView* webView, const GdkRGBA* rgba)
 {
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk3.cpp
@@ -148,4 +148,40 @@ guint createShowOptionMenuSignal(WebKitWebViewClass* webViewClass)
         GDK_TYPE_EVENT | G_SIGNAL_TYPE_STATIC_SCOPE,
         GDK_TYPE_RECTANGLE | G_SIGNAL_TYPE_STATIC_SCOPE);
 }
+
+/**
+ * webkit_web_view_set_background_color:
+ * @web_view: a #WebKitWebView
+ * @rgba: a #GdkRGBA
+ *
+ * Sets the color that will be used to draw the @web_view background.
+ *
+ * Sets the color that will be used to draw the @web_view background before
+ * the actual contents are rendered. Note that if the web page loaded in @web_view
+ * specifies a background color, it will take precedence over the @rgba color.
+ * By default the @web_view background color is opaque white.
+ * Note that the parent window must have a RGBA visual and
+ * #GtkWidget:app-paintable property set to %TRUE for backgrounds colors to work.
+ *
+ * ```c
+ * static void browser_window_set_background_color (BrowserWindow *window,
+ *                                                  const GdkRGBA *rgba)
+ * {
+ *     WebKitWebView *web_view;
+ *     GdkScreen *screen = gtk_window_get_screen (GTK_WINDOW (window));
+ *     GdkVisual *rgba_visual = gdk_screen_get_rgba_visual (screen);
+ *
+ *     if (!rgba_visual)
+ *          return;
+ *
+ *     gtk_widget_set_visual (GTK_WIDGET (window), rgba_visual);
+ *     gtk_widget_set_app_paintable (GTK_WIDGET (window), TRUE);
+ *
+ *     web_view = browser_window_get_web_view (window);
+ *     webkit_web_view_set_background_color (web_view, rgba);
+ * }
+ * ```
+ *
+ * Since: 2.8
+ */
 #endif

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk4.cpp
@@ -135,4 +135,19 @@ guint createShowOptionMenuSignal(WebKitWebViewClass* webViewClass)
         WEBKIT_TYPE_OPTION_MENU,
         GDK_TYPE_RECTANGLE | G_SIGNAL_TYPE_STATIC_SCOPE);
 }
+
+/**
+ * webkit_web_view_set_background_color:
+ * @web_view: a #WebKitWebView
+ * @rgba: a #GdkRGBA
+ *
+ * Sets the color that will be used to draw the @web_view background.
+ *
+ * Sets the color that will be used to draw the @web_view background before
+ * the actual contents are rendered. Note that if the web page loaded in @web_view
+ * specifies a background color, it will take precedence over the @rgba color.
+ * By default the @web_view background color is opaque white.
+ *
+ * Since: 2.8
+ */
 #endif


### PR DESCRIPTION
#### 2d8800de7fc8d629a862b484b3302ac60c14ef80
<pre>
[GTK] Remove GTK 3 comment from GTK 4 web view background color docs
<a href="https://bugs.webkit.org/show_bug.cgi?id=276488">https://bugs.webkit.org/show_bug.cgi?id=276488</a>

Reviewed by Carlos Garcia Campos.

* Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk3.cpp:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk4.cpp:

Canonical link: <a href="https://commits.webkit.org/280892@main">https://commits.webkit.org/280892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bab20b48e6df6f6a17d4f3263b3fd412f67a372

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61503 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8326 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46904 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5925 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27731 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31665 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7330 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53612 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63188 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54128 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1801 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54254 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1530 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8644 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33038 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34124 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35208 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->