### PR TITLE
[Static Analyzer CI] Add smart pointer analysis queue to EWS

### DIFF
--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -56,6 +56,7 @@ class Events(service.BuildbotService):
         'run-layout-tests-without-change', 'layout-tests-repeat-failures-without-change',
         'run-layout-tests-in-stress-mode', 'run-layout-tests-in-guard-malloc-stress-mode',
         'run-api-tests', 'run-api-tests-without-change', 're-run-api-tests',
+        'scan-build-smart-pointer', 'parse-static-analyzer-results', 'find-unexpected-smart-pointer-results',
         'jscore-test', 'jscore-test-without-change',
         'add-reviewer-to-commit-message', 'commit-patch', 'push-commit-to-webkit-repo', 'canonicalize-commit',
         'build-webkit-org-unit-tests', 'buildbot-check-config', 'buildbot-check-config-for-build-webkit', 'buildbot-check-config-for-ews',

--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -28,11 +28,11 @@ from .steps import (AddReviewerToCommitMessage, ApplyPatch, ApplyWatchList, Cano
                     CheckOutPullRequest, CheckOutSource, CheckOutSpecificRevision, CheckChangeRelevance,
                     CheckStatusOnEWSQueues, CheckStyle, CleanGitRepo, CleanDerivedSources, CompileJSC, CompileWebKit, ConfigureBuild, DetermineLabelOwner,
                     DownloadBuiltProduct, ExtractBuiltProduct, FetchBranches, FindModifiedLayoutTests, GetTestExpectationsBaseline, GetUpdatedTestExpectations, GitHub,
-                    InstallGtkDependencies, InstallHooks, InstallWpeDependencies, InstallWinDependencies, KillOldProcesses, PrintConfiguration, PushCommitToWebKitRepo, PushPullRequestBranch,
+                    InstallGtkDependencies, InstallHooks, InstallWpeDependencies, InstallWinDependencies, KillOldProcesses, PrintClangVersion, PrintConfiguration, PushCommitToWebKitRepo, PushPullRequestBranch,
                     MapBranchAlias, RemoveAndAddLabels, RetrievePRDataFromLabel, RunAPITests, RunBindingsTests, RunBuildWebKitOrgUnitTests, RunBuildbotCheckConfigForBuildWebKit, RunBuildbotCheckConfigForEWS,
                     RunEWSUnitTests, RunResultsdbpyTests, RunJavaScriptCoreTests, RunWebKit1Tests, RunWebKitPerlTests,
                     RunWebKitPyTests, RunWebKitTests, RunWebKitTestsRedTree, RunWebKitTestsInStressMode, RunWebKitTestsInStressGuardmallocMode,
-                    SetBuildSummary, ShowIdentifier, TriggerCrashLogSubmission, UpdateWorkingDirectory, UpdatePullRequest,
+                    ScanBuildSmartPointer, SetBuildSummary, ShowIdentifier, TriggerCrashLogSubmission, UpdateWorkingDirectory, UpdatePullRequest,
                     ValidateCommitMessage, ValidateChange, ValidateCommitterAndReviewer, WaitForCrashCollection,
                     InstallBuiltProduct, ValidateRemote, ValidateSquashed, GITHUB_PROJECTS)
 
@@ -95,6 +95,26 @@ class WatchListFactory(factory.BuildFactory):
         self.addStep(ApplyPatch())
         self.addStep(CheckOutPullRequest())
         self.addStep(ApplyWatchList())
+
+
+class SmartPointerStaticAnalyzerFactory(factory.BuildFactory):
+    findModifiedLayoutTests = False
+
+    def __init__(self, platform, configuration=None, architectures=None, buildOnly=True, triggers=None, triggered_by=None, remotes=None, additionalArguments=None, checkRelevance=False, **kwargs):
+        factory.BuildFactory.__init__(self)
+        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architectures=architectures, buildOnly=buildOnly, triggers=triggers, triggered_by=triggered_by, remotes=remotes, additionalArguments=additionalArguments))
+        if checkRelevance:
+            self.addStep(CheckChangeRelevance())
+        self.addStep(ValidateChange())
+        self.addStep(PrintConfiguration())
+        self.addStep(CleanGitRepo())
+        self.addStep(CheckOutSource())
+        self.addStep(FetchBranches())
+        self.addStep(ShowIdentifier())
+        self.addStep(PrintClangVersion())
+        self.addStep(CheckOutPullRequest())
+        self.addStep(KillOldProcesses())
+        self.addStep(ScanBuildSmartPointer())
 
 
 class BindingsFactory(Factory):

