### PR TITLE
[iOS] Fullscreen captions are cut off when video is "zoomed"

### DIFF
--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
@@ -46,6 +46,7 @@ WEBCORE_EXPORT @interface WebAVPlayerLayer : CALayer
 @property (nonatomic, assign, nullable) WebCore::VideoPresentationModel* presentationModel;
 @property (nonatomic, retain, nonnull) AVPlayerController *playerController;
 @property (nonatomic, retain, nonnull) CALayer *videoSublayer;
+@property (nonatomic, retain, nullable) CALayer *captionsLayer;
 @property (nonatomic, copy, nullable) NSDictionary *pixelBufferAttributes;
 @property CGSize videoDimensions;
 @property (nonatomic) NSEdgeInsets legibleContentInsets;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
@@ -63,6 +63,9 @@ public:
     void presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) final;
     void dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) final;
 
+    // VideoFullscreenCaptions:
+    WEBCORE_EXPORT void setupCaptionsLayer(CALayer *parent, const WebCore::FloatSize&) final;
+
 private:
     WEBCORE_EXPORT VideoPresentationInterfaceAVKit(PlaybackSessionInterfaceIOS&);
 

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm
@@ -794,6 +794,7 @@ void VideoPresentationInterfaceAVKit::setupFullscreen(UIView& videoView, const F
 {
     [playerController() setContentDimensions:videoDimensions];
     VideoPresentationInterfaceIOS::setupFullscreen(videoView, initialRect, videoDimensions, parentView, mode, allowsPictureInPicturePlayback, standby, blocksReturnToFullscreenFromPictureInPicture);
+    playerLayer().captionsLayer = captionsLayer();
 }
 
 void VideoPresentationInterfaceAVKit::updateRouteSharingPolicy()
@@ -918,6 +919,16 @@ bool supportsPictureInPicture()
 #else
     return false;
 #endif
+}
+
+void VideoPresentationInterfaceAVKit::setupCaptionsLayer(CALayer *, const WebCore::FloatSize&)
+{
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    [captionsLayer() removeFromSuperlayer];
+    playerLayer().captionsLayer = captionsLayer();
+    [playerLayer() layoutSublayers];
+    [CATransaction commit];
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -51,6 +51,7 @@ OBJC_CLASS UIView;
 OBJC_CLASS CALayer;
 OBJC_CLASS NSError;
 OBJC_CLASS WebAVPlayerController;
+OBJC_CLASS WebAVPlayerLayer;
 OBJC_CLASS WebAVPlayerLayerView;
 
 namespace WebCore {
@@ -86,6 +87,7 @@ public:
     WEBCORE_EXPORT virtual AVPlayerViewController *avPlayerViewController() const = 0;
     WebAVPlayerController *playerController() const;
     WebAVPlayerLayerView *playerLayerView() const { return m_playerLayerView.get(); }
+    WebAVPlayerLayer *playerLayer() const;
     WEBCORE_EXPORT void enterFullscreen();
     WEBCORE_EXPORT virtual bool exitFullscreen(const FloatRect& finalRect);
     WEBCORE_EXPORT void exitFullscreenWithoutAnimationToMode(HTMLMediaElementEnums::VideoFullscreenMode);

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -245,9 +245,7 @@ void VideoPresentationInterfaceIOS::doSetup()
         }
     }
 
-    WebAVPlayerLayer *playerLayer = (WebAVPlayerLayer *)[m_playerLayerView playerLayer];
-
-    playerLayer.presentationModel = videoPresentationModel().get();
+    playerLayer().presentationModel = videoPresentationModel().get();
 
     setupPlayerViewController();
 
@@ -282,15 +280,14 @@ void VideoPresentationInterfaceIOS::videoDimensionsChanged(const FloatSize& vide
     if (videoDimensions.isZero())
         return;
 
-    WebAVPlayerLayer *playerLayer = (WebAVPlayerLayer *)[m_playerLayerView playerLayer];
-    [playerLayer setVideoDimensions:videoDimensions];
+    playerLayer().videoDimensions = videoDimensions;
     setContentDimensions(videoDimensions);
     [m_playerLayerView setNeedsLayout];
 
 #if HAVE(PICTUREINPICTUREPLAYERLAYERVIEW)
     WebAVPictureInPicturePlayerLayerView *pipView = (WebAVPictureInPicturePlayerLayerView *)[m_playerLayerView pictureInPicturePlayerLayerView];
     WebAVPlayerLayer *pipPlayerLayer = (WebAVPlayerLayer *)[pipView layer];
-    [pipPlayerLayer setVideoDimensions:playerLayer.videoDimensions];
+    [pipPlayerLayer setVideoDimensions:playerLayer().videoDimensions];
     [pipView setNeedsLayout];
 #endif
 }
@@ -324,6 +321,11 @@ void VideoPresentationInterfaceIOS::setInlineRect(const FloatRect& inlineRect, b
 WebAVPlayerController *VideoPresentationInterfaceIOS::playerController() const
 {
     return m_playbackSessionInterface->playerController();
+}
+
+WebAVPlayerLayer *VideoPresentationInterfaceIOS::playerLayer() const
+{
+    return (WebAVPlayerLayer *)[m_playerLayerView playerLayer];
 }
 
 void VideoPresentationInterfaceIOS::applicationDidBecomeActive()


### PR DESCRIPTION
#### 809d9cfc50337a7ca0ca631e88157ca23ce4bbb6
<pre>
[iOS] Fullscreen captions are cut off when video is &quot;zoomed&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=276621">https://bugs.webkit.org/show_bug.cgi?id=276621</a>
<a href="https://rdar.apple.com/130994690">rdar://130994690</a>

Reviewed by Andy Estes.

Promote &quot;captionLayer&quot; to be a first-class child of WebAVPlayerLayer. This allows the captionLayer
to be resized separately from the video content. When the videoGravity changes, the captionLayer
is resized to intersect the video contents bounds with the bounds of the WebAVPlayerLayer itself.

* Source/WebCore/platform/cocoa/WebAVPlayerLayer.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer setCaptionsLayer:]):
(-[WebAVPlayerLayer captionsLayer]):
(-[WebAVPlayerLayer layoutSublayers]):
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.mm:
(WebCore::VideoPresentationInterfaceAVKit::setupFullscreen):
(WebCore::VideoPresentationInterfaceAVKit::setupCaptionsLayer):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::doSetup):
(WebCore::VideoPresentationInterfaceIOS::videoDimensionsChanged):
(WebCore::VideoPresentationInterfaceIOS::playerLayer const):

Canonical link: <a href="https://commits.webkit.org/280995@main">https://commits.webkit.org/280995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e5eb8c095d2f0c64e9ecee4ca361d7c35f85ec6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61866 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8686 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47197 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6207 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28033 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7653 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7690 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63571 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54515 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54576 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12880 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1845 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33398 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34484 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35568 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34229 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->