### PR TITLE
Crash in WebViewRenderingUpdateScheduler::postRenderingUpdateCallback

### DIFF
--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h
@@ -24,12 +24,15 @@
  */
 
 #import <WebCore/RunLoopObserver.h>
+#import <wtf/CheckedPtr.h>
 #import <wtf/FastMalloc.h>
+#import <wtf/WeakPtr.h>
 
 @class WebView;
 
-class WebViewRenderingUpdateScheduler {
+class WebViewRenderingUpdateScheduler : public CanMakeWeakPtr<WebViewRenderingUpdateScheduler>, public CanMakeCheckedPtr<WebViewRenderingUpdateScheduler> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebViewRenderingUpdateScheduler);
 public:
     explicit WebViewRenderingUpdateScheduler(WebView*);
     ~WebViewRenderingUpdateScheduler();

--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
@@ -38,14 +38,29 @@
 WebViewRenderingUpdateScheduler::WebViewRenderingUpdateScheduler(WebView* webView)
     : m_webView(webView)
 {
+    ASSERT(isMainThread());
     ASSERT_ARG(webView, webView);
 
-    m_renderingUpdateRunLoopObserver = makeUnique<WebCore::RunLoopObserver>(WebCore::RunLoopObserver::WellKnownOrder::RenderingUpdate, [this] {
-        this->renderingUpdateRunLoopObserverCallback();
+    m_renderingUpdateRunLoopObserver = makeUnique<WebCore::RunLoopObserver>(WebCore::RunLoopObserver::WellKnownOrder::RenderingUpdate, [weakThis = WeakPtr { this }] {
+#if PLATFORM(IOS_FAMILY)
+        // Normally the layer flush callback happens before the web lock auto-unlock observer runs.
+        // However if the flush is rescheduled from the callback it may get pushed past it, to the next cycle.
+        WebThreadLock();
+#endif
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
+            return;
+        checkedThis->renderingUpdateRunLoopObserverCallback();
     });
 
-    m_postRenderingUpdateRunLoopObserver = makeUnique<WebCore::RunLoopObserver>(WebCore::RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [this] {
-        this->postRenderingUpdateCallback();
+    m_postRenderingUpdateRunLoopObserver = makeUnique<WebCore::RunLoopObserver>(WebCore::RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [weakThis = WeakPtr { this }] {
+#if PLATFORM(IOS_FAMILY)
+        WebThreadLock();
+#endif
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
+            return;
+        checkedThis->postRenderingUpdateCallback();
     });
 }
 
@@ -61,6 +76,7 @@ void WebViewRenderingUpdateScheduler::scheduleRenderingUpdate()
 
 void WebViewRenderingUpdateScheduler::invalidate()
 {
+    ASSERT(isMainThread());
     m_webView = nullptr;
     m_renderingUpdateRunLoopObserver->invalidate();
     m_postRenderingUpdateRunLoopObserver->invalidate();
@@ -96,12 +112,6 @@ void WebViewRenderingUpdateScheduler::registerCACommitHandlers()
 
 void WebViewRenderingUpdateScheduler::renderingUpdateRunLoopObserverCallback()
 {
-#if PLATFORM(IOS_FAMILY)
-    // Normally the layer flush callback happens before the web lock auto-unlock observer runs.
-    // However if the flush is rescheduled from the callback it may get pushed past it, to the next cycle.
-    WebThreadLock();
-#endif
-
     SetForScope insideCallbackScope(m_insideCallback, true);
     m_rescheduledInsideCallback = false;
 
@@ -114,10 +124,6 @@ void WebViewRenderingUpdateScheduler::renderingUpdateRunLoopObserverCallback()
 
 void WebViewRenderingUpdateScheduler::postRenderingUpdateCallback()
 {
-#if PLATFORM(IOS_FAMILY)
-    WebThreadLock();
-#endif
-
     @autoreleasepool {
         [m_webView _didCompleteRenderingFrame];
         m_postRenderingUpdateRunLoopObserver->invalidate();


### PR DESCRIPTION
#### 03200a8c08079e188c3de7a97109a51202cc6c64
<pre>
Crash in WebViewRenderingUpdateScheduler::postRenderingUpdateCallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=276620">https://bugs.webkit.org/show_bug.cgi?id=276620</a>

Reviewed by Chris Dumez and Wenson Hsieh.

Speculative fix. Use WeakPtr and CheckedPtr to better life-time manage WebViewRenderingUpdateScheduler,
and grab the web thread lock before converting WeakPtr to CheckedPtr.

* Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.h:
* Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm:
(WebViewRenderingUpdateScheduler::WebViewRenderingUpdateScheduler):
(WebViewRenderingUpdateScheduler::invalidate):
(WebViewRenderingUpdateScheduler::renderingUpdateRunLoopObserverCallback):
(WebViewRenderingUpdateScheduler::postRenderingUpdateCallback):

Canonical link: <a href="https://commits.webkit.org/280989@main">https://commits.webkit.org/280989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c1b79ec641db2ca6c423cf57c2e3d06a285f108

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61870 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8690 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8884 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47198 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6212 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28034 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31983 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/7655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7694 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7924 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63575 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2159 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7985 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54516 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54577 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1846 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8690 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33402 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34488 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->