### PR TITLE
[visionOS] Cannot disable captions in native fullscreen

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h
@@ -47,7 +47,9 @@ public:
     WEBCORE_EXPORT void removeCaptionsLayer();
 
 protected:
+    bool m_captionsLayerHidden  { false };
     RetainPtr<CALayer> m_captionsLayer;
+    RetainPtr<id> m_captionsLayerContents;
 };
 
 }

--- a/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm
@@ -36,6 +36,10 @@ VideoFullscreenCaptions::~VideoFullscreenCaptions() = default;
 
 void VideoFullscreenCaptions::setTrackRepresentationImage(PlatformImagePtr textTrack)
 {
+    if (m_captionsLayerHidden) {
+        m_captionsLayerContents = (__bridge id)textTrack.get();
+        return;
+    }
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
     [m_captionsLayer setContents:(__bridge id)textTrack.get()];
@@ -49,7 +53,21 @@ void VideoFullscreenCaptions::setTrackRepresentationContentsScale(float scale)
 
 void VideoFullscreenCaptions::setTrackRepresentationHidden(bool hidden)
 {
-    [m_captionsLayer setHidden:hidden];
+    if (hidden == m_captionsLayerHidden)
+        return;
+    m_captionsLayerHidden = hidden;
+
+    // LinearMediaKit will un-hide the captionsLayer, so ensure the layer
+    // is visually hidden by removing (and storing) the contents of the
+    // captionsLayer.
+    [m_captionsLayer setHidden:m_captionsLayerHidden];
+    if (m_captionsLayerHidden) {
+        m_captionsLayerContents = [m_captionsLayer contents];
+        [m_captionsLayer setContents:nil];
+    } else {
+        [m_captionsLayer setContents:m_captionsLayerContents.get()];
+        m_captionsLayerContents = nil;
+    }
 }
 
 CALayer *VideoFullscreenCaptions::captionsLayer()


### PR DESCRIPTION
#### 25f0f294ef46a9560ceedc25efe211cb7c330068
<pre>
[visionOS] Cannot disable captions in native fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=276668">https://bugs.webkit.org/show_bug.cgi?id=276668</a>
<a href="https://rdar.apple.com/131477154">rdar://131477154</a>

Reviewed by Andy Estes.

LinearMediaKit can un-hide the caption layer provided via Playable at any point, so
setting the caption layer&apos;s `hidden` property is unreliable to actually hide the layer.

In addition to hiding the layer, also remove the layer&apos;s contents (and store it for
re-use later).

* Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h:
* Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm:
(WebCore::VideoFullscreenCaptions::setTrackRepresentationImage):
(WebCore::VideoFullscreenCaptions::setTrackRepresentationHidden):

Canonical link: <a href="https://commits.webkit.org/281025@main">https://commits.webkit.org/281025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a455e6f43f452e5566754b8cd2d0851b2132169

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47305 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6323 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28149 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7799 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7857 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63738 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54626 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54693 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12904 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1966 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34651 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34396 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->