### PR TITLE
Temporarily missing elements when scrolling a Google "places" search (content-visibility: auto)

### DIFF
--- a/LayoutTests/fast/viewport/ios/content-visibility-layout-viewport-during-unstable-scroll-expected.txt
+++ b/LayoutTests/fast/viewport/ios/content-visibility-layout-viewport-during-unstable-scroll-expected.txt
@@ -1,0 +1,22 @@
+PASS nthSection(1).checkVisibility({ contentVisibilityAuto: true }) is true
+PASS nthSection(2).checkVisibility({ contentVisibilityAuto: true }) is true
+PASS numberOfVisibleItems() >= 8 is true
+PASS nthSection(1).checkVisibility({ contentVisibilityAuto: true }) is false
+PASS nthSection(4).checkVisibility({ contentVisibilityAuto: true }) is true
+PASS numberOfVisibleItems() >= 8 is true
+PASS nthSection(1).checkVisibility({ contentVisibilityAuto: true }) is false
+PASS nthSection(4).checkVisibility({ contentVisibilityAuto: true }) is true
+PASS nthSection(1).checkVisibility({ contentVisibilityAuto: true }) is true
+PASS nthSection(2).checkVisibility({ contentVisibilityAuto: true }) is true
+PASS nthSection(1).checkVisibility({ contentVisibilityAuto: true }) is true
+PASS nthSection(2).checkVisibility({ contentVisibilityAuto: true }) is true
+PASS numberOfVisibleItems() >= 8 is true
+PASS nthSection(1).checkVisibility({ contentVisibilityAuto: true }) is false
+PASS nthSection(10).checkVisibility({ contentVisibilityAuto: true }) is true
+PASS numberOfVisibleItems() >= 8 is true
+PASS nthSection(1).checkVisibility({ contentVisibilityAuto: true }) is false
+PASS nthSection(10).checkVisibility({ contentVisibilityAuto: true }) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/viewport/ios/content-visibility-layout-viewport-during-unstable-scroll.html
+++ b/LayoutTests/fast/viewport/ios/content-visibility-layout-viewport-during-unstable-scroll.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test that layout viewport used for content-visibility: auto is up-to-date</title>
+    <meta name="viewport" content="initial-scale=1">
+    <style>
+        html, body { margin: 0; padding: 0; }
+        section {
+            height: 100px;
+            border-bottom: 1px solid blue;
+            box-sizing: border-box;
+            content-visibility: auto;
+        }
+        #console {
+            position: fixed;
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+        <section><p> </p></section>
+    </main>
+    <div id="console"></div>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        function nthSection(n) {
+            return document.querySelectorAll("p")[n - 1];
+        }
+
+        function numberOfVisibleItems() {
+            return [...document.querySelectorAll("p")]
+                .filter(element => element.checkVisibility({ contentVisibilityAuto: true }))
+                .length;
+        }
+
+        function scrollingStartScript({ y }) {
+            return `(function() {
+                uiController.stableStateOverride = false;
+                uiController.beginInteractiveObscuredInsetsChange();
+                uiController.immediateScrollToOffset(0, ${y});
+                uiController.doAfterPresentationUpdate(function() {
+                    uiController.doAfterPresentationUpdate(function() {
+                        uiController.doAfterPresentationUpdate(function() {
+                            uiController.uiScriptComplete();
+                        });
+                    });
+                });
+            })()`;
+        }
+        function scrollingEndScript() {
+            return `(function() {
+                uiController.stableStateOverride = true;
+                uiController.doAfterNextStablePresentationUpdate(function() {
+                    uiController.endInteractiveObscuredInsetsChange();
+                    uiController.uiScriptComplete();
+                });
+            })()`;
+        }
+
+        function waitForScript(script) {
+            return new Promise(resolve => {
+                testRunner.runUIScript(script, resolve);
+            });
+        }
+
+        addEventListener("load", async () => {
+            await UIHelper.ensurePresentationUpdate();
+
+            const initialVisibleItems = numberOfVisibleItems();
+            shouldBeTrue(`nthSection(1).checkVisibility({ contentVisibilityAuto: true })`);
+            shouldBeTrue(`nthSection(2).checkVisibility({ contentVisibilityAuto: true })`);
+
+            await waitForScript(scrollingStartScript({ y: 300 }));
+
+            shouldBeTrue(`numberOfVisibleItems() >= ${initialVisibleItems}`);
+            shouldBeFalse(`nthSection(1).checkVisibility({ contentVisibilityAuto: true })`);
+            shouldBeTrue(`nthSection(4).checkVisibility({ contentVisibilityAuto: true })`);
+
+            await waitForScript(scrollingEndScript());
+
+            shouldBeTrue(`numberOfVisibleItems() >= ${initialVisibleItems}`);
+            shouldBeFalse(`nthSection(1).checkVisibility({ contentVisibilityAuto: true })`);
+            shouldBeTrue(`nthSection(4).checkVisibility({ contentVisibilityAuto: true })`);
+
+            await waitForScript(scrollingStartScript({ y: 0 }));
+
+            shouldBeTrue(`nthSection(1).checkVisibility({ contentVisibilityAuto: true })`);
+            shouldBeTrue(`nthSection(2).checkVisibility({ contentVisibilityAuto: true })`);
+
+            await waitForScript(scrollingEndScript());
+
+            shouldBeTrue(`nthSection(1).checkVisibility({ contentVisibilityAuto: true })`);
+            shouldBeTrue(`nthSection(2).checkVisibility({ contentVisibilityAuto: true })`);
+
+            await waitForScript(scrollingStartScript({ y: 1000 }));
+
+            shouldBeTrue(`numberOfVisibleItems() >= ${initialVisibleItems}`);
+            shouldBeFalse(`nthSection(1).checkVisibility({ contentVisibilityAuto: true })`);
+            shouldBeTrue(`nthSection(10).checkVisibility({ contentVisibilityAuto: true })`);
+
+            await waitForScript(scrollingEndScript());
+
+            shouldBeTrue(`numberOfVisibleItems() >= ${initialVisibleItems}`);
+            shouldBeFalse(`nthSection(1).checkVisibility({ contentVisibilityAuto: true })`);
+            shouldBeTrue(`nthSection(10).checkVisibility({ contentVisibilityAuto: true })`);
+
+            finishJSTest();
+        });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -735,13 +735,11 @@ void AsyncScrollingCoordinator::reconcileScrollingState(LocalFrameView& frameVie
         [&frameView](std::optional<FloatPoint> origin) {
             if (origin)
                 frameView.setBaseLayoutViewportOrigin(LayoutPoint(origin.value()), LocalFrameView::TriggerLayoutOrNot::No);
-        }, [&frameView, &layoutViewportRect, viewportRectStability](std::optional<FloatRect> overrideRect) {
+        }, [&layoutViewportRect](std::optional<FloatRect> overrideRect) {
             if (!overrideRect)
                 return;
 
             layoutViewportRect = overrideRect;
-            if (viewportRectStability != ViewportRectStability::ChangingObscuredInsetsInteractively)
-                frameView.setLayoutViewportOverrideRect(LayoutRect(overrideRect.value()), viewportRectStability == ViewportRectStability::Stable ? LocalFrameView::TriggerLayoutOrNot::Yes : LocalFrameView::TriggerLayoutOrNot::No);
         }
     );
 


