### PR TITLE
MobileSafari hangs for 2.6 to 5.2 seconds in WebKit::WebExtensionWindow::tabs(WebKit::WebExtensionWindow::SkipValidation) const.

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -382,7 +382,7 @@ WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFCrashWithSecurityImplication(v
 #if ENABLE(SECURITY_ASSERTIONS)
 #define ASSERT_NOT_REACHED_WITH_SECURITY_IMPLICATION(...) CRASH_WITH_SECURITY_IMPLICATION_AND_INFO(__VA_ARGS__)
 #define ASSERT_WITH_SECURITY_IMPLICATION(assertion) \
-    (!(assertion) ? \
+    (UNLIKELY(!(assertion)) ? \
         (WTFReportAssertionFailure(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #assertion), \
          CRASH_WITH_SECURITY_IMPLICATION()) : \
         (void)0)
@@ -399,7 +399,7 @@ WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFCrashWithSecurityImplication(v
 #else /* ASSERT_ENABLED */
 
 #define ASSERT(assertion, ...) do { \
-    if (!(assertion)) { \
+    if (UNLIKELY(!(assertion))) { \
         WTFReportAssertionFailure(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #assertion); \
         BACKTRACE(); \
         CRASH_WITH_INFO(__VA_ARGS__); \
@@ -407,7 +407,7 @@ WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFCrashWithSecurityImplication(v
 } while (0)
 
 #define ASSERT_UNDER_CONSTEXPR_CONTEXT(assertion) do { \
-    if (!(assertion)) { \
+    if (UNLIKELY(!(assertion))) { \
         WTFReportAssertionFailure(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #assertion); \
         if (!std::is_constant_evaluated()) \
             BACKTRACE(); \
@@ -416,7 +416,7 @@ WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFCrashWithSecurityImplication(v
 } while (0)
 
 #define ASSERT_AT(assertion, file, line, function) do { \
-    if (!(assertion)) { \
+    if (UNLIKELY(!(assertion))) { \
         WTFReportAssertionFailure(file, line, function, #assertion); \
         BACKTRACE(); \
         CRASH(); \
@@ -448,7 +448,7 @@ WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFCrashWithSecurityImplication(v
 } while (0)
 
 #define ASSERT_IMPLIES(condition, assertion) do { \
-    if ((condition) && !(assertion)) { \
+    if (UNLIKELY((condition) && !(assertion))) { \
         WTFReportAssertionFailure(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #condition " => " #assertion); \
         BACKTRACE(); \
         CRASH(); \
@@ -469,7 +469,7 @@ WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFCrashWithSecurityImplication(v
  
 */
 #define ASSERT_WITH_SECURITY_IMPLICATION(assertion) do { \
-    if (!(assertion)) { \
+    if (UNLIKELY(!(assertion))) { \
         WTFReportAssertionFailure(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #assertion); \
         BACKTRACE(); \
         CRASH_WITH_SECURITY_IMPLICATION(); \
@@ -485,7 +485,7 @@ WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFCrashWithSecurityImplication(v
 #define ASSERT_WITH_MESSAGE(assertion, ...) ((void)0)
 #else
 #define ASSERT_WITH_MESSAGE(assertion, ...) do { \
-    if (!(assertion)) { \
+    if (UNLIKELY(!(assertion))) { \
         WTFReportAssertionFailureWithMessage(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #assertion, __VA_ARGS__); \
         BACKTRACE(); \
         CRASH(); \
@@ -504,7 +504,7 @@ constexpr bool assertionFailureDueToUnreachableCode = false;
 #define ASSERT_WITH_MESSAGE_UNUSED(variable, assertion, ...) ((void)variable)
 #else
 #define ASSERT_WITH_MESSAGE_UNUSED(variable, assertion, ...) do { \
-    if (!(assertion)) { \
+    if (UNLIKELY(!(assertion))) { \
         WTFReportAssertionFailureWithMessage(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #assertion, __VA_ARGS__); \
         BACKTRACE(); \
         CRASH(); \
@@ -522,7 +522,7 @@ constexpr bool assertionFailureDueToUnreachableCode = false;
 #else
 
 #define ASSERT_ARG(argName, assertion) do { \
-    if (!(assertion)) { \
+    if (UNLIKELY(!(assertion))) { \
         WTFReportArgumentAssertionFailure(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #argName, #assertion); \
         BACKTRACE(); \
         CRASH(); \
@@ -622,7 +622,7 @@ constexpr bool assertionFailureDueToUnreachableCode = false;
 #define RELEASE_LOG_DEBUG(channel, ...) ((void)0)
 
 #define RELEASE_LOG_IF(isAllowed, channel, ...) ((void)0)
-#define RELEASE_LOG_ERROR_IF(isAllowed, channel, ...) do { if (isAllowed) RELEASE_LOG_ERROR(channel, __VA_ARGS__); } while (0)
+#define RELEASE_LOG_ERROR_IF(isAllowed, channel, ...) do { if (UNLIKELY(isAllowed)) RELEASE_LOG_ERROR(channel, __VA_ARGS__); } while (0)
 #define RELEASE_LOG_INFO_IF(isAllowed, channel, ...) ((void)0)
 #define RELEASE_LOG_DEBUG_IF(isAllowed, channel, ...) ((void)0)
 
@@ -706,9 +706,9 @@ constexpr bool assertionFailureDueToUnreachableCode = false;
 
 #if !RELEASE_LOG_DISABLED
 #define RELEASE_LOG_IF(isAllowed, channel, ...) do { if (isAllowed) RELEASE_LOG(channel, __VA_ARGS__); } while (0)
-#define RELEASE_LOG_ERROR_IF(isAllowed, channel, ...) do { if (isAllowed) RELEASE_LOG_ERROR(channel, __VA_ARGS__); } while (0)
-#define RELEASE_LOG_INFO_IF(isAllowed, channel, ...) do { if (isAllowed) RELEASE_LOG_INFO(channel, __VA_ARGS__); } while (0)
-#define RELEASE_LOG_DEBUG_IF(isAllowed, channel, ...) do { if (isAllowed) RELEASE_LOG_DEBUG(channel, __VA_ARGS__); } while (0)
+#define RELEASE_LOG_ERROR_IF(isAllowed, channel, ...) do { if (UNLIKELY(isAllowed)) RELEASE_LOG_ERROR(channel, __VA_ARGS__); } while (0)
+#define RELEASE_LOG_INFO_IF(isAllowed, channel, ...) do { if (UNLIKELY(isAllowed)) RELEASE_LOG_INFO(channel, __VA_ARGS__); } while (0)
+#define RELEASE_LOG_DEBUG_IF(isAllowed, channel, ...) do { if (UNLIKELY(isAllowed)) RELEASE_LOG_DEBUG(channel, __VA_ARGS__); } while (0)
 #endif
 
 /* ALWAYS_LOG */

--- a/Source/WTF/wtf/WeakObjCPtr.h
+++ b/Source/WTF/wtf/WeakObjCPtr.h
@@ -82,8 +82,8 @@ public:
         return *this;
     }
 
-    bool operator!() const { return !get(); }
-    explicit operator bool() const { return !!get(); }
+    bool operator!() const { return !getAutoreleased(); }
+    explicit operator bool() const { return !!getAutoreleased(); }
 
     RetainPtr<ValueType> get() const;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -720,7 +720,7 @@ static inline WebKit::WebExtensionContext::TabSet toImpl(NSSet<id<_WKWebExtensio
     WebKit::WebExtensionContext::TabSet result;
     result.reserveInitialCapacity(tabs.count);
 
-    for (id<_WKWebExtensionTab> tab in tabs) {
+    for (id tab in tabs) {
         NSCParameterAssert([tab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
         result.addVoid(context.getOrCreateTab(tab));
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -108,8 +108,6 @@ void WebExtensionContext::runtimeOpenOptionsPage(CompletionHandler<void(Expected
             return;
         }
 
-        THROW_UNLESS([newTab conformsToProtocol:@protocol(_WKWebExtensionTab)], @"Object returned by webExtensionController:openNewTabWithOptions:forExtensionContext:completionHandler: does not conform to the _WKWebExtensionTab protocol");
-
         completionHandler({ });
     }).get()];
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -110,8 +110,6 @@ void WebExtensionContext::tabsCreate(std::optional<WebPageProxyIdentifier> webPa
             return;
         }
 
-        THROW_UNLESS([newTab conformsToProtocol:@protocol(_WKWebExtensionTab)], @"Object returned by webExtensionController:openNewTabWithOptions:forExtensionContext:completionHandler: does not conform to the _WKWebExtensionTab protocol");
-
         completionHandler({ getOrCreateTab(newTab)->parameters() });
     }).get()];
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
@@ -113,10 +113,7 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
             return;
         }
 
-        THROW_UNLESS([newWindow conformsToProtocol:@protocol(_WKWebExtensionWindow)], @"Object returned by webExtensionController:openNewWindowWithOptions:forExtensionContext:completionHandler: does not conform to the _WKWebExtensionWindow protocol");
-
         RefPtr window = getOrCreateWindow(newWindow);
-
         completionHandler(window->extensionHasAccess() ? std::optional(window->parameters()) : std::nullopt);
     }).get()];
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
@@ -58,7 +58,6 @@ WebExtensionWindow::WebExtensionWindow(const WebExtensionContext& context, _WKWe
     , m_respondsToFocus([delegate respondsToSelector:@selector(focusForWebExtensionContext:completionHandler:)])
     , m_respondsToClose([delegate respondsToSelector:@selector(closeForWebExtensionContext:completionHandler:)])
 {
-    ASSERT([delegate conformsToProtocol:@protocol(_WKWebExtensionWindow)]);
 }
 
 WebExtensionContext* WebExtensionWindow::extensionContext() const
@@ -158,23 +157,20 @@ bool WebExtensionWindow::extensionHasAccess() const
 
 WebExtensionWindow::TabVector WebExtensionWindow::tabs(SkipValidation skipValidation) const
 {
-    TabVector result;
-
     if (!isValid() || !m_respondsToTabs || !m_respondsToActiveTab)
-        return result;
+        return { };
 
     auto *tabs = [m_delegate tabsForWebExtensionContext:m_extensionContext->wrapper()];
     THROW_UNLESS([tabs isKindOfClass:NSArray.class], @"Object returned by tabsForWebExtensionContext: is not an array");
 
     if (!tabs.count)
-        return result;
+        return { };
 
+    TabVector result;
     result.reserveInitialCapacity(tabs.count);
 
-    for (id<_WKWebExtensionTab> tab in tabs) {
-        THROW_UNLESS([tab conformsToProtocol:@protocol(_WKWebExtensionTab)], @"Object in array returned by tabsForWebExtensionContext: does not conform to the _WKWebExtensionTab protocol");
+    for (id tab in tabs)
         result.append(m_extensionContext->getOrCreateTab(tab));
-    }
 
     if (skipValidation == SkipValidation::No) {
         // SkipValidation::Yes is needed to avoid reentry, since activeTab() calls tabs().
@@ -197,8 +193,6 @@ RefPtr<WebExtensionTab> WebExtensionWindow::activeTab(SkipValidation skipValidat
     auto activeTab = [m_delegate activeTabForWebExtensionContext:m_extensionContext->wrapper()];
     if (!activeTab)
         return nullptr;
-
-    THROW_UNLESS([activeTab conformsToProtocol:@protocol(_WKWebExtensionTab)], @"Object returned by activeTabForWebExtensionContext: does not conform to the _WKWebExtensionTab protocol");
 
     Ref result = m_extensionContext->getOrCreateTab(activeTab);
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -30,7 +30,6 @@
 #include "APIObject.h"
 #include "CocoaImage.h"
 #include <wtf/Forward.h>
-#include <wtf/WeakObjCPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -589,7 +589,12 @@ private:
 
     void performTasksAfterBackgroundContentLoads();
 
+#ifdef NDEBUG
+    // This is method is a no-op in release builds since it has a performance impact with little benefit to release builds.
+    void reportWebViewConfigurationErrorIfNeeded(const WebExtensionTab&) const { };
+#else
     void reportWebViewConfigurationErrorIfNeeded(const WebExtensionTab&) const;
+#endif
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     URL inspectorBackgroundPageURL() const;


### PR DESCRIPTION
#### d7c940fc0a09e4cfbc249ad1c62e2d7e2da1430a
<pre>
MobileSafari hangs for 2.6 to 5.2 seconds in WebKit::WebExtensionWindow::tabs(WebKit::WebExtensionWindow::SkipValidation) const.
<a href="https://webkit.org/b/276552">https://webkit.org/b/276552</a>
<a href="https://rdar.apple.com/131567261">rdar://131567261</a>

Reviewed by Brian Weinstein.

Reduced amount of time spent in web extension classes by removing all internal `conformsToProtocol:`
checks. This saves 31.78% of time spent. We still do protocol checks at the API entry points. All the
methods in these protocols are optional, and we have `respondsToSelector:` checks that are cached.

Removed expensive checks in release builds for the web view configuration of tabs every time we get
a `WebExtensionTab`. This saves 23.69% of time spent. This method is still helpful and used in debug
builds for catching misconfiguration issues.

Stopped making a throw-away `RetainPtr` when checking a `WeakObjCPtr` as a `bool`. This saves 6.7% of
time spent. We can use `getAutoreleased()` instead when converting the raw pointer value to `bool`.
This was happening in all the `WebExtensionWindow` and `WebExtensionTab` methods that do `isValid()`
checks at the beginning of the method.

Adopted `UNLIKELY()` in uncommon code branches, logging macros, and assertions to help the compiler
optimize these paths better in release builds.

In total, this change removes 62.18% of time spent and should be at least 2.64x faster.

* Source/WTF/wtf/Assertions.h: Use UNLIKELY() in more cases.
* Source/WTF/wtf/WeakObjCPtr.h:
(WTF::WeakObjCPtr::operator! const): Use getAutoreleased() to avoid making a throw-away RetainPtr.
(WTF::WeakObjCPtr::operator bool const): Ditto.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(toImpl): Drive-by to simplify loop type that will be renamed soon.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeOpenOptionsPage): Removed conformsToProtocol: check.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsCreate): Removed conformsToProtocol: check.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsCreate): Removed conformsToProtocol: check.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::getWindow const): Adopt UNLIKELY() and remove conformsToProtocol:.
(WebKit::WebExtensionContext::getTab const): Ditto.
(WebKit::WebExtensionContext::getCurrentTab const): Ditto.
(WebKit::WebExtensionContext::populateWindowsAndTabs): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::WebExtensionTab): Removed conformsToProtocol: check.
(WebKit::WebExtensionTab::window const): Ditto.
(WebKit::WebExtensionTab::parentTab const): Ditto.
(WebKit::WebExtensionTab::mainWebView const): Reduce property access with variables.
(WebKit::WebExtensionTab::duplicate): Removed conformsToProtocol: check.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::WebExtensionWindow::WebExtensionWindow): Removed conformsToProtocol: check.
(WebKit::WebExtensionWindow::tabs const): Ditto.
(WebKit::WebExtensionWindow::activeTab const): Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::reportWebViewConfigurationErrorIfNeeded const): Made a no-op in release
builds since it has a performance impact with little benefit to release builds.

Canonical link: <a href="https://commits.webkit.org/280925@main">https://commits.webkit.org/280925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1d653fcc313cbcb7787b4fc86d69d8a28860696

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61668 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/8488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8677 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47032 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/8488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35045 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/50174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/27864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31809 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/7469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7492 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/51135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53757 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/7737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/63367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57285 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1957 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/63367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50185 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/63367 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1678 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79046 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8657 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13122 "Found 1 new JSC stress test failure: stress/proxy-set.js.mini-mode (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34286 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->