### PR TITLE
For accounting for the `d` presentation attribute when resolving the computed style.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1077,17 +1077,17 @@ CSSCounterStyleAtRulesEnabled:
 
 CSSDPropertyEnabled:
   type: bool
-  status: testable
+  status: stable
   category: css
   humanReadableName: "CSS d property"
   humanReadableDescription: "Enable support for the CSS d property and SVG d presentation attribute"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 CSSFieldSizingEnabled:
   type: bool

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3280,7 +3280,7 @@ enum class ForcedLayout : uint8_t { No, Yes, ParentDocument };
 
 RefPtr<CSSValue> ComputedStyleExtractor::propertyValue(CSSPropertyID propertyID, UpdateLayout updateLayout, PropertyValueType valueType) const
 {
-    auto* styledElement = m_element.get();
+    RefPtr styledElement = m_element.get();
     if (!styledElement)
         return nullptr;
 
@@ -3295,6 +3295,9 @@ RefPtr<CSSValue> ComputedStyleExtractor::propertyValue(CSSPropertyID propertyID,
 
     if (updateLayout == UpdateLayout::Yes) {
         Ref document = m_element->document();
+
+        if (RefPtr actualStyledElement = dynamicDowncast<StyledElement>(styledElement))
+            actualStyledElement->willUpdateStyleForComputedProperty(propertyID);
 
         updateStyleIfNeededForProperty(*styledElement, propertyID);
         if (propertyID == CSSPropertyDisplay && !styledRenderer()) {

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -74,6 +74,8 @@ public:
     virtual const MutableStyleProperties* additionalPresentationalHintStyle() const { return nullptr; }
     virtual void collectExtraStyleForPresentationalHints(MutableStyleProperties&) { }
 
+    virtual void willUpdateStyleForComputedProperty(CSSPropertyID) { };
+
 protected:
     StyledElement(const QualifiedName& name, Document& document, OptionSet<TypeFlag> type)
         : Element(name, document, type)

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -841,7 +841,7 @@ bool SVGElement::rendererIsNeeded(const RenderStyle& style)
     return false;
 }
 
-CSSPropertyID SVGElement::cssPropertyIdForSVGAttributeName(const QualifiedName& attrName, const Settings& settings)
+CSSPropertyID SVGElement::cssPropertyIdForSVGAttributeName(const QualifiedName& attrName) const
 {
     if (!attrName.namespaceURI().isNull())
         return CSSPropertyInvalid;
@@ -871,10 +871,6 @@ CSSPropertyID SVGElement::cssPropertyIdForSVGAttributeName(const QualifiedName& 
         return CSSPropertyCx;
     case AttributeNames::cyAttr:
         return CSSPropertyCy;
-    case AttributeNames::dAttr:
-        if (settings.cssDPropertyEnabled())
-            return CSSPropertyD;
-        break;
     case AttributeNames::directionAttr:
         return CSSPropertyDirection;
     case AttributeNames::displayAttr:
@@ -1000,14 +996,14 @@ CSSPropertyID SVGElement::cssPropertyIdForSVGAttributeName(const QualifiedName& 
 
 bool SVGElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
-    if (cssPropertyIdForSVGAttributeName(name, document().settings()) > 0)
+    if (cssPropertyIdForSVGAttributeName(name) > 0)
         return true;
     return StyledElement::hasPresentationalHintsForAttribute(name);
 }
 
 void SVGElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    CSSPropertyID propertyID = cssPropertyIdForSVGAttributeName(name, document().settings());
+    CSSPropertyID propertyID = cssPropertyIdForSVGAttributeName(name);
     if (propertyID > 0)
         addPropertyToPresentationalHintStyle(style, propertyID, value);
 }
@@ -1020,7 +1016,7 @@ void SVGElement::updateSVGRendererForElementChange()
 
 void SVGElement::svgAttributeChanged(const QualifiedName& attrName)
 {
-    CSSPropertyID propId = cssPropertyIdForSVGAttributeName(attrName, document().settings());
+    CSSPropertyID propId = cssPropertyIdForSVGAttributeName(attrName);
     if (propId > 0) {
         invalidateInstances();
         return;

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -45,7 +45,6 @@ class SVGPropertyAnimatorFactory;
 class SVGResourceElementClient;
 class SVGSVGElement;
 class SVGUseElement;
-class Settings;
 class Timer;
 
 class SVGElement : public StyledElement, public SVGPropertyOwner {
@@ -183,7 +182,7 @@ protected:
     SVGElementRareData& ensureSVGRareData();
 
     void reportAttributeParsingError(SVGParsingError, const QualifiedName&, const AtomString&);
-    static CSSPropertyID cssPropertyIdForSVGAttributeName(const QualifiedName&, const Settings&);
+    virtual CSSPropertyID cssPropertyIdForSVGAttributeName(const QualifiedName&) const;
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -80,7 +80,7 @@ Ref<StyleRuleFontFace> SVGFontFaceElement::protectedFontFaceRule() const
 
 void SVGFontFaceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    CSSPropertyID propertyId = cssPropertyIdForSVGAttributeName(name, document().settings());
+    CSSPropertyID propertyId = cssPropertyIdForSVGAttributeName(name);
     if (propertyId > 0) {
         // FIXME: Parse using the @font-face descriptor grammars, not the property grammars.
         Ref fontFaceRule = m_fontFaceRule;

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -146,13 +146,22 @@ void SVGPathElement::svgAttributeChanged(const QualifiedName& attrName)
             path->setNeedsShapeUpdate();
 
         updateSVGRendererForElementChange();
-        if (document().settings().cssDPropertyEnabled())
+        if (m_pathDataWasSetByStyle && document().settings().cssDPropertyEnabled())
             setPresentationalHintStyleIsDirty();
         invalidateResourceImageBuffersIfNeeded();
         return;
     }
 
     SVGGeometryElement::svgAttributeChanged(attrName);
+}
+
+CSSPropertyID SVGPathElement::cssPropertyIdForSVGAttributeName(const QualifiedName& attrName) const
+{
+    if (attrName == SVGNames::dAttr) {
+        if (m_pathDataWasSetByStyle && document().settings().cssDPropertyEnabled())
+            return CSSPropertyD;
+    }
+    return SVGGeometryElement::cssPropertyIdForSVGAttributeName(attrName);
 }
 
 void SVGPathElement::invalidateMPathDependencies()
@@ -289,6 +298,7 @@ void SVGPathElement::collectDPresentationalHint(MutableStyleProperties& style)
 
 void SVGPathElement::pathDidChange()
 {
+    m_pathDataWasSetByStyle = true;
     invalidateMPathDependencies();
 }
 

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -294,6 +294,12 @@ void SVGPathElement::collectDPresentationalHint(MutableStyleProperties& style)
     // The WindRule value passed here is not relevant for the `d` property.
     auto cssPathValue = CSSPathValue::create(Ref { m_pathSegList }->currentPathByteStream(), WindRule::NonZero);
     addPropertyToPresentationalHintStyle(style, property, WTFMove(cssPathValue));
+
+void SVGPathElement::willUpdateStyleForComputedProperty(CSSPropertyID property)
+{
+    if (property == CSSPropertyD && document().settings().cssDPropertyEnabled())
+        setPresentationalHintStyleIsDirty();
+    SVGGeometryElement::willUpdateStyleForComputedProperty(property);
 }
 
 void SVGPathElement::pathDidChange()

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -127,6 +127,7 @@ private:
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
     void collectExtraStyleForPresentationalHints(MutableStyleProperties&) override;
     void collectDPresentationalHint(MutableStyleProperties&);
+    void willUpdateStyleForComputedProperty(CSSPropertyID) final;
 
     Ref<SVGAnimatedPathSegList> m_pathSegList { SVGAnimatedPathSegList::create(this) };
     bool m_pathDataWasSetByStyle { false };

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -112,6 +112,7 @@ private:
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;
+    CSSPropertyID cssPropertyIdForSVGAttributeName(const QualifiedName&) const final;
 
     bool isValid() const final { return SVGTests::isValid(); }
     bool supportsMarkers() const final { return true; }
@@ -128,6 +129,7 @@ private:
     void collectDPresentationalHint(MutableStyleProperties&);
 
     Ref<SVGAnimatedPathSegList> m_pathSegList { SVGAnimatedPathSegList::create(this) };
+    bool m_pathDataWasSetByStyle { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### fab63973c7f3f5cc8b9cd65984e1059fba7bb961
<pre>
For accounting for the `d` presentation attribute when resolving the computed style.
</pre>
----------------------------------------------------------------------
#### aeb5a4a7bcba091f9eb29073c12c17cd31414d5c
<pre>
[svg] enable support for the &apos;d&apos; property by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=276172">https://bugs.webkit.org/show_bug.cgi?id=276172</a>
<a href="https://rdar.apple.com/129035240">rdar://129035240</a>

Reviewed by NOBODY (OOPS!).

Turn on the support for the `d` CSS property by default.

In order to be able to do that, we need to address the performance regression
in the Speedometer3 subtest `React-Stockcharts-SVG` by selectively calling
`setPresentationalHintStyleIsDirty()` under `SVGPathElement::svgAttributeChanged()`
only if we&apos;ve previously seen a change in the `d` CSS property. In other words,
we only kick in the presentation attribute machinery if we&apos;ve determined that
the CSS `d` property was used.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::svgAttributeChanged):
(WebCore::SVGPathElement::pathDidChange):
* Source/WebCore/svg/SVGPathElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fc023cef5be2e8693cfc68277a843ad72d805e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64428 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43792 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17024 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68449 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15035 "Hash 0fc023ce for PR 30743 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66547 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51504 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15315 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/68449 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/15035 "Hash 0fc023ce for PR 30743 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67496 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/51504 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/17024 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/68449 "Hash 0fc023ce for PR 30743 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/51504 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/17024 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13909 "Hash 0fc023ce for PR 30743 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/57539 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/51504 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/17024 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70150 "Hash 0fc023ce for PR 30743 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63672 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8375 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/15315 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/70150 "Hash 0fc023ce for PR 30743 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8409 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/17024 "Hash 0fc023ce for PR 30743 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/70150 "Hash 0fc023ce for PR 30743 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/17024 "Hash 0fc023ce for PR 30743 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85433 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39606 "Hash 0fc023ce for PR 30743 does not build (failure)") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15071 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40684 "Hash 0fc023ce for PR 30743 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41867 "Hash 0fc023ce for PR 30743 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40427 "Hash 0fc023ce for PR 30743 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->