### PR TITLE
Fix Form Submit incorrect query

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-expected.txt
@@ -2,6 +2,6 @@
 
 
 
-FAIL PreventDefaulting form onsubmit should allow submit() to succeed assert_equals: expected "v6" but got "v7"
-FAIL PreventDefaulting form onsubmit should allow submit() to succeed and the second submit() which is invalid should not supersede first one assert_equals: expected "v2" but got "v4"
+PASS PreventDefaulting form onsubmit should allow submit() to succeed
+PASS PreventDefaulting form onsubmit should allow submit() to succeed and the second submit() which is invalid should not supersede first one
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-requestsubmit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-requestsubmit-expected.txt
@@ -48,25 +48,25 @@ PASS test runTest with submitterType: button, preventDefaultRequestSubmit: false
 PASS test runTest with submitterType: button, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: true, passSubmitter: false
 PASS test runTest with submitterType: button, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: false, passSubmitter: true
 PASS test runTest with submitterType: button, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: false, passSubmitter: false
-FAIL test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: true
 PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: false
 FAIL test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: false, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
 PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: false, passSubmitter: false
 PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: false, preventDefault: false, passSubmitter: true
 PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: false, preventDefault: false, passSubmitter: false
-FAIL test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: true
 PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: false
 FAIL test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: false, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
 PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: false, passSubmitter: false
 PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: false, preventDefault: false, passSubmitter: true
 PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: false, preventDefault: false, passSubmitter: false
-FAIL test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: true
 PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: false
 FAIL test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: false, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
 PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: false, passSubmitter: false
 PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: false, preventDefault: false, passSubmitter: true
 PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: false, preventDefault: false, passSubmitter: false
-FAIL test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: true
 PASS test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: false
 FAIL test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: false, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
 PASS test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: false, passSubmitter: false

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -374,7 +374,7 @@ void HTMLFormElement::submit(Event* event, bool processingUserGesture, FormSubmi
     if (!view || !frame)
         return;
 
-    if (m_isSubmittingOrPreparingForSubmission) {
+    if (trigger != SubmittedByJavaScript && m_isSubmittingOrPreparingForSubmission) {
         m_shouldSubmit = true;
         return;
     }


### PR DESCRIPTION
#### b1875e2b51b39bd75a81f83e9a3b3aa1e9291091
<pre>
Fix Form Submit incorrect query
<a href="https://bugs.webkit.org/show_bug.cgi?id=243595">https://bugs.webkit.org/show_bug.cgi?id=243595</a>

Reviewed by Ryosuke Niwa.

When we submit a form and call submit() again in JavaScript code
that was called, for example, from onsubmit, we lose this submit
event. This happens because some control flags were activated
in the normal submit event and the form was already processing a
submit event generated by the user clicking the submit button.

To solve this problem, the change is:

- Checking if the form submit event is coming from JavaScript code and allowing the event to complete and reset the flags related with form submit.

* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::submit):

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-requestsubmit-expected.txt:

Canonical link: <a href="https://commits.webkit.org/285498@main">https://commits.webkit.org/285498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/998388d9da4befe484e4ff6b8f96bb71cabc4016

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/52274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/77046 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/24083 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74964 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/60079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23899 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/57281 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15770 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/47260 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37708 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43907 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/20167 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/22412 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78718 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/17095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/65730 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/17143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/65003 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/16063 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13315 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6969 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/11193 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/48072 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2859 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/49139 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48884 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->