### PR TITLE
Sync `RTCPMuxPolicy` as per web specification

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCConfiguration.idl
+++ b/Source/WebCore/Modules/mediastream/RTCConfiguration.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcicetransportpolicy
+
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
@@ -31,6 +33,8 @@
     "relay",
     "all"
 };
+
+// https://w3c.github.io/webrtc-pc/#dom-rtcbundlepolicy
 
 [
     Conditional=WEB_RTC,
@@ -42,14 +46,17 @@
     "max-bundle"
 };
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcrtcpmuxpolicy
+
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     ImplementedAs=RTCPMuxPolicy
 ] enum RTCPMuxPolicy {
-    "negotiate",
     "require"
 };
+
+// https://w3c.github.io/webrtc-pc/#dom-rtcconfiguration
 
 [
     Conditional=WEB_RTC,

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Apple Inc.
+ * Copyright (C) 2017-2024 Apple Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -119,8 +119,6 @@ static inline webrtc::PeerConnectionInterface::BundlePolicy bundlePolicyfromConf
 static inline webrtc::PeerConnectionInterface::RtcpMuxPolicy rtcpMuxPolicyfromConfiguration(const MediaEndpointConfiguration& configuration)
 {
     switch (configuration.rtcpMuxPolicy) {
-    case RTCPMuxPolicy::Negotiate:
-        return webrtc::PeerConnectionInterface::kRtcpMuxPolicyNegotiate;
     case RTCPMuxPolicy::Require:
         return webrtc::PeerConnectionInterface::kRtcpMuxPolicyRequire;
     }

--- a/Source/WebCore/platform/mediastream/RTCPMuxPolicy.h
+++ b/Source/WebCore/platform/mediastream/RTCPMuxPolicy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,6 @@
 namespace WebCore {
 
 enum class RTCPMuxPolicy {
-    Negotiate,
     Require
 };
 


### PR DESCRIPTION
<pre>
Sync `RTCPMuxPolicy` as per web specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=276597">https://bugs.webkit.org/show_bug.cgi?id=276597</a>

Reviewed by NOBODY (OOPS!).

This patch is to align `RTCPMuxPolicy` enum as per web specification [1]:

[1] <a href="https://w3c.github.io/webrtc-pc/#dom-rtcrtcpmuxpolicy">https://w3c.github.io/webrtc-pc/#dom-rtcrtcpmuxpolicy</a>

There is no `negotiate` value now in web specification, so this patch removes it.

* Source/WebCore/Modules/mediastream/RTCConfiguration.idl:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp:
(WebCore::rtcpMuxPolicyfromConfiguration):
* Source/WebCore/platform/mediastream/RTCPMuxPolicy.h:
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fffadb45ca2f163d530f5f30ccf8133ec1c7e678

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61792 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8612 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47132 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6146 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27965 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31914 "Found 2 new test failures: imported/w3c/web-platform-tests/webrtc/RTCConfiguration-rtcpMuxPolicy.html imported/w3c/web-platform-tests/websockets/basic-auth.any.html?wss (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7585 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7616 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53865 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7853 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/RTCConfiguration-rtcpMuxPolicy.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63496 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2081 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7913 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/RTCConfiguration-rtcpMuxPolicy.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54434 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54505 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1780 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33324 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34410 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35494 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34155 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->