### PR TITLE
Add logging to diagnose crash at DynamicContentScalingImageBufferBackend::createBackendHandle

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
@@ -29,6 +29,7 @@
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
 
 #import "Logging.h"
+#import "WKCrashReporter.h"
 #import <CoreRE/RECGCommandsContext.h>
 #import <WebCore/DynamicContentScalingDisplayList.h>
 #import <WebCore/GraphicsContextCG.h>
@@ -39,6 +40,7 @@
 #import <wtf/MachSendRight.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/text/StringConcatenate.h>
 
 template<> struct WTF::CFTypeTrait<CAMachPortRef> {
     static inline CFTypeID typeID(void) { return CAMachPortGetTypeID(); }
@@ -118,7 +120,15 @@ std::optional<ImageBufferBackendHandle> DynamicContentScalingImageBufferBackend:
 
     Vector<MachSendRight> sendRights;
     if (m_resourceCache) {
-        sendRights = makeVector(ports.get(), [] (id port) -> std::optional<MachSendRight> {
+        sendRights = makeVector(ports.get(), [] (CFTypeRef port) -> std::optional<MachSendRight> {
+            // FIXME: Remove this once rdar://131143854 is resolved.
+            if (!dynamic_cf_cast<CAMachPortRef>(port)) {
+                auto typeID = CFGetTypeID(port);
+                String typeDescription { adoptCF(CFCopyTypeIDDescription(typeID)).get() };
+                String objectDescription { adoptCF(CFCopyDescription(port)).get() };
+                auto description = makeString("Unexpected type in DCS ports array: "_s, typeID, " "_s, typeDescription, " "_s, objectDescription);
+                logAndSetCrashLogMessage(description.utf8().data());
+            }
             // We `create` instead of `adopt` because CAMachPort has no API to leak its reference.
             return { MachSendRight::create(CAMachPortGetPort(checked_cf_cast<CAMachPortRef>(port))) };
         });


### PR DESCRIPTION
#### bbcbab6308949bc4fee25f6f127d1a44452570ef
<pre>
Add logging to diagnose crash at DynamicContentScalingImageBufferBackend::createBackendHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=276525">https://bugs.webkit.org/show_bug.cgi?id=276525</a>
<a href="https://rdar.apple.com/131587916">rdar://131587916</a>

Reviewed by Simon Fraser.

* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm:
(WebKit::DynamicContentScalingImageBufferBackend::createBackendHandle const):
Add some logging to try to help diagnose a mysterious rare crash where we get
an unexpected object in the ports array.

Canonical link: <a href="https://commits.webkit.org/280893@main">https://commits.webkit.org/280893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d20b13ddedbdab1af128a9de392af99fc99023ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61586 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8407 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46972 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5988 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27802 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31736 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7411 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63274 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54197 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54332 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/12818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1603 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8645 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33119 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34205 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->