### PR TITLE
Don't mix up glyph IDs when multiple installed fonts share a name

### DIFF
--- a/LayoutTests/fast/text/font-fallback-expected.html
+++ b/LayoutTests/fast/text/font-fallback-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<style>
+@font-face {
+    font-family: 'Ahem';
+    src: url('../../resources/Ahem.ttf');
+}
+
+html { font-family: Helvetica, Arial, Times, serif; }
+span { font-family: Ahem; }
+a { font-family: Ahem, Helvetica, Arial, Times, serif; } // should hit system fallback
+
+</style>
+
+<p><span>A</span><a>う</a><span>A</span>Ψ
+
+<p><span>A</span><a>คう</a><span>A</span>Ψक

--- a/LayoutTests/fast/text/font-fallback.html
+++ b/LayoutTests/fast/text/font-fallback.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<style>
+@font-face {
+    font-family: 'Ahem';
+    src: url('../../resources/Ahem.ttf');
+}
+@font-face {
+	font-family: AhemCJK;
+    src: url('../../resources/Ahem_CJK.ttf');
+}
+
+html { font-family: Ahem, Helvetica, Arial, AhemCJK, Times, serif; }
+
+</style>
+
+<p>Aう七Ψ
+
+<p>Aคう七Ψक

--- a/LayoutTests/fast/text/postscript-bold-expected.html
+++ b/LayoutTests/fast/text/postscript-bold-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<style>
+p { font-synthesis: none; font-size: 60px; margin: 0; }
+</style>
+
+<p style="font-family: PingFangSC-Medium">【】
+
+<p style="font-family: PingFangSC-Regular; font-weight: 400">【】
+
+<p style="font-family: PingFangTC-Light">【】
+
+<p style="font-family: PingFangTC-Regular; font-weight: bold">【】
+
+<!-- PingFang*-Regular is not the correct weight to fall back on, but that's what we're doing right now in CoreText. -->

--- a/LayoutTests/fast/text/postscript-bold.html
+++ b/LayoutTests/fast/text/postscript-bold.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-300" />
+<style>
+
+@font-face {
+    font-family: 'iBooks_PingFang_TC';
+    src: local('PingFangTC-Light');
+    font-weight: normal;
+}
+
+@font-face {
+    font-family: 'iBooks_PingFang_TC';
+    src: local('PingFangTC-Bold');
+    font-weight: bold;
+}
+
+p { font-synthesis: none; font-size: 60px; margin: 0; }
+</style>
+
+<!-- The current point of this test is to make sure we're not mixing up glyph IDs.
+     In the future, it should also check on correct selection of font weights. -->
+
+<p style="font-family: PingFangSC-Medium">【】
+
+<p style="font-family: PingFangSC-Regular; font-weight: bold">【】
+
+<p style="font-family: iBooks_PingFang_TC">【】
+
+<p style="font-family: iBooks_PingFang_TC; font-weight: bold">【】

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -339,6 +339,7 @@ fast/url/user-visible [ Skip ]
 # These tests reference specific fonts on Mac port.
 fast/text/font-weights.html [ Skip ]
 fast/text/font-weights-zh.html [ Skip ]
+fast/text/postscript-bold.html [ Skip ]
 
 # SoftBank emoji isn't supported
 fast/text/softbank-emoji.html [ Skip ]

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -208,7 +208,7 @@ public:
     bool shouldNotBeUsedForArabic() const { return m_shouldNotBeUsedForArabic; };
 #endif
 #if USE(CORE_TEXT)
-    CTFontRef getCTFont() const { return m_platformData.font(); }
+    CTFontRef getCTFont() const { return m_platformData.ctFont(); }
     RetainPtr<CFDictionaryRef> getCFStringAttributes(bool enableKerning, FontOrientation, const AtomString& locale) const;
     bool supportsSmallCaps() const;
     bool supportsAllSmallCaps() const;

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -297,8 +297,7 @@ public:
     RetainPtr<CFTypeRef> objectForEqualityCheck() const;
     bool hasCustomTracking() const { return isSystemFont(); }
 
-    CTFontRef font() const { return m_font.get(); }
-    CTFontRef ctFont() const;
+    CTFontRef ctFont() const { return m_font.get(); }
 #endif
 
 #if PLATFORM(COCOA)
@@ -408,9 +407,7 @@ private:
 #if PLATFORM(WIN)
     RefPtr<SharedGDIObject<HFONT>> m_font; // FIXME: Delete this in favor of m_ctFont or m_dwFont or m_scaledFont.
 #elif USE(CORE_TEXT)
-    // FIXME: Get rid of one of these. These two fonts are subtly different, and it is not obvious which one to use where.
     RetainPtr<CTFontRef> m_font;
