### PR TITLE
Add a way for WKWebView clients to simulate a click over visible text in the page

### DIFF
--- a/Source/WebCore/dom/BoundaryPoint.cpp
+++ b/Source/WebCore/dom/BoundaryPoint.cpp
@@ -32,7 +32,6 @@ namespace WebCore {
 
 template std::partial_ordering treeOrder<Tree>(const BoundaryPoint&, const BoundaryPoint&);
 template std::partial_ordering treeOrder<ShadowIncludingTree>(const BoundaryPoint&, const BoundaryPoint&);
-template std::partial_ordering treeOrder<ComposedTree>(const BoundaryPoint&, const BoundaryPoint&);
 
 std::optional<BoundaryPoint> makeBoundaryPointBeforeNode(Node& node)
 {
@@ -65,7 +64,7 @@ static bool isOffsetBeforeChild(ContainerNode& container, unsigned offset, Node&
     return false;
 }
 
-template<TreeType treeType> std::partial_ordering treeOrder(const BoundaryPoint& a, const BoundaryPoint& b)
+template<TreeType treeType> std::partial_ordering treeOrderInternal(const BoundaryPoint& a, const BoundaryPoint& b)
 {
     if (a.container.ptr() == b.container.ptr())
         return a.offset <=> b.offset;
@@ -85,6 +84,16 @@ template<TreeType treeType> std::partial_ordering treeOrder(const BoundaryPoint&
     }
 
     return treeOrder<treeType>(a.container, b.container);
+}
+
+template<TreeType treeType> std::partial_ordering treeOrder(const BoundaryPoint& a, const BoundaryPoint& b)
+{
+    return treeOrderInternal<treeType>(a, b);
+}
+
+template<> std::partial_ordering treeOrder<ComposedTree>(const BoundaryPoint& a, const BoundaryPoint& b)
+{
+    return treeOrderInternal<ComposedTree>(a, b);
 }
 
 std::partial_ordering treeOrderForTesting(TreeType type, const BoundaryPoint& a, const BoundaryPoint& b)

--- a/Source/WebCore/dom/BoundaryPoint.h
+++ b/Source/WebCore/dom/BoundaryPoint.h
@@ -44,6 +44,7 @@ bool operator==(const BoundaryPoint&, const BoundaryPoint&);
 WTF::TextStream& operator<<(WTF::TextStream&, const BoundaryPoint&);
 
 template<TreeType = Tree> std::partial_ordering treeOrder(const BoundaryPoint&, const BoundaryPoint&);
+template<> WEBCORE_EXPORT std::partial_ordering treeOrder<ComposedTree>(const BoundaryPoint&, const BoundaryPoint&);
 
 WEBCORE_EXPORT std::optional<BoundaryPoint> makeBoundaryPointBeforeNode(Node&);
 WEBCORE_EXPORT std::optional<BoundaryPoint> makeBoundaryPointAfterNode(Node&);

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -302,7 +302,7 @@ public:
     inline ContainerNode* parentOrShadowHostNode() const; // Defined in ShadowRoot.h
     inline RefPtr<ContainerNode> protectedParentOrShadowHostNode() const; // Defined in ShadowRoot.h
     ContainerNode* parentInComposedTree() const;
-    Element* parentElementInComposedTree() const;
+    WEBCORE_EXPORT Element* parentElementInComposedTree() const;
     Element* parentOrShadowHostElement() const;
     inline void setParentNode(ContainerNode*); // Defined in ContainerNode.h.
     Node& rootNode() const;
@@ -509,7 +509,7 @@ public:
     void clearNodeLists();
 
     virtual bool willRespondToMouseMoveEvents() const;
-    bool willRespondToMouseClickEvents(const RenderStyle* = nullptr) const;
+    WEBCORE_EXPORT bool willRespondToMouseClickEvents(const RenderStyle* = nullptr) const;
     Editability computeEditabilityForMouseClickEvents(const RenderStyle* = nullptr) const;
     virtual bool willRespondToMouseClickEventsWithEditability(Editability) const;
     virtual bool willRespondToTouchEvents() const;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -4687,6 +4687,19 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
     });
 }
 
