### PR TITLE
YouTube: Unable to move the volume slider by dragging after disabling Video Viewer

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.js
@@ -228,4 +228,10 @@ class MediaControls extends LayoutNode
         else
             super.commitProperty(propertyName);
     }
+
+    disable()
+    {
+        this.element.removeEventListener("focusin", this);
+        window.removeEventListener("dragstart", this, true);
+    }
 }

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -333,6 +333,9 @@ class MediaController
                 supportingObject.disable();
         }
 
+        if (previousControls)
+            previousControls.disable();
+
         this.controls = new ControlsClass;
         this.controls.delegate = this;
 


### PR DESCRIPTION
#### 306889650017bc78e563434ff46d5a2567735c8a
<pre>
YouTube: Unable to move the volume slider by dragging after disabling Video Viewer
<a href="https://bugs.webkit.org/show_bug.cgi?id=276496">https://bugs.webkit.org/show_bug.cgi?id=276496</a>
<a href="https://rdar.apple.com/128587639">rdar://128587639</a>

Reviewed by Eric Carlson.

When entering fullscreen, we add a dragstart event listener to the window that we never remove.
This makes it so that after we have exited fullscreen, the dragstart event listener is still
active, and it has a side effect of making the elements on the page to be draggable. This is
noticeable when the user is moving youtube&apos;s volume slider. Instead of this moving the knob on
the slider, this drags an image of the slider.

To fix this, we should remove the dragstart event listener on the window when we exit fullscreen.
This will remove the event listener&apos;s side effect that is causing this bug.

* Source/WebCore/Modules/modern-media-controls/controls/media-controls.js:
(MediaControls.prototype.disable):
(MediaControls):
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype._updateControlsIfNeeded):

Canonical link: <a href="https://commits.webkit.org/280873@main">https://commits.webkit.org/280873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bfffd274c84265ed70b04e1efb6c473dbbe6e00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8343 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46918 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5939 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34911 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50035 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27745 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7329 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7347 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53626 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63206 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54143 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1818 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54272 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1543 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8632 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33055 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34141 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35225 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->