### PR TITLE
text-underline-offset should support percentages

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/animations/text-underline-offset-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/animations/text-underline-offset-interpolation-expected.txt
@@ -15,4 +15,308 @@ PASS Web Animations: property <text-underline-offset> from [15px] to [0px] at (0
 PASS Web Animations: property <text-underline-offset> from [15px] to [0px] at (0.3) should be [10.5px]
 PASS Web Animations: property <text-underline-offset> from [15px] to [0px] at (0.6) should be [6px]
 PASS Web Animations: property <text-underline-offset> from [15px] to [0px] at (1) should be [0px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [0px] at (0) should be [16px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [0px] at (0.3) should be [11.2px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [0px] at (0.6) should be [6.4px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [0px] at (1) should be [0px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [0px] at (0) should be [16px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [0px] at (0.3) should be [11.2px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [0px] at (0.6) should be [6.4px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [0px] at (1) should be [0px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [0px] at (0) should be [16px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [0px] at (0.3) should be [11.2px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [0px] at (0.6) should be [6.4px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [0px] at (1) should be [0px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [0px] at (0) should be [16px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [0px] at (0.3) should be [11.2px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [0px] at (0.6) should be [6.4px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [0px] at (1) should be [0px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [32px] at (0) should be [16px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [32px] at (0.3) should be [20.8px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [32px] at (0.6) should be [25.6px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [32px] at (1) should be [32px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [32px] at (0) should be [16px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [32px] at (0.3) should be [20.8px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [32px] at (0.6) should be [25.6px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [32px] at (1) should be [32px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [32px] at (0) should be [16px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [32px] at (0.3) should be [20.8px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [32px] at (0.6) should be [25.6px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [32px] at (1) should be [32px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [32px] at (0) should be [16px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [32px] at (0.3) should be [20.8px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [32px] at (0.6) should be [25.6px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [32px] at (1) should be [32px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [0em] at (0) should be [16px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [0em] at (0.3) should be [11.2px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [0em] at (0.6) should be [6.4px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [0em] at (1) should be [0px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [0em] at (0) should be [16px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [0em] at (0.3) should be [11.2px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [0em] at (0.6) should be [6.4px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [0em] at (1) should be [0px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [0em] at (0) should be [16px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [0em] at (0.3) should be [11.2px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [0em] at (0.6) should be [6.4px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [0em] at (1) should be [0px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [0em] at (0) should be [16px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [0em] at (0.3) should be [11.2px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [0em] at (0.6) should be [6.4px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [0em] at (1) should be [0px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [2em] at (0) should be [16px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [2em] at (0.3) should be [20.8px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [2em] at (0.6) should be [25.6px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [2em] at (1) should be [32px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [2em] at (0) should be [16px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [2em] at (0.3) should be [20.8px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [2em] at (0.6) should be [25.6px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [2em] at (1) should be [32px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [2em] at (0) should be [16px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [2em] at (0.3) should be [20.8px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [2em] at (0.6) should be [25.6px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [2em] at (1) should be [32px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [2em] at (0) should be [16px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [2em] at (0.3) should be [20.8px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [2em] at (0.6) should be [25.6px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [2em] at (1) should be [32px]
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [0%] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [0%] at (0.3) should be [70%] assert_equals: expected "70 % " but got "11.2px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [0%] at (0.6) should be [40%] assert_equals: expected "40 % " but got "6.4px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [0%] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [0%] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [0%] at (0.3) should be [70%] assert_equals: expected "70 % " but got "11.2px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [0%] at (0.6) should be [40%] assert_equals: expected "40 % " but got "6.4px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [0%] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [0%] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [0%] at (0.3) should be [70%] assert_equals: expected "70 % " but got "11.2px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [0%] at (0.6) should be [40%] assert_equals: expected "40 % " but got "6.4px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [0%] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [0%] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [0%] at (0.3) should be [70%] assert_equals: expected "70 % " but got "11.2px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [0%] at (0.6) should be [40%] assert_equals: expected "40 % " but got "6.4px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [0%] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [200%] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [200%] at (0.3) should be [130%] assert_equals: expected "130 % " but got "20.8px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [200%] at (0.6) should be [160%] assert_equals: expected "160 % " but got "25.6px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [200%] at (1) should be [200%] assert_equals: expected "200 % " but got "32px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [200%] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [200%] at (0.3) should be [130%] assert_equals: expected "130 % " but got "20.8px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [200%] at (0.6) should be [160%] assert_equals: expected "160 % " but got "25.6px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [200%] at (1) should be [200%] assert_equals: expected "200 % " but got "32px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [200%] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [200%] at (0.3) should be [130%] assert_equals: expected "130 % " but got "20.8px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [200%] at (0.6) should be [160%] assert_equals: expected "160 % " but got "25.6px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [200%] at (1) should be [200%] assert_equals: expected "200 % " but got "32px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [200%] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [200%] at (0.3) should be [130%] assert_equals: expected "130 % " but got "20.8px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [200%] at (0.6) should be [160%] assert_equals: expected "160 % " but got "25.6px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [200%] at (1) should be [200%] assert_equals: expected "200 % " but got "32px "
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [0em] at (0) should be [16px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [0em] at (0.3) should be [11.2px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [0em] at (0.6) should be [6.4px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [0em] at (1) should be [0px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [0em] at (0) should be [16px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [0em] at (0.3) should be [11.2px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [0em] at (0.6) should be [6.4px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [0em] at (1) should be [0px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [0em] at (0) should be [16px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [0em] at (0.3) should be [11.2px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [0em] at (0.6) should be [6.4px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [0em] at (1) should be [0px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [0em] at (0) should be [16px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [0em] at (0.3) should be [11.2px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [0em] at (0.6) should be [6.4px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [0em] at (1) should be [0px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [2em] at (0) should be [16px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [2em] at (0.3) should be [20.8px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [2em] at (0.6) should be [25.6px]
+PASS CSS Transitions: property <text-underline-offset> from [16px] to [2em] at (1) should be [32px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [2em] at (0) should be [16px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [2em] at (0.3) should be [20.8px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [2em] at (0.6) should be [25.6px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [2em] at (1) should be [32px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [2em] at (0) should be [16px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [2em] at (0.3) should be [20.8px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [2em] at (0.6) should be [25.6px]
+PASS CSS Animations: property <text-underline-offset> from [16px] to [2em] at (1) should be [32px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [2em] at (0) should be [16px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [2em] at (0.3) should be [20.8px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [2em] at (0.6) should be [25.6px]
+PASS Web Animations: property <text-underline-offset> from [16px] to [2em] at (1) should be [32px]
+FAIL CSS Transitions: property <text-underline-offset> from [16px] to [0%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL CSS Transitions: property <text-underline-offset> from [16px] to [0%] at (0.3) should be [calc(0% + 11.2px)] assert_equals: expected "calc ( 0 % + 11.2px ) " but got "11.2px "
+FAIL CSS Transitions: property <text-underline-offset> from [16px] to [0%] at (0.6) should be [calc(0% + 6.4px)] assert_equals: expected "calc ( 0 % + 6.4px ) " but got "6.4px "
+FAIL CSS Transitions: property <text-underline-offset> from [16px] to [0%] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [0%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [0%] at (0.3) should be [calc(0% + 11.2px)] assert_equals: expected "calc ( 0 % + 11.2px ) " but got "11.2px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [0%] at (0.6) should be [calc(0% + 6.4px)] assert_equals: expected "calc ( 0 % + 6.4px ) " but got "6.4px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [0%] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Animations: property <text-underline-offset> from [16px] to [0%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL CSS Animations: property <text-underline-offset> from [16px] to [0%] at (0.3) should be [calc(0% + 11.2px)] assert_equals: expected "calc ( 0 % + 11.2px ) " but got "11.2px "
+FAIL CSS Animations: property <text-underline-offset> from [16px] to [0%] at (0.6) should be [calc(0% + 6.4px)] assert_equals: expected "calc ( 0 % + 6.4px ) " but got "6.4px "
+FAIL CSS Animations: property <text-underline-offset> from [16px] to [0%] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL Web Animations: property <text-underline-offset> from [16px] to [0%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL Web Animations: property <text-underline-offset> from [16px] to [0%] at (0.3) should be [calc(0% + 11.2px)] assert_equals: expected "calc ( 0 % + 11.2px ) " but got "11.2px "
+FAIL Web Animations: property <text-underline-offset> from [16px] to [0%] at (0.6) should be [calc(0% + 6.4px)] assert_equals: expected "calc ( 0 % + 6.4px ) " but got "6.4px "
+FAIL Web Animations: property <text-underline-offset> from [16px] to [0%] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Transitions: property <text-underline-offset> from [16px] to [200%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL CSS Transitions: property <text-underline-offset> from [16px] to [200%] at (0.3) should be [calc(120% + 11.2px)] assert_equals: expected "calc ( 120 % + 11.2px ) " but got "20.8px "
+FAIL CSS Transitions: property <text-underline-offset> from [16px] to [200%] at (0.6) should be [calc(120% + 6.4px)] assert_equals: expected "calc ( 120 % + 6.4px ) " but got "25.6px "
+FAIL CSS Transitions: property <text-underline-offset> from [16px] to [200%] at (1) should be [200%] assert_equals: expected "200 % " but got "32px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [200%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [200%] at (0.3) should be [calc(120% + 11.2px)] assert_equals: expected "calc ( 120 % + 11.2px ) " but got "20.8px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [200%] at (0.6) should be [calc(120% + 6.4px)] assert_equals: expected "calc ( 120 % + 6.4px ) " but got "25.6px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [16px] to [200%] at (1) should be [200%] assert_equals: expected "200 % " but got "32px "
+FAIL CSS Animations: property <text-underline-offset> from [16px] to [200%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL CSS Animations: property <text-underline-offset> from [16px] to [200%] at (0.3) should be [calc(120% + 11.2px)] assert_equals: expected "calc ( 120 % + 11.2px ) " but got "20.8px "
+FAIL CSS Animations: property <text-underline-offset> from [16px] to [200%] at (0.6) should be [calc(120% + 6.4px)] assert_equals: expected "calc ( 120 % + 6.4px ) " but got "25.6px "
+FAIL CSS Animations: property <text-underline-offset> from [16px] to [200%] at (1) should be [200%] assert_equals: expected "200 % " but got "32px "
+FAIL Web Animations: property <text-underline-offset> from [16px] to [200%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL Web Animations: property <text-underline-offset> from [16px] to [200%] at (0.3) should be [calc(120% + 11.2px)] assert_equals: expected "calc ( 120 % + 11.2px ) " but got "20.8px "
+FAIL Web Animations: property <text-underline-offset> from [16px] to [200%] at (0.6) should be [calc(120% + 6.4px)] assert_equals: expected "calc ( 120 % + 6.4px ) " but got "25.6px "
+FAIL Web Animations: property <text-underline-offset> from [16px] to [200%] at (1) should be [200%] assert_equals: expected "200 % " but got "32px "
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [0px] at (0) should be [16px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [0px] at (0.3) should be [11.2px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [0px] at (0.6) should be [6.4px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [0px] at (1) should be [0px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [0px] at (0) should be [16px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [0px] at (0.3) should be [11.2px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [0px] at (0.6) should be [6.4px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [0px] at (1) should be [0px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [0px] at (0) should be [16px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [0px] at (0.3) should be [11.2px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [0px] at (0.6) should be [6.4px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [0px] at (1) should be [0px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [0px] at (0) should be [16px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [0px] at (0.3) should be [11.2px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [0px] at (0.6) should be [6.4px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [0px] at (1) should be [0px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [32px] at (0) should be [16px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [32px] at (0.3) should be [20.8px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [32px] at (0.6) should be [25.6px]
+PASS CSS Transitions: property <text-underline-offset> from [1em] to [32px] at (1) should be [32px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [32px] at (0) should be [16px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [32px] at (0.3) should be [20.8px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [32px] at (0.6) should be [25.6px]
+PASS CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [32px] at (1) should be [32px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [32px] at (0) should be [16px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [32px] at (0.3) should be [20.8px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [32px] at (0.6) should be [25.6px]
+PASS CSS Animations: property <text-underline-offset> from [1em] to [32px] at (1) should be [32px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [32px] at (0) should be [16px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [32px] at (0.3) should be [20.8px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [32px] at (0.6) should be [25.6px]
+PASS Web Animations: property <text-underline-offset> from [1em] to [32px] at (1) should be [32px]
+FAIL CSS Transitions: property <text-underline-offset> from [1em] to [0%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL CSS Transitions: property <text-underline-offset> from [1em] to [0%] at (0.3) should be [calc(0% + 11.2px)] assert_equals: expected "calc ( 0 % + 11.2px ) " but got "11.2px "
+FAIL CSS Transitions: property <text-underline-offset> from [1em] to [0%] at (0.6) should be [calc(0% + 6.4px)] assert_equals: expected "calc ( 0 % + 6.4px ) " but got "6.4px "
+FAIL CSS Transitions: property <text-underline-offset> from [1em] to [0%] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [0%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [0%] at (0.3) should be [calc(0% + 11.2px)] assert_equals: expected "calc ( 0 % + 11.2px ) " but got "11.2px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [0%] at (0.6) should be [calc(0% + 6.4px)] assert_equals: expected "calc ( 0 % + 6.4px ) " but got "6.4px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [0%] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Animations: property <text-underline-offset> from [1em] to [0%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL CSS Animations: property <text-underline-offset> from [1em] to [0%] at (0.3) should be [calc(0% + 11.2px)] assert_equals: expected "calc ( 0 % + 11.2px ) " but got "11.2px "
+FAIL CSS Animations: property <text-underline-offset> from [1em] to [0%] at (0.6) should be [calc(0% + 6.4px)] assert_equals: expected "calc ( 0 % + 6.4px ) " but got "6.4px "
+FAIL CSS Animations: property <text-underline-offset> from [1em] to [0%] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL Web Animations: property <text-underline-offset> from [1em] to [0%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL Web Animations: property <text-underline-offset> from [1em] to [0%] at (0.3) should be [calc(0% + 11.2px)] assert_equals: expected "calc ( 0 % + 11.2px ) " but got "11.2px "
+FAIL Web Animations: property <text-underline-offset> from [1em] to [0%] at (0.6) should be [calc(0% + 6.4px)] assert_equals: expected "calc ( 0 % + 6.4px ) " but got "6.4px "
+FAIL Web Animations: property <text-underline-offset> from [1em] to [0%] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Transitions: property <text-underline-offset> from [1em] to [200%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL CSS Transitions: property <text-underline-offset> from [1em] to [200%] at (0.3) should be [calc(60% + 11.2px)] assert_equals: expected "calc ( 60 % + 11.2px ) " but got "20.8px "
+FAIL CSS Transitions: property <text-underline-offset> from [1em] to [200%] at (0.6) should be [calc(120% + 6.4px)] assert_equals: expected "calc ( 120 % + 6.4px ) " but got "25.6px "
+FAIL CSS Transitions: property <text-underline-offset> from [1em] to [200%] at (1) should be [200%] assert_equals: expected "200 % " but got "32px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [200%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [200%] at (0.3) should be [calc(60% + 11.2px)] assert_equals: expected "calc ( 60 % + 11.2px ) " but got "20.8px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [200%] at (0.6) should be [calc(120% + 6.4px)] assert_equals: expected "calc ( 120 % + 6.4px ) " but got "25.6px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [1em] to [200%] at (1) should be [200%] assert_equals: expected "200 % " but got "32px "
+FAIL CSS Animations: property <text-underline-offset> from [1em] to [200%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL CSS Animations: property <text-underline-offset> from [1em] to [200%] at (0.3) should be [calc(60% + 11.2px)] assert_equals: expected "calc ( 60 % + 11.2px ) " but got "20.8px "
+FAIL CSS Animations: property <text-underline-offset> from [1em] to [200%] at (0.6) should be [calc(120% + 6.4px)] assert_equals: expected "calc ( 120 % + 6.4px ) " but got "25.6px "
+FAIL CSS Animations: property <text-underline-offset> from [1em] to [200%] at (1) should be [200%] assert_equals: expected "200 % " but got "32px "
+FAIL Web Animations: property <text-underline-offset> from [1em] to [200%] at (0) should be [calc(0% + 16px)] assert_equals: expected "calc ( 0 % + 16px ) " but got "16px "
+FAIL Web Animations: property <text-underline-offset> from [1em] to [200%] at (0.3) should be [calc(60% + 11.2px)] assert_equals: expected "calc ( 60 % + 11.2px ) " but got "20.8px "
+FAIL Web Animations: property <text-underline-offset> from [1em] to [200%] at (0.6) should be [calc(120% + 6.4px)] assert_equals: expected "calc ( 120 % + 6.4px ) " but got "25.6px "
+FAIL Web Animations: property <text-underline-offset> from [1em] to [200%] at (1) should be [200%] assert_equals: expected "200 % " but got "32px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [0px] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [0px] at (0.3) should be [70%] assert_equals: expected "70 % " but got "11.2px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [0px] at (0.6) should be [40%] assert_equals: expected "40 % " but got "6.4px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [0px] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [0px] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [0px] at (0.3) should be [70%] assert_equals: expected "70 % " but got "11.2px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [0px] at (0.6) should be [40%] assert_equals: expected "40 % " but got "6.4px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [0px] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [0px] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [0px] at (0.3) should be [70%] assert_equals: expected "70 % " but got "11.2px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [0px] at (0.6) should be [40%] assert_equals: expected "40 % " but got "6.4px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [0px] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [0px] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [0px] at (0.3) should be [70%] assert_equals: expected "70 % " but got "11.2px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [0px] at (0.6) should be [40%] assert_equals: expected "40 % " but got "6.4px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [0px] at (1) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [32px] at (0) should be [calc(100% + 0px)] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [32px] at (0.3) should be [calc(100% + 9.6px)] assert_equals: expected "calc ( 100 % + 9.6px ) " but got "20.8px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [32px] at (0.6) should be [calc(100% + 19.2px)] assert_equals: expected "calc ( 100 % + 19.2px ) " but got "25.6px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [32px] at (1) should be [calc(100% + 32px)] assert_equals: expected "calc ( 100 % + 32px ) " but got "32px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [32px] at (0) should be [calc(100% + 0px)] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [32px] at (0.3) should be [calc(100% + 9.6px)] assert_equals: expected "calc ( 100 % + 9.6px ) " but got "20.8px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [32px] at (0.6) should be [calc(100% + 19.2px)] assert_equals: expected "calc ( 100 % + 19.2px ) " but got "25.6px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [32px] at (1) should be [calc(100% + 32px)] assert_equals: expected "calc ( 100 % + 32px ) " but got "32px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [32px] at (0) should be [calc(100% + 0px)] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [32px] at (0.3) should be [calc(100% + 9.6px)] assert_equals: expected "calc ( 100 % + 9.6px ) " but got "20.8px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [32px] at (0.6) should be [calc(100% + 19.2px)] assert_equals: expected "calc ( 100 % + 19.2px ) " but got "25.6px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [32px] at (1) should be [calc(100% + 32px)] assert_equals: expected "calc ( 100 % + 32px ) " but got "32px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [32px] at (0) should be [calc(100% + 0px)] assert_equals: expected "100 % " but got "16px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [32px] at (0.3) should be [calc(100% + 9.6px)] assert_equals: expected "calc ( 100 % + 9.6px ) " but got "20.8px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [32px] at (0.6) should be [calc(100% + 19.2px)] assert_equals: expected "calc ( 100 % + 19.2px ) " but got "25.6px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [32px] at (1) should be [calc(100% + 32px)] assert_equals: expected "calc ( 100 % + 32px ) " but got "32px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [0em] at (0) should be [calc(100% + 0em)] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [0em] at (0.3) should be [calc(70% + 0em)] assert_equals: expected "70 % " but got "11.2px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [0em] at (0.6) should be [calc(40% + 0em)] assert_equals: expected "40 % " but got "6.4px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [0em] at (1) should be [calc(0% + 0em)] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [0em] at (0) should be [calc(100% + 0em)] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [0em] at (0.3) should be [calc(70% + 0em)] assert_equals: expected "70 % " but got "11.2px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [0em] at (0.6) should be [calc(40% + 0em)] assert_equals: expected "40 % " but got "6.4px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [0em] at (1) should be [calc(0% + 0em)] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [0em] at (0) should be [calc(100% + 0em)] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [0em] at (0.3) should be [calc(70% + 0em)] assert_equals: expected "70 % " but got "11.2px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [0em] at (0.6) should be [calc(40% + 0em)] assert_equals: expected "40 % " but got "6.4px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [0em] at (1) should be [calc(0% + 0em)] assert_equals: expected "0 % " but got "0px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [0em] at (0) should be [calc(100% + 0em)] assert_equals: expected "100 % " but got "16px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [0em] at (0.3) should be [calc(70% + 0em)] assert_equals: expected "70 % " but got "11.2px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [0em] at (0.6) should be [calc(40% + 0em)] assert_equals: expected "40 % " but got "6.4px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [0em] at (1) should be [calc(0% + 0em)] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [2em] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [2em] at (0.3) should be [calc(70% + 9.6px)] assert_equals: expected "calc ( 70 % + 9.6px ) " but got "20.8px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [2em] at (0.6) should be [calc(40% + 19.2px)] assert_equals: expected "calc ( 40 % + 19.2px ) " but got "25.6px "
+FAIL CSS Transitions: property <text-underline-offset> from [100%] to [2em] at (1) should be [calc(0% + 32px)] assert_equals: expected "calc ( 0 % + 32px ) " but got "32px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [2em] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [2em] at (0.3) should be [calc(70% + 9.6px)] assert_equals: expected "calc ( 70 % + 9.6px ) " but got "20.8px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [2em] at (0.6) should be [calc(40% + 19.2px)] assert_equals: expected "calc ( 40 % + 19.2px ) " but got "25.6px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [100%] to [2em] at (1) should be [calc(0% + 32px)] assert_equals: expected "calc ( 0 % + 32px ) " but got "32px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [2em] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [2em] at (0.3) should be [calc(70% + 9.6px)] assert_equals: expected "calc ( 70 % + 9.6px ) " but got "20.8px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [2em] at (0.6) should be [calc(40% + 19.2px)] assert_equals: expected "calc ( 40 % + 19.2px ) " but got "25.6px "
+FAIL CSS Animations: property <text-underline-offset> from [100%] to [2em] at (1) should be [calc(0% + 32px)] assert_equals: expected "calc ( 0 % + 32px ) " but got "32px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [2em] at (0) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [2em] at (0.3) should be [calc(70% + 9.6px)] assert_equals: expected "calc ( 70 % + 9.6px ) " but got "20.8px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [2em] at (0.6) should be [calc(40% + 19.2px)] assert_equals: expected "calc ( 40 % + 19.2px ) " but got "25.6px "
+FAIL Web Animations: property <text-underline-offset> from [100%] to [2em] at (1) should be [calc(0% + 32px)] assert_equals: expected "calc ( 0 % + 32px ) " but got "32px "
+FAIL CSS Transitions: property <text-underline-offset> from [0%] to [100%] at (0) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Transitions: property <text-underline-offset> from [0%] to [100%] at (0.3) should be [30%] assert_equals: expected "30 % " but got "4.8px "
+FAIL CSS Transitions: property <text-underline-offset> from [0%] to [100%] at (0.6) should be [60%] assert_equals: expected "60 % " but got "9.6px "
+FAIL CSS Transitions: property <text-underline-offset> from [0%] to [100%] at (1) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [0%] to [100%] at (0) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [0%] to [100%] at (0.3) should be [30%] assert_equals: expected "30 % " but got "4.8px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [0%] to [100%] at (0.6) should be [60%] assert_equals: expected "60 % " but got "9.6px "
+FAIL CSS Transitions with transition: all: property <text-underline-offset> from [0%] to [100%] at (1) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL CSS Animations: property <text-underline-offset> from [0%] to [100%] at (0) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL CSS Animations: property <text-underline-offset> from [0%] to [100%] at (0.3) should be [30%] assert_equals: expected "30 % " but got "4.8px "
+FAIL CSS Animations: property <text-underline-offset> from [0%] to [100%] at (0.6) should be [60%] assert_equals: expected "60 % " but got "9.6px "
+FAIL CSS Animations: property <text-underline-offset> from [0%] to [100%] at (1) should be [100%] assert_equals: expected "100 % " but got "16px "
+FAIL Web Animations: property <text-underline-offset> from [0%] to [100%] at (0) should be [0%] assert_equals: expected "0 % " but got "0px "
+FAIL Web Animations: property <text-underline-offset> from [0%] to [100%] at (0.3) should be [30%] assert_equals: expected "30 % " but got "4.8px "
+FAIL Web Animations: property <text-underline-offset> from [0%] to [100%] at (0.6) should be [60%] assert_equals: expected "60 % " but got "9.6px "
+FAIL Web Animations: property <text-underline-offset> from [0%] to [100%] at (1) should be [100%] assert_equals: expected "100 % " but got "16px "
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/animations/text-underline-offset-interpolation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/animations/text-underline-offset-interpolation.html
@@ -9,7 +9,7 @@
 
 <style>
 .target {
-  font: 10px sans-serif;
+  font: 16px sans-serif;
 }
 </style>
 
@@ -29,4 +29,212 @@ test_interpolation({
   {at: 1, expect: '0px'},
 ]);
 
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '16px',
+  to: '0px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '16px',
+  to: '32px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '1em',
+  to: '0em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '1em',
+  to: '2em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '100%',
+  to: '0%',
+}, [
+  {at: 0, expect: '100%'},
+  {at: 0.3, expect: '70%'},
+  {at: 0.6, expect: '40%'},
+  {at: 1, expect: '0%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '100%',
+  to: '200%',
+}, [
+  {at: 0, expect: '100%'},
+  {at: 0.3, expect: '130%'},
+  {at: 0.6, expect: '160%'},
+  {at: 1, expect: '200%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '16px',
+  to: '0em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '16px',
+  to: '2em',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '16px',
+  to: '0%',
+}, [
+  {at: 0, expect: 'calc(0% + 16px)'},
+  {at: 0.3, expect: 'calc(0% + 11.2px)'},
+  {at: 0.6, expect: 'calc(0% + 6.4px)'},
+  {at: 1, expect: '0%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '16px',
+  to: '200%',
+}, [
+  {at: 0, expect: 'calc(0% + 16px)'},
+  {at: 0.3, expect: 'calc(120% + 11.2px)'},
+  {at: 0.6, expect: 'calc(120% + 6.4px)'},
+  {at: 1, expect: '200%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '1em',
+  to: '0px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '11.2px'},
+  {at: 0.6, expect: '6.4px'},
+  {at: 1, expect: '0px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '1em',
+  to: '32px',
+}, [
+  {at: 0, expect: '16px'},
+  {at: 0.3, expect: '20.8px'},
+  {at: 0.6, expect: '25.6px'},
+  {at: 1, expect: '32px'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '1em',
+  to: '0%',
+}, [
+  {at: 0, expect: 'calc(0% + 16px)'},
+  {at: 0.3, expect: 'calc(0% + 11.2px)'},
+  {at: 0.6, expect: 'calc(0% + 6.4px)'},
+  {at: 1, expect: '0%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '1em',
+  to: '200%',
+}, [
+  {at: 0, expect: 'calc(0% + 16px)'},
+  {at: 0.3, expect: 'calc(60% + 11.2px)'},
+  {at: 0.6, expect: 'calc(120% + 6.4px)'},
+  {at: 1, expect: '200%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '100%',
+  to: '0px',
+}, [
+  {at: 0, expect: '100%'},
+  {at: 0.3, expect: '70%'},
+  {at: 0.6, expect: '40%'},
+  {at: 1, expect: '0%'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '100%',
+  to: '32px',
+}, [
+  {at: 0, expect: 'calc(100% + 0px)'},
+  {at: 0.3, expect: 'calc(100% + 9.6px)'},
+  {at: 0.6, expect: 'calc(100% + 19.2px)'},
+  {at: 1, expect: 'calc(100% + 32px)'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '100%',
+  to: '0em',
+}, [
+  {at: 0, expect: 'calc(100% + 0em)'},
+  {at: 0.3, expect: 'calc(70% + 0em)'},
+  {at: 0.6, expect: 'calc(40% + 0em)'},
+  {at: 1, expect: 'calc(0% + 0em)'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '100%',
+  to: '2em',
+}, [
+  {at: 0, expect: '100%'},
+  {at: 0.3, expect: 'calc(70% + 9.6px)'},
+  {at: 0.6, expect: 'calc(40% + 19.2px)'},
+  {at: 1, expect: 'calc(0% + 32px)'},
+]);
+
+test_interpolation({
+  property: 'text-underline-offset',
+  from: '0%',
+  to: '100%',
+}, [
+  {at: 0, expect: '0%'},
+  {at: 0.3, expect: '30%'},
+  {at: 0.6, expect: '60%'},
+  {at: 1, expect: '100%'},
+]);
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-calc-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-calc-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>text-underline-offset calc() support</title>
+<link rel="author" title="Zak Ridouh" href="mailto:zakr@apple.com" />
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset" />
+<style>
+div {
+  display: flex;
+  font-size: 22px;
+}
+.underline {
+  text-decoration-color: green;
+  text-decoration-line: underline;
+  text-decoration-thickness: 15px;
+  text-decoration-skip-ink: none;
+}
+.ref {
+  text-underline-offset: 1em;
+}
+</style>
+<p>Test passes if black and green bar pairs are the same shape and size.</p>
+<div>
+  <span class="underline ref">XXXXXX</span>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-calc-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-calc-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>text-underline-offset calc() support</title>
+<link rel="author" title="Zak Ridouh" href="mailto:zakr@apple.com" />
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset" />
+<style>
+div {
+  display: flex;
+  font-size: 22px;
+}
+.underline {
+  text-decoration-color: green;
+  text-decoration-line: underline;
+  text-decoration-thickness: 15px;
+  text-decoration-skip-ink: none;
+}
+.ref {
+  text-underline-offset: 1em;
+}
+</style>
+<p>Test passes if black and green bar pairs are the same shape and size.</p>
+<div>
+  <span class="underline ref">XXXXXX</span>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-calc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-calc.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>text-underline-offset calc() support</title>
+<link rel="author" title="Zak Ridouh" href="mailto:zakr@apple.com" />
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset" />
+<meta name="assert" content="Test checks whether text-underline-offset supports calc() values.">
+<link rel="match" href="text-underline-offset-calc-ref.html">
+<style>
+div {
+  display: flex;
+  font-size: 22px;
+}
+.underline {
+  text-decoration-color: green;
+  text-decoration-line: underline;
+  text-decoration-thickness: 15px;
+  text-decoration-skip-ink: none;
+}
+.ref {
+  text-underline-offset: 1em;
+}
+.test1 {
+  text-underline-offset: calc(1em);
+}
+.test2 {
+  text-underline-offset: calc(100%);
+}
+.test3 {
+  text-underline-offset: calc(50% + 11px);
+}
+.test4 {
+  text-underline-offset: calc(50% + 0.5em);
+}
+.test5 {
+  text-underline-offset: calc(0.5em + 11px);
+}
+</style>
+<p>Test passes if black and green bar pairs are the same shape and size.</p>
+<div>
+  <span class="underline ref">X</span>
+  <span class="underline test1">X</span>
+  <span class="underline test2">X</span>
+  <span class="underline test3">X</span>
+  <span class="underline test4">X</span>
+  <span class="underline test5">X</span>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-computed-expected.txt
@@ -1,4 +1,17 @@
 
 PASS Property text-underline-offset value 'auto'
 PASS Property text-underline-offset value 'calc(10px - 8px)'
+PASS Property text-underline-offset value '32px'
+PASS Property text-underline-offset value '2em'
+PASS Property text-underline-offset value '200%'
+PASS Property text-underline-offset value 'calc(2em - 0px)'
+PASS Property text-underline-offset value 'calc(200% - 0px)'
+PASS Property text-underline-offset value 'calc(0.5em - 0px)'
+PASS Property text-underline-offset value 'calc(50% - 0px)'
+PASS Property text-underline-offset value 'calc(2em - 8px)'
+PASS Property text-underline-offset value 'calc(2em - 0.5em)'
+PASS Property text-underline-offset value 'calc(2em - 50%)'
+PASS Property text-underline-offset value 'calc(200% - 8px)'
+PASS Property text-underline-offset value 'calc(200% - 0.5em)'
+PASS Property text-underline-offset value 'calc(200% - 50%)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-computed.html
@@ -14,6 +14,23 @@
 <script>
 test_computed_value("text-underline-offset", "auto");
 test_computed_value("text-underline-offset", "calc(10px - 8px)", "2px");
+
+test_computed_value("text-underline-offset", "32px", "32px");
+test_computed_value("text-underline-offset", "2em", "32px");
+test_computed_value("text-underline-offset", "200%", "200%");
+
+test_computed_value("text-underline-offset", "calc(2em - 0px)", "32px");
+test_computed_value("text-underline-offset", "calc(200% - 0px)", "200%");
+test_computed_value("text-underline-offset", "calc(0.5em - 0px)", "8px");
+test_computed_value("text-underline-offset", "calc(50% - 0px)", "50%");
+
+test_computed_value("text-underline-offset", "calc(2em - 8px)", "24px");
+test_computed_value("text-underline-offset", "calc(2em - 0.5em)", "24px");
+test_computed_value("text-underline-offset", "calc(2em - 50%)", "calc(-50% + 32px)");
+
+test_computed_value("text-underline-offset", "calc(200% - 8px)");
+test_computed_value("text-underline-offset", "calc(200% - 0.5em)", "calc(200% - 8px)");
+test_computed_value("text-underline-offset", "calc(200% - 50%)", "150%");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-percentage-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-percentage-expected.html
@@ -3,22 +3,28 @@
 <head>
     <meta charset="utf-8">
     <title>Reference case for text-underline-offset</title>
-    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+    <link rel="author" title="Zak Ridouh" href="mailto:zakr@apple.com">
+    <link rel="author" title="Apple" href="https://www.apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset">
     <style>
-        #main{
-            border-bottom: 1px solid cyan;
+        #main {
+            border-bottom: 2px solid purple;
             display: flex;
         }
-        #text, #norm{
+        #text, #norm {
             text-decoration-color: green;
             text-decoration-line: underline;
-            text-decoration-skip-ink: none;
-            text-underline-offset: 0px;
-            font: 20px/1 Ahem;
+            text-decoration-thickness: 15px;
+            font: 20px/2 Arial;
             color: transparent;
             position: relative;
-            top: 21px;
             margin-right: 10px;
+        }
+        #text {
+            text-underline-offset: 5px;
+        }
+        #norm {
+            text-underline-offset: 5px;
         }
     </style>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-percentage-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-percentage-ref.html
@@ -3,22 +3,28 @@
 <head>
     <meta charset="utf-8">
     <title>Reference case for text-underline-offset</title>
-    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+    <link rel="author" title="Zak Ridouh" href="mailto:zakr@apple.com">
+    <link rel="author" title="Apple" href="https://www.apple.com">
+    <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset">
     <style>
-        #main{
-            border-bottom: 1px solid cyan;
+        #main {
+            border-bottom: 2px solid purple;
             display: flex;
         }
-        #text, #norm{
+        #text, #norm {
             text-decoration-color: green;
             text-decoration-line: underline;
-            text-decoration-skip-ink: none;
-            text-underline-offset: 0px;
-            font: 20px/1 Ahem;
+            text-decoration-thickness: 15px;
+            font: 20px/2 Arial;
             color: transparent;
             position: relative;
-            top: 21px;
             margin-right: 10px;
+        }
+        #text {
+            text-underline-offset: 5px;
+        }
+        #norm {
+            text-underline-offset: 5px;
         }
     </style>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-percentage.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-percentage.html
@@ -2,33 +2,30 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>Test case for text-underline-offset</title>
-    <link rel="author" title="Charlie Marlow" href="mailto:cmarlow@mozilla.com">
-    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <title>Test case for text-underline-offset percentage support</title>
+    <link rel="author" title="Zak Ridouh" href="mailto:zakr@apple.com">
+    <link rel="author" title="Apple" href="https://www.apple.com">
     <link rel="help" href="https://drafts.csswg.org/css-text-decor-4/#underline-offset">
-    <link rel="match" href="reference/text-underline-offset-002-ref.html">
-    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+    <link rel="match" href="text-underline-offset-percentage-ref.html">
     <style>
-        #main{
-            border-bottom: 1px solid cyan;
+        #main {
+            border-bottom: 2px solid purple;
             display: flex;
         }
-        #text, #norm{
+        #text, #norm {
             text-decoration-color: green;
             text-decoration-line: underline;
-            text-decoration-skip-ink: none;
-            font: 20px/1 Ahem;
+            text-decoration-thickness: 15px;
+            font: 20px/2 Arial;
             color: transparent;
             position: relative;
             margin-right: 10px;
         }
-        #text{
-            top: 10px;
-            text-underline-offset: 11px;
+        #text {
+            text-underline-offset: 25%;
         }
-        #norm{
-            top: 21px;
-            text-underline-offset: 0px;
+        #norm {
+            text-underline-offset: 25%;
         }
     </style>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-valid-expected.txt
@@ -4,6 +4,11 @@ PASS e.style['text-underline-offset'] = "-10px" should set the property value
 PASS e.style['text-underline-offset'] = "2001em" should set the property value
 PASS e.style['text-underline-offset'] = "-49em" should set the property value
 PASS e.style['text-underline-offset'] = "53px" should set the property value
+PASS e.style['text-underline-offset'] = "5%" should set the property value
+PASS e.style['text-underline-offset'] = "89%" should set the property value
+PASS e.style['text-underline-offset'] = "-30%" should set the property value
+PASS e.style['text-underline-offset'] = "187%" should set the property value
+PASS e.style['text-underline-offset'] = "calc(45% - 0.3em)" should set the property value
 PASS e.style['text-underline-offset'] = "calc(40em - 10px)" should set the property value
 PASS e.style['text-underline-offset'] = "calc(-13em + 50px)" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-valid.html
@@ -16,6 +16,11 @@ test_valid_value("text-underline-offset", "-10px");
 test_valid_value("text-underline-offset", "2001em");
 test_valid_value("text-underline-offset", "-49em");
 test_valid_value("text-underline-offset", "53px");
+test_valid_value("text-underline-offset", "5%");
+test_valid_value("text-underline-offset", "89%");
+test_valid_value("text-underline-offset", "-30%");
+test_valid_value("text-underline-offset", "187%");
+test_valid_value("text-underline-offset", "calc(45% - 0.3em)");
 test_valid_value("text-underline-offset", "calc(40em - 10px)");
 test_valid_value("text-underline-offset", "calc(-13em + 50px)");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt
@@ -9,10 +9,10 @@ PASS Can set 'text-underline-offset' to a length: 0px
 PASS Can set 'text-underline-offset' to a length: -3.14em
 PASS Can set 'text-underline-offset' to a length: 3.14cm
 PASS Can set 'text-underline-offset' to a length: calc(0px + 0em)
-FAIL Can set 'text-underline-offset' to a percent: 0% Invalid values
-FAIL Can set 'text-underline-offset' to a percent: -3.14% Invalid values
-FAIL Can set 'text-underline-offset' to a percent: 3.14% Invalid values
-FAIL Can set 'text-underline-offset' to a percent: calc(0% + 0%) Invalid values
+PASS Can set 'text-underline-offset' to a percent: 0%
+PASS Can set 'text-underline-offset' to a percent: -3.14%
+PASS Can set 'text-underline-offset' to a percent: 3.14%
+PASS Can set 'text-underline-offset' to a percent: calc(0% + 0%)
 PASS Setting 'text-underline-offset' to a time: 0s throws TypeError
 PASS Setting 'text-underline-offset' to a time: -3.14ms throws TypeError
 PASS Setting 'text-underline-offset' to a time: 3.14s throws TypeError

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8393,23 +8393,21 @@
             "inherited": true,
             "codegen-properties": {
                 "converter": "TextUnderlineOffset",
-                "parser-grammar": "auto | <length>",
-                "parser-grammar-comment": "The current specification has a <length-percentage>, not just <length>"
+                "parser-grammar": "auto | <length-percentage>"
             },
             "specification": {
                 "category": "css-text-decor",
-                "url": "https://www.w3.org/TR/css-text-decor-4/#underline-offset"
+                "url": "https://drafts.csswg.org/css-text-decor-4/#underline-offset"
             }
         },
         "text-decoration-thickness": {
             "codegen-properties": {
                 "converter": "TextDecorationThickness",
-                "parser-grammar": "auto | from-font | <length-percentage>",
-                "parser-grammar-comment": "The current specification has a <length-percentage>, not just <length>"
+                "parser-grammar": "auto | from-font | <length-percentage>"
             },
             "specification": {
                 "category": "css-text-decor",
-                "url": "https://www.w3.org/TR/css-text-decor-4/#text-decoration-thickness"
+                "url": "https://drafts.csswg.org/css-text-decor-4/#text-decoration-thickness-property"
             }
         },
         "-webkit-text-decorations-in-effect": {

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2129,12 +2129,15 @@ static RefPtr<CSSValue> renderTextDecorationSkipToCSSValue(TextDecorationSkipInk
     return CSSPrimitiveValue::create(CSSValueInitial);
 }
 
-static Ref<CSSValue> textUnderlineOffsetToCSSValue(const TextUnderlineOffset& textUnderlineOffset)
+static Ref<CSSValue> textUnderlineOffsetToCSSValue(const RenderStyle& style, const TextUnderlineOffset& textUnderlineOffset)
 {
     if (textUnderlineOffset.isAuto())
         return CSSPrimitiveValue::create(CSSValueAuto);
     ASSERT(textUnderlineOffset.isLength());
-    return CSSPrimitiveValue::create(textUnderlineOffset.lengthValue(), CSSUnitType::CSS_PX);
+    auto& length = textUnderlineOffset.length();
+    if (length.isPercent())
+        return CSSPrimitiveValue::create(length.percent(), CSSUnitType::CSS_PERCENTAGE);
+    return CSSPrimitiveValue::create(length, style);
 }
 
 static Ref<CSSValue> textDecorationThicknessToCSSValue(const RenderStyle& style, const TextDecorationThickness& textDecorationThickness)
@@ -2145,10 +2148,10 @@ static Ref<CSSValue> textDecorationThicknessToCSSValue(const RenderStyle& style,
         return CSSPrimitiveValue::create(CSSValueFromFont);
 
     ASSERT(textDecorationThickness.isLength());
-    const auto& length = textDecorationThickness.length();
+    auto& length = textDecorationThickness.length();
     if (length.isPercent())
         return CSSPrimitiveValue::create(length.percent(), CSSUnitType::CSS_PERCENTAGE);
-    return ComputedStyleExtractor::zoomAdjustedPixelValueForLength(length, style);
+    return CSSPrimitiveValue::create(length, style);
 }
 
 static Ref<CSSValue> renderEmphasisPositionFlagsToCSSValue(OptionSet<TextEmphasisPosition> textEmphasisPosition)
@@ -4069,7 +4072,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyTextUnderlinePosition:
         return textUnderlinePositionToCSSValue(style.textUnderlinePosition());
     case CSSPropertyTextUnderlineOffset:
-        return textUnderlineOffsetToCSSValue(style.textUnderlineOffset());
+        return textUnderlineOffsetToCSSValue(style, style.textUnderlineOffset());
     case CSSPropertyTextDecorationThickness:
         return textDecorationThicknessToCSSValue(style, style.textDecorationThickness());
     case CSSPropertyWebkitTextDecorationsInEffect:

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1918,7 +1918,7 @@ public:
     static constexpr TextDecorationStyle initialTextDecorationStyle();
     static constexpr TextDecorationSkipInk initialTextDecorationSkipInk();
     static constexpr OptionSet<TextUnderlinePosition> initialTextUnderlinePosition();
-    static constexpr TextUnderlineOffset initialTextUnderlineOffset();
+    static inline TextUnderlineOffset initialTextUnderlineOffset();
     static inline TextDecorationThickness initialTextDecorationThickness();
     static float initialZoom() { return 1.0f; }
     static constexpr TextZoom initialTextZoom();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -486,7 +486,7 @@ constexpr TextOverflow RenderStyle::initialTextOverflow() { return TextOverflow:
 constexpr TextSecurity RenderStyle::initialTextSecurity() { return TextSecurity::None; }
 inline StyleColor RenderStyle::initialTextStrokeColor() { return StyleColor::currentColor(); }
 constexpr OptionSet<TextTransform> RenderStyle::initialTextTransform() { return { }; }
-constexpr TextUnderlineOffset RenderStyle::initialTextUnderlineOffset() { return TextUnderlineOffset::createWithAuto(); }
+inline TextUnderlineOffset RenderStyle::initialTextUnderlineOffset() { return TextUnderlineOffset::createWithAuto(); }
 constexpr OptionSet<TextUnderlinePosition> RenderStyle::initialTextUnderlinePosition() { return { }; }
 constexpr TextWrapMode RenderStyle::initialTextWrapMode() { return TextWrapMode::Wrap; }
 constexpr TextWrapStyle RenderStyle::initialTextWrapStyle() { return TextWrapStyle::Auto; }

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -160,18 +160,18 @@ static float computedUnderlineOffset(const UnderlineOffsetArguments& context)
         if (textUnderlinePosition.contains(TextUnderlinePosition::Right)) {
             ASSERT(!textUnderlinePosition.contains(TextUnderlinePosition::Left));
             // In vertical typographic modes, the underline is aligned as for under, except it is always aligned to the right edge of the text.
-            underlineOffset = 0.f - (styleToUse.textUnderlineOffset().lengthOr(0.f) + defaultGap(styleToUse));
+            underlineOffset = 0.f - (styleToUse.textUnderlineOffset().resolve(styleToUse.computedFontSize()) + defaultGap(styleToUse));
         } else {
             // Position underline relative to the bottom edge of the lowest element's content box.
             auto desiredOffset = context.textUnderlinePositionUnder->textRunLogicalHeight + std::max(context.textUnderlinePositionUnder->textRunOffsetFromBottomMost, 0.f);
-            desiredOffset += styleToUse.textUnderlineOffset().lengthOr(0.f) + defaultGap(styleToUse);
+            desiredOffset += styleToUse.textUnderlineOffset().resolve(styleToUse.computedFontSize()) + defaultGap(styleToUse);
             underlineOffset = std::max<float>(desiredOffset, fontMetrics.intAscent());
         }
     } else if (textUnderlinePosition.contains(TextUnderlinePosition::FromFont)) {
         ASSERT(!textUnderlinePosition.contains(TextUnderlinePosition::Under));
-        underlineOffset = fontMetrics.intAscent() + fontMetrics.underlinePosition().value_or(0) + styleToUse.textUnderlineOffset().lengthOr(0.f);
+        underlineOffset = fontMetrics.intAscent() + fontMetrics.underlinePosition().value_or(0) + styleToUse.textUnderlineOffset().resolve(styleToUse.computedFontSize());
     } else
-        underlineOffset = fontMetrics.intAscent() + styleToUse.textUnderlineOffset().lengthOr(defaultGap(styleToUse));
+        underlineOffset = fontMetrics.intAscent() + styleToUse.textUnderlineOffset().resolve(styleToUse.computedFontSize(), defaultGap(styleToUse));
     return underlineOffset;
 }
 

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -903,15 +903,7 @@ inline OptionSet<TextUnderlinePosition> BuilderConverter::convertTextUnderlinePo
 
 inline TextUnderlineOffset BuilderConverter::convertTextUnderlineOffset(BuilderState& builderState, const CSSValue& value)
 {
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-    switch (primitiveValue.valueID()) {
-    case CSSValueAuto:
-        return TextUnderlineOffset::createWithAuto();
-    default:
-        ASSERT(primitiveValue.isLength());
-        auto computedLength = convertComputedLength<float>(builderState, primitiveValue);
-        return TextUnderlineOffset::createWithLength(computedLength);
-    }
+    return TextUnderlineOffset::createWithLength(BuilderConverter::convertLengthOrAuto(builderState, value));
 }
 
 inline TextDecorationThickness BuilderConverter::convertTextDecorationThickness(BuilderState& builderState, const CSSValue& value)


### PR DESCRIPTION
#### 834ed1dcd01004b6fa48e5d348acba481253e88b
<pre>
text-underline-offset should support percentages
<a href="https://bugs.webkit.org/show_bug.cgi?id=263431">https://bugs.webkit.org/show_bug.cgi?id=263431</a>
<a href="https://rdar.apple.com/117246233">rdar://117246233</a>

Reviewed by Tim Nguyen.

This commit adds support for percentages in text-underline-offset [1].

Interpolation between different supported length types, such as em, %, and px
is supported and tested. Validate proper rendering with new tests. As specified
in the spec, % scales as a percentage of em/size of the font it inherits.

[1] <a href="https://drafts.csswg.org/css-text-decor-4/#valdef-text-underline-offset-percentage">https://drafts.csswg.org/css-text-decor-4/#valdef-text-underline-offset-percentage</a>

    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/animations/text-underline-offset-interpolation-expected.txt:
    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/animations/text-underline-offset-interpolation.html:
    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-002-expected.html:
    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-002.html:
    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-calc-expected.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-calc-ref.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-calc.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-computed-expected.txt:
    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-computed.html:
    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-percentage-expected.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-percentage-ref.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-percentage.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-valid-expected.txt:
    * LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-offset-valid.html:
    * LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-offset-expected.txt:
    * Source/WebCore/animation/CSSPropertyAnimation.cpp:
    (WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
    * Source/WebCore/css/CSSProperties.json:
    * Source/WebCore/css/ComputedStyleExtractor.cpp:
    (WebCore::textUnderlineOffsetToCSSValue):
    (WebCore::textDecorationThicknessToCSSValue):
    (WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
    * Source/WebCore/rendering/style/RenderStyle.h:
    * Source/WebCore/rendering/style/RenderStyleInlines.h:
    (WebCore::RenderStyle::initialTextUnderlineOffset):
    * Source/WebCore/rendering/style/TextUnderlineOffset.h:
    (WebCore::TextUnderlineOffset::createWithAuto):
    (WebCore::TextUnderlineOffset::createWithLength):
    (WebCore::TextUnderlineOffset::isAuto const):
    (WebCore::TextUnderlineOffset::isLength const):
    (WebCore::TextUnderlineOffset::length const):
    (WebCore::TextUnderlineOffset::resolve const):
    (WebCore::TextUnderlineOffset::TextUnderlineOffset):
    (WebCore::operator&lt;&lt;):
    (WebCore::TextUnderlineOffset::setLengthValue): Deleted.
    (WebCore::TextUnderlineOffset::lengthValue const): Deleted.
    (WebCore::TextUnderlineOffset::lengthOr const): Deleted.
    * Source/WebCore/style/InlineTextBoxStyle.cpp:
    (WebCore::computedUnderlineOffset):
    * Source/WebCore/style/StyleBuilderConverter.h:
    (WebCore::Style::BuilderConverter::convertTextUnderlineOffset):

Canonical link: <a href="https://commits.webkit.org/282611@main">https://commits.webkit.org/282611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b58bd84d4809fef07541289a0bbb2cb8ce1aec02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67626 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14213 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14493 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51271 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9834 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55081 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31900 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12457 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13086 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12799 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69322 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12349 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58546 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58761 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14087 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6299 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38782 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39861 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40973 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39604 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->