### PR TITLE
[JSC] Inline Proxy IC calls in DFG

### DIFF
--- a/JSTests/microbenchmarks/indexed-proxy-get-dfg-call.js
+++ b/JSTests/microbenchmarks/indexed-proxy-get-dfg-call.js
@@ -1,0 +1,12 @@
+var array = new Proxy([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19], Reflect);
+
+function test() {
+    var total = 0;
+    for (var i = 0; i < array.length; ++i)
+        total += array[i];
+    return total;
+}
+noInline(test);
+
+for (var i = 0; i < 1e5; ++i)
+    test();

--- a/JSTests/microbenchmarks/indexed-proxy-has-dfg-call.js
+++ b/JSTests/microbenchmarks/indexed-proxy-has-dfg-call.js
@@ -1,0 +1,12 @@
+var array = new Proxy([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19], Reflect);
+
+function test() {
+    var total = 0;
+    for (var i = 0; i < array.length; ++i)
+        total += (i in array);
+    return total;
+}
+noInline(test);
+
+for (var i = 0; i < 1e5; ++i)
+    test();

--- a/JSTests/microbenchmarks/indexed-proxy-put-dfg-call.js
+++ b/JSTests/microbenchmarks/indexed-proxy-put-dfg-call.js
@@ -1,0 +1,10 @@
+var array = new Proxy([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19], Reflect);
+
+function test() {
+    for (var i = 0; i < array.length; ++i)
+        array[i] = i;
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i)
+    test();

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1432,10 +1432,17 @@ op :op_construct_return_location
 op :op_call_varargs_return_location
 op :op_construct_varargs_return_location
 op :op_get_by_id_return_location
+op :op_get_by_id_direct_return_location
 op :op_get_length_return_location
 op :op_get_by_val_return_location
 op :op_put_by_id_return_location
 op :op_put_by_val_return_location
