### PR TITLE
[Writing Tools] Remove deprecated Writing Tools context menu item implementation

### DIFF
--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -129,10 +129,6 @@ class EmptyContextMenuClient final : public ContextMenuClient {
     void handleTranslation(const TranslationContextMenuInfo&) final { }
 #endif
 
-#if ENABLE(WRITING_TOOLS)
-    void handleWritingToolsDeprecated(IntRect) final { };
-#endif
-
 #if PLATFORM(GTK)
     void insertEmoji(LocalFrame&) final { }
 #endif

--- a/Source/WebCore/page/ContextMenuClient.h
+++ b/Source/WebCore/page/ContextMenuClient.h
@@ -62,10 +62,6 @@ public:
     virtual void handleTranslation(const TranslationContextMenuInfo&) = 0;
 #endif
 
-#if ENABLE(WRITING_TOOLS)
-    virtual void handleWritingToolsDeprecated(IntRect selectionBoundsInRootView) = 0;
-#endif
-
 #if PLATFORM(GTK)
     virtual void insertEmoji(LocalFrame&) = 0;
 #endif

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -648,10 +648,8 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         break;
 
     case ContextMenuItemTagWritingTools:
-#if ENABLE(WRITING_TOOLS)
-        if (RefPtr view = frame->view())
-            m_client->handleWritingToolsDeprecated(view->contentsToRootView(enclosingIntRect(frame->selection().selectionBounds())));
-#endif
+        // The Writing Tools context menu item action is handled in the client layer.
+        RELEASE_ASSERT_NOT_REACHED();
         break;
 
 #if ENABLE(PDFJS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
@@ -60,7 +60,7 @@ NSString * const _WKMenuItemIdentifierShareMenu = @"WKMenuItemIdentifierShareMen
 NSString * const _WKMenuItemIdentifierSpeechMenu = @"WKMenuItemIdentifierSpeechMenu";
 
 NSString * const _WKMenuItemIdentifierTranslate = @"WKMenuItemIdentifierTranslate";
-NSString * const _WKMenuItemIdentifierWritingTools = @"WKMenuItemIdentifierWritingTools";
+NSString * const _WKMenuItemIdentifierWritingTools = @"__NSTextViewContextSubmenuIdentifierWritingTools"; // AppKit creates this menu item.
 NSString * const _WKMenuItemIdentifierCopySubject = @"WKMenuItemIdentifierCopySubject";
 
 NSString * const _WKMenuItemIdentifierSpellingMenu = @"WKMenuItemIdentifierSpellingMenu";

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -874,11 +874,6 @@ bool WebPageProxy::canHandleContextMenuWritingTools() const
     return protectedPageClient()->canHandleContextMenuWritingTools();
 }
 
-void WebPageProxy::handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView)
-{
-    protectedPageClient()->handleContextMenuWritingToolsDeprecated(selectionBoundsInRootView);
-}
-
 #endif // ENABLE(WRITING_TOOLS)
 
 #endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -742,7 +742,6 @@ public:
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
     virtual bool canHandleContextMenuWritingTools() const = 0;
-    virtual void handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView) = 0;
     virtual void handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool, WebCore::IntRect) { }
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2253,7 +2253,6 @@ public:
 #if ENABLE(WRITING_TOOLS)
 #if ENABLE(CONTEXT_MENUS)
     bool canHandleContextMenuWritingTools() const;
-    void handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView);
     void handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool);
 #endif
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -232,10 +232,6 @@ messages -> WebPageProxy {
     HandleContextMenuTranslation(struct WebCore::TranslationContextMenuInfo info)
 #endif
 
-#if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
-    HandleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView)
-#endif
-
 #if ENABLE(WRITING_TOOLS)
     ProofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(struct WebCore::WritingTools::Session::ID sessionID, struct WebCore::WritingTools::TextSuggestion::ID replacementID, WebCore::IntRect selectionBoundsInRootView)
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -309,7 +309,6 @@ private:
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
     bool canHandleContextMenuWritingTools() const override;
-    void handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView) override;
     void handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool, WebCore::IntRect) override;
 #endif
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1108,11 +1108,6 @@ bool PageClientImpl::canHandleContextMenuWritingTools() const
     return m_impl->canHandleContextMenuWritingTools();
 }
 
