### PR TITLE
[JSC] add support for `Uint8Array.fromBase64` and `Uint8Array.prototype.setFromBase64`

### DIFF
--- a/JSTests/stress/uint8array-fromBase64.js
+++ b/JSTests/stress/uint8array-fromBase64.js
@@ -1,0 +1,580 @@
+//@ requireOptions("--useUint8ArrayBase64Methods=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+function shouldThrow(callback, errorConstructor) {
+    try {
+        callback();
+    } catch (e) {
+        shouldBe(e instanceof errorConstructor, true);
+        return
+    }
+    throw new Error('FAIL: should have thrown');
+}
+
+shouldBeArray(Uint8Array.fromBase64(""), []);
+shouldBeArray(Uint8Array.fromBase64("AA"), [0]);
+shouldBeArray(Uint8Array.fromBase64("AQ"), [1]);
+shouldBeArray(Uint8Array.fromBase64("gA"), [128]);
+shouldBeArray(Uint8Array.fromBase64("/g"), [254]);
+shouldBeArray(Uint8Array.fromBase64("/w"), [255]);
+shouldBeArray(Uint8Array.fromBase64("AAE"), [0, 1]);
+shouldBeArray(Uint8Array.fromBase64("/v8"), [254, 255]);
+shouldBeArray(Uint8Array.fromBase64("AAGA/v8"), [0, 1, 128, 254, 255]);
+shouldBeArray(Uint8Array.fromBase64("AA=="), [0]);
+shouldBeArray(Uint8Array.fromBase64("AQ=="), [1]);
+shouldBeArray(Uint8Array.fromBase64("gA=="), [128]);
+shouldBeArray(Uint8Array.fromBase64("/g=="), [254]);
+shouldBeArray(Uint8Array.fromBase64("/w=="), [255]);
+shouldBeArray(Uint8Array.fromBase64("AAE="), [0, 1]);
+shouldBeArray(Uint8Array.fromBase64("/v8="), [254, 255]);
+shouldBeArray(Uint8Array.fromBase64("AAGA/v8="), [0, 1, 128, 254, 255]);
+shouldBeArray(Uint8Array.fromBase64("  "), []);
+shouldBeArray(Uint8Array.fromBase64("  A  A  "), [0]);
+shouldBeArray(Uint8Array.fromBase64("  A  Q  "), [1]);
+shouldBeArray(Uint8Array.fromBase64("  g  A  "), [128]);
+shouldBeArray(Uint8Array.fromBase64("  /  g  "), [254]);
+shouldBeArray(Uint8Array.fromBase64("  /  w  "), [255]);
+shouldBeArray(Uint8Array.fromBase64("  A  A  E  "), [0, 1]);
+shouldBeArray(Uint8Array.fromBase64("  /  v  8  "), [254, 255]);
+shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  /  v  8  "), [0, 1, 128, 254, 255]);
+shouldBeArray(Uint8Array.fromBase64("  A  A  =  =  "), [0]);
+shouldBeArray(Uint8Array.fromBase64("  A  Q  =  =  "), [1]);
+shouldBeArray(Uint8Array.fromBase64("  g  A  =  =  "), [128]);
+shouldBeArray(Uint8Array.fromBase64("  /  g  =  =  "), [254]);
+shouldBeArray(Uint8Array.fromBase64("  /  w  =  =  "), [255]);
+shouldBeArray(Uint8Array.fromBase64("  A  A  E  =  "), [0, 1]);
+shouldBeArray(Uint8Array.fromBase64("  /  v  8  =  "), [254, 255]);
+shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  /  v  8  =  "), [0, 1, 128, 254, 255]);
+
+shouldBeArray(Uint8Array.fromBase64("", {}), []);
+shouldBeArray(Uint8Array.fromBase64("AA", {}), [0]);
+shouldBeArray(Uint8Array.fromBase64("AQ", {}), [1]);
+shouldBeArray(Uint8Array.fromBase64("gA", {}), [128]);
+shouldBeArray(Uint8Array.fromBase64("/g", {}), [254]);
+shouldBeArray(Uint8Array.fromBase64("/w", {}), [255]);
+shouldBeArray(Uint8Array.fromBase64("AAE", {}), [0, 1]);
+shouldBeArray(Uint8Array.fromBase64("/v8", {}), [254, 255]);
+shouldBeArray(Uint8Array.fromBase64("AAGA/v8", {}), [0, 1, 128, 254, 255]);
+shouldBeArray(Uint8Array.fromBase64("AA==", {}), [0]);
+shouldBeArray(Uint8Array.fromBase64("AQ==", {}), [1]);
+shouldBeArray(Uint8Array.fromBase64("gA==", {}), [128]);
+shouldBeArray(Uint8Array.fromBase64("/g==", {}), [254]);
+shouldBeArray(Uint8Array.fromBase64("/w==", {}), [255]);
+shouldBeArray(Uint8Array.fromBase64("AAE=", {}), [0, 1]);
+shouldBeArray(Uint8Array.fromBase64("/v8=", {}), [254, 255]);
+shouldBeArray(Uint8Array.fromBase64("AAGA/v8=", {}), [0, 1, 128, 254, 255]);
+shouldBeArray(Uint8Array.fromBase64("  ", {}), []);
+shouldBeArray(Uint8Array.fromBase64("  A  A  ", {}), [0]);
+shouldBeArray(Uint8Array.fromBase64("  A  Q  ", {}), [1]);
+shouldBeArray(Uint8Array.fromBase64("  g  A  ", {}), [128]);
+shouldBeArray(Uint8Array.fromBase64("  /  g  ", {}), [254]);
+shouldBeArray(Uint8Array.fromBase64("  /  w  ", {}), [255]);
+shouldBeArray(Uint8Array.fromBase64("  A  A  E  ", {}), [0, 1]);
+shouldBeArray(Uint8Array.fromBase64("  /  v  8  ", {}), [254, 255]);
+shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  /  v  8  ", {}), [0, 1, 128, 254, 255]);
+shouldBeArray(Uint8Array.fromBase64("  A  A  =  =  ", {}), [0]);
+shouldBeArray(Uint8Array.fromBase64("  A  Q  =  =  ", {}), [1]);
+shouldBeArray(Uint8Array.fromBase64("  g  A  =  =  ", {}), [128]);
+shouldBeArray(Uint8Array.fromBase64("  /  g  =  =  ", {}), [254]);
+shouldBeArray(Uint8Array.fromBase64("  /  w  =  =  ", {}), [255]);
+shouldBeArray(Uint8Array.fromBase64("  A  A  E  =  ", {}), [0, 1]);
+shouldBeArray(Uint8Array.fromBase64("  /  v  8  =  ", {}), [254, 255]);
+shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  /  v  8  =  ", {}), [0, 1, 128, 254, 255]);
+
+for (let alphabet of [undefined, "base64"]) {
+    [
+        {alphabet},
+        {get alphabet() { return alphabet; }},
+    ].forEach((options) => {
+        shouldBeArray(Uint8Array.fromBase64("", options), []);
+        shouldBeArray(Uint8Array.fromBase64("AA", options), [0]);
+        shouldBeArray(Uint8Array.fromBase64("AQ", options), [1]);
+        shouldBeArray(Uint8Array.fromBase64("gA", options), [128]);
+        shouldBeArray(Uint8Array.fromBase64("/g", options), [254]);
+        shouldBeArray(Uint8Array.fromBase64("/w", options), [255]);
+        shouldBeArray(Uint8Array.fromBase64("AAE", options), [0, 1]);
+        shouldBeArray(Uint8Array.fromBase64("/v8", options), [254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("AAGA/v8", options), [0, 1, 128, 254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("AA==", options), [0]);
+        shouldBeArray(Uint8Array.fromBase64("AQ==", options), [1]);
+        shouldBeArray(Uint8Array.fromBase64("gA==", options), [128]);
+        shouldBeArray(Uint8Array.fromBase64("/g==", options), [254]);
+        shouldBeArray(Uint8Array.fromBase64("/w==", options), [255]);
+        shouldBeArray(Uint8Array.fromBase64("AAE=", options), [0, 1]);
+        shouldBeArray(Uint8Array.fromBase64("/v8=", options), [254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("AAGA/v8=", options), [0, 1, 128, 254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("  ", options), []);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  ", options), [0]);
+        shouldBeArray(Uint8Array.fromBase64("  A  Q  ", options), [1]);
+        shouldBeArray(Uint8Array.fromBase64("  g  A  ", options), [128]);
+        shouldBeArray(Uint8Array.fromBase64("  /  g  ", options), [254]);
+        shouldBeArray(Uint8Array.fromBase64("  /  w  ", options), [255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  E  ", options), [0, 1]);
+        shouldBeArray(Uint8Array.fromBase64("  /  v  8  ", options), [254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  /  v  8  ", options), [0, 1, 128, 254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  =  =  ", options), [0]);
+        shouldBeArray(Uint8Array.fromBase64("  A  Q  =  =  ", options), [1]);
+        shouldBeArray(Uint8Array.fromBase64("  g  A  =  =  ", options), [128]);
+        shouldBeArray(Uint8Array.fromBase64("  /  g  =  =  ", options), [254]);
+        shouldBeArray(Uint8Array.fromBase64("  /  w  =  =  ", options), [255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  E  =  ", options), [0, 1]);
+        shouldBeArray(Uint8Array.fromBase64("  /  v  8  =  ", options), [254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  /  v  8  =  ", options), [0, 1, 128, 254, 255]);
+    });
+
+    for (let lastChunkHandling of [undefined, "loose", "strict", "stop-before-partial"]) {
+        [
+            {alphabet, lastChunkHandling},
+            {get alphabet() { return alphabet; }, get lastChunkHandling() { return lastChunkHandling; }},
+        ].forEach((options) => {
+            shouldBeArray(Uint8Array.fromBase64("", options), []);
+            shouldBeArray(Uint8Array.fromBase64("AA==", options), [0]);
+            shouldBeArray(Uint8Array.fromBase64("AQ==", options), [1]);
+            shouldBeArray(Uint8Array.fromBase64("gA==", options), [128]);
+            shouldBeArray(Uint8Array.fromBase64("/g==", options), [254]);
+            shouldBeArray(Uint8Array.fromBase64("/w==", options), [255]);
+            shouldBeArray(Uint8Array.fromBase64("AAE=", options), [0, 1]);
+            shouldBeArray(Uint8Array.fromBase64("/v8=", options), [254, 255]);
+            shouldBeArray(Uint8Array.fromBase64("AAGA/v8=", options), [0, 1, 128, 254, 255]);
+            shouldBeArray(Uint8Array.fromBase64("  ", options), []);
+            shouldBeArray(Uint8Array.fromBase64("  A  A  =  =  ", options), [0]);
+            shouldBeArray(Uint8Array.fromBase64("  A  Q  =  =  ", options), [1]);
+            shouldBeArray(Uint8Array.fromBase64("  g  A  =  =  ", options), [128]);
+            shouldBeArray(Uint8Array.fromBase64("  /  g  =  =  ", options), [254]);
+            shouldBeArray(Uint8Array.fromBase64("  /  w  =  =  ", options), [255]);
+            shouldBeArray(Uint8Array.fromBase64("  A  A  E  =  ", options), [0, 1]);
+            shouldBeArray(Uint8Array.fromBase64("  /  v  8  =  ", options), [254, 255]);
+            shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  /  v  8  =  ", options), [0, 1, 128, 254, 255]);
+        });
+
+        [
+            "AA===", "  A  A  =  =  =  ",
+            "AQ===", "  A  Q  =  =  =  ",
+            "gA===", "  g  A  =  =  =  ",
+            "/g===", "  /  g  =  =  =  ",
+            "/w===", "  /  w  =  =  =  ",
+            "AAE==", "  A  A  E  =  =  ",
+            "/v8==", "  /  v  8  =  =  ",
+            "AAGA/v8==", "  A  A  G  A  /  v  8  =  =  ",
+        ].forEach((string) => {
+            [
+                {alphabet, lastChunkHandling},
+                {get alphabet() { return alphabet; }, get lastChunkHandling() { return lastChunkHandling; }},
+            ].forEach((options) => {
+                shouldThrow(() => {
+                    Uint8Array.fromBase64(string, options);
+                }, SyntaxError);
+            });
+        });
+    }
+
+    for (let lastChunkHandling of [undefined, "loose"]) {
+        [
+            {alphabet, lastChunkHandling},
+            {get alphabet() { return alphabet; }, get lastChunkHandling() { return lastChunkHandling; }},
+        ].forEach((options) => {
+            shouldBeArray(Uint8Array.fromBase64("AA", options), [0]);
+            shouldBeArray(Uint8Array.fromBase64("AQ", options), [1]);
+            shouldBeArray(Uint8Array.fromBase64("gA", options), [128]);
+            shouldBeArray(Uint8Array.fromBase64("/g", options), [254]);
+            shouldBeArray(Uint8Array.fromBase64("/w", options), [255]);
+            shouldBeArray(Uint8Array.fromBase64("AAE", options), [0, 1]);
+            shouldBeArray(Uint8Array.fromBase64("/v8", options), [254, 255]);
+            shouldBeArray(Uint8Array.fromBase64("AAGA/v8", options), [0, 1, 128, 254, 255]);
+            shouldBeArray(Uint8Array.fromBase64("  ", options), []);
+            shouldBeArray(Uint8Array.fromBase64("  A  A  ", options), [0]);
+            shouldBeArray(Uint8Array.fromBase64("  A  Q  ", options), [1]);
+            shouldBeArray(Uint8Array.fromBase64("  g  A  ", options), [128]);
+            shouldBeArray(Uint8Array.fromBase64("  /  g  ", options), [254]);
+            shouldBeArray(Uint8Array.fromBase64("  /  w  ", options), [255]);
+            shouldBeArray(Uint8Array.fromBase64("  A  A  E  ", options), [0, 1]);
+            shouldBeArray(Uint8Array.fromBase64("  /  v  8  ", options), [254, 255]);
+            shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  /  v  8  ", options), [0, 1, 128, 254, 255]);
+        });
+    }
+
+    [
+        "AA", "  A  A  ",
+        "AQ", "  A  Q  ",
+        "gA", "  g  A  ",
+        "/g", "  /  g  ",
+        "/w", "  /  w  ",
+        "AAE", "  A  A  E  ",
+        "/v8", "  /  v  8  ",
+    ].forEach((string) => {
+        [
+            {alphabet, lastChunkHandling: "stop-before-partial"},
+            {get alphabet() { return alphabet; }, get lastChunkHandling() { return "stop-before-partial"; }},
+        ].forEach((options) => {
+            shouldBeArray(Uint8Array.fromBase64(string, options), []);
+        });
+
+        [
+            {alphabet, lastChunkHandling: "strict"},
+            {get alphabet() { return alphabet; }, get lastChunkHandling() { return "strict"; }},
+        ].forEach((options) => {
+            shouldThrow(() => {
+                Uint8Array.fromBase64(string, options);
+            }, SyntaxError);
+        });
+    });
+
+    [
+        {alphabet, lastChunkHandling: "stop-before-partial"},
+        {get alphabet() { return alphabet; }, get lastChunkHandling() { return "stop-before-partial"; }},
+    ].forEach((options) => {
+        shouldBeArray(Uint8Array.fromBase64("AAGA/v8", options), [0, 1, 128]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  /  v  8  ", options), [0, 1, 128]);
+    });
+
+    [
+        {alphabet, lastChunkHandling: "strict"},
+        {get alphabet() { return alphabet; }, get lastChunkHandling() { return "strict"; }},
+    ].forEach((options) => {
+        shouldThrow(() => {
+            Uint8Array.fromBase64("AAGA/v8", options);
+        }, SyntaxError);
+        shouldThrow(() => {
+            Uint8Array.fromBase64("  A  A  G  A  /  v  8  ", options);
+        }, SyntaxError);
+    });
+}
+
+[
+    {alphabet: "base64url"},
+    {get alphabet() { return "base64url"; }},
+].forEach((options) => {
+    shouldBeArray(Uint8Array.fromBase64("", options), []);
+    shouldBeArray(Uint8Array.fromBase64("AA", options), [0]);
+    shouldBeArray(Uint8Array.fromBase64("AQ", options), [1]);
+    shouldBeArray(Uint8Array.fromBase64("gA", options), [128]);
+    shouldBeArray(Uint8Array.fromBase64("_g", options), [254]);
+    shouldBeArray(Uint8Array.fromBase64("_w", options), [255]);
+    shouldBeArray(Uint8Array.fromBase64("AAE", options), [0, 1]);
+    shouldBeArray(Uint8Array.fromBase64("_v8", options), [254, 255]);
+    shouldBeArray(Uint8Array.fromBase64("AAGA_v8", options), [0, 1, 128, 254, 255]);
+    shouldBeArray(Uint8Array.fromBase64("AA==", options), [0]);
+    shouldBeArray(Uint8Array.fromBase64("AQ==", options), [1]);
+    shouldBeArray(Uint8Array.fromBase64("gA==", options), [128]);
+    shouldBeArray(Uint8Array.fromBase64("_g==", options), [254]);
+    shouldBeArray(Uint8Array.fromBase64("_w==", options), [255]);
+    shouldBeArray(Uint8Array.fromBase64("AAE=", options), [0, 1]);
+    shouldBeArray(Uint8Array.fromBase64("_v8=", options), [254, 255]);
+    shouldBeArray(Uint8Array.fromBase64("AAGA_v8=", options), [0, 1, 128, 254, 255]);
+    shouldBeArray(Uint8Array.fromBase64("  ", options), []);
+    shouldBeArray(Uint8Array.fromBase64("  A  A  ", options), [0]);
+    shouldBeArray(Uint8Array.fromBase64("  A  Q  ", options), [1]);
+    shouldBeArray(Uint8Array.fromBase64("  g  A  ", options), [128]);
+    shouldBeArray(Uint8Array.fromBase64("  _  g  ", options), [254]);
+    shouldBeArray(Uint8Array.fromBase64("  _  w  ", options), [255]);
+    shouldBeArray(Uint8Array.fromBase64("  A  A  E  ", options), [0, 1]);
+    shouldBeArray(Uint8Array.fromBase64("  _  v  8  ", options), [254, 255]);
+    shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  _  v  8  ", options), [0, 1, 128, 254, 255]);
+    shouldBeArray(Uint8Array.fromBase64("  A  A  =  =  ", options), [0]);
+    shouldBeArray(Uint8Array.fromBase64("  A  Q  =  =  ", options), [1]);
+    shouldBeArray(Uint8Array.fromBase64("  g  A  =  =  ", options), [128]);
+    shouldBeArray(Uint8Array.fromBase64("  _  g  =  =  ", options), [254]);
+    shouldBeArray(Uint8Array.fromBase64("  _  w  =  =  ", options), [255]);
+    shouldBeArray(Uint8Array.fromBase64("  A  A  E  =  ", options), [0, 1]);
+    shouldBeArray(Uint8Array.fromBase64("  _  v  8  =  ", options), [254, 255]);
+    shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  _  v  8  =  ", options), [0, 1, 128, 254, 255]);
+});
+
+for (let lastChunkHandling of [undefined, "loose", "strict", "stop-before-partial"]) {
+    [
+        {alphabet: "base64url", lastChunkHandling},
+        {get alphabet() { return "base64url"; }, get lastChunkHandling() { return lastChunkHandling; }},
+    ].forEach((options) => {
+        shouldBeArray(Uint8Array.fromBase64("", options), []);
+        shouldBeArray(Uint8Array.fromBase64("AA==", options), [0]);
+        shouldBeArray(Uint8Array.fromBase64("AQ==", options), [1]);
+        shouldBeArray(Uint8Array.fromBase64("gA==", options), [128]);
+        shouldBeArray(Uint8Array.fromBase64("_g==", options), [254]);
+        shouldBeArray(Uint8Array.fromBase64("_w==", options), [255]);
+        shouldBeArray(Uint8Array.fromBase64("AAE=", options), [0, 1]);
+        shouldBeArray(Uint8Array.fromBase64("_v8=", options), [254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("AAGA_v8=", options), [0, 1, 128, 254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("  ", options), []);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  =  =  ", options), [0]);
+        shouldBeArray(Uint8Array.fromBase64("  A  Q  =  =  ", options), [1]);
+        shouldBeArray(Uint8Array.fromBase64("  g  A  =  =  ", options), [128]);
+        shouldBeArray(Uint8Array.fromBase64("  _  g  =  =  ", options), [254]);
+        shouldBeArray(Uint8Array.fromBase64("  _  w  =  =  ", options), [255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  E  =  ", options), [0, 1]);
+        shouldBeArray(Uint8Array.fromBase64("  _  v  8  =  ", options), [254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  _  v  8  =  ", options), [0, 1, 128, 254, 255]);
+    });
+
+    [
+        "AA===", "  A  A  =  =  =  ",
+        "AQ===", "  A  Q  =  =  =  ",
+        "gA===", "  g  A  =  =  =  ",
+        "_g===", "  _  g  =  =  =  ",
+        "_w===", "  _  w  =  =  =  ",
+        "AAE==", "  A  A  E  =  =  ",
+        "_v8==", "  _  v  8  =  =  ",
+        "AAGA_v8==", "  A  A  G  A  _  v8==",
+    ].forEach((string) => {
+        [
+            {alphabet: "base64url", lastChunkHandling},
+            {get alphabet() { return "base64url"; }, get lastChunkHandling() { return lastChunkHandling; }},
+        ].forEach((options) => {
+            shouldThrow(() => {
+                Uint8Array.fromBase64(string, options);
+            }, SyntaxError);
+        });
+    });
+}
+
+for (let lastChunkHandling of [undefined, "loose"]) {
+    [
+        {alphabet: "base64url", lastChunkHandling},
+        {get alphabet() { return "base64url"; }, get lastChunkHandling() { return lastChunkHandling; }},
+    ].forEach((options) => {
+        shouldBeArray(Uint8Array.fromBase64("AA", options), [0]);
+        shouldBeArray(Uint8Array.fromBase64("AQ", options), [1]);
+        shouldBeArray(Uint8Array.fromBase64("gA", options), [128]);
+        shouldBeArray(Uint8Array.fromBase64("_g", options), [254]);
+        shouldBeArray(Uint8Array.fromBase64("_w", options), [255]);
+        shouldBeArray(Uint8Array.fromBase64("AAE", options), [0, 1]);
+        shouldBeArray(Uint8Array.fromBase64("_v8", options), [254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("AAGA_v8", options), [0, 1, 128, 254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("  ", options), []);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  ", options), [0]);
+        shouldBeArray(Uint8Array.fromBase64("  A  Q  ", options), [1]);
+        shouldBeArray(Uint8Array.fromBase64("  g  A  ", options), [128]);
+        shouldBeArray(Uint8Array.fromBase64("  _  g  ", options), [254]);
+        shouldBeArray(Uint8Array.fromBase64("  _  w  ", options), [255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  E  ", options), [0, 1]);
+        shouldBeArray(Uint8Array.fromBase64("  _  v  8  ", options), [254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  _  v  8  ", options), [0, 1, 128, 254, 255]);
+    });
+}
+
+[
+    "AA", "  A  A  ",
+    "AQ", "  A  Q  ",
+    "gA", "  g  A  ",
+    "_g", "  _  g  ",
+    "_w", "  _  w  ",
+    "AAE", "  A  A  E  ",
+    "_v8", "  _  v  8  ",
+].forEach((string) => {
+    [
+        {alphabet: "base64url", lastChunkHandling: "stop-before-partial"},
+        {get alphabet() { return "base64url"; }, get lastChunkHandling() { return "stop-before-partial"; }},
+    ].forEach((options) => {
+        shouldBeArray(Uint8Array.fromBase64(string, options), []);
+    });
+
+    [
+        {alphabet: "base64url", lastChunkHandling: "strict"},
+        {get alphabet() { return "base64url"; }, get lastChunkHandling() { return "strict"; }},
+    ].forEach((options) => {
+        shouldThrow(() => {
+            Uint8Array.fromBase64(string, options);
+        }, SyntaxError);
+    });
+});
+
+[
+    {alphabet: "base64url", lastChunkHandling: "stop-before-partial"},
+    {get alphabet() { return "base64url"; }, get lastChunkHandling() { return "stop-before-partial"; }},
+].forEach((options) => {
+    shouldBeArray(Uint8Array.fromBase64("AAGA_v8", options), [0, 1, 128]);
+    shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  _  v  8  ", options), [0, 1, 128]);
+});
+
+[
+    {alphabet: "base64url", lastChunkHandling: "strict"},
+    {get alphabet() { return "base64url"; }, get lastChunkHandling() { return "strict"; }},
+].forEach((options) => {
+    shouldThrow(() => {
+        Uint8Array.fromBase64("AAGA_v8", options);
+    }, SyntaxError);
+    shouldThrow(() => {
+        Uint8Array.fromBase64("  A  A  G  A  _  v  8  ", options);
+    }, SyntaxError);
+});
+
+for (let lastChunkHandling of [undefined, "loose", "strict", "stop-before-partial"]) {
+    [
+        {lastChunkHandling},
+        {get lastChunkHandling() { return lastChunkHandling; }},
+    ].forEach((options) => {
+        shouldBeArray(Uint8Array.fromBase64("", options), []);
+        shouldBeArray(Uint8Array.fromBase64("AA==", options), [0]);
+        shouldBeArray(Uint8Array.fromBase64("AQ==", options), [1]);
+        shouldBeArray(Uint8Array.fromBase64("gA==", options), [128]);
+        shouldBeArray(Uint8Array.fromBase64("/g==", options), [254]);
+        shouldBeArray(Uint8Array.fromBase64("/w==", options), [255]);
+        shouldBeArray(Uint8Array.fromBase64("AAE=", options), [0, 1]);
+        shouldBeArray(Uint8Array.fromBase64("/v8=", options), [254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("AAGA/v8=", options), [0, 1, 128, 254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  =  =  ", options), [0]);
+        shouldBeArray(Uint8Array.fromBase64("  A  Q  =  =  ", options), [1]);
+        shouldBeArray(Uint8Array.fromBase64("  g  A  =  =  ", options), [128]);
+        shouldBeArray(Uint8Array.fromBase64("  /  g  =  =  ", options), [254]);
+        shouldBeArray(Uint8Array.fromBase64("  /  w  =  =  ", options), [255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  E  =  ", options), [0, 1]);
+        shouldBeArray(Uint8Array.fromBase64("  /  v  8  =  ", options), [254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  /  v  8  =  ", options), [0, 1, 128, 254, 255]);
+    });
+
+    [
+        "AA===", "  A  A  =  =  =  ",
+        "AQ===", "  A  Q  =  =  =  ",
+        "gA===", "  g  A  =  =  =  ",
+        "/g===", "  /  g  =  =  =  ",
+        "/w===", "  /  w  =  =  =  ",
+        "AAE==", "  A  A  E  =  =  ",
+        "/v8==", "  /  v  8  =  =  ",
+        "AAGA/v8==", "  A  A  G  A  /  v  8  =  =  ",
+    ].forEach((string) => {
+        [
+            {lastChunkHandling},
+            {get lastChunkHandling() { return lastChunkHandling; }},
+        ].forEach((options) => {
+            shouldThrow(() => {
+                Uint8Array.fromBase64(string, options);
+            }, SyntaxError);
+        });
+    });
+}
+
+for (let lastChunkHandling of [undefined, "loose"]) {
+    [
+        {lastChunkHandling},
+        {get lastChunkHandling() { return lastChunkHandling; }},
+    ].forEach((options) => {
+        shouldBeArray(Uint8Array.fromBase64("AA", options), [0]);
+        shouldBeArray(Uint8Array.fromBase64("AQ", options), [1]);
+        shouldBeArray(Uint8Array.fromBase64("gA", options), [128]);
+        shouldBeArray(Uint8Array.fromBase64("/g", options), [254]);
+        shouldBeArray(Uint8Array.fromBase64("/w", options), [255]);
+        shouldBeArray(Uint8Array.fromBase64("AAE", options), [0, 1]);
+        shouldBeArray(Uint8Array.fromBase64("/v8", options), [254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("AAGA/v8", options), [0, 1, 128, 254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("  ", options), []);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  ", options), [0]);
+        shouldBeArray(Uint8Array.fromBase64("  A  Q  ", options), [1]);
+        shouldBeArray(Uint8Array.fromBase64("  g  A  ", options), [128]);
+        shouldBeArray(Uint8Array.fromBase64("  /  g  ", options), [254]);
+        shouldBeArray(Uint8Array.fromBase64("  /  w  ", options), [255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  E  ", options), [0, 1]);
+        shouldBeArray(Uint8Array.fromBase64("  /  v  8  ", options), [254, 255]);
+        shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  /  v  8  ", options), [0, 1, 128, 254, 255]);
+    });
+}
+
+[
+    "AA", "  A  A  ",
+    "AQ", "  A  Q  ",
+    "gA", "  g  A  ",
+    "/g", "  /  g  ",
+    "/w", "  /  w  ",
+    "AAE", "  A  A  E  ",
+    "/v8", "  /  v  8  ",
+].forEach((string) => {
+    [
+        {lastChunkHandling: "stop-before-partial"},
+        {get lastChunkHandling() { return "stop-before-partial"; }},
+    ].forEach((options) => {
+        shouldBeArray(Uint8Array.fromBase64(string, options), []);
+    });
+
+    [
+        {lastChunkHandling: "strict"},
+        {get lastChunkHandling() { return "strict"; }},
+    ].forEach((options) => {
+        shouldThrow(() => {
+            Uint8Array.fromBase64(string, options);
+        }, SyntaxError);
+    });
+});
+
+[
+    {lastChunkHandling: "stop-before-partial"},
+    {get lastChunkHandling() { return "stop-before-partial"; }},
+].forEach((options) => {
+    shouldBeArray(Uint8Array.fromBase64("AAGA/v8", options), [0, 1, 128]);
+    shouldBeArray(Uint8Array.fromBase64("  A  A  G  A  /  v  8  ", options), [0, 1, 128]);
+});
+
+[
+    {lastChunkHandling: "strict"},
+    {get lastChunkHandling() { return "strict"; }},
+].forEach((options) => {
+    shouldThrow(() => {
+        Uint8Array.fromBase64("AAGA/v8", options);
+    }, SyntaxError);
+    shouldThrow(() => {
+        Uint8Array.fromBase64("  A  A  G  A  /  v  8  ", options);
+    }, SyntaxError);
+});
+
+for (let invalid of [undefined, null, false, true, 42, {}, []]) {
+    shouldThrow(() => {
+        Uint8Array.fromBase64(invalid);
+    }, TypeError);
+}
+
+for (let options of [null, false, true, 42, "test"]) {
+    shouldThrow(() => {
+        Uint8Array.fromBase64("", options);
+    }, TypeError);
+}
+
+for (let alphabet of [null, false, true, 42, "invalid", {}, []]) {
+    shouldThrow(() => {
+        Uint8Array.fromBase64("", {alphabet});
+    }, TypeError);
+
+    shouldThrow(() => {
+        Uint8Array.fromBase64("", {
+            get alphabet() { return alphabet; },
+        });
+    }, TypeError);
+
+    shouldThrow(() => {
+        Uint8Array.fromBase64("", {
+            alphabet: {
+                toString() {
+                    return alphabet;
+                },
+            },
+        });
+    }, TypeError);
+}
+
+for (let lastChunkHandling of [null, false, true, 42, "invalid", {}, []]) {
+    shouldThrow(() => {
+        Uint8Array.fromBase64("", {lastChunkHandling});
+    }, TypeError);
+
+    shouldThrow(() => {
+        Uint8Array.fromBase64("", {
+            get lastChunkHandling() { return lastChunkHandling; },
+        });
+    }, TypeError);
+
+    shouldThrow(() => {
+        Uint8Array.fromBase64("", {
+            lastChunkHandling: {
+                toString() {
+                    return lastChunkHandling;
+                },
+            },
+        });
+    }, TypeError);
+}

--- a/JSTests/stress/uint8array-fromHex.js
+++ b/JSTests/stress/uint8array-fromHex.js
@@ -11,6 +11,16 @@ function shouldBeArray(actual, expected) {
         shouldBe(actual[i], expected[i]);
 }
 
+function shouldThrow(callback, errorConstructor) {
+    try {
+        callback();
+    } catch (e) {
+        shouldBe(e instanceof errorConstructor, true);
+        return
+    }
+    throw new Error('FAIL: should have thrown');
+}
+
 shouldBeArray(Uint8Array.fromHex(""), []);
 shouldBeArray(Uint8Array.fromHex("00"), [0]);
 shouldBeArray(Uint8Array.fromHex("01"), [1]);
@@ -26,17 +36,13 @@ shouldBeArray(Uint8Array.fromHex("000180feff"), [0, 1, 128, 254, 255]);
 shouldBeArray(Uint8Array.fromHex("000180FEFF"), [0, 1, 128, 254, 255]);
 
 for (let invalid of [undefined, null, false, true, 42, {}, []]) {
-    try {
+    shouldThrow(() => {
         Uint8Array.fromHex(invalid);
-    } catch (e) {
-        shouldBe(e instanceof TypeError, true);
-    }
+    }, TypeError);
 }
 
 for (let invalid of ["0", "012", "0g", "0G", "g0", "G0", "0✅", "✅0"]) {
-    try {
+    shouldThrow(() => {
         Uint8Array.fromHex(invalid);
-    } catch (e) {
-        shouldBe(e instanceof SyntaxError, true);
-    }
+    }, SyntaxError);
 }

--- a/JSTests/stress/uint8array-setFromBase64.js
+++ b/JSTests/stress/uint8array-setFromBase64.js
@@ -1,0 +1,704 @@
+//@ requireOptions("--useUint8ArrayBase64Methods=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+function shouldBeObject(actual, expected) {
+    for (let key in expected) {
+        shouldBe(key in actual, true);
+        shouldBe(actual[key], expected[key]);
+    }
+
+    for (let key in actual)
+        shouldBe(key in expected, true);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+function shouldThrow(callback, errorConstructor) {
+    try {
+        callback();
+    } catch (e) {
+        shouldBe(e instanceof errorConstructor, true);
+        return
+    }
+    throw new Error('FAIL: should have thrown');
+}
+
+function test(input, options, expectedResult, expectedValue) {
+    let uint8array = new Uint8Array([42, 42, 42, 42, 42]);
+
+    let result;
+    if (options)
+        result = uint8array.setFromBase64(input, options);
+    else
+        result = uint8array.setFromBase64(input);
+
+    while (expectedValue.length < 5)
+        expectedValue.push(42);
+
+    shouldBeObject(result, expectedResult);
+    shouldBeArray(uint8array, expectedValue);
+}
+
+test("", undefined, {read: 0, written: 0}, []);
+test("AA", undefined, {read: 2, written: 1}, [0]);
+test("AQ", undefined, {read: 2, written: 1}, [1]);
+test("gA", undefined, {read: 2, written: 1}, [128]);
+test("/g", undefined, {read: 2, written: 1}, [254]);
+test("/w", undefined, {read: 2, written: 1}, [255]);
+test("AAE", undefined, {read: 3, written: 2}, [0, 1]);
+test("/v8", undefined, {read: 3, written: 2}, [254, 255]);
+test("AAGA/v8", undefined, {read: 7, written: 5}, [0, 1, 128, 254, 255]);
+test("AAGA/v8z", undefined, {read: 4, written: 3}, [0, 1, 128]);
+test("AAGA/v8zzA", undefined, {read: 4, written: 3}, [0, 1, 128]);
+test("AA==", undefined, {read: 4, written: 1}, [0]);
+test("AQ==", undefined, {read: 4, written: 1}, [1]);
+test("gA==", undefined, {read: 4, written: 1}, [128]);
+test("/g==", undefined, {read: 4, written: 1}, [254]);
+test("/w==", undefined, {read: 4, written: 1}, [255]);
+test("AAE=", undefined, {read: 4, written: 2}, [0, 1]);
+test("/v8=", undefined, {read: 4, written: 2}, [254, 255]);
+test("AAGA/v8=", undefined, {read: 8, written: 5}, [0, 1, 128, 254, 255]);
+test("AAGA/v8z", undefined, {read: 4, written: 3}, [0, 1, 128]);
+test("AAGA/v8zzA==", undefined, {read: 4, written: 3}, [0, 1, 128]);
+test("  ", undefined, {read: 2, written: 0}, []);
+test("  A  A  ", undefined, {read: 8, written: 1}, [0]);
+test("  A  Q  ", undefined, {read: 8, written: 1}, [1]);
+test("  g  A  ", undefined, {read: 8, written: 1}, [128]);
+test("  /  g  ", undefined, {read: 8, written: 1}, [254]);
+test("  /  w  ", undefined, {read: 8, written: 1}, [255]);
+test("  A  A  E  ", undefined, {read: 11, written: 2}, [0, 1]);
+test("  /  v  8  ", undefined, {read: 11, written: 2}, [254, 255]);
+test("  A  A  G  A  /  v  8  ", undefined, {read: 23, written: 5}, [0, 1, 128, 254, 255]);
+test("  A  A  G  A  /  v  8  z  ", undefined, {read: 12, written: 3}, [0, 1, 128]);
+test("  A  A  G  A  /  v  8  z  z  A  ", undefined, {read: 12, written: 3}, [0, 1, 128]);
+test("  A  A  =  =  ", undefined, {read: 14, written: 1}, [0]);
+test("  A  Q  =  =  ", undefined, {read: 14, written: 1}, [1]);
+test("  g  A  =  =  ", undefined, {read: 14, written: 1}, [128]);
+test("  /  g  =  =  ", undefined, {read: 14, written: 1}, [254]);
+test("  /  w  =  =  ", undefined, {read: 14, written: 1}, [255]);
+test("  A  A  E  =  ", undefined, {read: 14, written: 2}, [0, 1]);
+test("  /  v  8  =  ", undefined, {read: 14, written: 2}, [254, 255]);
+test("  A  A  G  A  /  v  8  =  ", undefined, {read: 26, written: 5}, [0, 1, 128, 254, 255]);
+test("  A  A  G  A  /  v  8  z  ", undefined, {read: 12, written: 3}, [0, 1, 128]);
+test("  A  A  G  A  /  v  8  z  z  A  =  =  ", undefined, {read: 12, written: 3}, [0, 1, 128]);
+
+test("", {}, {read: 0, written: 0}, []);
+test("AA", {}, {read: 2, written: 1}, [0]);
+test("AQ", {}, {read: 2, written: 1}, [1]);
+test("gA", {}, {read: 2, written: 1}, [128]);
+test("/g", {}, {read: 2, written: 1}, [254]);
+test("/w", {}, {read: 2, written: 1}, [255]);
+test("AAE", {}, {read: 3, written: 2}, [0, 1]);
+test("/v8", {}, {read: 3, written: 2}, [254, 255]);
+test("AAGA/v8", {}, {read: 7, written: 5}, [0, 1, 128, 254, 255]);
+test("AAGA/v8z", {}, {read: 4, written: 3}, [0, 1, 128]);
+test("AAGA/v8zzA", {}, {read: 4, written: 3}, [0, 1, 128]);
+test("AA==", {}, {read: 4, written: 1}, [0]);
+test("AQ==", {}, {read: 4, written: 1}, [1]);
+test("gA==", {}, {read: 4, written: 1}, [128]);
+test("/g==", {}, {read: 4, written: 1}, [254]);
+test("/w==", {}, {read: 4, written: 1}, [255]);
+test("AAE=", {}, {read: 4, written: 2}, [0, 1]);
+test("/v8=", {}, {read: 4, written: 2}, [254, 255]);
+test("AAGA/v8=", {}, {read: 8, written: 5}, [0, 1, 128, 254, 255]);
+test("AAGA/v8z", {}, {read: 4, written: 3}, [0, 1, 128]);
+test("AAGA/v8zzA==", {}, {read: 4, written: 3}, [0, 1, 128]);
+test("  ", {}, {read: 2, written: 0}, []);
+test("  A  A  ", {}, {read: 8, written: 1}, [0]);
+test("  A  Q  ", {}, {read: 8, written: 1}, [1]);
+test("  g  A  ", {}, {read: 8, written: 1}, [128]);
+test("  /  g  ", {}, {read: 8, written: 1}, [254]);
+test("  /  w  ", {}, {read: 8, written: 1}, [255]);
+test("  A  A  E  ", {}, {read: 11, written: 2}, [0, 1]);
+test("  /  v  8  ", {}, {read: 11, written: 2}, [254, 255]);
+test("  A  A  G  A  /  v  8  ", {}, {read: 23, written: 5}, [0, 1, 128, 254, 255]);
+test("  A  A  G  A  /  v  8  z  ", {}, {read: 12, written: 3}, [0, 1, 128]);
+test("  A  A  G  A  /  v  8  z  z  A  ", {}, {read: 12, written: 3}, [0, 1, 128]);
+test("  A  A  =  =  ", {}, {read: 14, written: 1}, [0]);
+test("  A  Q  =  =  ", {}, {read: 14, written: 1}, [1]);
+test("  g  A  =  =  ", {}, {read: 14, written: 1}, [128]);
+test("  /  g  =  =  ", {}, {read: 14, written: 1}, [254]);
+test("  /  w  =  =  ", {}, {read: 14, written: 1}, [255]);
+test("  A  A  E  =  ", {}, {read: 14, written: 2}, [0, 1]);
+test("  /  v  8  =  ", {}, {read: 14, written: 2}, [254, 255]);
+test("  A  A  G  A  /  v  8  =  ", {}, {read: 26, written: 5}, [0, 1, 128, 254, 255]);
+test("  A  A  G  A  /  v  8  z  ", {}, {read: 12, written: 3}, [0, 1, 128]);
+test("  A  A  G  A  /  v  8  z  z  A  =  =  ", {}, {read: 12, written: 3}, [0, 1, 128]);
+
+for (let alphabet of [undefined, "base64"]) {
+    [
+        {alphabet},
+        {get alphabet() { return alphabet; }},
+    ].forEach((options) => {
+        test("", options, {read: 0, written: 0}, []);
+        test("AA", options, {read: 2, written: 1}, [0]);
+        test("AQ", options, {read: 2, written: 1}, [1]);
+        test("gA", options, {read: 2, written: 1}, [128]);
+        test("/g", options, {read: 2, written: 1}, [254]);
+        test("/w", options, {read: 2, written: 1}, [255]);
+        test("AAE", options, {read: 3, written: 2}, [0, 1]);
+        test("/v8", options, {read: 3, written: 2}, [254, 255]);
+        test("AAGA/v8", options, {read: 7, written: 5}, [0, 1, 128, 254, 255]);
+        test("AAGA/v8z", options, {read: 4, written: 3}, [0, 1, 128]);
+        test("AAGA/v8zzA", options, {read: 4, written: 3}, [0, 1, 128]);
+        test("AA==", options, {read: 4, written: 1}, [0]);
+        test("AQ==", options, {read: 4, written: 1}, [1]);
+        test("gA==", options, {read: 4, written: 1}, [128]);
+        test("/g==", options, {read: 4, written: 1}, [254]);
+        test("/w==", options, {read: 4, written: 1}, [255]);
+        test("AAE=", options, {read: 4, written: 2}, [0, 1]);
+        test("/v8=", options, {read: 4, written: 2}, [254, 255]);
+        test("AAGA/v8=", options, {read: 8, written: 5}, [0, 1, 128, 254, 255]);
+        test("AAGA/v8z", options, {read: 4, written: 3}, [0, 1, 128]);
+        test("AAGA/v8zzA==", options, {read: 4, written: 3}, [0, 1, 128]);
+        test("  ", options, {read: 2, written: 0}, []);
+        test("  A  A  ", options, {read: 8, written: 1}, [0]);
+        test("  A  Q  ", options, {read: 8, written: 1}, [1]);
+        test("  g  A  ", options, {read: 8, written: 1}, [128]);
+        test("  /  g  ", options, {read: 8, written: 1}, [254]);
+        test("  /  w  ", options, {read: 8, written: 1}, [255]);
+        test("  A  A  E  ", options, {read: 11, written: 2}, [0, 1]);
+        test("  /  v  8  ", options, {read: 11, written: 2}, [254, 255]);
+        test("  A  A  G  A  /  v  8  ", options, {read: 23, written: 5}, [0, 1, 128, 254, 255]);
+        test("  A  A  G  A  /  v  8  z  ", options, {read: 12, written: 3}, [0, 1, 128]);
+        test("  A  A  G  A  /  v  8  z  z  A  ", options, {read: 12, written: 3}, [0, 1, 128]);
+        test("  A  A  =  =  ", options, {read: 14, written: 1}, [0]);
+        test("  A  Q  =  =  ", options, {read: 14, written: 1}, [1]);
+        test("  g  A  =  =  ", options, {read: 14, written: 1}, [128]);
+        test("  /  g  =  =  ", options, {read: 14, written: 1}, [254]);
+        test("  /  w  =  =  ", options, {read: 14, written: 1}, [255]);
+        test("  A  A  E  =  ", options, {read: 14, written: 2}, [0, 1]);
+        test("  /  v  8  =  ", options, {read: 14, written: 2}, [254, 255]);
+        test("  A  A  G  A  /  v  8  =  ", options, {read: 26, written: 5}, [0, 1, 128, 254, 255]);
+        test("  A  A  G  A  /  v  8  z  ", options, {read: 12, written: 3}, [0, 1, 128]);
+        test("  A  A  G  A  /  v  8  z  z  A  =  =  ", options, {read: 12, written: 3}, [0, 1, 128]);
+    });
+
+    for (let lastChunkHandling of [undefined, "loose", "strict", "stop-before-partial"]) {
+        [
+            {alphabet, lastChunkHandling},
+            {get alphabet() { return alphabet; }, get lastChunkHandling() { return lastChunkHandling; }},
+        ].forEach((options) => {
+            test("", options, {read: 0, written: 0}, []);
+            test("AA==", options, {read: 4, written: 1}, [0]);
+            test("AQ==", options, {read: 4, written: 1}, [1]);
+            test("gA==", options, {read: 4, written: 1}, [128]);
+            test("/g==", options, {read: 4, written: 1}, [254]);
+            test("/w==", options, {read: 4, written: 1}, [255]);
+            test("AAE=", options, {read: 4, written: 2}, [0, 1]);
+            test("/v8=", options, {read: 4, written: 2}, [254, 255]);
+            test("AAGA/v8=", options, {read: 8, written: 5}, [0, 1, 128, 254, 255]);
+            test("AAGA/v8z", options, {read: 4, written: 3}, [0, 1, 128]);
+            test("AAGA/v8zzA", options, {read: 4, written: 3}, [0, 1, 128]);
+            test("AAGA/v8zzA==", options, {read: 4, written: 3}, [0, 1, 128]);
+            test("  ", options, {read: 2, written: 0}, []);
+            test("  A  A  =  =  ", options, {read: 14, written: 1}, [0]);
+            test("  A  Q  =  =  ", options, {read: 14, written: 1}, [1]);
+            test("  g  A  =  =  ", options, {read: 14, written: 1}, [128]);
+            test("  /  g  =  =  ", options, {read: 14, written: 1}, [254]);
+            test("  /  w  =  =  ", options, {read: 14, written: 1}, [255]);
+            test("  A  A  E  =  ", options, {read: 14, written: 2}, [0, 1]);
+            test("  /  v  8  =  ", options, {read: 14, written: 2}, [254, 255]);
+            test("  A  A  G  A  /  v  8  =  ", options, {read: 26, written: 5}, [0, 1, 128, 254, 255]);
+            test("  A  A  G  A  /  v  8  z  ", options, {read: 12, written: 3}, [0, 1, 128]);
+            test("  A  A  G  A  /  v  8  z  z  A  ", options, {read: 12, written: 3}, [0, 1, 128]);
+            test("  A  A  G  A  /  v  8  z  z  A  =  =  ", options, {read: 12, written: 3}, [0, 1, 128]);
+        });
+
+        [
+            "AA===", "  A  A  =  =  =  ",
+            "AQ===", "  A  Q  =  =  =  ",
+            "gA===", "  g  A  =  =  =  ",
+            "/g===", "  /  g  =  =  =  ",
+            "/w===", "  /  w  =  =  =  ",
+            "AAE==", "  A  A  E  =  =  ",
+            "/v8==", "  /  v  8  =  =  ",
+            "AAGA/v8==", "  A  A  G  A  /  v  8  =  =  ",
+        ].forEach((string) => {
+            [
+                {alphabet, lastChunkHandling},
+                {get alphabet() { return alphabet; }, get lastChunkHandling() { return lastChunkHandling; }},
+            ].forEach((options) => {
+                shouldThrow(() => {
+                    test(string, options, {read: 0, written: 0}, []);
+                }, SyntaxError);
+            });
+        });
+    }
+
+    for (let lastChunkHandling of [undefined, "loose"]) {
+        [
+            {alphabet, lastChunkHandling},
+            {get alphabet() { return alphabet; }, get lastChunkHandling() { return lastChunkHandling; }},
+        ].forEach((options) => {
+            test("AA", options, {read: 2, written: 1}, [0]);
+            test("AQ", options, {read: 2, written: 1}, [1]);
+            test("gA", options, {read: 2, written: 1}, [128]);
+            test("/g", options, {read: 2, written: 1}, [254]);
+            test("/w", options, {read: 2, written: 1}, [255]);
+            test("AAE", options, {read: 3, written: 2}, [0, 1]);
+            test("/v8", options, {read: 3, written: 2}, [254, 255]);
+            test("AAGA/v8", options, {read: 7, written: 5}, [0, 1, 128, 254, 255]);
+            test("  A  A  ", options, {read: 8, written: 1}, [0]);
+            test("  A  Q  ", options, {read: 8, written: 1}, [1]);
+            test("  g  A  ", options, {read: 8, written: 1}, [128]);
+            test("  /  g  ", options, {read: 8, written: 1}, [254]);
+            test("  /  w  ", options, {read: 8, written: 1}, [255]);
+            test("  A  A  E  ", options, {read: 11, written: 2}, [0, 1]);
+            test("  /  v  8  ", options, {read: 11, written: 2}, [254, 255]);
+            test("  A  A  G  A  /  v  8  ", options, {read: 23, written: 5}, [0, 1, 128, 254, 255]);
+        });
+    }
+
+    [
+        "AA", "  A  A  ",
+        "AQ", "  A  Q  ",
+        "gA", "  g  A  ",
+        "/g", "  /  g  ",
+        "/w", "  /  w  ",
+        "AAE", "  A  A  E  ",
+        "/v8", "  /  v  8  ",
+    ].forEach((string) => {
+        [
+            {alphabet, lastChunkHandling: "stop-before-partial"},
+            {get alphabet() { return alphabet; }, get lastChunkHandling() { return "stop-before-partial"; }},
+        ].forEach((options) => {
+            test(string, options, {read: 0, written: 0}, []);
+        });
+
+        [
+            {alphabet, lastChunkHandling: "strict"},
+            {get alphabet() { return alphabet; }, get lastChunkHandling() { return "strict"; }},
+        ].forEach((options) => {
+            shouldThrow(() => {
+                test(string, options, {read: 0, written: 0}, []);
+            }, SyntaxError);
+        });
+    });
+
+    [
+        {alphabet, lastChunkHandling: "stop-before-partial"},
+        {get alphabet() { return alphabet; }, get lastChunkHandling() { return "stop-before-partial"; }},
+    ].forEach((options) => {
+        test("AAGA/v8", options, {read: 4, written: 3}, [0, 1, 128]);
+        test("  A  A  G  A  /  v  8  ", options, {read: 12, written: 3}, [0, 1, 128]);
+    });
+
+    [
+        {alphabet, lastChunkHandling: "strict"},
+        {get alphabet() { return alphabet; }, get lastChunkHandling() { return "strict"; }},
+    ].forEach((options) => {
+        shouldThrow(() => {
+            test("AAGA/v8", options, {read: 0, written: 0}, []);
+        }, SyntaxError);
+        shouldThrow(() => {
+            test("  A  A  G  A  /  v  8  ", options, {read: 0, written: 0}, []);
+        }, SyntaxError);
+    });
+}
+
+[
+    {alphabet: "base64url"},
+    {get alphabet() { return "base64url"; }},
+].forEach((options) => {
+    test("", options, {read: 0, written: 0}, []);
+    test("AA", options, {read: 2, written: 1}, [0]);
+    test("AQ", options, {read: 2, written: 1}, [1]);
+    test("gA", options, {read: 2, written: 1}, [128]);
+    test("_g", options, {read: 2, written: 1}, [254]);
+    test("_w", options, {read: 2, written: 1}, [255]);
+    test("AAE", options, {read: 3, written: 2}, [0, 1]);
+    test("_v8", options, {read: 3, written: 2}, [254, 255]);
+    test("AAGA_v8", options, {read: 7, written: 5}, [0, 1, 128, 254, 255]);
+    test("AAGA_v8z", options, {read: 4, written: 3}, [0, 1, 128]);
+    test("AAGA_v8zzA", options, {read: 4, written: 3}, [0, 1, 128]);
+    test("AA==", options, {read: 4, written: 1}, [0]);
+    test("AQ==", options, {read: 4, written: 1}, [1]);
+    test("gA==", options, {read: 4, written: 1}, [128]);
+    test("_g==", options, {read: 4, written: 1}, [254]);
+    test("_w==", options, {read: 4, written: 1}, [255]);
+    test("AAE=", options, {read: 4, written: 2}, [0, 1]);
+    test("_v8=", options, {read: 4, written: 2}, [254, 255]);
+    test("AAGA_v8=", options, {read: 8, written: 5}, [0, 1, 128, 254, 255]);
+    test("AAGA_v8z", options, {read: 4, written: 3}, [0, 1, 128]);
+    test("AAGA_v8zzA==", options, {read: 4, written: 3}, [0, 1, 128]);
+    test("  ", options, {read: 2, written: 0}, []);
+    test("  A  A  ", options, {read: 8, written: 1}, [0]);
+    test("  A  Q  ", options, {read: 8, written: 1}, [1]);
+    test("  g  A  ", options, {read: 8, written: 1}, [128]);
+    test("  _  g  ", options, {read: 8, written: 1}, [254]);
+    test("  _  w  ", options, {read: 8, written: 1}, [255]);
+    test("  A  A  E  ", options, {read: 11, written: 2}, [0, 1]);
+    test("  _  v  8  ", options, {read: 11, written: 2}, [254, 255]);
+    test("  A  A  G  A  _  v  8  ", options, {read: 23, written: 5}, [0, 1, 128, 254, 255]);
+    test("  A  A  G  A  _  v  8  z  ", options, {read: 12, written: 3}, [0, 1, 128]);
+    test("  A  A  G  A  _  v  8  z  z  A  ", options, {read: 12, written: 3}, [0, 1, 128]);
+    test("  A  A  =  =  ", options, {read: 14, written: 1}, [0]);
+    test("  A  Q  =  =  ", options, {read: 14, written: 1}, [1]);
+    test("  g  A  =  =  ", options, {read: 14, written: 1}, [128]);
+    test("  _  g  =  =  ", options, {read: 14, written: 1}, [254]);
+    test("  _  w  =  =  ", options, {read: 14, written: 1}, [255]);
+    test("  A  A  E  =  ", options, {read: 14, written: 2}, [0, 1]);
+    test("  _  v  8  =  ", options, {read: 14, written: 2}, [254, 255]);
+    test("  A  A  G  A  _  v  8  =  ", options, {read: 26, written: 5}, [0, 1, 128, 254, 255]);
+    test("  A  A  G  A  _  v  8  z  ", options, {read: 12, written: 3}, [0, 1, 128]);
+    test("  A  A  G  A  _  v  8  z  z  A  =  =  ", options, {read: 12, written: 3}, [0, 1, 128]);
+});
+
+for (let lastChunkHandling of [undefined, "loose", "strict", "stop-before-partial"]) {
+    [
+        {alphabet: "base64url", lastChunkHandling},
+        {get alphabet() { return "base64url"; }, get lastChunkHandling() { return lastChunkHandling; }},
+    ].forEach((options) => {
+        test("", options, {read: 0, written: 0}, []);
+        test("AA==", options, {read: 4, written: 1}, [0]);
+        test("AQ==", options, {read: 4, written: 1}, [1]);
+        test("gA==", options, {read: 4, written: 1}, [128]);
+        test("_g==", options, {read: 4, written: 1}, [254]);
+        test("_w==", options, {read: 4, written: 1}, [255]);
+        test("AAE=", options, {read: 4, written: 2}, [0, 1]);
+        test("_v8=", options, {read: 4, written: 2}, [254, 255]);
+        test("AAGA_v8=", options, {read: 8, written: 5}, [0, 1, 128, 254, 255]);
+        test("AAGA_v8z", options, {read: 4, written: 3}, [0, 1, 128]);
+        test("AAGA_v8zzA", options, {read: 4, written: 3}, [0, 1, 128]);
+        test("AAGA_v8zzA==", options, {read: 4, written: 3}, [0, 1, 128]);
+        test("  ", options, {read: 2, written: 0}, []);
+        test("  A  A  =  =  ", options, {read: 14, written: 1}, [0]);
+        test("  A  Q  =  =  ", options, {read: 14, written: 1}, [1]);
+        test("  g  A  =  =  ", options, {read: 14, written: 1}, [128]);
+        test("  _  g  =  =  ", options, {read: 14, written: 1}, [254]);
+        test("  _  w  =  =  ", options, {read: 14, written: 1}, [255]);
+        test("  A  A  E  =  ", options, {read: 14, written: 2}, [0, 1]);
+        test("  _  v  8  =  ", options, {read: 14, written: 2}, [254, 255]);
+        test("  A  A  G  A  _  v  8  =  ", options, {read: 26, written: 5}, [0, 1, 128, 254, 255]);
+        test("  A  A  G  A  _  v  8  z  ", options, {read: 12, written: 3}, [0, 1, 128]);
+        test("  A  A  G  A  _  v  8  z  z  A  ", options, {read: 12, written: 3}, [0, 1, 128]);
+        test("  A  A  G  A  _  v  8  z  z  A  =  =  ", options, {read: 12, written: 3}, [0, 1, 128]);
+    });
+
+    [
+        "AA===", "  A  A  =  =  =  ",
+        "AQ===", "  A  Q  =  =  =  ",
+        "gA===", "  g  A  =  =  =  ",
+        "_g===", "  _  g  =  =  =  ",
+        "_w===", "  _  w  =  =  =  ",
+        "AAE==", "  A  A  E  =  =  ",
+        "_v8==", "  _  v  8  =  =  ",
+        "AAGA_v8==", "  A  A  G  A  _  v  8  =  =  ",
+    ].forEach((string) => {
+        [
+            {alphabet: "base64url", lastChunkHandling},
+            {get alphabet() { return "base64url"; }, get lastChunkHandling() { return lastChunkHandling; }},
+        ].forEach((options) => {
+            shouldThrow(() => {
+                test(string, options, {read: 0, written: 0}, []);
+            }, SyntaxError);
+        });
+    });
+}
+
+for (let lastChunkHandling of [undefined, "loose"]) {
+    [
+        {alphabet: "base64url", lastChunkHandling},
+        {get alphabet() { return "base64url"; }, get lastChunkHandling() { return lastChunkHandling; }},
+    ].forEach((options) => {
+        test("AA", options, {read: 2, written: 1}, [0]);
+        test("AQ", options, {read: 2, written: 1}, [1]);
+        test("gA", options, {read: 2, written: 1}, [128]);
+        test("_g", options, {read: 2, written: 1}, [254]);
+        test("_w", options, {read: 2, written: 1}, [255]);
+        test("AAE", options, {read: 3, written: 2}, [0, 1]);
+        test("_v8", options, {read: 3, written: 2}, [254, 255]);
+        test("AAGA_v8", options, {read: 7, written: 5}, [0, 1, 128, 254, 255]);
+        test("  A  A  ", options, {read: 8, written: 1}, [0]);
+        test("  A  Q  ", options, {read: 8, written: 1}, [1]);
+        test("  g  A  ", options, {read: 8, written: 1}, [128]);
+        test("  _  g  ", options, {read: 8, written: 1}, [254]);
+        test("  _  w  ", options, {read: 8, written: 1}, [255]);
+        test("  A  A  E  ", options, {read: 11, written: 2}, [0, 1]);
+        test("  _  v  8  ", options, {read: 11, written: 2}, [254, 255]);
+        test("  A  A  G  A  _  v  8  ", options, {read: 23, written: 5}, [0, 1, 128, 254, 255]);
+    });
+}
+
+[
+    "AA", "  A  A  ",
+    "AQ", "  A  Q  ",
+    "gA", "  g  A  ",
+    "_g", "  _  g  ",
+    "_w", "  _  w  ",
+    "AAE", "  A  A  E  ",
+    "_v8", "  _  v  8  ",
+].forEach((string) => {
+    [
+        {alphabet: "base64url", lastChunkHandling: "stop-before-partial"},
+        {get alphabet() { return "base64url"; }, get lastChunkHandling() { return "stop-before-partial"; }},
+    ].forEach((options) => {
+        test(string, options, {read: 0, written: 0}, []);
+    });
+
+    [
+        {alphabet: "base64url", lastChunkHandling: "strict"},
+        {get alphabet() { return "base64url"; }, get lastChunkHandling() { return "strict"; }},
+    ].forEach((options) => {
+        shouldThrow(() => {
+            test(string, options, {read: 0, written: 0}, []);
+        }, SyntaxError);
+    });
+});
+
+[
+    {alphabet: "base64url", lastChunkHandling: "stop-before-partial"},
+    {get alphabet() { return "base64url"; }, get lastChunkHandling() { return "stop-before-partial"; }},
+].forEach((options) => {
+    test("AAGA_v8", options, {read: 4, written: 3}, [0, 1, 128]);
+    test("  A  A  G  A  _  v  8  ", options, {read: 12, written: 3}, [0, 1, 128]);
+});
+
+[
+    {alphabet: "base64url", lastChunkHandling: "strict"},
+    {get alphabet() { return "base64url"; }, get lastChunkHandling() { return "strict"; }},
+].forEach((options) => {
+    shouldThrow(() => {
+        test("AAGA_v8", options, {read: 0, written: 0}, []);
+    }, SyntaxError);
+    shouldThrow(() => {
+        test("  A  A  G  A  _  v  8  ", options, {read: 0, written: 0}, []);
+    }, SyntaxError);
+});
+
+for (let lastChunkHandling of [undefined, "loose", "strict", "stop-before-partial"]) {
+    [
+        {lastChunkHandling},
+        {get lastChunkHandling() { return lastChunkHandling; }},
+    ].forEach((options) => {
+        test("", options, {read: 0, written: 0}, []);
+        test("AA==", options, {read: 4, written: 1}, [0]);
+        test("AQ==", options, {read: 4, written: 1}, [1]);
+        test("gA==", options, {read: 4, written: 1}, [128]);
+        test("/g==", options, {read: 4, written: 1}, [254]);
+        test("/w==", options, {read: 4, written: 1}, [255]);
+        test("AAE=", options, {read: 4, written: 2}, [0, 1]);
+        test("/v8=", options, {read: 4, written: 2}, [254, 255]);
+        test("AAGA/v8=", options, {read: 8, written: 5}, [0, 1, 128, 254, 255]);
+        test("AAGA/v8z", options, {read: 4, written: 3}, [0, 1, 128]);
+        test("AAGA/v8zzA", options, {read: 4, written: 3}, [0, 1, 128]);
+        test("AAGA/v8zzA==", options, {read: 4, written: 3}, [0, 1, 128]);
+        test("  ", options, {read: 2, written: 0}, []);
+        test("  A  A  =  =  ", options, {read: 14, written: 1}, [0]);
+        test("  A  Q  =  =  ", options, {read: 14, written: 1}, [1]);
+        test("  g  A  =  =  ", options, {read: 14, written: 1}, [128]);
+        test("  /  g  =  =  ", options, {read: 14, written: 1}, [254]);
+        test("  /  w  =  =  ", options, {read: 14, written: 1}, [255]);
+        test("  A  A  E  =  ", options, {read: 14, written: 2}, [0, 1]);
+        test("  /  v  8  =  ", options, {read: 14, written: 2}, [254, 255]);
+        test("  A  A  G  A  /  v  8  =  ", options, {read: 26, written: 5}, [0, 1, 128, 254, 255]);
+        test("  A  A  G  A  /  v  8  z  ", options, {read: 12, written: 3}, [0, 1, 128]);
+        test("  A  A  G  A  /  v  8  z  z  A  ", options, {read: 12, written: 3}, [0, 1, 128]);
+        test("  A  A  G  A  /  v  8  z  z  A  =  =  ", options, {read: 12, written: 3}, [0, 1, 128]);
+    });
+
+    [
+        "AA===", "  A  A  =  =  =  ",
+        "AQ===", "  A  Q  =  =  =  ",
+        "gA===", "  g  A  =  =  =  ",
+        "/g===", "  /  g  =  =  =  ",
+        "/w===", "  /  w  =  =  =  ",
+        "AAE==", "  A  A  E  =  =  ",
+        "/v8==", "  /  v  8  =  =  ",
+        "AAGA/v8==", "  A  A  G  A  /  v  8  =  =  ",
+    ].forEach((string) => {
+        [
+            {lastChunkHandling},
+            {get lastChunkHandling() { return lastChunkHandling; }},
+        ].forEach((options) => {
+            shouldThrow(() => {
+                test(string, options, {read: 0, written: 0}, []);
+            }, SyntaxError);
+        });
+    });
+}
+
+for (let lastChunkHandling of [undefined, "loose"]) {
+    [
+        {lastChunkHandling},
+        {get lastChunkHandling() { return lastChunkHandling; }},
+    ].forEach((options) => {
+        test("AA", options, {read: 2, written: 1}, [0]);
+        test("AQ", options, {read: 2, written: 1}, [1]);
+        test("gA", options, {read: 2, written: 1}, [128]);
+        test("/g", options, {read: 2, written: 1}, [254]);
+        test("/w", options, {read: 2, written: 1}, [255]);
+        test("AAE", options, {read: 3, written: 2}, [0, 1]);
+        test("/v8", options, {read: 3, written: 2}, [254, 255]);
+        test("AAGA/v8", options, {read: 7, written: 5}, [0, 1, 128, 254, 255]);
+        test("  A  A  ", options, {read: 8, written: 1}, [0]);
+        test("  A  Q  ", options, {read: 8, written: 1}, [1]);
+        test("  g  A  ", options, {read: 8, written: 1}, [128]);
+        test("  /  g  ", options, {read: 8, written: 1}, [254]);
+        test("  /  w  ", options, {read: 8, written: 1}, [255]);
+        test("  A  A  E  ", options, {read: 11, written: 2}, [0, 1]);
+        test("  /  v  8  ", options, {read: 11, written: 2}, [254, 255]);
+        test("  A  A  G  A  /  v  8  ", options, {read: 23, written: 5}, [0, 1, 128, 254, 255]);
+    });
+}
+
+[
+    "AA", "  A  A  ",
+    "AQ", "  A  Q  ",
+    "gA", "  g  A  ",
+    "/g", "  /  g  ",
+    "/w", "  /  w  ",
+    "AAE", "  A  A  E  ",
+    "/v8", "  /  v  8  ",
+].forEach((string) => {
+    [
+        {lastChunkHandling: "stop-before-partial"},
+        {get lastChunkHandling() { return "stop-before-partial"; }},
+    ].forEach((options) => {
+        test(string, options, {read: 0, written: 0}, []);
+    });
+
+    [
+        {lastChunkHandling: "strict"},
+        {get lastChunkHandling() { return "strict"; }},
+    ].forEach((options) => {
+        shouldThrow(() => {
+            test(string, options, {read: 0, written: 0}, []);
+        }, SyntaxError);
+    });
+});
+
+[
+    {lastChunkHandling: "stop-before-partial"},
+    {get lastChunkHandling() { return "stop-before-partial"; }},
+].forEach((options) => {
+    test("AAGA/v8", options, {read: 4, written: 3}, [0, 1, 128]);
+    test("  A  A  G  A  /  v  8  ", options, {read: 12, written: 3}, [0, 1, 128]);
+});
+
+[
+    {lastChunkHandling: "strict"},
+    {get lastChunkHandling() { return "strict"; }},
+].forEach((options) => {
+    shouldThrow(() => {
+        test("AAGA/v8", options, {read: 0, written: 0}, []);
+    }, SyntaxError);
+    shouldThrow(() => {
+        test("  A  A  G  A  /  v  8  ", options, {read: 0, written: 0}, []);
+    }, SyntaxError);
+});
+
+shouldThrow(() => {
+    let uint8array = new Uint8Array;
+    $.detachArrayBuffer(uint8array.buffer);
+    uint8array.setFromBase64("");
+}, TypeError);
+
+for (let alphabet of [undefined, "base64", "base64url"]) {
+    shouldThrow(() => {
+        let uint8array = new Uint8Array;
+        uint8array.setFromBase64("", {
+            get alphabet() {
+                $.detachArrayBuffer(uint8array.buffer);
+                return alphabet;
+            },
+        });
+    }, TypeError);
+
+    shouldThrow(() => {
+        (new Uint8Array).setFromBase64("", {
+            alphabet: {
+                toString() {
+                    return alphabet;
+                },
+            },
+        });
+    }, TypeError);
+}
+
+for (let lastChunkHandling of [undefined, "loose", "strict", "stop-before-partial"]) {
+    shouldThrow(() => {
+        let uint8array = new Uint8Array;
+        uint8array.setFromBase64("", {
+            get lastChunkHandling() {
+                $.detachArrayBuffer(uint8array.buffer);
+                return lastChunkHandling;
+            },
+        });
+    }, TypeError);
+
+    shouldThrow(() => {
+        (new Uint8Array).setFromBase64("", {
+            lastChunkHandling: {
+                toString() {
+                    return lastChunkHandling;
+                },
+            },
+        });
+    }, TypeError);
+}
+
+for (let invalid of [undefined, null, false, true, 42, {}, []]) {
+    shouldThrow(() => {
+        (new Uint8Array).setFromBase64(invalid);
+    }, TypeError);
+}
+
+for (let options of [null, false, true, 42, "test"]) {
+    shouldThrow(() => {
+        (new Uint8Array).setFromBase64("", options);
+    }, TypeError);
+}
+
+for (let alphabet of [null, false, true, 42, "invalid", {}, []]) {
+    shouldThrow(() => {
+        (new Uint8Array).setFromBase64("", {alphabet});
+    }, TypeError);
+
+    shouldThrow(() => {
+        (new Uint8Array).setFromBase64("", {
+            get alphabet() { return alphabet; },
+        });
+    }, TypeError);
+
+    shouldThrow(() => {
+        (new Uint8Array).setFromBase64("", {
+            alphabet: {
+                toString() {
+                    return alphabet;
+                },
+            },
+        });
+    }, TypeError);
+}
+
+for (let lastChunkHandling of [null, false, true, 42, "invalid", {}, []]) {
+    shouldThrow(() => {
+        (new Uint8Array).setFromBase64("", {lastChunkHandling});
+    }, TypeError);
+
+    shouldThrow(() => {
+        (new Uint8Array).setFromBase64("", {
+            get lastChunkHandling() { return lastChunkHandling; },
+        });
+    }, TypeError);
+
+    shouldThrow(() => {
+        (new Uint8Array).setFromBase64("", {
+            lastChunkHandling: {
+                toString() {
+                    return lastChunkHandling;
+                },
+            },
+        });
+    }, TypeError);
+}

--- a/JSTests/stress/uint8array-setFromHex.js
+++ b/JSTests/stress/uint8array-setFromHex.js
@@ -21,6 +21,16 @@ function shouldBeArray(actual, expected) {
         shouldBe(actual[i], expected[i]);
 }
 
+function shouldThrow(callback, errorConstructor) {
+    try {
+        callback();
+    } catch (e) {
+        shouldBe(e instanceof errorConstructor, true);
+        return
+    }
+    throw new Error('FAIL: should have thrown');
+}
+
 function test(input, expectedResult, expectedValue) {
     let uint8array = new Uint8Array([42, 42, 42, 42, 42]);
 
@@ -48,26 +58,20 @@ test("000180FEFF33", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
 test("000180feff33cc", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
 test("000180FEFF33CC", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
 
-try {
+shouldThrow(() => {
     let uint8array = new Uint8Array;
     $.detachArrayBuffer(uint8array.buffer);
     uint8array.setFromHex("");
-} catch (e) {
-    shouldBe(e instanceof TypeError, true);
-}
+}, TypeError);
 
 for (let invalid of [undefined, null, false, true, 42, {}, []]) {
-    try {
+    shouldThrow(() => {
         (new Uint8Array).setFromHex(invalid);
-    } catch (e) {
-        shouldBe(e instanceof TypeError, true);
-    }
+    }, TypeError);
 }
 
-for (let invalid of ["0", "012", "0g", "g0", "0✅", "✅0"]) {
-    try {
-        (new Uint8Array).setFromHex(invalid);
-    } catch (e) {
-        shouldBe(e instanceof SyntaxError, true);
-    }
+for (let invalid of ["0", "012", "0g", "0G", "g0", "G0", "0✅", "✅0"]) {
+    shouldThrow(() => {
+        (new Uint8Array([42, 42, 42, 42, 42])).setFromHex(invalid);
+    }, SyntaxError);
 }

--- a/JSTests/stress/uint8array-toBase64.js
+++ b/JSTests/stress/uint8array-toBase64.js
@@ -5,6 +5,16 @@ function shouldBe(actual, expected) {
         throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
 }
 
+function shouldThrow(callback, errorConstructor) {
+    try {
+        callback();
+    } catch (e) {
+        shouldBe(e instanceof errorConstructor, true);
+        return
+    }
+    throw new Error('FAIL: should have thrown');
+}
+
 shouldBe((new Uint8Array([])).toBase64(), "");
 shouldBe((new Uint8Array([0])).toBase64(), "AA==");
 shouldBe((new Uint8Array([1])).toBase64(), "AQ==");
@@ -199,16 +209,14 @@ for (let omitPadding of [true, 42, "test", [], {}]) {
     shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toBase64({get alphabet() { return "base64url"; }, get omitPadding() { return omitPadding; }}), "AAGA_v8");
 }
 
-try {
+shouldThrow(() => {
     let uint8array = new Uint8Array;
     $.detachArrayBuffer(uint8array.buffer);
     uint8array.toBase64();
-} catch (e) {
-    shouldBe(e instanceof TypeError, true);
-}
+}, TypeError);
 
 for (let alphabet of [undefined, "base64", "base64url"]) {
-    try {
+    shouldThrow(() => {
         let uint8array = new Uint8Array;
         uint8array.toBase64({
             get alphabet() {
@@ -216,11 +224,9 @@ for (let alphabet of [undefined, "base64", "base64url"]) {
                 return alphabet;
             },
         });
-    } catch (e) {
-        shouldBe(e instanceof TypeError, true);
-    }
+    }, TypeError);
 
-    try {
+    shouldThrow(() => {
         (new Uint8Array).toBase64({
             alphabet: {
                 toString() {
@@ -228,31 +234,23 @@ for (let alphabet of [undefined, "base64", "base64url"]) {
                 },
             },
         });
-    } catch (e) {
-        shouldBe(e instanceof TypeError, true);
-    }
+    }, TypeError);
 }
 
-for (let options of [undefined, null, false, true, 42, "test", []]) {
-    try {
+for (let options of [null, false, true, 42, "test"]) {
+    shouldThrow(() => {
         (new Uint8Array).toBase64(options);
-    } catch (e) {
-        shouldBe(e instanceof TypeError, true);
-    }
+    }, TypeError);
 }
 
 for (let alphabet of [null, false, true, 42, "invalid", {}, []]) {
-    try {
+    shouldThrow(() => {
         (new Uint8Array).toBase64({alphabet});
-    } catch (e) {
-        shouldBe(e instanceof TypeError, true);
-    }
+    }, TypeError);
 
-    try {
+    shouldThrow(() => {
         (new Uint8Array).toBase64({
             get alphabet() { return alphabet; },
         });
-    } catch (e) {
-        shouldBe(e instanceof TypeError, true);
-    }
+    }, TypeError);
 }

--- a/JSTests/stress/uint8array-toHex.js
+++ b/JSTests/stress/uint8array-toHex.js
@@ -5,6 +5,16 @@ function shouldBe(actual, expected) {
         throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
 }
 
+function shouldThrow(callback, errorConstructor) {
+    try {
+        callback();
+    } catch (e) {
+        shouldBe(e instanceof errorConstructor, true);
+        return
+    }
+    throw new Error('FAIL: should have thrown');
+}
+
 shouldBe((new Uint8Array([])).toHex(), "");
 shouldBe((new Uint8Array([0])).toHex(), "00");
 shouldBe((new Uint8Array([1])).toHex(), "01");
@@ -34,10 +44,8 @@ shouldBe((new Uint8Array([0, 1, 128, 254, 255])).toHex(), "000180feff");
     shouldBe(buffer.toHex(), expected);
 }
 
-try {
+shouldThrow(() => {
     let uint8array = new Uint8Array;
     $.detachArrayBuffer(uint8array.buffer);
     uint8array.toHex();
-} catch (e) {
-    shouldBe(e instanceof TypeError, true);
-}
+}, TypeError);

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -4725,6 +4725,7 @@
 		918E15BD2447B22600447A56 /* AggregateErrorPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AggregateErrorPrototype.h; sourceTree = "<group>"; };
 		918E15BE2447B22700447A56 /* AggregateErrorPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AggregateErrorPrototype.cpp; sourceTree = "<group>"; };
 		918E15BF2447B22700447A56 /* AggregateErrorConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AggregateErrorConstructor.h; sourceTree = "<group>"; };
+		91C326592BFFB2B3009C7E2B /* JSGenericTypedArrayView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSGenericTypedArrayView.cpp; sourceTree = "<group>"; };
 		91C3265B2BFFB2B9009C7E2B /* JSGenericTypedArrayViewConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSGenericTypedArrayViewConstructor.cpp; sourceTree = "<group>"; };
 		91C3265D2BFFB2BF009C7E2B /* JSGenericTypedArrayViewPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSGenericTypedArrayViewPrototype.cpp; sourceTree = "<group>"; };
 		91D1578C24E0BE35001F4CED /* Breakpoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Breakpoint.cpp; sourceTree = "<group>"; };
@@ -8337,6 +8338,7 @@
 				70B7918C1C024462002481E2 /* JSGeneratorFunction.cpp */,
 				70B7918D1C024462002481E2 /* JSGeneratorFunction.h */,
 				276B39092A71D2B400252F4E /* JSGeneratorFunctionInlines.h */,
+				91C326592BFFB2B3009C7E2B /* JSGenericTypedArrayView.cpp */,
 				0F2B66C317B6B5AB00A7AE3F /* JSGenericTypedArrayView.h */,
 				91C3265B2BFFB2B9009C7E2B /* JSGenericTypedArrayViewConstructor.cpp */,
 				0F2B66C417B6B5AB00A7AE3F /* JSGenericTypedArrayViewConstructor.h */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -917,6 +917,7 @@ runtime/JSFinalizationRegistry.cpp
 runtime/JSFunction.cpp
 runtime/JSGenerator.cpp
 runtime/JSGeneratorFunction.cpp
+runtime/JSGenericTypedArrayView.cpp
 runtime/JSGenericTypedArrayViewConstructor.cpp
 runtime/JSGenericTypedArrayViewPrototype.cpp
 runtime/JSGlobalLexicalEnvironment.cpp

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -184,6 +184,7 @@
     macro(language) \
     macro(languageDisplay) \
     macro(largestUnit) \
+    macro(lastChunkHandling) \
     macro(lastIndex) \
     macro(length) \
     macro(line) \

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2024 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSGenericTypedArrayView.h"
+
+#include <wtf/text/Base64.h>
+
+namespace JSC {
+
+std::optional<std::pair<size_t, Vector<uint8_t>>> fromBase64(StringView string, size_t maxLength, Alphabet alphabet, LastChunkHandling lastChunkHandling)
+{
+    size_t read = 0;
+    size_t length = static_cast<size_t>(string.length());
+
+    Vector<uint8_t> bytes;
+    bytes.reserveInitialCapacity(std::min(length, maxLength));
+
+    if (!maxLength)
+        return { { read, WTFMove(bytes) } };
+
+    UChar chunk[4] = { 0, 0, 0, 0 };
+    size_t chunkLength = 0;
+
+    for (size_t i = 0; i < length;) {
+        UChar c = string[i++];
+
+        if (isASCIIWhitespace(c))
+            continue;
+
+        if (c == '=') {
+            if (chunkLength < 2)
+                return std::nullopt;
+
+            while (i < length && isASCIIWhitespace(string[i]))
+                ++i;
+
+            if (chunkLength == 2) {
+                if (i == length) {
+                    if (lastChunkHandling == LastChunkHandling::StopBeforePartial)
+                        return { { read, WTFMove(bytes) } };
+
+                    return std::nullopt;
+                }
+
+                if (string[i] == '=') {
+                    do {
+                        ++i;
+                    } while (i < length && isASCIIWhitespace(string[i]));
+                }
+            }
+
+            if (i < length)
+                return std::nullopt;
+
+            for (size_t j = chunkLength; j < 4; ++j)
+                chunk[j] = 'A';
+
+            auto decoded = base64Decode(StringView(std::span(chunk, 4)));
+            if (!decoded)
+                return std::nullopt;
+
+            if (chunkLength == 2 || chunkLength == 3) {
+                if (lastChunkHandling == LastChunkHandling::Strict && decoded->at(chunkLength - 1))
+                    return std::nullopt;
+
+                decoded->shrink(chunkLength - 1);
+            }
+
+            bytes.appendVector(WTFMove(*decoded));
+            return { { length, WTFMove(bytes) } };
+        }
+
+        if (alphabet == Alphabet::Base64URL) {
+            if (c == '+' || c == '/')
+                return std::nullopt;
+
+            if (c == '-')
+                c = '+';
+            else if (c == '_')
+                c = '/';
+        }
+
+        if (!StringView("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"_s).contains(c))
+            return std::nullopt;
+
+        auto remaining = maxLength - bytes.size();
+        if ((remaining == 1 && chunkLength == 2) || (remaining == 2 && chunkLength == 3))
+            return { { read, WTFMove(bytes) } };
+
+        chunk[chunkLength++] = c;
+        if (chunkLength != 4)
+            continue;
+
+        auto decoded = base64Decode(StringView(std::span(chunk, chunkLength)));
+        ASSERT(decoded);
+        if (!decoded)
+            return std::nullopt;
+
+        read = i;
+
+        bytes.appendVector(WTFMove(*decoded));
+        if (bytes.size() == maxLength)
+            return { { read, WTFMove(bytes) } };
+
+        for (size_t j = 0; j < 4; ++j)
+            chunk[j] = 0;
+        chunkLength = 0;
+    }
+
+    if (chunkLength) {
+        if (lastChunkHandling == LastChunkHandling::StopBeforePartial)
+            return { { read, WTFMove(bytes) } };
+
+        if (lastChunkHandling == LastChunkHandling::Strict || chunkLength == 1)
+            return std::nullopt;
+
+        for (size_t j = chunkLength; j < 4; ++j)
+            chunk[j] = 'A';
+
+        auto decoded = base64Decode(StringView(std::span(chunk, chunkLength)));
+        ASSERT(decoded);
+        if (!decoded)
+            return std::nullopt;
+
+        if (chunkLength == 2 || chunkLength == 3)
+            decoded->shrink(chunkLength - 1);
+
+        bytes.appendVector(WTFMove(*decoded));
+    }
+
+    return { { length, WTFMove(bytes) } };
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -228,4 +228,8 @@ public:
 template<typename Adaptor> inline RefPtr<typename Adaptor::ViewType> toPossiblySharedNativeTypedView(VM&, JSValue);
 template<typename Adaptor> inline RefPtr<typename Adaptor::ViewType> toUnsharedNativeTypedView(VM&, JSValue);
 
+enum class Alphabet : uint8_t { Base64, Base64URL };
+enum class LastChunkHandling : uint8_t { Loose, Strict, StopBeforePartial };
+std::optional<std::pair<size_t, Vector<uint8_t>>> fromBase64(StringView, size_t, Alphabet, LastChunkHandling);
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h
@@ -141,6 +141,7 @@ private:
     void finishCreation(VM&, JSGlobalObject*, JSObject* prototype, const String& name);
 };
 
+JSC_DECLARE_HOST_FUNCTION(uint8ArrayConstructorFromBase64);
 JSC_DECLARE_HOST_FUNCTION(uint8ArrayConstructorFromHex);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -54,8 +54,10 @@ void JSGenericTypedArrayViewConstructor<ViewClass>::finishCreation(VM& vm, JSGlo
     putDirectWithoutTransition(vm, vm.propertyNames->BYTES_PER_ELEMENT, jsNumber(ViewClass::elementSize), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly | PropertyAttribute::DontDelete);
 
     if constexpr (std::is_same_v<ViewClass, JSUint8Array>) {
-        if (Options::useUint8ArrayBase64Methods())
+        if (Options::useUint8ArrayBase64Methods()) {
+            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("fromBase64"_s, uint8ArrayConstructorFromBase64, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
             JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("fromHex"_s, uint8ArrayConstructorFromHex, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+        }
     }
 }
 

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.h
@@ -56,6 +56,7 @@ private:
     void finishCreation(VM&, JSGlobalObject*);
 };
 
+JSC_DECLARE_HOST_FUNCTION(uint8ArrayPrototypeSetFromBase64);
 JSC_DECLARE_HOST_FUNCTION(uint8ArrayPrototypeSetFromHex);
 JSC_DECLARE_HOST_FUNCTION(uint8ArrayPrototypeToBase64);
 JSC_DECLARE_HOST_FUNCTION(uint8ArrayPrototypeToHex);

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h
@@ -49,6 +49,7 @@ void JSGenericTypedArrayViewPrototype<ViewClass>::finishCreation(
 
     if constexpr (std::is_same_v<ViewClass, JSUint8Array>) {
         if (Options::useUint8ArrayBase64Methods()) {
+            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("setFromBase64"_s, uint8ArrayPrototypeSetFromBase64, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
             JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("setFromHex"_s, uint8ArrayPrototypeSetFromHex, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
             JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toBase64"_s, uint8ArrayPrototypeToBase64, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
             JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toHex"_s, uint8ArrayPrototypeToHex, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);


### PR DESCRIPTION
#### ca33dbdecfc7d6e7eeb2df1b64587cc06b90346e
<pre>
[JSC] add support for `Uint8Array.fromBase64` and `Uint8Array.prototype.setFromBase64`
<a href="https://bugs.webkit.org/show_bug.cgi?id=276215">https://bugs.webkit.org/show_bug.cgi?id=276215</a>

Reviewed by Yusuke Suzuki.

These methods will make it easier for developers to decode typed character/byte data.

Note that there are other methods in the related proposal, but for ease of reviewing they will be implemented separately.

Spec: &lt;<a href="https://tc39.es/proposal-arraybuffer-base64/spec/">https://tc39.es/proposal-arraybuffer-base64/spec/</a>&gt;
Proposal: &lt;<a href="https://github.com/tc39/proposal-arraybuffer-base64">https://github.com/tc39/proposal-arraybuffer-base64</a>&gt;

* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:
(JSC::JSGenericTypedArrayViewConstructor&lt;ViewClass&gt;::finishCreation):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp:
(JSC::uint8ArrayConstructorFromBase64): Added.

* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h:
(JSC::JSGenericTypedArrayViewPrototype&lt;ViewClass&gt;::finishCreation):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp:
(JSC::uint8ArrayPrototypeSetFromBase64): Added.

* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.cpp: Added.
(JSC::fromBase64):
Create shared utility file for special base64 parsing logic.

* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
Create builtin identifier for `lastChunkHandling`.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:

* JSTests/stress/uint8array-fromBase64.js: Added.
* JSTests/stress/uint8array-setFromBase64.js: Added.

* JSTests/stress/uint8array-fromHex.js:
* JSTests/stress/uint8array-setFromHex.js:
* JSTests/stress/uint8array-toBase64.js:
* JSTests/stress/uint8array-toHex.js:

Drive-by: fix a few invalid tests and check that things that should throw actually do.
Canonical link: <a href="https://commits.webkit.org/281014@main">https://commits.webkit.org/281014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aba268eb999e08cb0e33d61e49e7bed977038ef1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61938 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8758 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47246 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6256 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28087 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7722 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7762 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51405 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63643 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57556 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54563 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54628 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1904 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79316 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8703 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33470 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13190 "Found 11 new JSC stress test failures: stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.dfg-eager, stress/proxy-set.js.dfg-eager-no-cjit-validate, stress/proxy-set.js.eager-jettison-no-cjit, stress/proxy-set.js.mini-mode, stress/proxy-set.js.no-cjit-collect-continuously, stress/proxy-set.js.no-cjit-validate-phases ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34556 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34301 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->