### PR TITLE
[css-grid] Add LayoutRequirement to indicate when a grid item needs stretching in column axis.

### DIFF
--- a/Source/WebCore/rendering/GridLayoutState.h
+++ b/Source/WebCore/rendering/GridLayoutState.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RenderBox.h"
+#include <wtf/CheckedPtr.h>
+
+namespace WebCore {
+
+enum class ItemLayoutRequirement : bool { NeedsColumnAxisStretchAlignment = 1 };
+using ItemsLayoutRequirements = SingleThreadWeakHashMap<RenderBox, ItemLayoutRequirement>;
+
+class GridLayoutState : public CanMakeCheckedPtr<GridLayoutState>, public CanMakeWeakPtr<GridLayoutState> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GridLayoutState);
+public:
+    ItemsLayoutRequirements& itemsLayoutRequirements() { return m_itemsLayoutRequirements; }
+
+private:
+    ItemsLayoutRequirements m_itemsLayoutRequirements;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -26,6 +26,7 @@
 
 #include "Grid.h"
 #include "GridBaselineAlignment.h"
+#include "GridLayoutState.h"
 #include "GridTrackSize.h"
 #include "LayoutSize.h"
 #include "RenderBoxInlines.h"
@@ -119,7 +120,7 @@ public:
     GridTrackSizingAlgorithm(const RenderGrid*, Grid&);
     ~GridTrackSizingAlgorithm();
 
-    void setup(GridTrackSizingDirection, unsigned numTracks, SizingOperation, std::optional<LayoutUnit> availableSpace);
+    void setup(GridTrackSizingDirection, unsigned numTracks, SizingOperation, std::optional<LayoutUnit> availableSpace, GridLayoutState&);
     void run();
     void reset();
 
@@ -262,6 +263,8 @@ private:
 
     const RenderGrid* m_renderGrid;
     std::unique_ptr<GridTrackSizingAlgorithmStrategy> m_strategy;
