### PR TITLE
[UnifiedPDF] Discrete presentation mode rewrite

### DIFF
--- a/LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html
+++ b/LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true PDFPluginHUDEnabled=false ] -->
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-50">
+    <meta name="fuzzy" content="maxDifference=0-3; totalPixels=0-50">
     <style>
         iframe {
             width: 700px;

--- a/LayoutTests/pdf/unifiedpdf/annotations/dropdown-select-second-option.html
+++ b/LayoutTests/pdf/unifiedpdf/annotations/dropdown-select-second-option.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html><!-- webkit-test-runner [ UnifiedPDFEnabled=true PDFPluginHUDEnabled=false ] -->
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-10;totalPixels=0-25" />
+<meta name="fuzzy" content="maxDifference=0-12;totalPixels=0-25" />
 </head>
 <script src="../../../resources/ui-helper.js"></script>
 <script>

--- a/LayoutTests/platform/mac-ventura/TestExpectations
+++ b/LayoutTests/platform/mac-ventura/TestExpectations
@@ -6,3 +6,12 @@ webkit.org/b/268789 [ Debug ] imported/w3c/web-platform-tests/css/css-break/tabl
 # This is to still test and have logs, because actually not all the tests are failing, it's a just a few of them.
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey.https.any.html [ Pass Failure ]
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey.https.any.worker.html [ Pass Failure ]
+
+# Skip these tests that enable UnifiedPDFPlugin, since it's only meaningful for macOS 14+.
+http/tests/pdf/linearized-pdf-in-iframe.html [ Skip ]
+http/tests/pdf/linearized-pdf-in-display-none-iframe.html [ Skip ]
+compositing/plugins/pdf/pdf-in-embed-rounded-border.html [ Skip ]
+compositing/plugins/pdf/pdf-plugin-printing.html [ Skip ]
+pdf/unifiedpdf/annotations/checkbox-set-active.html [ Skip ]
+pdf/unifiedpdf/annotations/radio-buttons-select-second.html [ Skip ]
+pdf/unifiedpdf/annotations/dropdown-select-second-option.html [ Skip ]

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1449,8 +1449,8 @@ public:
 
     void initDNSPrefetch();
 
-    void didAddWheelEventHandler(Node&);
-    void didRemoveWheelEventHandler(Node&, EventHandlerRemoval = EventHandlerRemoval::One);
+    WEBCORE_EXPORT void didAddWheelEventHandler(Node&);
+    WEBCORE_EXPORT void didRemoveWheelEventHandler(Node&, EventHandlerRemoval = EventHandlerRemoval::One);
 
     void didAddOrRemoveMouseEventHandler(Node&);
 

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -389,10 +389,10 @@ public:
     // This function is static so that it can be called from the main thread or the scrolling thread.
     WEBCORE_EXPORT static void computeScrollbarValueAndOverhang(float currentPosition, float totalSize, float visibleSize, float& scrollbarValue, float& overhangAmount);
 
-    static std::optional<BoxSide> targetSideForScrollDelta(FloatSize, ScrollEventAxis);
+    WEBCORE_EXPORT static std::optional<BoxSide> targetSideForScrollDelta(FloatSize, ScrollEventAxis);
 
     // "Pinned" means scrolled at or beyond the edge.
-    bool isPinnedOnSide(BoxSide) const;
+    WEBCORE_EXPORT bool isPinnedOnSide(BoxSide) const;
     WEBCORE_EXPORT RectEdges<bool> edgePinnedState() const;
 
     // True if scrolling happens by moving compositing layers.

--- a/Source/WebCore/platform/animation/TimingFunction.cpp
+++ b/Source/WebCore/platform/animation/TimingFunction.cpp
@@ -249,4 +249,23 @@ String TimingFunction::cssText() const
     return stream.release();
 }
 
+Ref<CubicBezierTimingFunction> CubicBezierTimingFunction::create(TimingFunctionPreset preset)
+{
+    switch (preset) {
+    case TimingFunctionPreset::Ease:
+        return create(TimingFunctionPreset::Ease, 0.25, 0.1, 0.25, 1.0);
+    case TimingFunctionPreset::EaseIn:
+        return create(TimingFunctionPreset::EaseIn, 0.42, 0.0, 1.0, 1.0);
+    case TimingFunctionPreset::EaseOut:
+        return create(TimingFunctionPreset::EaseOut, 0.0, 0.0, 0.58, 1.0);
+    case TimingFunctionPreset::EaseInOut:
+        return create(TimingFunctionPreset::EaseInOut, 0.42, 0.0, 0.58, 1.0);
+    case TimingFunctionPreset::Custom:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return create();
+}
+
+
 } // namespace WebCore

--- a/Source/WebCore/platform/animation/TimingFunction.h
+++ b/Source/WebCore/platform/animation/TimingFunction.h
@@ -124,23 +124,7 @@ public:
         return adoptRef(*new CubicBezierTimingFunction(preset, x1, y1, x2, y2));
     }
 
-    static Ref<CubicBezierTimingFunction> create(TimingFunctionPreset preset)
-    {
-        switch (preset) {
-        case TimingFunctionPreset::Ease:
-            return create(TimingFunctionPreset::Ease, 0.25, 0.1, 0.25, 1.0);
-        case TimingFunctionPreset::EaseIn:
-            return create(TimingFunctionPreset::EaseIn, 0.42, 0.0, 1.0, 1.0);
-        case TimingFunctionPreset::EaseOut:
-            return create(TimingFunctionPreset::EaseOut, 0.0, 0.0, 0.58, 1.0);
-        case TimingFunctionPreset::EaseInOut:
-            return create(TimingFunctionPreset::EaseInOut, 0.42, 0.0, 0.58, 1.0);
-        case TimingFunctionPreset::Custom:
-            break;
-        }
-        ASSERT_NOT_REACHED();
-        return create();
-    }
+    WEBCORE_EXPORT static Ref<CubicBezierTimingFunction> create(TimingFunctionPreset);
 
     bool operator==(const TimingFunction& other) const final
     {

--- a/Source/WebCore/platform/graphics/transforms/TransformOperations.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperations.h
@@ -48,7 +48,7 @@ public:
 
     bool operator==(const TransformOperations&) const;
 
-    TransformOperations clone() const;
+    WEBCORE_EXPORT TransformOperations clone() const;
     TransformOperations selfOrCopyWithResolvedCalculatedValues(const FloatSize&) const;
 
     const_iterator begin() const { return m_operations.begin(); }

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -710,8 +710,11 @@ WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
 WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
 WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorItem.mm
 WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
+WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
 WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
 WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm
+WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
 WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 
 WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3331,6 +3331,12 @@
 		0F850FE41ED7C39F00FB77A7 /* WebPerformanceLoggingClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebPerformanceLoggingClient.cpp; sourceTree = "<group>"; };
 		0F850FE51ED7C39F00FB77A7 /* WebPerformanceLoggingClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPerformanceLoggingClient.h; sourceTree = "<group>"; };
 		0F86361B27BDC2B6006E6D52 /* BufferIdentifierSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BufferIdentifierSet.h; sourceTree = "<group>"; };
+		0F8B2A172BED80DC0006F515 /* PDFPresentationController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PDFPresentationController.h; sourceTree = "<group>"; };
+		0F8B2A182BED80DC0006F515 /* PDFPresentationController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PDFPresentationController.mm; sourceTree = "<group>"; };
+		0F8B2A192BED80F10006F515 /* PDFScrollingPresentationController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PDFScrollingPresentationController.h; sourceTree = "<group>"; };
+		0F8B2A1A2BED80F10006F515 /* PDFScrollingPresentationController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PDFScrollingPresentationController.mm; sourceTree = "<group>"; };
+		0F8B2A1B2BED8C1B0006F515 /* PDFDiscretePresentationController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PDFDiscretePresentationController.h; sourceTree = "<group>"; };
+		0F8B2A1C2BED8C1B0006F515 /* PDFDiscretePresentationController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PDFDiscretePresentationController.mm; sourceTree = "<group>"; };
 		0F931C1A18C5711900DBA7C3 /* ScrollingTreeOverflowScrollingNodeIOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScrollingTreeOverflowScrollingNodeIOS.h; sourceTree = "<group>"; };
 		0F931C1A18C5711900DBB8D4 /* ScrollingTreeScrollingNodeDelegateIOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScrollingTreeScrollingNodeDelegateIOS.h; sourceTree = "<group>"; };
 		0F931C1B18C5711900DBA7C3 /* ScrollingTreeOverflowScrollingNodeIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollingTreeOverflowScrollingNodeIOS.mm; sourceTree = "<group>"; };
@@ -8775,10 +8781,16 @@
 				33DAECED2B99D05A005C596E /* PDFDataDetectorItem.mm */,
 				33DAECEE2B9AAE91005C596E /* PDFDataDetectorOverlayController.h */,
 				33DAECEF2B9AAE92005C596E /* PDFDataDetectorOverlayController.mm */,
+				0F8B2A1B2BED8C1B0006F515 /* PDFDiscretePresentationController.h */,
+				0F8B2A1C2BED8C1B0006F515 /* PDFDiscretePresentationController.mm */,
 				0F3D56732AC651390086D64E /* PDFDocumentLayout.h */,
 				0F3D56722AC651390086D64E /* PDFDocumentLayout.mm */,
 				0F9B0BC22B7DB9BF0003E962 /* PDFPageCoverage.h */,
 				0F9B0BC32B7DB9BF0003E962 /* PDFPageCoverage.mm */,
+				0F8B2A172BED80DC0006F515 /* PDFPresentationController.h */,
+				0F8B2A182BED80DC0006F515 /* PDFPresentationController.mm */,
+				0F8B2A192BED80F10006F515 /* PDFScrollingPresentationController.h */,
+				0F8B2A1A2BED80F10006F515 /* PDFScrollingPresentationController.mm */,
 				0FFACF042AC2453300ED8DB6 /* UnifiedPDFPlugin.h */,
 				0FFACF032AC2453300ED8DB6 /* UnifiedPDFPlugin.mm */,
 			);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -327,6 +327,7 @@ protected:
     WebCore::ScrollPosition minimumScrollPosition() const final;
     WebCore::ScrollPosition maximumScrollPosition() const final;
     WebCore::IntSize visibleSize() const final { return m_size; }
+    WebCore::IntSize overhangAmount() const final;
     WebCore::IntPoint lastKnownMousePositionInView() const override;
 
     float deviceScaleFactor() const override;
@@ -352,6 +353,8 @@ protected:
     virtual void updateScrollbars();
     virtual Ref<WebCore::Scrollbar> createScrollbar(WebCore::ScrollbarOrientation);
     virtual void destroyScrollbar(WebCore::ScrollbarOrientation);
+
+    void wantsWheelEventsChanged();
 
     virtual void incrementalLoadingDidProgress() { }
     virtual void incrementalLoadingDidCancel() { }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(UNIFIED_PDF)
