### PR TITLE
Null check fetch in WebSWServerToContextConnection destructor

### DIFF
--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -60,8 +60,10 @@ WebSWServerToContextConnection::WebSWServerToContextConnection(NetworkConnection
 WebSWServerToContextConnection::~WebSWServerToContextConnection()
 {
     auto fetches = WTFMove(m_ongoingFetches);
-    for (auto& fetch : fetches.values())
-        Ref { fetch.get() }->contextClosed();
+    for (auto& weakPtr : fetches.values()) {
+        if (RefPtr fetch = weakPtr.get())
+            fetch->contextClosed();
+    }
 
     auto downloads = WTFMove(m_ongoingDownloads);
     for (auto& weakPtr : downloads.values()) {

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -125,7 +125,7 @@ private:
     void setInspectable(WebCore::ServiceWorkerIsInspectable) final;
 
     WeakRef<NetworkConnectionToWebProcess> m_connection;
-    HashMap<WebCore::FetchIdentifier, WeakRef<ServiceWorkerFetchTask>> m_ongoingFetches;
+    HashMap<WebCore::FetchIdentifier, WeakPtr<ServiceWorkerFetchTask>> m_ongoingFetches;
     HashMap<WebCore::FetchIdentifier, ThreadSafeWeakPtr<ServiceWorkerDownloadTask>> m_ongoingDownloads;
     bool m_isThrottleable { true };
     WebPageProxyIdentifier m_webPageProxyID;


### PR DESCRIPTION
#### 60d010a4128bc3aef9b5f4867c487d5ff6722e24
<pre>
Null check fetch in WebSWServerToContextConnection destructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=276557">https://bugs.webkit.org/show_bug.cgi?id=276557</a>
<a href="https://rdar.apple.com/131637662">rdar://131637662</a>

Reviewed by Brady Eidson.

This fixes a crash during teardown I saw locally with this stack trace:

WebKit::ServiceWorkerFetchTask::contextClosed() + 68
WebKit::WebSWServerToContextConnection::~WebSWServerToContextConnection() + 176
WebKit::WebSWServerToContextConnection::operator delete(WebKit::WebSWServerToContextConnection*, std::destroying_delete_t, unsigned long) + 16
WebKit::NetworkConnectionToWebProcess::didClose(IPC::Connection&amp;) + 108
WTF::Detail::CallableWrapper&lt;IPC::Connection::dispatchDidCloseAndInvalidate()::$_0, void&gt;::call() + 68
WTF::RunLoop::performWork() + 204
...

* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::~WebSWServerToContextConnection):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:

Canonical link: <a href="https://commits.webkit.org/280972@main">https://commits.webkit.org/280972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d57efebc5216f3dde4c41cd96a24b45af6dc19c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61672 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8492 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47033 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6048 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27865 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31812 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7496 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63364 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7807 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54496 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54402 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12870 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1682 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33204 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34290 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35374 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34035 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->