### PR TITLE
Add support for opacity to the CSS parser fast-path

### DIFF
--- a/LayoutTests/fast/css/parsing-opacity-expected.txt
+++ b/LayoutTests/fast/css/parsing-opacity-expected.txt
@@ -17,6 +17,7 @@ PASS innerStyle("opacity", "100.25%") is "1.0025"
 PASS computedStyle("opacity", "0") is "0"
 PASS computedStyle("opacity", "0.5") is "0.5"
 PASS computedStyle("opacity", "1") is "1"
+PASS computedStyle("opacity", "1.") is "1"
 PASS computedStyle("opacity", "1000") is "1"
 PASS computedStyle("opacity", "-400") is "0"
 PASS computedStyle("opacity", "25%") is "0.25"
@@ -29,6 +30,10 @@ PASS innerStyle("opacity", "2px") is ""
 PASS innerStyle("opacity", "auto") is ""
 PASS innerStyle("opacity", "none") is ""
 PASS innerStyle("opacity", "'str'") is ""
+PASS innerStyle("opacity", "'inf'") is ""
+PASS innerStyle("opacity", "23.4a%") is ""
+PASS innerStyle("opacity", "23.4 a%") is ""
+PASS innerStyle("opacity", "23.4%%") is ""
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/parsing-opacity.html
+++ b/LayoutTests/fast/css/parsing-opacity.html
@@ -54,6 +54,7 @@ testInner("opacity", "100.25%", "1.0025");
 testComputed("opacity", "0", "0");
 testComputed("opacity", "0.5", "0.5");
 testComputed("opacity", "1", "1");
+testComputed("opacity", "1.", "1");
 testComputed("opacity", "1000", "1");
 testComputed("opacity", "-400", "0");
 testComputed("opacity", "25%", "0.25");
@@ -66,6 +67,10 @@ negativeTest("opacity", "2px");
 negativeTest("opacity", "auto");
 negativeTest("opacity", "none");
 negativeTest("opacity", "'str'");
+negativeTest("opacity", "'inf'");
+negativeTest("opacity", "23.4a%");
+negativeTest("opacity", "23.4 a%");
+negativeTest("opacity", "23.4%%");
 
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/Source/WebCore/css/parser/CSSParserFastPaths.h
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.h
@@ -55,7 +55,7 @@ public:
     static std::optional<SRGBA<uint8_t>> parseHexColor(StringView); // Hex colors of length 3, 4, 6, or 8, without leading "#".
     static std::optional<SRGBA<uint8_t>> parseNamedColor(StringView);
 
-    static bool isSimpleLengthPropertyID(CSSPropertyID, bool& acceptsNegativeNumbers);
+    static bool isSimpleLengthPropertyID(CSSPropertyID, ValueRange&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -175,8 +175,8 @@ RefPtr<CSSValue> CSSUnitValue::toCSSValue() const
 // FIXME: This function could be mostly generated from CSSProperties.json.
 static bool isValueOutOfRangeForProperty(CSSPropertyID propertyID, double value, CSSUnitType unit)
 {
-    bool acceptsNegativeNumbers = true;
-    if (CSSParserFastPaths::isSimpleLengthPropertyID(propertyID, acceptsNegativeNumbers) && !acceptsNegativeNumbers && value < 0)
+    ValueRange valueRange = ValueRange::All;
+    if (CSSParserFastPaths::isSimpleLengthPropertyID(propertyID, valueRange) && valueRange == ValueRange::NonNegative && value < 0)
         return true;
 
     switch (propertyID) {


### PR DESCRIPTION
#### 4d43216e1ba385baa7009dec90791314f7eb7e40
<pre>
Add support for opacity to the CSS parser fast-path
<a href="https://bugs.webkit.org/show_bug.cgi?id=276646">https://bugs.webkit.org/show_bug.cgi?id=276646</a>
<a href="https://rdar.apple.com/131808782">rdar://131808782</a>

Reviewed by Sam Weinig.

Add support for parsing opacity to CSSParserFastPaths, supporting numeric and percentage
forms.

Rearrange CSSParserFastPaths::maybeParseValue() to switch on the propertyID; previously we
we calling `parseSimpleTransform()` for things we knew were not a transform.

Hoist the call to `isSimpleLengthPropertyID()` out of `parseSimpleLengthValue()`. The
`isCSSViewportParsingEnabledForMode()` check there is obsolete and can probably be removed,
since we don&apos;t support `@viewport`. For simple length properties, we still fall through to
`parseKeywordValue()` for values like `auto`.

Support the `none` display value.

Remove `transformCanLikelyUseFastPath()` because it&apos;s faster to just call call
`parseSimpleTransformList()`.

* LayoutTests/fast/css/parsing-opacity-expected.txt:
* LayoutTests/fast/css/parsing-opacity.html:
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::CSSParserFastPaths::isSimpleLengthPropertyID):
(WebCore::parseSimpleNumberOrPercentage):
(WebCore::parseSimpleLengthValue):
(WebCore::parseColorIntOrPercentage):
(WebCore::parseHexColorInternal):
(WebCore::parseNumericColor):
(WebCore::parseSimpleTransformList):
(WebCore::parseSimpleTransform):
(WebCore::parseDisplay):
(WebCore::parseOpacity):
(WebCore::CSSParserFastPaths::maybeParseValue):
(WebCore::transformCanLikelyUseFastPath): Deleted.
* Source/WebCore/css/parser/CSSParserFastPaths.h:
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::isValueOutOfRangeForProperty):

Canonical link: <a href="https://commits.webkit.org/281010@main">https://commits.webkit.org/281010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d603e11c116124537f4218c25c50399c16ba70f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8838 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47294 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6302 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60424 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28137 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/32101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7795 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7842 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63723 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2307 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54612 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54678 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12896 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1950 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/34636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->