### PR TITLE
Implement 'dirtiness' of HTMLOptionElement

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-selected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-selected-expected.txt
@@ -1,5 +1,5 @@
 
 PASS not dirty
-FAIL dirty, selected assert_equals: expected true but got false
-FAIL dirty, not selected assert_equals: expected false but got true
+PASS dirty, selected
+PASS dirty, not selected
 

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -190,10 +190,8 @@ void HTMLOptionElement::attributeChanged(const QualifiedName& name, const AtomSt
         // FIXME: Use PseudoClassChangeInvalidation in other elements that implement matchesDefaultPseudoClass().
         Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClass::Default, !newValue.isNull());
         m_isDefault = !newValue.isNull();
-
-        // FIXME: WebKit still need to implement 'dirtiness'. See: https://bugs.webkit.org/show_bug.cgi?id=258073
         // https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-selectedness
-        if (oldValue.isNull() != newValue.isNull())
+        if (oldValue.isNull() != newValue.isNull() && !m_isDirty)
             setSelected(!newValue.isNull());
         break;
     }
@@ -236,6 +234,24 @@ void HTMLOptionElement::setSelected(bool selected)
 
     if (RefPtr select = ownerSelectElement())
         select->optionSelectionStateChanged(*this, selected);
+}
+
+void HTMLOptionElement::setDirty(bool value)
+{
+    m_isDirty = value;
+}
+
+void HTMLOptionElement::setSelectedForBinding(bool selected)
+{
+    bool wasSelected = m_isSelected;
+    setSelected(selected);
+
+    // Firefox and Blink seem not to set dirtiness if an option is owned by a select
+    // element and selectedness is not changed.
+    if (ownerSelectElement() && wasSelected == m_isSelected)
+        return;
+
+    m_isDirty = true;
 }
 
 void HTMLOptionElement::setSelectedState(bool selected, AllowStyleInvalidation allowStyleInvalidation)

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -52,6 +52,8 @@ public:
 
     WEBCORE_EXPORT bool selected(AllowStyleInvalidation = AllowStyleInvalidation::Yes) const;
     WEBCORE_EXPORT void setSelected(bool);
+    bool selectedForBinding() const { return selected(); }
+    WEBCORE_EXPORT void setSelectedForBinding(bool);
 
     WEBCORE_EXPORT HTMLSelectElement* ownerSelectElement() const;
 
@@ -64,7 +66,10 @@ public:
 
     String textIndentedToRespectGroupLabel() const;
 
+    // Update 'selectedness'.
     void setSelectedState(bool, AllowStyleInvalidation = AllowStyleInvalidation::Yes);
+    // Update 'dirtiness'.
+    void setDirty(bool);
     bool selectedWithoutUpdate() const { return m_isSelected; }
 
 private:
@@ -86,8 +91,13 @@ private:
     String collectOptionInnerTextCollapsingWhitespace() const;
 
     bool m_disabled { false };
+    // Represents 'selectedness'.
+    // https://html.spec.whatwg.org/multipage/forms.html#concept-option-selectedness
     bool m_isSelected { false };
     bool m_isDefault { false };
+    // Represents 'dirtiness'.
+    // https://html.spec.whatwg.org/multipage/forms.html#concept-option-dirtiness
+    bool m_isDirty { false };
 };
 
 } // namespace

--- a/Source/WebCore/html/HTMLOptionElement.idl
+++ b/Source/WebCore/html/HTMLOptionElement.idl
@@ -28,7 +28,7 @@
     [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString label;
     [CEReactions=NotNeeded, Reflect="selected"] attribute boolean defaultSelected;
-    attribute boolean selected;
+    [ImplementedAs=selectedForBinding] attribute boolean selected;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString value;
 
     [CEReactions=Needed] attribute DOMString text;

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -136,7 +136,7 @@ void HTMLSelectElement::optionSelectedByUser(int optionIndex, bool fireOnChangeN
     if (optionIndex == selectedIndex())
         return;
 
-    selectOption(optionIndex, DeselectOtherOptions | (fireOnChangeNow ? DispatchChangeEvent : 0) | UserDriven);
+    selectOption(optionIndex, DeselectOtherOptions | MakeOptionDirty | (fireOnChangeNow ? DispatchChangeEvent : 0) | UserDriven);
 }
 
 bool HTMLSelectElement::hasPlaceholderLabelOption() const
@@ -690,11 +690,13 @@ void HTMLSelectElement::updateListBoxSelection(bool deselectOtherOptions)
         if (!element || element->isDisabledFormControl())
             continue;
 
-        if (i >= start && i <= end)
+        if (i >= start && i <= end) {
             element->setSelectedState(m_activeSelectionState);
-        else if (deselectOtherOptions || i >= m_cachedStateForActiveSelection.size())
+            element->setDirty(true);
+        } else if (deselectOtherOptions || i >= m_cachedStateForActiveSelection.size()) {
             element->setSelectedState(false);
-        else
+            element->setDirty(true);
+        } else
             element->setSelectedState(m_cachedStateForActiveSelection[i]);
     }
 
