### PR TITLE
[svg] setting `d: none` on a `<path>` does not override the `d` SVG attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/spaces-at-end-of-path-data-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/spaces-at-end-of-path-data-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Allow trailing empty entry in value list assert_not_equals: got disallowed value "none"
+PASS Allow trailing empty entry in value list
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-none-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-none-expected.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M 0 0 H 100 V 100 H 0 Z" fill="green" />
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-none-ref.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-none-ref.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M 0 0 H 100 V 100 H 0 Z" fill="green" />
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-none.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-none.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/paths.html#TheDProperty"/>
+    <h:link rel="match" href="d-none-ref.svg"/>
+    <h:meta name="assert" content="Setting 'd: none' overrides the 'd' SVG attribute."/>
+  </metadata>
+  <path d="M 0 0 H 100 V 100 H 0 Z" fill="green" />
+  <path d="M 0 0 H 100 V 100 H 0 Z" fill="red" style="d: none" />
+</svg>

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -39,7 +39,6 @@
 #include "ElementInlines.h"
 #include "ElementRareData.h"
 #include "HTMLElement.h"
-#include "HTMLImageElement.h"
 #include "HTMLParserIdioms.h"
 #include "InlineStylePropertyMap.h"
 #include "InspectorInstrumentation.h"
@@ -333,9 +332,7 @@ void StyledElement::rebuildPresentationalHintStyle()
     auto style = MutableStyleProperties::create(isSVG ? SVGAttributeMode : HTMLQuirksMode);
     for (auto& attribute : attributesIterator())
         collectPresentationalHintsForAttribute(attribute.name(), attribute.value(), style);
-
-    if (auto* imageElement = dynamicDowncast<HTMLImageElement>(*this))
-        imageElement->collectExtraStyleForPresentationalHints(style);
+    collectExtraStyleForPresentationalHints(style);
 
     // ShareableElementData doesn't store presentation attribute style, so make sure we have a UniqueElementData.
     auto& elementData = ensureUniqueElementData();

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -70,6 +70,7 @@ public:
     const ImmutableStyleProperties* presentationalHintStyle() const;
     virtual void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) { }
     virtual const MutableStyleProperties* additionalPresentationalHintStyle() const { return nullptr; }
+    virtual void collectExtraStyleForPresentationalHints(MutableStyleProperties&) { }
 
 protected:
     StyledElement(const QualifiedName& name, Document& document, OptionSet<TypeFlag> type)

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -184,8 +184,6 @@ public:
 
     bool originClean(const SecurityOrigin&) const;
 
-    void collectExtraStyleForPresentationalHints(MutableStyleProperties&);
-
     Image* image() const;
 
 protected:
@@ -203,6 +201,7 @@ private:
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;
     void invalidateAttributeMapping();
+    void collectExtraStyleForPresentationalHints(MutableStyleProperties&) override;
 
     Ref<Element> cloneElementWithoutAttributesAndChildren(Document& targetDocument) final;
 

--- a/Source/WebCore/svg/SVGPathByteStream.h
+++ b/Source/WebCore/svg/SVGPathByteStream.h
@@ -149,6 +149,12 @@ public:
     {
     }
 
+    static SVGPathByteStream& empty()
+    {
+        static MainThreadNeverDestroyed<SVGPathByteStream> singleton;
+        return singleton;
+    }
+
     SVGPathByteStream& operator=(const SVGPathByteStream& other)
     {
         if (this == &other)

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -36,7 +36,7 @@ class SVGPathElement final : public SVGGeometryElement {
     WTF_MAKE_ISO_ALLOCATED(SVGPathElement);
 public:
     static Ref<SVGPathElement> create(const QualifiedName&, Document&);
-    
+
     static Ref<SVGPathSegClosePath> createSVGPathSegClosePath() { return SVGPathSegClosePath::create(); }
     static Ref<SVGPathSegMovetoAbs> createSVGPathSegMovetoAbs(float x, float y) { return SVGPathSegMovetoAbs::create(x, y); }
     static Ref<SVGPathSegMovetoRel> createSVGPathSegMovetoRel(float x, float y) { return SVGPathSegMovetoRel::create(x, y); }
@@ -123,8 +123,9 @@ private:
     void invalidateMPathDependencies();
 
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
+    void collectExtraStyleForPresentationalHints(MutableStyleProperties&) override;
+    void collectDPresentationalHint(MutableStyleProperties&);
 
-private:
     Ref<SVGAnimatedPathSegList> m_pathSegList { SVGAnimatedPathSegList::create(this) };
 };
 


### PR DESCRIPTION
#### e33f42cd046adc916beddbf75157f692f6f22ad7
<pre>
[svg] setting `d: none` on a `&lt;path&gt;` does not override the `d` SVG attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=276653">https://bugs.webkit.org/show_bug.cgi?id=276653</a>

Reviewed by Nikolas Zimmermann.

If the `d` CSS property is set to `none`, the resulting `SVGRenderStyle::d()` value is `nullptr`.
We must account for this in `SVGPathElement::path()` and `SVGPathElement::pathByteStream()` and
return an empty path in the case that we don&apos;t have a `BasicShapePath` set on the style. In fact,
at long as the `d` CSS property is enabled, we should never return the SVG attribute value.

Making this code change alone yielded two test regressions:

    - svg/custom/svg-curve-with-relative-coordinates.html
    - svg/animations/path-animation.svg

Indeed, neither of those two tests explicitly sets the `d` SVG attribute, relying instead on `&lt;animate&gt;` or
the `pathSegList` DOM API to set the path data. The lack of a `d` SVG attribute means the traditional mechanism
to compile a list of presentation attributes for a `&lt;path&gt;` attribute will not pick up the `d` property.

So we add a new method to collect additional presentational hints as was already done for the HTML `&lt;img&gt;`
element, promoting the `collectExtraStyleForPresentationalHints()` method from `HTMLImageElement` to a virtual
method on `StyledElement` and making `SVGPathElement` override it. Using this method, we can collect the `d`
presentational hint if it hasn&apos;t already been picked up.

Finally, since the lack of accounting for `d: none` when rendering wasn&apos;t caught by existing tests, we add
a new WPT reftest.

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/spaces-at-end-of-path-data-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-none-expected.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-none-ref.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-none.svg: Added.
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::rebuildPresentationalHintStyle):
* Source/WebCore/dom/StyledElement.h:
(WebCore::StyledElement::collectExtraStyleForPresentationalHints):
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/svg/SVGPathByteStream.h:
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::pathByteStream const):
(WebCore::SVGPathElement::path const):
(WebCore::SVGPathElement::collectPresentationalHintsForAttribute):
(WebCore::SVGPathElement::collectExtraStyleForPresentationalHints):
(WebCore::SVGPathElement::collectDPresentationalHint):
* Source/WebCore/svg/SVGPathElement.h:

Canonical link: <a href="https://commits.webkit.org/281041@main">https://commits.webkit.org/281041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c11eb368cffd1f24d7529213689d6808e7cb12d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61955 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8775 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47255 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6267 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32051 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7734 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7779 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63660 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54572 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54637 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1914 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8724 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33487 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34573 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35657 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->