### PR TITLE
[JSC] Optimize JSMap::Get for DFG and FTL by utilizing data pointer instead of data index

### DIFF
--- a/JSTests/microbenchmarks/js-map-get-int-no-dfg-no-inline.js
+++ b/JSTests/microbenchmarks/js-map-get-int-no-dfg-no-inline.js
@@ -3,22 +3,25 @@ let m = new Map();
 function testSet(m, k, v) {
     m.set(k, v);
 }
-noDFG(testSet);
 noInline(testSet);
+noDFG(testSet);
+noFTL(testSet);
 
 function testGet(m, k) {
     m.get(k);
 }
-noDFG(testGet);
 noInline(testGet);
+noDFG(testGet);
+noFTL(testGet);
 
-let count = 1e4;
+let count = 1e2;
 for (let i = 0; i < count; ++i) {
     testSet(m, i, i);
 }
 
+let sum = 0;
 for (let i = 0; i < count; ++i) {
-    for (let j = 0; j < 20; j++) {
-        testGet(m, i, i);
+    for (let j = 0; j < 1e4; j++) {
+        sum += testGet(m, i);
     }
 }

--- a/JSTests/microbenchmarks/js-map-get-int.js
+++ b/JSTests/microbenchmarks/js-map-get-int.js
@@ -3,19 +3,24 @@ let m = new Map();
 function testSet(m, k, v) {
     m.set(k, v);
 }
+noInline(testSet);
+noDFG(testSet);
+noFTL(testSet);
 
 function testGet(m, k) {
-    m.get(k);
+    return m.get(k);
 }
+noInline(testGet);
 
-let count = 1e4;
+let count = 1e2;
 for (let i = 0; i < count; ++i) {
     testSet(m, i, i);
 }
 
+let sum = 0;
 for (let i = 0; i < count; ++i) {
-    for (let j = 0; j < 20; j++) {
-        testGet(m, i, i);
+    for (let j = 0; j < 1e4; j++) {
+        sum += testGet(m, i);
     }
 }
 

--- a/JSTests/microbenchmarks/js-map-get-string-no-dfg-no-inline.js
+++ b/JSTests/microbenchmarks/js-map-get-string-no-dfg-no-inline.js
@@ -3,25 +3,28 @@ let m = new Map();
 function testSet(m, k, v) {
     m.set(k, v);
 }
-noDFG(testSet);
 noInline(testSet);
+noDFG(testSet);
+noFTL(testSet);
 
 function testGet(m, k) {
-    m.get(k);
+    return m.get(k);
 }
-noDFG(testGet);
 noInline(testGet);
+noDFG(testGet);
+noFTL(testGet);
 
-let count = 1e4;
+let count = 1e2;
 for (let i = 0; i < count; ++i) {
     let s = i.toString();
     testSet(m, s, s);
 }
 
+let res;
 for (let i = 0; i < count; ++i) {
     let s = i.toString();
-    for (let j = 0; j < 20; j++) {
-        testGet(m, s);
+    for (let j = 0; j < 1e4; j++) {
+        res = testGet(m, s);
     }
 }
 

--- a/JSTests/microbenchmarks/js-map-get-string.js
+++ b/JSTests/microbenchmarks/js-map-get-string.js
@@ -3,20 +3,25 @@ let m = new Map();
 function testSet(m, k, v) {
     m.set(k, v);
 }
+noInline(testSet);
+noDFG(testSet);
+noFTL(testSet);
 
 function testGet(m, k) {
-    m.get(k);
+    return m.get(k);
 }
+noInline(testGet);
 
-let count = 1e4;
+let count = 1e2;
 for (let i = 0; i < count; ++i) {
     let s = i.toString();
     testSet(m, s, s);
 }
 
+let res;
 for (let i = 0; i < count; ++i) {
     let s = i.toString();
-    for (let j = 0; j < 20; j++) {
-        testGet(m, s);
+    for (let j = 0; j < 1e4; j++) {
+        res = testGet(m, s);
     }
 }

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -1566,7 +1566,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case MapIterationEntryValue:
     case MapIteratorKey:
     case MapIteratorValue:
-    case MapValue:
+    case LoadMapValue:
     case ExtractValueFromWeakMapGet:
         makeHeapTopForNode(node);
         break;
@@ -1575,8 +1575,11 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case MapSet:
         break;
 
+    case MapGet:
+        clearForNode(node);
+        break;
+
     case MapIterationEntry:
-    case MapKeyIndex:
         setTypeForNode(node, SpecInt32Only);
         break;
 
@@ -1586,6 +1589,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
 
     case MapIteratorNext:
+    case IsEmptyStorage:
         setTypeForNode(node, SpecBoolean);
         break;
 

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -236,6 +236,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case CompareStrictEq:
     case SameValue:
     case IsEmpty:
+    case IsEmptyStorage:
     case TypeOfIsUndefined:
     case IsUndefinedOrNull:
     case IsBoolean:
@@ -2083,7 +2084,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         def(PureValue(node));
         return;
 
-    case MapKeyIndex: {
+    case MapGet: {
         Edge& mapEdge = node->child1();
         Edge& keyEdge = node->child2();
         Edge& hashEdge = node->child3();
@@ -2092,12 +2093,11 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         def(HeapLocation(MapEntryKeyLoc, heap, mapEdge, keyEdge, hashEdge), LazyNode(node));
         return;
     }
-    case MapValue: {
-        Edge& mapEdge = node->child1();
-        Edge& indexEdge = node->child2();
+    case LoadMapValue: {
+        Edge& keySlotEdge = node->child1();
         AbstractHeapKind heap = JSMapFields;
         read(heap);
-        def(HeapLocation(MapValueLoc, heap, mapEdge, indexEdge), LazyNode(node));
+        def(HeapLocation(LoadMapValueLoc, heap, keySlotEdge), LazyNode(node));
         return;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -143,6 +143,7 @@ bool doesGC(Graph& graph, Node* node)
     case ProfileControlFlow:
     case OverridesHasInstance:
     case IsEmpty:
+    case IsEmptyStorage:
     case TypeOfIsUndefined:
     case TypeOfIsObject:
     case TypeOfIsFunction:
@@ -167,8 +168,8 @@ bool doesGC(Graph& graph, Node* node)
     case SuperSamplerEnd:
     case CPUIntrinsic:
     case NormalizeMapKey: // HeapBigInt => BigInt32 conversion does not involve GC.
-    case MapKeyIndex:
-    case MapValue:
+    case MapGet:
+    case LoadMapValue:
     case MapIteratorNext:
     case MapIteratorKey:
     case MapIteratorValue:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2719,12 +2719,12 @@ private:
             break;
         }
 
-        case MapValue:
-            fixEdge<MapObjectUse>(node->child1());
-            fixEdge<Int32Use>(node->child2());
+        case LoadMapValue:
+        case IsEmptyStorage:
+            fixEdge<UntypedUse>(node->child1());
             break;
 
-        case MapKeyIndex:
+        case MapGet:
             if (node->child1().useKind() == MapObjectUse)
                 fixEdge<MapObjectUse>(node->child1());
             else if (node->child1().useKind() == SetObjectUse)

--- a/Source/JavaScriptCore/dfg/DFGHeapLocation.cpp
+++ b/Source/JavaScriptCore/dfg/DFGHeapLocation.cpp
@@ -270,8 +270,8 @@ void printInternal(PrintStream& out, LocationKind kind)
         out.print("MapEntryValueLoc");
         return;
 
-    case MapValueLoc:
-        out.print("MapValueLoc");
+    case LoadMapValueLoc:
+        out.print("LoadMapValueLoc");
         return;
 
     case WeakMapGetLoc:

--- a/Source/JavaScriptCore/dfg/DFGHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGHeapLocation.h
@@ -89,7 +89,7 @@ enum LocationKind {
     MapIterationEntryValueLoc,
     MapEntryKeyLoc,
     MapEntryValueLoc,
-    MapValueLoc,
+    LoadMapValueLoc,
     WeakMapGetLoc,
     InternalFieldObjectLoc,
     DOMStateLoc,

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1985,8 +1985,8 @@ public:
         case ToObject:
         case CallNumberConstructor:
         case CallObjectConstructor:
-        case MapKeyIndex:
-        case MapValue:
+        case MapGet:
+        case LoadMapValue:
         case MapIteratorKey:
         case MapIteratorValue:
         case MapIterationEntryKey:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -432,6 +432,7 @@ namespace JSC { namespace DFG {
     \
     macro(IsCellWithType, NodeResultBoolean) \
     macro(IsEmpty, NodeResultBoolean) \
+    macro(IsEmptyStorage, NodeResultBoolean) \
     macro(HasStructureWithFlags, NodeResultBoolean) \
     macro(TypeOfIsUndefined, NodeResultBoolean) \
     macro(TypeOfIsObject, NodeResultBoolean) \
@@ -554,8 +555,8 @@ namespace JSC { namespace DFG {
     /* Nodes for JSMap and JSSet */ \
     macro(MapHash, NodeResultInt32) \
     macro(NormalizeMapKey, NodeResultJS) \
-    macro(MapKeyIndex, NodeResultInt32) \
-    macro(MapValue, NodeResultJS) \
+    macro(MapGet, NodeResultStorage) \
+    macro(LoadMapValue, NodeResultJS) \
     macro(MapIteratorNext, NodeResultBoolean) \
     macro(MapIteratorKey, NodeResultJS) \
     macro(MapIteratorValue, NodeResultJS) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4160,32 +4160,25 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMapHashHeapBigInt, UCPUStrictInt32, (
     OPERATION_RETURN(scope, toUCPUStrictInt32(jsMapHash(input)));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationMapKeyIndex, UCPUStrictInt32, (JSGlobalObject* globalObject, JSCell* map, EncodedJSValue key, int32_t hash))
+JSC_DEFINE_JIT_OPERATION(operationMapGet, JSValue*, (JSGlobalObject* globalObject, JSCell* cell, EncodedJSValue key, int32_t hash))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSMap::TableIndex keyIndex = jsCast<JSMap*>(map)->getKeyIndex(globalObject, JSValue::decode(key), hash);
-    OPERATION_RETURN(scope, toUCPUStrictInt32(keyIndex));
+    JSMap* map = jsCast<JSMap*>(cell);
+    JSValue* keySlot = map->getKeySlot(globalObject, JSValue::decode(key), hash);
+    OPERATION_RETURN(scope, keySlot);
 }
-JSC_DEFINE_JIT_OPERATION(operationSetKeyIndex, UCPUStrictInt32, (JSGlobalObject* globalObject, JSCell* set, EncodedJSValue key, int32_t hash))
+JSC_DEFINE_JIT_OPERATION(operationSetGet, JSValue*, (JSGlobalObject* globalObject, JSCell* cell, EncodedJSValue key, int32_t hash))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSMap::TableIndex keyIndex = jsCast<JSSet*>(set)->getKeyIndex(globalObject, JSValue::decode(key), hash);
-    OPERATION_RETURN(scope, toUCPUStrictInt32(keyIndex));
-}
-JSC_DEFINE_JIT_OPERATION(operationMapValue, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* map, int32_t keyIndex))
-{
-    VM& vm = globalObject->vm();
-    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
-    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue value = jsCast<JSMap*>(map)->get(keyIndex);
-    OPERATION_RETURN(scope, JSValue::encode(value));
+    JSSet* set = jsCast<JSSet*>(cell);
+    JSValue* keySlot = set->getKeySlot(globalObject, JSValue::decode(key), hash);
+    OPERATION_RETURN(scope, keySlot);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationMapStorage, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* cell))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -292,9 +292,8 @@ JSC_DECLARE_JIT_OPERATION(operationNormalizeMapKeyHeapBigInt, EncodedJSValue, (V
 JSC_DECLARE_JIT_OPERATION(operationMapHash, UCPUStrictInt32, (JSGlobalObject*, EncodedJSValue input));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMapHashHeapBigInt, UCPUStrictInt32, (VM*, JSBigInt*));
 
-JSC_DECLARE_JIT_OPERATION(operationMapKeyIndex, UCPUStrictInt32, (JSGlobalObject*, JSCell*, EncodedJSValue, int32_t));
-JSC_DECLARE_JIT_OPERATION(operationSetKeyIndex, UCPUStrictInt32, (JSGlobalObject*, JSCell*, EncodedJSValue, int32_t));
-JSC_DECLARE_JIT_OPERATION(operationMapValue, EncodedJSValue, (JSGlobalObject*, JSCell*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationMapGet, JSValue*, (JSGlobalObject*, JSCell*, EncodedJSValue, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationSetGet, JSValue*, (JSGlobalObject*, JSCell*, EncodedJSValue, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationMapStorage, EncodedJSValue, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationSetStorage, EncodedJSValue, (JSGlobalObject*, JSCell*));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1047,7 +1047,7 @@ private:
         case GetClosureVar:
         case GetInternalField:
         case GetFromArguments:
-        case MapValue:
+        case LoadMapValue:
         case MapIteratorKey:
         case MapIteratorValue:
         case MapIterationEntryKey:
@@ -1118,7 +1118,6 @@ private:
 
         case MapHash:
         case MapIterationEntry:
-        case MapKeyIndex:
             setPrediction(SpecInt32Only);
             break;
 
@@ -1219,6 +1218,7 @@ private:
         case InstanceOf:
         case InstanceOfCustom:
         case IsEmpty:
+        case IsEmptyStorage:
         case TypeOfIsUndefined:
         case TypeOfIsObject:
         case TypeOfIsFunction:
@@ -1244,6 +1244,7 @@ private:
             setPrediction(SpecStringIdent);
             break;
         }
+        case MapGet:
         case GetButterfly:
         case GetIndexedPropertyStorage:
         case AllocatePropertyStorage:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -263,6 +263,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case ToLength:
     case OverridesHasInstance:
     case IsEmpty:
+    case IsEmptyStorage:
     case TypeOfIsUndefined:
     case TypeOfIsObject:
     case TypeOfIsFunction:
@@ -314,8 +315,8 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case StringSlice:
     case StringSubstring:
     case ToLowerCase:
-    case MapKeyIndex:
-    case MapValue:
+    case MapGet:
+    case LoadMapValue:
     case MapStorage:
     case MapIterationNext:
     case MapIterationEntry:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1479,9 +1479,10 @@ public:
     void compileCallCustomAccessorSetter(Node*);
     void compileNormalizeMapKey(Node*);
     template<typename MapOrSet>
-    ALWAYS_INLINE void compileGetMapIndexImpl(Node*);
-    void compileMapKeyIndex(Node*);
-    void compileMapValue(Node*);
+    ALWAYS_INLINE void compileMapGetImpl(Node*);
+    void compileMapGet(Node*);
+    void compileLoadMapValue(Node*);
+    void compileIsEmptyStorage(Node*);
     void compileMapIteratorNext(Node*);
     void compileMapIteratorKey(Node*);
     void compileMapIteratorValue(Node*);

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
@@ -44,6 +44,7 @@ namespace JSC { namespace FTL {
 #define FOR_EACH_ABSTRACT_HEAP(macro) \
     macro(typedArrayProperties) \
     macro(JSCellHeaderAndNamedProperties) \
+    macro(OrderedHashTableData) \
 
 #define FOR_EACH_ABSTRACT_FIELD(macro) \
     macro(ArrayBuffer_data, ArrayBuffer::offsetOfData()) \

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -273,8 +273,8 @@ inline CapabilityLevel canCompile(Node* node)
     case IsCellWithType:
     case MapHash:
     case NormalizeMapKey:
-    case MapKeyIndex:
-    case MapValue:
+    case MapGet:
+    case LoadMapValue:
     case MapIterationNext:
     case MapIterationEntry:
     case MapIterationEntryKey:
@@ -291,6 +291,7 @@ inline CapabilityLevel canCompile(Node* node)
     case WeakSetAdd:
     case WeakMapSet:
     case IsEmpty:
+    case IsEmptyStorage:
     case TypeOfIsUndefined:
     case TypeOfIsObject:
     case TypeOfIsFunction:

--- a/Source/JavaScriptCore/runtime/OrderedHashTable.h
+++ b/Source/JavaScriptCore/runtime/OrderedHashTable.h
@@ -61,11 +61,11 @@ public:
         }
     }
 
-    ALWAYS_INLINE TableIndex getKeyIndex(JSGlobalObject* globalObject, JSValue key, uint32_t hash)
+    ALWAYS_INLINE JSValue* getKeySlot(JSGlobalObject* globalObject, JSValue key, uint32_t hash)
     {
         if (m_storage)
-            return Helper::find(globalObject, storageRef(), key, hash).entryKeyIndex;
-        return Helper::InvalidTableIndex;
+            return Helper::find(globalObject, storageRef(), key, hash).entryKeySlot;
+        return nullptr;
     }
 
     ALWAYS_INLINE bool has(JSGlobalObject* globalObject, JSValue key)


### PR DESCRIPTION
#### b250c04ecf7f8f4c76db0ebf41bafe2886346e81
<pre>
[JSC] Optimize JSMap::Get for DFG and FTL by utilizing data pointer instead of data index
<a href="https://bugs.webkit.org/show_bug.cgi?id=276650">https://bugs.webkit.org/show_bug.cgi?id=276650</a>
<a href="https://rdar.apple.com/131813452">rdar://131813452</a>

Reviewed by Yusuke Suzuki.

JSMap is backed by a single array. Previously, JSMap::Get generates two
DFG nodes `MapKeyIndex` and `MapValue`, where:
* MapKeyIndex: Find the key index with a map storage and a key value.
* MapValue: Load the corresponding value with a map storage and a key index.

So, instead of loading and using the same map storage twice, we could do
* MapGet: Find the key slot in the map storage.
* MapValue: Load the value with the corresponding key slot.

Microbenchmark results with 20 iterations:

                                             without                     with

js-map-get-string                         5.6139+-0.0185     ^      5.5335+-0.0207        ^ definitely 1.0145x faster
js-map-get-string-no-dfg-no-inline       14.2257+-0.0283           14.1996+-0.0162
js-map-get-int                            5.7287+-0.0175     ^      5.5497+-0.0185        ^ definitely 1.0323x faster
js-map-get-int-no-dfg-no-inline          20.2157+-0.0181     ?     20.2332+-0.0168        ?

&lt;geometric&gt;                               9.8062+-0.0158     ^      9.6913+-0.0162        ^ definitely 1.0119x faster

* JSTests/microbenchmarks/js-map-get-int-no-dfg-no-inline.js:
(testSet):
(testGet):
* JSTests/microbenchmarks/js-map-get-int.js:
(testGet):
* JSTests/microbenchmarks/js-map-get-string-no-dfg-no-inline.js:
(testSet):
(testGet):
* JSTests/microbenchmarks/js-map-get-string.js:
(testGet):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGHeapLocation.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/dfg/DFGHeapLocation.h:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasHeapPrediction):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileMapGetImpl):
(JSC::DFG::SpeculativeJIT::compileMapGet):
(JSC::DFG::SpeculativeJIT::compileLoadMapValue):
(JSC::DFG::SpeculativeJIT::compile):
(JSC::DFG::SpeculativeJIT::compileGetMapIndexImpl): Deleted.
(JSC::DFG::SpeculativeJIT::compileMapKeyIndex): Deleted.
(JSC::DFG::SpeculativeJIT::compileMapValue): Deleted.
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h:
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/OrderedHashTable.h:
(JSC::OrderedHashTable::getKeySlot):
(JSC::OrderedHashTable::getKeyIndex): Deleted.
* Source/JavaScriptCore/runtime/OrderedHashTableHelper.h:
(JSC::OrderedHashTableHelper::find):

Canonical link: <a href="https://commits.webkit.org/281039@main">https://commits.webkit.org/281039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b3d8c1171042bce2c71f4900864c08e81db4551

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62053 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8872 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47326 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6334 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50519 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28171 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7818 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7876 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51519 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63757 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57670 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8120 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54645 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2349 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50541 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; Skipped layout-tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54712 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1982 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79430 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8723 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33584 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13215 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34670 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35754 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34415 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->