### PR TITLE
Remove NewOrExistingInterval logic from SVGSMILElement

### DIFF
--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -169,10 +169,8 @@ private:
 
     void disconnectConditions();
 
-    // Syncbase timing
-    enum NewOrExistingInterval { NewInterval, ExistingInterval };
-    void notifyDependentsIntervalChanged(NewOrExistingInterval);
-    void createInstanceTimesFromSyncbase(SVGSMILElement* syncbase, NewOrExistingInterval);
+    void notifyDependentsIntervalChanged();
+    void createInstanceTimesFromSyncbase(SVGSMILElement* syncbase);
     void addTimeDependent(SVGSMILElement*);
     void removeTimeDependent(SVGSMILElement*);
 


### PR DESCRIPTION
#### c74316fea7fb12333ece6afaa139e83446f2bb8d
<pre>
Remove NewOrExistingInterval logic from SVGSMILElement

<a href="https://bugs.webkit.org/show_bug.cgi?id=276035">https://bugs.webkit.org/show_bug.cgi?id=276035</a>
<a href="https://rdar.apple.com/problem/131231710">rdar://problem/131231710</a>

Reviewed by Simon Fraser.

Merge: <a href="https://github.com/chromium/chromium/commit/087c89766ea4939c200c526b446ad15b5dbbba5f">https://github.com/chromium/chromium/commit/087c89766ea4939c200c526b446ad15b5dbbba5f</a>

The NewOrExistingInterval logic is no longer used and can be removed. No
new tests as this is just a refactoring.

* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::resolveFirstInterval):
(WebCore::SVGSMILElement::resolveNextInterval):
(WebCore::SVGSMILElement::beginListChanged):
(WebCore::SVGSMILElement::endListChanged):
(WebCore::SVGSMILElement::checkRestart):
(WebCore::SVGSMILElement::notifyDependentsIntervalChanged):
(WebCore::SVGSMILElement::createInstanceTimesFromSyncbase):
(WebCore::SVGSMILElement::addTimeDependent):
* Source/WebCore/svg/animation/SVGSMILElement.h:

Canonical link: <a href="https://commits.webkit.org/280998@main">https://commits.webkit.org/280998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42f952112e45253148a851d58b5cb99207237a5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61622 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8442 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47002 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6015 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27833 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7427 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7446 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53715 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63310 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54225 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50143 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54364 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12884 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1638 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33154 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34240 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->