### PR TITLE
Web Inspector: Multiline REPL editor is broken

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleDrawer.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleDrawer.js
@@ -124,14 +124,14 @@ WI.ConsoleDrawer = class ConsoleDrawer extends WI.ContentBrowser
             return;
 
         let resizerElement = event.target;
-        let quickConsoleHeight = window.innerHeight - (this.element.totalOffsetTop + this.height);
+        let quickConsoleHeight = WI.quickConsole.element.offsetHeight;
         let mouseOffset = quickConsoleHeight - (event.pageY - resizerElement.totalOffsetTop);
 
         function dockedResizerDrag(event)
         {
             let height = window.innerHeight - event.pageY - mouseOffset;
             this._drawerHeightSetting.value = height;
-            this._updateDrawerHeight(height);
+            this._updateDrawerHeight(height, quickConsoleHeight);
             this.collapsed = false;
         }
 
@@ -148,13 +148,13 @@ WI.ConsoleDrawer = class ConsoleDrawer extends WI.ContentBrowser
 
     _restoreDrawerHeight()
     {
-        this._updateDrawerHeight(this._drawerHeightSetting.value);
+        this._updateDrawerHeight(this._drawerHeightSetting.value, WI.quickConsole.element.offsetHeight);
     }
 
-    _updateDrawerHeight(height)
+    _updateDrawerHeight(height, quickConsoleHeight)
     {
         const minimumHeight = 64;
-        const maximumHeight = this.element.parentNode.offsetHeight - WI.TabBrowser.MinimumHeight - WI.QuickConsole.MinimumHeight;
+        let maximumHeight = this.element.parentNode.offsetHeight - WI.TabBrowser.MinimumHeight - quickConsoleHeight;
 
         let heightCSSValue = Number.constrain(height, minimumHeight, maximumHeight) + "px";
         if (this.element.style.height === heightCSSValue)

--- a/Source/WebInspectorUI/UserInterface/Views/Main.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Main.css
@@ -175,6 +175,7 @@ body.docked:is(.right, .left) #navigation-sidebar.collapsed > .resizer {
 #content {
     display: grid;
     height: 100%; /* This reduces paint areas when typing in the console. http://webkit.org/b/145324 */
+    flex: 1;
 }
 
 body:not(.narrow) #content {

--- a/Source/WebInspectorUI/UserInterface/Views/QuickConsole.css
+++ b/Source/WebInspectorUI/UserInterface/Views/QuickConsole.css
@@ -29,6 +29,7 @@
 
     display: flex;
     align-items: flex-end;
+    max-height: 33vh;
 
     color: var(--text-color);
     background-color: var(--background-color-content);
@@ -51,7 +52,8 @@
 
     align-items: flex-start;
 
-    max-height: 33vh;
+    max-height: 100%;
+    will-change: z-index; /* Workaround for <rdar://125601926> - Content renders on top of the scroll bar */
 
     overflow-y: auto;
     overflow-x: hidden;

--- a/Source/WebInspectorUI/UserInterface/Views/QuickConsole.js
+++ b/Source/WebInspectorUI/UserInterface/Views/QuickConsole.js
@@ -482,5 +482,3 @@ WI.QuickConsole = class QuickConsole extends WI.View
         this.element.classList.toggle("showing-log", WI.isShowingConsoleTab() || WI.isShowingSplitConsole());
     }
 };
-
-WI.QuickConsole.MinimumHeight = 30; /* Keep in sync with `--console-prompt-min-height` */

--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -105,7 +105,7 @@
     --yellow-highlight-text-color: var(--text-color);
 
     --console-secondary-text-color: hsla(0, 0%, 0%, 0.33);
-    --console-prompt-min-height: 30px; /* Keep in sync with `WI.QuickConsole.MinimumHeight` */
+    --console-prompt-min-height: 30px;
 
     --message-text-view-font-size: 16px;
     --message-text-view-large-font-size: 28px;


### PR DESCRIPTION
#### 0da0eedeaa3f18bfd0bb2f1f4831f4fe3eaa4893
<pre>
Web Inspector: Multiline REPL editor is broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=276530">https://bugs.webkit.org/show_bug.cgi?id=276530</a>
<a href="https://rdar.apple.com/131756916">rdar://131756916</a>

Reviewed by BJ Burg and Devin Rousso.

The content area of the console prompt is controlled by CodeMirror
which sets the dimensions of a multi-line input as you type.
It lives in a second level flex container and is intended to be capped at 33vh.

At the first level flex container, the space available to be distributed to flex items
is influenced by the size of the Console Drawer and the min-width of #tab-browser.

Due to alignment within the flex layout and insufficient space,
the multi-line console prompt nested within the second level flex container
was allowed to grow within the second-level container without causing overflow.
This masks some keyboard input and focus.

This patch ensures the maximum height of the Console Drawer takes into account the
space used by the console prompt. It also moves the 33vh max-height limit
to the first level flex container to enforce the limit and ensure a scroll container
as soon as its contents overflow.

* Source/WebInspectorUI/UserInterface/Views/ConsoleDrawer.js:
(WI.ConsoleDrawer.prototype._updateDrawerHeight):
* Source/WebInspectorUI/UserInterface/Views/Main.css:
(#content):
* Source/WebInspectorUI/UserInterface/Views/QuickConsole.css:
(.quick-console):
(.quick-console &gt; .console-prompt):

Canonical link: <a href="https://commits.webkit.org/283412@main">https://commits.webkit.org/283412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db1649145dcc6b47c8681cdcc50247f42928c612

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/66222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/45595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/18841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/70254 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/16832 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/53394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/17113 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/53131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/11729 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/69289 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/57335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/33772 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/38724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/14715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/15708 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/60617 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/15060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/71957 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/10177 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/14452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/60454 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/10209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/57399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/60754 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14593 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/8404 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/2037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/41403 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/42479 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/43662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/42223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->