### PR TITLE
Remove remainders of CSSViewportRule

### DIFF
--- a/LayoutTests/fast/viewport/viewport-legacy-xhtmlmp-remove-and-add.html
+++ b/LayoutTests/fast/viewport/viewport-legacy-xhtmlmp-remove-and-add.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.0//EN" "http://www.wapforum.org/DTD/xhtml-mobile10.dtd">
 <head>
     <!--
-    Related spec: https://www.w3.org/TR/css-viewport/
+    Related spec: https://www.w3.org/TR/2016/WD-css-device-adapt-1-20160329/
 
     XHTML-MP is used for mobile documents which are assumed to be designed for
     handheld devices, hence using the viewport size as the initial containing

--- a/LayoutTests/fast/viewport/viewport-legacy-xhtmlmp.html
+++ b/LayoutTests/fast/viewport/viewport-legacy-xhtmlmp.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.0//EN" "http://www.wapforum.org/DTD/xhtml-mobile10.dtd">
 <head>
     <!--
-    Related spec: https://www.w3.org/TR/css-viewport/
+    Related spec: https://www.w3.org/TR/2016/WD-css-device-adapt-1-20160329/
 
     XHTML-MP is used for mobile documents which are assumed to be designed for
     handheld devices, hence using the viewport size as the initial containing

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1261,7 +1261,6 @@ $(PROJECT_DIR)/css/SelectorPseudoElementMap.in
 $(PROJECT_DIR)/css/StyleMedia.idl
 $(PROJECT_DIR)/css/StyleSheet.idl
 $(PROJECT_DIR)/css/StyleSheetList.idl
