### PR TITLE
Carve-out 'table overflow' handling in StyleAdjuster

### DIFF
--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -605,43 +605,6 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
     else
         style.setTextDecorationsInEffect(style.textDecorationLine());
 
-    bool overflowIsClipOrVisible = isOverflowClipOrVisible(style.overflowX()) && isOverflowClipOrVisible(style.overflowX());
-
-    if (!overflowIsClipOrVisible && (style.display() == DisplayType::Table || style.display() == DisplayType::InlineTable)) {
-        // Tables only support overflow:hidden and overflow:visible and ignore anything else,
-        // see https://drafts.csswg.org/css2/#overflow. As a table is not a block
-        // container box the rules for resolving conflicting x and y values in CSS Overflow Module
-        // Level 3 do not apply. Arguably overflow-x and overflow-y aren't allowed on tables but
-        // all UAs allow it.
-        if (style.overflowX() != Overflow::Hidden)
-            style.setOverflowX(Overflow::Visible);
-        if (style.overflowY() != Overflow::Hidden)
-            style.setOverflowY(Overflow::Visible);
-        // If we are left with conflicting overflow values for the x and y axes on a table then resolve
-        // both to Overflow::Visible. This is interoperable behaviour but is not specced anywhere.
-        if (style.overflowX() == Overflow::Visible)
-            style.setOverflowY(Overflow::Visible);
-        else if (style.overflowY() == Overflow::Visible)
-            style.setOverflowX(Overflow::Visible);
-    } else if (!isOverflowClipOrVisible(style.overflowY())) {
-        // FIXME: Once we implement pagination controls, overflow-x should default to hidden
-        // if overflow-y is set to -webkit-paged-x or -webkit-page-y. For now, we'll let it
-        // default to auto so we can at least scroll through the pages.
-        // Values of 'clip' and 'visible' can only be used with 'clip' and 'visible'.
-        // If they aren't, 'clip' and 'visible' is reset.
-        if (style.overflowX() == Overflow::Visible)
-            style.setOverflowX(Overflow::Auto);
-        else if (style.overflowX() == Overflow::Clip)
-            style.setOverflowX(Overflow::Hidden);
-    } else if (!isOverflowClipOrVisible(style.overflowX())) {
-        // Values of 'clip' and 'visible' can only be used with 'clip' and 'visible'.
-        // If they aren't, 'clip' and 'visible' is reset.
-        if (style.overflowY() == Overflow::Visible)
-            style.setOverflowY(Overflow::Auto);
-        else if (style.overflowY() == Overflow::Clip)
-            style.setOverflowY(Overflow::Hidden);
-    }
-
     // Call setStylesForPaginationMode() if a pagination mode is set for any non-root elements. If these
     // styles are specified on a root element, then they will be incorporated in
     // Style::createForm_document.
@@ -767,6 +730,46 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
     }
 
     adjustForSiteSpecificQuirks(style);
