### PR TITLE
Deprecate injected bundle frame access interfaces

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h
@@ -66,7 +66,7 @@ WK_EXPORT void WKBundlePageSetPolicyClient(WKBundlePageRef page, WKBundlePagePol
 WK_EXPORT void WKBundlePageSetUIClient(WKBundlePageRef page, WKBundlePageUIClientBase* client);
 WK_EXPORT void WKBundlePageSetFullScreenClient(WKBundlePageRef page, WKBundlePageFullScreenClientBase* client);
 
-WK_EXPORT WKBundleFrameRef WKBundlePageGetMainFrame(WKBundlePageRef page);
+WK_EXPORT WKBundleFrameRef WKBundlePageGetMainFrame(WKBundlePageRef page) WK_C_API_DEPRECATED_WITH_MESSAGE("With site isolation, the main frame is not necessarily local to the current bundle process.");
 WK_EXPORT WKFrameHandleRef WKBundleFrameCreateFrameHandle(WKBundleFrameRef);
 
 WK_EXPORT WKBundleBackForwardListRef WKBundlePageGetBackForwardList(WKBundlePageRef page) WK_C_API_DEPRECATED;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -875,6 +875,7 @@ const gchar* webkit_web_page_get_uri(WebKitWebPage* webPage)
  * Returns: (transfer none): the #WebKitFrame that is the main frame of @web_page
  *
  * Since: 2.2
+ * Deprecated: 2.46
  */
 WebKitFrame* webkit_web_page_get_main_frame(WebKitWebPage* webPage)
 {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.h.in
@@ -93,7 +93,7 @@ webkit_web_page_get_id                      (WebKitWebPage *web_page);
 WEBKIT_API const gchar *
 webkit_web_page_get_uri                     (WebKitWebPage *web_page);
 
-WEBKIT_API WebKitFrame *
+WEBKIT_DEPRECATED WebKitFrame *
 webkit_web_page_get_main_frame              (WebKitWebPage *web_page);
 
 WEBKIT_API WebKitWebEditor *

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.h
@@ -39,7 +39,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 
 @property (readonly) WKDOMRange *selectedRange;
 
-@property (readonly) WKWebProcessPlugInFrame *mainFrame;
+@property (readonly) WKWebProcessPlugInFrame *mainFrame WK_API_DEPRECATED("With site isolation, the main frame is not necessarily local to the current bundle process.", macos(10.10, WK_MAC_TBA), ios(8.0, WK_IOS_TBA));
 
 @property (weak) id <WKWebProcessPlugInLoadDelegate> loadDelegate;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebArchive_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebArchive_Bundle.cpp
@@ -57,8 +57,10 @@ void WebArchiveTest::didReceiveMessage(WKBundleRef bundle, WKStringRef messageNa
 
     if (WKGetTypeID(body) != WKBundlePageGetTypeID())
         return;
-    
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WKBundleFrameRef frame = WKBundlePageGetMainFrame(static_cast<WKBundlePageRef>(body));
+    ALLOW_DEPRECATED_DECLARATIONS_END
     if (!frame)
         return;
     WKBundlePostMessage(bundle, Util::toWK("DidGetWebArchive").get(), adoptWK(WKBundleFrameCopyWebArchive(frame)).get());

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/DOMElementTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/DOMElementTest.cpp
@@ -30,7 +30,9 @@ public:
 private:
     bool testAutoFill(WebKitWebPage* page)
     {
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
         WebKitFrame* frame = webkit_web_page_get_main_frame(page);
+        G_GNUC_END_IGNORE_DEPRECATIONS
         g_assert_true(WEBKIT_IS_FRAME(frame));
 
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(frame));

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/EditorTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/EditorTest.cpp
@@ -40,7 +40,9 @@ private:
         s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(editor));
         g_signal_connect_swapped(editor, "selection-changed", G_CALLBACK(selectionChangedCallback), &selectionChanged);
 
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(webkit_web_page_get_main_frame(page)));
+        G_GNUC_END_IGNORE_DEPRECATIONS
         g_assert_true(JSC_IS_CONTEXT(jsContext.get()));
         s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp
@@ -30,7 +30,9 @@ public:
 private:
     bool testMainFrame(WebKitWebPage* page)
     {
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
         WebKitFrame* frame = webkit_web_page_get_main_frame(page);
+        G_GNUC_END_IGNORE_DEPRECATIONS
         g_assert_true(WEBKIT_IS_FRAME(frame));
         g_assert_true(webkit_frame_is_main_frame(frame));
 
@@ -39,7 +41,9 @@ private:
 
     bool testURI(WebKitWebPage* page)
     {
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
         WebKitFrame* frame = webkit_web_page_get_main_frame(page);
+        G_GNUC_END_IGNORE_DEPRECATIONS
         g_assert_true(WEBKIT_IS_FRAME(frame));
         g_assert_cmpstr(webkit_web_page_get_uri(page), ==, webkit_frame_get_uri(frame));
 
@@ -48,7 +52,9 @@ private:
 
     bool testJavaScriptContext(WebKitWebPage* page)
     {
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
         WebKitFrame* frame = webkit_web_page_get_main_frame(page);
+        G_GNUC_END_IGNORE_DEPRECATIONS
         g_assert_true(WEBKIT_IS_FRAME(frame));
 #if PLATFORM(GTK) && !USE(GTK4)
         G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
@@ -65,7 +71,9 @@ private:
 
     bool testJavaScriptValues(WebKitWebPage* page)
     {
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
         WebKitFrame* frame = webkit_web_page_get_main_frame(page);
+        G_GNUC_END_IGNORE_DEPRECATIONS
         g_assert_true(WEBKIT_IS_FRAME(frame));
 
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(frame));
@@ -144,7 +152,9 @@ private:
 
     bool testSubframe(WebKitWebPage* page)
     {
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
         WebKitFrame* mainFrame = webkit_web_page_get_main_frame(page);
+        G_GNUC_END_IGNORE_DEPRECATIONS
         g_assert_true(WEBKIT_IS_FRAME(mainFrame));
 
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(mainFrame));

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessExtensionTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessExtensionTest.cpp
@@ -195,7 +195,9 @@ static void emitURIChanged(GDBusConnection* connection, const char* uri)
 
 static void uriChangedCallback(WebKitWebPage* webPage, GParamSpec* pspec, WebKitWebProcessExtension* extension)
 {
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     WebKitFrame* frame = webkit_web_page_get_main_frame(webPage);
+    G_GNUC_END_IGNORE_DEPRECATIONS
     g_assert_true(WEBKIT_IS_FRAME(frame));
     g_assert_true(webkit_frame_is_main_frame(frame));
     g_assert_cmpstr(webkit_web_page_get_uri(webPage), ==, webkit_frame_get_uri(frame));
@@ -322,7 +324,9 @@ static void consoleMessageSentCallback(WebKitWebPage* webPage, WebKitConsoleMess
         webkit_console_message_get_level(consoleMessage), webkit_console_message_get_text(consoleMessage),
         webkit_console_message_get_line(consoleMessage), webkit_console_message_get_source_id(consoleMessage));
     GUniquePtr<char> messageString(g_variant_print(variant.get(), FALSE));
+    G_GNUC_BEGIN_IGNORE_DEPRECATIONS
     GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(webkit_web_page_get_main_frame(webPage)));
+    G_GNUC_END_IGNORE_DEPRECATIONS
     GRefPtr<JSCValue> console = adoptGRef(jsc_context_evaluate(jsContext.get(), "window.webkit.messageHandlers.console", -1));
     g_assert_true(JSC_IS_VALUE(console.get()));
     if (jsc_value_is_object(console.get())) {
@@ -646,7 +650,9 @@ static void methodCallCallback(GDBusConnection* connection, const char* sender, 
         if (!page)
             return;
 
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(webkit_web_page_get_main_frame(page)));
+        G_GNUC_END_IGNORE_DEPRECATIONS
         GRefPtr<JSCValue> titleValue = adoptGRef(jsc_context_evaluate(jsContext.get(), "document.title", -1));
         GUniquePtr<char> title(jsc_value_to_string(titleValue.get()));
         g_dbus_method_invocation_return_value(invocation, g_variant_new("(s)", title.get()));
@@ -658,7 +664,9 @@ static void methodCallCallback(GDBusConnection* connection, const char* sender, 
         if (!page)
             return;
 
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
         WebKitFrame* frame = webkit_web_page_get_main_frame(page);
+        G_GNUC_END_IGNORE_DEPRECATIONS
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(frame));
         GRefPtr<JSCValue> jsDocument = adoptGRef(jsc_context_get_value(jsContext.get(), "document"));
         GRefPtr<JSCValue> jsInputElement = adoptGRef(jsc_value_object_invoke_method(jsDocument.get(), "getElementById", G_TYPE_STRING, elementID, G_TYPE_NONE));
@@ -675,7 +683,9 @@ static void methodCallCallback(GDBusConnection* connection, const char* sender, 
         GRefPtr<WebKitScriptWorld> world = adoptGRef(webkit_script_world_new());
         g_assert_true(webkit_script_world_get_default() != world.get());
         g_assert_true(g_str_has_prefix(webkit_script_world_get_name(world.get()), "UniqueWorld_"));
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
         WebKitFrame* frame = webkit_web_page_get_main_frame(page);
+        G_GNUC_END_IGNORE_DEPRECATIONS
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context_for_script_world(frame, world.get()));
         GRefPtr<JSCValue> result = adoptGRef(jsc_context_evaluate(jsContext.get(), script, -1));
         g_dbus_method_invocation_return_value(invocation, 0);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -113,7 +113,9 @@ static WTF::String dumpPath(WKBundlePageRef page, WKBundleScriptWorldRef world, 
     if (!node)
         return "(null)"_s;
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WKBundleFrameRef frame = WKBundlePageGetMainFrame(page);
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     JSGlobalContextRef context = WKBundleFrameGetJavaScriptContextForWorld(frame, world);
     JSValueRef nodeValue = WKBundleFrameGetJavaScriptWrapperForNodeForWorld(frame, node, world);
@@ -128,7 +130,9 @@ static WTF::String string(WKBundlePageRef page, WKBundleScriptWorldRef world, WK
     if (!rangeRef)
         return "(null)"_s;
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     auto frame = WKBundlePageGetMainFrame(page);
+    ALLOW_DEPRECATED_DECLARATIONS_END
     auto context = WKBundleFrameGetJavaScriptContextForWorld(frame, world);
     auto rangeValue = WKBundleFrameGetJavaScriptWrapperForRangeForWorld(frame, rangeRef, world);
     ASSERT(JSValueIsObject(context, rangeValue));
@@ -183,7 +187,9 @@ WTF::String pathSuitableForTestResult(WKURLRef fileURL)
     if (!isLocalFileScheme(schemeString.get()))
         return toWTFString(adoptWK(WKURLCopyString(fileURL)));
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(InjectedBundle::singleton().page()->page());
+    ALLOW_DEPRECATED_DECLARATIONS_END
     auto mainFrameURL = adoptWK(WKBundleFrameCopyURL(mainFrame));
     if (!mainFrameURL)
         mainFrameURL = adoptWK(WKBundleFrameCopyProvisionalURL(mainFrame));
@@ -353,7 +359,9 @@ void InjectedBundlePage::prepare()
     
     WKBundleClearHistoryForTesting(m_page);
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WKBundleFrameClearOpener(WKBundlePageGetMainFrame(m_page));
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     WKBundlePageSetTracksRepaints(m_page, false);
     
@@ -364,7 +372,9 @@ void InjectedBundlePage::prepare()
 
 void InjectedBundlePage::resetAfterTest()
 {
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WKBundleFrameRef frame = WKBundlePageGetMainFrame(m_page);
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     // WebKit currently doesn't reset focus even when navigating to a new page. This may or may not be a bug
     // (see <https://bugs.webkit.org/show_bug.cgi?id=138334>), however for tests, we want to start each one with a clean state.
@@ -684,7 +694,9 @@ static void dumpDescendantFrameScrollPositions(WKBundleFrameRef frame, StringBui
 
 void InjectedBundlePage::dumpAllFrameScrollPositions(StringBuilder& stringBuilder)
 {
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WKBundleFrameRef frame = WKBundlePageGetMainFrame(m_page);
+    ALLOW_DEPRECATED_DECLARATIONS_END
     dumpFrameScrollPosition(frame, stringBuilder);
     dumpDescendantFrameScrollPositions(frame, stringBuilder);
 }
@@ -720,7 +732,9 @@ void InjectedBundlePage::dump(bool forceRepaint)
     }
     WKBundlePageFlushPendingEditorStateUpdate(m_page);
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WKBundleFrameRef frame = WKBundlePageGetMainFrame(m_page);
+    ALLOW_DEPRECATED_DECLARATIONS_END
     auto urlRef = adoptWK(WKBundleFrameCopyURL(frame));
     if (!urlRef)
         return;
@@ -756,8 +770,11 @@ void InjectedBundlePage::dump(bool forceRepaint)
 
     if (testRunner->shouldDumpAllFrameScrollPositions())
         dumpAllFrameScrollPositions(stringBuilder);
-    else if (testRunner->shouldDumpMainFrameScrollPosition())
+    else if (testRunner->shouldDumpMainFrameScrollPosition()) {
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         dumpFrameScrollPosition(WKBundlePageGetMainFrame(m_page), stringBuilder);
+        ALLOW_DEPRECATED_DECLARATIONS_END
+    }
 
     if (testRunner->shouldDumpBackForwardListsForAllWindows())
         injectedBundle.dumpBackForwardListsForAllPages(stringBuilder);
@@ -766,7 +783,9 @@ void InjectedBundlePage::dump(bool forceRepaint)
         bool shouldCreateSnapshot = testRunner->isPrinting();
         if (shouldCreateSnapshot) {
             WKSnapshotOptions options = kWKSnapshotOptionsShareable;
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             WKRect snapshotRect = WKBundleFrameGetVisibleContentBounds(WKBundlePageGetMainFrame(m_page));
+            ALLOW_DEPRECATED_DECLARATIONS_END
 
             if (testRunner->isPrinting())
                 options |= kWKSnapshotOptionsPrinting;
@@ -992,7 +1011,9 @@ WKURLRequestRef InjectedBundlePage::willSendRequestForFrame(WKBundlePageRef page
         && !isLocalHost(host.get())) {
         bool mainFrameIsExternal = false;
         if (injectedBundle.isTestRunning()) {
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(m_page);
+            ALLOW_DEPRECATED_DECLARATIONS_END
             auto mainFrameURL = adoptWK(WKBundleFrameCopyURL(mainFrame));
             if (!mainFrameURL || WKStringIsEqualToUTF8CString(adoptWK(WKURLCopyString(mainFrameURL.get())).get(), "about:blank"))
                 mainFrameURL = adoptWK(WKBundleFrameCopyProvisionalURL(mainFrame));
@@ -1660,7 +1681,9 @@ String InjectedBundlePage::platformResponseMimeType(WKURLResponseRef)
 
 static bool hasTestWaitAttribute(WKBundlePageRef page)
 {
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     auto frame = WKBundlePageGetMainFrame(page);
+    ALLOW_DEPRECATED_DECLARATIONS_END
     return frame && hasTestWaitAttribute(WKBundleFrameGetJavaScriptContext(frame));
 }
 
@@ -1720,8 +1743,10 @@ void InjectedBundlePage::frameDidChangeLocation(WKBundleFrameRef frame)
         return;
     }
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (auto frame = WKBundlePageGetMainFrame(page->page()))
         sendTestRenderedEvent(WKBundleFrameGetJavaScriptContext(frame));
+    ALLOW_DEPRECATED_DECLARATIONS_END
     dumpAfterWaitAttributeIsRemoved(page->page());
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -246,7 +246,9 @@ void TestRunner::notifyDone()
     if (!injectedBundle.isTestRunning())
         return;
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     bool mainFrameIsRemote = WKBundleFrameIsRemote(WKBundlePageGetMainFrame(injectedBundle.pageRef()));
+    ALLOW_DEPRECATED_DECLARATIONS_END
     if (mainFrameIsRemote) {
         setWaitUntilDone(false);
         return postPageMessage("NotifyDone");

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityNotificationHandler.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityNotificationHandler.cpp
@@ -45,7 +45,9 @@ AccessibilityNotificationHandler::AccessibilityNotificationHandler(JSValueRef ca
 {
     WKAccessibilityEnable();
 #if ENABLE(DEVELOPER_MODE)
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(InjectedBundle::singleton().page()->page());
+    ALLOW_DEPRECATED_DECLARATIONS_END
     JSContextRef jsContext = WKBundleFrameGetJavaScriptContext(mainFrame);
     JSValueProtect(jsContext, m_callback);
 
@@ -53,7 +55,9 @@ AccessibilityNotificationHandler::AccessibilityNotificationHandler(JSValueRef ca
         if (m_element && m_element.get() != &element)
             return;
 
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(InjectedBundle::singleton().page()->page());
+        ALLOW_DEPRECATED_DECLARATIONS_END
         JSContextRef jsContext = WKBundleFrameGetJavaScriptContext(mainFrame);
 
         JSRetainPtr<JSStringRef> jsNotificationEventName(Adopt, JSStringCreateWithUTF8CString(notificationName));
@@ -98,7 +102,9 @@ AccessibilityNotificationHandler::~AccessibilityNotificationHandler()
 #if ENABLE(DEVELOPER_MODE)
     WebCore::AccessibilityAtspi::singleton().removeNotificationObserver(this);
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(InjectedBundle::singleton().page()->page());
+    ALLOW_DEPRECATED_DECLARATIONS_END
     JSContextRef jsContext = WKBundleFrameGetJavaScriptContext(mainFrame);
     JSValueUnprotect(jsContext, m_callback);
 #endif


### PR DESCRIPTION
#### 5fa09b4d3b192cb25cff5aad2f8fe41c3210dad5
<pre>
Deprecate injected bundle frame access interfaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=276554">https://bugs.webkit.org/show_bug.cgi?id=276554</a>
<a href="https://rdar.apple.com/131635665">rdar://131635665</a>

Reviewed by Carlos Garcia Campos.

With site isolation, even the main frame might not be in the current process if the current process
is the process hosting cross-site iframe content.  WKBundleFrameGetParentFrame and WKBundleFrameCopyChildFrames
are already deprecated, but this needs to be done too.  It would be nice to deprecate
webkit_web_page_get_main_frame as well, but I don&apos;t maintain that API.  I&apos;ll bring it up in the mailing list.

* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h:
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.h:

Canonical link: <a href="https://commits.webkit.org/281688@main">https://commits.webkit.org/281688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f838adbca034ed84802f2bd0eaf615615a93a8d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64458 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11074 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48969 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7700 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29801 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33846 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9665 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9987 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55718 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66188 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4470 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9775 "layout-tests (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56336 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56507 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3708 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9122 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35694 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36776 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37867 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36521 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->