@@ -874,7 +876,7 @@ int HTMLSelectElement::selectedIndex() const
 
 void HTMLSelectElement::setSelectedIndex(int index)
 {
-    selectOption(index, DeselectOtherOptions);
+    selectOption(index, DeselectOtherOptions | MakeOptionDirty);
 }
 
 void HTMLSelectElement::optionSelectionStateChanged(HTMLOptionElement& option, bool optionIsSelected)
@@ -890,7 +892,7 @@ void HTMLSelectElement::optionSelectionStateChanged(HTMLOptionElement& option, b
 
 void HTMLSelectElement::selectOption(int optionIndex, SelectOptionFlags flags)
 {
-    bool shouldDeselect = !m_multiple || (flags & DeselectOtherOptions);
+    bool shouldDeselect = !m_multiple || (flags & (DeselectOtherOptions | MakeOptionDirty));
 
     auto& items = listItems();
     int listIndex = optionToListIndex(optionIndex);
@@ -908,6 +910,8 @@ void HTMLSelectElement::selectOption(int optionIndex, SelectOptionFlags flags)
         if (m_activeSelectionEndIndex < 0 || shouldDeselect)
             setActiveSelectionEndIndex(listIndex);
         option->setSelectedState(true);
+        if (flags & MakeOptionDirty)
+            option->setDirty(true);
     }
 
     invalidateSelectedItems();
@@ -1037,14 +1041,18 @@ void HTMLSelectElement::restoreFormControlState(const FormControlState& state)
         return;
 
     for (auto& element : items) {
-        if (RefPtr option = dynamicDowncast<HTMLOptionElement>(*element))
+        if (RefPtr option = dynamicDowncast<HTMLOptionElement>(*element)) {
             option->setSelectedState(false);
+            option->setDirty(false);
+        }
     }
 
     if (!multiple()) {
         size_t foundIndex = searchOptionsForValue(state[0], 0, itemsSize);
-        if (foundIndex != notFound)
+        if (foundIndex != notFound) {
             Ref { downcast<HTMLOptionElement>(*items[foundIndex]) }->setSelectedState(true);
+            Ref { downcast<HTMLOptionElement>(*items[foundIndex]) }->setDirty(true);
+        }
     } else {
         size_t startIndex = 0;
         for (auto& value : state) {
@@ -1054,6 +1062,7 @@ void HTMLSelectElement::restoreFormControlState(const FormControlState& state)
             if (foundIndex == notFound)
                 continue;
             Ref { downcast<HTMLOptionElement>(*items[foundIndex]) }->setSelectedState(true);
+            Ref { downcast<HTMLOptionElement>(*items[foundIndex]) }->setDirty(true);
             startIndex = foundIndex + 1;
         }
     }
@@ -1074,7 +1083,7 @@ void HTMLSelectElement::parseMultipleAttribute(const AtomString& value)
         invalidateStyleAndRenderersForSubtree();
     if (oldMultiple != m_multiple) {
         if (oldSelectedIndex >= 0)
-            setSelectedIndex(oldSelectedIndex);
+            selectOption(oldSelectedIndex, DeselectOtherOptions);
         else
             reset();
     }
@@ -1119,6 +1128,7 @@ void HTMLSelectElement::reset()
         } else
             option->setSelectedState(false);
 
+        option->setDirty(false);
         if (!firstOption && !option->isDisabledFormControl())
             firstOption = WTFMove(option);
     }
@@ -1217,7 +1227,7 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
             handled = false;
 
         if (handled && static_cast<size_t>(listIndex) < listItems.size())
-            selectOption(listToOptionIndex(listIndex), DeselectOtherOptions | DispatchChangeEvent | UserDriven);
+            selectOption(listToOptionIndex(listIndex), DeselectOtherOptions | MakeOptionDirty | DispatchChangeEvent | UserDriven);
 
         if (handled)
             keyboardEvent->setDefaultHandled();
@@ -1340,8 +1350,10 @@ void HTMLSelectElement::updateSelectedState(int listIndex, bool multi, bool shif
         // selection), should select or deselect.
         if (option->selected() && multiSelect)
             m_activeSelectionState = false;
-        if (!m_activeSelectionState)
+        if (!m_activeSelectionState) {
             option->setSelectedState(false);
+            option->setDirty(true);
+        }
     }
 
     // If we're not in any special multiple selection mode, then deselect all