+}
+
+void Adjuster::adjustTableOverflow(RenderStyle& style) const
+{
+    bool overflowIsClipOrVisible = isOverflowClipOrVisible(style.overflowX()) && isOverflowClipOrVisible(style.overflowX());
+
+    if (!overflowIsClipOrVisible && (style.display() == DisplayType::Table || style.display() == DisplayType::InlineTable)) {
+        // Tables only support overflow:hidden and overflow:visible and ignore anything else,
+        // see https://drafts.csswg.org/css2/#overflow. As a table is not a block
+        // container box the rules for resolving conflicting x and y values in CSS Overflow Module
+        // Level 3 do not apply. Arguably overflow-x and overflow-y aren't allowed on tables but
+        // all UAs allow it.
+        if (style.overflowX() != Overflow::Hidden)
+            style.setOverflowX(Overflow::Visible);
+        if (style.overflowY() != Overflow::Hidden)
+            style.setOverflowY(Overflow::Visible);
+        // If we are left with conflicting overflow values for the x and y axes on a table then resolve
+        // both to Overflow::Visible. This is interoperable behaviour but is not specced anywhere.
+        if (style.overflowX() == Overflow::Visible)
+            style.setOverflowY(Overflow::Visible);
+        else if (style.overflowY() == Overflow::Visible)
+            style.setOverflowX(Overflow::Visible);
+    } else if (!isOverflowClipOrVisible(style.overflowY())) {
+        // FIXME: Once we implement pagination controls, overflow-x should default to hidden
+        // if overflow-y is set to -webkit-paged-x or -webkit-page-y. For now, we'll let it
+        // default to auto so we can at least scroll through the pages.
+        // Values of 'clip' and 'visible' can only be used with 'clip' and 'visible'.
+        // If they aren't, 'clip' and 'visible' is reset.
+        if (style.overflowX() == Overflow::Visible)
+            style.setOverflowX(Overflow::Auto);
+        else if (style.overflowX() == Overflow::Clip)
+            style.setOverflowX(Overflow::Hidden);
+    } else if (!isOverflowClipOrVisible(style.overflowX())) {
+        // Values of 'clip' and 'visible' can only be used with 'clip' and 'visible'.
+        // If they aren't, 'clip' and 'visible' is reset.
+        if (style.overflowY() == Overflow::Visible)
+            style.setOverflowY(Overflow::Auto);
+        else if (style.overflowY() == Overflow::Clip)
+            style.setOverflowY(Overflow::Hidden);
+    }
 }
 
 static bool hasEffectiveDisplayNoneForDisplayContents(const Element& element)

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -50,6 +50,7 @@ public:
 
     void adjust(RenderStyle&, const RenderStyle* userAgentAppearanceStyle) const;
     void adjustAnimatedStyle(RenderStyle&, OptionSet<AnimationImpact>) const;
+    void adjustTableOverflow(RenderStyle&) const;
 
     static void adjustVisibilityForPseudoElement(RenderStyle&, const Element& host);
     static void adjustSVGElementStyle(RenderStyle&, const SVGElement&);


### PR DESCRIPTION
<pre>
Carve-out 'table overflow' handling in StyleAdjuster
<a href="https://bugs.webkit.org/show_bug.cgi?id=276510">https://bugs.webkit.org/show_bug.cgi?id=276510</a>

Reviewed by NOBODY (OOPS!).

In the past, while trying to fix bugs in StyleAdjuster, I noticed
that `adjust()` function is quite complex / big.

This patch is to carve out small functionality in separate dedicated
function to make it easier to amend and manage in future. In this patch,
we take out 'table overflow' handling from 'adjust()' into
separate new 'adjustTableOverflow' function to reduce complexity.

* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
(WebCore::Style::Adjuster::adjustTableOverflow const):
* Source/WebCore/style/StyleAdjuster.h:
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13de32a8d153a9ca52d37c9a47b3e5f93f2f2d1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61566 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8389 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8577 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46958 "Found 57 new test failures: compositing/clipping/border-radius-async-overflow-clipping-layer.html compositing/overflow/rtl-scrollbar-layer-positioning.html compositing/overflow/scroll-ancestor-update.html css3/flexbox/flexbox-baseline.html css3/scroll-snap/scroll-snap-positions-overflow-resize.html css3/scroll-snap/scroll-snap-programmatic-overflow-scroll.html css3/scroll-snap/scroll-snap-style-changed-align.html fast/css-grid-layout/min-width-height-auto-overflow.html fast/css/getComputedStyle/getComputedStyle-overflow.html fast/css/invalidation-errors-2.html ... (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5975 "Found 5 new test failures: fast/css-grid-layout/min-width-height-auto-overflow.html fast/css/getComputedStyle/getComputedStyle-overflow.html fast/flexbox/repaint-scrollbar.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-002.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-003.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59974 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34954 "Found 60 new test failures: compositing/clipping/border-radius-async-overflow-clipping-layer.html compositing/layer-creation/clipping-scope/nested-scroller-overlap.html compositing/layer-creation/clipping-scope/overlap-constrained-inside-scroller.html compositing/layer-creation/clipping-scope/overlap-constrained-inside-stacking-context-scroller.html compositing/layer-creation/clipping-scope/scroller-with-negative-z-children.html compositing/layer-creation/clipping-scope/shared-layers-in-scroller.html compositing/layer-creation/scroll-partial-update.html compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-clipped-by-scroll.html compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-nested.html compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27787 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31720 "Found 28 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-002.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-003.html imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-003.html imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-004.html imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-005.html imported/w3c/web-platform-tests/css/css-contain/container-queries/auto-scrollbars.html imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-081.html imported/w3c/web-platform-tests/css/css-flexbox/abspos/position-absolute-005.html imported/w3c/web-platform-tests/css/css-flexbox/cross-axis-scrollbar.html imported/w3c/web-platform-tests/css/css-flexbox/fieldset-as-item-overflow.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7379 "Found 60 new test failures: compositing/clipping/border-radius-async-overflow-clipping-layer.html compositing/clipping/cached-cliprect-with-compositing-boundary.html compositing/layer-creation/scroll-partial-update.html compositing/overflow/scroll-ancestor-update.html compositing/scrolling/async-overflow-scrolling/mac/overflow-in-flex-empty-tiles.html css3/flexbox/flexbox-baseline.html css3/scroll-snap/scroll-snap-positions-overflow-resize.html css3/scroll-snap/scroll-snap-programmatic-overflow-scroll.html css3/scroll-snap/scroll-snap-style-changed-align.html fast/css-grid-layout/min-width-height-auto-overflow.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7393 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53666 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7648 "Found 60 new test failures: compositing/clipping/border-radius-async-overflow-clipping-layer.html compositing/layer-creation/clipping-scope/nested-scroller-overlap.html compositing/layer-creation/clipping-scope/overlap-constrained-inside-scroller.html compositing/layer-creation/clipping-scope/overlap-constrained-inside-stacking-context-scroller.html compositing/layer-creation/clipping-scope/scroller-with-negative-z-children.html compositing/layer-creation/clipping-scope/shared-layers-in-scroller.html compositing/layer-creation/scroll-partial-update.html compositing/overflow/rtl-scrollbar-layer-positioning.html compositing/overflow/scroll-ancestor-update.html compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-clipped-by-scroll.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63254 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1858 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7715 "Found 60 new test failures: compositing/clipping/border-radius-async-overflow-clipping-layer.html compositing/layer-creation/clipping-scope/nested-scroller-overlap.html compositing/layer-creation/clipping-scope/overlap-constrained-inside-scroller.html compositing/layer-creation/clipping-scope/overlap-constrained-inside-stacking-context-scroller.html compositing/layer-creation/clipping-scope/scroller-with-negative-z-children.html compositing/layer-creation/clipping-scope/shared-layers-in-scroller.html compositing/layer-creation/scroll-partial-update.html compositing/overflow/rtl-scrollbar-layer-positioning.html compositing/overflow/scroll-ancestor-update.html compositing/scrolling/async-overflow-scrolling/clipped-layer-in-overflow-clipped-by-scroll.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54182 "Found 54 new test failures: compositing/clipping/border-radius-async-overflow-clipping-layer.html compositing/layer-creation/scroll-partial-update.html compositing/overflow/rtl-scrollbar-layer-positioning.html compositing/overflow/scroll-ancestor-update.html css3/flexbox/flexbox-baseline.html css3/scroll-snap/scroll-snap-positions-overflow-resize.html css3/scroll-snap/scroll-snap-programmatic-overflow-scroll.html css3/scroll-snap/scroll-snap-style-changed-align.html fast/css-grid-layout/min-width-height-auto-overflow.html fast/css/getComputedStyle/getComputedStyle-overflow.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54317 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1588 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33101 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34187 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->