### PR TITLE
[EME] MediaKeySystemController and client leaks

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
@@ -59,7 +59,7 @@ MediaKeySystemController::~MediaKeySystemController()
 
 void provideMediaKeySystemTo(Page& page, MediaKeySystemClient& client)
 {
-    MediaKeySystemController::provideTo(&page, MediaKeySystemController::supplementName(), makeUnique<MediaKeySystemController>(client));
+    Supplement<Page>::provideTo(&page, MediaKeySystemController::supplementName(), makeUnique<MediaKeySystemController>(client));
 }
 
 void MediaKeySystemController::logRequestMediaKeySystemDenial(Document& document)

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.h
@@ -28,6 +28,7 @@
 
 #include "MediaKeySystemClient.h"
 #include "Supplementable.h"
+#include <wtf/Noncopyable.h>
 
 namespace WebCore {
 
@@ -35,6 +36,7 @@ class MediaKeySystemRequest;
 
 class MediaKeySystemController : public Supplement<Page> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(MediaKeySystemController);
 public:
     explicit MediaKeySystemController(MediaKeySystemClient&);
     ~MediaKeySystemController();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp
@@ -41,14 +41,19 @@ WebMediaKeySystemClient::WebMediaKeySystemClient(WebPage& page)
 {
 }
 
+void WebMediaKeySystemClient::pageDestroyed()
+{
+    delete this;
+}
+
 void WebMediaKeySystemClient::requestMediaKeySystem(MediaKeySystemRequest& request)
 {
-    m_page.mediaKeySystemPermissionRequestManager().startMediaKeySystemRequest(request);
+    m_page->mediaKeySystemPermissionRequestManager().startMediaKeySystemRequest(request);
 }
 
 void WebMediaKeySystemClient::cancelMediaKeySystemRequest(MediaKeySystemRequest& request)
 {
-    m_page.mediaKeySystemPermissionRequestManager().cancelMediaKeySystemRequest(request);
+    m_page->mediaKeySystemPermissionRequestManager().cancelMediaKeySystemRequest(request);
 }
 
 } // namespace WebKit;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h
@@ -33,19 +33,19 @@ namespace WebKit {
 
 class WebPage;
 
-class WebMediaKeySystemClient : public WebCore::MediaKeySystemClient {
+class WebMediaKeySystemClient final : public WebCore::MediaKeySystemClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WebMediaKeySystemClient(WebPage&);
     ~WebMediaKeySystemClient() { }
 
 private:
-    void pageDestroyed() override { }
+    void pageDestroyed() final;
 
-    void requestMediaKeySystem(WebCore::MediaKeySystemRequest&) override;
-    void cancelMediaKeySystemRequest(WebCore::MediaKeySystemRequest&) override;
+    void requestMediaKeySystem(WebCore::MediaKeySystemRequest&) final;
+    void cancelMediaKeySystemRequest(WebCore::MediaKeySystemRequest&) final;
 
-    WebPage& m_page;
+    WeakRef<WebPage> m_page;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 89a20910a56be13d2b83e33e800eea6f5ce3c283
<pre>
[EME] MediaKeySystemController and client leaks
<a href="https://bugs.webkit.org/show_bug.cgi?id=276660">https://bugs.webkit.org/show_bug.cgi?id=276660</a>

Reviewed by Andy Estes.

The client is now destroyed once the page has been destroyed. Driving-by, use WeakRef in the client
to keep track of the page and make the controller non-copyable.

* Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp:
(WebCore::MediaKeySystemController::MediaKeySystemController):
(WebCore::provideMediaKeySystemTo):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.cpp:
(WebKit::WebMediaKeySystemClient::pageDestroyed):
(WebKit::WebMediaKeySystemClient::requestMediaKeySystem):
(WebKit::WebMediaKeySystemClient::cancelMediaKeySystemRequest):
* Source/WebKit/WebProcess/WebCoreSupport/WebMediaKeySystemClient.h:
(WebKit::WebMediaKeySystemClient::~WebMediaKeySystemClient): Deleted.

Canonical link: <a href="https://commits.webkit.org/281048@main">https://commits.webkit.org/281048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ac69b97ada612203444236fcae4b515183fc543

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62158 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8976 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47383 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6391 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50602 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28235 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7904 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7980 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54137 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63861 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8186 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54704 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54786 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12912 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2065 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33688 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34774 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34519 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->