### PR TITLE
[run-benchmark] Add motionmark1.3 plan variant that enforces 60fps

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3-60FPS.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3-60FPS.patch
@@ -1,0 +1,32 @@
+diff --git a/resources/runner/motionmark.js b/resources/runner/motionmark.js
+index a2ea114..14a9cba 100644
+--- a/resources/runner/motionmark.js
++++ b/resources/runner/motionmark.js
+@@ -493,11 +496,12 @@ window.benchmarkController = {
+         this._startButton.disabled = true;
+         this._startButton.textContent = Strings.text.determininingFrameRate;
+ 
+-        let targetFrameRate;
++        let targetFrameRate = this.benchmarkDefaultParameters["frame-rate"];
++        /* Do no autodetect the frame-rate, use the one from benchmarkDefaultParameters (60FPS).
+         try {
+             targetFrameRate = await benchmarkController.determineFrameRate();
+         } catch (e) {
+-        }
++        }*/
+         this.frameRateDeterminationComplete(targetFrameRate);
+     },
+     
+diff --git a/resources/strings.js b/resources/strings.js
+index c82e047..45d7771 100644
+--- a/resources/strings.js
++++ b/resources/strings.js
+@@ -23,7 +23,7 @@
+  * THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ var Strings = {
+-    version: "1.3",
++    version: "1.3-60fps",
+     text: {
+         testName: "Test Name",
+         score: "Score",

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3-60fps.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3-60fps.plan
@@ -1,0 +1,5 @@
+{
+    "import_plan_file": "motionmark1.3.plan",
+    "output_file": "motionmark1.3-60fps.result",
+    "extra_patches": ["data/patches/extra/MotionMark1.3-60FPS.patch"]
+}


### PR DESCRIPTION
#### dc34ca810cb0d90efaaebfbd8efb805d7c1c5063
<pre>
[run-benchmark] Add motionmark1.3 plan variant that enforces 60fps
<a href="https://bugs.webkit.org/show_bug.cgi?id=276629">https://bugs.webkit.org/show_bug.cgi?id=276629</a>

Reviewed by Nikolas Zimmermann.

We would like to have a benchmark plan for MotionMark that skips the
auto-detection of the device frame-rate and always uses 60FPS, so we
can use this to track performance regressions on devices like desktop
machines and we can be sure that the benchmark does not auto-detect
a different frame-rate than 60FPS, so all the baselines remain the
same for all the devices running this specific benchmark plan.

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/extra/MotionMark1.3-60FPS.patch: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3-60fps.plan: Added.

Canonical link: <a href="https://commits.webkit.org/281052@main">https://commits.webkit.org/281052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/093fc5eca491346d6b12bfa47cfb28db0b400fc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61889 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8709 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47209 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6223 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28048 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/58075 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31997 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7670 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7713 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63594 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54529 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54592 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1861 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8728 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33421 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34507 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35591 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->