### PR TITLE
AX: active descendant not exposed when isolated tree mode is on

### DIFF
--- a/LayoutTests/accessibility/mac/active-descendant-after-visibility-change-expected.txt
+++ b/LayoutTests/accessibility/mac/active-descendant-after-visibility-change-expected.txt
@@ -1,0 +1,8 @@
+This test ensures objects that aria-activedescendant is correct after a visibility change.
+
+The listbox option should be focused: AXRole: AXStaticText AXTitle: Red
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/active-descendant-after-visibility-change.html
+++ b/LayoutTests/accessibility/mac/active-descendant-after-visibility-change.html
@@ -1,0 +1,62 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+
+<body>
+
+<div id="all">
+    <div>
+        <button id="open">Open</button>
+    </div>
+    <div id="listbox" tabindex="0" role="listbox" hidden>
+        <div id="option1" tabindex="-1" role="option">Red</div>
+        <div id="option2" tabindex="-1" role="option">Orange</div>
+    </div>
+</div>
+
+<script>
+var output = "This test ensures objects that aria-activedescendant is correct after a visibility change.\n\n";
+
+document.getElementById("open").addEventListener("click", () => {
+    document.getElementById("listbox").hidden = false;
+    document.getElementById("listbox").setAttribute("aria-activedescendant", "option1");
+    setTimeout(() => {
+        document.getElementById("listbox").focus();
+    }, 0);
+});
+
+function notifyCallback(element, notification) {
+    if (notification == "AXFocusChanged") {
+        var axFocused = accessibilityController.focusedElement;
+
+        // Ignore focus on the button, wait for focus on the listbox option.
+        if (axFocused.role == "AXRole: AXButton") {
+            return;
+        }
+
+        output += `The listbox option should be focused: ${axFocused.role} ${axFocused.title}\n`;
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        document.getElementById("all").hidden = true;
+        finishJSTest();
+    }
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    accessibilityController.addNotificationListener(notifyCallback);
+
+    setTimeout(() => {
+        var axOpenButton = accessibilityController.accessibleElementById("open");
+        axOpenButton.press();
+    }, 100);
+}
+
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -4099,15 +4099,18 @@ void AXObjectCache::performDeferredCacheUpdate(ForceLayout forceLayout)
         }
     };
     AXLOGDeferredCollection("ReplacedObjectsList"_s, m_deferredReplacedObjects);
+    bool anyRelationsDirty = false;
     for (AXID axID : m_deferredReplacedObjects) {
         // If the replaced object was part of any relation, we need to make sure the relations are updated.
         // Relations for this object may have been removed already (via the renderer being destroyed), so
         // we should check if this axID was recently removed so we can dirty relations.
         if (m_relations.contains(axID) || m_recentlyRemovedRelations.contains(axID))
-            markRelationsDirty();
+            anyRelationsDirty = true;
         remove(axID);
     }
     m_deferredReplacedObjects.clear();
+    if (anyRelationsDirty)
+        markRelationsDirty();
 
     AXLOGDeferredCollection("RecomputeTableIsExposedList"_s, m_deferredRecomputeTableIsExposedList);
     m_deferredRecomputeTableIsExposedList.forEach([this] (auto& tableElement) {


### PR DESCRIPTION
#### 348b978dc50e5a3be518f51c006c7d86b5382793
<pre>
AX: active descendant not exposed when isolated tree mode is on
<a href="https://bugs.webkit.org/show_bug.cgi?id=276628">https://bugs.webkit.org/show_bug.cgi?id=276628</a>
<a href="https://rdar.apple.com/131784854">rdar://131784854</a>

Reviewed by Tyler Wilcock.

When a node gets a new renderer, such as when it changes visibility, a deferred cache update
is needed to ensure the new renderer is in the cache, and relations need to be recomputed.

However, it was possible for relations to be recomputed before the loop finished, so some
nodes that needed deferred cache updates wouldn&apos;t get taken into account and their
relations wouldn&apos;t be computed correctly. The fix is to mark relations dirty only at the
end of the loop after all of the nodes needing deferred updates had their AXIDs removed.

* LayoutTests/accessibility/mac/active-descendant-after-visibility-change-expected.txt: Added.
* LayoutTests/accessibility/mac/active-descendant-after-visibility-change.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::performDeferredCacheUpdate):

Canonical link: <a href="https://commits.webkit.org/281043@main">https://commits.webkit.org/281043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c05bff5461e29e016fb43a8c300b9e2d5c8d9eff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62138 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8956 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47370 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6378 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7889 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7960 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54120 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63841 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8169 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54766 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12907 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2048 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34754 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->