### PR TITLE
[Remote Inspection] `elementAndAncestorsAreOnlyRenderedChildren` sometimes yields false positives

### DIFF
--- a/LayoutTests/fast/element-targeting/target-container-with-anonymous-sibling-expected.txt
+++ b/LayoutTests/fast/element-targeting/target-container-with-anonymous-sibling-expected.txt
@@ -1,0 +1,5 @@
+PASS box is document.querySelector(selector)
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.

--- a/LayoutTests/fast/element-targeting/target-container-with-anonymous-sibling.html
+++ b/LayoutTests/fast/element-targeting/target-container-with-anonymous-sibling.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+body, html {
+    margin: 0;
+}
+
+.box {
+    width: 100px;
+    height: 100px;
+    background: tomato;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 100;
+}
+</style>
+</head>
+<body>
+Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.
+<div class="box"></div>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async event => {
+    box = document.querySelector(".box");
+    selector = await UIHelper.adjustVisibilityForFrontmostTarget(box);
+    shouldBe("box", "document.querySelector(selector)");
+    finishJSTest();
+});
+</script>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2180,7 +2180,7 @@ window.UIHelper = class UIHelper {
 
         return new Promise(resolve => {
             testRunner.runUIScript(`(() => {
-                uiController.adjustVisibilityForFrontmostTarget(${x}, ${y}, result => uiController.uiScriptComplete(result));
+                uiController.adjustVisibilityForFrontmostTarget(${x}, ${y}, result => uiController.uiScriptComplete(result || ""));
             })()`, resolve);
         });
     }

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -133,15 +133,15 @@ static inline bool elementAndAncestorsAreOnlyRenderedChildren(const Element& ele
         return false;
 
     for (auto& ancestor : ancestorsOfType<RenderElement>(*renderer)) {
-        unsigned numberOfRenderedChildren = 0;
-        for (auto& child : childrenOfType<RenderElement>(ancestor)) {
-            if (RefPtr childElement = child.element(); childElement && !childElement->visibilityAdjustment().contains(VisibilityAdjustment::Subtree))
-                numberOfRenderedChildren++;
-        }
-        if (numberOfRenderedChildren >= 2)
-            return false;
-    }
+        unsigned numberOfVisibleChildren = 0;
+        for (auto& child : childrenOfType<RenderObject>(ancestor)) {
+            if (child.style().usedVisibility() == Visibility::Hidden)
+                continue;
 
+            if (++numberOfVisibleChildren >= 2)
+                return false;
+        }
+    }
     return true;
 }
 


### PR DESCRIPTION
#### 0c29e60b7f0a3238a625297d8c6a6c6b57ec1bb7
<pre>
[Remote Inspection] `elementAndAncestorsAreOnlyRenderedChildren` sometimes yields false positives
<a href="https://bugs.webkit.org/show_bug.cgi?id=276503">https://bugs.webkit.org/show_bug.cgi?id=276503</a>
<a href="https://rdar.apple.com/131535241">rdar://131535241</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

`elementAndAncestorsAreOnlyRenderedChildren` is currently incorrect in the case where a parent
renderer has anonymous renderers as children, for which `element()` is null. This causes us to
(falsely) assume that certain elements are only children in the render tree (along with all of their
ancestors), and avoid surfacing them as target candidates.

Fix this by refactoring the function, such that it doesn&apos;t ignore anonymous renderers.

* LayoutTests/fast/element-targeting/target-container-with-anonymous-sibling-expected.txt: Added.
* LayoutTests/fast/element-targeting/target-container-with-anonymous-sibling.html: Added.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.adjustVisibilityForFrontmostTarget):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::elementAndAncestorsAreOnlyRenderedChildren):

Canonical link: <a href="https://commits.webkit.org/280879@main">https://commits.webkit.org/280879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/492fb2d84a2ec116c3dcb04784dbdce9ca899910

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8354 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60037 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46930 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5951 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27756 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7346 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7358 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53638 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63217 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54153 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1830 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54285 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12809 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1555 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33066 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34152 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33897 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->