+- (void)_simulateClickOverFirstMatchingTextInViewportWithUserInteraction:(NSString *)targetText completionHandler:(void(^)(BOOL))completionHandler
+{
+    if (!targetText.length)
+        [NSException raise:NSInvalidArgumentException format:@"The target text must be non-empty."];
+
+    if (!self._isValid)
+        return completionHandler(NO);
+
+    _page->simulateClickOverFirstMatchingTextInViewportWithUserInteraction(targetText, [completionHandler = makeBlockPtr(completionHandler)](bool success) {
+        completionHandler(static_cast<BOOL>(success));
+    });
+}
+
 @end
 
 @implementation WKWebView (WKDeprecated)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -569,6 +569,8 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 - (void)_playPredominantOrNowPlayingMediaSession:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 - (void)_pauseNowPlayingMediaSession:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+- (void)_simulateClickOverFirstMatchingTextInViewportWithUserInteraction:(NSString *)targetText completionHandler:(void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @end
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -14324,6 +14324,11 @@ void WebPageProxy::nowPlayingMetadataChanged(const WebCore::NowPlayingMetadata& 
     });
 }
 
+void WebPageProxy::simulateClickOverFirstMatchingTextInViewportWithUserInteraction(String&& targetText, CompletionHandler<void(bool)>&& completion)
+{
+    sendWithAsyncReply(Messages::WebPage::SimulateClickOverFirstMatchingTextInViewportWithUserInteraction(WTFMove(targetText)), WTFMove(completion));
+}
+
 void WebPageProxy::didAdjustVisibilityWithSelectors(Vector<String>&& selectors)
 {
     m_uiClient->didAdjustVisibilityWithSelectors(*this, WTFMove(selectors));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2488,6 +2488,8 @@ public:
 
     void closeCurrentTypingCommand();
 
+    void simulateClickOverFirstMatchingTextInViewportWithUserInteraction(String&& targetText, CompletionHandler<void(bool)>&&);
+
 private:
     void getWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -541,6 +541,8 @@ public:
     void startPlayingPredominantVideo(CompletionHandler<void(bool)>&&);
 #endif
 
+    void simulateClickOverFirstMatchingTextInViewportWithUserInteraction(const String& targetText, CompletionHandler<void(bool)>&&);
+
 #if PLATFORM(IOS_FAMILY)
     void setAllowsMediaDocumentInlinePlayback(bool);
     bool allowsMediaDocumentInlinePlayback() const { return m_allowsMediaDocumentInlinePlayback; }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -817,4 +817,6 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #endif
 
     CloseCurrentTypingCommand()
+
+    SimulateClickOverFirstMatchingTextInViewportWithUserInteraction(String targetText) -> (bool success)
 }

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -241,6 +241,7 @@ Tests/WebKitCocoa/SessionStorage.mm
 Tests/WebKitCocoa/ShouldGoToBackForwardListItem.mm
 Tests/WebKitCocoa/ShouldOpenExternalURLsInNewWindowActions.mm
 Tests/WebKitCocoa/ShrinkToFit.mm
+Tests/WebKitCocoa/SimulateClickOverText.mm
 Tests/WebKitCocoa/SiteIsolation.mm
 Tests/WebKitCocoa/SnapshotStore.mm
 Tests/WebKitCocoa/SpeechRecognition.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1263,6 +1263,7 @@
 		F4BDA43027F8D19C00F9647D /* element-fullscreen.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4BDA42F27F8CF5600F9647D /* element-fullscreen.html */; };
 		F4BFA68E1E4AD08000154298 /* LegacyDragAndDropTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4BFA68C1E4AD08000154298 /* LegacyDragAndDropTests.mm */; };
 		F4C2AB221DD6D95E00E06D5B /* enormous-video-with-sound.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4C2AB211DD6D94100E06D5B /* enormous-video-with-sound.html */; };
+		F4C3F2AB2C4488730029A47D /* click-targets.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4C3F2A32C44832B0029A47D /* click-targets.html */; };
 		F4C8797F2059D8D3009CD00B /* ScrollViewInsetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4C8797E2059D8D3009CD00B /* ScrollViewInsetTests.mm */; };
 		F4CB8A7D2856462B0017ECD3 /* TestPDFHostViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4CB8A7C285644FB0017ECD3 /* TestPDFHostViewController.mm */; };
 		F4CC8F4D2C0A759D00D7E76E /* element-targeting-9.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4CC8F452C0A74BA00D7E76E /* element-targeting-9.html */; };
@@ -1580,6 +1581,7 @@
 				2EFF06C51D8867760004BB30 /* change-video-source-on-click.html in Copy Resources */,
 				2EFF06C71D886A580004BB30 /* change-video-source-on-end.html in Copy Resources */,
 				9BD4239C1E04C01C00200395 /* chinese-character-with-image.html in Copy Resources */,
+				F4C3F2AB2C4488730029A47D /* click-targets.html in Copy Resources */,
 				839AA35F21A26B0300980DD6 /* client-side-redirect.html in Copy Resources */,
 				F422A3EB235BB16200CF00CA /* clipboard.html in Copy Resources */,
 				1A50AA201A2A51FC00F4C345 /* close-from-within-create-page.html in Copy Resources */,
