### PR TITLE
[JSC] Fix ASSERT(canSafelyBeUsed()) failure in Waiter's WeakPtr<TicketData>::get() with ThreadSafeWeakPtr

### DIFF
--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
@@ -208,6 +208,9 @@ void DeferredWorkTimer::scheduleWorkSoon(Ticket ticket, Task&& task)
         setTimeUntilFire(0_s);
 }
 
+// Since TicketData is ThreadSafeWeakPtr now, we should optimize the DeferredWorkTimer's
+// workflow, e.g. directly clear the TicketData from cancelPendingWork.
+// https://bugs.webkit.org/show_bug.cgi?id=276538
 bool DeferredWorkTimer::cancelPendingWork(Ticket ticket)
 {
     ASSERT(m_pendingTickets.contains(ticket));
@@ -229,7 +232,7 @@ void DeferredWorkTimer::cancelPendingWorkSafe(JSGlobalObject* globalObject)
     for (Ref<TicketData> ticket : *globalObject->m_weakTickets) {
         if (!ticket->isCancelled())
             cancelPendingWork(ticket.ptr());
-        m_tasks.append(std::make_tuple(ticket.ptr(), [](DeferredWorkTimer::Ticket) mutable { }));
+        m_tasks.append(std::make_tuple(ticket.ptr(), [](DeferredWorkTimer::Ticket) { }));
     }
     if (!isScheduled() && !m_currentlyRunningTask)
         setTimeUntilFire(0_s);

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
@@ -32,7 +32,7 @@
 #include <wtf/FixedVector.h>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -46,7 +46,7 @@ class DeferredWorkTimer final : public JSRunLoopTimer {
 public:
     using Base = JSRunLoopTimer;
 
-    class TicketData : public CanMakeWeakPtr<TicketData>, public ThreadSafeRefCounted<TicketData>  {
+    class TicketData : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<TicketData>  {
     private:
         WTF_MAKE_TZONE_ALLOCATED(TicketData);
         WTF_MAKE_NONCOPYABLE(TicketData);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -3309,7 +3309,7 @@ void JSGlobalObject::addWeakTicket(DeferredWorkTimer::Ticket ticket)
 {
     Locker locker { cellLock() };
     if (!m_weakTickets) {
-        auto weakTickets = makeUnique<WeakHashSet<DeferredWorkTimer::TicketData>>();
+        auto weakTickets = makeUnique<ThreadSafeWeakHashSet<DeferredWorkTimer::TicketData>>();
         WTF::storeStoreFence();
         m_weakTickets = WTFMove(weakTickets);
     }

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -511,7 +511,7 @@ public:
 
     void addWeakTicket(DeferredWorkTimer::Ticket);
     void clearWeakTickets();
-    std::unique_ptr<WeakHashSet<DeferredWorkTimer::TicketData>> m_weakTickets;
+    std::unique_ptr<ThreadSafeWeakHashSet<DeferredWorkTimer::TicketData>> m_weakTickets;
 
     inline std::unique_ptr<ObjectAdaptiveStructureWatchpoint>& typedArrayConstructorSpeciesAbsenceWatchpoint(TypedArrayType);
     inline std::unique_ptr<ObjectAdaptiveStructureWatchpoint>& typedArrayPrototypeSymbolIteratorAbsenceWatchpoint(TypedArrayType);

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -56,23 +56,6 @@ Waiter::Waiter(JSPromise* promise)
 {
 }
 
-Waiter::~Waiter()
-{
-    if (m_ticket) {
-        ASSERT(m_ticket->isCancelled());
-        scheduleWorkAndClearTicket([](DeferredWorkTimer::Ticket) mutable { });
-    }
-}
-
-void Waiter::scheduleWorkAndClearTicket(DeferredWorkTimer::Task&& task)
-{
-    ASSERT(m_isAsync && m_vm && !isOnList());
-    // If the ticket is already be removed from the the pending tickets, then do nothing here.
-    if (!m_ticket)
-        return;
-    auto ticket = std::exchange(m_ticket, nullptr);
-    m_vm->deferredWorkTimer->scheduleWorkSoon(ticket.get(), WTFMove(task));
-}
 
 WaiterListManager& WaiterListManager::singleton()
 {
@@ -231,7 +214,7 @@ void WaiterListManager::notifyWaiterImpl(const AbstractLocker& listLocker, Ref<W
     ASSERT(!waiter->isOnList());
 
     if (waiter->isAsync()) {
-        waiter->scheduleWorkAndClearTicket([resolveResult](DeferredWorkTimer::Ticket ticket) {
+        waiter->scheduleWorkAndClear(listLocker, [resolveResult](DeferredWorkTimer::Ticket ticket) {
             JSPromise* promise = jsCast<JSPromise*>(ticket->target());
             JSGlobalObject* globalObject = promise->globalObject();
             ASSERT(ticket->globalObject() == globalObject);
@@ -239,9 +222,6 @@ void WaiterListManager::notifyWaiterImpl(const AbstractLocker& listLocker, Ref<W
             JSValue result = resolveResult == ResolveResult::Ok ? vm.smallStrings.okString() : vm.smallStrings.timedOutString();
             promise->resolve(globalObject, result);
         });
-
-        // The AsyncWaiter's timer holds the waiter's reference. We must cancel it after the waiter done its job.
-        waiter->cancelTimer(listLocker);
         return;
     }
 
@@ -275,13 +255,25 @@ size_t WaiterListManager::totalWaiterCount()
     return totalCount;
 }
 
-void WaiterListManager::cancelAsyncWaiter(const AbstractLocker& listLocker, Waiter* waiter)
+void Waiter::scheduleWorkAndClear(const AbstractLocker& listLocker, DeferredWorkTimer::Task&& task)
 {
-    ASSERT(waiter->isAsync());
-    RefPtr<DeferredWorkTimer::TicketData> ticket = waiter->ticket(listLocker);
-    if (ticket)
-        waiter->vm()->deferredWorkTimer->cancelPendingWork(ticket.get());
-    waiter->cancelTimer(listLocker);
+    ASSERT(m_isAsync && m_vm && !isOnList());
+    if (auto ticket = this->ticket(listLocker)) {
+        m_vm->deferredWorkTimer->scheduleWorkSoon(ticket.get(), WTFMove(task));
+        clearTicket(listLocker);
+    }
+    clearTimer(listLocker);
+}
+
+void Waiter::cancelAndClear(const AbstractLocker& listLocker)
+{
+    ASSERT(m_isAsync);
+    if (auto ticket = this->ticket(listLocker)) {
+        m_vm->deferredWorkTimer->cancelPendingWork(ticket.get());
+        m_vm->deferredWorkTimer->scheduleWorkSoon(ticket.get(), [](DeferredWorkTimer::Ticket) { });
+        clearTicket(listLocker);
+    }
+    clearTimer(listLocker);
 }
 
 void WaiterListManager::unregister(VM* vm)
@@ -300,7 +292,7 @@ void WaiterListManager::unregister(VM* vm)
                 // If the vm is about destructing, then it shouldn't
                 // been blocked. That means we shouldn't find any SyncWaiter.
                 ASSERT(waiter->isAsync());
-                cancelAsyncWaiter(listLocker, waiter);
+                waiter->cancelAndClear(listLocker);
                 return true;
             }
             return false;
@@ -316,14 +308,13 @@ void WaiterListManager::unregister(JSGlobalObject* globalObject)
         Locker listLocker { list->lock };
         list->removeIf(listLocker, [&](Waiter* waiter) {
             if (waiter->isAsync()) {
-                RefPtr<DeferredWorkTimer::TicketData> ticket = waiter->ticket(listLocker);
-                if (ticket && !ticket->isCancelled() && ticket->globalObject() == globalObject) {
+                if (auto ticket = waiter->ticket(listLocker); ticket && !ticket->isCancelled() && ticket->globalObject() == globalObject) {
                     dataLogLnIf(WaiterListsManagerInternal::verbose,
                         "<WaiterListManager> <Thread:", Thread::current(),
                         "> unregister JSGlobalObject is cancelling waiter=", *waiter,
                         " in WaiterList for ptr ", RawPointer(entry.key));
 
-                    cancelAsyncWaiter(listLocker, waiter);
+                    waiter->cancelAndClear(listLocker);
                     return true;
                 }
             }
@@ -353,14 +344,14 @@ void WaiterListManager::unregister(uint8_t* arrayPtr, size_t size)
                 // See example, waitasync-timeout-finite-gc.js.
                 //
                 // OK, let's say if the ticket has a valid timer and its globalObject is about being
-                // destructed later but before the timeout. Then, we cannot cancel the timer from
+                // destructed later but before the timeout. Then, we cannot cancel the work from
                 // `unregister(JSGlobalObject* globalObject)` since the waiter is already removed
                 // from the lists by this code. So, should we keep it in the list? No, in either
                 // case, we have to remove it since all lists associating to the SAB (about destructing)
                 // must be removed. This is because there may be a new SAB with a waiter at the same address.
                 // Therefore, we will let `clearWeakTickets` to handle this special case.
                 if (!waiter->hasTimer(listLocker))
-                    cancelAsyncWaiter(listLocker, waiter);
+                    waiter->cancelAndClear(listLocker);
                 return true;
             });
 
@@ -399,11 +390,12 @@ void Waiter::dump(PrintStream& out) const
         return;
     }
 
-    out.print(", ticket=", RawPointer(m_ticket.get()));
-    if (m_ticket && !m_ticket->isCancelled()) {
-        out.print(", m_ticket->globalObject=", RawPointer(m_ticket->globalObject()));
-        out.print(", m_ticket->target=", RawPointer(jsCast<JSObject*>(m_ticket->dependencies().last().get())));
-        out.print(", m_ticket->scriptExecutionOwner=", RawPointer(m_ticket->scriptExecutionOwner()));
+    auto ticket = this->ticket(NoLockingNecessary);
+    out.print(", ticket=", RawPointer(ticket.get()));
+    if (ticket && !ticket->isCancelled()) {
+        out.print(", m_ticket->globalObject=", RawPointer(ticket->globalObject()));
+        out.print(", m_ticket->target=", RawPointer(jsCast<JSObject*>(ticket->dependencies().last().get())));
+        out.print(", m_ticket->scriptExecutionOwner=", RawPointer(ticket->scriptExecutionOwner()));
     }
 
     out.print(", m_timer=", RawPointer(m_timer.get()));

--- a/Source/JavaScriptCore/runtime/WaiterListManager.h
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.h
@@ -43,7 +43,6 @@ class Waiter final : public WTF::BasicRawSentinelNode<Waiter>, public ThreadSafe
 public:
     Waiter(VM*);
     Waiter(JSPromise*);
-    ~Waiter();
 
     bool isAsync() const
     {
@@ -71,13 +70,17 @@ public:
         return m_condition;
     }
 
-    DeferredWorkTimer::Ticket ticket(const AbstractLocker&) const
+    RefPtr<DeferredWorkTimer::TicketData> ticket(const AbstractLocker&) const
     {
         ASSERT(m_isAsync);
         return m_ticket.get();
     }
 
-    void scheduleWorkAndClearTicket(DeferredWorkTimer::Task&&);
+    void clearTicket(const AbstractLocker&)
+    {
+        ASSERT(m_isAsync);
+        m_ticket = nullptr;
+    }
 
     void setTimer(const AbstractLocker&, Ref<RunLoop::DispatchTimer>&& timer)
     {
@@ -90,21 +93,25 @@ public:
         return !!m_timer;
     }
 
-    void cancelTimer(const AbstractLocker&)
+    void clearTimer(const AbstractLocker&)
     {
         ASSERT(m_isAsync);
         // If the timeout for AsyncWaiter is infinity, we won't dispatch any timer.
         if (!m_timer)
             return;
         m_timer->stop();
-        // This releases the strong reference to the Waiter in the timer.
+        // The AsyncWaiter's timer holds the waiter's reference. This
+        // releases the strong reference to the Waiter in the timer.
         m_timer = nullptr;
     }
 
+    void scheduleWorkAndClear(const AbstractLocker&, DeferredWorkTimer::Task&&);
+    void cancelAndClear(const AbstractLocker&);
     void dump(PrintStream&) const;
+
 private:
     VM* m_vm { nullptr };
-    WeakPtr<DeferredWorkTimer::TicketData> m_ticket { nullptr };
+    ThreadSafeWeakPtr<DeferredWorkTimer::TicketData> m_ticket { nullptr };
     RefPtr<RunLoop::DispatchTimer> m_timer { nullptr };
     Condition m_condition;
     bool m_isAsync { false };

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -61,7 +61,7 @@ StreamingCompiler::~StreamingCompiler()
 {
     if (m_ticket) {
         auto ticket = std::exchange(m_ticket, nullptr);
-        m_vm.deferredWorkTimer->scheduleWorkSoon(ticket, [](DeferredWorkTimer::Ticket) mutable { });
+        m_vm.deferredWorkTimer->scheduleWorkSoon(ticket, [](DeferredWorkTimer::Ticket) { });
     }
 }
 


### PR DESCRIPTION
#### 36e90619cf8a0f01a4cf8f0d414140c78410279b
<pre>
[JSC] Fix ASSERT(canSafelyBeUsed()) failure in Waiter&apos;s WeakPtr&lt;TicketData&gt;::get() with ThreadSafeWeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=276527">https://bugs.webkit.org/show_bug.cgi?id=276527</a>
<a href="https://rdar.apple.com/131590927">rdar://131590927</a>

Reviewed by Keith Miller.

The WeakPtr&lt;TicketData&gt; in the Waiter of WaiterListManager can be
accessed from various threads. Most of the accesses to the TicketData
are guarded by the corresponding WaiterList&apos;s lock. However,
DeferredWorkTimer::cancelPendingWorkSafe can force the cancellation
of the pending TicketData during the destruction of JSGlobalObject.
Therefore, let&apos;s use ThreadSafeWeakPtr to secure the usage of the Waiter&apos;s TicketData.

This patch enhances the robustness of WaiterListManager by:
1. Replacing WeakPtr with ThreadSafeWeakPtr for the Waiter&apos;s TicketData.
2. Refactoring scheduleWorkAndClearTicket to scheduleWorkAndClear.
3. Refactoring cancelAsyncWaiter to cancelAndClear.

* Source/JavaScriptCore/runtime/DeferredWorkTimer.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::addWeakTicket):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/WaiterListManager.cpp:
(JSC::WaiterListManager::notifyWaiterImpl):
(JSC::Waiter::scheduleWorkAndClear):
(JSC::Waiter::cancelAndClear):
(JSC::WaiterListManager::unregister):
(JSC::Waiter::dump const):
(JSC::Waiter::~Waiter): Deleted.
(JSC::Waiter::scheduleWorkAndClearTicket): Deleted.
(JSC::WaiterListManager::cancelAsyncWaiter): Deleted.
* Source/JavaScriptCore/runtime/WaiterListManager.h:

Canonical link: <a href="https://commits.webkit.org/280909@main">https://commits.webkit.org/280909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fd6aaf3dd61c82abee84b483413243deb594d43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8447 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8636 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/6018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60032 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/50137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/27839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/31772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/7432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7451 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51094 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/7700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63315 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57244 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1916 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1923 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/50148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/54371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/1641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79005 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8650 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/13109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34245 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33990 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->