### PR TITLE
[JSC] Optimize and clean up Min / Max

### DIFF
--- a/JSTests/microbenchmarks/math-max.js
+++ b/JSTests/microbenchmarks/math-max.js
@@ -1,0 +1,12 @@
+function max(a, b)
+{
+    return Math.max(a, b);
+}
+noInline(max);
+
+for (var i = 0; i < 1e6; ++i) {
+    max(5, 5);
+    max(5, 400.2);
+    max(400.2, 5);
+    max(24.3, 400.2);
+}

--- a/Source/JavaScriptCore/b3/B3Common.h
+++ b/Source/JavaScriptCore/b3/B3Common.h
@@ -91,26 +91,6 @@ static IntType chillUMod(IntType numerator, IntType denominator)
     return unsignedNumerator % unsignedDenominator;
 }
 
-template<typename FloatType>
-static FloatType fMax(FloatType a, FloatType b)
-{
-    if (std::isnan(a) || std::isnan(b))
-        return a + b;
-    if (a == static_cast<FloatType>(0.0) && b == static_cast<FloatType>(0.0) && std::signbit(a) != std::signbit(b))
-        return static_cast<FloatType>(0.0);
-    return std::max(a, b);
-}
-
-template<typename FloatType>
-static FloatType fMin(FloatType a, FloatType b)
-{
-    if (std::isnan(a) || std::isnan(b))
-        return a + b;
-    if (a == static_cast<FloatType>(0.0) && b == static_cast<FloatType>(0.0) && std::signbit(a) != std::signbit(b))
-        return static_cast<FloatType>(-0.0);
-    return std::min(a, b);
-}
-
 template<typename IntType>
 static IntType rotateRight(IntType value, int32_t shift)
 {

--- a/Source/JavaScriptCore/b3/B3ConstDoubleValue.cpp
+++ b/Source/JavaScriptCore/b3/B3ConstDoubleValue.cpp
@@ -140,14 +140,14 @@ Value* ConstDoubleValue::fMinConstant(Procedure& proc, const Value* other) const
 {
     if (!other->hasDouble())
         return nullptr;
-    return proc.add<ConstDoubleValue>(origin(), fMin(m_value, other->asDouble()));
+    return proc.add<ConstDoubleValue>(origin(), Math::fMin(m_value, other->asDouble()));
 }
 
 Value* ConstDoubleValue::fMaxConstant(Procedure& proc, const Value* other) const
 {
     if (!other->hasDouble())
         return nullptr;
-    return proc.add<ConstDoubleValue>(origin(), fMax(m_value, other->asDouble()));
+    return proc.add<ConstDoubleValue>(origin(), Math::fMax(m_value, other->asDouble()));
 }
 
 TriState ConstDoubleValue::equalConstant(const Value* other) const

--- a/Source/JavaScriptCore/b3/B3ConstFloatValue.cpp
+++ b/Source/JavaScriptCore/b3/B3ConstFloatValue.cpp
@@ -132,14 +132,14 @@ Value* ConstFloatValue::fMinConstant(Procedure& proc, const Value* other) const
 {
     if (!other->hasFloat())
         return nullptr;
-    return proc.add<ConstFloatValue>(origin(), fMin(m_value, other->asFloat()));
+    return proc.add<ConstFloatValue>(origin(), Math::fMin(m_value, other->asFloat()));
 }
 
 Value* ConstFloatValue::fMaxConstant(Procedure& proc, const Value* other) const
 {
     if (!other->hasFloat())
         return nullptr;
-    return proc.add<ConstFloatValue>(origin(), fMax(m_value, other->asFloat()));
+    return proc.add<ConstFloatValue>(origin(), Math::fMax(m_value, other->asFloat()));
 }
 
 TriState ConstFloatValue::equalConstant(const Value* other) const

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -777,27 +777,19 @@ JSC_DEFINE_JIT_OPERATION(operationArithTrunc, EncodedJSValue, (JSGlobalObject* g
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArithMinMultipleDouble, double, (const double* buffer, unsigned elementCount))
 {
-    double result = +std::numeric_limits<double>::infinity();
-    for (unsigned index = 0; index < elementCount; ++index) {
-        double val = buffer[index];
-        if (std::isnan(val))
-            return PNaN;
-        if (val < result || (!val && !result && std::signbit(val)))
-            result = val;
-    }
+    ASSERT(0 < elementCount);
+    double result = buffer[0];
+    for (unsigned index = 1; index < elementCount; ++index)
+        result = Math::jsMinDouble(result, buffer[index]);
     return result;
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArithMaxMultipleDouble, double, (const double* buffer, unsigned elementCount))
 {
-    double result = -std::numeric_limits<double>::infinity();
-    for (unsigned index = 0; index < elementCount; ++index) {
-        double val = buffer[index];
-        if (std::isnan(val))
-            return PNaN;
-        if (val > result || (!val && !result && !std::signbit(val)))
-            result = val;
-    }
+    ASSERT(0 < elementCount);
+    double result = buffer[0];
+    for (unsigned index = 1; index < elementCount; ++index)
+        result = Math::jsMaxDouble(result, buffer[index]);
     return result;
 }
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -3089,62 +3089,12 @@ private:
         }
 
         case DoubleRepUse: {
-            if (m_node->numChildren() == 2) {
-                LValue left = lowDouble(m_graph.child(m_node, 0));
-                LValue right = lowDouble(m_graph.child(m_node, 1));
-
-                LBasicBlock notLessThan = m_out.newBlock();
-                LBasicBlock isEqual = m_out.newBlock();
-                LBasicBlock notEqual = m_out.newBlock();
-                LBasicBlock continuation = m_out.newBlock();
-
-                Vector<ValueFromBlock, 2> results;
-
-                results.append(m_out.anchor(left));
-                m_out.branch(
-                    m_node->op() == ArithMin
-                        ? m_out.doubleLessThan(left, right)
-                        : m_out.doubleGreaterThan(left, right),
-                    unsure(continuation), unsure(notLessThan));
-
-                // The spec for Math.min and Math.max states that +0 is considered to be larger than -0.
-                LBasicBlock lastNext = m_out.appendTo(notLessThan, isEqual);
-                m_out.branch(
-                    m_out.doubleEqual(left, right),
-                        rarely(isEqual), usually(notEqual));
-
-                lastNext = m_out.appendTo(isEqual, notEqual);
-                results.append(m_out.anchor(
-                    m_node->op() == ArithMin
-                        ? m_out.bitOr(left, right)
-                        : m_out.bitAnd(left, right)));
-                m_out.jump(continuation);
-
-                lastNext = m_out.appendTo(notEqual, continuation);
-                results.append(
-                    m_out.anchor(
-                        m_out.select(
-                            m_node->op() == ArithMin
-                                ? m_out.doubleGreaterThan(left, right)
-                                : m_out.doubleLessThan(left, right),
-                            right, m_out.constDouble(PNaN))));
-                m_out.jump(continuation);
-
-                m_out.appendTo(continuation, lastNext);
-                setDouble(m_out.phi(Double, results));
-                break;
+            LValue left = lowDouble(m_graph.child(m_node, 0));
+            for (unsigned index = 1; index < m_node->numChildren(); ++index) {
+                LValue right = lowDouble(m_graph.child(m_node, index));
+                left = (m_node->op() == ArithMin) ? m_out.doubleMin(left, right) : m_out.doubleMax(left, right);
             }
-
-            size_t scratchSize = sizeof(double) * m_node->numChildren();
-            ScratchBuffer* scratchBuffer = vm().scratchBufferForSize(scratchSize);
-            LValue buffer = m_out.constIntPtr(static_cast<const double*>(scratchBuffer->dataBuffer()));
-
-            for (unsigned index = 0; index < m_node->numChildren(); ++index) {
-                LValue value = lowDouble(m_graph.child(m_node, index));
-                m_out.storeDouble(value, m_out.baseIndex(m_heaps.indexedDoubleProperties, buffer, m_out.constInt32(index), jsNumber(index)));
-            }
-
-            setDouble(vmCall(Double, m_node->op() == ArithMin ? operationArithMinMultipleDouble : operationArithMaxMultipleDouble, buffer, m_out.constInt32(m_node->numChildren())));
+            setDouble(left);
             break;
         }
 

--- a/Source/JavaScriptCore/ftl/FTLOutput.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOutput.cpp
@@ -332,6 +332,16 @@ LValue Output::doubleSqrt(LValue value)
     return m_block->appendNew<B3::Value>(m_proc, B3::Sqrt, origin(), value);
 }
 
+LValue Output::doubleMax(LValue lhs, LValue rhs)
+{
+    return m_block->appendNew<B3::Value>(m_proc, B3::FMax, origin(), lhs, rhs);
+}
+
+LValue Output::doubleMin(LValue lhs, LValue rhs)
+{
+    return m_block->appendNew<B3::Value>(m_proc, B3::FMin, origin(), lhs, rhs);
+}
+
 LValue Output::doubleToInt(LValue value)
 {
     PatchpointValue* result = patchpoint(Int32);

--- a/Source/JavaScriptCore/ftl/FTLOutput.h
+++ b/Source/JavaScriptCore/ftl/FTLOutput.h
@@ -190,7 +190,8 @@ public:
 
     LValue doubleSqrt(LValue);
 
-    LValue doubleLog(LValue);
+    LValue doubleMax(LValue, LValue);
+    LValue doubleMin(LValue, LValue);
 
     LValue doubleToInt(LValue);
     LValue doubleToInt64(LValue);

--- a/Source/JavaScriptCore/jit/ThunkGenerators.h
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.h
@@ -92,6 +92,10 @@ MacroAssemblerCodeRef<JITThunkPtrTag> boundFunctionCallGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> remoteFunctionCallGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> toIntegerOrInfinityThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> toLengthThunkGenerator(VM&);
+#if CPU(ARM64)
+MacroAssemblerCodeRef<JITThunkPtrTag> maxThunkGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> minThunkGenerator(VM&);
+#endif
 
 #if USE(JSVALUE64)
 MacroAssemblerCodeRef<JITThunkPtrTag> objectIsThunkGenerator(VM&);

--- a/Source/JavaScriptCore/runtime/MathObject.cpp
+++ b/Source/JavaScriptCore/runtime/MathObject.cpp
@@ -231,14 +231,16 @@ JSC_DEFINE_HOST_FUNCTION(mathProtoFuncMax, (JSGlobalObject* globalObject, CallFr
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     unsigned argsCount = callFrame->argumentCount();
-    double result = -std::numeric_limits<double>::infinity();
-    for (unsigned k = 0; k < argsCount; ++k) {
-        double val = callFrame->uncheckedArgument(k).toNumber(globalObject);
-        RETURN_IF_EXCEPTION(scope, encodedJSValue());
-        if (std::isnan(val)) {
-            result = PNaN;
-        } else if (val > result || (!val && !result && !std::signbit(val)))
-            result = val;
+    if (UNLIKELY(!argsCount))
+        return JSValue::encode(jsNumber(-std::numeric_limits<double>::infinity()));
+
+    double result = callFrame->uncheckedArgument(0).toNumber(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    for (unsigned i = 1; i < argsCount; ++i) {
+        double value = callFrame->uncheckedArgument(i).toNumber(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        result = Math::jsMaxDouble(result, value);
     }
     return JSValue::encode(jsNumber(result));
 }
@@ -248,14 +250,16 @@ JSC_DEFINE_HOST_FUNCTION(mathProtoFuncMin, (JSGlobalObject* globalObject, CallFr
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     unsigned argsCount = callFrame->argumentCount();
-    double result = +std::numeric_limits<double>::infinity();
-    for (unsigned k = 0; k < argsCount; ++k) {
-        double val = callFrame->uncheckedArgument(k).toNumber(globalObject);
-        RETURN_IF_EXCEPTION(scope, encodedJSValue());
-        if (std::isnan(val)) {
-            result = PNaN;
-        } else if (val < result || (!val && !result && std::signbit(val)))
-            result = val;
+    if (UNLIKELY(!argsCount))
+        return JSValue::encode(jsNumber(std::numeric_limits<double>::infinity()));
+
+    double result = callFrame->uncheckedArgument(0).toNumber(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    for (unsigned i = 1; i < argsCount; ++i) {
+        double value = callFrame->uncheckedArgument(i).toNumber(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        result = Math::jsMinDouble(result, value);
     }
     return JSValue::encode(jsNumber(result));
 }


### PR DESCRIPTION
#### 81e9f6868ad1953daa05923a488fc205322fceb3
<pre>
[JSC] Optimize and clean up Min / Max
<a href="https://bugs.webkit.org/show_bug.cgi?id=276694">https://bugs.webkit.org/show_bug.cgi?id=276694</a>
<a href="https://rdar.apple.com/131882633">rdar://131882633</a>

Reviewed by Justin Michaud.

This patch does holistic Math.min / Math.max optimization.

1. We add thunks for them in ARM64, which have super fast path for Int32-Int32 / Int32-Double / Double-Int32 / Double-Double. (We do not use it for now, we need a bit tweaking)
2. Use ARM64 fmax / fmin in DFG and FTL JIT and thunk. The semantics of fmax / fmin is aligned to JS&apos;s semantics, so we can leverage it.
3. Add jsMaxDouble / jsMinDouble and use them in Math.max / Math.min runtime functions.
4. Use inline asm to use fmax / fmin in jsMaxDouble / jsMinDouble in ARM64.

Simple FTL perf is getting 11% faster.

                               ToT                     Patched

    math-max             10.4292+-0.1181     ^      9.3465+-0.0937        ^ definitely 1.1158x faster

And if we disable DFG / FTL, Math.min / Math.max are 1.9x faster.

                               ToT                     Patched

    math-max             50.0668+-0.3260     ^     26.2990+-0.0774        ^ definitely 1.9038x faster

* JSTests/microbenchmarks/math-max.js: Added.
(max):
* Source/JavaScriptCore/b3/B3Common.h:
(JSC::B3::fMax): Deleted.
(JSC::B3::fMin): Deleted.
* Source/JavaScriptCore/b3/B3ConstDoubleValue.cpp:
(JSC::B3::ConstDoubleValue::fMinConstant const):
(JSC::B3::ConstDoubleValue::fMaxConstant const):
* Source/JavaScriptCore/b3/B3ConstFloatValue.cpp:
(JSC::B3::ConstFloatValue::fMinConstant const):
(JSC::B3::ConstFloatValue::fMaxConstant const):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArithMinOrMax):
* Source/JavaScriptCore/ftl/FTLOutput.cpp:
(JSC::FTL::Output::doubleMax):
(JSC::FTL::Output::doubleMin):
* Source/JavaScriptCore/ftl/FTLOutput.h:
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
(JSC::maxThunkGenerator):
(JSC::minThunkGenerator):
* Source/JavaScriptCore/jit/ThunkGenerators.h:
* Source/JavaScriptCore/runtime/MathCommon.h:
(JSC::Math::fMax):
(JSC::Math::fMin):
(JSC::Math::jsMaxDouble):
(JSC::Math::jsMinDouble):
* Source/JavaScriptCore/runtime/MathObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::thunkGeneratorForIntrinsic):

Canonical link: <a href="https://commits.webkit.org/281118@main">https://commits.webkit.org/281118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a536641b39d914cd3b126116daeffe5237e989d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62458 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9270 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9470 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/6601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60857 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50870 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/28437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/32431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/8160 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8274 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/51919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/8440 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64159 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58068 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2739 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2748 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54998 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/2296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79829 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8774 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13808 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/36153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/34814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->