### PR TITLE
Minor optimizations to ImageQualityController::chooseInterpolationQuality()

### DIFF
--- a/Source/WebCore/rendering/ImageQualityController.cpp
+++ b/Source/WebCore/rendering/ImageQualityController.cpp
@@ -129,15 +129,12 @@ InterpolationQuality ImageQualityController::chooseInterpolationQuality(Graphics
 
     // Look ourselves up in the hashtables.
     auto i = m_objectLayerSizeMap.find(object);
-    LayerSizeMap* innerMap = i != m_objectLayerSizeMap.end() ? &i->value : 0;
-    LayoutSize oldSize;
-    bool isFirstResize = true;
+    auto* innerMap = i != m_objectLayerSizeMap.end() ? &i->value : 0;
+    std::optional<LayoutSize> oldSize;
     if (innerMap) {
-        LayerSizeMap::iterator j = innerMap->find(layer);
-        if (j != innerMap->end()) {
-            isFirstResize = false;
+        auto j = innerMap->find(layer);
+        if (j != innerMap->end())
             oldSize = j->value;
-        }
     }
 
     // If the containing FrameView is being resized, paint at low quality until resizing is finished.
@@ -153,9 +150,11 @@ InterpolationQuality ImageQualityController::chooseInterpolationQuality(Graphics
             return InterpolationQuality::Default;
     }
 
-    const AffineTransform& currentTransform = context.getCTM();
-    bool contextIsScaled = !currentTransform.isIdentityOrTranslationOrFlipped();
-    if (!contextIsScaled && size == imageSize) {
+    auto contextIsScaled = [](GraphicsContext& context) {
+        return !context.getCTM().isIdentityOrTranslationOrFlipped();
+    };
+
+    if (size == imageSize && !contextIsScaled(context)) {
         // There is no scale in effect. If we had a scale in effect before, we can just remove this object from the list.
         removeLayer(object, innerMap, layer);
         return InterpolationQuality::Default;
@@ -168,30 +167,37 @@ InterpolationQuality ImageQualityController::chooseInterpolationQuality(Graphics
             return InterpolationQuality::Low;
     }
 
+    auto saveEntryIfNewOrSizeChanged = [&]() {
+        if (!oldSize || oldSize.value() != size)
+            set(object, innerMap, layer, size);
+    };
+
     // If an animated resize is active, paint in low quality and kick the timer ahead.
     if (m_animatedResizeIsActive) {
-        set(object, innerMap, layer, size);
+        saveEntryIfNewOrSizeChanged();
         restartTimer();
         return InterpolationQuality::Low;
     }
+
     // If this is the first time resizing this image, or its size is the
     // same as the last resize, draw at high res, but record the paint
     // size and set the timer.
-    if (isFirstResize || oldSize == size) {
+    if (!oldSize || oldSize.value() == size) {
+        saveEntryIfNewOrSizeChanged();
         restartTimer();
-        set(object, innerMap, layer, size);
         return InterpolationQuality::Default;
     }
-    // If the timer is no longer active, draw at high quality and don't
-    // set the timer.
+
+    // If the timer is no longer active, draw at high quality and don't set the timer.
     if (!m_timer.isActive()) {
         removeLayer(object, innerMap, layer);
         return InterpolationQuality::Default;
     }
+
     // This object has been resized to two different sizes while the timer
     // is active, so draw at low quality, set the flag for animated resizes and
     // the object to the list for high quality redraw.
-    set(object, innerMap, layer, size);
+    saveEntryIfNewOrSizeChanged();
     m_animatedResizeIsActive = true;
     restartTimer();
     return InterpolationQuality::Low;


### PR DESCRIPTION
#### ebe344773276d8262e2605e7a3ba8d6bbdfc9dd1
<pre>
Minor optimizations to ImageQualityController::chooseInterpolationQuality()
<a href="https://bugs.webkit.org/show_bug.cgi?id=276526">https://bugs.webkit.org/show_bug.cgi?id=276526</a>
<a href="https://rdar.apple.com/131590813">rdar://131590813</a>

Reviewed by Tim Horton.

Avoid calling `context.getCTM().isIdentityOrTranslationOrFlipped()` if we don&apos;t need to.

Avoid pushing values into the two-layered hash maps if the image size hasn&apos;t changed.

* Source/WebCore/rendering/ImageQualityController.cpp:
(WebCore::ImageQualityController::chooseInterpolationQuality):

Canonical link: <a href="https://commits.webkit.org/280910@main">https://commits.webkit.org/280910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51437a7b460e2d0c649e535f29c27e240de9c1f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61589 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8410 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8598 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46973 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5989 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34975 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27803 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7397 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7414 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53687 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63277 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54199 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54348 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12830 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1607 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33122 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34208 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35292 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33953 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->