### PR TITLE
Values other than list-item should hide marker.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-expected.txt
@@ -2,6 +2,6 @@
 
 
 
-FAIL PreventDefaulting form onsubmit should allow submit() to succeed assert_equals: expected "v6" but got "v7"
-FAIL PreventDefaulting form onsubmit should allow submit() to succeed and the second submit() which is invalid should not supersede first one assert_equals: expected "v2" but got "v4"
+PASS PreventDefaulting form onsubmit should allow submit() to succeed
+PASS PreventDefaulting form onsubmit should allow submit() to succeed and the second submit() which is invalid should not supersede first one
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-requestsubmit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-requestsubmit-expected.txt
@@ -48,25 +48,25 @@ PASS test runTest with submitterType: button, preventDefaultRequestSubmit: false
 PASS test runTest with submitterType: button, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: true, passSubmitter: false
 PASS test runTest with submitterType: button, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: false, passSubmitter: true
 PASS test runTest with submitterType: button, preventDefaultRequestSubmit: false, preventDefaultSubmitButton: false, passSubmitter: false
-FAIL test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: true
 PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: false
 FAIL test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: false, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
 PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: true, preventDefault: false, passSubmitter: false
 PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: false, preventDefault: false, passSubmitter: true
 PASS test runTest2 with submitterType: input, callRequestSubmit: true, callSubmit: false, preventDefault: false, passSubmitter: false
-FAIL test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: true
 PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: false
 FAIL test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: false, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
 PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: true, preventDefault: false, passSubmitter: false
 PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: false, preventDefault: false, passSubmitter: true
 PASS test runTest2 with submitterType: input, callRequestSubmit: false, callSubmit: false, preventDefault: false, passSubmitter: false
-FAIL test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: true
 PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: true, passSubmitter: false
 FAIL test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: false, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
 PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: true, preventDefault: false, passSubmitter: false
 PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: false, preventDefault: false, passSubmitter: true
 PASS test runTest2 with submitterType: button, callRequestSubmit: true, callSubmit: false, preventDefault: false, passSubmitter: false
-FAIL test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
+PASS test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: true
 PASS test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: true, passSubmitter: false
 FAIL test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: false, passSubmitter: true assert_equals: expected (object) null but got (string) "v3"
 PASS test runTest2 with submitterType: button, callRequestSubmit: false, callSubmit: true, preventDefault: false, passSubmitter: false

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -363,6 +363,7 @@ void HTMLFormElement::submit(Event* event, bool processingUserGesture, FormSubmi
 {
     // The submitIfPossible function also does this check, but we need to do it here
     // too, since there are some code paths that bypass that function.
+
     if (!isConnected())
         return;
 
@@ -374,7 +375,7 @@ void HTMLFormElement::submit(Event* event, bool processingUserGesture, FormSubmi
     if (!view || !frame)
         return;
 
-    if (m_isSubmittingOrPreparingForSubmission) {
+    if (trigger != SubmittedByJavaScript && m_isSubmittingOrPreparingForSubmission) {
         m_shouldSubmit = true;
         return;
     }
@@ -524,7 +525,7 @@ unsigned HTMLFormElement::formElementIndexWithFormAttribute(Element* element, un
         else
             left = middle + 1;
     }
-    
+
     ASSERT(left < m_listedElementsBeforeIndex || left >= m_listedElementsAfterIndex);
     position = element->compareDocumentPosition(*m_listedElements[left]);
     if (position & DOCUMENT_POSITION_FOLLOWING)
@@ -968,15 +969,15 @@ RefPtr<DOMFormData> HTMLFormElement::constructEntryList(RefPtr<HTMLFormControlEl
 {
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-form-data-set
     ASSERT(isMainThread());
-    
+
     if (m_isConstructingEntryList)
         return nullptr;
-    
+
     SetForScope isConstructingEntryListScope(m_isConstructingEntryList, true);
 
     if (submitter)
         submitter->setActivatedSubmit(true);
-    
+
     for (auto& control : this->copyListedElementsVector()) {
         auto& element = control->asHTMLElement();
         if (!element.isDisabledFormControl())
@@ -988,12 +989,12 @@ RefPtr<DOMFormData> HTMLFormElement::constructEntryList(RefPtr<HTMLFormControlEl
             }
         }
     }
-    
+
     dispatchEvent(FormDataEvent::create(eventNames().formdataEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::No, domFormData.copyRef()));
 
     if (submitter)
         submitter->setActivatedSubmit(false);
-    
+
     return domFormData->clone();
 }
 

--- a/Source/WebCore/html/shadow/DetailsMarkerControl.cpp
+++ b/Source/WebCore/html/shadow/DetailsMarkerControl.cpp
@@ -61,7 +61,7 @@ RenderPtr<RenderElement> DetailsMarkerControl::createElementRenderer(RenderStyle
 
 bool DetailsMarkerControl::rendererIsNeeded(const RenderStyle& style)
 {
-    return downcast<HTMLSummaryElement>(shadowHost())->isActiveSummary() && HTMLDivElement::rendererIsNeeded(style);
+    return downcast<HTMLSummaryElement>(shadowHost())->isActiveSummary() && HTMLDivElement::rendererIsNeeded(style) && downcast<HTMLSummaryElement>(shadowHost())->computedStyle()->display() == DisplayType::ListItem;
 }
 
 }


### PR DESCRIPTION
#### 6938540d8c9f44c8dc79e8e7de9c14b6732d4d6d
<pre>
Values other than list-item should hide marker.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264381.">https://bugs.webkit.org/show_bug.cgi?id=264381.</a>

Reviewed by NOBODY (OOPS!).

Make the marker appear on the summary element when we define only a list-item display mode.

* Source/WebCore/html/shadow/DetailsMarkerControl.cpp:
(WebCore::DetailsMarkerControl::rendererIsNeeded):
</pre>
----------------------------------------------------------------------
#### 684a45beaf530acc96dbc78230c5de9e787c3ef1
<pre>
Fix Form Submit incorrect query.
<a href="https://bugs.webkit.org/show_bug.cgi?id=243595.">https://bugs.webkit.org/show_bug.cgi?id=243595.</a>

When we submit a form and call submit()  again in JavaScript code
that was called, for example, from onsubmit, we lose this submit
event. This happens because some control flags were activated
in the normal submit event and the form was already processing a
submit event generated by the user clicking the submit button.

To solve this problem, the change is:

- Checking if the form submit event is coming from JavaScript code and allowing the event to complete and reset the flags related with form submit.

* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::submit):

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-preventdefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/form-submission-0/form-double-submit-requestsubmit-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6938540d8c9f44c8dc79e8e7de9c14b6732d4d6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58182 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/37510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/10664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/61807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/8627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/60311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/45146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/8820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/61807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/8627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/60213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/45146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/10664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/61807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/45146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/10664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/7631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/45146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/10664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/63511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/2096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/8820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/63511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/2103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/10664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/63511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/34425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/34170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->