### PR TITLE
[visionOS] Safari window is sometimes hidden after exiting element fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -339,7 +339,7 @@ private:
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     void didEnterFullscreen() final { };
-    void didExitFullscreen() final;
+    void didExitFullscreen() final { };
     void didCleanupFullscreen() final;
 #endif
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1097,13 +1097,6 @@ void PageClientImpl::hardwareKeyboardAvailabilityChanged()
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
 
-void PageClientImpl::didExitFullscreen()
-{
-#if ENABLE(FULLSCREEN_API)
-    [[webView() fullScreenWindowController] didExitFullscreen];
-#endif
-}
-
 void PageClientImpl::didCleanupFullscreen()
 {
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
@@ -54,7 +54,6 @@
 - (void)close;
 - (void)webViewDidRemoveFromSuperviewWhileInFullscreen;
 - (void)videoControlsManagerDidChange;
-- (void)didExitFullscreen;
 - (void)didCleanupFullscreen;
 
 #if PLATFORM(VISION)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -2035,22 +2035,6 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 #endif
 }
 
-- (void)didExitFullscreen
-{
-#if PLATFORM(VISION)
-    if (!self.isFullScreen || !WebKit::useSpatialFullScreenTransition())
-        return;
-
-    // FIXME 126894293: When entering video fullscreen, LinearMediaKit changes the client scene's
-    // windows' transform3D, then fails to restore them to their original values when exiting
-    // fullscreen. As a result, the element fullscreen window may no longer be frontmost when
-    // exiting back to element fullscreen from video fullscreen. Work around this by restoring the
-    // expected transform3D values here.
-    [_lastKnownParentWindow setTransform3D:CATransform3DTranslate([_lastKnownParentWindow transform3D], 0, 0, kOutgoingWindowZOffset)];
-    [_window setTransform3D:[_parentWindowState transform3D]];
-#endif
-}
-
 - (void)didCleanupFullscreen
 {
 #if ENABLE(LINEAR_MEDIA_PLAYER)


### PR DESCRIPTION
#### 677b11ce01d0dca2299d9d6d0135dcde940f169b
<pre>
[visionOS] Safari window is sometimes hidden after exiting element fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=276670">https://bugs.webkit.org/show_bug.cgi?id=276670</a>
<a href="https://rdar.apple.com/131617118">rdar://131617118</a>

Reviewed by Jer Noble and Tim Horton.

In 277877@main a workaround was added to address an issue where the element fullscreen window was
not frontmost after exiting docked fullscreen. In some circumstances, however, exiting docked
fullscreen may also exit element fullscreen and this could result in a transform with
`kOutgoingWindowZOffset` being set on the WKWebView&apos;s window *after* WKFullScreenWindowControllerIOS
had already undid that transform. The result would be that the window remained hidden even though
the element fullscreen window had been closed.

Since the workaround was added the underlying bug tracked by <a href="https://rdar.apple.com/126894293">rdar://126894293</a> has been resolved.
Since the workaround is no longer necessary and causes the issue described above, this change
removes it.

* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::didExitFullscreen): Deleted.
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController didExitFullscreen]): Deleted.

Canonical link: <a href="https://commits.webkit.org/281029@main">https://commits.webkit.org/281029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91fcefcd131503a0231b11213b40c40aa034f8b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62046 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8865 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47317 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6327 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28161 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32114 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7869 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63750 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54636 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54702 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12905 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1974 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34663 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34408 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->