### PR TITLE
[GStreamer] Make use of ASCIILiteral in video encoder

### DIFF
--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -90,7 +90,7 @@ static GType videoEncoderLatencyModeGetType()
     return latencyModeGType;
 }
 
-using SetBitrateFunc = Function<void(GObject* encoder, const char* propertyName, int bitrate)>;
+using SetBitrateFunc = Function<void(GObject* encoder, ASCIILiteral propertyName, int bitrate)>;
 using SetupFunc = Function<void(WebKitVideoEncoder*)>;
 using SetBitrateModeFunc = Function<void(GstElement*, BitrateMode)>;
 using SetLatencyModeFunc = Function<void(GstElement*, LatencyMode)>;
@@ -98,8 +98,8 @@ using SetBitRateAllocationFunc = Function<void(GstElement*, const WebKitVideoEnc
 
 struct EncoderDefinition {
     GRefPtr<GstCaps> caps;
-    const char* name;
-    const char* parserName;
+    ASCIILiteral name;
+    ASCIILiteral parserName;
     GRefPtr<GstElementFactory> factory;
     GRefPtr<GstCaps> encodedFormat;
     SetBitrateFunc setBitrate;
@@ -107,8 +107,8 @@ struct EncoderDefinition {
     SetBitrateModeFunc setBitrateMode;
     SetLatencyModeFunc setLatencyMode;
     SetBitRateAllocationFunc setBitRateAllocation;
-    const char* bitratePropertyName;
-    const char* keyframeIntervalPropertyName;
+    ASCIILiteral bitratePropertyName;
+    ASCIILiteral keyframeIntervalPropertyName;
 };
 
 static void defaultSetBitRateAllocation(GstElement*, const WebKitVideoEncoderBitRateAllocation&)
@@ -139,24 +139,24 @@ public:
         return encoders;
     }
 
-    static void registerEncoder(EncoderId id, const char* name, const char* parserName, const char* capsString, const char* encodedFormatString,
-        SetupFunc&& setupEncoder, const char* bitratePropertyName, SetBitrateFunc&& setBitrate, const char* keyframeIntervalPropertyName, SetBitrateModeFunc&& setBitrateMode, SetLatencyModeFunc&& setLatency, SetBitRateAllocationFunc&& setBitRateAllocation = defaultSetBitRateAllocation)
+    static void registerEncoder(EncoderId id, ASCIILiteral name, ASCIILiteral parserName, ASCIILiteral capsString, ASCIILiteral encodedFormatString,
+        SetupFunc&& setupEncoder, ASCIILiteral bitratePropertyName, SetBitrateFunc&& setBitrate, ASCIILiteral keyframeIntervalPropertyName, SetBitrateModeFunc&& setBitrateMode, SetLatencyModeFunc&& setLatency, SetBitRateAllocationFunc&& setBitRateAllocation = defaultSetBitRateAllocation)
     {
         auto encoderFactory = adoptGRef(gst_element_factory_find(name));
         if (!encoderFactory) {
-            GST_WARNING("Encoder %s not found, will not be used", name);
+            GST_WARNING("Encoder %s not found, will not be used", name.characters());
             return;
         }
 
         if (gst_plugin_feature_get_rank(GST_PLUGIN_FEATURE_CAST(encoderFactory.get())) < GST_RANK_MARGINAL) {
-            GST_WARNING("Encoder %s rank is below MARGINAL, will not be used.", name);
+            GST_WARNING("Encoder %s rank is below MARGINAL, will not be used.", name.characters());
             return;
         }
 
         if (parserName) {
             auto parserFactory = adoptGRef(gst_element_factory_find(parserName));
             if (!parserFactory) {
-                GST_WARNING("Parser %s is required for encoder %s. Skipping registration", parserName, name);
+                GST_WARNING("Parser %s is required for encoder %s. Skipping registration", parserName.characters(), name.characters());
                 return;
             }
         }
@@ -184,7 +184,7 @@ public:
             .bitratePropertyName = bitratePropertyName,
             .keyframeIntervalPropertyName = keyframeIntervalPropertyName,
         }));
-        GST_INFO("Encoder %s registered", name);
+        GST_INFO("Encoder %s registered", name.characters());
     }
 
     static EncoderDefinition* definition(EncoderId id)