+op :op_put_by_val_direct_return_location
+op :op_in_by_id_return_location
+op :op_in_by_val_return_location
+op :op_enumerator_get_by_val_return_location
+op :op_enumerator_put_by_val_return_location
+op :op_enumerator_in_by_val_return_location
 op :op_iterator_open_return_location
 op :op_iterator_next_return_location
 op :op_call_direct_eval_slow_return_location

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -265,7 +265,8 @@ GetByStatus GetByStatus::computeForStubInfoWithoutExitSiteFeedback(const Concurr
             switch (access.type()) {
             case AccessCase::ModuleNamespaceLoad:
                 return GetByStatus(access.as<ModuleNamespaceAccessCase>());
-            case AccessCase::ProxyObjectLoad: {
+            case AccessCase::ProxyObjectLoad:
+            case AccessCase::IndexedProxyObjectLoad: {
                 auto status = GetByStatus(GetByStatus::ProxyObject, true);
                 auto callLinkStatus = makeUnique<CallLinkStatus>();
                 if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, 0, access))

--- a/Source/JavaScriptCore/bytecode/InByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/InByStatus.cpp
@@ -51,14 +51,14 @@ void InByStatus::shrinkToFit()
 }
 
 #if ENABLE(JIT)
-InByStatus InByStatus::computeFor(CodeBlock* profiledBlock, ICStatusMap& map, BytecodeIndex bytecodeIndex, ExitFlag didExit, CodeOrigin codeOrigin)
+InByStatus InByStatus::computeFor(CodeBlock* profiledBlock, ICStatusMap& map, BytecodeIndex bytecodeIndex, ExitFlag didExit, CallLinkStatus::ExitSiteData callExitSiteData, CodeOrigin codeOrigin)
 {
     ConcurrentJSLocker locker(profiledBlock->m_lock);
 
     InByStatus result;
 
 #if ENABLE(DFG_JIT)
-    result = computeForStubInfoWithoutExitSiteFeedback(locker, profiledBlock->vm(), map.get(CodeOrigin(bytecodeIndex)).stubInfo, codeOrigin);
+    result = computeForStubInfoWithoutExitSiteFeedback(locker, profiledBlock, map.get(CodeOrigin(bytecodeIndex)).stubInfo, callExitSiteData, codeOrigin);
 
     if (!result.takesSlowPath() && didExit)
         return InByStatus(TakesSlowPath);
@@ -66,14 +66,10 @@ InByStatus InByStatus::computeFor(CodeBlock* profiledBlock, ICStatusMap& map, By
     UNUSED_PARAM(map);
     UNUSED_PARAM(bytecodeIndex);
     UNUSED_PARAM(didExit);
+    UNUSED_PARAM(callExitSiteData);
 #endif
 
     return result;
-}
-
-InByStatus InByStatus::computeFor(CodeBlock* profiledBlock, ICStatusMap& map, BytecodeIndex bytecodeIndex, CodeOrigin codeOrigin)
-{
-    return computeFor(profiledBlock, map, bytecodeIndex, hasBadCacheExitSite(profiledBlock, bytecodeIndex), codeOrigin);
 }
 
 InByStatus InByStatus::computeFor(
@@ -81,6 +77,7 @@ InByStatus InByStatus::computeFor(
     ICStatusContextStack& contextStack, CodeOrigin codeOrigin)
 {
     BytecodeIndex bytecodeIndex = codeOrigin.bytecodeIndex();
+    CallLinkStatus::ExitSiteData callExitSiteData = CallLinkStatus::computeExitSiteData(profiledBlock, bytecodeIndex);
     ExitFlag didExit = hasBadCacheExitSite(profiledBlock, bytecodeIndex);
     
     for (ICStatusContext* context : contextStack) {
@@ -88,7 +85,7 @@ InByStatus InByStatus::computeFor(
         
         auto bless = [&] (const InByStatus& result) -> InByStatus {
             if (!context->isInlined(codeOrigin)) {
-                InByStatus baselineResult = computeFor(profiledBlock, baselineMap, bytecodeIndex, didExit, codeOrigin);
+                InByStatus baselineResult = computeFor(profiledBlock, baselineMap, bytecodeIndex, didExit, callExitSiteData, codeOrigin);
                 baselineResult.merge(result);
                 return baselineResult;
             }
@@ -102,7 +99,7 @@ InByStatus InByStatus::computeFor(
             InByStatus result;
             {
                 ConcurrentJSLocker locker(context->optimizedCodeBlock->m_lock);
-                result = computeForStubInfoWithoutExitSiteFeedback(locker, profiledBlock->vm(), status.stubInfo, codeOrigin);
+                result = computeForStubInfoWithoutExitSiteFeedback(locker, profiledBlock, status.stubInfo, callExitSiteData, codeOrigin);
             }
             if (result.isSet())
                 return bless(result);
@@ -113,23 +110,14 @@ InByStatus InByStatus::computeFor(
             return bless(*status.inStatus);
     }
     
-    return computeFor(profiledBlock, baselineMap, bytecodeIndex, didExit, codeOrigin);
+    return computeFor(profiledBlock, baselineMap, bytecodeIndex, didExit, callExitSiteData, codeOrigin);
 }
 #endif // ENABLE(JIT)
 
 #if ENABLE(DFG_JIT)
-InByStatus InByStatus::computeForStubInfo(const ConcurrentJSLocker& locker, CodeBlock* profiledBlock, StructureStubInfo* stubInfo, CodeOrigin codeOrigin)
+InByStatus InByStatus::computeForStubInfoWithoutExitSiteFeedback(const ConcurrentJSLocker& locker, CodeBlock* profiledBlock, StructureStubInfo* stubInfo, CallLinkStatus::ExitSiteData callExitSiteData, CodeOrigin codeOrigin)
 {
-    InByStatus result = InByStatus::computeForStubInfoWithoutExitSiteFeedback(locker, profiledBlock->vm(), stubInfo, codeOrigin);
-
-    if (!result.takesSlowPath() && hasBadCacheExitSite(profiledBlock, codeOrigin.bytecodeIndex()))
-        return InByStatus(TakesSlowPath);
-    return result;
-}
-
-InByStatus InByStatus::computeForStubInfoWithoutExitSiteFeedback(const ConcurrentJSLocker&, VM& vm, StructureStubInfo* stubInfo, CodeOrigin codeOrigin)
-{
-    StubInfoSummary summary = StructureStubInfo::summary(vm, stubInfo);
+    StubInfoSummary summary = StructureStubInfo::summary(profiledBlock->vm(), stubInfo);
     if (!isInlineable(summary))
         return InByStatus(summary);
     
@@ -179,6 +167,15 @@ InByStatus InByStatus::computeForStubInfoWithoutExitSiteFeedback(const Concurren
                 if (isSameStyledCodeOrigin(stubInfo->codeOrigin, codeOrigin) && !stubInfo->tookSlowPath)
                     return InByStatus(Megamorphic);
                 break;
+            }
+            case AccessCase::ProxyObjectIn:
+            case AccessCase::IndexedProxyObjectIn: {
+                auto status = InByStatus(InByStatus::ProxyObject);
+                auto callLinkStatus = makeUnique<CallLinkStatus>();
+                if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, 0, access))
+                    *callLinkStatus = CallLinkStatus::computeFor(locker, profiledBlock, *callLinkInfo, callExitSiteData);
+                status.appendVariant(InByVariant(access.identifier(), { }, invalidOffset, { }, WTFMove(callLinkStatus)));
+                return status;
             }
             default:
                 break;
@@ -274,7 +271,8 @@ void InByStatus::merge(const InByStatus& other)
         return;
 
     case Simple:
-        if (other.m_state != Simple) {
+    case ProxyObject:
+        if (m_state != other.m_state) {
             *this = InByStatus(TakesSlowPath);
             return;
         }
@@ -286,7 +284,7 @@ void InByStatus::merge(const InByStatus& other)
         }
         shrinkToFit();
         return;
-        
+
     case TakesSlowPath:
         return;
     }
@@ -345,6 +343,9 @@ void InByStatus::dump(PrintStream& out) const
         break;
     case Simple:
         out.print("Simple");
+        break;
+    case ProxyObject:
+        out.print("ProxyObject");
         break;
     case Megamorphic:
         out.print("Megamorphic");

--- a/Source/JavaScriptCore/bytecode/InByStatus.h
+++ b/Source/JavaScriptCore/bytecode/InByStatus.h
@@ -49,6 +49,8 @@ public:
         // It's cached for a simple access to a known object property with
         // a possible structure chain and a possible specific value.
         Simple,
+        // It's cached for a proxy object case.
+        ProxyObject,
         // It's cached for a megamorphic case.
         Megamorphic,
         // It's known to often take slow path.
@@ -81,14 +83,9 @@ public:
         }
         RELEASE_ASSERT_NOT_REACHED();
     }
-    
-    static InByStatus computeFor(CodeBlock*, ICStatusMap&, BytecodeIndex, CodeOrigin);
-    static InByStatus computeFor(CodeBlock*, ICStatusMap&, BytecodeIndex, ExitFlag, CodeOrigin);
-    static InByStatus computeFor(CodeBlock* baselineBlock, ICStatusMap& baselineMap, ICStatusContextStack&, CodeOrigin);
 
-#if ENABLE(DFG_JIT)
-    static InByStatus computeForStubInfo(const ConcurrentJSLocker&, CodeBlock* baselineBlock, StructureStubInfo*, CodeOrigin);
-#endif
+    static InByStatus computeFor(CodeBlock*, ICStatusMap&, BytecodeIndex, ExitFlag, CallLinkStatus::ExitSiteData callExitSiteData, CodeOrigin);
+    static InByStatus computeFor(CodeBlock* baselineBlock, ICStatusMap& baselineMap, ICStatusContextStack&, CodeOrigin);
 
     State state() const { return m_state; }
 
@@ -96,6 +93,7 @@ public:
     explicit operator bool() const { return isSet(); }
     bool isSimple() const { return m_state == Simple; }
     bool isMegamorphic() const { return m_state == Megamorphic; }
+    bool isProxyObject() const { return m_state == ProxyObject; }
 
     size_t numVariants() const { return m_variants.size(); }
     const Vector<InByVariant, 1>& variants() const { return m_variants; }
@@ -119,7 +117,7 @@ public:
 
 private:
 #if ENABLE(DFG_JIT)
-    static InByStatus computeForStubInfoWithoutExitSiteFeedback(const ConcurrentJSLocker&, VM&, StructureStubInfo*, CodeOrigin);
+    static InByStatus computeForStubInfoWithoutExitSiteFeedback(const ConcurrentJSLocker&, CodeBlock*, StructureStubInfo*, CallLinkStatus::ExitSiteData, CodeOrigin);
 #endif
     bool appendVariant(const InByVariant&);
     void shrinkToFit();

--- a/Source/JavaScriptCore/bytecode/InByVariant.h
+++ b/Source/JavaScriptCore/bytecode/InByVariant.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "CacheableIdentifier.h"
+#include "CallLinkStatus.h"
 #include "ObjectPropertyConditionSet.h"
 #include "PropertyOffset.h"
 #include "StructureSet.h"
@@ -37,13 +38,18 @@ namespace DOMJIT {
 class GetterSetter;
 }
 
+class CallLinkStatus;
 class InByStatus;
 struct DumpContext;
 
 class InByVariant {
     WTF_MAKE_TZONE_ALLOCATED(InByVariant);
 public:
-    InByVariant(CacheableIdentifier, const StructureSet& = StructureSet(), PropertyOffset = invalidOffset, const ObjectPropertyConditionSet& = ObjectPropertyConditionSet());
+    InByVariant(CacheableIdentifier, const StructureSet& = StructureSet(), PropertyOffset = invalidOffset, const ObjectPropertyConditionSet& = ObjectPropertyConditionSet(), std::unique_ptr<CallLinkStatus> = nullptr);
+    ~InByVariant();
+
+    InByVariant(const InByVariant&);
+    InByVariant& operator=(const InByVariant&);
 
     bool isSet() const { return !!m_structureSet.size(); }
     explicit operator bool() const { return isSet(); }
@@ -54,6 +60,7 @@ public:
     const ObjectPropertyConditionSet& conditionSet() const { return m_conditionSet; }
 
     PropertyOffset offset() const { return m_offset; }
+    CallLinkStatus* callLinkStatus() const { return m_callLinkStatus.get(); }
 
     bool isHit() const { return offset() != invalidOffset; }
 
@@ -86,6 +93,7 @@ private:
     ObjectPropertyConditionSet m_conditionSet;
     PropertyOffset m_offset;
     CacheableIdentifier m_identifier;
+    std::unique_ptr<CallLinkStatus> m_callLinkStatus;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
@@ -123,6 +123,9 @@ void printInternal(PrintStream& out, JSC::InlineCallFrame::Kind kind)
     case JSC::InlineCallFrame::ProxyObjectStoreCall:
         out.print("ProxyObjectStoreCall");
         return;
+    case JSC::InlineCallFrame::ProxyObjectInCall:
+        out.print("ProxyObjectInCall");
+        return;
     case JSC::InlineCallFrame::BoundFunctionCall:
         out.print("BoundFunctionCall");
         return;

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.h
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.h
@@ -59,6 +59,7 @@ struct InlineCallFrame {
         SetterCall,
         ProxyObjectLoadCall,
         ProxyObjectStoreCall,
+        ProxyObjectInCall,
         BoundFunctionCall,
         BoundFunctionTailCall,
     };
@@ -73,6 +74,7 @@ struct InlineCallFrame {
         case SetterCall:
         case ProxyObjectLoadCall:
         case ProxyObjectStoreCall:
+        case ProxyObjectInCall:
         case BoundFunctionCall:
             return CallMode::Regular;
         case TailCall:
@@ -123,6 +125,7 @@ struct InlineCallFrame {
         case SetterCall:
         case ProxyObjectLoadCall:
         case ProxyObjectStoreCall:
+        case ProxyObjectInCall:
         case BoundFunctionCall:
         case BoundFunctionTailCall:
             return CodeForCall;

--- a/Source/JavaScriptCore/bytecode/PutByStatus.h
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.h
@@ -55,6 +55,8 @@ public:
         Simple,
         // It's cached for a custom accessor with a possible structure chain.
         CustomAccessor,
+        // It's cached for a proxy object.
+        ProxyObject,
         // It's cached for a megamorphic case.
         Megamorphic,
         // It will likely take the slow path.
@@ -83,6 +85,7 @@ public:
         case MakesCalls:
         case ObservedSlowPathAndMakesCalls:
         case Megamorphic:
+        case ProxyObject:
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();
@@ -115,6 +118,7 @@ public:
     bool isSimple() const { return m_state == Simple; }
     bool isCustomAccessor() const { return m_state == CustomAccessor; }
     bool isMegamorphic() const { return m_state == Megamorphic; }
+    bool isProxyObject() const { return m_state == ProxyObject; }
     bool takesSlowPath() const
     {
         switch (m_state) {

--- a/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
@@ -180,8 +180,12 @@ static CodePtr<JSEntryPtrTag> callerReturnPC(CodeBlock* baselineCodeBlockForCall
                 jumpTarget = LLINT_RETURN_LOCATION(op_get_by_id);
             else if (callInstruction.opcodeID() == op_get_length)
                 jumpTarget = LLINT_RETURN_LOCATION(op_get_length);
+            else if (callInstruction.opcodeID() == op_get_by_id_direct)
+                jumpTarget = LLINT_RETURN_LOCATION(op_get_by_id_direct);
             else if (callInstruction.opcodeID() == op_get_by_val)
                 jumpTarget = LLINT_RETURN_LOCATION(op_get_by_val);
+            else if (callInstruction.opcodeID() == op_enumerator_get_by_val)
+                jumpTarget = LLINT_RETURN_LOCATION(op_enumerator_get_by_val);
             else
                 RELEASE_ASSERT_NOT_REACHED();
             break;
@@ -192,6 +196,21 @@ static CodePtr<JSEntryPtrTag> callerReturnPC(CodeBlock* baselineCodeBlockForCall
                 jumpTarget = LLINT_RETURN_LOCATION(op_put_by_id);
             else if (callInstruction.opcodeID() == op_put_by_val)
                 jumpTarget = LLINT_RETURN_LOCATION(op_put_by_val);
+            else if (callInstruction.opcodeID() == op_put_by_val_direct)
+                jumpTarget = LLINT_RETURN_LOCATION(op_put_by_val_direct);
+            else if (callInstruction.opcodeID() == op_enumerator_put_by_val)
+                jumpTarget = LLINT_RETURN_LOCATION(op_enumerator_put_by_val);
+            else
+                RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
+        case InlineCallFrame::ProxyObjectInCall: {
+            if (callInstruction.opcodeID() == op_in_by_id)
+                jumpTarget = LLINT_RETURN_LOCATION(op_in_by_id);
+            else if (callInstruction.opcodeID() == op_in_by_val)
+                jumpTarget = LLINT_RETURN_LOCATION(op_in_by_val);
+            else if (callInstruction.opcodeID() == op_enumerator_in_by_val)
+                jumpTarget = LLINT_RETURN_LOCATION(op_enumerator_in_by_val);
             else
                 RELEASE_ASSERT_NOT_REACHED();
             break;
@@ -216,7 +235,8 @@ static CodePtr<JSEntryPtrTag> callerReturnPC(CodeBlock* baselineCodeBlockForCall
         case InlineCallFrame::GetterCall:
         case InlineCallFrame::SetterCall:
         case InlineCallFrame::ProxyObjectLoadCall:
-        case InlineCallFrame::ProxyObjectStoreCall: {
+        case InlineCallFrame::ProxyObjectStoreCall:
+        case InlineCallFrame::ProxyObjectInCall: {
             StructureStubInfo* stubInfo = baselineCodeBlockForCaller->findStubInfo(CodeOrigin(callBytecodeIndex));
             RELEASE_ASSERT(stubInfo, callInstruction.opcodeID());
             jumpTarget = stubInfo->doneLocation.retagged<JSEntryPtrTag>();

--- a/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -799,10 +799,17 @@ MacroAssemblerCodeRef<JSEntryPtrTag> returnLocationThunk(OpcodeID opcodeID, Opco
     LLINT_RETURN_LOCATION(op_call_varargs)
     LLINT_RETURN_LOCATION(op_construct_varargs)
     LLINT_RETURN_LOCATION(op_get_by_id)
+    LLINT_RETURN_LOCATION(op_get_by_id_direct)
     LLINT_RETURN_LOCATION(op_get_length)
     LLINT_RETURN_LOCATION(op_get_by_val)
     LLINT_RETURN_LOCATION(op_put_by_id)
     LLINT_RETURN_LOCATION(op_put_by_val)
+    LLINT_RETURN_LOCATION(op_put_by_val_direct)
+    LLINT_RETURN_LOCATION(op_in_by_id)
+    LLINT_RETURN_LOCATION(op_in_by_val)
+    LLINT_RETURN_LOCATION(op_enumerator_get_by_val)
+    LLINT_RETURN_LOCATION(op_enumerator_put_by_val)
+    LLINT_RETURN_LOCATION(op_enumerator_in_by_val)
     default:
         RELEASE_ASSERT_NOT_REACHED();
         return { };

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2097,8 +2097,6 @@ macro llintSlowPathOp(opcodeName)
     end)
 end
 
-llintSlowPathOp(in_by_id)
-llintSlowPathOp(in_by_val)
 llintSlowPathOp(has_private_name)
 llintSlowPathOp(has_private_brand)
 llintSlowPathOp(del_by_id)

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -1523,6 +1523,11 @@ llintOpWithMetadata(op_get_by_id_direct, OpGetByIdDirect, macro (size, get, disp
 .opGetByIdDirectSlow:
     callSlowPath(_llint_slow_path_get_by_id_direct)
     dispatch()
+
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_get_by_id_direct, size)
+    valueProfile(size, OpGetByIdDirect, m_valueProfile, r1, r0, t2)
+    return(r1, r0)
 end)
 
 # Assumption: The base object is in t3
@@ -1743,7 +1748,6 @@ llintOpWithMetadata(op_put_by_id, OpPutById, macro (size, get, dispatch, metadat
 .osrReturnPoint:
     getterSetterOSRExitReturnPoint(op_put_by_id, size)
     dispatch()
-
 end)
 
 
@@ -1825,7 +1829,6 @@ llintOpWithMetadata(op_get_by_val, OpGetByVal, macro (size, get, dispatch, metad
     getterSetterOSRExitReturnPoint(op_get_by_val, size)
     valueProfile(size, OpGetByVal, m_valueProfile, r1, r0, t2)
     return(r1, r0)
-
 end)
 
 llintOpWithMetadata(op_get_private_name, OpGetPrivateName, macro (size, get, dispatch, metadata, return)
@@ -2013,7 +2016,11 @@ putByValOp(put_by_val, OpPutByVal, macro (size, dispatch)
     dispatch()
 end)
 
-putByValOp(put_by_val_direct, OpPutByValDirect, macro (a, b) end)
+putByValOp(put_by_val_direct, OpPutByValDirect, macro (size, dispatch)
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_put_by_val_direct, size)
+    dispatch()
+end)
 
 
 macro llintJumpTrueOrFalseOp(opcodeName, opcodeStruct, conditionOp, notUsed)
@@ -3385,11 +3392,49 @@ llintOpWithMetadata(op_set_private_brand, OpSetPrivateBrand, macro (size, get, d
     dispatch()
 end)
 
+llintOpWithReturn(op_in_by_id, OpInById, macro (size, get, dispatch, return)
+    callSlowPath(_llint_slow_path_in_by_id)
+    dispatch()
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_in_by_id, size)
+    return(r1, r0)
+end)
+
+llintOpWithReturn(op_in_by_val, OpInByVal, macro (size, get, dispatch, return)
+    callSlowPath(_llint_slow_path_in_by_val)
+    dispatch()
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_in_by_val, size)
+    return(r1, r0)
+end)
+
+llintOpWithReturn(op_enumerator_in_by_val, OpEnumeratorInByVal, macro (size, get, dispatch, return)
+    callSlowPath(_slow_path_enumerator_in_by_val)
+    dispatch()
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_enumerator_in_by_val, size)
+    return(r1, r0)
+end)
+
+llintOpWithReturn(op_enumerator_get_by_val, OpEnumeratorGetByVal, macro (size, get, dispatch, return)
+    callSlowPath(_slow_path_enumerator_get_by_val)
+    dispatch()
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_enumerator_get_by_val, size)
+    valueProfile(size, OpEnumeratorGetByVal, m_valueProfile, r1, r0, t2)
+    return(r1, r0)
+end)
+
+llintOpWithReturn(op_enumerator_put_by_val, OpEnumeratorPutByVal, macro (size, get, dispatch, return)
+    callSlowPath(_slow_path_enumerator_put_by_val)
+    dispatch()
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_enumerator_put_by_val, size)
+    dispatch()
+end)
+
 slowPathOp(get_property_enumerator)
 slowPathOp(enumerator_next)
-slowPathOp(enumerator_get_by_val)
-slowPathOp(enumerator_in_by_val)
-slowPathOp(enumerator_put_by_val)
 slowPathOp(enumerator_has_own_property)
 slowPathOp(mod)
 

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -1651,6 +1651,11 @@ llintOpWithMetadata(op_get_by_id_direct, OpGetByIdDirect, macro (size, get, disp
 .opGetByIdDirectSlow:
     callSlowPath(_llint_slow_path_get_by_id_direct)
     dispatch()
+
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_get_by_id_direct, size)
+    valueProfile(size, OpGetByIdDirect, m_valueProfile, r0, t2)
+    return(r0)
 end)
 
 # The base object is expected in t3
@@ -1921,7 +1926,6 @@ llintOpWithMetadata(op_get_by_val, OpGetByVal, macro (size, get, dispatch, metad
     getterSetterOSRExitReturnPoint(op_get_by_val, size)
     valueProfile(size, OpGetByVal, m_valueProfile, r0, t5)
     return(r0)
-
 end)
 
 llintOpWithMetadata(op_get_private_name, OpGetPrivateName, macro (size, get, dispatch, metadata, return)
@@ -2140,8 +2144,11 @@ putByValOp(put_by_val, OpPutByVal, macro (size, dispatch)
     dispatch()
 end)
 
-putByValOp(put_by_val_direct, OpPutByValDirect, macro (a, b) end)
-
+putByValOp(put_by_val_direct, OpPutByValDirect, macro (size, dispatch)
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_put_by_val_direct, size)
+    dispatch()
+end)
 
 macro llintJumpTrueOrFalseOp(opcodeName, opcodeStruct, miscConditionOp, truthyCellConditionOp)
     llintOpWithJump(op_%opcodeName%, opcodeStruct, macro (size, get, jump, dispatch)
@@ -3465,6 +3472,11 @@ llintOpWithMetadata(op_enumerator_get_by_val, OpEnumeratorGetByVal, macro (size,
 .getSlowPath:
     callSlowPath(_slow_path_enumerator_get_by_val)
     dispatch()
+
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_enumerator_get_by_val, size)
+    valueProfile(size, OpEnumeratorGetByVal, m_valueProfile, r0, t5)
+    return(r0)
 end)
 
 llintOpWithMetadata(op_enumerator_put_by_val, OpEnumeratorPutByVal, macro (size, get, dispatch, metadata, return)
@@ -3513,6 +3525,10 @@ llintOpWithMetadata(op_enumerator_put_by_val, OpEnumeratorPutByVal, macro (size,
 .putSlowPath:
     callSlowPath(_slow_path_enumerator_put_by_val)
     dispatch()
+
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_enumerator_put_by_val, size)
+    dispatch()
 end)
 
 macro hasPropertyImpl(opcodeStruct, size, get, dispatch, metadata, return, slowPath)
@@ -3543,10 +3559,29 @@ end
 
 llintOpWithMetadata(op_enumerator_in_by_val, OpEnumeratorInByVal, macro (size, get, dispatch, metadata, return)
     hasPropertyImpl(OpEnumeratorInByVal, size, get, dispatch, metadata, return, _slow_path_enumerator_in_by_val)
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_enumerator_in_by_val, size)
+    return(r0)
 end)
 
 llintOpWithMetadata(op_enumerator_has_own_property, OpEnumeratorHasOwnProperty, macro (size, get, dispatch, metadata, return)
     hasPropertyImpl(OpEnumeratorHasOwnProperty, size, get, dispatch, metadata, return, _slow_path_enumerator_has_own_property)
+end)
+
+llintOpWithReturn(op_in_by_id, OpInById, macro (size, get, dispatch, return)
+    callSlowPath(_llint_slow_path_in_by_id)
+    dispatch()
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_in_by_id, size)
+    return(r0)
+end)
+
+llintOpWithReturn(op_in_by_val, OpInByVal, macro (size, get, dispatch, return)
+    callSlowPath(_llint_slow_path_in_by_val)
+    dispatch()
+.osrReturnPoint:
+    getterSetterOSRExitReturnPoint(op_in_by_val, size)
+    return(r0)
 end)
 
 llintOpWithProfile(op_get_internal_field, OpGetInternalField, macro (size, get, dispatch, return)

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -707,6 +707,7 @@ public:
     JSFunction* regExpProtoExecFunction() const;
     JSFunction* stringProtoSubstringFunction() const;
     JSFunction* performProxyObjectHasFunction() const;
+    JSFunction* performProxyObjectHasFunctionConcurrently() const;
     JSFunction* performProxyObjectHasByValFunction() const;
     JSFunction* performProxyObjectHasByValFunctionConcurrently() const;
     JSFunction* performProxyObjectGetFunction() const;

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -220,6 +220,7 @@ inline JSFunction* JSGlobalObject::performPromiseThenFunction() const { return j
 inline JSFunction* JSGlobalObject::regExpProtoExecFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::regExpBuiltinExec)); }
 inline JSFunction* JSGlobalObject::stringProtoSubstringFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::stringSubstring)); }
 inline JSFunction* JSGlobalObject::performProxyObjectHasFunction() const { return m_performProxyObjectHasFunction.get(); }
+inline JSFunction* JSGlobalObject::performProxyObjectHasFunctionConcurrently() const { return performProxyObjectHasFunction(); }
 inline JSFunction* JSGlobalObject::performProxyObjectHasByValFunction() const { return m_performProxyObjectHasByValFunction.get(); }
 inline JSFunction* JSGlobalObject::performProxyObjectHasByValFunctionConcurrently() const { return performProxyObjectHasByValFunction(); }
 inline JSFunction* JSGlobalObject::performProxyObjectGetFunction() const { return m_performProxyObjectGetFunction.get(); }


### PR DESCRIPTION
#### 22af8f1310b162dbcb59c0d76d60a6bfce24f67e
<pre>
[JSC] Inline Proxy IC calls in DFG
<a href="https://bugs.webkit.org/show_bug.cgi?id=276574">https://bugs.webkit.org/show_bug.cgi?id=276574</a>
<a href="https://rdar.apple.com/131675707">rdar://131675707</a>

Reviewed by Yijia Huang.

This patch inlines ProxyObject IC into DFG / FTL when IC site only see one ProxyObject IC.
As the same to the already-existing Proxy Load inlining in DFG, we do this for Store and In.
Also we support Indexed Proxy Load / Store / In in DFG inlining too.

                                           ToT                     Patched

    indexed-proxy-has-dfg-call       46.8285+-0.0983     ^     43.8616+-0.1500        ^ definitely 1.0676x faster
    indexed-proxy-get-dfg-call       49.7546+-0.0843     ^     45.7176+-0.2335        ^ definitely 1.0883x faster
    indexed-proxy-put-dfg-call       40.6735+-0.0854     ^     39.6159+-0.1099        ^ definitely 1.0267x faster

* JSTests/microbenchmarks/indexed-proxy-get-dfg-call.js: Added.
(test):
* JSTests/microbenchmarks/indexed-proxy-has-dfg-call.js: Added.
(test):
* JSTests/microbenchmarks/indexed-proxy-put-dfg-call.js: Added.
(test):
* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeForStubInfoWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecode/InByStatus.cpp:
(JSC::InByStatus::computeFor):
(JSC::InByStatus::computeForStubInfoWithoutExitSiteFeedback):
(JSC::InByStatus::merge):
(JSC::InByStatus::dump const):
(JSC::InByStatus::computeForStubInfo): Deleted.
* Source/JavaScriptCore/bytecode/InByStatus.h:
* Source/JavaScriptCore/bytecode/InByVariant.cpp:
(JSC::InByVariant::InByVariant):
(JSC::InByVariant::operator=):
(JSC::InByVariant::attemptToMerge):
(JSC::InByVariant::finalize):
(JSC::InByVariant::dumpInContext const):
* Source/JavaScriptCore/bytecode/InByVariant.h:
(JSC::InByVariant::callLinkStatus const):
* Source/JavaScriptCore/bytecode/InlineCallFrame.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/InlineCallFrame.h:
(JSC::InlineCallFrame::callModeFor):
(JSC::InlineCallFrame::specializationKindFor):
* Source/JavaScriptCore/bytecode/PutByStatus.cpp:
(JSC::PutByStatus::computeForStubInfo):
(JSC::PutByStatus::merge):
(JSC::PutByStatus::dump const):
* Source/JavaScriptCore/bytecode/PutByStatus.h:
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::inlineCall):
(JSC::DFG::ByteCodeParser::emitProxyObjectLoadCall):
(JSC::DFG::ByteCodeParser::emitProxyObjectStoreCall):
(JSC::DFG::ByteCodeParser::emitProxyObjectInCall):
(JSC::DFG::ByteCodeParser::handleProxyObjectLoad):
(JSC::DFG::ByteCodeParser::handleIndexedProxyObjectLoad):
(JSC::DFG::ByteCodeParser::handleProxyObjectStore):
(JSC::DFG::ByteCodeParser::handleIndexedProxyObjectStore):
(JSC::DFG::ByteCodeParser::handleProxyObjectIn):
(JSC::DFG::ByteCodeParser::handleIndexedProxyObjectIn):
(JSC::DFG::ByteCodeParser::handleInById):
(JSC::DFG::ByteCodeParser::handlePutById):
(JSC::DFG::ByteCodeParser::parseBlock):
(JSC::DFG::ByteCodeParser::handlePutByVal):
* Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp:
(JSC::DFG::callerReturnPC):
* Source/JavaScriptCore/llint/LLIntThunks.cpp:
(JSC::LLInt::returnLocationThunk):
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::performProxyObjectHasFunctionConcurrently const):

Canonical link: <a href="https://commits.webkit.org/280973@main">https://commits.webkit.org/280973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b686eb24aea07beaf84c3f775ea9c79a77176a95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58114 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61739 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8559 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47084 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6099 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27918 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7535 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7563 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51206 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63440 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57356 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54359 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54457 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1734 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79117 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8682 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33271 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13142 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35441 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->