### PR TITLE
Establishing the connection to webinspectord can sometimes fail

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -162,6 +162,7 @@ public:
     void setUsePerTargetPresentingApplicationPIDs(bool usePerTargetPresentingApplicationPIDs) { m_usePerTargetPresentingApplicationPIDs = usePerTargetPresentingApplicationPIDs; }
 
     bool isSimulatingCustomerInstall() const { return m_simulateCustomerInstall; }
+    void connectToWebInspector();
 #endif
 
     void updateTargetListing(TargetID);

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -346,6 +346,13 @@ void RemoteInspector::setupXPCConnectionIfNeeded()
         pushListingsSoon();
 }
 
+void RemoteInspector::connectToWebInspector()
+{
+    dispatch_async(m_xpcQueue, ^{
+        RemoteInspector::singleton().setupXPCConnectionIfNeeded();
+    });
+}
+
 #pragma mark - Proxy Application Information
 
 void RemoteInspector::setParentProcessInformation(pid_t pid, RetainPtr<CFDataRef> auditData)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -614,6 +614,12 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
         RetainPtr<CFDataRef> auditData = adoptCF(CFDataCreate(nullptr, (const UInt8*)&*auditToken, sizeof(*auditToken)));
         Inspector::RemoteInspector::singleton().setParentProcessInformation(WebCore::presentingApplicationPID(), auditData);
     }
+    // We need to connect to webinspectord before the first page load for the XPC connection to be successfully opened.
+    // This is because we block launchd before the first page load, and launchd is required to establish the connection.
+    // This is only done if Web Inspector is enabled, which is determined by the size of the Web Inspector extension vector.
+    // See WebProcessProxy::shouldEnableRemoteInspector().
+    if (parameters.enableRemoteWebInspectorExtensionHandles.size())
+        Inspector::RemoteInspector::singleton().connectToWebInspector();
 #endif
 
 #if ENABLE(GAMEPAD)


### PR DESCRIPTION
#### 961481a24076e5ec9061c05aaee06770c3b00161
<pre>
Establishing the connection to webinspectord can sometimes fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=276512">https://bugs.webkit.org/show_bug.cgi?id=276512</a>
<a href="https://rdar.apple.com/130712941">rdar://130712941</a>

Reviewed by Chris Dumez.

There is currently a race condition when establishing the XPC connection from the WebContent process to
webinspectord. If the XPC connection is being established after we block access to launchd, establishing
the connection will not succeed. Launchd is being blocked before first page load. This patch addresses
this by establishing the XPC connection before this point in time.

* Source/JavaScriptCore/inspector/remote/RemoteInspector.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::connectToWebInspector):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/280912@main">https://commits.webkit.org/280912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb6a90cba3b22dda4a97d05038c278bfd17f5bda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61596 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8416 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46979 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5993 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27809 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31743 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7404 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7420 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51063 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53689 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63283 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57213 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54203 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54339 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1612 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78974 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8652 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33128 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13102 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34214 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35298 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33959 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->