### PR TITLE
[Navigation] Schedule navigate event until after back/forward/traverseTo

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7481,7 +7481,7 @@ imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-
 # General flakes, almost exclusively on mac-wk2-stress.
 imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-popstate.html [ Pass Timeout Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-url-censored.html [ Pass Failure ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames.html [ Failure Pass ]
+imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames.html [ Timeout ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-state-repeated-await.html [ Timeout Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download.html [ Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-detach-in-onnavigate.html [ Crash Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-same-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-same-doc-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for same-document navigation.back() and navigation.forward() assert_false: expected false got true
+PASS currententrychange fires for same-document navigation.back() and navigation.forward()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-back-forward-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-back-forward-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigate event destination.getState() on back/forward navigation assert_not_equals: got disallowed value undefined
+PASS navigate event destination.getState() on back/forward navigation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe-expected.txt
@@ -1,3 +1,5 @@
 
-NOTRUN entries() in an iframe must be updated after navigating back to a bfcached page Could have been BFCached but actually wasn't
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT entries() in an iframe must be updated after navigating back to a bfcached page Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames-expected.txt
@@ -1,6 +1,3 @@
+FAIL: Timed out waiting for notifyDone to be called
 
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigation.back() and navigation.forward() can navigate multiple frames Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/forward-to-pruned-entry-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/forward-to-pruned-entry-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL If forward pruning clobbers the target of a traverse, abort assert_unreached: navigateerror should not fire Reached unreachable code
+PASS If forward pruning clobbers the target of a traverse, abort
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-same-document-before-navigate-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-same-document-before-navigate-event-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL traverseTo() promise rejections when detaching an iframe before onnavigate (same-document) assert_unreached: navigate should not fire Reached unreachable code
+PASS traverseTo() promise rejections when detaching an iframe before onnavigate (same-document)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-repeated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-repeated-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Repeated navigation.traverseTo() with the same key assert_equals: committed promises must be equal expected object "[object Promise]" but got object "[object Promise]"
+PASS Repeated navigation.traverseTo() with the same key
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/currententrychange-before-popstate-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/currententrychange-before-popstate-intercept-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires before popstate for navigation.back() and navigation.forward() assert_false: expected false got true
+FAIL currententrychange fires before popstate for navigation.back() and navigation.forward() assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/same-document-away-and-back-navigation-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/same-document-away-and-back-navigation-api-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT entry.getState() behavior after navigating away using the navigation API, then back Test timed out
+PASS entry.getState() behavior after navigating away using the navigation API, then back
 

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -49,6 +49,7 @@ class SecurityOrigin;
 
 enum class NewLoadInProgress : bool { No, Yes };
 enum class ScheduleLocationChangeResult : uint8_t { Stopped, Completed, Started };
+enum class ScheduleHistoryNavigationResult : bool { Completed, Aborted };
 
 class NavigationScheduler final : public CanMakeCheckedPtr<NavigationScheduler> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
@@ -65,6 +66,7 @@ public:
     void scheduleFormSubmission(Ref<FormSubmission>&&);
     void scheduleRefresh(Document& initiatingDocument);
     void scheduleHistoryNavigation(int steps);
+    void scheduleHistoryNavigationByKey(const String&key, CompletionHandler<void(ScheduleHistoryNavigationResult)>&&);
     void schedulePageBlock(Document& originDocument);
 
     void startTimer();

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -317,7 +317,7 @@ Navigation::Result Navigation::navigate(const String& url, NavigateOptions&& opt
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#performing-a-navigation-api-traversal
-Navigation::Result Navigation::performTraversal(const String& key, Navigation::Options options, FrameLoadType loadType, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
+Navigation::Result Navigation::performTraversal(const String& key, Navigation::Options options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
     if (!window()->protectedDocument()->isFullyActive() || window()->document()->unloadCounter())
         return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::InvalidStateError, "Invalid state"_s);
@@ -335,12 +335,10 @@ Navigation::Result Navigation::performTraversal(const String& key, Navigation::O
     RefPtr apiMethodTracker = addUpcomingTrarveseAPIMethodTracker(WTFMove(committed), WTFMove(finished), key, options.info);
 
     // FIXME: 11. Let sourceSnapshotParams be the result of snapshotting source snapshot params given document.
-    // FIXME: 12. Append the following session history traversal steps to traversable
-
-    // FIXME: This is just a stub that loads a URL for now.
-    auto entry = findEntryByKey(key);
-    ASSERT(entry);
-    frame()->loader().loadItem(entry.value()->associatedHistoryItem(), &currentEntry()->associatedHistoryItem(), loadType, ShouldTreatAsContinuingLoad::No);
+    frame()->checkedNavigationScheduler()->scheduleHistoryNavigationByKey(key, [apiMethodTracker] (ScheduleHistoryNavigationResult result) {
+        if (result == ScheduleHistoryNavigationResult::Aborted)
+            createErrorResult(WTFMove(apiMethodTracker->committedPromise), WTFMove(apiMethodTracker->finishedPromise), ExceptionCode::AbortError, "Navigation aborted"_s);
+    });
 
     return apiMethodTrackerDerivedResult(*apiMethodTracker);
 }
@@ -364,7 +362,7 @@ Navigation::Result Navigation::traverseTo(const String& key, Options&& options, 
     if (!entry)
         return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::InvalidStateError, "Invalid key"_s);
 
-    return performTraversal(key, options, FrameLoadType::IndexedBackForward, WTFMove(committed), WTFMove(finished));
+    return performTraversal(key, options, WTFMove(committed), WTFMove(finished));
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-back
@@ -375,7 +373,7 @@ Navigation::Result Navigation::back(Options&& options, Ref<DeferredPromise>&& co
 
     Ref previousEntry = m_entries[m_currentEntryIndex.value() - 1];
 
-    return performTraversal(previousEntry->key(), options, FrameLoadType::Back, WTFMove(committed), WTFMove(finished));
+    return performTraversal(previousEntry->key(), options, WTFMove(committed), WTFMove(finished));
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-forward
@@ -386,7 +384,7 @@ Navigation::Result Navigation::forward(Options&& options, Ref<DeferredPromise>&&
 
     Ref nextEntry = m_entries[m_currentEntryIndex.value() + 1];
 
-    return performTraversal(nextEntry->key(), options, FrameLoadType::Forward, WTFMove(committed), WTFMove(finished));
+    return performTraversal(nextEntry->key(), options, WTFMove(committed), WTFMove(finished));
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-updatecurrententry

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -148,6 +148,8 @@ public:
 
     void abortOngoingNavigationIfNeeded();
 
+    std::optional<Ref<NavigationHistoryEntry>> findEntryByKey(const String& key);
+
 private:
     explicit Navigation(LocalDOMWindow&);
 
@@ -158,8 +160,7 @@ private:
     void derefEventTarget() final { deref(); }
 
     bool hasEntriesAndEventsDisabled() const;
-    Result performTraversal(const String& key, Navigation::Options, FrameLoadType, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
-    std::optional<Ref<NavigationHistoryEntry>> findEntryByKey(const String& key);
+    Result performTraversal(const String& key, Navigation::Options, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
     ExceptionOr<RefPtr<SerializedScriptValue>> serializeState(JSC::JSValue state);
     bool innerDispatchNavigateEvent(NavigationNavigationType, Ref<NavigationDestination>&&, const String& downloadRequestFilename, FormState* = nullptr, SerializedScriptValue* classicHistoryAPIState = nullptr);
 


### PR DESCRIPTION
#### 4735fd370a76616fd6d29dfdd5e1144a928cdb10
<pre>
[Navigation] Schedule navigate event until after back/forward/traverseTo
<a href="https://bugs.webkit.org/show_bug.cgi?id=276546">https://bugs.webkit.org/show_bug.cgi?id=276546</a>

Reviewed by Alex Christensen.

The traverse is supposed to use the session history traversal queue [1]. WebKit does not seem to have this data structure implemented, but
seeing history.back() etc. should work similarly as navigation.back(), we can emulate that and use NavigationScheduler, which puts the navigation
on a timer.

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#performing-a-navigation-api-traversal">https://html.spec.whatwg.org/multipage/nav-history-apis.html#performing-a-navigation-api-traversal</a> (Step 12)

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-same-doc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-back-forward-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/forward-to-pruned-entry-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-detach-same-document-before-navigate-event-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-repeated-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/currententrychange-before-popstate-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/same-document-away-and-back-navigation-api-expected.txt:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledHistoryNavigationByKey::ScheduledHistoryNavigationByKey):
(WebCore::ScheduledHistoryNavigationByKey::~ScheduledHistoryNavigationByKey):
(WebCore::NavigationScheduler::scheduleHistoryNavigationByKey):
* Source/WebCore/loader/NavigationScheduler.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::performTraversal):
(WebCore::Navigation::traverseTo):
(WebCore::Navigation::back):
(WebCore::Navigation::forward):
(WebCore::Navigation::abortOngoingNavigation):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/282699@main">https://commits.webkit.org/282699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3782d8de987c13955c911449b99327190b1da55f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14598 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51534 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10081 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32153 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12769 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13471 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58759 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69711 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58854 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59001 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14150 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6587 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39167 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40246 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->