+
+    WeakPtr<GridLayoutState> m_gridLayoutState;
 
     // The track sizing algorithm is used for both layout and intrinsic size
     // computation. We're normally just interested in intrinsic inline sizes

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -35,6 +35,7 @@
 namespace WebCore {
 
 class GridArea;
+class GridLayoutState;
 class GridSpan;
 
 struct ContentAlignmentData {
@@ -135,7 +136,11 @@ public:
 
 private:
     friend class GridTrackSizingAlgorithm;
+    friend class GridTrackSizingAlgorithmStrategy;
     friend class GridMasonryLayout;
+
+    void computeLayoutRequirementsForItemsBeforeLayout(GridLayoutState&) const;
+    bool canSetColumnAxisStretchRequirementForItem(const RenderBox&) const;
 
     ItemPosition selfAlignmentNormalBehavior(const RenderBox* child = nullptr) const override
     {
@@ -185,16 +190,16 @@ private:
     bool hasStaticPositionForChild(const RenderBox&, GridTrackSizingDirection) const;
     void layoutPositionedObject(RenderBox&, bool relayoutChildren, bool fixedPositionObjectsOnly) override;
 
-    void computeTrackSizesForDefiniteSize(GridTrackSizingDirection, LayoutUnit availableSpace);
-    void computeTrackSizesForIndefiniteSize(GridTrackSizingAlgorithm&, GridTrackSizingDirection, LayoutUnit* minIntrinsicSize = nullptr, LayoutUnit* maxIntrinsicSize = nullptr) const;
+    void computeTrackSizesForDefiniteSize(GridTrackSizingDirection, LayoutUnit availableSpace, GridLayoutState&);
+    void computeTrackSizesForIndefiniteSize(GridTrackSizingAlgorithm&, GridTrackSizingDirection, GridLayoutState&, LayoutUnit* minIntrinsicSize = nullptr, LayoutUnit* maxIntrinsicSize = nullptr) const;
     LayoutUnit computeTrackBasedLogicalHeight() const;
 
-    void repeatTracksSizingIfNeeded(LayoutUnit availableSpaceForColumns, LayoutUnit availableSpaceForRows);
+    void repeatTracksSizingIfNeeded(LayoutUnit availableSpaceForColumns, LayoutUnit availableSpaceForRows, GridLayoutState&);
 
-    void updateGridAreaForAspectRatioItems(const Vector<RenderBox*>&);
+    void updateGridAreaForAspectRatioItems(const Vector<RenderBox*>&, GridLayoutState&);
 
-    void layoutGridItems();
-    void layoutMasonryItems();
+    void layoutGridItems(GridLayoutState&);
+    void layoutMasonryItems(GridLayoutState&);
 
     void populateGridPositionsForDirection(GridTrackSizingDirection);
 
@@ -221,7 +226,7 @@ private:
     LayoutUnit availableAlignmentSpaceForChildBeforeStretching(LayoutUnit gridAreaBreadthForChild, const RenderBox&, GridTrackSizingDirection) const;
     StyleSelfAlignmentData justifySelfForChild(const RenderBox&, StretchingMode = StretchingMode::Any, const RenderStyle* = nullptr) const;
     StyleSelfAlignmentData alignSelfForChild(const RenderBox&, StretchingMode = StretchingMode::Any, const RenderStyle* = nullptr) const;
-    void applyStretchAlignmentToChildIfNeeded(RenderBox&);
+    void applyStretchAlignmentToChildIfNeeded(RenderBox&, GridLayoutState&);
     void applySubgridStretchAlignmentToChildIfNeeded(RenderBox&);
     bool hasAutoSizeInColumnAxis(const RenderBox& child) const;
     bool hasAutoSizeInRowAxis(const RenderBox& child) const;


### PR DESCRIPTION
#### 364adc3b7d9e55c7947b770c1a95f435d002b988
<pre>
[css-grid] Add LayoutRequirement to indicate when a grid item needs stretching in column axis.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276609">https://bugs.webkit.org/show_bug.cgi?id=276609</a>
<a href="https://rdar.apple.com/problem/131751762">rdar://problem/131751762</a>

Reviewed by Alan Baradlay.

Currently grid will invalidate an item before stretching its block
size in one of the following scenarios

1.) Its current block size is not the stretched size
2.) It has percent height descendants

Let&apos;s try to limit 2 when we stretch in the column axis. This is done
by adding a new bit via LayoutRequirements to indicate when this should
be done.

There are two different scenarios in which we will currently set this
bit.

The first opportunity to set this bit is by checking damaged grid items
before we perform grid layout. If we find a damaged grid item,
then we will check if it needs to be stretched in the column axis by
checking its style.

The second time we may need to set this bit is during the grid track
sizing algorithm in GridTrackSizingAlgorithmStrategy::logicalHeightForChild.
Here we may clear any overriding sizes, mark the renderer as dirty, and
perform layout on it. If an item was previously stretched here then we
will lose its stretched size after this. If this is the case then we
will attempt to set the new bit if the item&apos;s style requires stretching.

Later on when we get to the stretch alignment logic, then we will check
to see if this bit is set when stretching an item in the column axis and
its block axis is in the same direction. In other cases we will fall
back to the original logic.

In order to accomplish this I added GridLayoutState, which is a new
helper class that should help keep track of extra layout related
information as we perform grid layout. This is a stack based class so
it will be created at the beginning of layout and destroyed at the end.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/GridLayoutState.h: Added.
(WebCore::GridLayoutState::itemsLayoutRequirements):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithmStrategy::logicalHeightForChild const):
(WebCore::GridTrackSizingAlgorithm::setup):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::computeTrackSizesForDefiniteSize):
(WebCore::RenderGrid::repeatTracksSizingIfNeeded):
(WebCore::RenderGrid::canSetColumnAxisStretchRequirementForItem const):
(WebCore::RenderGrid::computeLayoutRequirementsForItemsBeforeLayout const):
(WebCore::RenderGrid::layoutGrid):
(WebCore::RenderGrid::layoutMasonry):
(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
(WebCore::RenderGrid::computeTrackSizesForIndefiniteSize const):
(WebCore::RenderGrid::updateGridAreaForAspectRatioItems):
(WebCore::RenderGrid::layoutGridItems):
(WebCore::RenderGrid::layoutMasonryItems):
(WebCore::RenderGrid::applyStretchAlignmentToChildIfNeeded):
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/281090@main">https://commits.webkit.org/281090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89694dd504a89402a0019943deee96ab4856026e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61835 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8655 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47170 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6183 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28003 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7623 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7659 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63540 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2124 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54489 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54544 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12975 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1820 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33367 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->