### PR TITLE
errorValidatingDynamicOffsets can be bypassed in setBindGroup

### DIFF
--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -433,6 +433,8 @@ void ComputePassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& grou
 
     if (dynamicOffsetCount)
         m_bindGroupDynamicOffsets.set(groupIndex, Vector<uint32_t>(std::span { dynamicOffsets, dynamicOffsetCount }));
+    else
+        m_bindGroupDynamicOffsets.remove(groupIndex);
 
     Vector<const BindableResources*> resourceList;
     for (const auto& resource : group.resources()) {

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -1062,6 +1062,8 @@ void RenderPassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& group
     m_maxBindGroupSlot = std::max(groupIndex, m_maxBindGroupSlot);
     if (dynamicOffsetCount)
         m_bindGroupDynamicOffsets.set(groupIndex, Vector<uint32_t>(std::span { dynamicOffsets, dynamicOffsetCount }));
+    else
+        m_bindGroupDynamicOffsets.remove(groupIndex);
 
     for (const auto& resource : group.resources()) {
         if ((resource.renderStages & (MTLRenderStageVertex | MTLRenderStageFragment)) && resource.mtlResources.size())


### PR DESCRIPTION
#### 6eef85d192a8f02fa74fc620854c83dd0fff6fed
<pre>
errorValidatingDynamicOffsets can be bypassed in setBindGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=276617">https://bugs.webkit.org/show_bug.cgi?id=276617</a>
&lt;radar://131764000&gt;

Reviewed by Tadeu Zagallo.

We should call remove on the dynamic offsets when one
does not exist, otherwise the behavior of a draw call may
not be what is expected. We may honor the draw call, when
it should have been rejected by validation.

* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::setBindGroup):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setBindGroup):

Canonical link: <a href="https://commits.webkit.org/281055@main">https://commits.webkit.org/281055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5840a1da636da73f9c47a7e09b7d668ab693e9a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61848 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8668 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47184 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6197 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28018 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31967 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7672 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63553 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54502 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54558 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12928 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1832 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33380 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34466 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34211 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->