### PR TITLE
Update Tools/{gtk,wpe}/manifest.txt.in after PlatformWinCairo.cmake was removed

### DIFF
--- a/Tools/gtk/manifest.txt.in
+++ b/Tools/gtk/manifest.txt.in
@@ -3,11 +3,10 @@ exclude #$
 exclude ChangeLog
 exclude CMakeLists.txt.user
 exclude Makefile
-exclude PlatformAppleWin.cmake
 exclude PlatformMac.cmake
+exclude PlatformPlayStation.cmake
 exclude PlatformWPE.cmake
 exclude PlatformWin.cmake
-exclude PlatformWinCairo.cmake
 exclude tags$
 exclude ~$
 exclude \.#$
@@ -52,9 +51,9 @@ exclude Source/WebCore/platform/audio/resources
 exclude Source/WebCore/bindings/scripts/test
 exclude Source/WebCore/Resources
 exclude Source/WebKitLegacy/.*
-exclude Source/cmake/OptionsWinCairo.cmake$
-exclude Source/cmake/OptionsWindows.cmake$
-exclude Source/cmake/OptionsAppleWin.cmake$
+exclude Source/cmake/OptionsMac.cmake$
+exclude Source/cmake/OptionsPlayStation.cmake$
+exclude Source/cmake/OptionsWin.cmake$
 exclude Source/cmake/OptionsWPE.cmake$
 exclude Source/WebInspectorUI/Tools
 

--- a/Tools/wpe/manifest.txt.in
+++ b/Tools/wpe/manifest.txt.in
@@ -3,11 +3,10 @@ exclude #$
 exclude ChangeLog
 exclude CMakeLists.txt.user
 exclude Makefile
-exclude PlatformAppleWin.cmake
 exclude PlatformMac.cmake
+exclude PlatformPlayStation.cmake
 exclude PlatformGTK.cmake
 exclude PlatformWin.cmake
-exclude PlatformWinCairo.cmake
 exclude tags$
 exclude ~$
 exclude \.#$
@@ -52,9 +51,9 @@ exclude Source/WebCore/platform/audio/resources
 exclude Source/WebCore/bindings/scripts/test
 exclude Source/WebCore/Resources
 exclude Source/WebKitLegacy/.*
-exclude Source/cmake/OptionsWinCairo.cmake$
-exclude Source/cmake/OptionsWindows.cmake$
-exclude Source/cmake/OptionsAppleWin.cmake$
+exclude Source/cmake/OptionsMac.cmake$
+exclude Source/cmake/OptionsPlayStation.cmake$
+exclude Source/cmake/OptionsWin.cmake$
 exclude Source/cmake/OptionsGTK.cmake$
 exclude Source/WebInspectorUI/Tools
 


### PR DESCRIPTION
#### 4bc63e8fee1c89f385f2cc594fcaa21abe6bfd94
<pre>
Update Tools/{gtk,wpe}/manifest.txt.in after PlatformWinCairo.cmake was removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=276634">https://bugs.webkit.org/show_bug.cgi?id=276634</a>

Reviewed by Carlos Alberto Lopez Perez.

* Tools/gtk/manifest.txt.in:
* Tools/wpe/manifest.txt.in:
Removed PlatformWinCairo.cmake, OptionsAppleWin.cmake and OptionsWindows.cmake.
Added PlatformPlayStation.cmake, OptionsPlayStation.cmake and OptionsMac.cmake.

Canonical link: <a href="https://commits.webkit.org/281099@main">https://commits.webkit.org/281099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/078490d11df28e9b9902dea6ffa94213ed869ed4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58767 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/38095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11257 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/62398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/9211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60896 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/45732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/9411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/62398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/9211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60798 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/45732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/50824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/62398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/45732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/8120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8215 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/45732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/8398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/64100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/2680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/9411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/64100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/2689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/50848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/64100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8762 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/36094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/34755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->