### PR TITLE
Allow overriding threadSelfRestrict* funcs with a macro

### DIFF
--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -328,7 +328,7 @@ void LinkBuffer::copyCompactAndLinkCode(MacroAssembler& macroAssembler, JITCompi
     };
 
     if (g_jscConfig.useFastJITPermissions)
-        threadSelfRestrictRWXToRW();
+        threadSelfRestrict<MemoryRestriction::kRwxToRw>();
 #if ENABLE(MPROTECT_RX_TO_RWX)
     ExecutableAllocator::singleton().startWriting(outData, initialSize);
 #endif
@@ -429,7 +429,7 @@ void LinkBuffer::copyCompactAndLinkCode(MacroAssembler& macroAssembler, JITCompi
             Assembler::fillNops<MachineCodeCopyMode::JITMemcpy>(outData + compactSize, nopSizeInBytes);
     }
     if (g_jscConfig.useFastJITPermissions)
-        threadSelfRestrictRWXToRX();
+        threadSelfRestrict<MemoryRestriction::kRwxToRx>();
 
     if (m_executableMemory) {
         m_size = compactSize;

--- a/Source/JavaScriptCore/assembler/SecureARM64EHashPins.cpp
+++ b/Source/JavaScriptCore/assembler/SecureARM64EHashPins.cpp
@@ -39,12 +39,12 @@ namespace JSC {
 struct WriteToJITRegionScope {
     ALWAYS_INLINE WriteToJITRegionScope()
     {
-        threadSelfRestrictRWXToRW();
+        threadSelfRestrict<MemoryRestriction::kRwxToRw>();
     }
 
     ALWAYS_INLINE ~WriteToJITRegionScope()
     {
-        threadSelfRestrictRWXToRX();
+        threadSelfRestrict<MemoryRestriction::kRwxToRx>();
     }
 };
 

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -423,10 +423,10 @@ static ALWAYS_INLINE JITReservation initializeJITPageReservation()
     if (reservation.pageReservation) {
         ASSERT(reservation.pageReservation.size() == reservation.size);
         reservation.base = reservation.pageReservation.base();
-        g_jscConfig.useFastJITPermissions = threadSelfRestrictSupported();
+        g_jscConfig.useFastJITPermissions = threadSelfRestrictSupported<MemoryRestriction::kRwxToRw>();
 
         if (g_jscConfig.useFastJITPermissions)
-            threadSelfRestrictRWXToRX();
+            threadSelfRestrict<MemoryRestriction::kRwxToRx>();
 
 #if ENABLE(SEPARATED_WX_HEAP)
         if (!g_jscConfig.useFastJITPermissions) {

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.h
@@ -137,9 +137,9 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
 #endif
 
         if (g_jscConfig.useFastJITPermissions) {
-            threadSelfRestrictRWXToRW();
+            threadSelfRestrict<MemoryRestriction::kRwxToRw>();
             memcpy(dst, src, n);
-            threadSelfRestrictRWXToRX();
+            threadSelfRestrict<MemoryRestriction::kRwxToRx>();
             return dst;
         }
 


### PR DESCRIPTION
#### 9e6ac9c6050a0b9403a6d52aaf39a47fcf8d4d2d
<pre>
Allow overriding threadSelfRestrict* funcs with a macro
<a href="https://bugs.webkit.org/show_bug.cgi?id=276648">https://bugs.webkit.org/show_bug.cgi?id=276648</a>
<a href="https://rdar.apple.com/131809314">rdar://131809314</a>

Reviewed by Justin Michaud.

The new OS_THREAD_SELF_RESTRICT and OS_THREAD_SELF_RESTRICT_SUPPORTED
macros can be used to locally override the default functionality,
regardless of runtime options or target, by just defining the
appropriate macros upstream of FastJITPermissions.h.

* Source/JavaScriptCore/assembler/FastJITPermissions.h:
(threadSelfRestrictSupported):
(threadSelfRestrict):
(threadSelfRestrictRWXToRW): Deleted.
(threadSelfRestrictRWXToRX): Deleted.
* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::copyCompactAndLinkCode):
* Source/JavaScriptCore/assembler/SecureARM64EHashPins.cpp:
(JSC::WriteToJITRegionScope::WriteToJITRegionScope):
(JSC::WriteToJITRegionScope::~WriteToJITRegionScope):
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::initializeJITPageReservation):
* Source/JavaScriptCore/jit/ExecutableAllocator.h:
(JSC::performJITMemcpy):

Canonical link: <a href="https://commits.webkit.org/281033@main">https://commits.webkit.org/281033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a445977c798ea49e0840ad3cabeadeb94db19ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62106 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8924 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9121 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6357 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60511 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50556 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28197 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/32146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7858 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7928 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51571 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63809 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57722 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2393 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54672 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2401 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54741 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12903 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2020 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79483 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13231 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/34722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->