### PR TITLE
[scrollbar-styling] Implement scrollbar-width for UI-side compositing

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-expected.txt
@@ -1,0 +1,13 @@
+Test scrollbar-width on overflow and main document
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Overflow should have scrollbar-width:thin
+PASS Scrollbar state: enabled,thin
+Document should have scrollbar-width:thin
+PASS Scrollbar state: enabled,thin
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-iframe-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-iframe-expected.txt
@@ -1,0 +1,12 @@
+
+Test scrollbar-width on overflow in iframe
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Overflow in iframe should have scrollbar-width:thin
+PASS Scrollbar state: enabled,thin
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-iframe.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width-iframe.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 1000px;
+        }
+    </style>
+    <script src="../../../../resources/js-test-pre.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+    
+    <script>
+        jsTestIsAsync = true;
+
+        if (window.internals)
+            internals.setUsesOverlayScrollbars(true);
+
+        async function doTest()
+        {
+            description('Test scrollbar-width on overflow in iframe');
+            if (!window.internals) {
+                finishJSTest();
+                return;
+            }
+            
+            const iframe = document.getElementsByTagName('iframe')[0];
+            const iframeWindow = iframe.contentWindow;
+
+            const scroller = iframe.contentDocument.querySelector('.scroller');
+
+            iframeWindow.internals.setUsesOverlayScrollbars(true);
+
+            debug('Overflow in iframe should have scrollbar-width:thin');
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
+                let scrollbarWidth = state.indexOf('thin') != -1;
+                if (scrollbarWidth)
+                    testPassed('Scrollbar state: ' + state);
+                return scrollbarWidth;
+            });
+
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            doTest();
+        }, false);
+    </script>
+</head>
+<body>
+
+    <iframe srcdoc="
+        <style>
+        body {
+            scrollbar-width: thin;
+            height: 1000px;
+        }
+        .scroller {
+            margin: 10px;
+            width: 200px;
+            height: 200px;
+            border: 1px solid black;
+            overflow: auto;
+            scrollbar-width: thin;
+        }
+        .contents {
+            width: 100%;
+            height: 200%;
+        }
+        </style>
+        <div class='scroller'>
+            <div class='contents'></div>
+        </div>
+    "></iframe>
+    <div id="console"></div>
+    <script src="../../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-width.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        html {
+            scrollbar-width: thin;
+        }
+        body {
+            height: 1000px;
+        }
+        .scroller {
+            margin: 10px;
+            width: 200px;
+            height: 200px;
+            border: 1px solid black;
+            overflow: auto;
+            scrollbar-width: thin;
+        }
+        .contents {
+            width: 100%;
+            height: 200%;
+        }
+    </style>
+    <script src="../../../../resources/js-test-pre.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+    
+    <script>
+        jsTestIsAsync = true;
+
+        if (window.internals)
+            internals.setUsesOverlayScrollbars(true);
+
+        async function doTest()
+        {
+            description('Test scrollbar-width on overflow and main document');
+            if (!window.internals) {
+                finishJSTest();
+                return;
+            }
+            
+            const scroller = document.querySelector('.scroller');
+
+            debug('Overflow should have scrollbar-width:thin');
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
+                let scrollbarWidth = state.indexOf('thin') != -1;
+                if (scrollbarWidth)
+                    testPassed('Scrollbar state: ' + state);
+                return scrollbarWidth;
+            });
+
+            debug('Document should have scrollbar-width:thin');
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState();
+                let scrollbarWidth = state.indexOf('thin') != -1;
+                if (scrollbarWidth)
+                    testPassed('Scrollbar state: ' + state);
+                return scrollbarWidth;
+            });
+
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            doTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="contents"></div>
+    </div>
+    <div id="console"></div>
+    <script src="../../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/mac/scrollbars/select-overlay-scrollbar-hovered-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/select-overlay-scrollbar-hovered-expected.txt
@@ -5,9 +5,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 Initial state
-enabled
+enabled,thin
 Hovering vertical scrollbar should show expanded scrollbar
