### PR TITLE
[WPE][GTK] First round of memory leak fixes, reported by LeakSanitizer

### DIFF
--- a/Source/WebCore/platform/audio/glib/MediaSessionGLib.h
+++ b/Source/WebCore/platform/audio/glib/MediaSessionGLib.h
@@ -60,7 +60,7 @@ public:
     void setMprisRegistrationEligibility(MprisRegistrationEligiblilty eligibility) { m_registrationEligibility = eligibility; }
     MprisRegistrationEligiblilty mprisRegistrationEligibility() const { return m_registrationEligibility; }
 private:
-    void emitPropertiesChanged(GVariant*);
+    void emitPropertiesChanged(GRefPtr<GVariant>&&);
     std::optional<NowPlayingInfo> nowPlayingInfo();
     bool ensureMprisSessionRegistered();
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebProcessExtensionManager.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebProcessExtensionManager.cpp
@@ -53,8 +53,8 @@ static void parseUserData(API::Object* userData, String& webProcessExtensionsDir
     ASSERT(userData->type() == API::Object::Type::String);
 
     CString userDataString = static_cast<API::String*>(userData)->string().utf8();
-    GRefPtr<GVariant> variant = g_variant_parse(nullptr, userDataString.data(),
-        userDataString.data() + userDataString.length(), nullptr, nullptr);
+    GRefPtr<GVariant> variant = adoptGRef(g_variant_parse(nullptr, userDataString.data(),
+        userDataString.data() + userDataString.length(), nullptr, nullptr));
 
     ASSERT(variant);
     ASSERT(g_variant_check_format_string(variant.get(), "(m&smv)", FALSE));

--- a/Tools/MiniBrowser/gtk/BrowserWindow.c
+++ b/Tools/MiniBrowser/gtk/BrowserWindow.c
@@ -394,6 +394,8 @@ static void browserWindowTryClose(GSimpleAction *action, GVariant *parameter, gp
     GSList *link;
     for (link = webViews; link; link = link->next)
         webkit_web_view_try_close(link->data);
+    if (webViews)
+        g_slist_free(webViews);
 }
 
 static void backForwardlistChanged(WebKitBackForwardList *backForwardlist, WebKitBackForwardListItem *itemAdded, GList *itemsRemoved, BrowserWindow *window)


### PR DESCRIPTION
#### ff8510d36cc79a4cfc2c9f8bb9dcc55a302ad716
<pre>
[WPE][GTK] First round of memory leak fixes, reported by LeakSanitizer
<a href="https://bugs.webkit.org/show_bug.cgi?id=276655">https://bugs.webkit.org/show_bug.cgi?id=276655</a>

Reviewed by Xabier Rodriguez-Calvar and Michael Catanzaro.

Fix a few GVariant leaks in WebKit/WebCore and one GSList leak in MiniBrowser.

* Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp:
(WebCore::MediaSessionGLib::updateNowPlaying):
(WebCore::MediaSessionGLib::emitPropertiesChanged):
(WebCore::MediaSessionGLib::playbackStatusChanged):
* Source/WebCore/platform/audio/glib/MediaSessionGLib.h:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebProcessExtensionManager.cpp:
(WebKit::parseUserData):
* Tools/MiniBrowser/gtk/BrowserWindow.c:
(browserWindowTryClose):

Canonical link: <a href="https://commits.webkit.org/281047@main">https://commits.webkit.org/281047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56e9f29cfb1ed6fea47223712c5ec0237742bd8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8977 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9174 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47384 "Found 1 new test failure: http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6392 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35438 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/50606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7908 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63862 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54705 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54783 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/12913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2066 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8727 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33689 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35859 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->