+
+#include "PDFPresentationController.h"
+#include <WebCore/GraphicsLayerClient.h>
+
+namespace WebCore {
+class PlatformWheelEvent;
+}
+
+namespace WebKit {
+
+enum class PageTransitionState : uint8_t {
+    Idle,
+    DeterminingStretchAxis,
+    Stretching,
+    Settling,
+    StartingAnimationFromStationary,
+    StartingAnimationFromMomentum,
+    Animating
+};
+
+class PDFDiscretePresentationController final : public PDFPresentationController, public WebCore::GraphicsLayerClient {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(PDFDiscretePresentationController);
+public:
+    PDFDiscretePresentationController(UnifiedPDFPlugin&);
+
+
+private:
+    bool supportsDisplayMode(PDFDocumentLayout::DisplayMode) const override;
+    void willChangeDisplayMode(PDFDocumentLayout::DisplayMode) override;
+
+    void teardown() override;
+
+    PDFPageCoverage pageCoverageForContentsRect(const WebCore::FloatRect&, std::optional<PDFLayoutRow>) const override;
+    PDFPageCoverageAndScales pageCoverageAndScalesForContentsRect(const WebCore::FloatRect&, std::optional<PDFLayoutRow>, float tilingScaleFactor) const override;
+
+    WebCore::FloatRect convertFromContentsToPainting(const WebCore::FloatRect&, std::optional<PDFDocumentLayout::PageIndex>) const override;
+    WebCore::FloatRect convertFromPaintingToContents(const WebCore::FloatRect&, std::optional<PDFDocumentLayout::PageIndex>) const override;
+
+    void deviceOrPageScaleFactorChanged() override;
+
+    void setupLayers(WebCore::GraphicsLayer& scrolledContentsLayer) override;
+    void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor) override;
+
+    void updateIsInWindow(bool isInWindow) override;
+    void updateDebugBorders(bool showDebugBorders, bool showRepaintCounters) override;
+    void updateForCurrentScrollability(OptionSet<TiledBackingScrollability>) override;
+
+    void repaintForIncrementalLoad() override;
+    void setNeedsRepaintInDocumentRect(OptionSet<RepaintRequirement>, const WebCore::FloatRect& rectInDocumentCoordinates, std::optional<PDFLayoutRow>) override;
+
+    void didGeneratePreviewForPage(PDFDocumentLayout::PageIndex) override;
+
+    WebCore::GraphicsLayerClient& graphicsLayerClient() override { return *this; }
+
+    std::optional<PDFLayoutRow> visibleRow() const override;
+    std::optional<PDFLayoutRow> rowForLayerID(WebCore::PlatformLayerIdentifier) const override;
+
+    WebCore::FloatSize contentsOffsetForPage(PDFDocumentLayout::PageIndex) const;
+
+    bool handleKeyboardEvent(const WebKeyboardEvent&) override;
+
+    bool handleKeyboardCommand(const WebKeyboardEvent&);
+    bool handleKeyboardEventForPageNavigation(const WebKeyboardEvent&);
+
+    bool wantsWheelEvents() const override { return true; }
+    bool handleWheelEvent(const WebWheelEvent&) override;
+
+    bool handleBeginEvent(const WebCore::PlatformWheelEvent&);
+    bool handleChangedEvent(const WebCore::PlatformWheelEvent&);
+    bool handleEndedEvent(const WebCore::PlatformWheelEvent&);
+    bool handleCancelledEvent(const WebCore::PlatformWheelEvent&);
+
+    bool handleDiscreteWheelEvent(const WebCore::PlatformWheelEvent&);
+
+    bool eventCanStartPageTransition(const PlatformWheelEvent&) const;
+
+    bool canTransitionOnSide(WebCore::BoxSide) const;
+
+    // Transition state
+    enum class TransitionDirection : uint8_t {
+        PreviousHorizontal,
+        PreviousVertical,
+        NextHorizontal,
+        NextVertical
+    };
+
+    static constexpr bool isPreviousDirection(TransitionDirection direction)
+    {
+        return direction == TransitionDirection::PreviousHorizontal || direction == TransitionDirection::PreviousVertical;
+    }
+
+    static constexpr bool isNextDirection(TransitionDirection direction)
+    {
+        return direction == TransitionDirection::NextHorizontal || direction == TransitionDirection::NextVertical;
+    }
+
+    bool canTransitionInDirection(TransitionDirection) const;
+
+    void startOrStopAnimationTimerIfNecessary();
+    void animationTimerFired();
+    void animateRubberBand(MonotonicTime);
+
+    void startTransitionAnimation(PageTransitionState);
+    void transitionEndTimerFired();
+
+    void maybeEndGesture();
+    void gestureEndTimerFired();
+    void startPageTransitionOrSettle();
+
+    void updateState(PageTransitionState);
+    void updateLayerVisibilityForTransitionState(PageTransitionState previousState);
+    void updateLayersForTransitionState();
+
+    void applyWheelEventDelta(FloatSize);
+
+    std::optional<VisiblePDFPosition> pdfPositionForCurrentView(bool preservePosition) const override;
+    void restorePDFPosition(const VisiblePDFPosition&) override;
+
+    void ensurePageIsVisible(PDFDocumentLayout::PageIndex) override;
+
+    // GraphicsLayerClient
+    void notifyFlushRequired(const WebCore::GraphicsLayer*) override;
+    float pageScaleFactor() const override;
+    float deviceScaleFactor() const override;
+    std::optional<float> customContentsScale(const WebCore::GraphicsLayer*) const override;
+    bool layerNeedsPlatformContext(const WebCore::GraphicsLayer*) const override;
+    void tiledBackingUsageChanged(const WebCore::GraphicsLayer*, bool /*usingTiledBacking*/) override;
+    void paintContents(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect&, OptionSet<WebCore::GraphicsLayerPaintBehavior>) override;
+
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    void paintPDFSelection(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect, std::optional<PDFLayoutRow> = { });
+#endif
+
+    void paintBackgroundLayerForRow(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect, unsigned rowIndex);
+
+    void buildRows();
+
+    bool canGoToNextRow() const;
+    bool canGoToPreviousRow() const;
+
+    enum class Animated : bool { No, Yes };
+    void goToNextRow(Animated);
+    void goToPreviousRow(Animated);
+    void goToRowIndex(unsigned rowIndex, Animated);
+
+    void setVisibleRow(unsigned);
+    void updateLayersAfterChangeInVisibleRow(std::optional<unsigned> additionalVisibleRowIndex = { });
+
+    std::optional<unsigned> additionalVisibleRowIndexForDirection(TransitionDirection) const;
+
+    // First index is layer, second index is start/end.
+    static constexpr size_t topLayerIndex = 0;
+    static constexpr size_t bottomLayerIndex = 1;
+    static constexpr size_t startIndex = 0;
+    static constexpr size_t endIndex = 1;
+    std::array<std::array<float, 2>, 2> layerOpacitiesForStretchOffset(TransitionDirection, WebCore::FloatSize layerOffset, WebCore::FloatSize rowSize) const;
+    WebCore::FloatSize layerOffsetForStretch(TransitionDirection, WebCore::FloatSize stretchDistance, WebCore::FloatSize rowSize) const;
+    static float relevantAxisForDirection(TransitionDirection, WebCore::FloatSize);
+    static void setRelevantAxisForDirection(TransitionDirection, WebCore::FloatSize&, float value);
+
+    struct RowData {
+        PDFLayoutRow pages;
+        WebCore::FloatSize contentsOffset;
+        RefPtr<WebCore::GraphicsLayer> containerLayer;
+        RefPtr<WebCore::GraphicsLayer> leftPageContainerLayer;
+        RefPtr<WebCore::GraphicsLayer> rightPageContainerLayer;
+        RefPtr<WebCore::GraphicsLayer> contentsLayer;
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+        RefPtr<WebCore::GraphicsLayer> selectionLayer;
+#endif
+        bool isPageBackgroundLayer(const GraphicsLayer*) const;
+
+        RefPtr<WebCore::GraphicsLayer> leftPageBackgroundLayer() const;
+        RefPtr<WebCore::GraphicsLayer> rightPageBackgroundLayer() const;
+
+        RefPtr<WebCore::GraphicsLayer> backgroundLayerForPageIndex(PDFDocumentLayout::PageIndex) const;
+    };
+
+    const RowData* rowDataForLayerID(WebCore::PlatformLayerIdentifier) const;
+    WebCore::FloatPoint positionForRowContainerLayer(const PDFLayoutRow&) const;
+    WebCore::FloatSize rowContainerSize(const PDFLayoutRow&) const;
+
+    RefPtr<WebCore::GraphicsLayer> m_rowsContainerLayer;
+    Vector<RowData> m_rows;
+
+    HashMap<WebCore::PlatformLayerIdentifier, unsigned> m_layerIDToRowIndexMap;
+    std::optional<PDFDocumentLayout::DisplayMode> m_displayModeAtLastLayerSetup;
+
+    unsigned m_visibleRowIndex { 0 };
+
+    // Gesture state
+    WebCore::Timer m_gestureEndTimer { *this, &PDFDiscretePresentationController::gestureEndTimerFired };
+    WebCore::Timer m_animationTimer { *this, &PDFDiscretePresentationController::animationTimerFired };
+    WebCore::Timer m_transitionEndTimer { *this, &PDFDiscretePresentationController::transitionEndTimerFired };
+    MonotonicTime m_animationStartTime;
+    WebCore::FloatSize m_unappliedStretchDelta;
+    WebCore::FloatSize m_stretchDistance;
+    std::optional<WebCore::FloatSize> m_momentumVelocity;
+    float m_animationStartDistance { 0 };
+    PageTransitionState m_transitionState { PageTransitionState::Idle };
+    std::optional<TransitionDirection> m_transitionDirection;
+};
+
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -1,0 +1,1578 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PDFDiscretePresentationController.h"
+
+#if ENABLE(UNIFIED_PDF)
+
+#include "Logging.h"
+#include "WebEventConversion.h"
+#include "WebKeyboardEvent.h"
+#include "WebWheelEvent.h"
+#include <WebCore/Animation.h>
+#include <WebCore/GraphicsLayer.h>
+#include <WebCore/Length.h>
+#include <WebCore/NotImplemented.h>
+#include <WebCore/PlatformWheelEvent.h>
+#include <WebCore/TiledBacking.h>
+#include <WebCore/TimingFunction.h>
+#include <WebCore/TransformOperations.h>
+#include <WebCore/TransformationMatrix.h>
+#include <pal/spi/mac/NSScrollViewSPI.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+static constexpr auto pageSwapDistanceThreshold = 200.0f;
+static constexpr auto animationFrameInterval = 16.667_ms;
+
+static float elasticDeltaForTimeDelta(float initialPosition, float initialVelocity, Seconds elapsedTime)
+{
+#if PLATFORM(MAC)
+    return _NSElasticDeltaForTimeDelta(initialPosition, initialVelocity, elapsedTime.seconds());
+#else
+    notImplemented();
+    return 0;
+#endif
+}
+
+#if !LOG_DISABLED
+static TextStream& operator<<(TextStream& ts, PageTransitionState state)
+{
+    switch (state) {
+    case PageTransitionState::Idle: ts << "Idle"; break;
+    case PageTransitionState::DeterminingStretchAxis: ts << "DeterminingStretchAxis"; break;
+    case PageTransitionState::Stretching: ts << "Stretching"; break;
+    case PageTransitionState::Settling: ts << "Settling"; break;
+    case PageTransitionState::StartingAnimationFromStationary: ts << "StartingAnimationFromStationary"; break;
+    case PageTransitionState::StartingAnimationFromMomentum: ts << "StartingAnimationFromMomentum"; break;
+    case PageTransitionState::Animating: ts << "Animating"; break;
+    }
+    return ts;
+}
+#endif
+
+PDFDiscretePresentationController::PDFDiscretePresentationController(UnifiedPDFPlugin& plugin)
+    : PDFPresentationController(plugin)
+{
+
+}
+
+void PDFDiscretePresentationController::teardown()
+{
+    PDFPresentationController::teardown();
+
+    GraphicsLayer::unparentAndClear(m_rowsContainerLayer);
+    m_rows.clear();
+}
+
+bool PDFDiscretePresentationController::supportsDisplayMode(PDFDocumentLayout::DisplayMode mode) const
+{
+    return PDFDocumentLayout::isDiscreteDisplayMode(mode);
+}
+
+void PDFDiscretePresentationController::willChangeDisplayMode(PDFDocumentLayout::DisplayMode newMode)
+{
+    ASSERT(supportsDisplayMode(newMode));
+    m_visibleRowIndex = 0;
+}
+
+#pragma mark -
+
+bool PDFDiscretePresentationController::handleKeyboardEvent(const WebKeyboardEvent& event)
+{
+#if PLATFORM(MAC)
+    if (handleKeyboardCommand(event))
+        return true;
+
+    // FIXME: <https://webkit.org/b/276981> Need to check for scrollability first.
+
+    if (handleKeyboardEventForPageNavigation(event))
+        return true;
+#endif
+
+    return false;
+}
+
+// FIXME: <https://webkit.org/b/276981> Do we need this?
+bool PDFDiscretePresentationController::handleKeyboardCommand(const WebKeyboardEvent& event)
+{
+    return false;
+}
+
+bool PDFDiscretePresentationController::handleKeyboardEventForPageNavigation(const WebKeyboardEvent& event)
+{
+//    if (m_isScrollingWithAnimationToPageExtent)
+//        return false;
+
+    if (event.type() == WebEventType::KeyUp)
+        return false;
+
+    auto key = event.key();
+    if (key == "ArrowLeft"_s || key == "ArrowUp"_s || key == "PageUp"_s) {
+        if (!canGoToPreviousRow())
+            return false;
+
+        goToPreviousRow(Animated::No);
+        return true;
+    }
+
+    if (key == "ArrowRight"_s || key == "ArrowDown"_s || key == "PageDown"_s) {
+        if (!canGoToNextRow())
+            return false;
+
+        goToNextRow(Animated::No);
+        return true;
+    }
+
+    if (key == "Home"_s) {
+        if (!m_visibleRowIndex)
+            return false;
+
+        goToRowIndex(0, Animated::No);
+        return true;
+    }
+
+    if (key == "End"_s) {
+        auto lastRowIndex = m_rows.size() - 1;
+        if (m_visibleRowIndex == lastRowIndex)
+            return false;
+
+        goToRowIndex(lastRowIndex, Animated::No);
+        return true;
+    }
+
+    return false;
+}
+
+#pragma mark -
+
+bool PDFDiscretePresentationController::canTransitionOnSide(BoxSide side) const
+{
+    switch (side) {
+    case BoxSide::Left:
+    case BoxSide::Top:
+        return canGoToPreviousRow();
+    case BoxSide::Right:
+    case BoxSide::Bottom:
+        return canGoToNextRow();
+    }
+    return false;
+}
+
+bool PDFDiscretePresentationController::canTransitionInDirection(TransitionDirection direction) const
+{
+    if (isPreviousDirection(direction))
+        return canGoToPreviousRow();
+
+    return canGoToNextRow();
+}
+
+// FIXME: <https://webkit.org/b/276981> Still an issue with stretching.
+bool PDFDiscretePresentationController::handleWheelEvent(const WebWheelEvent& event)
+{
+    // This code has to handle wheel events for swiping in a way that's compatible with
+    // normal scrolling when zoomed in, and allowing history swipes. It does so as follows:
+    // * For begin events and non-gesture events, check for scrollability first.
+    // * For all other events, return `false` if our state is idle.
+
+    if (m_transitionState == PageTransitionState::Animating)
+        return true; // Consume the events. Ideally we'd allow this to start another animation.
+
+    auto wheelEvent = platform(event);
+
+    LOG_WITH_STREAM(PDF, stream << "PDFDiscretePresentationController::handleWheelEvent " << wheelEvent << " state " << m_transitionState);
+
+    if (wheelEvent.isNonGestureEvent())
+        return handleDiscreteWheelEvent(wheelEvent);
+
+    if (wheelEvent.phase() == PlatformWheelEventPhase::Began)
+        return handleBeginEvent(wheelEvent);
+
+    // Only Begin and non-gesture events take us out of the Idle state.
+    if (m_transitionState == PageTransitionState::Idle)
+        return false;
+
+    // When we receive the last non-momentum event, we don't know if momentum events are coming (but see rdar://85308435).
+    if (wheelEvent.isEndOfNonMomentumScroll()) {
+        if (m_transitionState == PageTransitionState::Idle)
+            return false;
+
+        maybeEndGesture();
+        return true;
+    }
+
+    if (wheelEvent.isTransitioningToMomentumScroll())
+        m_gestureEndTimer.stop();
+
+    if (wheelEvent.isEndOfMomentumScroll())
+        return handleEndedEvent(wheelEvent);
+
+    if (wheelEvent.isGestureCancel())
+        return handleCancelledEvent(wheelEvent);
+
+    if (wheelEvent.phase() == PlatformWheelEventPhase::Changed || wheelEvent.momentumPhase() == PlatformWheelEventPhase::Changed)
+        return handleChangedEvent(wheelEvent);
+
+    return false;
+}
+
+bool PDFDiscretePresentationController::eventCanStartPageTransition(const PlatformWheelEvent& wheelEvent) const
+{
+    auto wheelDelta = -wheelEvent.delta();
+
+    auto shouldTransitionOnSize = [&](BoxSide side) {
+        if (!m_plugin->isPinnedOnSide(side))
+            return false;
+
+        return canTransitionOnSide(side);
+    };
+
+    // Trying to determine which axis a gesture is for based on the small deltas in the begin event is unreliable,
+    // but if we unconditionally handle the begin event, history swiping doesn't work.
+    auto horizontalSide = ScrollableArea::targetSideForScrollDelta(wheelDelta, ScrollEventAxis::Horizontal);
+    if (horizontalSide && !shouldTransitionOnSize(*horizontalSide))
+        return false;
+
+    auto verticalSide = ScrollableArea::targetSideForScrollDelta(wheelDelta, ScrollEventAxis::Vertical);
+    if (verticalSide && !shouldTransitionOnSize(*verticalSide))
+        return false;
+
+    return true;
+}
+
+bool PDFDiscretePresentationController::handleBeginEvent(const PlatformWheelEvent& wheelEvent)
+{
+    if (!eventCanStartPageTransition(wheelEvent))
+        return false;
+
+    updateState(PageTransitionState::DeterminingStretchAxis);
+
+    auto wheelDelta = -wheelEvent.delta();
+    applyWheelEventDelta(wheelDelta);
+    return true;
+}
+
+bool PDFDiscretePresentationController::handleChangedEvent(const PlatformWheelEvent& wheelEvent)
+{
+    LOG_WITH_STREAM(PDF, stream << "PDFDiscretePresentationController::handleChangedEvent - state " << m_transitionState);
+
+    if (m_transitionState == PageTransitionState::Idle)
+        return false;
+
+    if (m_transitionState != PageTransitionState::DeterminingStretchAxis && m_transitionState != PageTransitionState::Stretching)
+        return true;
+
+    auto delta = -wheelEvent.delta();
+    applyWheelEventDelta(delta);
+
+    auto stetchOffset = relevantAxisForDirection(m_transitionDirection.value_or(TransitionDirection::NextVertical), m_stretchDistance);
+    if (std::abs(stetchOffset) >= pageSwapDistanceThreshold && wheelEvent.momentumPhase() == PlatformWheelEventPhase::Changed) {
+        auto eventWithVelocity = m_plugin->wheelEventCopyWithVelocity(wheelEvent);
+        auto velocity = eventWithVelocity.scrollingVelocity();
+        if (!velocity.isZero())
+            m_momentumVelocity = velocity;
+
+        updateState(PageTransitionState::StartingAnimationFromMomentum);
+        return true;
+    }
+
+    updateLayersForTransitionState();
+    return true;
+}
+
+bool PDFDiscretePresentationController::handleEndedEvent(const PlatformWheelEvent&)
+{
+    startPageTransitionOrSettle();
+    return true;
+}
+
+bool PDFDiscretePresentationController::handleCancelledEvent(const PlatformWheelEvent&)
+{
+    updateState(PageTransitionState::Idle);
+    return true;
+}
+
+bool PDFDiscretePresentationController::handleDiscreteWheelEvent(const PlatformWheelEvent& wheelEvent)
+{
+    if (!eventCanStartPageTransition(wheelEvent))
+        return false;
+
+    if ((wheelEvent.deltaY() > 0 || wheelEvent.deltaX() > 0) && canGoToPreviousRow()) {
+        goToPreviousRow(Animated::No);
+        return true;
+    }
+
+    if ((wheelEvent.deltaY() < 0 || wheelEvent.deltaX() < 0) && canGoToNextRow()) {
+        goToNextRow(Animated::No);
+        return true;
+    }
+
+    return false;
+}
+
+#pragma mark -
+
+void PDFDiscretePresentationController::maybeEndGesture()
+{
+    static constexpr auto gestureEndTimerDelay = 32_ms;
+    // Wait for two frames to see if momentum will start.
+    m_gestureEndTimer.startOneShot(gestureEndTimerDelay);
+}
+
+void PDFDiscretePresentationController::gestureEndTimerFired()
+{
+    startPageTransitionOrSettle();
+}
+
+void PDFDiscretePresentationController::startPageTransitionOrSettle()
+{
+    if (m_transitionState == PageTransitionState::DeterminingStretchAxis) {
+        updateState(PageTransitionState::Idle);
+        return;
+    }
+
+    if (m_transitionState != PageTransitionState::Stretching)
+        return;
+
+    auto stetchOffset = relevantAxisForDirection(m_transitionDirection.value_or(TransitionDirection::NextVertical), m_stretchDistance);
+    if (std::abs(stetchOffset) < pageSwapDistanceThreshold) {
+        updateState(PageTransitionState::Settling);
+        return;
+    }
+
+    if (stetchOffset < 0) {
+        updateState(PageTransitionState::StartingAnimationFromStationary);
+        return;
+    }
+
+    if (stetchOffset > 0) {
+        updateState(PageTransitionState::StartingAnimationFromStationary);
+        return;
+    }
+}
+
+void PDFDiscretePresentationController::updateState(PageTransitionState newState)
+{
+    if (newState == m_transitionState)
+        return;
+
+    LOG_WITH_STREAM(PDF, stream << "PDFDiscretePresentationController::updateState from " << m_transitionState << " to " << newState);
+    auto oldState = std::exchange(m_transitionState, newState);
+
+    switch (m_transitionState) {
+    case PageTransitionState::Idle:
+    case PageTransitionState::DeterminingStretchAxis:
+        m_unappliedStretchDelta = { };
+        m_stretchDistance = { };
+        m_transitionDirection = { };
+        m_momentumVelocity = { };
+        break;
+    case PageTransitionState::Stretching:
+        break;
+    case PageTransitionState::Settling:
+        break;
+    case PageTransitionState::StartingAnimationFromStationary:
+    case PageTransitionState::StartingAnimationFromMomentum:
+        startTransitionAnimation(m_transitionState);
+        m_transitionState = PageTransitionState::Animating;
+        break;
+    case PageTransitionState::Animating:
+        break;
+    }
+
+    startOrStopAnimationTimerIfNecessary();
+    updateLayersForTransitionState();
+    updateLayerVisibilityForTransitionState(oldState);
+}
+
+void PDFDiscretePresentationController::startOrStopAnimationTimerIfNecessary()
+{
+    switch (m_transitionState) {
+    case PageTransitionState::Idle:
+    case PageTransitionState::Stretching:
+    case PageTransitionState::DeterminingStretchAxis:
+    case PageTransitionState::StartingAnimationFromStationary:
+    case PageTransitionState::StartingAnimationFromMomentum:
+    case PageTransitionState::Animating:
+        m_animationTimer.stop();
+        break;
+    case PageTransitionState::Settling:
+        m_animationStartTime = MonotonicTime::now();
+        m_animationStartDistance = relevantAxisForDirection(m_transitionDirection.value_or(TransitionDirection::NextVertical), m_stretchDistance);
+        if (!m_animationTimer.isActive())
+            m_animationTimer.startRepeating(animationFrameInterval);
+        break;
+    }
+}
+
+void PDFDiscretePresentationController::animationTimerFired()
+{
+    switch (m_transitionState) {
+    case PageTransitionState::Idle:
+    case PageTransitionState::Stretching:
+    case PageTransitionState::DeterminingStretchAxis:
+    case PageTransitionState::StartingAnimationFromStationary:
+    case PageTransitionState::StartingAnimationFromMomentum:
+    case PageTransitionState::Animating:
+        break;
+    case PageTransitionState::Settling:
+        animateRubberBand(MonotonicTime::now());
+        break;
+    }
+}
+
+void PDFDiscretePresentationController::animateRubberBand(MonotonicTime now)
+{
+    static constexpr auto initialVelocity = 0.0f;
+
+    auto stretch = elasticDeltaForTimeDelta(m_animationStartDistance, initialVelocity, now - m_animationStartTime);
+    setRelevantAxisForDirection(m_transitionDirection.value_or(TransitionDirection::NextVertical), m_stretchDistance, stretch);
+    updateLayersForTransitionState();
+
+    if (std::abs(stretch) < 0.5)
+        updateState(PageTransitionState::Idle);
+}
+
+void PDFDiscretePresentationController::startTransitionAnimation(PageTransitionState animationStartState)
+{
+    if (!m_transitionDirection)
+        return;
+
+    static constexpr auto defaultTransitionDuration = 0.5_s;
+    static constexpr auto maximumTransitionDuration = 0.75_s;
+    static constexpr auto minimumTransitionDuration = 0.20_s;
+
+    auto transitionDuration = defaultTransitionDuration;
+
+    auto transformAnimationValueForTranslation = [](double keyTime, FloatSize offset) {
+        auto xLength = Length(offset.width(), LengthType::Fixed);
+        auto yLength = Length(offset.height(), LengthType::Fixed);
+
+        Vector<Ref<TransformOperation>> operations;
+        operations.reserveInitialCapacity(1);
+        operations.append(TranslateTransformOperation::create(xLength, yLength, Length(0, LengthType::Fixed), TransformOperationType::Translate));
+
+        return makeUnique<TransformAnimationValue>(keyTime, TransformOperations { WTFMove(operations) }, nullptr);
+    };
+
+    auto createPositionKeyframesForAnimation = [&](TransitionDirection direction, FloatSize initialOffset, FloatSize finalOffset) {
+        auto keyframes = KeyframeValueList { AnimatedProperty::Translate };
+        auto initialValue = transformAnimationValueForTranslation(0, initialOffset);
+        auto finalValue = transformAnimationValueForTranslation(1, finalOffset);
+        keyframes.insert(WTFMove(initialValue));
+        keyframes.insert(WTFMove(finalValue));
+        return keyframes;
+    };
+
+    auto createOpacityKeyframesForAnimation = [](TransitionDirection direction, std::array<float, 2> startEndOpacities) {
+        auto keyframes = KeyframeValueList { AnimatedProperty::Opacity };
+        keyframes.insert(makeUnique<FloatAnimationValue>(0, startEndOpacities[startIndex]));
+        keyframes.insert(makeUnique<FloatAnimationValue>(1, startEndOpacities[endIndex]));
+        return keyframes;
+    };
+
+    auto addAnimationsToRowContainer = [&](const RowData& animatingRow, const RowData& stationaryRow, TransitionDirection direction, FloatSize startOffset, FloatSize endOffset, const std::array<std::array<float, 2>, 2>& layerEndOpacities) {
+        auto transitionDuration = defaultTransitionDuration;
+
+        RefPtr<TimingFunction> moveTimingFunction;
+        RefPtr<TimingFunction> fadeTimingFunction;
+
+        if (animationStartState == PageTransitionState::StartingAnimationFromMomentum) {
+            moveTimingFunction = LinearTimingFunction::create();
+            fadeTimingFunction = LinearTimingFunction::create();
+
+            if (m_momentumVelocity) {
+                float velocity = std::abs(relevantAxisForDirection(direction, *m_momentumVelocity));
+                float distance = std::abs(relevantAxisForDirection(direction, endOffset - startOffset));
+
+                transitionDuration = Seconds { distance / velocity };
+                transitionDuration = std::min(std::max(transitionDuration, minimumTransitionDuration), maximumTransitionDuration);
+            }
+        } else {
+            auto timingFunctionPreset = isNextDirection(direction) ? CubicBezierTimingFunction::TimingFunctionPreset::EaseIn : CubicBezierTimingFunction::TimingFunctionPreset::EaseOut;
+            moveTimingFunction = CubicBezierTimingFunction::create(timingFunctionPreset);
+            fadeTimingFunction = CubicBezierTimingFunction::create(timingFunctionPreset);
+        }
+
+        auto moveFrames = createPositionKeyframesForAnimation(direction, startOffset, endOffset);
+        Ref moveAnimation = Animation::create();
+        moveAnimation->setDuration(transitionDuration.seconds());
+        moveAnimation->setTimingFunction(WTFMove(moveTimingFunction));
+        animatingRow.containerLayer->addAnimation(moveFrames, { }, moveAnimation.ptr(), "move"_s, 0);
+
+        auto fadeKeyframes = createOpacityKeyframesForAnimation(direction, layerEndOpacities[topLayerIndex]);
+        Ref fadeAnimation = Animation::create();
+        fadeAnimation->setDuration(transitionDuration.seconds());
+        fadeAnimation->setTimingFunction(WTFMove(fadeTimingFunction));
+        animatingRow.containerLayer->addAnimation(fadeKeyframes, { }, fadeAnimation.ptr(), "fade"_s, 0);
+
+        auto stationaryLayerFadeKeyframes = createOpacityKeyframesForAnimation(direction, layerEndOpacities[bottomLayerIndex]);
+        stationaryRow.containerLayer->addAnimation(stationaryLayerFadeKeyframes, { }, fadeAnimation.ptr(), "fade"_s, 0);
+
+        return transitionDuration;
+    };
+
+    auto setupAnimations = [&](const RowData& animatingRow, const RowData& stationaryRow, TransitionDirection direction, FloatSize stretchDistance, FloatSize endOffset, FloatSize rowSize) {
+        auto startOffset = layerOffsetForStretch(direction, stretchDistance, rowSize);
+
+        auto layerOpacities = layerOpacitiesForStretchOffset(direction, startOffset, rowSize);
+        transitionDuration = addAnimationsToRowContainer(animatingRow, stationaryRow, direction, startOffset, endOffset, layerOpacities);
+
+        // The animation runs on top of the non-stretched layer position and opacity.
+        auto layerPosition = positionForRowContainerLayer(animatingRow.pages);
+        animatingRow.containerLayer->setPosition(layerPosition);
+        animatingRow.containerLayer->setOpacity(1);
+        stationaryRow.containerLayer->setOpacity(1);
+
+        return transitionDuration;
+    };
+
+    switch (*m_transitionDirection) {
+    case TransitionDirection::PreviousHorizontal:
+    case TransitionDirection::PreviousVertical: {
+        // Top page animates down, fading in. Bottom page fades out.
+        auto animatingRowIndex = additionalVisibleRowIndexForDirection(*m_transitionDirection);
+        if (!animatingRowIndex)
+            return;
+
+        auto& animatingRow = m_rows[*animatingRowIndex];
+        auto& stationaryRow = m_rows[m_visibleRowIndex];
+        auto rowSize = rowContainerSize(animatingRow.pages);
+        auto endOffset = FloatSize { };
+        transitionDuration = setupAnimations(animatingRow, stationaryRow, *m_transitionDirection, m_stretchDistance, endOffset, rowSize);
+        break;
+    }
+
+    case TransitionDirection::NextHorizontal:
+    case TransitionDirection::NextVertical: {
+        // Top page animates up, fading out. Botom page fades in.
+        auto additionalVisibleRowIndex = additionalVisibleRowIndexForDirection(*m_transitionDirection);
+        if (!additionalVisibleRowIndex)
+            return;
+
+        auto& animatingRow = m_rows[m_visibleRowIndex];
+        auto& stationaryRow = m_rows[*additionalVisibleRowIndex];
+        auto rowSize = rowContainerSize(animatingRow.pages);
+        auto endOffset = layerOffsetForStretch(*m_transitionDirection, rowSize, rowSize);
+        transitionDuration = setupAnimations(animatingRow, stationaryRow, *m_transitionDirection, m_stretchDistance, endOffset, rowSize);
+        break;
+    }
+    }
+
+    m_transitionEndTimer.startOneShot(transitionDuration);
+}
+
+void PDFDiscretePresentationController::transitionEndTimerFired()
+{
+    if (!m_transitionDirection)
+        return;
+
+    switch (*m_transitionDirection) {
+    case TransitionDirection::PreviousHorizontal:
+    case TransitionDirection::PreviousVertical:
+        goToPreviousRow(Animated::No);
+        break;
+    case TransitionDirection::NextHorizontal:
+    case TransitionDirection::NextVertical:
+        goToNextRow(Animated::No);
+        break;
+    }
+
+    updateState(PageTransitionState::Idle);
+}
+
+std::optional<unsigned> PDFDiscretePresentationController::additionalVisibleRowIndexForDirection(TransitionDirection direction) const
+{
+    std::optional<unsigned> additionalVisibleRow;
+    if (m_transitionDirection) {
+        if (isPreviousDirection(*m_transitionDirection) && m_visibleRowIndex > 0)
+            additionalVisibleRow = m_visibleRowIndex - 1;
+        else if (isNextDirection(*m_transitionDirection) && m_visibleRowIndex < m_rows.size() - 1)
+            additionalVisibleRow = m_visibleRowIndex + 1;
+    }
+
+    return additionalVisibleRow;
+}
+
+void PDFDiscretePresentationController::updateLayerVisibilityForTransitionState(PageTransitionState previousState)
+{
+    switch (m_transitionState) {
+    case PageTransitionState::Idle:
+        updateLayersAfterChangeInVisibleRow(m_visibleRowIndex);
+        break;
+
+    case PageTransitionState::DeterminingStretchAxis:
+    case PageTransitionState::Settling:
+    case PageTransitionState::Animating:
+        break;
+
+    case PageTransitionState::Stretching:
+    case PageTransitionState::StartingAnimationFromStationary:
+    case PageTransitionState::StartingAnimationFromMomentum: {
+        std::optional<unsigned> additionalVisibleRow;
+        if (m_transitionDirection)
+            additionalVisibleRow = additionalVisibleRowIndexForDirection(*m_transitionDirection);
+
+        updateLayersAfterChangeInVisibleRow(additionalVisibleRow);
+        break;
+    }
+    }
+}
+
+void PDFDiscretePresentationController::applyWheelEventDelta(FloatSize delta)
+{
+    auto directionFromDelta = [](FloatSize accumulatedDelta) -> std::optional<TransitionDirection> {
+        // 3x the distance on one axis than the other, and at least 3px of movement.
+        auto horizontalDelta = std::abs(accumulatedDelta.width());
+        auto verticalDelta = std::abs(accumulatedDelta.height());
+
+        static constexpr auto minimumAxisMovement = 3.0f;
+        if (std::max(horizontalDelta, verticalDelta) < minimumAxisMovement)
+            return { };
+
+        static constexpr auto minimumAxisRatio = 1.5f;
+
+        if (horizontalDelta > verticalDelta && (!verticalDelta || horizontalDelta / verticalDelta >= minimumAxisRatio))
+            return accumulatedDelta.width() < 0 ? TransitionDirection::PreviousHorizontal : TransitionDirection::NextHorizontal;
+
+        if (verticalDelta > horizontalDelta && (!horizontalDelta || verticalDelta / horizontalDelta >= minimumAxisRatio))
+            return accumulatedDelta.height() < 0 ? TransitionDirection::PreviousVertical : TransitionDirection::NextVertical;
+
+        return { };
+    };
+
+    auto stretchDeltaConstrainedForTransitionDirection = [](FloatSize delta, TransitionDirection direction) {
+        switch (direction) {
+        case TransitionDirection::PreviousHorizontal:
+            if (delta.width() > 0)
+                delta.setWidth(0);
+            delta.setHeight(0);
+            break;
+        case TransitionDirection::PreviousVertical:
+            delta.setWidth(0);
+            if (delta.height() > 0)
+                delta.setHeight(0);
+            break;
+        case TransitionDirection::NextHorizontal:
+            delta.setHeight(0);
+            break;
+        case TransitionDirection::NextVertical:
+            delta.setWidth(0);
+            if (delta.height() < 0)
+                delta.setHeight(0);
+            break;
+        }
+        return delta;
+    };
+
+    if (!m_transitionDirection) {
+        ASSERT(m_transitionState == PageTransitionState::DeterminingStretchAxis);
+        m_unappliedStretchDelta += delta;
+
+        if (auto direction = directionFromDelta(m_unappliedStretchDelta)) {
+            if (!canTransitionInDirection(*direction)) {
+                updateState(PageTransitionState::Idle);
+                return;
+            }
+
+            m_transitionDirection = *direction;
+            m_stretchDistance = stretchDeltaConstrainedForTransitionDirection(std::exchange(m_unappliedStretchDelta, { }), *m_transitionDirection);
+            updateState(PageTransitionState::Stretching);
+            // FIXME: <https://webkit.org/b/276981> Need to check if we're allowed in this direction.
+        }
+        return;
+    }
+
+    ASSERT(m_transitionDirection);
+    // FIXME: <https://webkit.org/b/276981> Should we consult NSScrollWheelMultiplier like ScrollingEffectsController does?
+    m_stretchDistance = stretchDeltaConstrainedForTransitionDirection(m_stretchDistance + delta, *m_transitionDirection);
+
+    LOG_WITH_STREAM(PDF, stream << "PDFDiscretePresentationController::applyWheelEventDelta " << delta << " - stretch " << m_stretchDistance);
+
+}
+
+float PDFDiscretePresentationController::relevantAxisForDirection(TransitionDirection direction, FloatSize size)
+{
+    switch (direction) {
+    case TransitionDirection::PreviousHorizontal:
+    case TransitionDirection::NextHorizontal:
+        return size.width();
+    case TransitionDirection::PreviousVertical:
+    case TransitionDirection::NextVertical:
+        return size.height();
+    }
+    return 0;
+}
+
+void PDFDiscretePresentationController::setRelevantAxisForDirection(TransitionDirection direction, FloatSize& size, float value)
+{
+    switch (direction) {
+    case TransitionDirection::PreviousHorizontal:
+    case TransitionDirection::NextHorizontal:
+        size.setWidth(value);
+        break;
+    case TransitionDirection::PreviousVertical:
+    case TransitionDirection::NextVertical:
+        size.setHeight(value);
+        break;
+    }
+}
+
+std::array<std::array<float, 2>, 2> PDFDiscretePresentationController::layerOpacitiesForStretchOffset(TransitionDirection direction, FloatSize layerOffset, FloatSize rowSize) const
+{
+    auto topLayerThresholdDistance = relevantAxisForDirection(direction, rowSize) / 2;
+    switch (direction) {
+    case TransitionDirection::PreviousHorizontal:
+    case TransitionDirection::PreviousVertical: {
+        auto topLayerStartOpacity = std::min(std::abs(relevantAxisForDirection(direction, layerOffset)), topLayerThresholdDistance) / topLayerThresholdDistance;
+        auto bottomStartOpacity = std::min(std::abs(relevantAxisForDirection(direction, layerOffset)), pageSwapDistanceThreshold) / pageSwapDistanceThreshold;
+        return { {
+            { 1 - topLayerStartOpacity, 1.0f },
+            { bottomStartOpacity, 0.0f }
+        } };
+    }
+    case TransitionDirection::NextHorizontal:
+    case TransitionDirection::NextVertical: {
+        auto topLayerStartOpacity = std::min(std::abs(relevantAxisForDirection(direction, layerOffset)), topLayerThresholdDistance) / topLayerThresholdDistance;
+        auto bottomStartOpacity = std::min(std::abs(relevantAxisForDirection(direction, layerOffset)), pageSwapDistanceThreshold) / pageSwapDistanceThreshold;
+        return { {
+            { 1 - topLayerStartOpacity, 0.0f },
+            { bottomStartOpacity, 1.0f }
+        } };
+    }
+    }
+    return { { { 1, 1 }, { 1, 1 } } };
+}
+
+// FIXME: <https://webkit.org/b/276981> The gestures should be zoom-indpendent.
+FloatSize PDFDiscretePresentationController::layerOffsetForStretch(TransitionDirection direction, FloatSize stretchDistance, FloatSize rowSize) const
+{
+    auto constrainedForDirection = [](FloatSize size, TransitionDirection direction) {
+        switch (direction) {
+        case TransitionDirection::PreviousHorizontal:
+        case TransitionDirection::NextHorizontal:
+            return FloatSize { size.width(), 0 };
+        case TransitionDirection::PreviousVertical:
+        case TransitionDirection::NextVertical:
+            return FloatSize { 0, size.height() };
+        }
+    };
+
+    switch (direction) {
+    // Pulling from the left and from the top, respectively.
+    case TransitionDirection::PreviousHorizontal:
+    case TransitionDirection::PreviousVertical: {
+        // The previous page starts showing about 1/2 of the way in.
+        static constexpr float previousPageStartProportion = 0.5;
+
+        auto startOffset = constrainedForDirection(rowSize, direction);
+        startOffset.scale(previousPageStartProportion);
+        return -startOffset - stretchDistance;
+    }
+
+    case TransitionDirection::NextHorizontal: // Pushing right.
+    case TransitionDirection::NextVertical: // Pushing up.
+        return constrainedForDirection(-stretchDistance, direction);
+    }
+    return { };
+}
+
+void PDFDiscretePresentationController::updateLayersForTransitionState()
+{
+    switch (m_transitionState) {
+    case PageTransitionState::Idle: {
+        // We could optimize by only touching rows we know were animating.
+        for (auto& row : m_rows) {
+            auto layerPosition = positionForRowContainerLayer(row.pages);
+            row.containerLayer->setPosition(layerPosition);
+            row.containerLayer->setOpacity(1);
+            row.containerLayer->removeAnimation("move"_s, { });
+            row.containerLayer->removeAnimation("fade"_s, { });
+        }
+        break;
+    }
+    case PageTransitionState::DeterminingStretchAxis:
+        break;
+    case PageTransitionState::Stretching:
+    case PageTransitionState::Settling:
+    case PageTransitionState::StartingAnimationFromStationary:
+    case PageTransitionState::StartingAnimationFromMomentum: {
+        if (!m_transitionDirection)
+            return;
+
+        auto additionalVisibleRowIndex = additionalVisibleRowIndexForDirection(*m_transitionDirection);
+
+        // The lower index (which is on top) is the one that moves.
+        unsigned topLayerRowIndex = std::min(m_visibleRowIndex, additionalVisibleRowIndex.value_or(m_visibleRowIndex));
+        auto& topLayerRow = m_rows[topLayerRowIndex];
+        auto rowSize = rowContainerSize(topLayerRow.pages);
+        auto stretchOffset = layerOffsetForStretch(*m_transitionDirection, m_stretchDistance, rowSize);
+        auto layerPosition = positionForRowContainerLayer(topLayerRow.pages);
+        layerPosition += stretchOffset;
+        auto layerOpacities = layerOpacitiesForStretchOffset(*m_transitionDirection, stretchOffset, rowSize);
+
+        switch (*m_transitionDirection) {
+        case TransitionDirection::PreviousHorizontal:
+        case TransitionDirection::PreviousVertical: {
+            // Previous page pulls down up from the top or right.
+            topLayerRow.containerLayer->setPosition(layerPosition);
+            topLayerRow.containerLayer->setOpacity(layerOpacities[topLayerIndex][startIndex]);
+            if (additionalVisibleRowIndex) {
+                auto& bottomRow = m_rows[topLayerRowIndex + 1];
+                bottomRow.containerLayer->setOpacity(layerOpacities[bottomLayerIndex][startIndex]);
+            }
+            break;
+        }
+        case TransitionDirection::NextHorizontal:
+        case TransitionDirection::NextVertical: {
+            // Current page pushes up from the bottom, revealing the next page.
+            topLayerRow.containerLayer->setPosition(layerPosition);
+            topLayerRow.containerLayer->setOpacity(layerOpacities[topLayerIndex][startIndex]);
+            if (additionalVisibleRowIndex) {
+                auto& bottomRow = m_rows[topLayerRowIndex + 1];
+                bottomRow.containerLayer->setOpacity(layerOpacities[bottomLayerIndex][startIndex]);
+            }
+            break;
+        }
+        }
+        break;
+    }
+
+    case PageTransitionState::Animating:
+        break;
+    }
+}
+
+#pragma mark -
+
+bool PDFDiscretePresentationController::canGoToNextRow() const
+{
+    if (m_rows.isEmpty())
+        return false;
+
+    return m_visibleRowIndex < m_rows.size() - 1;
+}
+
+bool PDFDiscretePresentationController::canGoToPreviousRow() const
+{
+    return m_visibleRowIndex > 0;
+}
+
+void PDFDiscretePresentationController::goToNextRow(Animated)
+{
+    if (!canGoToNextRow())
+        return;
+
+    setVisibleRow(m_visibleRowIndex + 1);
+}
+
+void PDFDiscretePresentationController::goToPreviousRow(Animated)
+{
+    if (!canGoToPreviousRow())
+        return;
+
+    setVisibleRow(m_visibleRowIndex - 1);
+}
+
+void PDFDiscretePresentationController::goToRowIndex(unsigned rowIndex, Animated)
+{
+    if (rowIndex >= m_rows.size())
+        return;
+
+    setVisibleRow(rowIndex);
+}
+
+void PDFDiscretePresentationController::setVisibleRow(unsigned rowIndex)
+{
+    ASSERT(rowIndex < m_rows.size());
+
+    if (rowIndex == m_visibleRowIndex)
+        return;
+
+    m_plugin->willChangeVisibleRow();
+
+    m_visibleRowIndex = rowIndex;
+    updateLayersAfterChangeInVisibleRow();
+
+    m_plugin->didChangeVisibleRow();
+}
+
+#pragma mark -
+
+PDFPageCoverage PDFDiscretePresentationController::pageCoverageForContentsRect(const FloatRect& paintingRect, std::optional<PDFLayoutRow> row) const
+{
+    if (!row) {
+        // PDFDiscretePresentationController layout is row-based.
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+
+    auto contentsRect = convertFromPaintingToContents(paintingRect, row->pages[0]);
+
+    auto drawingRect = IntRect { { }, m_plugin->documentSize() };
+    drawingRect.intersect(enclosingIntRect(contentsRect));
+
+    auto rectInPDFLayoutCoordinates = m_plugin->convertDown(UnifiedPDFPlugin::CoordinateSpace::Contents, UnifiedPDFPlugin::CoordinateSpace::PDFDocumentLayout, FloatRect { drawingRect });
+
+    auto& documentLayout = m_plugin->documentLayout();
+    auto pageCoverage = PDFPageCoverage { };
+
+    auto addPageToCoverage = [&](PDFDocumentLayout::PageIndex pageIndex) {
+        auto pageBounds = documentLayout.layoutBoundsForPageAtIndex(pageIndex);
+        if (!pageBounds.intersects(rectInPDFLayoutCoordinates))
+            return;
+
+        pageCoverage.append(PerPageInfo { pageIndex, pageBounds });
+    };
+
+    for (auto pageIndex : row->pages)
+        addPageToCoverage(pageIndex);
+
+    return pageCoverage;
+}
+
+PDFPageCoverageAndScales PDFDiscretePresentationController::pageCoverageAndScalesForContentsRect(const FloatRect& clipRect, std::optional<PDFLayoutRow> row, float tilingScaleFactor) const
+{
+    if (!row) {
+        // PDFDiscretePresentationController layout is row-based.
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+
+    auto pageCoverageAndScales = PDFPageCoverageAndScales { pageCoverageForContentsRect(clipRect, row) };
+
+    pageCoverageAndScales.deviceScaleFactor = m_plugin->deviceScaleFactor();
+    pageCoverageAndScales.pdfDocumentScale = m_plugin->documentLayout().scale();
+    pageCoverageAndScales.tilingScaleFactor = tilingScaleFactor;
+    pageCoverageAndScales.contentsOffset = contentsOffsetForPage(row->pages[0]);
+
+    return pageCoverageAndScales;
+}
+
+FloatSize PDFDiscretePresentationController::contentsOffsetForPage(PDFDocumentLayout::PageIndex pageIndex) const
+{
+    auto rowIndex = m_plugin->documentLayout().rowIndexForPageIndex(pageIndex);
+    if (rowIndex >= m_rows.size())
+        return { };
+
+    return m_rows[rowIndex].contentsOffset;
+}
+
+FloatRect PDFDiscretePresentationController::convertFromContentsToPainting(const FloatRect& rect, std::optional<PDFDocumentLayout::PageIndex> pageIndex) const
+{
+    if (!pageIndex) {
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+
+    auto rowOffset = contentsOffsetForPage(*pageIndex);
+    auto adjustedRect = rect;
+    adjustedRect.move(-rowOffset);
+    return adjustedRect;
+}
+
+FloatRect PDFDiscretePresentationController::convertFromPaintingToContents(const FloatRect& rect, std::optional<PDFDocumentLayout::PageIndex> pageIndex) const
+{
+    if (!pageIndex) {
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+
+    auto rowOffset = contentsOffsetForPage(*pageIndex);
+    auto adjustedRect = rect;
+    adjustedRect.move(rowOffset);
+    return adjustedRect;
+}
+
+void PDFDiscretePresentationController::deviceOrPageScaleFactorChanged()
+{
+    for (auto& row : m_rows) {
+        // We need to manually propagate noteDeviceOrPageScaleFactorChangedIncludingDescendants to the layers of unparented rows.
+        if (!row.containerLayer->parent())
+            row.containerLayer->noteDeviceOrPageScaleFactorChangedIncludingDescendants();
+    }
+}
+
+void PDFDiscretePresentationController::setupLayers(GraphicsLayer& scrolledContentsLayer)
+{
+    if (!m_rowsContainerLayer) {
+        m_rowsContainerLayer = createGraphicsLayer("Rows container"_s, GraphicsLayer::Type::Normal);
+        m_rowsContainerLayer->setAnchorPoint({ });
+        scrolledContentsLayer.addChild(*m_rowsContainerLayer);
+    }
+
+    bool displayModeChanged = !m_displayModeAtLastLayerSetup || m_displayModeAtLastLayerSetup != m_plugin->documentLayout().displayMode();
+    m_displayModeAtLastLayerSetup = m_plugin->documentLayout().displayMode();
+
+    if (displayModeChanged) {
+        clearAsyncRenderer();
+        m_rows.clear();
+    }
+
+    buildRows();
+}
+
+void PDFDiscretePresentationController::buildRows()
+{
+    // For incrementally loading PDFs we may have some rows already. This has to handle incremental changes.
+    auto layoutRows = m_plugin->documentLayout().rows();
+
+    // FIXME: <https://webkit.org/b/276981> Need to unregister for removed layers.
+    m_rows.resize(layoutRows.size());
+
+    auto createRowPageBackgroundContainerLayers = [&](size_t rowIndex, PDFLayoutRow& layoutRow, RowData& row) {
+        ASSERT(!row.leftPageContainerLayer);
+
+        auto leftPageIndex = layoutRow.pages[0];
+
+        row.leftPageContainerLayer = makePageContainerLayer(leftPageIndex);
+        RefPtr pageBackgroundLayer = pageBackgroundLayerForPageContainerLayer(*row.leftPageContainerLayer);
+        m_layerIDToRowIndexMap.add(pageBackgroundLayer->primaryLayerID(), rowIndex);
+
+        if (row.pages.numPages() == 1) {
+            ASSERT(!row.rightPageContainerLayer);
+            return;
+        }
+
+        auto rightPageIndex = layoutRow.pages[1];
+        row.rightPageContainerLayer = makePageContainerLayer(rightPageIndex);
+        RefPtr rightPageBackgroundLayer = pageBackgroundLayerForPageContainerLayer(*row.rightPageContainerLayer);
+        m_layerIDToRowIndexMap.add(rightPageBackgroundLayer->primaryLayerID(), rowIndex);
+    };
+
+    auto parentRowLayers = [](RowData& row) {
+        ASSERT(row.containerLayer->children().isEmpty());
+        row.containerLayer->addChild(*row.leftPageContainerLayer);
+        if (row.rightPageContainerLayer)
+            row.containerLayer->addChild(*row.rightPageContainerLayer);
+
+        row.containerLayer->addChild(*row.contentsLayer);
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+        row.containerLayer->addChild(*row.selectionLayer);
+#endif
+    };
+
+    auto ensureLayersForRow = [&](size_t rowIndex, PDFLayoutRow& layoutRow, RowData& row) {
+        if (row.containerLayer)
+            return;
+
+        row.containerLayer = createGraphicsLayer(makeString("Row container "_s, rowIndex), GraphicsLayer::Type::Normal);
+        row.containerLayer->setAnchorPoint({ });
+
+        createRowPageBackgroundContainerLayers(rowIndex, layoutRow, row);
+
+        // This contents layer is used to paint both pages in two-up; it spans across both backgrounds.
+        row.contentsLayer = createGraphicsLayer(makeString("Row contents "_s, rowIndex), GraphicsLayer::Type::TiledBacking);
+        row.contentsLayer->setAnchorPoint({ });
+        row.contentsLayer->setDrawsContent(true);
+        row.contentsLayer->setAcceleratesDrawing(m_plugin->canPaintSelectionIntoOwnedLayer());
+
+        // This is the call that enables async rendering.
+        asyncRenderer()->startTrackingLayer(*row.contentsLayer);
+
+        m_layerIDToRowIndexMap.set(row.contentsLayer->primaryLayerID(), rowIndex);
+
+
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+        row.selectionLayer = createGraphicsLayer(makeString("Row selection "_s, rowIndex), GraphicsLayer::Type::TiledBacking);
+        row.selectionLayer->setAnchorPoint({ });
+        row.selectionLayer->setDrawsContent(true);
+        row.selectionLayer->setAcceleratesDrawing(true);
+        row.selectionLayer->setBlendMode(BlendMode::Multiply);
+        m_layerIDToRowIndexMap.set(row.selectionLayer->primaryLayerID(), rowIndex);
+#endif
+
+        parentRowLayers(row);
+    };
+
+    for (size_t rowIndex = 0; rowIndex < layoutRows.size(); ++rowIndex) {
+        auto& layoutRow = layoutRows[rowIndex];
+        auto& row = m_rows[rowIndex];
+
+        row.pages = layoutRow;
+
+        ensureLayersForRow(rowIndex, layoutRow, row);
+    }
+}
+
+FloatPoint PDFDiscretePresentationController::positionForRowContainerLayer(const PDFLayoutRow& row) const
+{
+    auto& documentLayout = m_plugin->documentLayout();
+
+    auto rowPageBounds = documentLayout.layoutBoundsForRow(row);
+    auto scaledRowBounds = rowPageBounds;
+    scaledRowBounds.scale(documentLayout.scale());
+
+    return scaledRowBounds.location();
+}
+
+FloatSize PDFDiscretePresentationController::rowContainerSize(const PDFLayoutRow& row) const
+{
+    auto& documentLayout = m_plugin->documentLayout();
+
+    auto rowPageBounds = documentLayout.layoutBoundsForRow(row);
+    auto scaledRowBounds = rowPageBounds;
+    scaledRowBounds.scale(documentLayout.scale());
+
+    return scaledRowBounds.size();
+}
+
+void PDFDiscretePresentationController::updateLayersOnLayoutChange(FloatSize documentSize, FloatSize centeringOffset, double scaleFactor)
+{
+    LOG_WITH_STREAM(PDF, stream << "PDFDiscretePresentationController::updateLayersOnLayoutChange - documentSize " << documentSize << " centeringOffset " << centeringOffset);
+
+    auto& documentLayout = m_plugin->documentLayout();
+
+    TransformationMatrix documentScaleTransform;
+    documentScaleTransform.scale(documentLayout.scale());
+
+    auto updatePageContainerLayerBounds = [&](GraphicsLayer* pageContainerLayer, PDFDocumentLayout::PageIndex pageIndex, const FloatRect& rowBounds) {
+        auto pageBounds = documentLayout.layoutBoundsForPageAtIndex(pageIndex);
+        // Account for row.containerLayer already being positioned by the origin of rowBounds.
+        pageBounds.moveBy(-rowBounds.location());
+
+        auto destinationRect = pageBounds;
+        destinationRect.scale(documentLayout.scale());
+
+        pageContainerLayer->setPosition(destinationRect.location());
+        pageContainerLayer->setSize(destinationRect.size());
+
+        RefPtr pageBackgroundLayer = pageBackgroundLayerForPageContainerLayer(*pageContainerLayer);
+        pageBackgroundLayer->setSize(pageBounds.size());
+        pageBackgroundLayer->setTransform(documentScaleTransform);
+    };
+
+    auto updateRowPageContainerLayers = [&](const RowData& row, const FloatRect& rowBounds) {
+        auto leftPageIndex = row.pages.pages[0];
+        updatePageContainerLayerBounds(row.leftPageContainerLayer.get(), leftPageIndex, rowBounds);
+
+        if (row.pages.numPages() == 1)
+            return;
+
+        auto rightPageIndex = row.pages.pages[1];
+        updatePageContainerLayerBounds(row.rightPageContainerLayer.get(), rightPageIndex, rowBounds);
+    };
+
+    TransformationMatrix transform;
+    transform.scale(scaleFactor);
+    transform.translate(centeringOffset.width(), centeringOffset.height());
+
+    m_rowsContainerLayer->setTransform(transform);
+
+    for (auto& row : m_rows) {
+        // Same as positionForRowContainerLayer().
+        auto rowPageBounds = documentLayout.layoutBoundsForRow(row.pages);
+        auto scaledRowBounds = rowPageBounds;
+        scaledRowBounds.scale(documentLayout.scale());
+
+        row.containerLayer->setPosition(scaledRowBounds.location());
+        row.containerLayer->setSize(scaledRowBounds.size());
+
+        updateRowPageContainerLayers(row, rowPageBounds);
+
+        row.contentsLayer->setPosition({ });
+
+        bool needsRepaint = false;
+        // This contents offset accounts for containerLayer being positioned with an offset from the edge of the
+        // plugin's "contents" area. When painting into row.contentsLayer, we need to take this into account.
+        // This is done via convertFromContentsToPainting()/convertFromPaintingToContents().
+        auto newContentsOffset = toFloatSize(scaledRowBounds.location());
+        if (row.contentsOffset != newContentsOffset) {
+            row.contentsOffset = newContentsOffset;
+            needsRepaint = true;
+        }
+
+        if (row.contentsLayer->size() != scaledRowBounds.size()) {
+            row.contentsLayer->setSize(scaledRowBounds.size());
+            needsRepaint = true;
+        }
+
+        if (needsRepaint)
+            row.contentsLayer->setNeedsDisplay();
+
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+        row.selectionLayer->setPosition({ });
+        row.selectionLayer->setSize(scaledRowBounds.size());
+        if (needsRepaint)
+            row.selectionLayer->setNeedsDisplay();
+#endif
+    }
+
+    updateLayersAfterChangeInVisibleRow();
+}
+
+void PDFDiscretePresentationController::updateLayersAfterChangeInVisibleRow(std::optional<unsigned> additionalVisibleRowIndex)
+{
+    if (m_visibleRowIndex >= m_rows.size())
+        return;
+
+    if (additionalVisibleRowIndex && *additionalVisibleRowIndex >= m_rows.size())
+        additionalVisibleRowIndex = { };
+
+    m_rowsContainerLayer->removeAllChildren();
+
+    auto& visibleRow = m_rows[m_visibleRowIndex];
+
+    auto updateRowTiledLayers = [](RowData& row, bool isInWindow) {
+        row.contentsLayer->setIsInWindow(isInWindow);
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+        row.selectionLayer->setIsInWindow(isInWindow);
+#endif
+    };
+
+    bool isInWindow = m_plugin->isInWindow();
+    updateRowTiledLayers(visibleRow, isInWindow);
+
+    RefPtr rowContainer = visibleRow.containerLayer;
+    m_rowsContainerLayer->addChild(rowContainer.releaseNonNull());
+
+    if (additionalVisibleRowIndex) {
+        auto& additionalVisibleRow = m_rows[*additionalVisibleRowIndex];
+        updateRowTiledLayers(additionalVisibleRow, isInWindow);
+
+        RefPtr rowContainer = additionalVisibleRow.containerLayer;
+        if (*additionalVisibleRowIndex < m_visibleRowIndex)
+            m_rowsContainerLayer->addChild(rowContainer.releaseNonNull());
+        else
+            m_rowsContainerLayer->addChildAtIndex(rowContainer.releaseNonNull(), 0);
+    }
+}
+
+void PDFDiscretePresentationController::updateIsInWindow(bool isInWindow)
+{
+    for (auto& row : m_rows) {
+        row.contentsLayer->setIsInWindow(isInWindow);
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+        row.selectionLayer->setIsInWindow(isInWindow);
+#endif
+    }
+}
+
+void PDFDiscretePresentationController::updateDebugBorders(bool showDebugBorders, bool showRepaintCounters)
+{
+    auto propagateSettingsToLayer = [&] (GraphicsLayer& layer) {
+        layer.setShowDebugBorder(showDebugBorders);
+        layer.setShowRepaintCounter(showRepaintCounters);
+    };
+
+    for (auto& row : m_rows) {
+        propagateSettingsToLayer(*row.containerLayer);
+
+        propagateSettingsToLayer(*row.leftPageContainerLayer);
+        propagateSettingsToLayer(*row.leftPageBackgroundLayer());
+
+        if (row.rightPageContainerLayer) {
+            propagateSettingsToLayer(*row.rightPageContainerLayer);
+            propagateSettingsToLayer(*row.rightPageBackgroundLayer());
+        }
+
+        propagateSettingsToLayer(*row.contentsLayer);
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+        propagateSettingsToLayer(*row.selectionLayer);
+#endif
+    }
+
+    if (RefPtr asyncRenderer = asyncRendererIfExists())
+        asyncRenderer->setShowDebugBorders(showDebugBorders);
+}
+
+void PDFDiscretePresentationController::updateForCurrentScrollability(OptionSet<TiledBackingScrollability>)
+{
+
+}
+
+void PDFDiscretePresentationController::repaintForIncrementalLoad()
+{
+    for (auto& row : m_rows) {
+        if (RefPtr leftBackgroundLayer = row.leftPageBackgroundLayer())
+            leftBackgroundLayer->setNeedsDisplay();
+
+        if (RefPtr rightBackgroundLayer = row.leftPageBackgroundLayer())
+            rightBackgroundLayer->setNeedsDisplay();
+
+        row.contentsLayer->setNeedsDisplay();
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+        row.selectionLayer->setNeedsDisplay();
+#endif
+    }
+}
+
+void PDFDiscretePresentationController::setNeedsRepaintInDocumentRect(OptionSet<RepaintRequirement> repaintRequirements, const FloatRect& rectInDocumentCoordinates, std::optional<PDFLayoutRow> layoutRow)
+{
+    ASSERT(layoutRow);
+    if (!layoutRow)
+        return;
+
+    auto rowIndex = m_plugin->documentLayout().rowIndexForPageIndex(layoutRow->pages[0]);
+    if (rowIndex >= m_rows.size())
+        return;
+
+    auto& row = m_rows[rowIndex];
+
+    auto contentsRect = m_plugin->convertUp(UnifiedPDFPlugin::CoordinateSpace::PDFDocumentLayout, UnifiedPDFPlugin::CoordinateSpace::Contents, rectInDocumentCoordinates);
+    contentsRect = convertFromContentsToPainting(contentsRect, row.pages.pages[0]);
+
+    if (repaintRequirements.contains(RepaintRequirement::PDFContent)) {
+        if (RefPtr asyncRenderer = asyncRendererIfExists())
+            asyncRenderer->pdfContentChangedInRect(row.contentsLayer.get(), m_plugin->nonNormalizedScaleFactor(), contentsRect);
+    }
+
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    if (repaintRequirements.contains(RepaintRequirement::Selection) && m_plugin->canPaintSelectionIntoOwnedLayer()) {
+        RefPtr { row.selectionLayer }->setNeedsDisplayInRect(contentsRect);
+        if (repaintRequirements.hasExactlyOneBitSet())
+            return;
+    }
+#endif
+
+    RefPtr { row.contentsLayer.get() }->setNeedsDisplayInRect(contentsRect);
+}
+
+void PDFDiscretePresentationController::didGeneratePreviewForPage(PDFDocumentLayout::PageIndex pageIndex)
+{
+    auto rowIndex = m_plugin->documentLayout().rowIndexForPageIndex(pageIndex);
+    if (rowIndex >= m_rows.size())
+        return;
+
+    auto& row = m_rows[rowIndex];
+    if (RefPtr backgroundLayer = row.backgroundLayerForPageIndex(pageIndex))
+        backgroundLayer->setNeedsDisplay();
+}
+
+#pragma mark -
+
+auto PDFDiscretePresentationController::pdfPositionForCurrentView(bool preservePosition) const -> std::optional<VisiblePDFPosition>
+{
+    if (!preservePosition)
+        return { };
+
+    if (!m_plugin->documentLayout().hasLaidOutPDFDocument())
+        return { };
+
+    auto visibleRow = this->visibleRow();
+    if (!visibleRow)
+        return { };
+
+    return VisiblePDFPosition { visibleRow->pages[0], { } };
+}
+
+void PDFDiscretePresentationController::restorePDFPosition(const VisiblePDFPosition& info)
+{
+    ensurePageIsVisible(info.pageIndex);
+}
+
+void PDFDiscretePresentationController::ensurePageIsVisible(PDFDocumentLayout::PageIndex pageIndex)
+{
+    auto rowIndex = m_plugin->documentLayout().rowIndexForPageIndex(pageIndex);
+    setVisibleRow(rowIndex);
+}
+
+#pragma mark -
+
+void PDFDiscretePresentationController::notifyFlushRequired(const GraphicsLayer*)
+{
+    m_plugin->scheduleRenderingUpdate();
+}
+
+// This is a GraphicsLayerClient function. The return value is used to compute layer contentsScale, so we don't
+// want to use the normalized scale factor.
+float PDFDiscretePresentationController::pageScaleFactor() const
+{
+    return m_plugin->nonNormalizedScaleFactor();
+}
+
+float PDFDiscretePresentationController::deviceScaleFactor() const
+{
+    return m_plugin->deviceScaleFactor();
+}
+
+std::optional<float> PDFDiscretePresentationController::customContentsScale(const GraphicsLayer* layer) const
+{
+    auto* rowData = rowDataForLayerID(layer->primaryLayerID());
+    if (!rowData)
+        return { };
+
+    if (rowData->isPageBackgroundLayer(layer))
+        return m_plugin->scaleForPagePreviews();
+
+    return { };
+}
+
+bool PDFDiscretePresentationController::layerNeedsPlatformContext(const GraphicsLayer* layer) const
+{
+    if (m_plugin->canPaintSelectionIntoOwnedLayer())
+        return false;
+
+    // We need a platform context if the plugin can not paint selections into its own layer,
+    // since we would then have to vend a platform context that PDFKit can paint into.
+    // However, this constraint only applies for the contents layer. No other layer needs to be WP-backed.
+    auto* rowData = rowDataForLayerID(layer->primaryLayerID());
+    if (!rowData)
+        return false;
+
+    return layer == rowData->contentsLayer.get();
+}
+
+void PDFDiscretePresentationController::tiledBackingUsageChanged(const GraphicsLayer* layer, bool usingTiledBacking)
+{
+    if (usingTiledBacking)
+        layer->tiledBacking()->setIsInWindow(m_plugin->isInWindow());
+}
+
+void PDFDiscretePresentationController::paintBackgroundLayerForRow(const GraphicsLayer* layer, GraphicsContext& context, const FloatRect& clipRect, unsigned rowIndex)
+{
+    if (rowIndex >= m_rows.size())
+        return;
+
+    auto& row = m_rows[rowIndex];
+    auto& documentLayout = m_plugin->documentLayout();
+
+    auto paintOnePageBackground = [&](PDFDocumentLayout::PageIndex pageIndex) {
+        auto destinationRect = documentLayout.layoutBoundsForPageAtIndex(pageIndex);
+        destinationRect.setLocation({ });
+
+        if (RefPtr asyncRenderer = asyncRendererIfExists())
+            asyncRenderer->paintPagePreview(context, clipRect, destinationRect, pageIndex);
+    };
+
+    if (layer == row.leftPageBackgroundLayer().get()) {
+        paintOnePageBackground(row.pages.pages[0]);
+        return;
+    }
+
+    if (layer == row.rightPageBackgroundLayer().get() && row.pages.numPages() == 2) {
+        paintOnePageBackground(row.pages.pages[1]);
+        return;
+    }
+}
+
+auto PDFDiscretePresentationController::rowDataForLayerID(PlatformLayerIdentifier layerID) const -> const RowData*
+{
+    auto rowIndex = m_layerIDToRowIndexMap.getOptional(layerID);
+    if (!rowIndex)
+        return nullptr;
+
+    if (*rowIndex >= m_rows.size())
+        return nullptr;
+
+    return &m_rows[*rowIndex];
+}
+
+std::optional<PDFLayoutRow> PDFDiscretePresentationController::visibleRow() const
+{
+    if (m_visibleRowIndex >= m_rows.size())
+        return { };
+
+    return m_rows[m_visibleRowIndex].pages;
+}
+
+std::optional<PDFLayoutRow> PDFDiscretePresentationController::rowForLayerID(PlatformLayerIdentifier layerID) const
+{
+    auto* rowData = rowDataForLayerID(layerID);
+    if (rowData)
+        return rowData->pages;
+
+    return { };
+}
+
+void PDFDiscretePresentationController::paintContents(const GraphicsLayer* layer, GraphicsContext& context, const FloatRect& clipRect, OptionSet<GraphicsLayerPaintBehavior>)
+{
+    auto rowIndex = m_layerIDToRowIndexMap.getOptional(layer->primaryLayerID());
+    if (!rowIndex)
+        return;
+
+    if (*rowIndex >= m_rows.size())
+        return;
+
+    auto& rowData = m_rows[*rowIndex];
+    if (rowData.isPageBackgroundLayer(layer)) {
+        paintBackgroundLayerForRow(layer, context, clipRect, *rowIndex);
+        return;
+    }
+
+    if (layer == rowData.contentsLayer.get()) {
+        RefPtr asyncRenderer = asyncRendererIfExists();
+        m_plugin->paintPDFContent(layer, context, clipRect, rowData.pages, UnifiedPDFPlugin::PaintingBehavior::All, asyncRenderer.get());
+        return;
+    }
+
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    if (layer == rowData.selectionLayer.get())
+        return paintPDFSelection(layer, context, clipRect, rowData.pages);
+#endif
+}
+
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+void PDFDiscretePresentationController::paintPDFSelection(const GraphicsLayer* layer, GraphicsContext& context, const FloatRect& clipRect, std::optional<PDFLayoutRow> row)
+{
+    m_plugin->paintPDFSelection(layer, context, clipRect, row);
+}
+#endif
+
+#pragma mark -
+
+bool PDFDiscretePresentationController::RowData::isPageBackgroundLayer(const GraphicsLayer* layer) const
+{
+    if (!layer)
+        return false;
+
+    if (layer == leftPageBackgroundLayer().get())
+        return true;
+
+    if (layer == rightPageBackgroundLayer().get())
+        return true;
+
+    return false;
+}
+
+RefPtr<GraphicsLayer> PDFDiscretePresentationController::RowData::leftPageBackgroundLayer() const
+{
+    return PDFPresentationController::pageBackgroundLayerForPageContainerLayer(*leftPageContainerLayer);
+}
+
+RefPtr<GraphicsLayer> PDFDiscretePresentationController::RowData::rightPageBackgroundLayer() const
+{
+    if (!rightPageContainerLayer)
+        return nullptr;
+
+    return PDFPresentationController::pageBackgroundLayerForPageContainerLayer(*rightPageContainerLayer);
+}
+
+RefPtr<GraphicsLayer> PDFDiscretePresentationController::RowData::backgroundLayerForPageIndex(PDFDocumentLayout::PageIndex pageIndex) const
+{
+    if (pageIndex == pages.pages[0])
+        return PDFPresentationController::pageBackgroundLayerForPageContainerLayer(*leftPageContainerLayer);
+
+    if (pages.numPages() == 2 && pageIndex == pages.pages[1] && rightPageContainerLayer)
+        return PDFPresentationController::pageBackgroundLayerForPageContainerLayer(*rightPageContainerLayer);
+
+    return nullptr;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h
@@ -46,6 +46,7 @@ using PDFPageCoverage = Vector<PerPageInfo>;
 
 struct PDFPageCoverageAndScales {
     PDFPageCoverage pages;
+    WebCore::FloatSize contentsOffset { };
     float deviceScaleFactor { 1 };
     float pdfDocumentScale { 1 };
     float tilingScaleFactor { 1 };

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm
@@ -38,7 +38,7 @@ TextStream& operator<<(TextStream& ts, const PerPageInfo& pageInfo)
 
 TextStream& operator<<(TextStream& ts, const PDFPageCoverageAndScales& coverage)
 {
-    ts << "PDFPageCoverage " << coverage.pages << " pdfDocumentScale " << coverage.pdfDocumentScale << " " << " tiling scale " << coverage.tilingScaleFactor;
+    ts << "PDFPageCoverage " << coverage.pages << " pdfDocumentScale " << coverage.pdfDocumentScale << " " << " tiling scale " << coverage.tilingScaleFactor << " contents offst " << coverage.contentsOffset;
     return ts;
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(UNIFIED_PDF)
+
+#include "PDFDocumentLayout.h"
+#include "PDFPageCoverage.h"
+#include <wtf/OptionSet.h>
+
+namespace WebCore {
+enum class TiledBackingScrollability : uint8_t;
+class GraphicsLayerClient;
+class GraphicsLayer;
+};
+
+namespace WebKit {
+
+class AsyncPDFRenderer;
+class WebKeyboardEvent;
+class UnifiedPDFPlugin;
+enum class RepaintRequirement : uint8_t;
+
+class PDFPresentationController {
+public:
+    static std::unique_ptr<PDFPresentationController> createForMode(PDFDocumentLayout::DisplayMode, UnifiedPDFPlugin&);
+
+    PDFPresentationController(UnifiedPDFPlugin&);
+    virtual ~PDFPresentationController();
+
+    // Subclasses must call the base class teardown().
+    virtual void teardown();
+
+    virtual bool supportsDisplayMode(PDFDocumentLayout::DisplayMode) const = 0;
+    virtual void willChangeDisplayMode(PDFDocumentLayout::DisplayMode newMode) = 0;
+
+    virtual PDFPageCoverage pageCoverageForContentsRect(const WebCore::FloatRect&, std::optional<PDFLayoutRow>) const = 0;
+    virtual PDFPageCoverageAndScales pageCoverageAndScalesForContentsRect(const WebCore::FloatRect&, std::optional<PDFLayoutRow>, float tilingScaleFactor) const = 0;
+
+    virtual WebCore::FloatRect convertFromContentsToPainting(const WebCore::FloatRect&, std::optional<PDFDocumentLayout::PageIndex> = { }) const = 0;
+    virtual WebCore::FloatRect convertFromPaintingToContents(const WebCore::FloatRect&, std::optional<PDFDocumentLayout::PageIndex> = { }) const = 0;
+
+    virtual void deviceOrPageScaleFactorChanged() = 0;
+
+    virtual void setupLayers(WebCore::GraphicsLayer&) = 0;
+    virtual void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor) = 0;
+
+    virtual void updateIsInWindow(bool isInWindow) = 0;
+    virtual void updateDebugBorders(bool showDebugBorders, bool showRepaintCounters) = 0;
+
+    virtual void updateForCurrentScrollability(OptionSet<WebCore::TiledBackingScrollability>) = 0;
+
+    virtual void didGeneratePreviewForPage(PDFDocumentLayout::PageIndex) = 0;
+
+    virtual void repaintForIncrementalLoad() = 0;
+    virtual void setNeedsRepaintInDocumentRect(OptionSet<RepaintRequirement>, const WebCore::FloatRect& rectInDocumentCoordinates, std::optional<PDFLayoutRow>) = 0;
+
+    virtual std::optional<PDFLayoutRow> visibleRow() const { return { }; }
+    virtual std::optional<PDFLayoutRow> rowForLayerID(WebCore::PlatformLayerIdentifier) const { return { }; }
+
+    struct VisiblePDFPosition {
+        PDFDocumentLayout::PageIndex pageIndex { 0 };
+        WebCore::FloatPoint pagePoint;
+    };
+
+    virtual std::optional<VisiblePDFPosition> pdfPositionForCurrentView(bool preservePosition = true) const = 0;
+    virtual void restorePDFPosition(const VisiblePDFPosition&) = 0;
+
+    virtual void ensurePageIsVisible(PDFDocumentLayout::PageIndex) = 0;
+
+    // Event handling.
+    virtual bool handleKeyboardEvent(const WebKeyboardEvent&) = 0;
+
+    virtual bool wantsWheelEvents() const { return false; }
+    virtual bool handleWheelEvent(const WebWheelEvent&) { return false; }
+
+protected:
+    virtual WebCore::GraphicsLayerClient& graphicsLayerClient() = 0;
+
+    RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String&, WebCore::GraphicsLayer::Type);
+    RefPtr<WebCore::GraphicsLayer> makePageContainerLayer(PDFDocumentLayout::PageIndex);
+
+    static RefPtr<WebCore::GraphicsLayer> pageBackgroundLayerForPageContainerLayer(WebCore::GraphicsLayer&);
+
+    Ref<AsyncPDFRenderer> asyncRenderer();
+    RefPtr<AsyncPDFRenderer> asyncRendererIfExists() const;
+    void clearAsyncRenderer();
+
+    Ref<UnifiedPDFPlugin> m_plugin;
+    RefPtr<AsyncPDFRenderer> m_asyncRenderer;
+
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PDFPresentationController.h"
+
+#if ENABLE(UNIFIED_PDF)
+
+#include "AsyncPDFRenderer.h"
+#include "PDFDiscretePresentationController.h"
+#include "PDFScrollingPresentationController.h"
+#include <WebCore/GraphicsLayer.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+std::unique_ptr<PDFPresentationController> PDFPresentationController::createForMode(PDFDocumentLayout::DisplayMode mode, UnifiedPDFPlugin& plugin)
+{
+    if (PDFDocumentLayout::isScrollingDisplayMode(mode))
+        return makeUnique<PDFScrollingPresentationController>(plugin);
+
+    if (PDFDocumentLayout::isDiscreteDisplayMode(mode))
+        return makeUnique<PDFDiscretePresentationController>(plugin);
+
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+PDFPresentationController::PDFPresentationController(UnifiedPDFPlugin& plugin)
+    : m_plugin(plugin)
+{
+
+}
+
+PDFPresentationController::~PDFPresentationController() = default;
+
+void PDFPresentationController::teardown()
+{
+    clearAsyncRenderer();
+}
+
+Ref<AsyncPDFRenderer> PDFPresentationController::asyncRenderer()
+{
+    if (m_asyncRenderer)
+        return *m_asyncRenderer;
+
+    m_asyncRenderer = AsyncPDFRenderer::create(m_plugin.get());
+    return *m_asyncRenderer;
+}
+
+RefPtr<AsyncPDFRenderer> PDFPresentationController::asyncRendererIfExists() const
+{
+    return m_asyncRenderer;
+}
+
+void PDFPresentationController::clearAsyncRenderer()
+{
+    if (RefPtr asyncRenderer = std::exchange(m_asyncRenderer, nullptr))
+        asyncRenderer->teardown();
+}
+
+RefPtr<GraphicsLayer> PDFPresentationController::createGraphicsLayer(const String& name, GraphicsLayer::Type layerType)
+{
+    auto* graphicsLayerFactory = m_plugin->graphicsLayerFactory();
+    if (!graphicsLayerFactory)
+        return nullptr;
+
+    Ref graphicsLayer = GraphicsLayer::create(graphicsLayerFactory, graphicsLayerClient(), layerType);
+    graphicsLayer->setName(name);
+    return graphicsLayer;
+}
+
+RefPtr<GraphicsLayer> PDFPresentationController::makePageContainerLayer(PDFDocumentLayout::PageIndex pageIndex)
+{
+    auto addLayerShadow = [](GraphicsLayer& layer, IntPoint shadowOffset, const Color& shadowColor, int shadowStdDeviation) {
+        Vector<Ref<FilterOperation>> filterOperations;
+        filterOperations.append(DropShadowFilterOperation::create(shadowOffset, shadowStdDeviation, shadowColor));
+        layer.setFilters(FilterOperations { WTFMove(filterOperations) });
+    };
+
+    constexpr auto containerShadowOffset = IntPoint { 0, 1 };
+    constexpr auto containerShadowColor = SRGBA<uint8_t> { 0, 0, 0, 46 };
+    constexpr int containerShadowStdDeviation = 2;
+
+    constexpr auto shadowOffset = IntPoint { 0, 2 };
+    constexpr auto shadowColor = SRGBA<uint8_t> { 0, 0, 0, 38 };
+    constexpr int shadowStdDeviation = 6;
+
+    RefPtr pageContainerLayer = createGraphicsLayer(makeString("Page container "_s, pageIndex), GraphicsLayer::Type::Normal);
+    RefPtr pageBackgroundLayer = createGraphicsLayer(makeString("Page background "_s, pageIndex), GraphicsLayer::Type::Normal);
+    // Can only be null if this->page() is null, which we checked above.
+    ASSERT(pageContainerLayer);
+    ASSERT(pageBackgroundLayer);
+
+    pageContainerLayer->setAnchorPoint({ });
+    addLayerShadow(*pageContainerLayer, containerShadowOffset, containerShadowColor, containerShadowStdDeviation);
+
+    pageBackgroundLayer->setAnchorPoint({ });
+    pageBackgroundLayer->setBackgroundColor(Color::white);
+
+    pageBackgroundLayer->setDrawsContent(true);
+    pageBackgroundLayer->setAcceleratesDrawing(true);
+    pageBackgroundLayer->setShouldUpdateRootRelativeScaleFactor(false);
+    pageBackgroundLayer->setNeedsDisplay(); // We only need to paint this layer once when page backgrounds change.
+
+    // FIXME: <https://webkit.org/b/276981> Need to add a 1px black border with alpha 0.0586.
+
+    addLayerShadow(*pageBackgroundLayer, shadowOffset, shadowColor, shadowStdDeviation);
+
+    pageContainerLayer->addChild(*pageBackgroundLayer);
+
+    return pageContainerLayer;
+}
+
+RefPtr<GraphicsLayer> PDFPresentationController::pageBackgroundLayerForPageContainerLayer(GraphicsLayer& pageContainerLayer)
+{
+    auto& children = pageContainerLayer.children();
+    if (children.size()) {
+        Ref layer = children[0];
+        return WTFMove(layer);
+    }
+
+    return nullptr;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(UNIFIED_PDF)
+
+#include "PDFPresentationController.h"
+#include <WebCore/GraphicsLayerClient.h>
+#include <wtf/CheckedPtr.h>
+
+namespace WebCore {
+class KeyboardScrollingAnimator;
+};
+
+namespace WebKit {
+
+class PDFScrollingPresentationController final : public PDFPresentationController, public WebCore::GraphicsLayerClient {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(PDFScrollingPresentationController);
+public:
+    PDFScrollingPresentationController(UnifiedPDFPlugin&);
+
+
+private:
+    bool supportsDisplayMode(PDFDocumentLayout::DisplayMode) const override;
+    void willChangeDisplayMode(PDFDocumentLayout::DisplayMode) override { }
+
+    void teardown() override;
+
+    PDFPageCoverage pageCoverageForContentsRect(const WebCore::FloatRect&, std::optional<PDFLayoutRow>) const override;
+    PDFPageCoverageAndScales pageCoverageAndScalesForContentsRect(const WebCore::FloatRect&, std::optional<PDFLayoutRow>, float tilingScaleFactor) const override;
+
+    WebCore::FloatRect convertFromContentsToPainting(const WebCore::FloatRect& rect, std::optional<PDFDocumentLayout::PageIndex>) const override { return rect; }
+    WebCore::FloatRect convertFromPaintingToContents(const WebCore::FloatRect& rect, std::optional<PDFDocumentLayout::PageIndex>) const override { return rect; }
+
+    void deviceOrPageScaleFactorChanged() override { }
+
+    void setupLayers(WebCore::GraphicsLayer& scrolledContentsLayer) override;
+    void updateLayersOnLayoutChange(WebCore::FloatSize documentSize, WebCore::FloatSize centeringOffset, double scaleFactor) override;
+
+    void updateIsInWindow(bool isInWindow) override;
+    void updateDebugBorders(bool showDebugBorders, bool showRepaintCounters) override;
+    void updateForCurrentScrollability(OptionSet<WebCore::TiledBackingScrollability>) override;
+
+    GraphicsLayerClient& graphicsLayerClient() override { return *this; }
+
+    bool handleKeyboardEvent(const WebKeyboardEvent&) override;
+#if PLATFORM(MAC)
+    bool handleKeyboardCommand(const WebKeyboardEvent&);
+    CheckedPtr<WebCore::KeyboardScrollingAnimator> checkedKeyboardScrollingAnimator() const;
+#endif
+
+    std::optional<VisiblePDFPosition> pdfPositionForCurrentView(bool preservePosition) const override;
+    void restorePDFPosition(const VisiblePDFPosition&) override;
+
+    void ensurePageIsVisible(PDFDocumentLayout::PageIndex) override { }
+
+    // GraphicsLayerClient
+    void notifyFlushRequired(const WebCore::GraphicsLayer*) override;
+    float pageScaleFactor() const override;
+    float deviceScaleFactor() const override;
+    std::optional<float> customContentsScale(const WebCore::GraphicsLayer*) const override;
+    bool layerNeedsPlatformContext(const WebCore::GraphicsLayer*) const override;
+    void tiledBackingUsageChanged(const WebCore::GraphicsLayer*, bool /*usingTiledBacking*/) override;
+    void paintContents(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect&, OptionSet<WebCore::GraphicsLayerPaintBehavior>) override;
+
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    void paintPDFSelection(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect, std::optional<PDFLayoutRow> = { });
+#endif
+
+    void updatePageBackgroundLayers();
+    std::optional<PDFDocumentLayout::PageIndex> pageIndexForPageBackgroundLayer(const WebCore::GraphicsLayer*) const;
+    WebCore::GraphicsLayer* backgroundLayerForPage(PDFDocumentLayout::PageIndex) const;
+
+    void didGeneratePreviewForPage(PDFDocumentLayout::PageIndex) override;
+
+    void paintBackgroundLayerForPage(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect, PDFDocumentLayout::PageIndex);
+
+    void repaintForIncrementalLoad() override;
+    void setNeedsRepaintInDocumentRect(OptionSet<RepaintRequirement>, const WebCore::FloatRect& rectInDocumentCoordinates, std::optional<PDFLayoutRow>) override;
+
+    RefPtr<WebCore::GraphicsLayer> m_pageBackgroundsContainerLayer;
+    RefPtr<WebCore::GraphicsLayer> m_contentsLayer;
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    RefPtr<WebCore::GraphicsLayer> m_selectionLayer;
+#endif
+
+    HashMap<RefPtr<WebCore::GraphicsLayer>, PDFDocumentLayout::PageIndex> m_pageBackgroundLayers;
+};
+
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -1,0 +1,450 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PDFScrollingPresentationController.h"
+
+#if ENABLE(UNIFIED_PDF)
+
+#include "Logging.h"
+#include "UnifiedPDFPlugin.h"
+#include "WebKeyboardEvent.h"
+#include <WebCore/GraphicsLayer.h>
+#include <WebCore/KeyboardScrollingAnimator.h>
+#include <WebCore/ScrollAnimator.h>
+#include <WebCore/TiledBacking.h>
+#include <WebCore/TransformationMatrix.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+PDFScrollingPresentationController::PDFScrollingPresentationController(UnifiedPDFPlugin& plugin)
+    : PDFPresentationController(plugin)
+{
+
+}
+
+void PDFScrollingPresentationController::teardown()
+{
+    PDFPresentationController::teardown();
+
+    GraphicsLayer::unparentAndClear(m_contentsLayer);
+    GraphicsLayer::unparentAndClear(m_pageBackgroundsContainerLayer);
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    GraphicsLayer::unparentAndClear(m_selectionLayer);
+#endif
+}
+
+bool PDFScrollingPresentationController::supportsDisplayMode(PDFDocumentLayout::DisplayMode mode) const
+{
+    return PDFDocumentLayout::isScrollingDisplayMode(mode);
+}
+
+#pragma mark -
+
+bool PDFScrollingPresentationController::handleKeyboardEvent(const WebKeyboardEvent& event)
+{
+#if PLATFORM(MAC)
+    if (handleKeyboardCommand(event))
+        return true;
+#endif
+
+    return false;
+}
+
+#if PLATFORM(MAC)
+CheckedPtr<WebCore::KeyboardScrollingAnimator> PDFScrollingPresentationController::checkedKeyboardScrollingAnimator() const
+{
+    return m_plugin->scrollAnimator().keyboardScrollingAnimator();
+}
+
+bool PDFScrollingPresentationController::handleKeyboardCommand(const WebKeyboardEvent& event)
+{
+    auto& commands = event.commands();
+    if (commands.size() != 1)
+        return false;
+
+    auto commandName = commands[0].commandName;
+    if (commandName == "scrollToBeginningOfDocument:"_s)
+        return checkedKeyboardScrollingAnimator()->beginKeyboardScrollGesture(ScrollDirection::ScrollUp, ScrollGranularity::Document, false);
+
+    if (commandName == "scrollToEndOfDocument:"_s)
+        return checkedKeyboardScrollingAnimator()->beginKeyboardScrollGesture(ScrollDirection::ScrollDown, ScrollGranularity::Document, false);
+
+    return false;
+}
+#endif
+
+#pragma mark -
+
+PDFPageCoverage PDFScrollingPresentationController::pageCoverageForContentsRect(const FloatRect& contentsRect, std::optional<PDFLayoutRow>) const
+{
+    auto drawingRect = IntRect { { }, m_plugin->documentSize() };
+    drawingRect.intersect(enclosingIntRect(contentsRect));
+    auto rectInPDFLayoutCoordinates = m_plugin->convertDown(UnifiedPDFPlugin::CoordinateSpace::Contents, UnifiedPDFPlugin::CoordinateSpace::PDFDocumentLayout, FloatRect { drawingRect });
+
+    auto& documentLayout = m_plugin->documentLayout();
+    auto pageCoverage = PDFPageCoverage { };
+    for (PDFDocumentLayout::PageIndex i = 0; i < documentLayout.pageCount(); ++i) {
+        auto page = documentLayout.pageAtIndex(i);
+        if (!page)
+            continue;
+
+        auto pageBounds = documentLayout.layoutBoundsForPageAtIndex(i);
+        if (!pageBounds.intersects(rectInPDFLayoutCoordinates))
+            continue;
+
+        pageCoverage.append(PerPageInfo { i, pageBounds });
+    }
+
+    return pageCoverage;
+}
+
+PDFPageCoverageAndScales PDFScrollingPresentationController::pageCoverageAndScalesForContentsRect(const FloatRect& clipRect, std::optional<PDFLayoutRow> row, float tilingScaleFactor) const
+{
+    auto pageCoverageAndScales = PDFPageCoverageAndScales { pageCoverageForContentsRect(clipRect, row) };
+
+    pageCoverageAndScales.deviceScaleFactor = m_plugin->deviceScaleFactor();
+    pageCoverageAndScales.pdfDocumentScale = m_plugin->documentLayout().scale();
+    pageCoverageAndScales.tilingScaleFactor = tilingScaleFactor;
+
+    return pageCoverageAndScales;
+}
+
+void PDFScrollingPresentationController::setupLayers(GraphicsLayer& scrolledContentsLayer)
+{
+    if (!m_pageBackgroundsContainerLayer) {
+        m_pageBackgroundsContainerLayer = createGraphicsLayer("Page backgrounds"_s, GraphicsLayer::Type::Normal);
+        m_pageBackgroundsContainerLayer->setAnchorPoint({ });
+        scrolledContentsLayer.addChild(*m_pageBackgroundsContainerLayer);
+    }
+
+    if (!m_contentsLayer) {
+        m_contentsLayer = createGraphicsLayer("PDF contents"_s, m_plugin->isFullMainFramePlugin() ? GraphicsLayer::Type::PageTiledBacking : GraphicsLayer::Type::TiledBacking);
+        m_contentsLayer->setAnchorPoint({ });
+        m_contentsLayer->setDrawsContent(true);
+        m_contentsLayer->setAcceleratesDrawing(m_plugin->canPaintSelectionIntoOwnedLayer());
+        scrolledContentsLayer.addChild(*m_contentsLayer);
+
+        // This is the call that enables async rendering.
+        asyncRenderer()->startTrackingLayer(*m_contentsLayer);
+    }
+
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    if (!m_selectionLayer) {
+        m_selectionLayer = createGraphicsLayer("PDF selections"_s, GraphicsLayer::Type::TiledBacking);
+        m_selectionLayer->setAnchorPoint({ });
+        m_selectionLayer->setDrawsContent(true);
+        m_selectionLayer->setAcceleratesDrawing(true);
+        m_selectionLayer->setBlendMode(BlendMode::Multiply);
+        scrolledContentsLayer.addChild(*m_selectionLayer);
+    }
+#endif
+}
+
+void PDFScrollingPresentationController::updateLayersOnLayoutChange(FloatSize documentSize, FloatSize centeringOffset, double scaleFactor)
+{
+    m_contentsLayer->setSize(documentSize);
+    m_contentsLayer->setNeedsDisplay();
+
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    m_selectionLayer->setSize(documentSize);
+    m_selectionLayer->setNeedsDisplay();
+#endif
+
+    TransformationMatrix transform;
+    transform.scale(scaleFactor);
+    transform.translate(centeringOffset.width(), centeringOffset.height());
+
+    m_contentsLayer->setTransform(transform);
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    m_selectionLayer->setTransform(transform);
+#endif
+    m_pageBackgroundsContainerLayer->setTransform(transform);
+
+    updatePageBackgroundLayers();
+}
+
+void PDFScrollingPresentationController::updatePageBackgroundLayers()
+{
+    auto& documentLayout = m_plugin->documentLayout();
+
+    Vector<Ref<GraphicsLayer>> pageContainerLayers = m_pageBackgroundsContainerLayer->children();
+
+    // pageContentsLayers are always the size of `layoutBoundsForPageAtIndex`; we generate a page preview
+    // buffer of the same size. On zooming, this layer just gets scaled, to avoid repainting.
+
+    for (PDFDocumentLayout::PageIndex i = 0; i < documentLayout.pageCount(); ++i) {
+        auto pageBoundsRect = documentLayout.layoutBoundsForPageAtIndex(i);
+        auto destinationRect = pageBoundsRect;
+        destinationRect.scale(documentLayout.scale());
+
+        auto pageContainerLayer = [&](PDFDocumentLayout::PageIndex pageIndex) {
+            if (pageIndex < pageContainerLayers.size())
+                return pageContainerLayers[pageIndex];
+
+            RefPtr pageContainerLayer = makePageContainerLayer(pageIndex);
+
+            // Sure would be nice if we could just stuff data onto a GraphicsLayer.
+            RefPtr pageBackgroundLayer = pageBackgroundLayerForPageContainerLayer(*pageContainerLayer);
+            m_pageBackgroundLayers.add(pageBackgroundLayer, pageIndex);
+
+            auto containerLayer = pageContainerLayer.releaseNonNull();
+            pageContainerLayers.append(WTFMove(containerLayer));
+
+            return pageContainerLayers[pageIndex];
+        }(i);
+
+        pageContainerLayer->setPosition(destinationRect.location());
+        pageContainerLayer->setSize(destinationRect.size());
+
+        auto pageBackgroundLayer = pageContainerLayer->children()[0];
+        pageBackgroundLayer->setSize(pageBoundsRect.size());
+
+        TransformationMatrix documentScaleTransform;
+        documentScaleTransform.scale(documentLayout.scale());
+        pageBackgroundLayer->setTransform(documentScaleTransform);
+    }
+
+    m_pageBackgroundsContainerLayer->setChildren(WTFMove(pageContainerLayers));
+}
+
+GraphicsLayer* PDFScrollingPresentationController::backgroundLayerForPage(PDFDocumentLayout::PageIndex pageIndex) const
+{
+    if (!m_pageBackgroundsContainerLayer)
+        return nullptr;
+
+    auto pageContainerLayers = m_pageBackgroundsContainerLayer->children();
+    if (pageContainerLayers.size() <= pageIndex)
+        return nullptr;
+
+    Ref pageContainerLayer = pageContainerLayers[pageIndex];
+    if (!pageContainerLayer->children().size())
+        return nullptr;
+
+    return pageContainerLayer->children()[0].ptr();
+}
+
+void PDFScrollingPresentationController::didGeneratePreviewForPage(PDFDocumentLayout::PageIndex pageIndex)
+{
+    if (RefPtr layer = backgroundLayerForPage(pageIndex))
+        layer->setNeedsDisplay();
+}
+
+void PDFScrollingPresentationController::repaintForIncrementalLoad()
+{
+    auto& documentLayout = m_plugin->documentLayout();
+    auto coverageRect = FloatRect { { }, documentLayout.contentsSize() };
+
+    if (auto* tiledBacking = m_contentsLayer->tiledBacking()) {
+        coverageRect = tiledBacking->coverageRect();
+        coverageRect = m_plugin->convertDown(UnifiedPDFPlugin::CoordinateSpace::Contents, UnifiedPDFPlugin::CoordinateSpace::PDFDocumentLayout, coverageRect);
+    }
+
+    setNeedsRepaintInDocumentRect(RepaintRequirement::PDFContent, coverageRect, { });
+}
+
+void PDFScrollingPresentationController::updateIsInWindow(bool isInWindow)
+{
+    m_contentsLayer->setIsInWindow(isInWindow);
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    if (m_selectionLayer)
+        m_selectionLayer->setIsInWindow(isInWindow);
+#endif
+
+    for (auto& pageLayer : m_pageBackgroundsContainerLayer->children()) {
+        if (pageLayer->children().size()) {
+            Ref pageContentsLayer = pageLayer->children()[0];
+            pageContentsLayer->setIsInWindow(isInWindow);
+        }
+    }
+}
+
+void PDFScrollingPresentationController::updateDebugBorders(bool showDebugBorders, bool showRepaintCounters)
+{
+    auto propagateSettingsToLayer = [&] (GraphicsLayer& layer) {
+        layer.setShowDebugBorder(showDebugBorders);
+        layer.setShowRepaintCounter(showRepaintCounters);
+    };
+
+    propagateSettingsToLayer(*m_pageBackgroundsContainerLayer);
+    propagateSettingsToLayer(*m_contentsLayer);
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    propagateSettingsToLayer(*m_selectionLayer);
+#endif
+
+    for (auto& pageLayer : m_pageBackgroundsContainerLayer->children()) {
+        propagateSettingsToLayer(pageLayer);
+        if (pageLayer->children().size())
+            propagateSettingsToLayer(pageLayer->children()[0]);
+    }
+
+    if (RefPtr asyncRenderer = asyncRendererIfExists())
+        asyncRenderer->setShowDebugBorders(showDebugBorders);
+}
+
+void PDFScrollingPresentationController::updateForCurrentScrollability(OptionSet<TiledBackingScrollability>)
+{
+    if (auto* tiledBacking = m_contentsLayer->tiledBacking())
+        tiledBacking->setScrollability(m_plugin->computeScrollability());
+}
+
+void PDFScrollingPresentationController::setNeedsRepaintInDocumentRect(OptionSet<RepaintRequirement> repaintRequirements, const FloatRect& rectInDocumentCoordinates, std::optional<PDFLayoutRow>)
+{
+    if (!repaintRequirements)
+        return;
+
+    auto contentsRect = m_plugin->convertUp(UnifiedPDFPlugin::CoordinateSpace::PDFDocumentLayout, UnifiedPDFPlugin::CoordinateSpace::Contents, rectInDocumentCoordinates);
+    if (repaintRequirements.contains(RepaintRequirement::PDFContent)) {
+        if (RefPtr asyncRenderer = asyncRendererIfExists())
+            asyncRenderer->pdfContentChangedInRect(m_contentsLayer.get(), m_plugin->nonNormalizedScaleFactor(), contentsRect);
+    }
+
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    if (repaintRequirements.contains(RepaintRequirement::Selection) && m_plugin->canPaintSelectionIntoOwnedLayer()) {
+        RefPtr { m_selectionLayer }->setNeedsDisplayInRect(contentsRect);
+        if (repaintRequirements.hasExactlyOneBitSet())
+            return;
+    }
+#endif
+
+    RefPtr { m_contentsLayer }->setNeedsDisplayInRect(contentsRect);
+}
+
+void PDFScrollingPresentationController::paintBackgroundLayerForPage(const GraphicsLayer*, GraphicsContext& context, const FloatRect& clipRect, PDFDocumentLayout::PageIndex pageIndex)
+{
+    auto& documentLayout = m_plugin->documentLayout();
+    auto destinationRect = documentLayout.layoutBoundsForPageAtIndex(pageIndex);
+    destinationRect.setLocation({ });
+
+    if (RefPtr asyncRenderer = asyncRendererIfExists())
+        asyncRenderer->paintPagePreview(context, clipRect, destinationRect, pageIndex);
+}
+
+std::optional<PDFDocumentLayout::PageIndex> PDFScrollingPresentationController::pageIndexForPageBackgroundLayer(const GraphicsLayer* layer) const
+{
+    auto it = m_pageBackgroundLayers.find(layer);
+    if (it == m_pageBackgroundLayers.end())
+        return { };
+
+    return it->value;
+}
+
+#pragma mark -
+
+auto PDFScrollingPresentationController::pdfPositionForCurrentView(bool preservePosition) const -> std::optional<VisiblePDFPosition>
+{
+    if (!preservePosition)
+        return { };
+
+    auto& documentLayout = m_plugin->documentLayout();
+
+    if (!documentLayout.hasLaidOutPDFDocument())
+        return { };
+
+    auto topLeftInDocumentSpace = m_plugin->convertDown(UnifiedPDFPlugin::CoordinateSpace::Plugin, UnifiedPDFPlugin::CoordinateSpace::PDFDocumentLayout, FloatPoint { });
+    auto [pageIndex, pointInPDFPageSpace] = documentLayout.pageIndexAndPagePointForDocumentYOffset(topLeftInDocumentSpace.y());
+
+    LOG_WITH_STREAM(PDF, stream << "PDFScrollingPresentationController::pdfPositionForCurrentView - point " << pointInPDFPageSpace << " in page " << pageIndex);
+
+    return VisiblePDFPosition { pageIndex, pointInPDFPageSpace };
+}
+
+void PDFScrollingPresentationController::restorePDFPosition(const VisiblePDFPosition& info)
+{
+    m_plugin->revealPointInPage(info.pagePoint, info.pageIndex);
+}
+
+#pragma mark -
+
+void PDFScrollingPresentationController::notifyFlushRequired(const GraphicsLayer*)
+{
+    m_plugin->scheduleRenderingUpdate();
+}
+
+// This is a GraphicsLayerClient function. The return value is used to compute layer contentsScale, so we don't
+// want to use the normalized scale factor.
+float PDFScrollingPresentationController::pageScaleFactor() const
+{
+    return m_plugin->nonNormalizedScaleFactor();
+}
+
+float PDFScrollingPresentationController::deviceScaleFactor() const
+{
+    return m_plugin->deviceScaleFactor();
+}
+
+std::optional<float> PDFScrollingPresentationController::customContentsScale(const GraphicsLayer* layer) const
+{
+    if (pageIndexForPageBackgroundLayer(layer))
+        return m_plugin->scaleForPagePreviews();
+
+    return { };
+}
+
+bool PDFScrollingPresentationController::layerNeedsPlatformContext(const GraphicsLayer* layer) const
+{
+    // We need a platform context if the plugin can not paint selections into its own layer,
+    // since we would then have to vend a platform context that PDFKit can paint into.
+    // However, this constraint only applies for the contents layer. No other layer needs to be WP-backed.
+    return layer == m_contentsLayer.get() && !m_plugin->canPaintSelectionIntoOwnedLayer();
+}
+
+void PDFScrollingPresentationController::tiledBackingUsageChanged(const GraphicsLayer* layer, bool usingTiledBacking)
+{
+    if (usingTiledBacking)
+        layer->tiledBacking()->setIsInWindow(m_plugin->isInWindow());
+}
+
+void PDFScrollingPresentationController::paintContents(const GraphicsLayer* layer, GraphicsContext& context, const FloatRect& clipRect, OptionSet<GraphicsLayerPaintBehavior>)
+{
+
+    if (layer == m_contentsLayer.get()) {
+        RefPtr asyncRenderer = asyncRendererIfExists();
+        m_plugin->paintPDFContent(layer, context, clipRect, { }, UnifiedPDFPlugin::PaintingBehavior::All, asyncRenderer.get());
+        return;
+    }
+
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+    if (layer == m_selectionLayer.get())
+        return paintPDFSelection(layer, context, clipRect, { });
+#endif
+
+    if (auto backgroundLayerPageIndex = pageIndexForPageBackgroundLayer(layer)) {
+        paintBackgroundLayerForPage(layer, context, clipRect, *backgroundLayerPageIndex);
+        return;
+    }
+}
+
+#if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
+void PDFScrollingPresentationController::paintPDFSelection(const GraphicsLayer* layer, GraphicsContext& context, const FloatRect& clipRect, std::optional<PDFLayoutRow> row)
+{
+    m_plugin->paintPDFSelection(layer, context, clipRect, row);
+}
+#endif
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_PDF)


### PR DESCRIPTION
#### 536ff7116f47121c9677e9f9daf0b5922f8424df
<pre>
[UnifiedPDF] Discrete presentation mode rewrite
<a href="https://bugs.webkit.org/show_bug.cgi?id=276622">https://bugs.webkit.org/show_bug.cgi?id=276622</a>
<a href="https://rdar.apple.com/125383130">rdar://125383130</a>

Reviewed by Tim Horton and Simon Fraser.

This patch rewrites document presentation in Unified PDF. We introduce
the notion of a `PDFPresentationController`, which handles how a PDF
document is presented. The PDF plugins also delegate event handling to
these presentation controllers.

We specialize the behavior of the presentation controller class
class to distinguish between continuous (scrolling) and discrete mode.

These changes are based primarily on a patch originally from Simon Fraser.

* LayoutTests/platform/mac-ventura/TestExpectations

Skip tests that enable UnifiedPDFPlugin on macOS 13. These tests crash
on that platform, and the UnifiedPDF plugin is meaningless before macOS
14 anyway.

* Source/WebCore/dom/Document.h:
* Source/WebCore/platform/ScrollableArea.h:
* Source/WebCore/platform/animation/TimingFunction.cpp:
(WebCore::CubicBezierTimingFunction::create):
* Source/WebCore/platform/animation/TimingFunction.h:
* Source/WebCore/platform/graphics/transforms/TransformOperations.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::overhangAmount const):
(WebKit::PDFPluginBase::wantsWheelEventsChanged):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::teardown):
(WebKit::AsyncPDFRenderer::releaseMemory):
(WebKit::AsyncPDFRenderer::startTrackingLayer):
(WebKit::AsyncPDFRenderer::stopTrackingLayer):
(WebKit::AsyncPDFRenderer::layerForTileGrid const):
(WebKit::AsyncPDFRenderer::renderInfoIsValidForTile const):
(WebKit::AsyncPDFRenderer::willRepaintTile):
(WebKit::AsyncPDFRenderer::coverageRectDidChange):
(WebKit::AsyncPDFRenderer::removePagePreviewsOutsideCoverageRect):
(WebKit::AsyncPDFRenderer::didAddGrid):
(WebKit::AsyncPDFRenderer::willRemoveGrid):
(WebKit::AsyncPDFRenderer::enqueueTilePaintIfNecessary):
(WebKit::AsyncPDFRenderer::renderInfoForTile const):
(WebKit::AsyncPDFRenderer::paintPDFIntoBuffer):
(WebKit::AsyncPDFRenderer::paintPDFPageIntoBuffer):
(WebKit::AsyncPDFRenderer::transferBufferToMainThread):
(WebKit::AsyncPDFRenderer::didCompleteTileRender):
(WebKit::AsyncPDFRenderer::paintTilesForPage):
(WebKit::AsyncPDFRenderer::pdfContentChangedInRect):
(WebKit::AsyncPDFRenderer::setupWithLayer): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h: Added.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm: Added.
(WebKit::elasticDeltaForTimeDelta):
(WebKit::operator&lt;&lt;):
(WebKit::PDFDiscretePresentationController::PDFDiscretePresentationController):
(WebKit::PDFDiscretePresentationController::teardown):
(WebKit::PDFDiscretePresentationController::supportsDisplayMode const):
(WebKit::PDFDiscretePresentationController::willChangeDisplayMode):
(WebKit::PDFDiscretePresentationController::handleKeyboardEvent):
(WebKit::PDFDiscretePresentationController::handleKeyboardCommand):
(WebKit::PDFDiscretePresentationController::handleKeyboardEventForPageNavigation):
(WebKit::PDFDiscretePresentationController::canTransitionOnSide const):
(WebKit::PDFDiscretePresentationController::canTransitionInDirection const):
(WebKit::PDFDiscretePresentationController::handleWheelEvent):
(WebKit::PDFDiscretePresentationController::eventCanStartPageTransition const):
(WebKit::PDFDiscretePresentationController::handleBeginEvent):
(WebKit::PDFDiscretePresentationController::handleChangedEvent):
(WebKit::PDFDiscretePresentationController::handleEndedEvent):
(WebKit::PDFDiscretePresentationController::handleCancelledEvent):
(WebKit::PDFDiscretePresentationController::handleDiscreteWheelEvent):
(WebKit::PDFDiscretePresentationController::maybeEndGesture):
(WebKit::PDFDiscretePresentationController::gestureEndTimerFired):
(WebKit::PDFDiscretePresentationController::startPageTransitionOrSettle):
(WebKit::PDFDiscretePresentationController::updateState):
(WebKit::PDFDiscretePresentationController::startOrStopAnimationTimerIfNecessary):
(WebKit::PDFDiscretePresentationController::animationTimerFired):
(WebKit::PDFDiscretePresentationController::animateRubberBand):
(WebKit::PDFDiscretePresentationController::startTransitionAnimation):
(WebKit::PDFDiscretePresentationController::transitionEndTimerFired):
(WebKit::PDFDiscretePresentationController::additionalVisibleRowIndexForDirection const):
(WebKit::PDFDiscretePresentationController::updateLayerVisibilityForTransitionState):
(WebKit::PDFDiscretePresentationController::applyWheelEventDelta):
(WebKit::PDFDiscretePresentationController::relevantAxisForDirection):
(WebKit::PDFDiscretePresentationController::setRelevantAxisForDirection):
(WebKit::PDFDiscretePresentationController::layerOpacitiesForStretchOffset const):
(WebKit::PDFDiscretePresentationController::layerOffsetForStretch const):
(WebKit::PDFDiscretePresentationController::updateLayersForTransitionState):
(WebKit::PDFDiscretePresentationController::canGoToNextRow const):
(WebKit::PDFDiscretePresentationController::canGoToPreviousRow const):
(WebKit::PDFDiscretePresentationController::goToNextRow):
(WebKit::PDFDiscretePresentationController::goToPreviousRow):
(WebKit::PDFDiscretePresentationController::goToRowIndex):
(WebKit::PDFDiscretePresentationController::setVisibleRow):
(WebKit::PDFDiscretePresentationController::pageCoverageForContentsRect const):
(WebKit::PDFDiscretePresentationController::pageCoverageAndScalesForContentsRect const):
(WebKit::PDFDiscretePresentationController::contentsOffsetForPage const):
(WebKit::PDFDiscretePresentationController::convertFromContentsToPainting const):
(WebKit::PDFDiscretePresentationController::convertFromPaintingToContents const):
(WebKit::PDFDiscretePresentationController::deviceOrPageScaleFactorChanged):
(WebKit::PDFDiscretePresentationController::setupLayers):
(WebKit::PDFDiscretePresentationController::buildRows):
(WebKit::PDFDiscretePresentationController::positionForRowContainerLayer const):
(WebKit::PDFDiscretePresentationController::rowContainerSize const):
(WebKit::PDFDiscretePresentationController::updateLayersOnLayoutChange):
(WebKit::PDFDiscretePresentationController::updateLayersAfterChangeInVisibleRow):
(WebKit::PDFDiscretePresentationController::updateIsInWindow):
(WebKit::PDFDiscretePresentationController::updateDebugBorders):
(WebKit::PDFDiscretePresentationController::updateForCurrentScrollability):
(WebKit::PDFDiscretePresentationController::repaintForIncrementalLoad):
(WebKit::PDFDiscretePresentationController::setNeedsRepaintInDocumentRect):
(WebKit::PDFDiscretePresentationController::didGeneratePreviewForPage):
(WebKit::PDFDiscretePresentationController::pdfPositionForCurrentView const):
(WebKit::PDFDiscretePresentationController::restorePDFPosition):
(WebKit::PDFDiscretePresentationController::ensurePageIsVisible):
(WebKit::PDFDiscretePresentationController::notifyFlushRequired):
(WebKit::PDFDiscretePresentationController::pageScaleFactor const):
(WebKit::PDFDiscretePresentationController::deviceScaleFactor const):
(WebKit::PDFDiscretePresentationController::customContentsScale const):
(WebKit::PDFDiscretePresentationController::layerNeedsPlatformContext const):
(WebKit::PDFDiscretePresentationController::tiledBackingUsageChanged):
(WebKit::PDFDiscretePresentationController::paintBackgroundLayerForRow):
(WebKit::PDFDiscretePresentationController::rowDataForLayerID const const):
(WebKit::PDFDiscretePresentationController::visibleRow const):
(WebKit::PDFDiscretePresentationController::rowForLayerID const):
(WebKit::PDFDiscretePresentationController::paintContents):
(WebKit::PDFDiscretePresentationController::paintPDFSelection):
(WebKit::PDFDiscretePresentationController::RowData::isPageBackgroundLayer const):
(WebKit::PDFDiscretePresentationController::RowData::leftPageBackgroundLayer const):
(WebKit::PDFDiscretePresentationController::RowData::rightPageBackgroundLayer const):
(WebKit::PDFDiscretePresentationController::RowData::backgroundLayerForPageIndex const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::nearestPageIndexForDocumentPoint const):
(WebKit::PDFDocumentLayout::updateLayout):
(WebKit::PDFDocumentLayout::layoutPages):
(WebKit::PDFDocumentLayout::layoutContinuousRows):
(WebKit::PDFDocumentLayout::layoutDiscreteRows):
(WebKit::PDFDocumentLayout::layoutRow):
(WebKit::PDFDocumentLayout::layoutSingleColumn): Deleted.
(WebKit::PDFDocumentLayout::layoutTwoUpColumn): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.mm:
(WebKit::operator&lt;&lt;):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h: Added.
(WebKit::PDFPresentationController::convertFromContentsToPainting):
(WebKit::PDFPresentationController::convertFromPaintingToContents):
(WebKit::PDFPresentationController::visibleRow const):
(WebKit::PDFPresentationController::rowForLayerID const):
(WebKit::PDFPresentationController::wantsWheelEvents const):
(WebKit::PDFPresentationController::handleWheelEvent):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm: Added.
(WebKit::PDFPresentationController::createForMode):
(WebKit::PDFPresentationController::PDFPresentationController):
(WebKit::PDFPresentationController::teardown):
(WebKit::PDFPresentationController::asyncRenderer):
(WebKit::PDFPresentationController::asyncRendererIfExists const):
(WebKit::PDFPresentationController::clearAsyncRenderer):
(WebKit::PDFPresentationController::createGraphicsLayer):
(WebKit::PDFPresentationController::makePageContainerLayer):
(WebKit::PDFPresentationController::pageBackgroundLayerForPageContainerLayer):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h: Added.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm: Added.
(WebKit::PDFScrollingPresentationController::PDFScrollingPresentationController):
(WebKit::PDFScrollingPresentationController::teardown):
(WebKit::PDFScrollingPresentationController::supportsDisplayMode const):
(WebKit::PDFScrollingPresentationController::handleKeyboardEvent):
(WebKit::PDFScrollingPresentationController::checkedKeyboardScrollingAnimator const):
(WebKit::PDFScrollingPresentationController::handleKeyboardCommand):
(WebKit::PDFScrollingPresentationController::pageCoverageForContentsRect const):
(WebKit::PDFScrollingPresentationController::pageCoverageAndScalesForContentsRect const):
(WebKit::PDFScrollingPresentationController::setupLayers):
(WebKit::PDFScrollingPresentationController::updateLayersOnLayoutChange):
(WebKit::PDFScrollingPresentationController::updatePageBackgroundLayers):
(WebKit::PDFScrollingPresentationController::backgroundLayerForPage const):
(WebKit::PDFScrollingPresentationController::didGeneratePreviewForPage):
(WebKit::PDFScrollingPresentationController::repaintForIncrementalLoad):
(WebKit::PDFScrollingPresentationController::updateIsInWindow):
(WebKit::PDFScrollingPresentationController::updateDebugBorders):
(WebKit::PDFScrollingPresentationController::updateForCurrentScrollability):
(WebKit::PDFScrollingPresentationController::setNeedsRepaintInDocumentRect):
(WebKit::PDFScrollingPresentationController::paintBackgroundLayerForPage):
(WebKit::PDFScrollingPresentationController::pageIndexForPageBackgroundLayer const):
(WebKit::PDFScrollingPresentationController::pdfPositionForCurrentView const):
(WebKit::PDFScrollingPresentationController::restorePDFPosition):
(WebKit::PDFScrollingPresentationController::notifyFlushRequired):
(WebKit::PDFScrollingPresentationController::pageScaleFactor const):
(WebKit::PDFScrollingPresentationController::deviceScaleFactor const):
(WebKit::PDFScrollingPresentationController::customContentsScale const):
(WebKit::PDFScrollingPresentationController::layerNeedsPlatformContext const):
(WebKit::PDFScrollingPresentationController::tiledBackingUsageChanged):
(WebKit::PDFScrollingPresentationController::paintContents):
(WebKit::PDFScrollingPresentationController::paintPDFSelection):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
(WebKit::UnifiedPDFPlugin::convertDown const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::teardown):
(WebKit::UnifiedPDFPlugin::setPresentationController):
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::graphicsLayerFactory const):
(WebKit::UnifiedPDFPlugin::setNeedsRepaintForAnnotation):
(WebKit::UnifiedPDFPlugin::setNeedsRepaintInDocumentRect):
(WebKit::UnifiedPDFPlugin::setNeedsRepaintInDocumentRects):
(WebKit::UnifiedPDFPlugin::ensureLayers):
(WebKit::UnifiedPDFPlugin::repaintForIncrementalLoad):
(WebKit::UnifiedPDFPlugin::didGeneratePreviewForPage):
(WebKit::UnifiedPDFPlugin::didSameDocumentNavigationForFrame):
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
(WebKit::UnifiedPDFPlugin::didChangeSettings):
(WebKit::UnifiedPDFPlugin::isInWindow const):
(WebKit::UnifiedPDFPlugin::didChangeIsInWindow):
(WebKit::UnifiedPDFPlugin::paint):
(WebKit::UnifiedPDFPlugin::paintContents):
(WebKit::UnifiedPDFPlugin::pageCoverageForContentsRect const):
(WebKit::UnifiedPDFPlugin::pageCoverageAndScalesForContentsRect const):
(WebKit::UnifiedPDFPlugin::paintPDFContent):
(WebKit::UnifiedPDFPlugin::paintPDFSelection):
(WebKit::UnifiedPDFPlugin::rowForLayerID const):
(WebKit::UnifiedPDFPlugin::pageScaleFactor const):
(WebKit::UnifiedPDFPlugin::didEndMagnificationGesture):
(WebKit::UnifiedPDFPlugin::setScaleFactor):
(WebKit::UnifiedPDFPlugin::setPageScaleFactor):
(WebKit::UnifiedPDFPlugin::deviceOrPageScaleFactorChanged):
(WebKit::UnifiedPDFPlugin::updateLayout):
(WebKit::UnifiedPDFPlugin::releaseMemory):
(WebKit::UnifiedPDFPlugin::didChangeScrollOffset):
(WebKit::UnifiedPDFPlugin::willChangeVisibleRow):
(WebKit::UnifiedPDFPlugin::didChangeVisibleRow):
(WebKit::UnifiedPDFPlugin::updateScrollingExtents):
(WebKit::UnifiedPDFPlugin::nearestPageIndexForDocumentPoint const):
(WebKit::UnifiedPDFPlugin::pageIndexForDocumentPoint const):
(WebKit::UnifiedPDFPlugin::indexForCurrentPageInView const):
(WebKit::UnifiedPDFPlugin::convertFromContentsToPainting const):
(WebKit::UnifiedPDFPlugin::convertFromPaintingToContents const):
(WebKit::UnifiedPDFPlugin::pdfElementTypesForPluginPoint const):
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::UnifiedPDFPlugin::wantsWheelEvents const):
(WebKit::UnifiedPDFPlugin::handleWheelEvent):
(WebKit::UnifiedPDFPlugin::wheelEventCopyWithVelocity const):
(WebKit::UnifiedPDFPlugin::handleKeyboardEvent):
(WebKit::UnifiedPDFPlugin::revealRectInPage):
(WebKit::UnifiedPDFPlugin::revealPointInPage):
(WebKit::UnifiedPDFPlugin::revealPage):
(WebKit::UnifiedPDFPlugin::scrollToPointInContentsSpace):
(WebKit::UnifiedPDFPlugin::createContextMenu const):
(WebKit::UnifiedPDFPlugin::pageCoverageForSelection const):
(WebKit::UnifiedPDFPlugin::repaintOnSelectionChange):
(WebKit::UnifiedPDFPlugin::continueAutoscroll):
(WebKit::UnifiedPDFPlugin::rectsForTextMatchesInRect const):
(WebKit::UnifiedPDFPlugin::textIndicatorForSelection):
(WebKit::UnifiedPDFPlugin::setDisplayMode):
(WebKit::UnifiedPDFPlugin::setDisplayModeAndUpdateLayout):
(WebKit::UnifiedPDFPlugin::asyncRenderer): Deleted.
(WebKit::UnifiedPDFPlugin::asyncRendererIfExists const): Deleted.
(WebKit::UnifiedPDFPlugin::updatePageBackgroundLayers): Deleted.
(WebKit::UnifiedPDFPlugin::paintBackgroundLayerForPage): Deleted.
(WebKit::UnifiedPDFPlugin::backgroundLayerForPage const): Deleted.
(WebKit::UnifiedPDFPlugin::pageIndexForPageBackgroundLayer const): Deleted.
(WebKit::UnifiedPDFPlugin::updateLayerPositions): Deleted.
(WebKit::UnifiedPDFPlugin::customContentsScale const): Deleted.
(WebKit::UnifiedPDFPlugin::layerNeedsPlatformContext const): Deleted.
(WebKit::UnifiedPDFPlugin::tiledBackingUsageChanged): Deleted.
(WebKit::UnifiedPDFPlugin::pageCoverageForRect const): Deleted.
(WebKit::UnifiedPDFPlugin::pageCoverageAndScalesForRect const): Deleted.
(WebKit::UnifiedPDFPlugin::scrollAnchoringForCurrentScrollPosition const): Deleted.
(WebKit::UnifiedPDFPlugin::restoreScrollPositionWithInfo): Deleted.
(WebKit::UnifiedPDFPlugin::populateScrollSnapIdentifiers): Deleted.
(WebKit::UnifiedPDFPlugin::pageForScrollSnapIdentifier const): Deleted.
(WebKit::UnifiedPDFPlugin::updateSnapOffsets): Deleted.
(WebKit::UnifiedPDFPlugin::determineCurrentlySnappedPage): Deleted.
(WebKit::UnifiedPDFPlugin::visibleRow const): Deleted.
(WebKit::UnifiedPDFPlugin::shouldDisplayPage): Deleted.
(WebKit::UnifiedPDFPlugin::convertDown const): Deleted.
(WebKit::UnifiedPDFPlugin::handleKeyboardCommand): Deleted.
(WebKit::UnifiedPDFPlugin::handleKeyboardEventForDiscreteDisplayMode): Deleted.
(WebKit::UnifiedPDFPlugin::snapToNearbyPageExtentForKeyboardScrolling): Deleted.
(WebKit::UnifiedPDFPlugin::showOrHideSelectionLayerAsNecessary): Deleted.

Canonical link: <a href="https://commits.webkit.org/281282@main">https://commits.webkit.org/281282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae84c8f29f949151e2959f6e25bd25e104086d47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59405 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63319 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/9915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10079 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48232 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/9915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51416 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29057 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8668 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8852 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65052 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3333 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51411 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/55679 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2767 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8866 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34564 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36733 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->