-$(PROJECT_DIR)/css/WebKitCSSViewportRule.idl
 $(PROJECT_DIR)/css/WebKitFontFamilyNames.in
 $(PROJECT_DIR)/css/counterStyles.css
 $(PROJECT_DIR)/css/fullscreen.css

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -1092,10 +1092,6 @@ RefPtr<CSSValue> CSSParserFastPaths::maybeParseValue(CSSPropertyID propertyID, S
 
     auto valueRange = ValueRange::All;
     if (CSSParserFastPaths::isSimpleLengthPropertyID(propertyID, valueRange)) {
-        // In @viewport, width and height are shorthands, not simple length values.
-        if (isCSSViewportParsingEnabledForMode(context.mode))
-            return nullptr;
-
         auto result = parseSimpleLengthValue(string, context.mode, valueRange);
         if (result)
             return result;

--- a/Source/WebCore/css/parser/CSSParserMode.h
+++ b/Source/WebCore/css/parser/CSSParserMode.h
@@ -38,9 +38,6 @@ enum CSSParserMode : uint8_t {
     HTMLQuirksMode,
     // SVG attributes are parsed in quirks mode but rules differ slightly.
     SVGAttributeMode,
-    // @viewport rules are parsed in standards mode but CSSOM modifications (via StylePropertySet)
-    // must call parseViewportProperties so needs a special mode.
-    CSSViewportRuleMode,
     // User agent stylesheets are parsed in standards mode but also allows internal properties and values.
     UASheetMode,
     // WebVTT places limitations on external resources.
@@ -62,11 +59,6 @@ inline bool isUnitlessValueParsingEnabledForMode(CSSParserMode mode)
     return mode == SVGAttributeMode;
 }
 
-inline bool isCSSViewportParsingEnabledForMode(CSSParserMode mode)
-{
-    return mode == CSSViewportRuleMode;
-}
-
 // FIXME-NEWPARSER: Next two functions should be removed eventually.
 inline CSSParserMode strictToCSSParserMode(bool inStrictMode)
 {
@@ -82,7 +74,6 @@ inline bool isStrictParserMode(CSSParserMode cssParserMode)
     case WebVTTMode:
         return true;
     case HTMLQuirksMode:
-    case CSSViewportRuleMode:
         return false;
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/dom/ViewportArguments.h
+++ b/Source/WebCore/dom/ViewportArguments.h
@@ -70,7 +70,6 @@ struct ViewportArguments {
         PluginDocument,
         ImageDocument,
 #endif
-        CSSDeviceAdaptation,
         ViewportMeta,
     } type;
 
@@ -85,14 +84,10 @@ struct ViewportArguments {
     {
     }
 
-    ViewportArguments(Type type, float width, float minWidth, float maxWidth, float height, float minHeight, float maxHeight, float zoom, float minZoom, float maxZoom, float userZoom, float orientation, float shrinkToFit, ViewportFit viewportFit, bool widthWasExplicit)
+    ViewportArguments(Type type, float width, float height, float zoom, float minZoom, float maxZoom, float userZoom, float orientation, float shrinkToFit, ViewportFit viewportFit, bool widthWasExplicit)
         : type(type)
         , width(width)
-        , minWidth(minWidth)
-        , maxWidth(maxWidth)
         , height(height)
-        , minHeight(minHeight)
-        , maxHeight(maxHeight)
         , zoom(zoom)
         , minZoom(minZoom)
         , maxZoom(maxZoom)
@@ -108,11 +103,7 @@ struct ViewportArguments {
     ViewportAttributes resolve(const FloatSize& initialViewportSize, const FloatSize& deviceSize, int defaultWidth) const;
 
     float width { ValueAuto };
-    float minWidth { ValueAuto };
-    float maxWidth { ValueAuto };
     float height { ValueAuto };
-    float minHeight { ValueAuto };
-    float maxHeight { ValueAuto };
     float zoom { ValueAuto };
     float minZoom { ValueAuto };
     float maxZoom { ValueAuto };
@@ -127,11 +118,7 @@ struct ViewportArguments {
         // Used for figuring out whether to reset the viewport or not,
         // thus we are not taking type into account.
         return width == other.width
-            && minWidth == other.minWidth
-            && maxWidth == other.maxWidth
             && height == other.height
-            && minHeight == other.minHeight
-            && maxHeight == other.maxHeight
             && zoom == other.zoom
             && minZoom == other.minZoom
             && maxZoom == other.maxZoom

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1926,18 +1926,13 @@ header: <WebCore/RectEdges.h>
     PluginDocument,
     ImageDocument,
 #endif
-    ViewportMeta,
-    CSSDeviceAdaptation
+    ViewportMeta
 };
 
 struct WebCore::ViewportArguments {
     WebCore::ViewportArguments::Type type;
     float width;
-    float minWidth;
-    float maxWidth;
     float height;
-    float minHeight;
-    float maxHeight;
     float zoom;
     float minZoom;
     float maxZoom;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4166,14 +4166,20 @@ void WebPage::resetViewportDefaultConfiguration(WebFrame* frame, bool hasMobileD
     auto updateViewportConfigurationForMobileDocType = [this, document] {
         m_viewportConfiguration.setDefaultConfiguration(ViewportConfiguration::xhtmlMobileParameters());
 
-        // Do not update the viewport arguments if they are already configured from, say, a meta tag.
-        if (m_viewportConfiguration.viewportArguments().type >= ViewportArguments::Type::CSSDeviceAdaptation)
+        // Do not update the viewport arguments if they are already configured by the website.
+        if (m_viewportConfiguration.viewportArguments().type == ViewportArguments::Type::ViewportMeta)
             return;
 
         if (!document || !document->isViewportDocument())
             return;
 
-        auto viewportArguments = ViewportArguments { ViewportArguments::Type::CSSDeviceAdaptation };
+        // https://www.w3.org/TR/2016/WD-css-device-adapt-1-20160329/#intro
+        // Certain DOCTYPEs (for instance XHTML Mobile Profile) are used to recognize mobile documents which are assumed
+        // to be designed for handheld devices, hence using the viewport size as the initial containing block size.
+        ViewportArguments viewportArguments { ViewportArguments::Type::ViewportMeta };
+        viewportArguments.width = ViewportArguments::ValueDeviceWidth;
+        viewportArguments.height = ViewportArguments::ValueDeviceHeight;
+        viewportArguments.zoom = 1;
         document->setViewportArguments(viewportArguments);
         viewportPropertiesDidChange(viewportArguments);
     };


### PR DESCRIPTION
#### f4beae1624cee8d1606723abb2d9ef6b13c43c55
<pre>
Remove remainders of CSSViewportRule
<a href="https://bugs.webkit.org/show_bug.cgi?id=276647">https://bugs.webkit.org/show_bug.cgi?id=276647</a>
<a href="https://rdar.apple.com/131811176">rdar://131811176</a>

Reviewed by Abrar Rahman Protyasha.

@viewport was removed a while ago in favor of the viewport meta tag.

Remove all remainders of it.

* LayoutTests/fast/viewport/viewport-legacy-xhtmlmp-remove-and-add.html:
* LayoutTests/fast/viewport/viewport-legacy-xhtmlmp.html:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::CSSParserFastPaths::maybeParseValue):
* Source/WebCore/css/parser/CSSParserMode.h:
(WebCore::isStrictParserMode):
(WebCore::isCSSViewportParsingEnabledForMode): Deleted.
* Source/WebCore/dom/ViewportArguments.cpp:
(WebCore::clampLengthValue):
(WebCore::clampScaleValue):
(WebCore::ViewportArguments::resolve const):
(WebCore::operator&lt;&lt;):
(WebCore::compareIgnoringAuto): Deleted.
* Source/WebCore/dom/ViewportArguments.h:
(WebCore::ViewportArguments::operator== const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::resetViewportDefaultConfiguration):

Canonical link: <a href="https://commits.webkit.org/281256@main">https://commits.webkit.org/281256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/594b04704ae677eb76055a1e52f1a43e30753b31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63124 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48110 "") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6865 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28933 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32729 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8478 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8618 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54686 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64834 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55441 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55538 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13129 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2592 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34330 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35413 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->