### PR TITLE
[iOS 18] Web view lays out at the wrong dimensions after rotating in element fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -316,7 +316,7 @@ struct PerWebProcessState {
     RetainPtr<UIView> _resizeAnimationView;
     CGFloat _lastAdjustmentForScroller;
 
-    CGSize _lastKnownWindowSize;
+    std::pair<CGSize, UIInterfaceOrientation> _lastKnownWindowSizeAndOrientation;
     RetainPtr<NSTimer> _endLiveResizeTimer;
 
     WebCore::FloatBoxExtent _obscuredInsetsWhenSaved;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -109,10 +109,6 @@
         [_contentView _action ## ForWebView:sender]; \
 }
 
-namespace WebKit {
-enum class UpdateLastKnownWindowSizeResult : bool { Changed, DidNotChange };
-}
-
 #define WKWEBVIEW_RELEASE_LOG(...) RELEASE_LOG(ViewState, __VA_ARGS__)
 
 static const Seconds delayBeforeNoVisibleContentsRectsLogging = 1_s;
@@ -1883,14 +1879,10 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     return false;
 }
 
-- (WebKit::UpdateLastKnownWindowSizeResult)_updateLastKnownWindowSize
+- (void)_updateLastKnownWindowSizeAndOrientation
 {
-    auto size = self.window.bounds.size;
-    if (CGSizeEqualToSize(_lastKnownWindowSize, size))
-        return WebKit::UpdateLastKnownWindowSizeResult::DidNotChange;
-
-    _lastKnownWindowSize = size;
-    return WebKit::UpdateLastKnownWindowSizeResult::Changed;
+    UIWindowScene *scene = self.window.windowScene;
+    _lastKnownWindowSizeAndOrientation = { scene.coordinateSpace.bounds.size, scene.interfaceOrientation };
 }
 
 - (void)didMoveToWindow
@@ -1909,7 +1901,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 #if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
     [self _endLiveResize];
 #endif
-    [self _updateLastKnownWindowSize];
+    [self _updateLastKnownWindowSizeAndOrientation];
 }
 
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
@@ -2384,6 +2376,9 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     if (CGRectIsEmpty(self.bounds))
         return;
 
+    if (_perProcessState.dynamicViewportUpdateMode != WebKit::DynamicViewportUpdateMode::NotResizing)
+        return;
+
     [self _rescheduleEndLiveResizeTimer];
 
     if (_perProcessState.liveResizeParameters)
@@ -2426,9 +2421,23 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 - (void)_frameOrBoundsWillChange
 {
 #if HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
-    if ([self _updateLastKnownWindowSize] == WebKit::UpdateLastKnownWindowSizeResult::Changed)
+    auto [sizeBeforeUpdate, orientationBeforeUpdate] = _lastKnownWindowSizeAndOrientation;
+    [self _updateLastKnownWindowSizeAndOrientation];
+
+    auto [sizeAfterUpdate, orientationAfterUpdate] = _lastKnownWindowSizeAndOrientation;
+    auto shouldScheduleAutomaticLiveResize = [&] {
+        if (sizeBeforeUpdate.width == sizeAfterUpdate.width)
+            return NO;
+
+        if (orientationBeforeUpdate != orientationAfterUpdate)
+            return NO;
+
+        return YES;
+    };
+
+    if (shouldScheduleAutomaticLiveResize())
         [self _beginAutomaticLiveResizeIfNeeded];
-#endif
+#endif // HAVE(UI_WINDOW_SCENE_LIVE_RESIZE)
 }
 
 - (void)_updateDrawingAreaSize


### PR DESCRIPTION
#### 26daa5456ac48a643162f426bb1ebebe6e46a5e5
<pre>
[iOS 18] Web view lays out at the wrong dimensions after rotating in element fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=276661">https://bugs.webkit.org/show_bug.cgi?id=276661</a>
<a href="https://rdar.apple.com/131329311">rdar://131329311</a>

Reviewed by Richard Robinson.

After the changes in 279030@main to enable live resize on iPad along with the rest of the
`BrowserEngineKit` integration when `UIKit/async_text_input_ipad` is enabled, rotating the device
on YouTube.com while watching a video in element fullscreen mode causes the webpage to lay out at
the wrong dimensions after rotation for about 500 ms, before adjusting to the new size.

This happens because the codepaths to engage live resize in response to frame or bounds changes
activates now, when it didn&apos;t before the change. This codepath was previously guarded by a check for
`-[UIWindowScene _isInLiveResize]`, which was only set when adjusting the dimensions of the window
in Stage Manager. However, since 279030@main stopped using that SPI in favor of matching the
automatic live resize behavior on visionOS, we no longer have that constraint, and will enter this
live resize codepath in more cases (e.g. when changing the interface orientation).

To mitigate this, we reintroduce some more constraints, to avoid automatic live resize in a couple
of cases:

1.  Only the window height is changing (there&apos;s typically no need to keep the web view stable in
    this case, since we&apos;d just reveal more content underneath the previous viewport which could be
    scrolled to anyways).

2.  The window is changing interface orientation (to address the immediate cause of this issue).

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:

Keep track of the last known interface orientation, in addition to the last known window size.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateLastKnownWindowSizeAndOrientation]):
(-[WKWebView didMoveToWindow]):
(-[WKWebView _beginAutomaticLiveResizeIfNeeded]):
(-[WKWebView _frameOrBoundsWillChange]):

See above for more details.

(-[WKWebView _updateLastKnownWindowSize]): Deleted.

Canonical link: <a href="https://commits.webkit.org/281008@main">https://commits.webkit.org/281008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/829cc69d99e56254973a3022c6444f47ac2cfc7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61995 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8815 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47288 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6296 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35321 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50469 "Found 1 new API test failure: TestWebKitAPI.ResourceLoadStatistics.GrandfatherCallback (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28130 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32079 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7819 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54031 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63700 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2284 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8082 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54605 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54671 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1944 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8699 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33527 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->