### PR TITLE
Values other than list-item should hide marker.

### DIFF
--- a/Source/WebCore/html/shadow/DetailsMarkerControl.cpp
+++ b/Source/WebCore/html/shadow/DetailsMarkerControl.cpp
@@ -61,7 +61,7 @@ RenderPtr<RenderElement> DetailsMarkerControl::createElementRenderer(RenderStyle
 
 bool DetailsMarkerControl::rendererIsNeeded(const RenderStyle& style)
 {
-    return downcast<HTMLSummaryElement>(shadowHost())->isActiveSummary() && HTMLDivElement::rendererIsNeeded(style);
+    return downcast<HTMLSummaryElement>(shadowHost())->isActiveSummary() && HTMLDivElement::rendererIsNeeded(style) && downcast<HTMLSummaryElement>(shadowHost())->computedStyle()->display() == DisplayType::ListItem;
 }
 
 }


### PR DESCRIPTION
#### ce7c640b3ef889c94846bee7e4e9fcdb7f00a704
<pre>
Values other than list-item should hide marker.
<a href="https://bugs.webkit.org/show_bug.cgi?id=264381.">https://bugs.webkit.org/show_bug.cgi?id=264381.</a>

Reviewed by NOBODY (OOPS!).

Make the marker appear on the summary element when we define only a list-item display mode.

* Source/WebCore/html/shadow/DetailsMarkerControl.cpp:
(WebCore::DetailsMarkerControl::rendererIsNeeded):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce7c640b3ef889c94846bee7e4e9fcdb7f00a704

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61809 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8629 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8822 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47149 "Found 66 new test failures: fast/css-generated-content/details-summary-before-after.html fast/html/details-add-child-1.html fast/html/details-add-child-2.html fast/html/details-add-details-child-1.html fast/html/details-add-details-child-2.html fast/html/details-add-summary-1-and-click.html fast/html/details-add-summary-1.html fast/html/details-add-summary-10-and-click.html fast/html/details-add-summary-10.html fast/html/details-add-summary-2-and-click.html ... (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6160 "Found 15 new test failures: fast/html/details-add-summary-1-and-click.html fast/html/details-add-summary-1.html fast/html/details-add-summary-10-and-click.html fast/html/details-add-summary-2-and-click.html fast/html/details-add-summary-2.html fast/html/details-add-summary-3-and-click.html fast/html/details-add-summary-3.html fast/html/details-add-summary-5.html fast/html/details-add-summary-6-and-click.html fast/html/details-add-summary-6.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60215 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35167 "Found 60 new test failures: fast/events/ios/rotation/layout-viewport-during-safari-type-rotation.html fast/forms/datalist/datalist-option-labels.html fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html fast/forms/state-restore-per-form.html fast/html/details-add-child-1.html fast/html/details-add-child-2.html fast/html/details-add-details-child-1.html fast/html/details-add-details-child-2.html fast/html/details-add-summary-1-and-click.html fast/html/details-add-summary-1.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27982 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31930 "Found 3 new test failures: imported/w3c/web-platform-tests/html/rendering/the-details-element/summary-display-list-item-001.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/anchor-with-inline-element.html imported/w3c/web-platform-tests/websockets/basic-auth.any.html?wss (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7601 "Found 60 new test failures: fast/css-generated-content/details-summary-before-after.html fast/html/details-add-child-1.html fast/html/details-add-child-2.html fast/html/details-add-details-child-1.html fast/html/details-add-details-child-2.html fast/html/details-add-summary-1.html fast/html/details-add-summary-10.html fast/html/details-add-summary-2.html fast/html/details-add-summary-3.html fast/html/details-add-summary-4.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7633 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53882 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7869 "Found 60 new test failures: fast/animation/request-animation-frame-throttling-lowPowerMode.html fast/css-generated-content/details-summary-before-after.html fast/html/details-add-child-1.html fast/html/details-add-child-2.html fast/html/details-add-details-child-1.html fast/html/details-add-details-child-2.html fast/html/details-add-summary-1-and-click.html fast/html/details-add-summary-1.html fast/html/details-add-summary-10-and-click.html fast/html/details-add-summary-10.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63513 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2098 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7928 "Found 60 new test failures: animations/stop-animation-on-suspend.html fast/css-generated-content/details-summary-before-after.html fast/css/aspect-ratio-min-height-replaced.html fast/forms/date/date-editable-components/date-editable-components-mouse-events.html fast/html/details-add-child-1.html fast/html/details-add-child-2.html fast/html/details-add-details-child-1.html fast/html/details-add-details-child-2.html fast/html/details-add-summary-1-and-click.html fast/html/details-add-summary-1.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54459 "Found 66 new test failures: fast/css-generated-content/details-summary-before-after.html fast/html/details-add-child-1.html fast/html/details-add-child-2.html fast/html/details-add-details-child-1.html fast/html/details-add-details-child-2.html fast/html/details-add-summary-1-and-click.html fast/html/details-add-summary-1.html fast/html/details-add-summary-10-and-click.html fast/html/details-add-summary-10.html fast/html/details-add-summary-2-and-click.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54520 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1796 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33341 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34427 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34172 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->