### PR TITLE
[Skia] Use after free when serializing SkColorSpace

### DIFF
--- a/Source/WebKit/Shared/skia/CoreIPCSkColorSpace.h
+++ b/Source/WebKit/Shared/skia/CoreIPCSkColorSpace.h
@@ -33,12 +33,12 @@ namespace WebKit {
 
 class CoreIPCSkColorSpace {
 public:
-    CoreIPCSkColorSpace(sk_sp<SkColorSpace> skColorSpace)
+    explicit CoreIPCSkColorSpace(sk_sp<SkColorSpace> skColorSpace)
         : m_skColorSpace(WTFMove(skColorSpace))
     {
     }
 
-    CoreIPCSkColorSpace(std::span<const uint8_t> data)
+    explicit CoreIPCSkColorSpace(std::span<const uint8_t> data)
         : m_skColorSpace(SkColorSpace::Deserialize(data.data(), data.size()))
     {
     }
@@ -47,13 +47,16 @@ public:
 
     std::span<const uint8_t> dataReference() const
     {
-        if (auto data = m_skColorSpace->serialize())
-            return { data->bytes(), data->size() };
+        if (!m_serializedColorSpace)
+            m_serializedColorSpace = m_skColorSpace->serialize();
+        if (m_serializedColorSpace)
+            return { m_serializedColorSpace->bytes(), m_serializedColorSpace->size() };
         return { };
     }
 
 private:
     sk_sp<SkColorSpace> m_skColorSpace;
+    mutable sk_sp<SkData> m_serializedColorSpace;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 3f928ad98a0e59c9121db11911238adaa291c583
<pre>
[Skia] Use after free when serializing SkColorSpace
<a href="https://bugs.webkit.org/show_bug.cgi?id=276589">https://bugs.webkit.org/show_bug.cgi?id=276589</a>

Reviewed by Philippe Normand.

We&apos;re returning a &quot;dangling span&quot; that references data from a
temporary SkData that has already been freed. Fix is to store the
SkData.

Unrelated: mark single-parameter constructors as explicit for good
measure.

* Source/WebKit/Shared/skia/CoreIPCSkColorSpace.h:
(WebKit::CoreIPCSkColorSpace::CoreIPCSkColorSpace):
(WebKit::CoreIPCSkColorSpace::dataReference const):

Canonical link: <a href="https://commits.webkit.org/281006@main">https://commits.webkit.org/281006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76baa8806acdb8c3878a620018ec4e7007fa3aab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61763 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8583 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47103 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6117 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27937 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31888 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53837 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63464 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2052 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7883 "Found 1 new test failure: fast/dynamic/layer-hit-test-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54395 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54477 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12893 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1753 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33295 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34381 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35465 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34126 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->