### PR TITLE
Make all callbacks Weak handles

### DIFF
--- a/LayoutTests/requestidlecallback/requestidlecallback-does-not-leak-document-expected.txt
+++ b/LayoutTests/requestidlecallback/requestidlecallback-does-not-leak-document-expected.txt
@@ -1,0 +1,10 @@
+Tests that the requestIdleCallback callback does not leak the document.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/requestidlecallback/requestidlecallback-does-not-leak-document.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-does-not-leak-document.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html><!-- webkit-test-runner [ RequestIdleCallbackEnabled=true ] -->
+<html>
+<body>
+<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/document-leak-test.js"></script>
+<script>
+description("Tests that the requestIdleCallback callback does not leak the document.");
+onload = () => runDocumentLeakTest({ frameURL: "./resources/requestidlecallback-frame.html", framesToCreate: 20 });
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/requestidlecallback/resources/requestidlecallback-frame.html
+++ b/LayoutTests/requestidlecallback/resources/requestidlecallback-frame.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html><!-- webkit-test-runner [ RequestIdleCallbackEnabled=true ] -->
+<html>
+<body>
+<script>
+function cb()
+{
+    let d = document;
+    let p = d.createElement("p");
+    p.innerText = "This shouldn't leak the document.";
+    d.body.appendChild(p);
+    window.requestIdleCallback(cb);
+}
+
+requestIdleCallback(cb);
+parent.postMessage("iframeLoaded");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -321,6 +321,8 @@ public:
         return adoptRef(*new GPUDeviceVideoFrameRequestCallback(externalTexture, videoElement, gpuDevice, scriptExecutionContext));
     }
 
+    bool hasCallback() const final { return true; }
+
     ~GPUDeviceVideoFrameRequestCallback() final { }
 private:
     GPUDeviceVideoFrameRequestCallback(GPUExternalTexture& externalTexture, HTMLVideoElement& videoElement, GPUDevice& gpuDevice, ScriptExecutionContext* scriptExecutionContext)

--- a/Source/WebCore/Modules/entriesapi/ErrorCallback.h
+++ b/Source/WebCore/Modules/entriesapi/ErrorCallback.h
@@ -42,6 +42,9 @@ public:
 
     // Helper to post callback task.
     void scheduleCallback(ScriptExecutionContext&, Ref<DOMException>&&);
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/entriesapi/ErrorCallback.idl
+++ b/Source/WebCore/Modules/entriesapi/ErrorCallback.idl
@@ -23,4 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ IsStrongCallback ] callback ErrorCallback = undefined (DOMException error);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback ErrorCallback = undefined (DOMException error);

--- a/Source/WebCore/Modules/entriesapi/FileCallback.h
+++ b/Source/WebCore/Modules/entriesapi/FileCallback.h
@@ -39,6 +39,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(File&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/entriesapi/FileCallback.idl
+++ b/Source/WebCore/Modules/entriesapi/FileCallback.idl
@@ -23,4 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ IsStrongCallback ] callback FileCallback = undefined (File file);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback FileCallback = undefined (File file);

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.h
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.h
@@ -42,6 +42,9 @@ public:
 
     // Helper to post callback task.
     void scheduleCallback(ScriptExecutionContext&, const Vector<Ref<FileSystemEntry>>&);
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.idl
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.idl
@@ -23,4 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ IsStrongCallback ] callback FileSystemEntriesCallback = undefined (sequence<FileSystemEntry> entries);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback FileSystemEntriesCallback = undefined (sequence<FileSystemEntry> entries);

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntryCallback.h
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntryCallback.h
@@ -39,6 +39,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(FileSystemEntry&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntryCallback.idl
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntryCallback.idl
@@ -23,4 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ IsStrongCallback ] callback FileSystemEntryCallback = undefined (FileSystemEntry entry);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback FileSystemEntryCallback = undefined (FileSystemEntry entry);

