### PR TITLE
Saved web page uses utf8 encoding but declared as non-utf8

### DIFF
--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -40,6 +40,7 @@
 #include "FrameLoader.h"
 #include "HTMLElement.h"
 #include "HTMLFrameElement.h"
+#include "HTMLHeadElement.h"
 #include "HTMLIFrameElement.h"
 #include "HTMLLinkElement.h"
 #include "HTMLNames.h"
@@ -387,9 +388,16 @@ const ShadowRoot* MarkupAccumulator::suitableShadowRoot(const Node& node)
 
 void MarkupAccumulator::startAppendingNode(const Node& node, Namespaces* namespaces)
 {
-    if (RefPtr element = dynamicDowncast<Element>(node))
+    if (RefPtr element = dynamicDowncast<Element>(node)) {
         appendStartTag(m_markup, *element, namespaces);
-    else if (auto* shadowRoot = suitableShadowRoot(node)) {
+
+        // Currently URL Replacement only happens when saving markup to disk and the file uses UTF-8 encoding.
+        // To ensure the file can be loaded correctly, change the specified encoding to UTF-8.
+        // FIXME: This can be dropped when file encoding matches declared encoding.
+        if (m_urlReplacementData && is<HTMLHeadElement>(element))
+            m_markup.append("<meta charset=\"UTF-8\"><!-- Encoding specified by WebKit -->"_s);
+
+    } else if (auto* shadowRoot = suitableShadowRoot(node)) {
         m_markup.append("<template shadowrootmode=\""_s);
         switch (shadowRoot->mode()) {
         case ShadowRootMode::Open:


### PR DESCRIPTION
#### 0040347ec43184bf8e4c452b1ee3b9c03d167301
<pre>
Saved web page uses utf8 encoding but declared as non-utf8
<a href="https://bugs.webkit.org/show_bug.cgi?id=276615">https://bugs.webkit.org/show_bug.cgi?id=276615</a>
<a href="https://rdar.apple.com/131759536">rdar://131759536</a>

Reviewed by Ryosuke Niwa.

When serializing DOM for saving to disk, the meta charset attribute that is used to declare encoding will be preserved,
but the file encoding is actually UTF-8. When loading the saved file in browser, the browser will use the declared
encoding but not the file encoding, so there could be decoding error. As a workaround, adding a new meta tag in the head
element to override the declared enocding.

API Test: WebArchive.SaveResourcesWithUTF8Encoding

* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::startAppendingNode):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:
(TestWebKitAPI::(WebArchive, SaveResourcesBasic)):
(TestWebKitAPI::(WebArchive, SaveResourcesWithUTF8Encoding)):

Canonical link: <a href="https://commits.webkit.org/280993@main">https://commits.webkit.org/280993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7835a78f16c4a008410d5443f2d6ae468a07ec9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58246 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61871 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8691 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47199 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6213 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28035 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7657 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7695 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53942 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63576 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54517 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54579 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12882 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1850 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33403 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34489 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35573 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->