### PR TITLE
Fix some typos.

### DIFF
--- a/LayoutTests/fast/css/font-face-implicit-local-font.html
+++ b/LayoutTests/fast/css/font-face-implicit-local-font.html
@@ -8,7 +8,7 @@
 <p>
     This tests that when @font-face rules with unicode-range are specified for a
     font that exists on the system, the system font is used for all characters
-    not explictly overridden.
+    not explicitly overridden.
 </p>
 <p>
     In the next line, the digits should be in Times, but the letters should be

--- a/LayoutTests/fast/mediastream/getUserMedia-echoCancellation-expected.txt
+++ b/LayoutTests/fast/mediastream/getUserMedia-echoCancellation-expected.txt
@@ -1,3 +1,3 @@
 
-PASS echoCancellation should be on by default if not explictly disabled
+PASS echoCancellation should be on by default if not explicitly disabled
 

--- a/LayoutTests/fast/mediastream/getUserMedia-echoCancellation.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-echoCancellation.html
@@ -7,5 +7,5 @@ promise_test(async () => {
 
     const stream2 = await navigator.mediaDevices.getUserMedia({ audio: true });
     assert_true(stream2.getAudioTracks()[0].getSettings().echoCancellation);
-}, "echoCancellation should be on by default if not explictly disabled");
+}, "echoCancellation should be on by default if not explicitly disabled");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/docs/writing-tests/testdriver.md
+++ b/LayoutTests/imported/w3c/web-platform-tests/docs/writing-tests/testdriver.md
@@ -208,7 +208,7 @@ actions.send();
 ```
 
 Note that if an action uses an element reference, the context will be
-derived from that element, and must match any explictly set
+derived from that element, and must match any explicitly set
 context. Using elements in multiple contexts in a single action chain
 is not supported.
 

--- a/LayoutTests/platform/glib/fast/css/font-face-implicit-local-font-expected.txt
+++ b/LayoutTests/platform/glib/fast/css/font-face-implicit-local-font-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 480: "This tests that when @font-face rules with unicode-range are specified for a "
           text run at (480,0) width 298: "font that exists on the system, the system font is"
           text run at (0,18) width 141: "used for all characters "
-          text run at (141,18) width 154: "not explictly overridden."
+          text run at (141,18) width 154: "not explicitly overridden."
       RenderBlock {P} at (0,52) size 784x18
         RenderText {#text} at (0,0) size 511x17
           text run at (0,0) width 444: "In the next line, the digits should be in Times, but the letters should be "

--- a/LayoutTests/platform/ios/fast/css/font-face-implicit-local-font-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/font-face-implicit-local-font-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 491: "This tests that when @font-face rules with unicode-range are specified for a "
           text run at (490,0) width 293: "font that exists on the system, the system font"
           text run at (0,20) width 160: "is used for all characters "
-          text run at (159,20) width 159: "not explictly overridden."
+          text run at (159,20) width 159: "not explicitly overridden."
       RenderBlock {P} at (0,56) size 784x20
         RenderText {#text} at (0,0) size 523x19
           text run at (0,0) width 455: "In the next line, the digits should be in Times, but the letters should be "

--- a/LayoutTests/platform/mac/fast/css/font-face-implicit-local-font-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/font-face-implicit-local-font-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 490: "This tests that when @font-face rules with unicode-range are specified for a "
           text run at (489,0) width 293: "font that exists on the system, the system font"
           text run at (0,18) width 160: "is used for all characters "
-          text run at (159,18) width 159: "not explictly overridden."
+          text run at (159,18) width 159: "not explicitly overridden."
       RenderBlock {P} at (0,52) size 784x18
         RenderText {#text} at (0,0) size 523x18
           text run at (0,0) width 455: "In the next line, the digits should be in Times, but the letters should be "

--- a/LayoutTests/platform/win/fast/css/font-face-implicit-local-font-expected.txt
+++ b/LayoutTests/platform/win/fast/css/font-face-implicit-local-font-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x600
           text run at (0,0) width 481: "This tests that when @font-face rules with unicode-range are specified for a "
           text run at (480,0) width 299: "font that exists on the system, the system font is"
           text run at (0,18) width 141: "used for all characters "
-          text run at (141,18) width 154: "not explictly overridden."
+          text run at (141,18) width 154: "not explicitly overridden."
       RenderBlock {P} at (0,52) size 784x18
         RenderText {#text} at (0,0) size 510x17
           text run at (0,0) width 443: "In the next line, the digits should be in Times, but the letters should be "

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -198,7 +198,7 @@ public:
     //
     // Operations are typically two operand - operation(source, srcDst)
     // For many operations the source may be an TrustedImm32, the srcDst operand
-    // may often be a memory location (explictly described using an Address
+    // may often be a memory location (explicitly described using an Address
     // object).
 
     void add32(RegisterID src, RegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -118,7 +118,7 @@ public:
     //
     // Operations are typically two operand - operation(source, srcDst)
     // For many operations the source may be an TrustedImm32, the srcDst operand
-    // may often be a memory location (explictly described using an Address
+    // may often be a memory location (explicitly described using an Address
     // object).
 
     void add32(RegisterID src, RegisterID dest)

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -16215,7 +16215,7 @@ IGNORE_CLANG_WARNINGS_END
         m_out.jump(continuation);
 
         m_out.appendTo(slowPath, continuation);
-        // We ensure allocation sinking explictly sets bottom values for all field members.
+        // We ensure allocation sinking explicitly sets bottom values for all field members.
         // Therefore, it doesn't matter what JSValue we pass in as the initialization value
         // because all fields will be overwritten.
         // FIXME: It may be worth creating an operation that calls a constructor on JSLexicalEnvironment that

--- a/Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp
+++ b/Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp
@@ -63,7 +63,7 @@ void MarkStackMergingConstraint::executeImplImpl(Visitor& visitor)
     // We want to skip this constraint for the GC verifier because:
     // 1. There should be no mutator marking action between the End phase and verifyGC().
     //    Hence, we can ignore these stacks.
-    // 2. The End phase explictly calls iterateExecutingAndCompilingCodeBlocks()
+    // 2. The End phase explicitly calls iterateExecutingAndCompilingCodeBlocks()
     //    to add executing CodeBlocks to m_heap.m_mutatorMarkStack. We want to
     //    leave those unperturbed.
     if (m_heap.m_isMarkingForGCVerifier)

--- a/Source/WebCore/html/parser/HTMLTokenizer.cpp
+++ b/Source/WebCore/html/parser/HTMLTokenizer.cpp
@@ -847,7 +847,7 @@ bool HTMLTokenizer::processToken(SegmentedString& source)
             m_token.appendToAttributeValue(decodedEntity.span());
         // We're supposed to switch back to the attribute value state that
         // we were in when we were switched into this state. Rather than
-        // keeping track of this explictly, we observe that the previous
+        // keeping track of this explicitly, we observe that the previous
         // state can be determined by m_additionalAllowedCharacter.
         if (m_additionalAllowedCharacter == '"')
             SWITCH_TO(AttributeValueDoubleQuotedState);

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -150,7 +150,7 @@ public:
     virtual void setPitchCorrectionAlgorithm(MediaPlayer::PitchCorrectionAlgorithm) { }
 
     // Indicates whether playback is currently paused indefinitely: such as having been paused
-    // explictly by the HTMLMediaElement or through remote media playback control.
+    // explicitly by the HTMLMediaElement or through remote media playback control.
     // This excludes video potentially playing but having stalled.
     virtual bool paused() const = 0;
 


### PR DESCRIPTION
#### 990c5e03b0e520bb59efd957ed14447d60f20175
<pre>
Fix some typos.
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* LayoutTests/fast/css/font-face-implicit-local-font.html:
* LayoutTests/fast/mediastream/getUserMedia-echoCancellation-expected.txt:
* LayoutTests/fast/mediastream/getUserMedia-echoCancellation.html:
* LayoutTests/imported/w3c/web-platform-tests/docs/writing-tests/testdriver.md:
* LayoutTests/platform/glib/fast/css/font-face-implicit-local-font-expected.txt:
* LayoutTests/platform/ios/fast/css/font-face-implicit-local-font-expected.txt:
* LayoutTests/platform/mac/fast/css/font-face-implicit-local-font-expected.txt:
* LayoutTests/platform/win/fast/css/font-face-implicit-local-font-expected.txt:
* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp:
(JSC::MarkStackMergingConstraint::executeImplImpl):
* Source/WebCore/html/parser/HTMLTokenizer.cpp:
(WebCore::HTMLTokenizer::processToken):
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/990c5e03b0e520bb59efd957ed14447d60f20175

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61749 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8569 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8760 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47093 "Found 1 new test failure: fast/css/font-face-implicit-local-font.html (failure)") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/6107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60154 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35114 "Found 1 new test failure: fast/css/font-face-implicit-local-font.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27927 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31877 "Exiting early after 10 failures. 20 tests run. 1 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7545 "Found 1 new test failure: fast/css/font-face-implicit-local-font.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7573 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51216 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53825 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7812 "Found 1 new test failure: fast/css/font-face-implicit-local-font.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63450 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57366 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2038 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7872 "Found 1 new test failure: fast/css/font-face-implicit-local-font.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54371 "Found 1 new test failure: fast/css/font-face-implicit-local-font.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2045 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50260 "Exiting early after 10 failures. 65 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54466 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/1744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79127 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33281 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13144 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34367 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35451 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34112 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->