@@ -3683,6 +3685,8 @@
 		F4C192CD2B027C93001F75CE /* TestResourceLoadDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TestResourceLoadDelegate.h; path = cocoa/TestResourceLoadDelegate.h; sourceTree = "<group>"; };
 		F4C192CE2B027C93001F75CE /* TestResourceLoadDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = TestResourceLoadDelegate.mm; path = cocoa/TestResourceLoadDelegate.mm; sourceTree = "<group>"; };
 		F4C2AB211DD6D94100E06D5B /* enormous-video-with-sound.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "enormous-video-with-sound.html"; sourceTree = "<group>"; };
+		F4C3F29A2C447EB50029A47D /* SimulateClickOverText.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SimulateClickOverText.mm; sourceTree = "<group>"; };
+		F4C3F2A32C44832B0029A47D /* click-targets.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "click-targets.html"; sourceTree = "<group>"; };
 		F4C8797E2059D8D3009CD00B /* ScrollViewInsetTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollViewInsetTests.mm; sourceTree = "<group>"; };
 		F4CB8A7B2856447F0017ECD3 /* TestPDFHostViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestPDFHostViewController.h; sourceTree = "<group>"; };
 		F4CB8A7C285644FB0017ECD3 /* TestPDFHostViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TestPDFHostViewController.mm; sourceTree = "<group>"; };
@@ -4291,6 +4295,7 @@
 				5CCB10DF2134579D00AC5AF0 /* ShouldGoToBackForwardListItem.mm */,
 				37BCA61B1B596BA9002012CA /* ShouldOpenExternalURLsInNewWindowActions.mm */,
 				2D9A53AE1B31FA8D0074D5AA /* ShrinkToFit.mm */,
+				F4C3F29A2C447EB50029A47D /* SimulateClickOverText.mm */,
 				5C29FE9128EE5F3D00D4FB00 /* SiteIsolation.mm */,
 				5C24A002294A75DD00463E2B /* SkipDecidePolicyForResponsePlugIn.mm */,
 				2DFF7B6C1DA487AF00814614 /* SnapshotStore.mm */,
@@ -4851,6 +4856,7 @@
 				F4E7A66227222BB100E74D36 /* canvas-image-data.html */,
 				2EFF06C41D8867700004BB30 /* change-video-source-on-click.html */,
 				2EFF06C61D886A560004BB30 /* change-video-source-on-end.html */,