-PASS Scrollbar state: enabled,expanded,visible_track,visible_thumb
+PASS Scrollbar state: enabled,expanded,visible_track,visible_thumb,thin
 Unhovering vertical scrollbar should hide it
 PASS Thumb and track hidden
 PASS successfullyParsed is true

--- a/LayoutTests/fast/scrolling/mac/scrollbars/select-overlay-scrollbar-reveal-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/select-overlay-scrollbar-reveal-expected.txt
@@ -5,11 +5,11 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 Initial state
-enabled
+enabled,thin
 MayBegin should show the scrollbar
-PASS Scrollbar state: enabled,visible_thumb
+PASS Scrollbar state: enabled,visible_thumb,thin
 Cancelled should hide the scrollbar
-PASS Scrollbar state: enabled
+PASS Scrollbar state: enabled,thin
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/Source/WebCore/PAL/pal/spi/mac/NSScrollerImpSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSScrollerImpSPI.h
@@ -78,6 +78,7 @@ typedef NSUInteger NSOverlayScrollerState;
 @property (readonly) CGFloat knobOverlapEndInset;
 @property (readonly) CGFloat trackOverlapEndInset;
 @property NSUserInterfaceLayoutDirection userInterfaceLayoutDirection;
+@property (readonly) NSControlSize controlSize;
 - (NSRect)rectForPart:(NSScrollerPart)partCode;
 - (void)drawKnobSlotInRect:(NSRect)slotRect highlight:(BOOL)flag alpha:(CGFloat)alpha;
 - (void)drawKnobSlotInRect:(NSRect)slotRect highlight:(BOOL)flag;

--- a/Source/WebCore/page/ChromeClient.cpp
+++ b/Source/WebCore/page/ChromeClient.cpp
@@ -51,8 +51,10 @@ RefPtr<ImageBuffer> ChromeClient::sinkIntoImageBuffer(std::unique_ptr<WebCore::S
 }
 
 
-void ChromeClient::ensureScrollbarsController(Page&, ScrollableArea& area) const
+void ChromeClient::ensureScrollbarsController(Page&, ScrollableArea& area, bool update) const
 {
+    if (update)
+        return;
     area.ScrollableArea::createScrollbarsController();
 }
 

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -436,7 +436,7 @@ public:
     virtual bool layerTreeStateIsFrozen() const { return false; }
 
     virtual RefPtr<ScrollingCoordinator> createScrollingCoordinator(Page&) const { return nullptr; }
-    WEBCORE_EXPORT virtual void ensureScrollbarsController(Page&, ScrollableArea&) const;
+    WEBCORE_EXPORT virtual void ensureScrollbarsController(Page&, ScrollableArea&, bool update = false) const;
 
     virtual bool canEnterVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode) const { return false; }
     virtual bool supportsVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode) { return false; }

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -499,6 +499,17 @@ void AsyncScrollingCoordinator::setScrollbarEnabled(Scrollbar& scrollbar)
     stateNode->setScrollbarEnabledState(scrollbar.orientation(), scrollbar.enabled());
 }
 
