### PR TITLE
Add unit test for FontCascade::characterRangeCodePath non surrogated ranges

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -218,7 +218,7 @@ public:
     enum class CodePath : uint8_t { Auto, Simple, Complex, SimpleWithGlyphOverflow };
     WEBCORE_EXPORT CodePath codePath(const TextRun&, std::optional<unsigned> from = std::nullopt, std::optional<unsigned> to = std::nullopt) const;
     static CodePath characterRangeCodePath(std::span<const LChar>) { return CodePath::Simple; }
-    static CodePath characterRangeCodePath(std::span<const UChar>);
+    WEBCORE_EXPORT static CodePath characterRangeCodePath(std::span<const UChar>);
 
     bool primaryFontIsSystemFont() const;
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 		49D2E5C22731E3BC00BCCAED /* file-with-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 49D2E5C12731E37400BCCAED /* file-with-iframe.html */; };
 		49D902B328209B3300E2C3B8 /* emptyTable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 49D902B228209B0500E2C3B8 /* emptyTable.html */; };
 		4BFDFFA71314776C0061F24B /* HitTestResultNodeHandle_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BFDFFA61314776C0061F24B /* HitTestResultNodeHandle_Bundle.cpp */; };
+		4C041C6C2C405622002218A4 /* FontCascade.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C041C6B2C405622002218A4 /* FontCascade.cpp */; };
 		4C453A44294A469500D91D2B /* Ahem-10000A.ttf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4C453A43294A468200D91D2B /* Ahem-10000A.ttf */; };
 		4CC961EC294A36CE00483F06 /* LockdownModeFonts.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 4CC961E4294A36A000483F06 /* LockdownModeFonts.html */; };
 		510477721D298DDD009747EB /* IDBDeleteRecovery.sqlite3 in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5104776F1D298D85009747EB /* IDBDeleteRecovery.sqlite3 */; };
@@ -2510,6 +2511,7 @@
 		4BB4160316815F9100824238 /* ElementAtPointInWebFrame.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ElementAtPointInWebFrame.mm; sourceTree = "<group>"; };
 		4BFDFFA61314776C0061F24B /* HitTestResultNodeHandle_Bundle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HitTestResultNodeHandle_Bundle.cpp; sourceTree = "<group>"; };
 		4BFDFFA8131477770061F24B /* HitTestResultNodeHandle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HitTestResultNodeHandle.cpp; sourceTree = "<group>"; };
+		4C041C6B2C405622002218A4 /* FontCascade.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FontCascade.cpp; sourceTree = "<group>"; };
 		4C453A43294A468200D91D2B /* Ahem-10000A.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Ahem-10000A.ttf"; sourceTree = "<group>"; };
 		4CC961E4294A36A000483F06 /* LockdownModeFonts.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = LockdownModeFonts.html; path = Tests/WebKitCocoa/LockdownModeFonts.html; sourceTree = SOURCE_ROOT; };
 		5102ED872950538D0053243E /* WKPageHasMediaStreamingActivity.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKPageHasMediaStreamingActivity.mm; sourceTree = "<group>"; };
@@ -4498,6 +4500,7 @@
 				F4AD183725ED791500B1A19F /* FloatQuadTests.cpp */,
 				7A909A711D877475007E10F8 /* FloatRectTests.cpp */,
 				7A909A721D877475007E10F8 /* FloatSizeTests.cpp */,
+				4C041C6B2C405622002218A4 /* FontCascade.cpp */,
 				95C52728275F35E100DA7E40 /* FontShadowTests.cpp */,
 				8E4A85361E1D1AA100F53B0F /* GridPosition.cpp */,
 				83B88A331C80056D00BB2418 /* HTMLParserIdioms.cpp */,
@@ -6657,6 +6660,7 @@
 				7A909A801D877480007E10F8 /* FloatSizeTests.cpp in Sources */,
 				F4BC0B142146C849002A0478 /* FocusPreservationTests.mm in Sources */,
 				F4A2E64D284541BA0001FEEF /* FocusWebView.mm in Sources */,
