### PR TITLE
[watchOS] Quickboard input view controller should have non-empty fallback text for unlabeled text fields

### DIFF
--- a/LayoutTests/fast/forms/watchos/form-control-label-text-expected.txt
+++ b/LayoutTests/fast/forms/watchos/form-control-label-text-expected.txt
@@ -2,7 +2,7 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 test label 4
-Label text should be missing: ""
+Label text should be a default non-empty fallback: "Enter text"
 Label text should use the placeholder: "test label 1"
 Label text should use the title: "test label 2"
 Label text should use the accessibility label: "test label 3"

--- a/LayoutTests/fast/forms/watchos/form-control-label-text.html
+++ b/LayoutTests/fast/forms/watchos/form-control-label-text.html
@@ -45,7 +45,7 @@ async function runTest() {
 <body onload="runTest()">
 <input id="field" style="width: 320px; height: 568px;"></input>
 <label id="label">test label 4</label>
-<div>Label text should be missing: "<code id="missingLabel"></code>"</div>
+<div>Label text should be a default non-empty fallback: "<code id="missingLabel"></code>"</div>
 <div>Label text should use the placeholder: "<code id="labelFromPlaceholder"></code>"</div>
 <div>Label text should use the title: "<code id="labelFromTitle"></code>"</div>
 <div>Label text should use the accessibility label: "<code id="labelFromAriaLabel"></code>"</div>

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -565,6 +565,21 @@
 /* Validation message for input form controls of type 'email' that have an invalid value */
 "Enter an email address" = "Enter an email address";
 
+/* Fallback label text for unlabeled telephone number input field. */
+"Phone number" = "Phone number";
+
+/* Fallback label text for unlabeled email address field. */
+"Email address" = "Email address";
+
+/* Fallback label text for unlabeled URL input field. */
+"URL" = "URL";
+
+/* Fallback label text for unlabeled text field. */
+"Enter text" = "Enter text";
+
+/* Fallback label text for password field. */
+"Password" = "Password";
+
 /* Custom protocol synchronous load failure description */
 "Error handling synchronous load with custom protocol" = "Error handling synchronous load with custom protocol";
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -9131,6 +9131,58 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
 #endif
 }
 
+#if PLATFORM(WATCHOS)
+static String fallbackLabelTextForUnlabeledInputFieldInZoomedFormControls(WebCore::InputMode inputMode, WebKit::InputType elementType)
+{
+    bool isPasswordField = false;
+
+    auto elementTypeIsAnyOf = [elementType](const std::initializer_list<WebKit::InputType>& elementTypes) {
+        return WTF::anyOf(elementTypes, [elementType](auto type) {
+            return elementType == type;
+        });
+    };
+
+    // If unspecified, try to infer the input mode from the input type
+    if (inputMode == WebCore::InputMode::Unspecified) {
+        if (elementTypeIsAnyOf({ WebKit::InputType::ContentEditable, WebKit::InputType::Text, WebKit::InputType::TextArea }))
+            inputMode = WebCore::InputMode::Text;
+        if (elementTypeIsAnyOf({ WebKit::InputType::URL }))
+            inputMode = WebCore::InputMode::Url;
+        if (elementTypeIsAnyOf({ WebKit::InputType::Number, WebKit::InputType::NumberPad }))
+            inputMode = WebCore::InputMode::Numeric;
+        if (elementTypeIsAnyOf({ WebKit::InputType::Search }))
+            inputMode = WebCore::InputMode::Search;
+        if (elementTypeIsAnyOf({ WebKit::InputType::Email }))
+            inputMode = WebCore::InputMode::Email;
+        if (elementTypeIsAnyOf({ WebKit::InputType::Phone }))
+            inputMode = WebCore::InputMode::Telephone;
+        if (elementTypeIsAnyOf({ WebKit::InputType::Password }))
+            isPasswordField = true;
+    }
+
+    if (isPasswordField)
+        return WEB_UI_STRING("Password", "Fallback label text for unlabeled password field.");
+
+    switch (inputMode) {
+    case WebCore::InputMode::Telephone:
+        return WEB_UI_STRING("Phone number", "Fallback label text for unlabeled telephone number input field.");
+    case WebCore::InputMode::Url:
+        return WEB_UI_STRING("URL", "Fallback label text for unlabeled URL input field.");
+    case WebCore::InputMode::Email:
+        return WEB_UI_STRING("Email address", "Fallback label text for unlabeled email address field.");
+    case WebCore::InputMode::Numeric:
+    case WebCore::InputMode::Decimal:
+        return WEB_UI_STRING("Enter a number", "Fallback label text for unlabeled numeric field.");
+    case WebCore::InputMode::Search:
+        return WEB_UI_STRING("Search", "Fallback label text for unlabeled search field");
+    case WebCore::InputMode::Unspecified:
+    case WebCore::InputMode::None:
+    case WebCore::InputMode::Text:
+        return WEB_UI_STRING("Enter text", "Fallback label text for unlabeled text field.");
+    }
+}
+#endif
+
 - (NSString *)inputLabelText
 {
     if (!_focusedElementInformation.label.isEmpty())
@@ -9141,6 +9193,11 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
 
     if (!_focusedElementInformation.title.isEmpty())
         return _focusedElementInformation.title;
+
+#if PLATFORM(WATCHOS)
+    if (_focusedElementInformation.placeholder.isEmpty())
+        return fallbackLabelTextForUnlabeledInputFieldInZoomedFormControls(_focusedElementInformation.inputMode, _focusedElementInformation.elementType);
+#endif
 
     return _focusedElementInformation.placeholder;
 }


### PR DESCRIPTION
#### 6036a9fa2afb795686f91c6cfd379b72d032d549
<pre>
[watchOS] Quickboard input view controller should have non-empty fallback text for unlabeled text fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=276550">https://bugs.webkit.org/show_bug.cgi?id=276550</a>
<a href="https://rdar.apple.com/125570089">rdar://125570089</a>

Reviewed by Wenson Hsieh.

For certain text input fields, Quickboard input view controller presents
a button that the user must press before entering scribble mode. In the
absence of any AX labels or placeholder text, a user is simply presented
with a blank button, which is not very intuitive.

In this patch, we fix this confusing UX by enforcing some non-empty
fallback text in the Quickboard input view controller. We condition this
fallback text based on the focused element&apos;s input mode, and in case
that is unspecified, we consult the element type to infer an appropriate
input mode.

* LayoutTests/fast/forms/watchos/form-control-label-text-expected.txt:
* LayoutTests/fast/forms/watchos/form-control-label-text.html:
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(fallbackLabelTextForUnlabeledInputFieldInZoomedFormControls):
(-[WKContentView inputLabelText]):

Canonical link: <a href="https://commits.webkit.org/280933@main">https://commits.webkit.org/280933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07559bd9dbd3d6858d06273404679198dbdaecce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47031 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6046 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27863 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31807 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7467 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7493 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53755 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63358 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7804 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54282 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54403 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12839 "Found 1 new test failure: media/video-playsinline.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1679 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8665 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33201 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34287 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34032 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->