### PR TITLE
Add Acceleration Curve Data to MomentumEventDispatcher

### DIFF
--- a/Source/WebKit/Shared/ScrollingAccelerationCurve.cpp
+++ b/Source/WebKit/Shared/ScrollingAccelerationCurve.cpp
@@ -136,7 +136,7 @@ TextStream& operator<<(TextStream& ts, const ScrollingAccelerationCurve& curve)
 
 #if !PLATFORM(MAC)
 
-std::optional<ScrollingAccelerationCurve> ScrollingAccelerationCurve::fromNativeWheelEvent(const NativeWebWheelEvent&)
+std::optional<ScrollingAccelerationCurve> ScrollingAccelerationCurve::fromNativeWheelEvent(const NativeWebWheelEvent&, bool scrollingPerformanceTestingEnabled)
 {
     return std::nullopt;
 }

--- a/Source/WebKit/Shared/ScrollingAccelerationCurve.h
+++ b/Source/WebKit/Shared/ScrollingAccelerationCurve.h
@@ -43,7 +43,7 @@ class ScrollingAccelerationCurve {
 public:
     ScrollingAccelerationCurve(float gainLinear, float gainParabolic, float gainCubic, float gainQuartic, float tangentSpeedLinear, float tangentSpeedParabolicRoot, float resolution, float frameRate);
 
-    static std::optional<ScrollingAccelerationCurve> fromNativeWheelEvent(const NativeWebWheelEvent&);
+    static std::optional<ScrollingAccelerationCurve> fromNativeWheelEvent(const NativeWebWheelEvent&, bool scrollingPerformanceTestingEnabled);
 
     static ScrollingAccelerationCurve interpolate(const ScrollingAccelerationCurve& from, const ScrollingAccelerationCurve& to, float amount);
 

--- a/Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm
+++ b/Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm
@@ -158,8 +158,22 @@ static std::optional<ScrollingAccelerationCurve> fromIOHIDDevice(IOHIDEventSende
     return fromIOHIDCurveArrayWithAcceleration((NSArray *)curves.get(), *scrollAcceleration, *resolution, frameRate);
 }
 
-std::optional<ScrollingAccelerationCurve> ScrollingAccelerationCurve::fromNativeWheelEvent(const NativeWebWheelEvent& nativeWebWheelEvent)
+std::optional<ScrollingAccelerationCurve> ScrollingAccelerationCurve::fromNativeWheelEvent(const NativeWebWheelEvent& nativeWebWheelEvent, bool scrollingPerformanceTestingEnabled)
 {
+    if (scrollingPerformanceTestingEnabled) {
+        ALWAYS_LOG_WITH_STREAM(stream << "ScrollingPerformance is enabled in fromNativeWheel Event. Returning hard-coded values.");
+        auto gainLinear = 0.92;
+        auto gainParabolic = 0.75;
+        auto gainCubic = 0.00;
+        auto gainQuartic = 0.00;
+        auto tangentSpeedLinear = 6.30;
+        auto tangentSpeedParabolicRoot = 12.00;
+        float resolution = 400.0;
+        float frameRate = 120.0;
+        auto curve = ScrollingAccelerationCurve(gainLinear, gainParabolic, gainCubic, gainQuartic, tangentSpeedLinear, tangentSpeedParabolicRoot, resolution, frameRate);
+        return curve;
+    }
+
     NSEvent *event = nativeWebWheelEvent.nativeEvent();
 
     auto cgEvent = event.CGEvent;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -164,7 +164,7 @@ void RemoteLayerTreeEventDispatcher::hasNodeWithAnimatedScrollChanged(bool hasAn
     startOrStopDisplayLink();
 }
 
-void RemoteLayerTreeEventDispatcher::cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent& wheelEvent)
+void RemoteLayerTreeEventDispatcher::cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent& wheelEvent, bool scrollingPerformanceTestingEnabled)
 {
     ASSERT(isMainRunLoop());
 
@@ -172,7 +172,7 @@ void RemoteLayerTreeEventDispatcher::cacheWheelEventScrollingAccelerationCurve(c
     if (wheelEvent.momentumPhase() != WebWheelEvent::PhaseBegan)
         return;
 
-    auto curve = ScrollingAccelerationCurve::fromNativeWheelEvent(wheelEvent);
+    auto curve = ScrollingAccelerationCurve::fromNativeWheelEvent(wheelEvent, scrollingPerformanceTestingEnabled);
     m_momentumEventDispatcher->setScrollingAccelerationCurve(m_pageIdentifier, curve);
 #endif
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -32,6 +32,7 @@
 #include "NativeWebWheelEvent.h"
 #include <WebCore/PlatformLayerIdentifier.h>
 #include <WebCore/ProcessQualified.h>
+#include <WebCore/ScrollingTree.h>
 #include <pal/HysteresisActivity.h>
 #include <wtf/Condition.h>
 #include <wtf/Deque.h>
@@ -76,7 +77,7 @@ public:
     
     void invalidate();
     
-    void cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent&);
+    void cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent&, bool scrollingPerformanceTestingEnabled);
 
     void handleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
     void wheelEventHandlingCompleted(const WebCore::PlatformWheelEvent&, std::optional<WebCore::ScrollingNodeID>, std::optional<WebCore::WheelScrollGestureState>, bool wasHandled);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -66,7 +66,7 @@ RemoteScrollingCoordinatorProxyMac::~RemoteScrollingCoordinatorProxyMac()
 void RemoteScrollingCoordinatorProxyMac::cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent& nativeWheelEvent)
 {
 #if ENABLE(SCROLLING_THREAD)
-    m_eventDispatcher->cacheWheelEventScrollingAccelerationCurve(nativeWheelEvent);
+    m_eventDispatcher->cacheWheelEventScrollingAccelerationCurve(nativeWheelEvent, scrollingPerformanceTestingEnabled());
 #else
     UNUSED_PARAM(nativeWheelEvent);
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3820,8 +3820,14 @@ void WebPageProxy::cacheWheelEventScrollingAccelerationCurve(const NativeWebWhee
     if (!preferences().momentumScrollingAnimatorEnabled())
         return;
 
+    bool scrollingPerformanceMode = false;
+    if (m_scrollingCoordinatorProxy) {
+        if (m_scrollingCoordinatorProxy->scrollingPerformanceTestingEnabled())
+            scrollingPerformanceMode = true;
+    }
+
     // FIXME: We should not have to fetch the curve repeatedly, but it can also change occasionally.
-    internals().scrollingAccelerationCurve = ScrollingAccelerationCurve::fromNativeWheelEvent(nativeWheelEvent);
+    internals().scrollingAccelerationCurve = ScrollingAccelerationCurve::fromNativeWheelEvent(nativeWheelEvent, scrollingPerformanceMode);
 #endif
 }
 
@@ -3839,8 +3845,9 @@ void WebPageProxy::sendWheelEventScrollingAccelerationCurveIfNecessary(const Web
     if (!connection)
         return;
 
-    connection->send(Messages::EventDispatcher::SetScrollingAccelerationCurve(webPageIDInMainFrameProcess(), internals().scrollingAccelerationCurve), 0, { }, Thread::QOS::UserInteractive);
-    internals().lastSentScrollingAccelerationCurve = internals().scrollingAccelerationCurve;
+    auto curve = internals().scrollingAccelerationCurve;
+    connection->send(Messages::EventDispatcher::SetScrollingAccelerationCurve(webPageIDInMainFrameProcess(), curve), 0, { }, Thread::QOS::UserInteractive);
+    internals().lastSentScrollingAccelerationCurve = curve;
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -29,6 +29,7 @@
 #include "MessageReceiver.h"
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/NowPlayingMetadataObserver.h>
+#include <WebCore/ScrollingTree.h>
 #include <pal/HysteresisActivity.h>
 #include <wtf/ApproximateTime.h>
 #include <wtf/CheckedRef.h>

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -56,6 +56,7 @@ bool MomentumEventDispatcher::eventShouldStartSyntheticMomentumPhase(WebCore::Pa
         return false;
 
     auto curveIterator = scrollingAccelerationCurveForPage(pageIdentifier);
+
     if (!curveIterator) {
         RELEASE_LOG(ScrollAnimations, "MomentumEventDispatcher not using synthetic momentum phase: no acceleration curve");
         return false;
@@ -266,6 +267,7 @@ std::optional<ScrollingAccelerationCurve> MomentumEventDispatcher::scrollingAcce
     auto curveIterator = m_accelerationCurves.find(pageIdentifier);
     if (curveIterator == m_accelerationCurves.end())
         return { };
+
     return curveIterator->value;
 }
 


### PR DESCRIPTION
#### 9d14fa07ee71271969944a5b1413f71acf7d602d
<pre>
Add Acceleration Curve Data to MomentumEventDispatcher
<a href="https://bugs.webkit.org/show_bug.cgi?id=276662">https://bugs.webkit.org/show_bug.cgi?id=276662</a>
<a href="https://rdar.apple.com/131846308">rdar://131846308</a>

Reviewed by NOBODY (OOPS!).

Add Acceleration Curve Data to MomentumEventDispatcher

* Source/WebKit/Shared/ScrollingAccelerationCurve.cpp:
(WebKit::ScrollingAccelerationCurve::fromNativeWheelEvent):
* Source/WebKit/Shared/ScrollingAccelerationCurve.h:
* Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm:
(WebKit::ScrollingAccelerationCurve::fromNativeWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::cacheWheelEventScrollingAccelerationCurve):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::cacheWheelEventScrollingAccelerationCurve):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::cacheWheelEventScrollingAccelerationCurve):
(WebKit::WebPageProxy::sendWheelEventScrollingAccelerationCurveIfNecessary):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::eventShouldStartSyntheticMomentumPhase const):
(WebKit::MomentumEventDispatcher::scrollingAccelerationCurveForPage const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d14fa07ee71271969944a5b1413f71acf7d602d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62308 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9125 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47481 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6495 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60712 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50741 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28337 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32315 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8129 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64012 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54803 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50768 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54890 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2180 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33837 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34923 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36007 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34668 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->