+				4C041C6C2C405622002218A4 /* FontCascade.cpp in Sources */,
 				F456AB1C213EDBA300CB2CEF /* FontManagerTests.mm in Sources */,
 				1C81802725FB09E200608B3E /* FontRegistrySandboxCheck.mm in Sources */,
 				95C52729275F35E100DA7E40 /* FontShadowTests.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <WebCore/FontCascade.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+using CodePath = FontCascade::CodePath;
+
+static void testCodePath(UChar codePoint, CodePath codePath)
+{
+    std::array<UChar, 1> target = { codePoint };
+    EXPECT_EQ(codePath, FontCascade::characterRangeCodePath(std::span<UChar>(target))) << "target: " << static_cast<int>(target[0]);
+}
+
+struct CodePathRange {
+    UChar start;
+    UChar end;
+    CodePath path;
+    CodePath belowPath { CodePath::Simple };
+    CodePath abovePath { CodePath::Simple };
+};
+
+static void testCodePathRange(CodePathRange range)
+{
+    std::array<UChar, 1> below = { static_cast<UChar>(range.start - 1) };
+    std::array<UChar, 1> start = { range.start };
+    std::array<UChar, 1> middle = { static_cast<UChar>((range.start + range.end) / 2) };
+    std::array<UChar, 1> end = { range.end };
+    std::array<UChar, 1> above = { static_cast<UChar>(range.end + 1) };
+
+    EXPECT_EQ(range.belowPath, FontCascade::characterRangeCodePath(std::span<UChar>(below))) << "below: " << std::hex << static_cast<int>(below[0]);
+    EXPECT_EQ(range.path, FontCascade::characterRangeCodePath(std::span<UChar>(start))) << "start: " << std::hex << static_cast<int>(start[0]);
+    EXPECT_EQ(range.path, FontCascade::characterRangeCodePath(std::span<UChar>(middle))) << "middle: " << std::hex << static_cast<int>(middle[0]);
+    EXPECT_EQ(range.path, FontCascade::characterRangeCodePath(std::span<UChar>(end))) << "end: " << std::hex << static_cast<int>(end[0]);
+    EXPECT_EQ(range.abovePath, FontCascade::characterRangeCodePath(std::span<UChar>(above))) << "above: " << std::hex << static_cast<int>(above[0]);
+}
+
+// Testing characterRangeCodePath for non-surrogate codepoints
+TEST(FontCascadeTest, characterRangeCodePath_NonSurrogates)
+{
+    // U+02E5 through U+02E9 (Modifier Letters : Tone letters)
+    testCodePathRange({ 0x02E5, 0x02E9, CodePath::Complex });
+    // U+0300 through U+036F Combining diacritical marks
+    testCodePathRange({ 0x0300, 0x036F, CodePath::Complex });
+    // U+0591 through U+05CF excluding U+05BE Hebrew combining marks, Hebrew punctuation Paseq, Sof Pasuq and Nun Hafukha
+    testCodePathRange({ 0x0591, 0x05BD, CodePath::Complex });
+    testCodePath(0x5BE, CodePath::Simple);
+    testCodePathRange({ 0x05BF, 0x05CF, CodePath::Complex });
+    // U+0600 through U+109F Arabic, Syriac, Thaana, NKo, Samaritan, Mandaic,
+    // Devanagari, Bengali, Gurmukhi, Gujarati, Oriya, Tamil, Telugu, Kannada,
+    // Malayalam, Sinhala, Thai, Lao, Tibetan, Myanmar
+    testCodePathRange({ 0x0600, 0x109F, CodePath::Complex });
+    // U+1100 through U+11FF Hangul Jamo (only Ancient Korean should be left here if you precompose;
+    // Modern Korean will be precomposed as a result of step A)
+    testCodePathRange({ 0x1100, 0x11FF, CodePath::Complex });
+    // U+135D through U+135F Ethiopic combining marks
+    testCodePathRange({ 0x135D, 0x135F, CodePath::Complex });
+    // U+1700 through U+18AF Tagalog, Hanunoo, Buhid, Taghanwa,Khmer, Mongolian
+    testCodePathRange({ 0x1700, 0x18AF, CodePath::Complex });
+    // U+1900 through U+194F Limbu (Unicode 4.0)
+    testCodePathRange({ 0x1900, 0x194F, CodePath::Complex });
+    // U+1980 through U+19DF New Tai Lue
+    testCodePathRange({ 0x1980, 0x19DF, CodePath::Complex });
+    // U+1A00 through U+1CFF Buginese, Tai Tham, Balinese, Batak, Lepcha, Vedic
+    testCodePathRange({ 0x1A00, 0x1CFF, CodePath::Complex });
+    // U+1DC0 through U+1DFF Comining diacritical mark supplement
+    testCodePathRange({ 0x1DC0, 0x1DFF, CodePath::Complex, CodePath::Simple, CodePath::SimpleWithGlyphOverflow });
+    // U+1E00 through U+2000 characters with diacritics and stacked diacritics
+    testCodePathRange({ 0x1E00, 0x2000, CodePath::SimpleWithGlyphOverflow, CodePath::Complex, CodePath::Simple });
+    // U+20D0 through U+20FF Combining marks for symbols
+    testCodePathRange({ 0x20D0, 0x20FF, CodePath::Complex });
+    testCodePath(0x26F9, CodePath::Complex);
+    // U+2CEF through U+2CF1 Combining marks for Coptic
+    testCodePathRange({ 0x2CEF, 0x2CF1, CodePath::Complex });
+    // U+302A through U+302F Ideographic and Hangul Tone marks
+    testCodePathRange({ 0x302A, 0x302F, CodePath::Complex });
+    // KATAKANA-HIRAGANA (SEMI-)VOICED SOUND MARKS require character composition
+    testCodePathRange({ 0x3099, 0x309C, CodePath::Complex });
+    // U+A67C through U+A67D Combining marks for old Cyrillic
+    testCodePathRange({ 0xA67C, 0xA67D, CodePath::Complex });
+    // U+A6F0 through U+A6F1 Combining mark for Bamum
+    testCodePathRange({ 0xA6F0, 0xA6F1, CodePath::Complex });
+    // U+A800 through U+ABFF Nagri, Phags-pa, Saurashtra, Devanagari Extended,
+    // Hangul Jamo Ext. A, Javanese, Myanmar Extended A, Tai Viet, Meetei Mayek,
+    testCodePathRange({ 0xA800, 0xABFF, CodePath::Complex });
+    // U+D7B0 through U+D7FF Hangul Jamo Ext. B
+    testCodePathRange({ 0xD7B0, 0xD7FF, CodePath::Complex });
+    // U+FE00 through U+FE0F Unicode variation selectors
+    testCodePathRange({ 0xFE00, 0xFE0F, CodePath::Complex });
+    // U+FE20 through U+FE2F Combining half marks
+    testCodePathRange({ 0xFE20, 0xFE2F, CodePath::Complex });
+}
+}


### PR DESCRIPTION
#### 64ce55deb8240e7b2078379961046fd26e490754
<pre>
Add unit test for FontCascade::characterRangeCodePath non surrogated ranges
<a href="https://bugs.webkit.org/show_bug.cgi?id=276494">https://bugs.webkit.org/show_bug.cgi?id=276494</a>
<a href="https://rdar.apple.com/131478343">rdar://131478343</a>

Reviewed by Ryan Reno.

Adding unit tests for the non-surrogated ranges of FontCascade::characterRangeCodePath

This was inspired by the following Blink patch:
<a href="https://codereview.chromium.org/18949006/">https://codereview.chromium.org/18949006/</a>

* Source/WebCore/platform/graphics/FontCascade.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp: Added.
(TestWebKitAPI::testCodePath):
(TestWebKitAPI::testCodePathRange):
(TestWebKitAPI::TEST(FontCascadeTest, characterRangeCodePath_NonSurrogates)):

Canonical link: <a href="https://commits.webkit.org/280888@main">https://commits.webkit.org/280888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6d6e03a2f328b60a8f5a7d5c4d7c4d963e66bc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61553 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8376 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46952 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5970 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34942 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27779 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31708 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7365 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7380 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63240 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7704 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54173 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50082 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/54308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12816 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1576 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33088 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35258 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->