+void AsyncScrollingCoordinator::setScrollbarWidth(ScrollableArea& scrollableArea, ScrollbarWidth scrollbarWidth)
+{
+    ASSERT(isMainThread());
+    ASSERT(page());
+
+    auto stateNode = dynamicDowncast<ScrollingStateScrollingNode>(stateNodeForScrollableArea(scrollableArea));
+    if (!stateNode)
+        return;
+    stateNode->setScrollbarWidth(scrollbarWidth);
+}
+
 void AsyncScrollingCoordinator::applyScrollingTreeLayerPositions()
 {
     m_scrollingTree->applyLayerPositions();
@@ -984,6 +995,7 @@ void AsyncScrollingCoordinator::setFrameScrollingNodeState(ScrollingNodeID nodeI
     frameScrollingNode->setAsyncFrameOrOverflowScrollingEnabled(settings.asyncFrameScrollingEnabled() || settings.asyncOverflowScrollingEnabled());
     frameScrollingNode->setScrollingPerformanceTestingEnabled(settings.scrollingPerformanceTestingEnabled());
     frameScrollingNode->setOverlayScrollbarsEnabled(ScrollbarTheme::theme().usesOverlayScrollbars());
+    frameScrollingNode->setScrollbarWidth(frameView.scrollbarWidthStyle());
     frameScrollingNode->setWheelEventGesturesBecomeNonBlocking(settings.wheelEventGesturesBecomeNonBlocking());
 
     frameScrollingNode->setMinLayoutViewportOrigin(frameView.minStableLayoutViewportOrigin());
@@ -1019,6 +1031,7 @@ void AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry(Scrolling
         scrollingNode->setScrollbarEnabledState(ScrollbarOrientation::Horizontal, horizontalScrollbar->enabled());
     if (verticalScrollbar)
         scrollingNode->setScrollbarEnabledState(ScrollbarOrientation::Vertical, verticalScrollbar->enabled());
+    scrollingNode->setScrollbarWidth(scrollableArea.scrollbarWidthStyle());
 
     scrollingNode->setScrollOrigin(scrollableArea.scrollOrigin());
     scrollingNode->setScrollPosition(scrollableArea.scrollPosition());

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -184,6 +184,7 @@ private:
     
     WEBCORE_EXPORT void setMouseIsOverScrollbar(Scrollbar*, bool isOverScrollbar) override;
     WEBCORE_EXPORT void setScrollbarEnabled(Scrollbar&) override;
+    WEBCORE_EXPORT void setScrollbarWidth(ScrollableArea&, ScrollbarWidth) override;
 
     void hysterisisTimerFired(PAL::HysteresisState);
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -215,6 +215,7 @@ public:
     WEBCORE_EXPORT virtual void setScrollbarEnabled(Scrollbar&) { }
     WEBCORE_EXPORT virtual void setLayerHostingContextIdentifierForFrameHostingNode(ScrollingNodeID, std::optional<LayerHostingContextIdentifier>) { }
     WEBCORE_EXPORT virtual void setScrollbarLayoutDirection(ScrollableArea&, UserInterfaceLayoutDirection) { }
+    WEBCORE_EXPORT virtual void setScrollbarWidth(ScrollableArea&, ScrollbarWidth) { }
 
     FrameIdentifier mainFrameIdentifier() const;
 

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
@@ -62,6 +62,7 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     ScrollbarHoverState&& scrollbarHoverState,
     ScrollbarEnabledState&& scrollbarEnabledState,
     UserInterfaceLayoutDirection scrollbarLayoutDirection,
+    ScrollbarWidth scrollbarWidth,
     RequestedKeyboardScrollData&& keyboardScrollData,
     float frameScaleFactor,
     EventTrackingRegions&& eventTrackingRegions,
@@ -112,6 +113,7 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     WTFMove(scrollbarHoverState),
     WTFMove(scrollbarEnabledState),
     scrollbarLayoutDirection,
+    scrollbarWidth,
     WTFMove(keyboardScrollData))
     , m_rootContentsLayer(rootContentsLayer.value_or(PlatformLayerIdentifier()))
     , m_counterScrollingLayer(counterScrollingLayer.value_or(PlatformLayerIdentifier()))

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
@@ -154,6 +154,7 @@ private:
         ScrollbarHoverState&&,
         ScrollbarEnabledState&&,
         UserInterfaceLayoutDirection,
+        ScrollbarWidth,
         RequestedKeyboardScrollData&&,
         float frameScaleFactor,
         EventTrackingRegions&&,

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -235,8 +235,9 @@ enum class ScrollingStateNodeProperty : uint64_t {
     ScrollbarHoverState                         = MouseActivityState << 1,
     ScrollbarEnabledState                       = ScrollbarHoverState << 1,
     ScrollbarLayoutDirection                    = ScrollbarEnabledState << 1,
+    ScrollbarWidth                              = ScrollbarLayoutDirection << 1,
     // ScrollingStateFrameScrollingNode
-    KeyboardScrollData                          = ScrollbarLayoutDirection << 1,
+    KeyboardScrollData                          = ScrollbarWidth << 1,
     FrameScaleFactor                            = KeyboardScrollData << 1,
     EventTrackingRegion                         = FrameScaleFactor << 1,
     RootContentsLayer                           = EventTrackingRegion << 1,

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp
@@ -61,6 +61,7 @@ ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode(
     ScrollbarHoverState&& scrollbarHoverState,
     ScrollbarEnabledState&& scrollbarEnabledState,
     UserInterfaceLayoutDirection scrollbarLayoutDirection,
+    ScrollbarWidth scrollbarWidth,
     RequestedKeyboardScrollData&& scrollData
 ) : ScrollingStateScrollingNode(
     ScrollingNodeType::Overflow,
@@ -91,6 +92,7 @@ ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode(
     WTFMove(scrollbarHoverState),
     WTFMove(scrollbarEnabledState),
     scrollbarLayoutDirection,
+    scrollbarWidth,
     WTFMove(scrollData)
 ) { }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h
@@ -70,6 +70,7 @@ private:
         ScrollbarHoverState&&,
         ScrollbarEnabledState&&,
         UserInterfaceLayoutDirection,
+        ScrollbarWidth,
         RequestedKeyboardScrollData&&
     );
     ScrollingStateOverflowScrollingNode(ScrollingStateTree&, ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp
@@ -61,6 +61,7 @@ ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode(
     ScrollbarHoverState&& scrollbarHoverState,
     ScrollbarEnabledState&& scrollbarEnabledState,
     UserInterfaceLayoutDirection scrollbarLayoutDirection,
+    ScrollbarWidth scrollbarWidth,
     RequestedKeyboardScrollData&& scrollData
 ) : ScrollingStateScrollingNode(
     ScrollingNodeType::PluginScrolling,
@@ -91,6 +92,7 @@ ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode(
     WTFMove(scrollbarHoverState),
     WTFMove(scrollbarEnabledState),
     scrollbarLayoutDirection,
+    scrollbarWidth,
     WTFMove(scrollData)
 )
 {

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h
@@ -76,6 +76,7 @@ private:
         ScrollbarHoverState&&,
         ScrollbarEnabledState&&,
         UserInterfaceLayoutDirection,
+        ScrollbarWidth,
         RequestedKeyboardScrollData&&
     );
 

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -68,6 +68,7 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(
     ScrollbarHoverState&& scrollbarHoverState,
     ScrollbarEnabledState&& scrollbarEnabledState,
     UserInterfaceLayoutDirection scrollbarLayoutDirection,
+    ScrollbarWidth scrollbarWidth,
     RequestedKeyboardScrollData&& keyboardScrollData
 ) : ScrollingStateNode(nodeType, nodeID, WTFMove(children), changedProperties, layerID)
     , m_scrollableAreaSize(scrollableAreaSize)
@@ -92,6 +93,7 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(
     , m_synchronousScrollingReasons(synchronousScrollingReasons)
 #endif
     , m_scrollbarLayoutDirection(scrollbarLayoutDirection)
+    , m_scrollbarWidth(scrollbarWidth)
     , m_isMonitoringWheelEvents(isMonitoringWheelEvents)
     , m_mouseIsOverContentArea(mouseIsOverContentArea)
 {
@@ -120,6 +122,7 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(const ScrollingStateScr
     , m_synchronousScrollingReasons(stateNode.synchronousScrollingReasons())
 #endif
     , m_scrollbarLayoutDirection(stateNode.scrollbarLayoutDirection())
+    , m_scrollbarWidth(stateNode.scrollbarWidth())
     , m_isMonitoringWheelEvents(stateNode.isMonitoringWheelEvents())
     , m_mouseIsOverContentArea(stateNode.mouseIsOverContentArea())
 {
@@ -383,6 +386,14 @@ void ScrollingStateScrollingNode::setScrollbarLayoutDirection(UserInterfaceLayou
 
     m_scrollbarLayoutDirection = scrollbarLayoutDirection;
     setPropertyChanged(Property::ScrollbarLayoutDirection);
+}
+
+void ScrollingStateScrollingNode::setScrollbarWidth(ScrollbarWidth scrollbarWidth)
+{
+    if (scrollbarWidth == m_scrollbarWidth)
+        return;
+    m_scrollbarWidth = scrollbarWidth;
+    setPropertyChanged(Property::ScrollbarWidth);
 }
 
 void ScrollingStateScrollingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -139,6 +139,9 @@ public:
     WEBCORE_EXPORT void setScrollbarLayoutDirection(UserInterfaceLayoutDirection);
     UserInterfaceLayoutDirection scrollbarLayoutDirection() const { return m_scrollbarLayoutDirection; }
 
+    WEBCORE_EXPORT void setScrollbarWidth(ScrollbarWidth);
+    ScrollbarWidth scrollbarWidth() const { return m_scrollbarWidth; }
+
 protected:
     ScrollingStateScrollingNode(
         ScrollingNodeType,
@@ -169,6 +172,7 @@ protected:
         ScrollbarHoverState&&,
         ScrollbarEnabledState&&,
         UserInterfaceLayoutDirection,
+        ScrollbarWidth,
         RequestedKeyboardScrollData&&
     );
     ScrollingStateScrollingNode(ScrollingStateTree&, ScrollingNodeType, ScrollingNodeID);
@@ -209,6 +213,7 @@ private:
     OptionSet<SynchronousScrollingReason> m_synchronousScrollingReasons;
 #endif
     UserInterfaceLayoutDirection m_scrollbarLayoutDirection { UserInterfaceLayoutDirection::LTR };
+    ScrollbarWidth m_scrollbarWidth { ScrollbarWidth::Auto };
 
     bool m_isMonitoringWheelEvents { false };
     bool m_mouseIsOverContentArea { false };

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -470,6 +470,9 @@ String ScrollerMac::scrollbarState() const
     if ([m_scrollerImp userInterfaceLayoutDirection] == NSUserInterfaceLayoutDirectionRightToLeft)
         result.append(",RTL"_s);
 
+    if ([m_scrollerImp controlSize] != NSControlSizeRegular)
+        result.append(",thin"_s);
+
     return result.toString();
 }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -112,6 +112,8 @@ public:
 
     bool mouseInContentArea() const { return m_mouseInContentArea; }
 
+    void setScrollbarWidth(ScrollbarWidth);
+
 private:
     ScrollerPairMac(ScrollingTreeScrollingNode&);
 
@@ -130,6 +132,7 @@ private:
     RetainPtr<NSScrollerImpPair> m_scrollerImpPair;
     RetainPtr<WebScrollerImpPairDelegateMac> m_scrollerImpPairDelegate;
 
+    ScrollbarWidth m_scrollbarWidth { ScrollbarWidth::Auto };
     std::atomic<bool> m_usingPresentationValues { false };
     std::atomic<ScrollbarStyle> m_scrollbarStyle { ScrollbarStyle::AlwaysVisible };
     bool m_inLiveResize { false };

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -285,11 +285,7 @@ bool ScrollerPairMac::useDarkAppearance() const
 
 ScrollbarWidth ScrollerPairMac::scrollbarWidthStyle() const
 {
-    RefPtr node = m_scrollingNode.get();
-    if (!node)
-        return ScrollbarWidth::Auto;
-
-    return node->scrollbarWidthStyle();
+    return m_scrollbarWidth;
 }
 
 ScrollerPairMac::Values ScrollerPairMac::valuesForOrientation(ScrollbarOrientation orientation)
@@ -427,6 +423,16 @@ void ScrollerPairMac::mouseIsInScrollbar(ScrollbarHoverState hoverState)
             horizontalScroller().mouseExitedScrollbar();
     }
     m_scrollbarHoverState = hoverState;
+}
+
+void ScrollerPairMac::setScrollbarWidth(ScrollbarWidth scrollbarWidth)
+{
+    if (m_scrollbarWidth == scrollbarWidth)
+        return;
+    m_scrollbarWidth = scrollbarWidth;
+
+    horizontalScroller().updateScrollbarStyle();
+    verticalScroller().updateScrollbarStyle();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -95,6 +95,11 @@ void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingS
         m_scrollerPair->verticalScroller().setScrollbarLayoutDirection(scrollbarLayoutDirection);
     }
 
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarWidth)) {
+        auto scrollbarWidth = scrollingStateNode.scrollbarWidth();
+        m_scrollerPair->setScrollbarWidth(scrollbarWidth);
+    }
+
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ContentAreaHoverState)) {
         if (scrollingStateNode.mouseIsOverContentArea())
             m_scrollerPair->mouseEnteredContentArea();

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -387,7 +387,7 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollGranularity);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, NativeScrollbarVisibility);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollPositionChangeOptions);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapPointSelectionMethod);
-WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarWidth);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarWidth);
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -506,6 +506,6 @@ private:
     Markable<ScrollingNodeID> m_scrollingNodeIDForTesting;
 };
 
