### PR TITLE
Sync `RTCIceServer` as per web-specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-extensions/RTCOAuthCredential-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-extensions/RTCOAuthCredential-expected.txt
@@ -5,14 +5,14 @@ FAIL new RTCPeerConnection(config) - with turns server, credentialType oauth, an
       credentialType: 'oauth',
       username: 'user',
       credential: 'cred'
-    }] })" threw object "TypeError: Type error" that is not a DOMException InvalidAccessError: property "code" is equal to undefined, expected 15
+    }] })" did not throw
 FAIL setConfiguration(config) - with turns server, credentialType oauth, and string credential should throw InvalidAccessError assert_throws_dom: function "() =>
     makePc({ iceServers: [{
       urls: 'turns:turn.example.org',
       credentialType: 'oauth',
       username: 'user',
       credential: 'cred'
-    }] })" threw object "TypeError: Type error" that is not a DOMException InvalidAccessError: property "code" is equal to undefined, expected 15
-FAIL new RTCPeerConnection(config) - with turns server, credential type and credential from spec should not throw Type error
-FAIL setConfiguration(config) - with turns server, credential type and credential from spec should not throw Type error
+    }] })" did not throw
+FAIL new RTCPeerConnection(config) - with turns server, credential type and credential from spec should not throw assert_equals: expected (string) "oauth" but got (undefined) undefined
+FAIL setConfiguration(config) - with turns server, credential type and credential from spec should not throw assert_equals: expected (string) "oauth" but got (undefined) undefined
 

--- a/Source/WebCore/Modules/mediastream/RTCIceServer.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceServer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,12 +34,9 @@
 namespace WebCore {
 
 struct RTCIceServer {
-    enum class CredentialType { Password };
-
     std::variant<String, Vector<String>> urls;
     String username;
     String credential;
-    CredentialType credentialType { CredentialType::Password };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCIceServer.idl
+++ b/Source/WebCore/Modules/mediastream/RTCIceServer.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,9 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-enum RTCIceCredentialType {
-  "password"
-};
+// https://w3c.github.io/webrtc-pc/#dom-rtciceserver
 
 [
     Conditional=WEB_RTC,
@@ -36,5 +34,4 @@ enum RTCIceCredentialType {
     required (DOMString or sequence<DOMString>) urls;
     DOMString username;
     DOMString credential;
-    RTCIceCredentialType credentialType = "password";
 };


### PR DESCRIPTION
#### b7d6d76abe3633be7686cafc00f6bd5489ad820a
<pre>
Sync `RTCIceServer` as per web-specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=276595">https://bugs.webkit.org/show_bug.cgi?id=276595</a>

Reviewed by Youenn Fablet.

This patch syncs `RTCIceServer` as per web specification [1]:

[1] <a href="https://w3c.github.io/webrtc-pc/#dom-rtciceserver">https://w3c.github.io/webrtc-pc/#dom-rtciceserver</a>

It removes `RTCIceCredentialType` as per [2]:

[2] <a href="https://github.com/w3c/webrtc-pc/pull/2767">https://github.com/w3c/webrtc-pc/pull/2767</a>

* Source/WebCore/Modules/mediastream/RTCIceServer.h:
* Source/WebCore/Modules/mediastream/RTCIceServer.idl:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-extensions/RTCOAuthCredential-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/281007@main">https://commits.webkit.org/281007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf27ad7618e88d13a3c77676f6c81e43fe5ad4dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8613 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47134 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6144 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27967 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31915 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7584 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7617 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53866 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63497 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54435 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2089 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54506 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12894 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1781 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33325 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34411 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->