--- a/Source/WebCore/Modules/geolocation/PositionCallback.h
+++ b/Source/WebCore/Modules/geolocation/PositionCallback.h
@@ -38,6 +38,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(GeolocationPosition*) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/geolocation/PositionCallback.idl
+++ b/Source/WebCore/Modules/geolocation/PositionCallback.idl
@@ -24,5 +24,5 @@
 
 [
     Conditional=GEOLOCATION,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback PositionCallback = undefined (GeolocationPosition? position); // FIXME: This should not be nullable.

--- a/Source/WebCore/Modules/geolocation/PositionErrorCallback.h
+++ b/Source/WebCore/Modules/geolocation/PositionErrorCallback.h
@@ -38,6 +38,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(GeolocationPositionError&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/geolocation/PositionErrorCallback.idl
+++ b/Source/WebCore/Modules/geolocation/PositionErrorCallback.idl
@@ -24,5 +24,5 @@
 
 [
     Conditional=GEOLOCATION,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback PositionErrorCallback = undefined (GeolocationPositionError error);

--- a/Source/WebCore/Modules/notifications/NotificationPermissionCallback.h
+++ b/Source/WebCore/Modules/notifications/NotificationPermissionCallback.h
@@ -40,6 +40,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(Notification::Permission) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/notifications/NotificationPermissionCallback.idl
+++ b/Source/WebCore/Modules/notifications/NotificationPermissionCallback.idl
@@ -26,5 +26,5 @@
 [
     Conditional=NOTIFICATIONS,
     EnabledBySetting=NotificationsEnabled,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback NotificationPermissionCallback = undefined (NotificationPermission permission);

--- a/Source/WebCore/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.h
@@ -39,6 +39,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<bool> handleEvent(bool) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 }

--- a/Source/WebCore/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.idl
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.idl
@@ -25,5 +25,5 @@
 [
     Conditional=WIRELESS_PLAYBACK_TARGET,
     EnabledBySetting=RemotePlaybackEnabled,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback RemotePlaybackAvailabilityCallback = boolean (boolean available);

--- a/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h
+++ b/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h
@@ -40,6 +40,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<RefPtr<DOMPromise>> handleEvent(WebLock*) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.idl
+++ b/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.idl
@@ -24,5 +24,5 @@
 
 [
     RethrowException,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback WebLockGrantedCallback = Promise<any> (WebLock? webLock);

--- a/Source/WebCore/Modules/webaudio/AudioBufferCallback.h
+++ b/Source/WebCore/Modules/webaudio/AudioBufferCallback.h
@@ -39,6 +39,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(AudioBuffer*) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/AudioBufferCallback.idl
+++ b/Source/WebCore/Modules/webaudio/AudioBufferCallback.idl
@@ -30,5 +30,5 @@
 [
     Conditional=WEB_AUDIO,
     JSGenerateToJSObject,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback AudioBufferCallback = undefined (AudioBuffer? audioBuffer);

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h
@@ -44,6 +44,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<RefPtr<AudioWorkletProcessor>> handleEvent(JSC::Strong<JSC::JSObject> options) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.idl
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.idl
@@ -28,5 +28,5 @@
 
 [
     Conditional=WEB_AUDIO,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback AudioWorkletProcessorConstructor = AudioWorkletProcessor (object options);

--- a/Source/WebCore/Modules/webdatabase/DatabaseCallback.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseCallback.h
@@ -43,6 +43,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(Database&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webdatabase/DatabaseCallback.idl
+++ b/Source/WebCore/Modules/webdatabase/DatabaseCallback.idl
@@ -26,4 +26,4 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ IsStrongCallback ] callback DatabaseCallback = undefined (Database database);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback DatabaseCallback = undefined (Database database);

--- a/Source/WebCore/Modules/webdatabase/SQLStatementCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLStatementCallback.h
@@ -42,6 +42,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(SQLTransaction&, SQLResultSet&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webdatabase/SQLStatementCallback.idl
+++ b/Source/WebCore/Modules/webdatabase/SQLStatementCallback.idl
@@ -26,4 +26,4 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ IsStrongCallback ] callback SQLStatementCallback = undefined (SQLTransaction transaction, SQLResultSet resultSet);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback SQLStatementCallback = undefined (SQLTransaction transaction, SQLResultSet resultSet);

--- a/Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.h
@@ -42,6 +42,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<bool> handleEvent(SQLTransaction&, SQLError&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.idl
+++ b/Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.idl
@@ -26,4 +26,4 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ IsStrongCallback ] callback SQLStatementErrorCallback = boolean (SQLTransaction transaction, SQLError error);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback SQLStatementErrorCallback = boolean (SQLTransaction transaction, SQLError error);

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionCallback.h
@@ -41,6 +41,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(SQLTransaction&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionCallback.idl
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionCallback.idl
@@ -26,4 +26,4 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ IsStrongCallback ] callback SQLTransactionCallback = undefined (SQLTransaction transaction);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback SQLTransactionCallback = undefined (SQLTransaction transaction);

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.h
@@ -41,6 +41,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(SQLError&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.idl
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.idl
@@ -26,4 +26,4 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ IsStrongCallback ] callback SQLTransactionErrorCallback = undefined (SQLError error);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback SQLTransactionErrorCallback = undefined (SQLError error);

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -620,6 +620,9 @@ public:
     {
         return adoptRef(*new InlineRequestAnimationFrameCallback(scriptExecutionContext, WTFMove(callback)));
     }
+
+    bool hasCallback() const final { return true; }
+
 private:
     InlineRequestAnimationFrameCallback(ScriptExecutionContext& scriptExecutionContext, Function<void()>&& callback)
         : RequestAnimationFrameCallback(&scriptExecutionContext), m_callback(WTFMove(callback)) 

--- a/Source/WebCore/Modules/webxr/XRFrameRequestCallback.h
+++ b/Source/WebCore/Modules/webxr/XRFrameRequestCallback.h
@@ -47,6 +47,8 @@ public:
     bool isFiredOrCancelled() const { return m_firedOrCancelled; }
 
 private:
+    virtual bool hasCallback() const = 0;
+
     unsigned m_id { 0 };
     bool m_firedOrCancelled { false };
 };

--- a/Source/WebCore/Modules/webxr/XRFrameRequestCallback.idl
+++ b/Source/WebCore/Modules/webxr/XRFrameRequestCallback.idl
@@ -29,5 +29,5 @@ typedef double DOMHighResTimeStamp;
 [
     Conditional=WEBXR,
     EnabledBySetting=WebXREnabled,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback XRFrameRequestCallback = undefined (DOMHighResTimeStamp time, WebXRFrame frame);

--- a/Source/WebCore/animation/CustomEffectCallback.h
+++ b/Source/WebCore/animation/CustomEffectCallback.h
@@ -37,6 +37,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(double progress) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CustomEffectCallback.idl
+++ b/Source/WebCore/animation/CustomEffectCallback.idl
@@ -23,4 +23,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ IsStrongCallback ] callback CustomEffectCallback = undefined (double progress);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback CustomEffectCallback = undefined (double progress);

--- a/Source/WebCore/bindings/js/JSCallbackData.cpp
+++ b/Source/WebCore/bindings/js/JSCallbackData.cpp
@@ -98,19 +98,12 @@ JSValue JSCallbackData::invokeCallback(JSDOMGlobalObject& globalObject, JSObject
 }
 
 template<typename Visitor>
-void JSCallbackDataWeak::visitJSFunction(Visitor& visitor)
+void JSCallbackData::visitJSFunction(Visitor& visitor)
 {
     visitor.append(m_callback);
 }
 
-template void JSCallbackDataWeak::visitJSFunction(JSC::AbstractSlotVisitor&);
-template void JSCallbackDataWeak::visitJSFunction(JSC::SlotVisitor&);
-
-bool JSCallbackDataWeak::WeakOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    if (UNLIKELY(reason))
-        *reason = "Context is opaque root"_s; // FIXME: what is the context.
-    return visitor.containsOpaqueRoot(context);
-}
+template void JSCallbackData::visitJSFunction(JSC::AbstractSlotVisitor&);
+template void JSCallbackData::visitJSFunction(JSC::SlotVisitor&);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -234,7 +234,7 @@
             "values": ["*"]
         },
         "GenerateIsReachable": {
-            "contextsAllowed": ["interface"],
+            "contextsAllowed": ["interface", "callback-function"],
             "values": ["", "Impl", "ImplWebGLRenderingContext", "ImplCanvasBase", "ImplDocument", "ImplElementRoot", "ImplOwnerNodeRoot", "ImplScriptExecutionContext", "ReachableFromDOMWindow", "ReachableFromNavigator"]
         },
         "Global": {
@@ -268,9 +268,6 @@
         },
         "IsImmutablePrototypeExoticObjectOnPrototype": {
             "contextsAllowed": ["interface"]
-        },
-        "IsStrongCallback": {
-            "contextsAllowed": ["callback-function", "interface"]
         },
         "JSBuiltin": {
             "contextsAllowed": ["interface", "attribute", "operation"]

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
@@ -33,7 +33,7 @@ using namespace JSC;
 
 JSTestCallbackFunction::JSTestCallbackFunction(JSObject* callback, JSDOMGlobalObject* globalObject)
     : TestCallbackFunction(globalObject->scriptExecutionContext())
-    , m_data(new JSCallbackDataWeak(callback, globalObject, this))
+    , m_data(new JSCallbackData(callback, globalObject, this))
 {
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
@@ -37,7 +37,7 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
 
     ~JSTestCallbackFunction() final;
-    JSCallbackDataWeak* callbackData() { return m_data; }
+    JSCallbackData* callbackData() { return m_data; }
 
     // Functions
     CallbackResult<typename IDLDOMString::ImplementationType> handleEvent(typename IDLLong::ParameterType argument) override;
@@ -51,7 +51,7 @@ private:
 
     void visitJSFunction(JSC::SlotVisitor&) override;
 
-    JSCallbackDataWeak* m_data;
+    JSCallbackData* m_data;
 };
 
 JSC::JSValue toJS(TestCallbackFunction&);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
@@ -19,7 +19,7 @@
 */
 
 #include "config.h"
-#include "JSTestCallbackFunctionStrong.h"
+#include "JSTestCallbackFunctionGenerateIsReachable.h"
 
 #include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertNumbers.h"
@@ -31,13 +31,13 @@
 namespace WebCore {
 using namespace JSC;
 
-JSTestCallbackFunctionStrong::JSTestCallbackFunctionStrong(JSObject* callback, JSDOMGlobalObject* globalObject)
-    : TestCallbackFunctionStrong(globalObject->scriptExecutionContext())
-    , m_data(new JSCallbackDataStrong(callback, globalObject, this))
+JSTestCallbackFunctionGenerateIsReachable::JSTestCallbackFunctionGenerateIsReachable(JSObject* callback, JSDOMGlobalObject* globalObject)
+    : TestCallbackFunctionGenerateIsReachable(globalObject->scriptExecutionContext())
+    , m_data(new JSCallbackData(callback, globalObject, globalObject->scriptExecutionContext()))
 {
 }
 
-JSTestCallbackFunctionStrong::~JSTestCallbackFunctionStrong()
+JSTestCallbackFunctionGenerateIsReachable::~JSTestCallbackFunctionGenerateIsReachable()
 {
     ScriptExecutionContext* context = scriptExecutionContext();
     // When the context is destroyed, all tasks with a reference to a callback
@@ -51,12 +51,12 @@ JSTestCallbackFunctionStrong::~JSTestCallbackFunctionStrong()
 #endif
 }
 
-CallbackResult<typename IDLDOMString::ImplementationType> JSTestCallbackFunctionStrong::handleEvent(typename IDLLong::ParameterType argument)
+CallbackResult<typename IDLDOMString::ImplementationType> JSTestCallbackFunctionGenerateIsReachable::handleEvent(typename IDLLong::ParameterType argument)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
 
-    Ref<JSTestCallbackFunctionStrong> protectedThis(*this);
+    Ref<JSTestCallbackFunctionGenerateIsReachable> protectedThis(*this);
 
     auto& globalObject = *m_data->globalObject();
     auto& vm = globalObject.vm();
@@ -83,12 +83,12 @@ CallbackResult<typename IDLDOMString::ImplementationType> JSTestCallbackFunction
     return { returnValue.releaseReturnValue() };
 }
 
-JSC::JSValue toJS(TestCallbackFunctionStrong& impl)
+JSC::JSValue toJS(TestCallbackFunctionGenerateIsReachable& impl)
 {
-    if (!static_cast<JSTestCallbackFunctionStrong&>(impl).callbackData())
+    if (!static_cast<JSTestCallbackFunctionGenerateIsReachable&>(impl).callbackData())
         return jsNull();
 
-    return static_cast<JSTestCallbackFunctionStrong&>(impl).callbackData()->callback();
+    return static_cast<JSTestCallbackFunctionGenerateIsReachable&>(impl).callbackData()->callback();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
@@ -22,36 +22,39 @@
 
 #include "IDLTypes.h"
 #include "JSCallbackData.h"
-#include "TestCallbackFunctionStrong.h"
+#include "TestCallbackFunctionGenerateIsReachable.h"
+#include "WebCoreOpaqueRootInlines.h"
 #include <wtf/Forward.h>
 
 namespace WebCore {
 
-class JSTestCallbackFunctionStrong final : public TestCallbackFunctionStrong {
+class JSTestCallbackFunctionGenerateIsReachable final : public TestCallbackFunctionGenerateIsReachable {
 public:
-    static Ref<JSTestCallbackFunctionStrong> create(JSC::JSObject* callback, JSDOMGlobalObject* globalObject)
+    static Ref<JSTestCallbackFunctionGenerateIsReachable> create(JSC::JSObject* callback, JSDOMGlobalObject* globalObject)
     {
-        return adoptRef(*new JSTestCallbackFunctionStrong(callback, globalObject));
+        return adoptRef(*new JSTestCallbackFunctionGenerateIsReachable(callback, globalObject));
     }
 
     ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
 
-    ~JSTestCallbackFunctionStrong() final;
-    JSCallbackDataStrong* callbackData() { return m_data; }
+    ~JSTestCallbackFunctionGenerateIsReachable() final;
+    JSCallbackData* callbackData() { return m_data; }
 
     // Functions
     CallbackResult<typename IDLDOMString::ImplementationType> handleEvent(typename IDLLong::ParameterType argument) override;
 
 private:
-    JSTestCallbackFunctionStrong(JSC::JSObject*, JSDOMGlobalObject*);
+    JSTestCallbackFunctionGenerateIsReachable(JSC::JSObject*, JSDOMGlobalObject*);
 
-    JSCallbackDataStrong* m_data;
+    bool hasCallback() const final { return m_data && m_data->callback(); }
+
+    JSCallbackData* m_data;
 };
 
-JSC::JSValue toJS(TestCallbackFunctionStrong&);
-inline JSC::JSValue toJS(TestCallbackFunctionStrong* impl) { return impl ? toJS(*impl) : JSC::jsNull(); }
+JSC::JSValue toJS(TestCallbackFunctionGenerateIsReachable&);
+inline JSC::JSValue toJS(TestCallbackFunctionGenerateIsReachable* impl) { return impl ? toJS(*impl) : JSC::jsNull(); }
 
-template<> struct JSDOMCallbackConverterTraits<JSTestCallbackFunctionStrong> {
-    using Base = TestCallbackFunctionStrong;
+template<> struct JSDOMCallbackConverterTraits<JSTestCallbackFunctionGenerateIsReachable> {
+    using Base = TestCallbackFunctionGenerateIsReachable;
 };
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.cpp
@@ -36,7 +36,7 @@ using namespace JSC;
 
 JSTestCallbackFunctionRethrow::JSTestCallbackFunctionRethrow(JSObject* callback, JSDOMGlobalObject* globalObject)
     : TestCallbackFunctionRethrow(globalObject->scriptExecutionContext())
-    , m_data(new JSCallbackDataWeak(callback, globalObject, this))
+    , m_data(new JSCallbackData(callback, globalObject, this))
 {
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.h
@@ -37,7 +37,7 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
 
     ~JSTestCallbackFunctionRethrow() final;
-    JSCallbackDataWeak* callbackData() { return m_data; }
+    JSCallbackData* callbackData() { return m_data; }
 
     // Functions
     CallbackResult<typename IDLDOMString::ImplementationType> handleEvent(typename IDLSequence<IDLLong>::ParameterType argument) override;
@@ -51,7 +51,7 @@ private:
 
     void visitJSFunction(JSC::SlotVisitor&) override;
 
-    JSCallbackDataWeak* m_data;
+    JSCallbackData* m_data;
 };
 
 JSC::JSValue toJS(TestCallbackFunctionRethrow&);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
@@ -37,7 +37,7 @@ using namespace JSC;
 
 JSTestCallbackFunctionWithThisObject::JSTestCallbackFunctionWithThisObject(JSObject* callback, JSDOMGlobalObject* globalObject)
     : TestCallbackFunctionWithThisObject(globalObject->scriptExecutionContext())
-    , m_data(new JSCallbackDataWeak(callback, globalObject, this))
+    , m_data(new JSCallbackData(callback, globalObject, this))
 {
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
@@ -37,7 +37,7 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
 
     ~JSTestCallbackFunctionWithThisObject() final;
-    JSCallbackDataWeak* callbackData() { return m_data; }
+    JSCallbackData* callbackData() { return m_data; }
 
     // Functions
     CallbackResult<typename IDLUndefined::ImplementationType> handleEvent(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLSequence<IDLInterface<TestNode>>::ParameterType parameter) override;
@@ -51,7 +51,7 @@ private:
 
     void visitJSFunction(JSC::SlotVisitor&) override;
 
-    JSCallbackDataWeak* m_data;
+    JSCallbackData* m_data;
 };
 
 JSC::JSValue toJS(TestCallbackFunctionWithThisObject&);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
@@ -37,7 +37,7 @@ using namespace JSC;
 
 JSTestCallbackFunctionWithTypedefs::JSTestCallbackFunctionWithTypedefs(JSObject* callback, JSDOMGlobalObject* globalObject)
     : TestCallbackFunctionWithTypedefs(globalObject->scriptExecutionContext())
-    , m_data(new JSCallbackDataWeak(callback, globalObject, this))
+    , m_data(new JSCallbackData(callback, globalObject, this))
 {
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
@@ -37,7 +37,7 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
 
     ~JSTestCallbackFunctionWithTypedefs() final;
-    JSCallbackDataWeak* callbackData() { return m_data; }
+    JSCallbackData* callbackData() { return m_data; }
 
     // Functions
     CallbackResult<typename IDLUndefined::ImplementationType> handleEvent(typename IDLSequence<IDLNullable<IDLLong>>::ParameterType sequenceArg, typename IDLLong::ParameterType longArg) override;
@@ -51,7 +51,7 @@ private:
 
     void visitJSFunction(JSC::SlotVisitor&) override;
 
-    JSCallbackDataWeak* m_data;
+    JSCallbackData* m_data;
 };
 
 JSC::JSValue toJS(TestCallbackFunctionWithTypedefs&);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
@@ -32,7 +32,7 @@ using namespace JSC;
 
 JSTestCallbackFunctionWithVariadic::JSTestCallbackFunctionWithVariadic(JSObject* callback, JSDOMGlobalObject* globalObject)
     : TestCallbackFunctionWithVariadic(globalObject->scriptExecutionContext())
-    , m_data(new JSCallbackDataWeak(callback, globalObject, this))
+    , m_data(new JSCallbackData(callback, globalObject, this))
 {
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
@@ -39,7 +39,7 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
 
     ~JSTestCallbackFunctionWithVariadic() final;
-    JSCallbackDataWeak* callbackData() { return m_data; }
+    JSCallbackData* callbackData() { return m_data; }
 
     // Functions
     CallbackResult<typename IDLDOMString::ImplementationType> handleEvent(VariadicArguments<IDLAny>&& arguments) override;
@@ -53,7 +53,7 @@ private:
 
     void visitJSFunction(JSC::SlotVisitor&) override;
 
-    JSCallbackDataWeak* m_data;
+    JSCallbackData* m_data;
 };
 
 JSC::JSValue toJS(TestCallbackFunctionWithVariadic&);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -135,7 +135,7 @@ template<> ConversionResult<IDLDictionary<TestCallbackInterface::Dictionary>> co
 
 JSTestCallbackInterface::JSTestCallbackInterface(JSObject* callback, JSDOMGlobalObject* globalObject)
     : TestCallbackInterface(globalObject->scriptExecutionContext())
-    , m_data(new JSCallbackDataWeak(callback, globalObject, this))
+    , m_data(new JSCallbackData(callback, globalObject, this))
 {
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
@@ -41,7 +41,7 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
 
     ~JSTestCallbackInterface() final;
-    JSCallbackDataWeak* callbackData() { return m_data; }
+    JSCallbackData* callbackData() { return m_data; }
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
 
     // Functions
@@ -65,7 +65,7 @@ private:
 
     void visitJSFunction(JSC::SlotVisitor&) override;
 
-    JSCallbackDataWeak* m_data;
+    JSCallbackData* m_data;
 };
 
 JSC::JSValue toJS(TestCallbackInterface&);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
@@ -45,7 +45,7 @@ using namespace JSC;
 
 JSTestVoidCallbackFunction::JSTestVoidCallbackFunction(JSObject* callback, JSDOMGlobalObject* globalObject)
     : TestVoidCallbackFunction(globalObject->scriptExecutionContext())
-    , m_data(new JSCallbackDataWeak(callback, globalObject, this))
+    , m_data(new JSCallbackData(callback, globalObject, this))
 {
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
@@ -39,7 +39,7 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
 
     ~JSTestVoidCallbackFunction() final;
-    JSCallbackDataWeak* callbackData() { return m_data; }
+    JSCallbackData* callbackData() { return m_data; }
 
     // Functions
     CallbackResult<typename IDLUndefined::ImplementationType> handleEvent(typename IDLFloat32Array::ParameterType arrayParam, typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strArg, typename IDLBoolean::ParameterType boolParam, typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam) override;
@@ -53,7 +53,7 @@ private:
 
     void visitJSFunction(JSC::SlotVisitor&) override;
 
-    JSCallbackDataWeak* m_data;
+    JSCallbackData* m_data;
 };
 
 JSC::JSValue toJS(TestVoidCallbackFunction&);

--- a/Source/WebCore/bindings/scripts/test/SupplementalDependencies.dep
+++ b/Source/WebCore/bindings/scripts/test/SupplementalDependencies.dep
@@ -19,8 +19,8 @@ JSTestCEReactions.h:
 JSTestCEReactionsStringifier.h: 
 JSTestCallTracer.h: 
 JSTestCallbackFunction.h: 
+JSTestCallbackFunctionGenerateIsReachable.h: 
 JSTestCallbackFunctionRethrow.h: 
-JSTestCallbackFunctionStrong.h: 
 JSTestCallbackFunctionWithThisObject.h: 
 JSTestCallbackFunctionWithTypedefs.h: 
 JSTestCallbackFunctionWithVariadic.h: 

--- a/Source/WebCore/bindings/scripts/test/TestCallbackFunctionGenerateIsReachable.idl
+++ b/Source/WebCore/bindings/scripts/test/TestCallbackFunctionGenerateIsReachable.idl
@@ -23,4 +23,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-[ IsStrongCallback ] callback TestCallbackFunctionStrong = DOMString (long argument);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback TestCallbackFunctionGenerateIsReachable = DOMString (long argument);

--- a/Source/WebCore/css/CSSPaintCallback.h
+++ b/Source/WebCore/css/CSSPaintCallback.h
@@ -48,6 +48,9 @@ public:
     virtual ~CSSPaintCallback()
     {
     }
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPaintCallback.idl
+++ b/Source/WebCore/css/CSSPaintCallback.idl
@@ -26,5 +26,5 @@
 [
     EnabledBySetting=CSSPaintingAPIEnabled,
     CallbackThisObject=any,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback CSSPaintCallback = undefined (PaintRenderingContext2D context, CSSPaintSize size, StylePropertyMapReadOnly styleMap, sequence<USVString> arguments);

--- a/Source/WebCore/dom/AbortAlgorithm.h
+++ b/Source/WebCore/dom/AbortAlgorithm.h
@@ -40,6 +40,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(JSC::JSValue) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/AbortAlgorithm.idl
+++ b/Source/WebCore/dom/AbortAlgorithm.idl
@@ -23,4 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ IsStrongCallback ] callback AbortAlgorithm = undefined (any value);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback AbortAlgorithm = undefined (any value);

--- a/Source/WebCore/dom/IdleRequestCallback.h
+++ b/Source/WebCore/dom/IdleRequestCallback.h
@@ -38,6 +38,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(IdleDeadline&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/IdleRequestCallback.idl
+++ b/Source/WebCore/dom/IdleRequestCallback.idl
@@ -23,4 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ IsStrongCallback ] callback IdleRequestCallback = undefined (IdleDeadline deadline);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback IdleRequestCallback = undefined (IdleDeadline deadline);

--- a/Source/WebCore/dom/RequestAnimationFrameCallback.h
+++ b/Source/WebCore/dom/RequestAnimationFrameCallback.h
@@ -52,6 +52,9 @@ public:
     // Allow a little more than 30fps to make sure we can at least hit that frame rate.
     static constexpr Seconds halfSpeedThrottlingAnimationInterval { 30_ms };
     static constexpr Seconds aggressiveThrottlingAnimationInterval { 10_s };
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/RequestAnimationFrameCallback.idl
+++ b/Source/WebCore/dom/RequestAnimationFrameCallback.idl
@@ -31,4 +31,4 @@
 // highResTime is passed as high resolution timestamp, see
 // http://www.w3.org/TR/hr-time/ for details.
 
-[ IsStrongCallback ] callback RequestAnimationFrameCallback = undefined (unrestricted double highResTime);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback RequestAnimationFrameCallback = undefined (unrestricted double highResTime);

--- a/Source/WebCore/dom/StringCallback.h
+++ b/Source/WebCore/dom/StringCallback.h
@@ -47,6 +47,9 @@ public:
 
     // Helper to post callback task.
     WEBCORE_EXPORT void scheduleCallback(ScriptExecutionContext&, const String& data);
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/StringCallback.idl
+++ b/Source/WebCore/dom/StringCallback.idl
@@ -30,5 +30,5 @@
 
 [
     ExportMacro=WEBCORE_EXPORT,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback StringCallback = undefined (DOMString data);

--- a/Source/WebCore/dom/ViewTransitionUpdateCallback.h
+++ b/Source/WebCore/dom/ViewTransitionUpdateCallback.h
@@ -39,6 +39,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<RefPtr<DOMPromise>> handleEvent() = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 }

--- a/Source/WebCore/dom/ViewTransitionUpdateCallback.idl
+++ b/Source/WebCore/dom/ViewTransitionUpdateCallback.idl
@@ -25,5 +25,5 @@
 
 [
     EnabledBySetting=ViewTransitionsEnabled,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback ViewTransitionUpdateCallback = Promise<any> ();

--- a/Source/WebCore/fileapi/BlobCallback.h
+++ b/Source/WebCore/fileapi/BlobCallback.h
@@ -42,6 +42,9 @@ public:
     virtual CallbackResult<void> handleEvent(Blob*) = 0;
 
     void scheduleCallback(ScriptExecutionContext&, RefPtr<Blob>&&);
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/fileapi/BlobCallback.idl
+++ b/Source/WebCore/fileapi/BlobCallback.idl
@@ -23,4 +23,4 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ IsStrongCallback ] callback BlobCallback = undefined (Blob? blob);
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback BlobCallback = undefined (Blob? blob);

--- a/Source/WebCore/html/VideoFrameRequestCallback.h
+++ b/Source/WebCore/html/VideoFrameRequestCallback.h
@@ -41,6 +41,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(double, const VideoFrameMetadata&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 }

--- a/Source/WebCore/html/VideoFrameRequestCallback.idl
+++ b/Source/WebCore/html/VideoFrameRequestCallback.idl
@@ -27,5 +27,5 @@ typedef double DOMHighResTimeStamp;
 
 [
     Conditional=VIDEO,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback VideoFrameRequestCallback = undefined(DOMHighResTimeStamp now, VideoFrameMetadata metadata);

--- a/Source/WebCore/html/VoidCallback.h
+++ b/Source/WebCore/html/VoidCallback.h
@@ -37,6 +37,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent() = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/VoidCallback.idl
+++ b/Source/WebCore/html/VoidCallback.idl
@@ -25,5 +25,5 @@
 
 [
     ExportMacro=WEBCORE_EXPORT,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback VoidCallback = undefined ();

--- a/Source/WebCore/inspector/RTCLogsCallback.h
+++ b/Source/WebCore/inspector/RTCLogsCallback.h
@@ -44,6 +44,9 @@ public:
     };
 
     virtual CallbackResult<void> handleEvent(const Logs&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/RTCLogsCallback.idl
+++ b/Source/WebCore/inspector/RTCLogsCallback.idl
@@ -35,5 +35,5 @@
 
 [
     Conditional=WEB_RTC,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback RTCLogsCallback = undefined (RTCLogs logs);

--- a/Source/WebCore/inspector/agents/InspectorDatabaseAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDatabaseAgent.cpp
@@ -73,6 +73,8 @@ public:
         return adoptRef(*new StatementCallback(context, WTFMove(requestCallback)));
     }
 
+    bool hasCallback() const final { return true; }
+
 private:
     StatementCallback(ScriptExecutionContext* context, Ref<ExecuteSQLCallback>&& requestCallback)
         : SQLStatementCallback(context)
@@ -111,6 +113,8 @@ public:
         return adoptRef(*new StatementErrorCallback(context, WTFMove(requestCallback)));
     }
 
+    bool hasCallback() const final { return true; }
+
 private:
     StatementErrorCallback(ScriptExecutionContext* context, Ref<ExecuteSQLCallback>&& requestCallback)
         : SQLStatementErrorCallback(context)
@@ -133,6 +137,8 @@ public:
     {
         return adoptRef(*new TransactionCallback(context, sqlStatement, WTFMove(requestCallback)));
     }
+
+    bool hasCallback() const final { return true; }
 
 private:
     TransactionCallback(ScriptExecutionContext* context, const String& sqlStatement, Ref<ExecuteSQLCallback>&& requestCallback)
@@ -164,6 +170,8 @@ public:
         return adoptRef(*new TransactionErrorCallback(context, WTFMove(requestCallback)));
     }
 
+    bool hasCallback() const final { return true; }
+
 private:
     TransactionErrorCallback(ScriptExecutionContext* context, Ref<ExecuteSQLCallback>&& requestCallback)
         : SQLTransactionErrorCallback(context)
@@ -188,6 +196,8 @@ public:
     }
 
     CallbackResult<void> handleEvent() final { return { }; }
+
+    bool hasCallback() const final { return true; }
 
 private:
     TransactionSuccessCallback(ScriptExecutionContext* context)

--- a/Source/WebCore/page/NavigationInterceptHandler.h
+++ b/Source/WebCore/page/NavigationInterceptHandler.h
@@ -36,6 +36,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<WTF::RefPtr<DOMPromise>> handleEvent() = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationInterceptHandler.idl
+++ b/Source/WebCore/page/NavigationInterceptHandler.idl
@@ -25,6 +25,6 @@
 
 [
     EnabledBySetting=NavigationAPIEnabled,
-    IsStrongCallback,
+    GenerateIsReachable=ImplScriptExecutionContext,
     SkipCallbackInvokeCheck
 ] callback NavigationInterceptHandler = Promise<undefined> ();

--- a/Source/WebCore/testing/XRSimulateUserActivationFunction.h
+++ b/Source/WebCore/testing/XRSimulateUserActivationFunction.h
@@ -40,6 +40,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(void) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/XRSimulateUserActivationFunction.idl
+++ b/Source/WebCore/testing/XRSimulateUserActivationFunction.idl
@@ -25,5 +25,5 @@
 [
     Conditional=WEBXR,
     EnabledBySetting=WebXREnabled,
-    IsStrongCallback
+    GenerateIsReachable=ImplScriptExecutionContext
 ] callback XRSimulateUserActivationFunction = undefined ();

--- a/Source/WebCore/xml/CustomXPathNSResolver.h
+++ b/Source/WebCore/xml/CustomXPathNSResolver.h
@@ -39,6 +39,9 @@ public:
     virtual CallbackResult<String> lookupNamespaceURIForBindings(const AtomString& prefix) = 0;
 
     AtomString lookupNamespaceURI(const AtomString& prefix);
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/xml/CustomXPathNSResolver.idl
+++ b/Source/WebCore/xml/CustomXPathNSResolver.idl
@@ -23,7 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Using [IsStrongCallback] here as XPathNSResolver wrappers are always temporary (no reference is kept)
-[ IsStrongCallback ] callback interface CustomXPathNSResolver {
+[ GenerateIsReachable=ImplScriptExecutionContext ] callback interface CustomXPathNSResolver {
     [ImplementedAs=lookupNamespaceURIForBindings, SkipCallbackInvokeCheck] DOMString? lookupNamespaceURI([AtomString] DOMString? prefix);
 };


### PR DESCRIPTION
#### dbe37108181c9061fdc12b5c61ab669c48f1419b
<pre>
Make all callbacks Weak handles
<a href="https://bugs.webkit.org/show_bug.cgi?id=276563">https://bugs.webkit.org/show_bug.cgi?id=276563</a>
<a href="https://rdar.apple.com/131646743">rdar://131646743</a>

Reviewed by Ryosuke Niwa.

Callback functions in Web APIs have been a frequent source of memory
leaks on real websites. This is due to the fact that the underlying
JavaScript function object was created as a JSC::Strong handle which
made it a root in the GC heap. This makes it simple for memory
mangagement for an API with a callback as the function object becomes
ineligible for garbage collection unless all references from C++ to
the wrapper are released. However, this makes it incredibly easy to create
subtle memory retention bugs due to circular references if the JS wrapper
lifetime is not managed appropriately on the C++ side (which can be
quite nontrivial). Usually the correct thing to do would be to make
callbacks Weak handles by using an extended IDL attribute and using
JS wrapper lifecycle management facilities like opaque roots to keep
the callbacks alive as long as needed by the owning object.

In 280611@main I replaced the `IsWeakCallback` attribute with
`IsStrongCallback` which would mean a developer would need to go out of
their way to make the callback handles Strong. This mitigation has
proven to be useful in testing on real sites. However, the design is
fragile and leaves us open to reintroducing leaks in the future. This patch
takes it one step further by making it impossible to make Strong handles for
callbacks.

We reuse the `GenerateIsReachable=ImplScriptExecutionContext` extended
IDL attribute to tell the code generator that we want to tie the
lifetime of the callback object to that of the script context (usually a
Document or Worker). This gives us most of the benefits of Strong
without allowing for circular references and greatly reducing leaks.
Note that it&apos;s not necessarily correct to tie the lifetime of the
callback to the ScriptExecutionContext but it makes it likely impossible
to cause Document leaks with a callback with this implementation.

By default, then, an unannotated callback in IDL will be a Weak handle
which will require some other object to keep it alive which is unchanged
behavior.

* LayoutTests/requestidlecallback/:
    Added a test to prove that a callback with
    `GenerateIsReachable=ImplScriptExecutionContext`
    will not leak the document.

* Source/WebCore:
    Every callback IDL that contained the attribute `IsStrongCallback`
    was replaced with `GenerateIsReachable=ImplScriptExecutionContext`.
    Additionally, every callback base class now needs to declare a
    pure virtual `hasCallback` member function for the generated wrapper
    code to override so those changes were also made.

* Source/WebCore/bindings/js/JSCallbackData.cpp:
* Source/WebCore/bindings/js/JSCallbackData.h:
    Fold JSCallbackDataWeak into JSCallbackData and delete
    JSCallbackDataStrong. The code generator is responsible for passing
    the correct owner pointer into the JSCallbackData constructor so
    that isReachableFromOpaqueRoots will query the visitor for the
    correct opaque root.

* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateCallbackHeaderContent):
(GenerateCallbackImplementationContent):
* Source/WebCore/bindings/scripts/IDLAttributes.json:

* Source/WebCore/bindings/scripts/test/JS/:
    bindings test rebaselines to account for the new codegen behavior.

Canonical link: <a href="https://commits.webkit.org/280975@main">https://commits.webkit.org/280975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcf9e5c2f4354ac0d29f551571e246bfe3e2c6a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61780 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8600 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47120 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6133 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27954 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7572 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7604 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51247 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63481 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57397 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54413 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54490 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12871 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1770 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79158 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33312 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13158 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34398 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35482 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34143 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->