-WTF::TextStream& operator<<(WTF::TextStream&, const ScrollableArea&);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const ScrollableArea&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ScrollbarsController.h
+++ b/Source/WebCore/platform/ScrollbarsController.h
@@ -37,6 +37,7 @@ namespace WebCore {
 class Scrollbar;
 class ScrollableArea;
 enum class ScrollbarOrientation : uint8_t;
+enum class ScrollbarWidth : uint8_t;
 
 class ScrollbarsController {
     WTF_MAKE_FAST_ALLOCATED;
@@ -112,6 +113,8 @@ public:
     WEBCORE_EXPORT void updateScrollbarsThickness();
 
     WEBCORE_EXPORT virtual void updateScrollbarStyle() { }
+
+    WEBCORE_EXPORT virtual void scrollbarWidthChanged(WebCore::ScrollbarWidth) { }
 
 private:
     ScrollableArea& m_scrollableArea;

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -862,7 +862,6 @@ void ScrollbarsControllerMac::willRemoveHorizontalScrollbar(Scrollbar* scrollbar
     if (!painter)
         return;
 
-    ASSERT(m_horizontalScrollerImpDelegate);
     [m_horizontalScrollerImpDelegate invalidate];
     m_horizontalScrollerImpDelegate = nullptr;
 
@@ -1056,6 +1055,9 @@ static String scrollbarState(Scrollbar* scrollbar)
 
     if (scrollerImp.userInterfaceLayoutDirection == NSUserInterfaceLayoutDirectionRightToLeft)
         result.append(",RTL"_s);
+
+    if (scrollerImp.controlSize != NSControlSizeRegular)
+        result.append(",thin"_s);
 
     return result.toString();
 }

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -344,6 +344,10 @@ void RenderBox::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle
         if (auto* scrollableArea = layer()->scrollableArea())
             scrollableArea->scrollbarsController().scrollbarLayoutDirectionChanged(shouldPlaceVerticalScrollbarOnLeft() ? UserInterfaceLayoutDirection::RTL : UserInterfaceLayoutDirection::LTR);
     }
+    if (layer() && oldStyle && oldStyle->scrollbarWidth() != newStyle.scrollbarWidth()) {
+        if (auto* scrollableArea = layer()->scrollableArea())
+            scrollableArea->scrollbarsController().scrollbarWidthChanged(newStyle.scrollbarWidth());
+    }
 
 #if ENABLE(DARK_MODE_CSS)
     if (layer() && oldStyle && oldStyle->colorScheme() != newStyle.colorScheme()) {

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -5433,6 +5433,8 @@ ScrollingNodeID RenderLayerCompositor::updateScrollingNodeForScrollingRole(Rende
             scrollingCoordinator->setScrollingNodeScrollableAreaGeometry(newNodeID, frameView);
             scrollingCoordinator->setFrameScrollingNodeState(newNodeID, frameView);
         }
+        page().chrome().client().ensureScrollbarsController(page(), frameView, true);
+
     } else {
         newNodeID = attachScrollingNode(layer, ScrollingNodeType::Overflow, treeState);
         if (!newNodeID) {
@@ -5452,7 +5454,7 @@ ScrollingNodeID RenderLayerCompositor::updateScrollingNodeForScrollingRole(Rende
                 scrollingCoordinator->setScrollingNodeScrollableAreaGeometry(newNodeID, *scrollableArea);
         }
         if (auto* scrollableArea = layer.scrollableArea())
-            page().chrome().client().ensureScrollbarsController(page(), *scrollableArea);
+            page().chrome().client().ensureScrollbarsController(page(), *scrollableArea, true);
     }
 
     return newNodeID;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -2047,5 +2047,4 @@ FrameIdentifier RenderLayerScrollableArea::rootFrameID() const
     return m_layer.renderer().frame().rootFrame().frameID();
 }
 
-
 } // namespace WebCore

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -93,6 +93,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarHoverState] WebCore::ScrollbarHoverState scrollbarHoverState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarLayoutDirection] WebCore::UserInterfaceLayoutDirection scrollbarLayoutDirection();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarWidth] WebCore::ScrollbarWidth scrollbarWidth();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::FrameScaleFactor] float frameScaleFactor()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::EventTrackingRegion] WebCore::EventTrackingRegions eventTrackingRegions()
@@ -145,6 +146,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarHoverState] WebCore::ScrollbarHoverState scrollbarHoverState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarLayoutDirection] WebCore::UserInterfaceLayoutDirection scrollbarLayoutDirection();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarWidth] WebCore::ScrollbarWidth scrollbarWidth();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData()
 };
 