### PR DESCRIPTION
#### 3eace12cf58fd2ab870702e46a4929b671429b92
<pre>
Temporarily missing elements when scrolling a Google &quot;places&quot; search (content-visibility: auto)
<a href="https://bugs.webkit.org/show_bug.cgi?id=276529">https://bugs.webkit.org/show_bug.cgi?id=276529</a>
<a href="https://rdar.apple.com/130375530">rdar://130375530</a>

Reviewed by Simon Fraser.

The layout viewport was not getting updated during an unstable scroll, which meant content-visibility would not update until scroll would be stabilized.

Fix this by unconditionally updating the layout viewport.

Also refactor some code to avoid duplicating the visual &amp; layout viewport updates.

* LayoutTests/fast/viewport/ios/content-visibility-layout-viewport-during-unstable-scroll-expected.txt: Added.
* LayoutTests/fast/viewport/ios/content-visibility-layout-viewport-during-unstable-scroll.html: Added.
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::reconcileScrollingState):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateVisibleContentRects):

Canonical link: <a href="https://commits.webkit.org/281074@main">https://commits.webkit.org/281074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bee27ac9d2f6c602ee580317e39b5c7f0b4e7855

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62305 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/9122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60807 "Failed to checkout and rebase branch from PR 30740") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9321 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/9122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60709 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/50744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/28334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/32312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/8040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8126 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/8317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64008 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2591 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2600 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/50771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/54887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2176 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8742 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/34920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/36004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/34665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->