### PR TITLE
[tvOS] Color pickers are invisible and cannot be dismissed

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -7783,7 +7783,11 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
         return adoptNS([[WKFormSelectControl alloc] initWithView:view]);
 #if ENABLE(INPUT_TYPE_COLOR)
     case WebKit::InputType::Color:
+#if PLATFORM(APPLETV)
+        return nil;
+#else
         return adoptNS([[WKFormColorControl alloc] initWithView:view]);
+#endif
 #endif // ENABLE(INPUT_TYPE_COLOR)
     case WebKit::InputType::Date:
     case WebKit::InputType::DateTimeLocal:


### PR DESCRIPTION
#### a45b58ba9dfd0141d9beddb8829c7f7605e6d798
<pre>
[tvOS] Color pickers are invisible and cannot be dismissed
<a href="https://bugs.webkit.org/show_bug.cgi?id=276686">https://bugs.webkit.org/show_bug.cgi?id=276686</a>
<a href="https://rdar.apple.com/127010401">rdar://127010401</a>

Reviewed by Richard Robinson.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(createInputPeripheralWithView):

Disable presentation of color pickers on tvOS, matching watchOS.

Canonical link: <a href="https://commits.webkit.org/281028@main">https://commits.webkit.org/281028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4db6cdf3bd0bfaeb6477c17f174b621bcf849876

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62085 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8903 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9100 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6347 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60490 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35385 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28182 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/32137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7907 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63788 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2372 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2380 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54724 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2003 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8713 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/34701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34446 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->