### PR TITLE
Speedup setting canvas colors from strings

### DIFF
--- a/Source/WebCore/css/color/CSSUnresolvedColorResolutionContext.h
+++ b/Source/WebCore/css/color/CSSUnresolvedColorResolutionContext.h
@@ -50,7 +50,7 @@ public:
 
 struct CSSUnresolvedColorResolutionContext {
     // Delegate for lazily computing color values.
-    std::unique_ptr<CSSUnresolvedColorResolutionDelegate> delegate = nullptr;
+    CSSUnresolvedColorResolutionDelegate* delegate = nullptr;
 
     // Whether links should be resolved to the visited style.
     Style::ForVisitedLink forVisitedLink = Style::ForVisitedLink::No;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp
@@ -868,12 +868,8 @@ Color consumeColorRaw(CSSParserTokenRange& range, const CSSParserContext& contex
 
 // MARK: - Raw parsing entry points
 
-Color parseColorRaw(const String& string, const CSSParserContext& context, const CSSColorParsingOptions& options, const CSSUnresolvedColorResolutionContext& eagerResolutionContext)
+Color parseColorRawSlow(const String& string, const CSSParserContext& context, const CSSColorParsingOptions& options, const CSSUnresolvedColorResolutionContext& eagerResolutionContext)
 {
-    bool strict = !isQuirksModeBehavior(context.mode);
-    if (auto color = CSSParserFastPaths::parseSimpleColor(string, strict))
-        return *color;
-
     CSSTokenizer tokenizer(string);
     CSSParserTokenRange range(tokenizer.tokenRange());
 


### PR DESCRIPTION
#### 567ebfd314d66058ab43964381737dd0ce12ea0d
<pre>
Speedup setting canvas colors from strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=276541">https://bugs.webkit.org/show_bug.cgi?id=276541</a>

Reviewed by Darin Adler.

Speedup the common case for setting canvas colors from strings by:

- Ensuring the common fast path (CSSParserFastPaths::parseSimpleColor) is
  called before any additional work is done to setup things like the eager
  resolution context.
- Remove the allocation of the eager resolution context by using it directly
  from the stack.

* Source/WebCore/css/color/CSSUnresolvedColorResolutionContext.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.cpp:
(WebCore::CSSPropertyParserHelpers::parseColorRawSlow):
(WebCore::CSSPropertyParserHelpers::parseColorRaw): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h:
(WebCore::CSSPropertyParserHelpers::parseColorRawSlow):
(WebCore::CSSPropertyParserHelpers::parseColorRaw):
* Source/WebCore/html/canvas/CanvasStyle.cpp:
(WebCore::CanvasStyleColorResolutionDelegate::currentColor const):
(WebCore::elementlessColorParsingParameters):
(WebCore::colorParsingParameters):
(WebCore::parseColor):

Canonical link: <a href="https://commits.webkit.org/280976@main">https://commits.webkit.org/280976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf2280b52dd2f08a199cef11f1a4e0081072082c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61844 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8664 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8858 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6190 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28012 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7632 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7668 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63549 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2133 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7965 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54498 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2141 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54553 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12869 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1827 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33376 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34462 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->