### PR TITLE
[JSC] Use simdutf for toBase64

### DIFF
--- a/JSTests/microbenchmarks/to-base64.js
+++ b/JSTests/microbenchmarks/to-base64.js
@@ -1,0 +1,14 @@
+//@ requireOptions("--useUint8ArrayBase64Methods=1")
+
+function test(buffer)
+{
+    return buffer.toBase64();
+}
+noInline(test);
+
+let buffer = new Uint8Array(16 * 1024);
+for (let i = 0; i < buffer.length; ++i)
+    buffer[i] = i & 0xff;
+
+for (let i = 0; i < 1e4; ++i)
+    test(buffer);

--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -96,10 +96,28 @@ static const char base64URLDecMap[decodeMapSize] = {
     0x31, 0x32, 0x33, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet
 };
 
+static inline simdutf::base64_options toSIMDUTFOptions(OptionSet<Base64EncodeOption> options)
+{
+    if (options.contains(Base64EncodeOption::URL)) {
+        if (options.contains(Base64EncodeOption::OmitPadding))
+            return simdutf::base64_url;
+        return simdutf::base64_url_with_padding;
+    }
+    if (options.contains(Base64EncodeOption::OmitPadding))
+        return simdutf::base64_default_no_padding;
+    return simdutf::base64_default;
+}
+
 template<typename CharacterType> static void base64EncodeInternal(std::span<const uint8_t> inputDataBuffer, std::span<CharacterType> destinationDataBuffer, OptionSet<Base64EncodeOption> options)
 {
     ASSERT(destinationDataBuffer.size() > 0);
     ASSERT(calculateBase64EncodedSize(inputDataBuffer.size(), options) == destinationDataBuffer.size());
+
+    if constexpr (sizeof(CharacterType) == 1) {
+        size_t bytesWritten = simdutf::binary_to_base64(bitwise_cast<const char*>(inputDataBuffer.data()), inputDataBuffer.size(), bitwise_cast<char*>(destinationDataBuffer.data()), toSIMDUTFOptions(options));
+        ASSERT_UNUSED(bytesWritten, bytesWritten == destinationDataBuffer.size());
+        return;
+    }
 
     auto encodeMap = options.contains(Base64EncodeOption::URL) ? base64URLEncMap : base64EncMap;
 
@@ -176,6 +194,14 @@ String base64EncodeToString(std::span<const std::byte> input, OptionSet<Base64En
 String base64EncodeToStringReturnNullIfOverflow(std::span<const std::byte> input, OptionSet<Base64EncodeOption> options)
 {
     return tryMakeString(base64Encoded(input, options));
+}
+
+unsigned calculateBase64EncodedSize(unsigned inputLength, OptionSet<Base64EncodeOption> options)
+{
+    if (inputLength > maximumBase64EncoderInputBufferSize)
+        return 0;
+
+    return simdutf::base64_length_from_binary(inputLength, toSIMDUTFOptions(options));
 }
 
 template<typename T, typename Malloc = VectorBufferMalloc>

--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -53,7 +53,7 @@ struct Base64Specification {
 // Rather than being perfectly precise, this is a bit conservative.
 static constexpr unsigned maximumBase64EncoderInputBufferSize = std::numeric_limits<unsigned>::max() / 77 * 76 / 4 * 3 - 2;
 
-unsigned calculateBase64EncodedSize(unsigned inputLength, OptionSet<Base64EncodeOption> options);
+WTF_EXPORT_PRIVATE unsigned calculateBase64EncodedSize(unsigned inputLength, OptionSet<Base64EncodeOption>);
 
 template<typename CharacterType> bool isBase64OrBase64URLCharacter(CharacterType);
 
@@ -160,20 +160,6 @@ inline std::optional<Vector<uint8_t>> base64URLDecode(std::span<const uint8_t> i
 template<typename CharacterType> bool isBase64OrBase64URLCharacter(CharacterType c)
 {
     return isASCIIAlphanumeric(c) || c == '+' || c == '/' || c == '-' || c == '_';
-}
-
-inline unsigned calculateBase64EncodedSize(unsigned inputLength, OptionSet<Base64EncodeOption> options)
-{
-    if (!inputLength)
-        return 0;
-
-    if (inputLength > maximumBase64EncoderInputBufferSize)
-        return 0;
-
-    if (options.contains(Base64EncodeOption::OmitPadding))
-        return ((inputLength * 4) + 2) / 3;
-
-    return ((inputLength + 2) / 3) * 4;
 }
 
 inline Base64Specification base64Encoded(std::span<const std::byte> input, OptionSet<Base64EncodeOption> options)


### PR DESCRIPTION
#### 67891d8bd765932bb54990b8604e9f6703147831
<pre>
[JSC] Use simdutf for toBase64
<a href="https://bugs.webkit.org/show_bug.cgi?id=276673">https://bugs.webkit.org/show_bug.cgi?id=276673</a>
<a href="https://rdar.apple.com/131862111">rdar://131862111</a>

Reviewed by Yijia Huang.

This patch integrates simdutf&apos;s base64 encoder for WebKit. Still we cannot use it for generating 16bit characters.

                               ToT                     Patched

    to-base64            72.2693+-0.2534     ^     11.4135+-0.0801        ^ definitely 6.3319x faster

* JSTests/microbenchmarks/to-base64.js: Added.
(test):
* Source/WTF/wtf/text/Base64.cpp:
(WTF::toSIMDUTFOptions):
(WTF::base64EncodeInternal):
(WTF::calculateBase64EncodedSize):
* Source/WTF/wtf/text/Base64.h:
(WTF::calculateBase64EncodedSize): Deleted.

Canonical link: <a href="https://commits.webkit.org/281035@main">https://commits.webkit.org/281035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6681f1dc4c2cde136ca1cf06567e5227e056626

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62079 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8897 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47340 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6348 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7838 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7901 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51544 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63782 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57695 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2366 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54660 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50561 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/54758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2000 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79455 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8720 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13223 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34695 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->