### PR TITLE
[ews] Add vision-wk2 queue trigger relationship

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/buildbot.py
+++ b/Tools/CISupport/ews-app/ews/common/buildbot.py
@@ -57,6 +57,7 @@ class Buildbot():
         'wpe-wk2': 'wpe',
         'wincairo-tests': 'wincairo',
         'jsc-armv7-tests': 'jsc-armv7',
+        'vision-sim': 'vision-wk2',
     }
 
     @classmethod


### PR DESCRIPTION
#### 947a010680139a63cee22eb357ccc30c445c86e2
<pre>
[ews] Add vision-wk2 queue trigger relationship
<a href="https://bugs.webkit.org/show_bug.cgi?id=276542">https://bugs.webkit.org/show_bug.cgi?id=276542</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-app/ews/common/buildbot.py:
(Buildbot):

Canonical link: <a href="https://commits.webkit.org/280911@main">https://commits.webkit.org/280911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7ef22ca7821008c4af8f14b3319fcd43efc0c08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37336 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/10485 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/61633 "Build was cancelled. Recent messages:Printed configuration") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/8453 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60136 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/44972 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/8642 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/61633 "Build was cancelled. Recent messages:Printed configuration") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/8453 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60038 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/44972 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/10485 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/61633 "Build was cancelled. Recent messages:Printed configuration") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/44972 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/10485 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7457 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/44972 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/10485 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/63321 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1922 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/8642 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/63321 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1929 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/10485 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/63321 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/1646 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79011 "Build is in progress. Recent messages:") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8651 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33165 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/79011 "Build is in progress. Recent messages:") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/34251 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35335 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/33996 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->