### PR TITLE
ReportingObserver can be kept alive longer than necessary.

### DIFF
--- a/LayoutTests/fast/reporting/reporting-observer-lifetime-expected.txt
+++ b/LayoutTests/fast/reporting/reporting-observer-lifetime-expected.txt
@@ -1,0 +1,5 @@
+PASS The ReportingObserver and callback were garbage collected.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/reporting/reporting-observer-lifetime.html
+++ b/LayoutTests/fast/reporting/reporting-observer-lifetime.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test-pre.js"></script>
+<script>
+jsTestIsAsync = true;
+if (!window.testRunner || !window.internals) {
+    testFailed("Requires testRunner and internals.");
+    finishJSTest();
+}
+
+let cb = () => { };
+let observer = new ReportingObserver(cb);
+observer.observe();
+
+function runTest()
+{
+    let weakCallback = new WeakRef(cb);
+    let weakObserver = new WeakRef(observer);
+    setTimeout(() => {
+        observer.disconnect();
+        observer = null;
+        cb = null;
+    }, 160);
+
+    var cnt = 0;
+    let handle = setInterval(() => {
+        gc();
+        cnt++;
+        if (!weakObserver.deref() && !weakCallback.deref()) {
+            clearInterval(handle);
+            testPassed("The ReportingObserver and callback were garbage collected.");
+            finishJSTest();
+        } else if (cnt >= 500) {
+            clearInterval(handle);
+            testFailed("The ReportingObserver and callback weren't collected in any reasonable time after clearing all references from JavaScript.");
+            finishJSTest();
+        }
+
+    }, 20);
+}
+onload = () => runTest();
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/Modules/reporting/ReportingObserver.h
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "ContextDestructionObserver.h"
+#include "ActiveDOMObject.h"
 #include <wtf/IsoMalloc.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
@@ -37,7 +37,7 @@ class ReportingObserverCallback;
 class ReportingScope;
 class ScriptExecutionContext;
 
-class ReportingObserver final : public RefCounted<ReportingObserver>, public ContextDestructionObserver  {
+class ReportingObserver final : public RefCounted<ReportingObserver>, public ActiveDOMObject  {
     WTF_MAKE_ISO_ALLOCATED(ReportingObserver);
 public:
     struct Options {
@@ -56,6 +56,11 @@ public:
     void appendQueuedReportIfCorrectType(const Ref<Report>&);
 
     ReportingObserverCallback& callbackConcurrently();
+
+    // ActiveDOMObject
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+    bool virtualHasPendingActivity() const final;
 
 private:
     explicit ReportingObserver(ScriptExecutionContext&, Ref<ReportingObserverCallback>&&, ReportingObserver::Options&&);

--- a/Source/WebCore/Modules/reporting/ReportingObserver.idl
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.idl
@@ -30,7 +30,7 @@ typedef sequence<Report> ReportList;
 [
     EnabledBySetting=ReportingEnabled,
     Exposed=(Window,Worker),
-    GenerateIsReachable=ImplScriptExecutionContext,
+    ActiveDOMObject,
     JSCustomMarkFunction
 ] interface ReportingObserver {
     [CallWith=CurrentScriptExecutionContext] constructor(ReportingObserverCallback callback, optional ReportingObserverOptions options);

--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -81,6 +81,13 @@ void ReportingScope::clearReports()
     m_queuedReportTypeCounts.clear();
 }
 
+bool ReportingScope::containsObserver(const ReportingObserver& observer) const
+{
+    return m_reportingObservers.containsIf([&observer](auto& item) {
+        return item.ptr() == &observer;
+    });
+}
+
 void ReportingScope::notifyReportObservers(Ref<Report>&& report)
 {
     // https://www.w3.org/TR/reporting-1/#notify-observers

--- a/Source/WebCore/Modules/reporting/ReportingScope.h
+++ b/Source/WebCore/Modules/reporting/ReportingScope.h
@@ -58,6 +58,8 @@ public:
     void notifyReportObservers(Ref<Report>&&);
     void appendQueuedReportsForRelevantType(ReportingObserver&);
 
+    bool containsObserver(const ReportingObserver&) const;
+
     static MemoryCompactRobinHoodHashMap<String, String> parseReportingEndpointsFromHeader(const String&, const URL& baseURL);
     void parseReportingEndpoints(const String&, const URL& baseURL);
 


### PR DESCRIPTION
#### 9e0be52714870b41c87cbc959458931757631918
<pre>
ReportingObserver can be kept alive longer than necessary.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276500">https://bugs.webkit.org/show_bug.cgi?id=276500</a>
<a href="https://rdar.apple.com/131559195">rdar://131559195</a>

Reviewed by Brent Fulgham.

ReportingObserver has the GenerateIsReachable=ImplScriptExecutionContext
extended IDL attribute. This will generate a isReachableFromOpaqueRoots
implementation which will keep the observer alive for as long as the
ScriptExecutionContext exists. However, if we are no longer observing
reports and all JS references to the object are gone, we should allow ourselves
to garbage collect it.

This change turns the ReportingObserver into an ActiveDOMObject whose
pending activity state depends on whether or not it is registered with
the ReportingScope.

* LayoutTests/fast/reporting/reporting-observer-lifetime-expected.txt: Added.
* LayoutTests/fast/reporting/reporting-observer-lifetime.html: Added.
* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
(WebCore::ReportingObserver::create):
(WebCore::ReportingObserver::ReportingObserver):
(WebCore::ReportingObserver::virtualHasPendingActivity const):
* Source/WebCore/Modules/reporting/ReportingObserver.h:
* Source/WebCore/Modules/reporting/ReportingObserver.idl:
* Source/WebCore/Modules/reporting/ReportingScope.cpp:
(WebCore::ReportingScope::containsObserver const):
* Source/WebCore/Modules/reporting/ReportingScope.h:

Canonical link: <a href="https://commits.webkit.org/280886@main">https://commits.webkit.org/280886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/396d31f3bc250246f907d5512fce594b6d661789

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61536 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8359 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8547 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46935 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5952 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27761 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31693 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7350 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7363 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53641 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63223 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54159 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1835 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50067 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54297 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12815 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1560 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33071 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34157 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->