### PR TITLE
Crash under certificatesMatch()

### DIFF
--- a/Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp
@@ -37,20 +37,20 @@ bool certificatesMatch(SecTrustRef trust1, SecTrustRef trust2)
     if (!trust1 || !trust2)
         return false;
 
-    auto chain1 = adoptCF(SecTrustCopyCertificateChain(trust1));
-    auto chain2 = adoptCF(SecTrustCopyCertificateChain(trust2));
-    CFIndex count1 = CFArrayGetCount(chain1.get());
-    CFIndex count2 = CFArrayGetCount(chain2.get());
+    RetainPtr chain1 = adoptCF(SecTrustCopyCertificateChain(trust1));
+    RetainPtr chain2 = adoptCF(SecTrustCopyCertificateChain(trust2));
+    CFIndex count1 = chain1 ? CFArrayGetCount(chain1.get()) : 0;
+    CFIndex count2 = chain2 ? CFArrayGetCount(chain2.get()) : 0;
 
     if (count1 != count2)
         return false;
 
-    for (CFIndex i = 0; i < count1; i++) {
-        auto cert1 = CFArrayGetValueAtIndex(chain1.get(), i);
-        auto cert2 = CFArrayGetValueAtIndex(chain2.get(), i);
+    for (CFIndex i = 0; i < count1; ++i) {
+        RetainPtr cert1 = CFArrayGetValueAtIndex(chain1.get(), i);
+        RetainPtr cert2 = CFArrayGetValueAtIndex(chain2.get(), i);
         RELEASE_ASSERT(cert1);
         RELEASE_ASSERT(cert2);
-        if (!CFEqual(cert1, cert2))
+        if (!CFEqual(cert1.get(), cert2.get()))
             return false;
     }
 


### PR DESCRIPTION
#### aea44e3d502304293f74e3683e0b8fd22cddf82d
<pre>
Crash under certificatesMatch()
<a href="https://bugs.webkit.org/show_bug.cgi?id=276543">https://bugs.webkit.org/show_bug.cgi?id=276543</a>
<a href="https://rdar.apple.com/129903650">rdar://129903650</a>

Reviewed by Brady Eidson and Sihui Liu.

Null check certificate chain returned by `SecTrustCopyCertificateChain()`
before calling `CFArrayGetCount()` on it.

* Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp:
(WebCore::certificatesMatch):

Canonical link: <a href="https://commits.webkit.org/280915@main">https://commits.webkit.org/280915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ac8410b8dce9346ef33bea9689da50cbffcbd22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61635 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8455 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8644 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6022 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31779 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/7437 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7459 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7705 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63323 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1924 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54376 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1649 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8653 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33167 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->