### PR TITLE
[Site Isolation] Ensure WebPageProxy is added after switching BrowsingContextGroup

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3085,6 +3085,7 @@ private:
 #endif
 
     void setAllowsLayoutViewportHeightExpansion(bool);
+    void setBrowsingContextGroup(BrowsingContextGroup&);
 
     struct Internals;
     Internals& internals() { return m_internals; }


### PR DESCRIPTION
#### a4d682ea4cb4e66b6a8344b4f8a8202646ff2a35
<pre>
[Site Isolation] Ensure WebPageProxy is added after switching BrowsingContextGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=276599">https://bugs.webkit.org/show_bug.cgi?id=276599</a>
<a href="https://rdar.apple.com/131728034">rdar://131728034</a>

Reviewed by Charlie Wolfe.

Some tests with cross-site iframe (e.g. http/tests/cookies/third-party-cookie-relaxing.html) are timed out when site
isolation is enabled and it is run after other tests. The direct cause is that UI process fails to send
WebProcess::CreateWebPage message to subframe process and thus the process does not correctly handle the subsequent
WebPage::LoadRequest message for the cross-site frame. Currently WebProcess::CreateWebPage message should be sent when
FrameProcess is added to BrowsingContextGroup, which will send the message to the process for all existing pages in the
group (see BrowsingContextGroup::addFrameProcess and RemotePageProxy::injectPageIntoNewProcess). The root cause is the
target WebPageProxy is not in BrowsingContextGroup::m_pages, since WebPageProxy does not add itself to
BrowsingContextGroup after switching group in WebPageProxy::swapToProvisionalPage. Note the ProvisionalPageProxy can
have different BrowsingContextGroup from its WebPageProxy if navigation requires session change (see
WebPageProxy::continueNavigationInNewProcess). And session change is something layout tests can do
testRunner.setShouldSwapToEphemeralSessionOnNextNavigation and testRunner.setShouldSwapToDefaultSessionOnNextNavigation.
In this case of third-party-cookie-relaxing.html, the previous cookies/private-cookie-storage.html test invokes these
functions and causes new BrowsingContextGroup to lose track of WebPageProxy.

To fix this, make sure WebPageProxy is removed from old BrowsingContextGroup and added to new BrowsingContextGroup.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setBrowsingContextGroup):
(WebKit::WebPageProxy::swapToProvisionalPage):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/280992@main">https://commits.webkit.org/280992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d3c4e1795f84b20ea095cd09837f5ba2c7a8b23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61852 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8672 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47188 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6198 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60258 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28022 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31971 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7676 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63557 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54511 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54570 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12881 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1836 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33384 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34470 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35554 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->