### PR TITLE
[iOS] Update GPU sandbox to match macOS behavior

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -565,6 +565,8 @@
     (sysctl-name
         "hw.activecpu"
         "hw.cachelinesize"
+        "hw.cpufamily"
+        "hw.cpusubfamily"
         "hw.l2cachesize"
         "hw.logicalcpu_max"
         "hw.machine"
@@ -575,6 +577,7 @@
         "hw.physicalcpu_max"
         "hw.product" ;; <rdar://problem/81334849>
         "kern.bootargs"
+        "kern.hv_vmm_present"
 #if ASAN_ENABLED
         "kern.osrelease"
 #endif
@@ -585,7 +588,9 @@
         "kern.willshutdown" ;; <rdar://122511261>
         "machdep.ptrauth_enabled"
         "vm.footprint_suspend"
-        "vm.malloc_ranges")) ;; <rdar://problem/105161083>
+        "vm.malloc_ranges") ;; <rdar://problem/105161083>
+    (sysctl-name-prefix "hw.perflevel") ;; <rdar://problem/76782530>
+)
 
 (allow iokit-get-properties
     (iokit-property "AAPL,DisplayPipe")
@@ -976,6 +981,7 @@
     mach_vm_remap_external
     semaphore_create
     semaphore_destroy
+    task_create_identity_token
     task_get_special_port_from_user
     task_info_from_user
     task_restartable_ranges_register


### PR DESCRIPTION
#### b069ece7b5e303fcd1010fadb197164a855f64a8
<pre>
[iOS] Update GPU sandbox to match macOS behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=276498">https://bugs.webkit.org/show_bug.cgi?id=276498</a>
&lt;<a href="https://rdar.apple.com/problem/131556690">rdar://problem/131556690</a>&gt;

Reviewed by Per Arne Vollan.

The iOS GPU sandbox denies access to a few sysctl calls that are allowed on macOS,
and (more importantly) are allowed in the iOS WebContent process. These are showing
up in telemetry when performing media and other web page loads, and are likely to be
impacting performance.

We should allow these sysctl-read calls, as well as a MIG routine needed for proper
memory attribution.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:

Canonical link: <a href="https://commits.webkit.org/280924@main">https://commits.webkit.org/280924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d060e9a4b17636cf0147b43fe15622cf4f23cddb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61526 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8349 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46924 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5941 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27750 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31683 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7353 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53631 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63212 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54147 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54280 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1549 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8656 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33061 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34147 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35231 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->