@@ -184,6 +186,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarHoverState] WebCore::ScrollbarHoverState scrollbarHoverState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarLayoutDirection] WebCore::UserInterfaceLayoutDirection scrollbarLayoutDirection();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarWidth] WebCore::ScrollbarWidth scrollbarWidth();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData()
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4090,6 +4090,7 @@ header: <WebCore/ScrollingStateNode.h>
     ScrollbarHoverState
     ScrollbarEnabledState
     ScrollbarLayoutDirection
+    ScrollbarWidth
     FrameScaleFactor
     EventTrackingRegion
     RootContentsLayer

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1189,12 +1189,13 @@ RefPtr<WebCore::ScrollingCoordinator> WebChromeClient::createScrollingCoordinato
 #endif
 
 #if PLATFORM(MAC)
-void WebChromeClient::ensureScrollbarsController(Page& corePage, ScrollableArea& area) const
+void WebChromeClient::ensureScrollbarsController(Page& corePage, ScrollableArea& area, bool update) const
 {
     auto page = protectedPage();
     ASSERT(page->corePage() == &corePage);
     auto* currentScrollbarsController = area.existingScrollbarsController();
-    if (area.mockScrollbarsControllerEnabled()) {
+
+    if (area.mockScrollbarsControllerEnabled() || (update && !currentScrollbarsController)) {
         ASSERT(!currentScrollbarsController || is<ScrollbarsControllerMock>(currentScrollbarsController));
         return;
     }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -298,7 +298,7 @@ private:
 #endif
 
 #if PLATFORM(MAC)
-    void ensureScrollbarsController(WebCore::Page&, WebCore::ScrollableArea&) const final;
+    void ensureScrollbarsController(WebCore::Page&, WebCore::ScrollableArea&, bool update = false) const final;
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
@@ -60,6 +60,8 @@ public:
 
     void updateScrollbarStyle() final;
 
+    void scrollbarWidthChanged(WebCore::ScrollbarWidth) final;
+
     bool isRemoteScrollbarsController() const final { return true; }
 
 private:

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
@@ -39,6 +39,8 @@ RemoteScrollbarsController::RemoteScrollbarsController(WebCore::ScrollableArea& 
     : ScrollbarsController(scrollableArea)
     , m_coordinator(ThreadSafeWeakPtr<WebCore::ScrollingCoordinator>(coordinator))
 {
+    if (auto scrollingCoordinator = m_coordinator.get())
+        scrollingCoordinator->setScrollbarWidth(scrollableArea, scrollableArea.scrollbarWidthStyle());
 }
 
 void RemoteScrollbarsController::scrollbarLayoutDirectionChanged(WebCore::UserInterfaceLayoutDirection scrollbarLayoutDirection)
@@ -123,6 +125,12 @@ void RemoteScrollbarsController::updateScrollbarEnabledState(WebCore::Scrollbar&
 {
     if (auto scrollingCoordinator = m_coordinator.get())
         scrollingCoordinator->setScrollbarEnabled(scrollbar);
+}
+
+void RemoteScrollbarsController::scrollbarWidthChanged(WebCore::ScrollbarWidth width)
+{
+    if (auto scrollingCoordinator = m_coordinator.get())
+        scrollingCoordinator->setScrollbarWidth(scrollableArea(), width);
 }
 
 void RemoteScrollbarsController::updateScrollbarStyle()


### PR DESCRIPTION
#### e27ca2b56be9822117da0ea79062e38e8598cd23
<pre>
[scrollbar-styling] Implement scrollbar-width for UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=276676">https://bugs.webkit.org/show_bug.cgi?id=276676</a>
<a href="https://rdar.apple.com/131864169">rdar://131864169</a>

Reviewed by Simon Fraser.

Plumb scrollbar-width property to UI process to update the NSScrollerImp.
Also ensure that scrollbars controller a RemoteScrollbarsController is properly
created for the main frame.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::setScrollbarWidth):
(WebCore::AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
(WebCore::ScrollingCoordinator::setScrollbarWidth):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp:
(WebCore::ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp:
(WebCore::ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp:
(WebCore::ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp:
(WebCore::ScrollingStateScrollingNode::ScrollingStateScrollingNode):
(WebCore::ScrollingStateScrollingNode::setScrollbarWidth):
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h:
(WebCore::ScrollingStateScrollingNode::scrollbarWidth const):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::scrollbarWidthStyle const):
(WebCore::ScrollerPairMac::setScrollbarWidth):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode):
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/platform/ScrollableArea.h:
* Source/WebCore/platform/ScrollbarsController.h:
(WebCore::ScrollbarsController::scrollbarWidthChanged):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::styleDidChange):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateScrollingNodeForScrollingRole):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::ensureScrollbarsController const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm:
(WebKit::RemoteScrollbarsController::RemoteScrollbarsController):
(WebKit::RemoteScrollbarsController::scrollbarWidthChanged):

Canonical link: <a href="https://commits.webkit.org/281411@main">https://commits.webkit.org/281411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b105101704374860b7cfeae003db4dc83e4db28e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59843 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63760 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10367 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10540 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/7253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36555 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/51821 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9059 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9290 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65490 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3771 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51800 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13261 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3136 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35002 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37171 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->