### PR TITLE
results.html generates wrong links for test names include percent

### DIFF
--- a/LayoutTests/fast/harness/results.html
+++ b/LayoutTests/fast/harness/results.html
@@ -913,7 +913,7 @@ class TestResultsController
     
     static resultLink(testPrefix, suffix, contents)
     {
-        return '<a class=result-link href="' + testPrefix + suffix + '" data-prefix="' + testPrefix + '">' + contents + '</a> ';
+        return '<a class=result-link href="' + encodeURI(testPrefix + suffix) + '" data-prefix="' + testPrefix + '">' + contents + '</a> ';
     }
 
     textResultLinks(prefix)

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py
@@ -100,6 +100,27 @@ class TestResultWriterTest(unittest.TestCase):
             "template_test/pbkdf2.https.any.worker_1-1000-expected.txt", expected
         )
 
+        expected = test_result_writer.TestResultWriter.expected_filename(
+            "template_test/pbkdf2.https.any.worker.html?a%20b", fs
+        )
+        self.assertEqual(
+            "template_test/pbkdf2.https.any.worker_a%20b-expected.txt", expected
+        )
+
+        expected = test_result_writer.TestResultWriter.expected_filename(
+            "template_test/pbkdf2.https.any.worker.html#1-1000", fs
+        )
+        self.assertEqual(
+            "template_test/pbkdf2.https.any.worker_1-1000-expected.txt", expected
+        )
+
+        expected = test_result_writer.TestResultWriter.expected_filename(
+            "template_test/pbkdf2.https.any.worker.html?1-1000#aaa", fs
+        )
+        self.assertEqual(
+            "template_test/pbkdf2.https.any.worker_1-1000#aaa-expected.txt", expected
+        )
+
     def test_actual_filename(self):
         host = MockHost()
         port = TestPort(host)


### PR DESCRIPTION
#### 99cb6b1f2f9e2885a54a5ade9b5d0a3073f5e398
<pre>
results.html generates wrong links for test names include percent
<a href="https://bugs.webkit.org/show_bug.cgi?id=276506">https://bugs.webkit.org/show_bug.cgi?id=276506</a>
<a href="https://rdar.apple.com/131409141">rdar://131409141</a>

Reviewed by Tim Nguyen.

* LayoutTests/fast/harness/results.html: Add a singular encodeURI call to go from a path to URL.
* Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py:
(TestResultWriterTest.test_expected_filename): Add some more tests about what expected names actually are.

Canonical link: <a href="https://commits.webkit.org/280881@main">https://commits.webkit.org/280881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb4655085337bb43808441bf1fbc289d702003e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61535 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8358 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46934 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5950 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27760 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/57439 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31692 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7351 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7362 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53640 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63222 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54158 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54292 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12813 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1558 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33070 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34156 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->