--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -38,7 +38,7 @@ from .factories import (APITestsFactory, BindingsFactory, BuildFactory, CommitQu
                         GTKTestsFactory, JSCBuildFactory, JSCBuildAndTestsFactory, JSCTestsFactory, MergeQueueFactory, SafeMergeQueueFactory, StressTestFactory,
                         StyleFactory, TestFactory, tvOSBuildFactory, WPEBuildFactory, WPECairoBuildFactory, WPETestsFactory, WebKitPerlFactory, WebKitPyFactory,
                         WinBuildFactory, WinTestsFactory, iOSBuildFactory, iOSEmbeddedBuildFactory, iOSTestsFactory,  visionOSBuildFactory, visionOSEmbeddedBuildFactory, visionOSTestsFactory, macOSBuildFactory, macOSBuildOnlyFactory,
-                        macOSWK1Factory, macOSWK2Factory, ServicesFactory, UnsafeMergeQueueFactory, WatchListFactory, watchOSBuildFactory)
+                        macOSWK1Factory, macOSWK2Factory, ServicesFactory, SmartPointerStaticAnalyzerFactory, UnsafeMergeQueueFactory, WatchListFactory, watchOSBuildFactory)
 
 from .utils import get_custom_suffix
 


### PR DESCRIPTION
#### 2d68279abbd5dc5a27a5f59521fbb1fbbbb83c7f
<pre>
[Static Analyzer CI] Add smart pointer analysis queue to EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=276625">https://bugs.webkit.org/show_bug.cgi?id=276625</a>
<a href="https://rdar.apple.com/131782284">rdar://131782284</a>

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/factories.py:
(SmartPointerStaticAnalyzerFactory.__init__): Added.

* Tools/CISupport/ews-build/steps.py:
(RevertAppliedChanges.__init__): Add exclude argument to ignore given patterns.
(RevertAppliedChanges.run):

(ScanBuildSmartPointer): Copied from build-webkit with following differences:
  - baseline arg added for building without PR changes applied
  - Call FindUnexpectedStaticAnalyzerResults with expectations = False if baseline build

(ParseStaticAnalyzerResults): Copied from build-webkit. Added baseline arg.

(FindUnexpectedStaticAnalyzerResults): Copied from build-webkit. Added expectations arg.
(FindUnexpectedStaticAnalyzerResults.run):
  - Run script with --check-expectations arg if expectations = True.
    If there are failures, rebuild without changes.
  - If expectations = False, compare PR results with baseline results.
(FindUnexpectedStaticAnalyzerResults.createResultMessage):

(DisplaySmartPointerResults): Copied from build-webkit. Slight differences in wording.
(DisplaySmartPointerResults.getFilesPerProject):
(DisplaySmartPointerResults.getResultSummary): Comment and block the PR if there are failures.

(PrintClangVersion): Copied from build-webkit with minor changes.
(ArchiveStaticAnalyzerResults): Ditto.
(UploadStaticAnalyzerResults): Ditto.
(ExtractStaticAnalyzerTestResults): Ditto.

Tools/CISupport/ews-build/events.py: Added steps to STEPS_TO_REPORT.
* Tools/CISupport/ews-build/steps_unittest.py:
* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/loadConfig.py:

Canonical link: <a href="https://commits.webkit.org/284319@main">https://commits.webkit.org/284319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6ae9b2d0bb03796b1938545ae873073a2201d9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/69053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/48453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21725 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/20211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/71170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/56254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/20060 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/73134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/20211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/72119 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/44232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/59617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/73134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/40898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/17047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/18585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/62847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/17392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/74843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/13035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/16637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/74843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/68731 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/13073 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/59700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/74843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/4122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10547 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/44257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/45330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/46526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/45072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->