### PR TITLE
[iPadOS] Plumb the image rect in root view space to VKCImageAnalysis when long pressing a QR code

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
@@ -153,6 +153,8 @@ typedef NS_ENUM(NSInteger, VKImageOrientation) {
 
 @interface VKWKLineInfo : VKWKTextInfo
 @property (nonatomic, readonly) NSArray<VKWKTextInfo *> *children;
+@property (nonatomic, readonly) BOOL shouldWrap;
+@property (nonatomic, readonly) NSUInteger layoutDirection;
 @end
 
 @class DDScannerResult;
@@ -168,6 +170,7 @@ typedef NS_ENUM(NSInteger, VKImageOrientation) {
 #if HAVE(VK_IMAGE_ANALYSIS_FOR_MACHINE_READABLE_CODES)
 @property (nonatomic) UIMenu *mrcMenu;
 @property (nonatomic, nullable, weak) UIViewController *presentingViewControllerForMrcAction;
+@property (nonatomic) CGRect rectForMrcActionInPresentingViewController;
 @property (nonatomic, readonly) NSArray<BCSAction *> *barcodeActions;
 #endif
 @end
@@ -176,10 +179,11 @@ NS_ASSUME_NONNULL_END
 
 #endif
 
-@interface VKWKLineInfo (Staging_85139101)
-@property (nonatomic, readonly) BOOL shouldWrap;
-@property (nonatomic, readonly) NSUInteger layoutDirection;
+#if HAVE(VK_IMAGE_ANALYSIS_FOR_MACHINE_READABLE_CODES)
+@interface VKImageAnalysis (Staging_127892794)
+@property (nonatomic) CGRect rectForMrcActionInPresentingViewController;
 @end
+#endif
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 

--- a/Tools/TestWebKitAPI/cocoa/ImageAnalysisTestingUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/ImageAnalysisTestingUtilities.mm
@@ -115,6 +115,7 @@
 #if HAVE(VK_IMAGE_ANALYSIS_FOR_MACHINE_READABLE_CODES)
 @property (nonatomic, readonly) UIMenu *mrcMenu;
 @property (nonatomic, weak) UIViewController *presentingViewControllerForMrcAction;
+@property (nonatomic) CGRect rectForMrcActionInPresentingViewController;
 #endif
 @end
 

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -90,6 +90,7 @@ static UIMenu *fakeMachineReadableCodeMenuForTesting()
 @interface FakeMachineReadableCodeImageAnalysis : NSObject
 @property (nonatomic, readonly) UIMenu *mrcMenu;
 @property (nonatomic, weak) UIViewController *presentingViewControllerForMrcAction;
+@property (nonatomic) CGRect rectForMrcActionInPresentingViewController;
 @end
 
 @implementation FakeMachineReadableCodeImageAnalysis


### PR DESCRIPTION
#### 6910086011dac0a98069ee26156aecbe087dc367
<pre>
[iPadOS] Plumb the image rect in root view space to VKCImageAnalysis when long pressing a QR code
<a href="https://bugs.webkit.org/show_bug.cgi?id=276593">https://bugs.webkit.org/show_bug.cgi?id=276593</a>
<a href="https://rdar.apple.com/131643168">rdar://131643168</a>

Reviewed by Richard Robinson.

Adopt the new `rectForMrcActionInPresentingViewController` property on `VKCImageAnalysis` when
presenting a context menu for QR codes. This allows the `Add to Calendar` action (which shows a
popover on iPad) to present from the long-pressed image, after the changes in <a href="https://rdar.apple.com/119388199">rdar://119388199</a>.

* Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView updateImageAnalysisForContextMenuPresentation:elementBounds:]):
(-[WKContentView _completeImageAnalysisRequestForContextMenu:requestIdentifier:hasTextResults:]):

Also move the call to `-updateImageAnalysisForContextMenuPresentation:` up before we ask for
`-mrcMenu`, so that the rect for MRC menu actions is honored when VisionKit creates the menu item.

(-[WKContentView updateImageAnalysisForContextMenuPresentation:]): Deleted.
* Tools/TestWebKitAPI/cocoa/ImageAnalysisTestingUtilities.mm:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:

Canonical link: <a href="https://commits.webkit.org/280955@main">https://commits.webkit.org/280955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5367a710760b2f6b877224520f17ca5a3236e095

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61794 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47133 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6145 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35154 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/50290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27966 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7587 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7618 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63498 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2083 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54433 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50302 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54504 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12858 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1779 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33326 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34412 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35496 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->