### PR TITLE
[libpas] handle overlapping segregated directories when maintaining indexes

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c
@@ -84,7 +84,8 @@ pas_bitfit_variant_selection pas_bitfit_heap_select_variant(size_t requested_obj
             continue;
 
         if (verbose)
-            pas_log("max object size = %zu\n", page_config.base.max_object_size);
+            pas_log("max object size = %zu min align = %zu\n",
+                    page_config.base.max_object_size, pas_page_base_config_min_align(page_config.base));
 
         PAS_ASSERT(
             page_config.base.max_object_size

--- a/Source/bmalloc/libpas/src/test/BmallocTests.cpp
+++ b/Source/bmalloc/libpas/src/test/BmallocTests.cpp
@@ -25,6 +25,7 @@
 
 #include "TestHarness.h"
 #include "bmalloc_heap.h"
+#include "bmalloc_heap_config.h"
 
 #include <cstdlib>
 
@@ -45,10 +46,46 @@ void testBmallocDeallocate()
     bmalloc_deallocate(mem);
 }
 
+void testBmallocForceBitfitAfterAlloc()
+{
+    void* mem0 = bmalloc_try_allocate(28616, pas_non_compact_allocation_mode);
+    CHECK(mem0);
+
+    void* mem1 = bmalloc_try_allocate(20768, pas_non_compact_allocation_mode);
+    CHECK(mem1);
+
+    // Simulate entering mini mode by forcing bitfit only.
+    bmalloc_intrinsic_runtime_config.base.max_segregated_object_size = 0;
+    bmalloc_intrinsic_runtime_config.base.max_bitfit_object_size = UINT_MAX;
+    bmalloc_primitive_runtime_config.base.max_segregated_object_size = 0;
+    bmalloc_primitive_runtime_config.base.max_bitfit_object_size = UINT_MAX;
+
+    void* mem2 = bmalloc_try_allocate(20648, pas_non_compact_allocation_mode);
+    CHECK(mem2);
+}
+
+void testBmallocSmallIndexOverlap()
+{
+    // object_size = 16 * index for this heap.
+    // Creates directory A with min_index = 97, object_size = 1616
+    void* mem0 = bmalloc_try_allocate(1552, pas_non_compact_allocation_mode);
+    CHECK(mem0);
+    // Extends directory A to have min_index = 96, object_size = 1616
+    void* mem1 = bmalloc_try_allocate(1536, pas_non_compact_allocation_mode);
+    CHECK(mem1);
+    // Install index is 94. Directory A is a "candidate" but doesn't satisfy alignment,
+    // so new directory B is created with min_index = 94, object_size = 1536.
+    // Directory B overlaps directory A at index 96 (1536 / 16).
+    void* mem2 = bmalloc_try_allocate_with_alignment(1504, 32, pas_non_compact_allocation_mode);
+    CHECK(mem2);
+}
+
 } // anonymous namespace
 
 void addBmallocTests()
 {
     ADD_TEST(testBmallocAllocate());
     ADD_TEST(testBmallocDeallocate());
+    ADD_TEST(testBmallocForceBitfitAfterAlloc());
+    ADD_TEST(testBmallocSmallIndexOverlap());
 }


### PR DESCRIPTION
#### 731007338146aeb164ca1964688e59ff838364f4
<pre>
[libpas] handle overlapping segregated directories when maintaining indexes
<a href="https://bugs.webkit.org/show_bug.cgi?id=276432">https://bugs.webkit.org/show_bug.cgi?id=276432</a>
<a href="https://rdar.apple.com/131476542">rdar://131476542</a>

Reviewed by Yusuke Suzuki.

The previous attempt (280317@main) at handling this situation violated
a constraint that some pages have due to the object size not being
aligned properly. See that commit for why other approaches to
preventing overlapping directories don&apos;t work well.

Also, overlapping directories are less rare with directories in the
small index compared to medium, and can occur when allocating with
alignment, even without disabling segregated pages (which is the only
case we&apos;ve seen this occur for directories in the medium index).

So, rather than trying to prevent overlapping directories, fix up the
small and medium indexing code to handle them in a determinstic way.

The small index code already had a strategy in place for handling
overlapping directories: a directory is installed only up to the
index preceding the min_index of the next directory. See the existing
code with comment:

/* Install this result in all indices starting with this one that don&apos;t already have a
   size class and where this size class would be big enough. */

(emphasis on: &quot;that don&apos;t already have a size class&quot;).

This change uses the same strategy for medium indexes, which fixes
the issue that the assert in check_medium_directories() is complaining
about.

It turns out that although there was code to handle this case when
updating the small index, the code that verifies (and rematerializes,
though I&apos;m not sure if that code ever executes) was incorrect
for indices in the small index. This is only noticible when PAS_TESTING
is enabled, which only happens for the &quot;testing&quot; variant of the pas tests.
And the pas tests apparently do not have any coverage of these corner
cases. So this bug has always been there but never noticed.

So, the code to verify (and rematerialize) both the small and medium
indexes is updated to traverse the directories in order (previously
this was done only for medium directories) and the same rule is applied:
the current directory is indexed only up (but not including) the start
of the next directory&apos;s min_index.

Also add test cases to cover more of these corner cases.

* Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c:
(pas_bitfit_heap_select_variant):
* Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c:
(size_directory_min_heap_compare):
(recompute_size_lookup):
(pas_segregated_heap_ensure_size_directory_for_size):
* Source/bmalloc/libpas/src/test/BmallocTests.cpp:
(std::testBmallocForceBitfitAfterAlloc):
(std::testBmallocX):
(addBmallocTests):

Canonical link: <a href="https://commits.webkit.org/281012@main">https://commits.webkit.org/281012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c4a44ca3e0716fe6f97c5f2ad6daf40316c2e27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58412 "13 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8856 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9053 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6319 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60443 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28152 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/32115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7860 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/51503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63741 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57654 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2325 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54629 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54695 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1970 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79414 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8701 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13210 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/34654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/34399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->