@@ -1356,8 +1368,10 @@ void HTMLSelectElement::updateSelectedState(int listIndex, bool multi, bool shif
         setActiveSelectionAnchorIndex(selectedIndex());
 
     // Set the selection state of the clicked option.
-    if (RefPtr option = dynamicDowncast<HTMLOptionElement>(clickedElement); option && !option->isDisabledFormControl())
+    if (RefPtr option = dynamicDowncast<HTMLOptionElement>(clickedElement); option && !option->isDisabledFormControl()) {
         option->setSelectedState(true);
+        option->setDirty(true);
+    }
 
     // If there was no selectedIndex() for the previous initialization, or If
     // we're doing a single selection, or a multiple selection (using cmd or
@@ -1636,7 +1650,7 @@ void HTMLSelectElement::typeAheadFind(KeyboardEvent& event)
     int index = m_typeAhead.handleEvent(&event, TypeAhead::MatchPrefix | TypeAhead::CycleFirstChar);
     if (index < 0)
         return;
-    selectOption(listToOptionIndex(index), DeselectOtherOptions | DispatchChangeEvent | UserDriven);
+    selectOption(listToOptionIndex(index), DeselectOtherOptions | MakeOptionDirty | DispatchChangeEvent | UserDriven);
     if (!usesMenuList())
         listBoxOnChange();
 }

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -171,6 +171,7 @@ private:
         DeselectOtherOptions = 1 << 0,
         DispatchChangeEvent = 1 << 1,
         UserDriven = 1 << 2,
+        MakeOptionDirty = 1 << 3,
     };
     typedef unsigned SelectOptionFlags;
     void selectOption(int optionIndex, SelectOptionFlags = 0);


### PR DESCRIPTION
#### a5be9b06de7e5b646102d830bea8c2b149bc9f73
<pre>
Implement &apos;dirtiness&apos; of HTMLOptionElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=258073">https://bugs.webkit.org/show_bug.cgi?id=258073</a>
<a href="https://rdar.apple.com/problem/111096541">rdar://problem/111096541</a>

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/a17cc1eda58ad8270dc56ebafab215e67e6c1bfe">https://chromium.googlesource.com/chromium/src.git/+/a17cc1eda58ad8270dc56ebafab215e67e6c1bfe</a> ,
<a href="https://chromium.googlesource.com/chromium/src.git/+/f67251360e4b76d188bb1523d7a0952c2f449e68">https://chromium.googlesource.com/chromium/src.git/+/f67251360e4b76d188bb1523d7a0952c2f449e68</a> and
<a href="https://chromium.googlesource.com/chromium/src/+/6d095ec7a71eb72e2ad9992d1ca3080f5726f6bf">https://chromium.googlesource.com/chromium/src/+/6d095ec7a71eb72e2ad9992d1ca3080f5726f6bf</a>

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

This patch implements the concept of &apos;dirtiness&apos; as per [1]:

[1] <a href="https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-dirtiness">https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-dirtiness</a>

The flag is referred when &apos;selected&apos; attribute is added or removed.
This flag is set to true when a user updates selectedness explicitly, or
HTMLSelectElement::value setter, selectedIndex setter, or
HTMLOptionElement::selected setter.
The flag is reset to false on resetting `select`.

We need to introduce HTMLOptionElement::setSelectedForBinding because
setSelected is used internally, and the dirtiness should not be changed for the
internal callsites.

Additionally, HTMLOptionElement.prototype.selected setter should
not make an option dirty if it doesn&apos;t change its selectedness
and the option is owned by a select element.

* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::attributeChanged):
(WebCore::HTMLOptionElement::setDirty):
(WebCore::HTMLOptionElement::setSelectedForBinding):
* Source/WebCore/html/HTMLOptionElement.h:
* Source/WebCore/html/HTMLOptionElement.idl:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::optionSelectedByUser):
(WebCore::HTMLSelectElement::updateListBoxSelection):
(WebCore::HTMLSelectElement::setSelectedIndex):
(WebCore::HTMLSelectElement::selectOption):
(WebCore::HTMLSelectElement::restoreFormControlState):
(WebCore::HTMLSelectElement::parseMultipleAttribute):
(WebCore::HTMLSelectElement::reset):
(WebCore::HTMLSelectElement::menuListDefaultEventHandler):
(WebCore::HTMLSelectElement::updateSelectedState):
(WebCore::HTMLSelectElement::typeAheadFind):
* Source/WebCore/html/HTMLSelectElement.h:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-selected-expected.txt: Progression
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5be9b06de7e5b646102d830bea8c2b149bc9f73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128664 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74191 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5bb6a9aa-e496-4d5e-9d43-98619baf87bb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92802 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61686 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d167d6c2-064f-48d0-8a65-aae4a81577d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73458 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc85eb7c-9c51-42a2-ade5-efdd406d406c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27504 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72156 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131421 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101367 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101237 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46605 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24722 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45778 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48893 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54627 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48363 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51713 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50043 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->