-    mutable RetainPtr<CTFontRef> m_ctFont;
 #endif
 
 #if USE(CAIRO)

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -760,11 +760,11 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
 {
     const FontPlatformData& platformData = originalFontData.platformData();
 
-    auto fullName = String(adoptCF(CTFontCopyFullName(platformData.font())).get());
+    auto fullName = String(adoptCF(CTFontCopyFullName(platformData.ctFont())).get());
     if (!fullName.isEmpty())
         m_fontNamesRequiringSystemFallbackForPrewarming.add(fullName);
 
-    auto result = lookupFallbackFont(platformData.font(), description.weight(), description.computedLocale(), description.shouldAllowUserInstalledFonts(), characterCluster);
+    auto result = lookupFallbackFont(platformData.ctFont(), description.weight(), description.computedLocale(), description.shouldAllowUserInstalledFonts(), characterCluster);
     result = preparePlatformFont(UnrealizedCoreTextFont { WTFMove(result) }, description, { });
 
     if (!result)
@@ -778,7 +778,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
     auto [syntheticBold, syntheticOblique] = computeNecessarySynthesis(substituteFont, description, ShouldComputePhysicalTraits::No, isForPlatformFont == IsForPlatformFont::Yes).boldObliquePair();
 
     const FontCustomPlatformData* customPlatformData = nullptr;
-    if (safeCFEqual(platformData.font(), substituteFont))
+    if (safeCFEqual(platformData.ctFont(), substituteFont))
         customPlatformData = platformData.customPlatformData();
     FontPlatformData alternateFont(substituteFont, platformData.size(), syntheticBold, syntheticOblique, platformData.orientation(), platformData.widthVariant(), platformData.textRenderingMode(), customPlatformData);
 

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -397,7 +397,7 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, const G
 bool FontCascade::primaryFontIsSystemFont() const
 {
     const auto& fontData = primaryFont();
-    return isSystemFont(fontData.platformData().ctFont());
+    return isSystemFont(fontData.getCTFont());
 }
 
 const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView) const

--- a/Source/WebCore/platform/graphics/mac/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/mac/ComplexTextControllerCoreText.mm
@@ -177,7 +177,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
             font = &m_font.fallbackRangesAt(0).fontForFirstRange();
         stringAttributes = adoptCF(CFDictionaryCreateMutableCopy(kCFAllocatorDefault, 0, font->getCFStringAttributes(m_font.enableKerning(), font->platformData().orientation(), m_font.fontDescription().computedLocale()).get()));
         // We don't know which font should be used to render this grapheme cluster, so enable CoreText's fallback mechanism by using the CTFont which doesn't have CoreText's fallback disabled.
-        CFDictionarySetValue(const_cast<CFMutableDictionaryRef>(stringAttributes.get()), kCTFontAttributeName, font->platformData().font());
+        CFDictionarySetValue(const_cast<CFMutableDictionaryRef>(stringAttributes.get()), kCTFontAttributeName, font->platformData().ctFont());
     } else
         stringAttributes = font->getCFStringAttributes(m_font.enableKerning(), font->platformData().orientation(), m_font.fontDescription().computedLocale());
 


### PR DESCRIPTION
#### d621347fbb522a61863862482451ae76e47d696f
<pre>
Don&apos;t mix up glyph IDs when multiple installed fonts share a name
<a href="https://bugs.webkit.org/show_bug.cgi?id=167068">https://bugs.webkit.org/show_bug.cgi?id=167068</a>
<a href="https://rdar.apple.com/129891005">rdar://129891005</a>

Reviewed by Vitor Roriz.

On CoreText platforms, we store two CTFontRefs for a given Font.
If they end up pointing to different fonts, this causes major problems
such as mixing up glyph IDs and rendering nonsense text.

This patch merges them into a single object by
* Dropping the LastResort CoreText fallback, which seems no longer needed.
* Applying the width variants for all uses, which should be more correct anyway.
* Updating all callers accordingly.

* Source/WebCore/platform/graphics/Font.h:
(WebCore::Font::getCTFont const):
* Source/WebCore/platform/graphics/FontPlatformData.h:
(WebCore::FontPlatformData::ctFont const):
(WebCore::FontPlatformData::font const): Deleted.
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::FontCache::systemFallbackForCharacterCluster):
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::FontCascade::primaryFontIsSystemFont const):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::platformInit):
(WebCore::Font::platformCharWidthInit):
(WebCore::Font::supportsSmallCaps const):
(WebCore::Font::supportsAllSmallCaps const):
(WebCore::Font::supportsPetiteCaps const):
(WebCore::Font::supportsAllPetiteCaps const):
(WebCore::Font::createFontWithoutSynthesizableFeatures const):
(WebCore::Font::platformCreateScaledFont const):
(WebCore::Font::platformWidthForGlyph const):
(WebCore::Font::applyTransforms const):
(WebCore::Font::determinePitch):
(WebCore::Font::platformBoundsForGlyph const):
(WebCore::Font::platformPathForGlyph const):
(WebCore::Font::platformSupportsCodePoint const):
(WebCore::Font::isProbablyOnlyUsedToRenderIcons const):
(WebCore::Font::otSVGTable const):
(WebCore::Font::hasComplexColorFormatTables const):
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::mapFontWidthVariantToCTFeatureSelector):
(WebCore::FontPlatformData::FontPlatformData):
(WebCore::FontPlatformData::updateSize):
(WebCore::FontPlatformData::toIPCData const):
(WebCore::cascadeToLastResortAttributesDictionary): Deleted.
(WebCore::cascadeToLastResortAndVariationsFontDescriptor): Deleted.
(WebCore::FontPlatformData::ctFont const): Deleted.
* Source/WebCore/platform/graphics/mac/ComplexTextControllerCoreText.mm:
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):

Canonical link: <a href="https://commits.webkit.org/281022@main">https://commits.webkit.org/281022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ec8228b27017e6dd988d89dc91559d10f3f9c87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62049 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8868 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47322 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6330 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60455 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35361 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28166 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/32116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7815 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7872 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63753 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2337 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54641 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54707 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1979 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8708 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34666 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->