@@ -317,7 +317,7 @@ static bool videoEncoderSetEncoder(WebKitVideoEncoder* self, EncoderId encoderId
         if (priv->encoder) {
 #ifndef GST_DISABLE_GST_DEBUG
             auto previousEncoder = Encoders::definition(priv->encoderId);
-            GST_DEBUG_OBJECT(self, "Switching from %s to %s", previousEncoder->name, encoderDefinition->name);
+            GST_DEBUG_OBJECT(self, "Switching from %s to %s", previousEncoder->name.characters(), encoderDefinition->name.characters());
 #endif
             gst_element_set_locked_state(priv->encoder.get(), TRUE);
             gst_element_set_state(priv->encoder.get(), GST_STATE_NULL);
@@ -328,7 +328,7 @@ static bool videoEncoderSetEncoder(WebKitVideoEncoder* self, EncoderId encoderId
         gst_bin_add(GST_BIN_CAST(self), priv->encoder.get());
         shouldLinkEncoder = true;
     } else {
-        GST_DEBUG_OBJECT(self, "Reconfiguring existing %s encoder", encoderDefinition->name);
+        GST_DEBUG_OBJECT(self, "Reconfiguring existing %s encoder", encoderDefinition->name.characters());
         gst_element_set_state(priv->encoder.get(), GST_STATE_READY);
     }
 
@@ -460,7 +460,7 @@ EncoderId videoEncoderFindForFormat(WebKitVideoEncoder* self, const GRefPtr<GstC
     GST_DEBUG_OBJECT(self, "Looking for an encoder matching caps %" GST_PTR_FORMAT, caps.get());
     for (const auto& [id, encoder] : Encoders::singleton()) {
         if (gst_element_factory_can_src_any_caps(encoder.factory.get(), caps.get())) {
-            GST_DEBUG_OBJECT(self, "Compatible encoder found: %s", encoder.name);
+            GST_DEBUG_OBJECT(self, "Compatible encoder found: %s", encoder.name.characters());
             candidates.append(std::make_pair(id, &encoder));
         }
     }
@@ -474,7 +474,7 @@ EncoderId videoEncoderFindForFormat(WebKitVideoEncoder* self, const GRefPtr<GstC
         return rankA > rankB;
     });
 
-    GST_DEBUG_OBJECT(self, "The highest ranked encoder is %s", candidates[0].second->name);
+    GST_DEBUG_OBJECT(self, "The highest ranked encoder is %s", candidates[0].second->name.characters());
     return candidates[0].first;
 }
 
@@ -565,13 +565,13 @@ static void videoEncoderSetProperty(GObject* object, guint propertyId, const GVa
     }
 }
 
-static void setBitrateKbitPerSec(GObject* encoder, const char* propertyName, int bitrate)
+static void setBitrateKbitPerSec(GObject* encoder, ASCIILiteral propertyName, int bitrate)
 {
     GST_INFO_OBJECT(encoder, "Setting bitrate to %d Kbits/sec", bitrate);
     g_object_set(encoder, propertyName, bitrate, nullptr);
 }
 
-static void setBitrateBitPerSec(GObject* encoder, const char* propertyName, int bitrate)
+static void setBitrateBitPerSec(GObject* encoder, ASCIILiteral propertyName, int bitrate)
 {
     GST_INFO_OBJECT(encoder, "Setting bitrate to %d bits/sec", bitrate);
     g_object_set(encoder, propertyName, bitrate * KBIT_TO_BIT, nullptr);
@@ -662,11 +662,10 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
     gst_element_class_set_static_metadata(elementClass, "WebKit video encoder", "Codec/Encoder/Video", "Encodes video for streaming", "Igalia");
     gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&sinkTemplate));
 