-void PageClientImpl::handleContextMenuWritingToolsDeprecated(IntRect selectionBoundsInRootView)
-{
-    m_impl->handleContextMenuWritingToolsDeprecated(selectionBoundsInRootView);
-}
-
 void PageClientImpl::handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool tool, WebCore::IntRect selectionRect)
 {
     RetainPtr webView = this->webView();

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -865,9 +865,6 @@ void WebContextMenuProxyMac::getContextMenuItem(const WebContextMenuItemData& it
         if ([NSMenuItem.class respondsToSelector:@selector(standardWritingToolsMenuItem)]) {
             RetainPtr menuItem = [NSMenuItem standardWritingToolsMenuItem];
 
-            // FIXME: (rdar://127608508) Use the default identifier once the deprecated menu item is removed.
-            [menuItem setIdentifier:_WKMenuItemIdentifierWritingTools];
-
             for (NSMenuItem *subItem in [menuItem submenu].itemArray) {
                 if (subItem.isSeparatorItem)
                     continue;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -714,8 +714,6 @@ public:
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
     bool canHandleContextMenuWritingTools() const;
-    // FIXME: (rdar://127608508) Remove all uses of this method when possible, in favor of the non-deprecated implementation.
-    void handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView);
 #endif
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6460,16 +6460,6 @@ bool WebViewImpl::canHandleContextMenuWritingTools() const
     return [PAL::getWTWritingToolsViewControllerClass() isAvailable] && m_page->writingToolsBehavior() != WebCore::WritingTools::Behavior::None;
 }
 
-void WebViewImpl::handleContextMenuWritingToolsDeprecated(IntRect selectionBoundsInRootView)
-{
-    if (!canHandleContextMenuWritingTools()) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    auto view = m_view.get();
-    [[PAL::getWTWritingToolsClass() sharedInstance] showPanelForSelectionRect:selectionBoundsInRootView ofView:view.get() forDelegate:(NSObject<WTWritingToolsDelegate> *)view.get()];
-}
 #endif
 
 bool WebViewImpl::acceptsPreviewPanelControl(QLPreviewPanel *)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
@@ -61,10 +61,6 @@ private:
     void handleTranslation(const WebCore::TranslationContextMenuInfo&) final;
 #endif
 
-#if ENABLE(WRITING_TOOLS)
-    void handleWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView) final;
-#endif
-
 #if PLATFORM(GTK)
     void insertEmoji(WebCore::LocalFrame&) override;
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -79,18 +79,6 @@ void WebContextMenuClient::handleTranslation(const WebCore::TranslationContextMe
 
 #endif // HAVE(TRANSLATION_UI_SERVICES)
 
-#if ENABLE(WRITING_TOOLS)
-
-void WebContextMenuClient::handleWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView)
-{
-    if (!m_page)
-        return;
-
-    m_page->send(Messages::WebPageProxy::HandleContextMenuWritingToolsDeprecated(selectionBoundsInRootView));
-}
-
-#endif
-
 } // namespace WebKit
 
 #endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9307,13 +9307,6 @@ void WebPage::handleContextMenuTranslation(const TranslationContextMenuInfo& inf
 }
 #endif
 
-#if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
-void WebPage::handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView)
-{
-    send(Messages::WebPageProxy::HandleContextMenuWritingToolsDeprecated(selectionBoundsInRootView));
-}
-#endif
-
 void WebPage::scrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint&)
 {
     RefPtr frameView = localMainFrameView();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1628,10 +1628,6 @@ public:
     void handleContextMenuTranslation(const WebCore::TranslationContextMenuInfo&);
 #endif
 
-#if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
-    void handleContextMenuWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView);
-#endif
-
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
     void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&);
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h
@@ -76,10 +76,6 @@ public:
     void handleTranslation(const WebCore::TranslationContextMenuInfo&) final;
 #endif
 
-#if ENABLE(WRITING_TOOLS)
-    void handleWritingToolsDeprecated(WebCore::IntRect selectionBoundsInRootView) final;
-#endif
-
 private:
     NSMenu *contextMenuForEvent(NSEvent *, NSView *, bool& isServicesMenu);
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -146,14 +146,6 @@ void WebContextMenuClient::handleTranslation(const TranslationContextMenuInfo& i
 
 #endif
 
-#if ENABLE(WRITING_TOOLS)
-
-void WebContextMenuClient::handleWritingToolsDeprecated(IntRect selectionBoundsInRootView)
-{
-}
-
-#endif
-
 #if ENABLE(SERVICE_CONTROLS)
 
 void WebContextMenuClient::sharingServicePickerWillBeDestroyed(WebSharingServicePickerController &)


### PR DESCRIPTION
#### 7fa000b96098dfaaffbbf02332f611b45902ddf5
<pre>
[Writing Tools] Remove deprecated Writing Tools context menu item implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=276578">https://bugs.webkit.org/show_bug.cgi?id=276578</a>
<a href="https://rdar.apple.com/131678538">rdar://131678538</a>

Reviewed by Aditya Keerthi and Wenson Hsieh.

* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/ContextMenuClient.h:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::handleContextMenuWritingToolsDeprecated): Deleted.
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::handleContextMenuWritingToolsDeprecated): Deleted.
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::getContextMenuItem):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::handleContextMenuWritingToolsDeprecated): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm:
(WebKit::WebContextMenuClient::handleWritingToolsDeprecated): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::handleContextMenuWritingToolsDeprecated): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm:
(WebContextMenuClient::handleWritingToolsDeprecated): Deleted.

Canonical link: <a href="https://commits.webkit.org/280971@main">https://commits.webkit.org/280971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a569847c763265c7cfe1e159dbab1e24d88ed24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8653 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47169 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6182 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28002 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7628 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7657 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53908 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63538 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2122 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54488 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54543 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1823 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8681 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33365 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34451 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35535 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34196 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->