+				F4C3F2A32C44832B0029A47D /* click-targets.html */,
 				839AA35E21A26ACD00980DD6 /* client-side-redirect.html */,
 				F422A3EA235BB14500CF00CA /* clipboard.html */,
 				9B9332CD2320C73E002D50E8 /* cocoa-writer-markup-with-lists.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SimulateClickOverText.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SimulateClickOverText.mm
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <wtf/RetainPtr.h>
+
+@interface WKWebView (SimulateClickOverText)
+- (BOOL)simulateClickOverText:(NSString *)text;
+@end
+
+@implementation WKWebView (SimulateClickOverText)
+
+- (BOOL)simulateClickOverText:(NSString *)text
+{
+    __block bool done = false;
+    __block BOOL result = NO;
+    [self _simulateClickOverFirstMatchingTextInViewportWithUserInteraction:text completionHandler:^(BOOL success) {
+        result = success;
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    return result;
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+TEST(SimulateClickOverText, ClickTargets)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    [webView synchronouslyLoadTestPageNamed:@"click-targets"];
+
+    [webView simulateClickOverText:@"Bugzilla"];
+    [webView simulateClickOverText:@"Sign up"];
+    [webView simulateClickOverText:@"First name"];
+
+    RetainPtr expectedEvents = @[ @"mousedown", @"mouseup", @"click" ];
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('a.top').events"]]);
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('button.top').events"]]);
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('input.top').events"]]);
+    EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('a.bottom').events"]);
+    EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('button.bottom').events"]);
+    EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('input.bottom').events"]);
+}
+
+TEST(SimulateClickOverText, ClickTargetsAfterScrolling)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    [webView synchronouslyLoadTestPageNamed:@"click-targets"];
+    [webView stringByEvaluatingJavaScript:@"scrollBy(0, 5000)"];
+    [webView waitForNextPresentationUpdate];
+
+    [webView simulateClickOverText:@"Bugzilla"];
+    [webView simulateClickOverText:@"Sign up"];
+    [webView simulateClickOverText:@"First name"];
+
+    RetainPtr expectedEvents = @[ @"mousedown", @"mouseup", @"click" ];
+    EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('a.top').events"]);
+    EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('button.top').events"]);
+    EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('input.top').events"]);
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('a.bottom').events"]]);
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('button.bottom').events"]]);
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('input.bottom').events"]]);
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/click-targets.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/click-targets.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<style>
+body {
+    font-family: system-ui;
+    font-size: 16px;
+}
+
+.button {
+    color: white;
+    padding: 0.5em;
+    font-size: 16px;
+    border-radius: 4px;
+    border: none;
+}
+
+.green {
+    background: green;
+}
+
+div.container {
+    margin: 1em 0;
+}
+
+div.tall {
+    height: 5000px;
+}
+</style>
+<script>
+addEventListener("load", () => {
+    for (const element of [...document.querySelectorAll("a, button, input")]) {
+        for (const type of ["mousedown", "mouseup", "click"]) {
+            element.addEventListener(type, event => {
+                const target = event.target;
+                if (target.events)
+                    target.events.push(event.type);
+                else
+                    target.events = [event.type];
+                event.preventDefault();
+            });
+        }
+    }
+});
+</script>
+</head>
+<body>
+    <div class="container"><a class="top" href="https://bugs.webkit.org">Bugzilla</a></div>
+    <div class="container"><button class="top green button">Sign Up</button></div>
+    <div class="container"><input class="top" type="text" placeholder="First name"></div>
+    <div class="tall"></div>
+    <div class="container"><a class="bottom" href="https://bugs.webkit.org">Bugzilla</a></div>
+    <div class="container"><button class="bottom green button">Sign Up</button></div>
+    <div class="container"><input class="bottom" type="text" placeholder="First name"></div>
+    <div class="tall"></div>
+</body>
+</html>


### PR DESCRIPTION
#### e004985d096c19792336fb1ef1fd9f0ce825e02a
<pre>
Add a way for WKWebView clients to simulate a click over visible text in the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=276613">https://bugs.webkit.org/show_bug.cgi?id=276613</a>
<a href="https://rdar.apple.com/131758473">rdar://131758473</a>

Reviewed by Ryosuke Niwa.

Add a way to simulate mouse events over clickable elements on the webpage, based on matches of found
text. See below for more details.

Tests:  SimulateClickOverText.ClickTargets
        SimulateClickOverText.ClickTargetsAfterScrolling

* Source/WebCore/dom/BoundaryPoint.cpp:
(WebCore::treeOrderInternal):
(WebCore::treeOrder):

Export only `treeOrder&lt;ComposedTree&gt;(const BoundaryPoint&amp;, const BoundaryPoint&amp;)`.

(WebCore::treeOrder&lt;ComposedTree&gt;):
* Source/WebCore/dom/BoundaryPoint.h:
* Source/WebCore/dom/Node.h:

Add `WEBCORE_EXPORT`s to several methods and helper functions.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _pauseNowPlayingMediaSession:]):
(-[WKWebView _simulateClickOverFirstMatchingTextInViewportWithUserInteraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::simulateClickOverFirstMatchingTextInViewportWithUserInteraction):

Add plumbing from `WKWebView` -&gt; `WebPageProxy` -&gt; `WebPage`.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::simulateClickOverFirstMatchingTextInViewportWithUserInteraction):

Implement the main heuristic here. At a high level, this is how it works:

1.  Use `findPlainText` to search for the target text in the main document.
2.  Filter out any matches that aren&apos;t within links, or otherwise clickable containers by walking up
    the composed tree.
3.  Compute the first text rect (in content coordinates) for each matching range; filter out any
    matches that are outside of the visual viewport.
4.  Perform one final hit-test to filter out potential targets that are obscured.
5.  If there are 2 or more candidates after the above filtering, exit early and don&apos;t attempt to
    click anything (we may need a more sophisticated strategy to deal with ambiguous targets in the
    future).
6.  Otherwise, if there is exactly one match, create and send synthetic click events.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SimulateClickOverText.mm: Added.
(-[WKWebView simulateClickOverText:]):
(TestWebKitAPI::TEST(SimulateClickOverText, ClickTargets)):
(TestWebKitAPI::TEST(SimulateClickOverText, ClickTargetsAfterScrolling)):

Add a couple of API tests to exercise the new functionality by verifying that mouse and click events
are dispatched on several types of visible (and clickable) DOM elements when simulating clicks based
on found text.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/click-targets.html: Added.

Canonical link: <a href="https://commits.webkit.org/280991@main">https://commits.webkit.org/280991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9aa5f93f8b6705277914b2778291bda2851a6c83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61862 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8876 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6209 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28031 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7651 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7686 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63567 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7981 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54513 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54572 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/12878 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1843 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8692 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33394 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34480 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->