-    Encoders::registerEncoder(OmxH264, "omxh264enc", "h264parse", "video/x-h264",
-        "video/x-h264,alignment=au,stream-format=byte-stream,profile=baseline",
+    Encoders::registerEncoder(OmxH264, "omxh264enc"_s, "h264parse"_s, "video/x-h264"_s, "video/x-h264,alignment=au,stream-format=byte-stream,profile=baseline"_s,
         [](WebKitVideoEncoder* self) {
             g_object_set(self->priv->parser.get(), "config-interval", 1, nullptr);
-        }, "target-bitrate", setBitrateBitPerSec, "interval-intraframes", [](GstElement* encoder, BitrateMode mode) {
+        }, "target-bitrate"_s, setBitrateBitPerSec, "interval-intraframes"_s, [](GstElement* encoder, BitrateMode mode) {
             switch (mode) {
             case CONSTANT_BITRATE_MODE:
                 gst_util_set_object_arg(G_OBJECT(encoder), "control-rate", "constant");
@@ -678,12 +677,12 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
         }, [](GstElement*, LatencyMode) {
             notImplemented();
         });
-    Encoders::registerEncoder(X264, "x264enc", "h264parse", "video/x-h264",
-        "video/x-h264,alignment=au,stream-format=byte-stream",
+    Encoders::registerEncoder(X264, "x264enc"_s, "h264parse"_s, "video/x-h264"_s,
+        "video/x-h264,alignment=au,stream-format=byte-stream"_s,
         [](WebKitVideoEncoder* self) {
             g_object_set(self->priv->encoder.get(), "key-int-max", 15, "threads", NUMBER_OF_THREADS, "b-adapt", FALSE, "vbv-buf-capacity", 120, nullptr);
             g_object_set(self->priv->parser.get(), "config-interval", 1, nullptr);
-        }, "bitrate", setBitrateKbitPerSec, "key-int-max", [](GstElement* encoder, BitrateMode mode) {
+        }, "bitrate"_s, setBitrateKbitPerSec, "key-int-max"_s, [](GstElement* encoder, BitrateMode mode) {
             switch (mode) {
             case CONSTANT_BITRATE_MODE:
                 gst_util_set_object_arg(G_OBJECT(encoder), "pass", "cbr");
@@ -705,12 +704,12 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                 break;
             };
         });
-    Encoders::registerEncoder(OpenH264, "openh264enc", "h264parse", "video/x-h264",
-        "video/x-h264,alignment=au,stream-format=byte-stream",
+    Encoders::registerEncoder(OpenH264, "openh264enc"_s, "h264parse"_s, "video/x-h264"_s,
+        "video/x-h264,alignment=au,stream-format=byte-stream"_s,
         [](WebKitVideoEncoder* self) {
             g_object_set(self->priv->parser.get(), "config-interval", 1, nullptr);
             g_object_set(self->priv->outputCapsFilter.get(), "caps", self->priv->encodedCaps.get(), nullptr);
-        }, "bitrate", setBitrateBitPerSec, "gop-size", [](GstElement*, BitrateMode) {
+        }, "bitrate"_s, setBitrateBitPerSec, "gop-size"_s, [](GstElement*, BitrateMode) {
             notImplemented();
         }, [](GstElement*, LatencyMode) {
             notImplemented();
@@ -721,11 +720,11 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
         gst_util_set_object_arg(G_OBJECT(self->priv->encoder.get()), "error-resilient", "default");
     };
 
-    Encoders::registerEncoder(Vp8, "vp8enc", nullptr, "video/x-vp8", nullptr,
+    Encoders::registerEncoder(Vp8, "vp8enc"_s, nullptr, "video/x-vp8"_s, nullptr,
         [&](WebKitVideoEncoder* self) {
             gst_util_set_object_arg(G_OBJECT(self->priv->encoder.get()), "keyframe-mode", "disabled");
             setVpxEncoderInputFormat(self);
-        }, "target-bitrate", setBitrateBitPerSec, "keyframe-max-dist", [](GstElement* encoder, BitrateMode mode) {
+        }, "target-bitrate"_s, setBitrateBitPerSec, "keyframe-max-dist"_s, [](GstElement* encoder, BitrateMode mode) {
             switch (mode) {
             case CONSTANT_BITRATE_MODE:
                 gst_util_set_object_arg(G_OBJECT(encoder), "end-usage", "cbr");
@@ -754,15 +753,15 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
             GValue boolValue G_VALUE_INIT;
             unsigned numberLayers = 1;
             Vector<bool> layerSyncFlags;
-            const char* scalabilityString = nullptr;
-            const char* layerFlags = nullptr;
+            ASCIILiteral scalabilityString;
+            ASCIILiteral layerFlags;
 
             g_value_init(&intValue, G_TYPE_INT);
 
             switch (bitRateAllocation.scalabilityMode()) {
             case VideoEncoder::ScalabilityMode::L1T1:
                 numberLayers = 1;
-                scalabilityString = "L1T1";
+                scalabilityString = "L1T1"_s;
                 if (auto value = bitRateAllocation.getBitRate(0, 0)) {
                     g_value_set_int(&intValue, *value);
                     g_value_array_append(bitrates.get(), &intValue);
@@ -775,7 +774,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                 break;
             case VideoEncoder::ScalabilityMode::L1T2:
                 numberLayers = 2;
-                scalabilityString = "L1T2";
+                scalabilityString = "L1T2"_s;
                 if (auto value = bitRateAllocation.getBitRate(0, 1)) {
                     g_value_set_int(&intValue, *value);
                     g_value_array_append(bitrates.get(), &intValue);
@@ -803,12 +802,12 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                     /* layer 0 */
                     "no-ref-golden+no-upd-golden+no-upd-alt,"
                     /* layer 1 */
-                    "no-upd-last+no-upd-alt>";
+                    "no-upd-last+no-upd-alt>"_s;
                 layerSyncFlags = { false, true, false, false };
                 break;
             case VideoEncoder::ScalabilityMode::L1T3:
                 numberLayers = 3;
-                scalabilityString = "L1T3";
+                scalabilityString = "L1T3"_s;
                 if (auto value = bitRateAllocation.getBitRate(0, 2)) {
                     g_value_set_int(&intValue, *value);
                     g_value_array_append(bitrates.get(), &intValue);
@@ -849,13 +848,13 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                     /* layer 1 */
                     "no-upd-last+no-upd-alt,"
                     /* layer 2 */
-                    "no-upd-last+no-upd-golden+no-upd-alt+no-upd-entropy>";
+                    "no-upd-last+no-upd-golden+no-upd-alt+no-upd-entropy>"_s;
                 layerSyncFlags = { false, true, true, false, false, false, false, false };
                 break;
             }
             g_value_unset(&intValue);
 
-            GST_DEBUG_OBJECT(encoder, "Configuring for %s scalability mode", scalabilityString);
+            GST_DEBUG_OBJECT(encoder, "Configuring for %s scalability mode", scalabilityString.characters());
             g_object_set(encoder, "temporal-scalability-number-layers", numberLayers,
                 "temporal-scalability-rate-decimator", decimators.get(),
                 "temporal-scalability-target-bitrate", bitrates.get(), nullptr);
@@ -879,10 +878,10 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
             ALLOW_DEPRECATED_DECLARATIONS_END;
         });
 
-    Encoders::registerEncoder(Vp9, "vp9enc", nullptr, "video/x-vp9", nullptr,
+    Encoders::registerEncoder(Vp9, "vp9enc"_s, nullptr, "video/x-vp9"_s, nullptr,
         [&](WebKitVideoEncoder* self) {
             setVpxEncoderInputFormat(self);
-        }, "target-bitrate", setBitrateBitPerSec, "keyframe-max-dist", [](GstElement* encoder, BitrateMode mode) {
+        }, "target-bitrate"_s, setBitrateBitPerSec, "keyframe-max-dist"_s, [](GstElement* encoder, BitrateMode mode) {
             switch (mode) {
             case CONSTANT_BITRATE_MODE:
                 gst_util_set_object_arg(G_OBJECT(encoder), "end-usage", "cbr");
@@ -905,26 +904,26 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
             };
         });
 
-    Encoders::registerEncoder(VaapiH264LP, "vah264lpenc", "h264parse", "video/x-h264", nullptr, setupVaEncoder,
-        "bitrate", setBitrateKbitPerSec, "key-int-max", [](GstElement*, BitrateMode) {
+    Encoders::registerEncoder(VaapiH264LP, "vah264lpenc"_s, "h264parse"_s, "video/x-h264"_s, nullptr, setupVaEncoder,
+        "bitrate"_s, setBitrateKbitPerSec, "key-int-max"_s, [](GstElement*, BitrateMode) {
             // Not supported.
         }, setVaLatencyMode);
 
-    Encoders::registerEncoder(VaapiH264, "vah264enc", "h264parse", "video/x-h264", nullptr,
-        setupVaEncoder, "bitrate", setBitrateKbitPerSec, "key-int-max", setVaBitrateMode, setVaLatencyMode);
+    Encoders::registerEncoder(VaapiH264, "vah264enc"_s, "h264parse"_s, "video/x-h264"_s, nullptr,
+        setupVaEncoder, "bitrate"_s, setBitrateKbitPerSec, "key-int-max"_s, setVaBitrateMode, setVaLatencyMode);
 
-    Encoders::registerEncoder(VaapiH265, "vah265enc", "h265parse", "video/x-h265", nullptr,
-        setupVaEncoder, "bitrate", setBitrateKbitPerSec, "key-int-max", setVaBitrateMode, setVaLatencyMode);
+    Encoders::registerEncoder(VaapiH265, "vah265enc"_s, "h265parse"_s, "video/x-h265"_s, nullptr,
+        setupVaEncoder, "bitrate"_s, setBitrateKbitPerSec, "key-int-max"_s, setVaBitrateMode, setVaLatencyMode);
 
-    Encoders::registerEncoder(VaapiAv1, "vaav1enc", "av1parse", "video/x-av1", nullptr,
-        [](auto) { }, "bitrate", setBitrateKbitPerSec, "key-int-max", setVaBitrateMode, setVaLatencyMode);
+    Encoders::registerEncoder(VaapiAv1, "vaav1enc"_s, "av1parse"_s, "video/x-av1"_s, nullptr,
+        [](auto) { }, "bitrate"_s, setBitrateKbitPerSec, "key-int-max"_s, setVaBitrateMode, setVaLatencyMode);
 
     if (webkitGstCheckVersion(1, 22, 0)) {
-        Encoders::registerEncoder(Av1, "av1enc", "av1parse", "video/x-av1", nullptr,
+        Encoders::registerEncoder(Av1, "av1enc"_s, "av1parse"_s, "video/x-av1"_s, nullptr,
             [](WebKitVideoEncoder* self) {
                 g_object_set(self->priv->encoder.get(), "threads", NUMBER_OF_THREADS, nullptr);
                 gst_util_set_object_arg(G_OBJECT(self->priv->encoder.get()), "keyframe-mode", "disabled");
-            }, "target-bitrate", setBitrateKbitPerSec, "keyframe-max-dist", [](GstElement* encoder, BitrateMode mode) {
+            }, "target-bitrate"_s, setBitrateKbitPerSec, "keyframe-max-dist"_s, [](GstElement* encoder, BitrateMode mode) {
                 switch (mode) {
                 case CONSTANT_BITRATE_MODE:
                     gst_util_set_object_arg(G_OBJECT(encoder), "end-usage", "cbr");
@@ -949,11 +948,11 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
     }
 
     static GQuark x265BitrateQuark = g_quark_from_static_string("x265-bitrate-mode");
-    Encoders::registerEncoder(X265, "x265enc", "h265parse", "video/x-h265",
-        "video/x-h265,alignment=au,stream-format=byte-stream",
+    Encoders::registerEncoder(X265, "x265enc"_s, "h265parse"_s, "video/x-h265"_s,
+        "video/x-h265,alignment=au,stream-format=byte-stream"_s,
         [](WebKitVideoEncoder* self) {
             g_object_set(self->priv->encoder.get(), "key-int-max", 15, nullptr);
-        }, "bitrate", [](GObject* object, const char* propertyName, int bitrate) {
+        }, "bitrate"_s, [](GObject* object, ASCIILiteral propertyName, int bitrate) {
             if (UNLIKELY(!bitrate))
                 return;
             setBitrateKbitPerSec(object, propertyName, bitrate);
@@ -968,7 +967,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                 break;
             };
             g_object_set(object, "option-string", options.ascii().data(), nullptr);
-        }, "key-int-max", [](GstElement* encoder, BitrateMode mode) {
+        }, "key-int-max"_s, [](GstElement* encoder, BitrateMode mode) {
             g_object_set_qdata(G_OBJECT(encoder), x265BitrateQuark, GINT_TO_POINTER(mode));
         }, [](GstElement* encoder, LatencyMode mode) {
             switch (mode) {


### PR DESCRIPTION
#### 736ccfb3ad4fdb495da711148024318289bacc92
<pre>
[GStreamer] Make use of ASCIILiteral in video encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=276532">https://bugs.webkit.org/show_bug.cgi?id=276532</a>

Reviewed by Xabier Rodriguez-Calvar.

* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(Encoders::registerEncoder):
(videoEncoderSetEncoder):
(videoEncoderFindForFormat):
(setBitrateKbitPerSec):
(setBitrateBitPerSec):
(webkit_video_encoder_class_init):

Canonical link: <a href="https://commits.webkit.org/280960@main">https://commits.webkit.org/280960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16eb67df2755c43d3f38208ada36a7d867c94c01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61611 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8431 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8619 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46992 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6004 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27823 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7416 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7435 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63298 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54214 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54353 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12860 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1627 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33143 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34229 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35313 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33974 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->