### PR TITLE
[JSC] Implement fromHex and setFromHex in SIMD

### DIFF
--- a/JSTests/microbenchmarks/from-hex.js
+++ b/JSTests/microbenchmarks/from-hex.js
@@ -1,0 +1,15 @@
+//@ requireOptions("--useUint8ArrayBase64Methods=1")
+
+function test(string)
+{
+    return Uint8Array.fromHex(string);
+}
+noInline(test);
+
+let buffer = new Uint8Array(16 * 1024);
+for (let i = 0; i < buffer.length; ++i)
+    buffer[i] = i & 0xff;
+let string = buffer.toHex();
+
+for (let i = 0; i < 1e3; ++i)
+    test(string);

--- a/JSTests/stress/uint8array-fromHex.js
+++ b/JSTests/stress/uint8array-fromHex.js
@@ -35,13 +35,33 @@ shouldBeArray(Uint8Array.fromHex("FEFF"), [254, 255]);
 shouldBeArray(Uint8Array.fromHex("000180feff"), [0, 1, 128, 254, 255]);
 shouldBeArray(Uint8Array.fromHex("000180FEFF"), [0, 1, 128, 254, 255]);
 
+{
+    let expected = ''
+    let buffer = new Uint8Array(16 * 1024 + 15);
+    for (let i = 0; i < buffer.length; ++i) {
+        buffer[i] = i & 0xff;
+        expected += (i & 0xff).toString(16).padStart(2, '0');
+    }
+    shouldBeArray(Uint8Array.fromHex(expected), buffer);
+}
+{
+    let expected = ''
+    let buffer = new Uint8Array(15);
+    for (let i = 0; i < buffer.length; ++i) {
+        buffer[i] = i & 0xff;
+        expected += (i & 0xff).toString(16).padStart(2, '0');
+    }
+    shouldBeArray(Uint8Array.fromHex(expected), buffer);
+}
+
+
 for (let invalid of [undefined, null, false, true, 42, {}, []]) {
     shouldThrow(() => {
         Uint8Array.fromHex(invalid);
     }, TypeError);
 }
 
-for (let invalid of ["0", "012", "0g", "0G", "g0", "G0", "0✅", "✅0"]) {
+for (let invalid of ["0", "012", "0g", "0G", "g0", "G0", "0✅", "✅0", "00000000000000000000000000000000✅0", "00000000000000000000000000000000000000✅0", "00000000000000000000000000000000v0", "00000000000000000000000000000000000000g0"]) {
     shouldThrow(() => {
         Uint8Array.fromHex(invalid);
     }, SyntaxError);

--- a/JSTests/stress/uint8array-setFromHex.js
+++ b/JSTests/stress/uint8array-setFromHex.js
@@ -57,6 +57,76 @@ test("000180feff33", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
 test("000180FEFF33", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
 test("000180feff33cc", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
 test("000180FEFF33CC", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+test("000180FEFF33CC✅0✅0✅0✅0", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+test("000180FEFF33CCgggggggg", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+
+function testLarge(input, expectedResult, expectedValue) {
+    let uint8array = new Uint8Array(1024);
+    for (let i = 0; i < uint8array.length; ++i)
+        uint8array[i] = 42;
+
+    let result = uint8array.setFromHex(input);
+
+    shouldBeObject(result, expectedResult);
+    let i = 0;
+    for (; i < expectedValue.length; ++i)
+        shouldBe(uint8array[i], expectedValue[i]);
+    for (; i < uint8array.length; ++i)
+        shouldBe(uint8array[i], 42);
+}
+
+testLarge("", {read: 0, written: 0}, []);
+testLarge("00", {read: 2, written: 1}, [0, 42, 42, 42, 42]);
+testLarge("01", {read: 2, written: 1}, [1, 42, 42, 42, 42]);
+testLarge("80", {read: 2, written: 1}, [128, 42, 42, 42, 42]);
+testLarge("fe", {read: 2, written: 1}, [254, 42, 42, 42, 42]);
+testLarge("FE", {read: 2, written: 1}, [254, 42, 42, 42, 42]);
+testLarge("ff", {read: 2, written: 1}, [255, 42, 42, 42, 42]);
+testLarge("FF", {read: 2, written: 1}, [255, 42, 42, 42, 42]);
+testLarge("0001", {read: 4, written: 2}, [0, 1, 42, 42, 42]);
+testLarge("feff", {read: 4, written: 2}, [254, 255, 42, 42, 42]);
+testLarge("FEFF", {read: 4, written: 2}, [254, 255, 42, 42, 42]);
+testLarge("000180feff", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+testLarge("000180FEFF", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+testLarge("000180feff33", {read: 12, written: 6}, [0, 1, 128, 254, 255, 51]);
+testLarge("000180FEFF33", {read: 12, written: 6}, [0, 1, 128, 254, 255, 51]);
+testLarge("000180feff33cc", {read: 14, written: 7}, [0, 1, 128, 254, 255, 51, 204]);
+testLarge("000180FEFF33CC", {read: 14, written: 7}, [0, 1, 128, 254, 255, 51, 204]);
+testLarge($vm.make16BitStringIfPossible(""), {read: 0, written: 0}, []);
+testLarge($vm.make16BitStringIfPossible("00"), {read: 2, written: 1}, [0, 42, 42, 42, 42]);
+testLarge($vm.make16BitStringIfPossible("01"), {read: 2, written: 1}, [1, 42, 42, 42, 42]);
+testLarge($vm.make16BitStringIfPossible("80"), {read: 2, written: 1}, [128, 42, 42, 42, 42]);
+testLarge($vm.make16BitStringIfPossible("fe"), {read: 2, written: 1}, [254, 42, 42, 42, 42]);
+testLarge($vm.make16BitStringIfPossible("FE"), {read: 2, written: 1}, [254, 42, 42, 42, 42]);
+testLarge($vm.make16BitStringIfPossible("ff"), {read: 2, written: 1}, [255, 42, 42, 42, 42]);
+testLarge($vm.make16BitStringIfPossible("FF"), {read: 2, written: 1}, [255, 42, 42, 42, 42]);
+testLarge($vm.make16BitStringIfPossible("0001"), {read: 4, written: 2}, [0, 1, 42, 42, 42]);
+testLarge($vm.make16BitStringIfPossible("feff"), {read: 4, written: 2}, [254, 255, 42, 42, 42]);
+testLarge($vm.make16BitStringIfPossible("FEFF"), {read: 4, written: 2}, [254, 255, 42, 42, 42]);
+testLarge($vm.make16BitStringIfPossible("000180feff"), {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+testLarge($vm.make16BitStringIfPossible("000180FEFF"), {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+testLarge($vm.make16BitStringIfPossible("000180feff33"), {read: 12, written: 6}, [0, 1, 128, 254, 255, 51]);
+testLarge($vm.make16BitStringIfPossible("000180FEFF33"), {read: 12, written: 6}, [0, 1, 128, 254, 255, 51]);
+testLarge($vm.make16BitStringIfPossible("000180feff33cc"), {read: 14, written: 7}, [0, 1, 128, 254, 255, 51, 204]);
+testLarge($vm.make16BitStringIfPossible("000180FEFF33CC"), {read: 14, written: 7}, [0, 1, 128, 254, 255, 51, 204]);
+shouldThrow(() => {
+    testLarge("000180FEFF33CC✅0✅0✅0✅0", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+}, SyntaxError);
+shouldThrow(() => {
+    testLarge("000180FEFF33CCgggggggg", {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+}, SyntaxError);
+
+testLarge("000180feff33cc0000000000000000000000000000aa00aa00aa00aa00aa00aa00", {read: 66, written: 33}, [0,1,128,254,255,51,204,0,0,0,0,0,0,0,0,0,0,0,0,0,0,170,0,170,0,170,0,170,0,170,0,170,0]);
+testLarge("000180FEFF33CC0000000000000000000000000000aa00aa00aa00aa00aa00aa00", {read: 66, written: 33}, [0,1,128,254,255,51,204,0,0,0,0,0,0,0,0,0,0,0,0,0,0,170,0,170,0,170,0,170,0,170,0,170,0]);
+testLarge($vm.make16BitStringIfPossible("000180feff33cc0000000000000000000000000000aa00aa00aa00aa00aa00aa00"), {read: 66, written: 33}, [0,1,128,254,255,51,204,0,0,0,0,0,0,0,0,0,0,0,0,0,0,170,0,170,0,170,0,170,0,170,0,170,0]);
+testLarge($vm.make16BitStringIfPossible("000180FEFF33CC0000000000000000000000000000aa00aa00aa00aa00aa00aa00"), {read: 66, written: 33}, [0,1,128,254,255,51,204,0,0,0,0,0,0,0,0,0,0,0,0,0,0,170,0,170,0,170,0,170,0,170,0,170,0]);
+
+shouldThrow(() => {
+    testLarge($vm.make16BitStringIfPossible("000180FEFF33CC✅0✅0✅0✅0"), {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+}, SyntaxError);
+shouldThrow(() => {
+    testLarge($vm.make16BitStringIfPossible("000180FEFF33CCgggggggg"), {read: 10, written: 5}, [0, 1, 128, 254, 255]);
+}, SyntaxError);
 
 shouldThrow(() => {
     let uint8array = new Uint8Array;

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
@@ -96,6 +96,112 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64, (JSGlobalObject* globa
     return JSValue::encode(uint8Array);
 }
 
+template<typename CharacterType>
+inline static WARN_UNUSED_RETURN size_t decodeHexImpl(std::span<CharacterType> span, std::span<uint8_t> result)
+{
+    ASSERT(span.size() == result.size() * 2);
+
+    // http://0x80.pl/notesen/2022-01-17-validating-hex-parse.html
+    auto vectorDecode8 = [&](simde_uint8x16_t input, uint8_t* output) ALWAYS_INLINE_LAMBDA {
+        auto decodeNibbles = [&](simde_uint8x16_t v) ALWAYS_INLINE_LAMBDA {
+            // Move digits '0'..'9' into range 0xf6..0xff.
+            auto t1 = simde_vaddq_u8(v, SIMD::splat8(0xff - '9'));
+            // And then correct the range to 0xf0..0xf9. All other bytes become less than 0xf0.
+            auto t2 = simde_vqsubq_u8(t1, SIMD::splat8(6));
+            // Convert '0'..'9' into nibbles 0..9. Non-digit bytes become greater than 0x0f.
+            auto t3 = simde_vsubq_u8(t2, SIMD::splat8(0xf0));
+            // Convert into uppercase 'a'..'f' => 'A'..'F'.
+            auto t4 = simde_vandq_u8(v, SIMD::splat8(0xdf));
+            // Move hex letter 'A'..'F' into range 0..5.
+            auto t5 = simde_vsubq_u8(t4, SIMD::splat8('A'));
+            // And correct the range into 10..15. The non-hex letters bytes become greater than 0x0f.
+            auto t6 = simde_vqaddq_u8(t5, SIMD::splat8(10));
+            // Finally choose the result: either valid nibble (0..9/10..15) or some byte greater than 0x0f.
+            auto t7 = simde_vminq_u8(t3, t6);
+            // Detect errors, i.e. bytes greater than 15.
+            auto t8 = SIMD::greaterThan(t7, SIMD::splat8(15));
+            return std::tuple { t7, t8 };
+        };
+
+        auto [nibbles, flags] = decodeNibbles(input);
+        if (UNLIKELY(SIMD::isNonZero(flags)))
+            return false;
+
+        auto converted = simde_vreinterpretq_u16_u8(nibbles);
+        auto low = simde_vshrq_n_u16(converted, 8);
+        auto high = simde_vshlq_n_u16(converted, 4);
+        simde_vst1_u8(output, simde_vmovn_u16(simde_vorrq_u16(low, high)));
+        return true;
+    };
+
+    const auto* begin = span.data();
+    const auto* end = span.data() + span.size();
+    const auto* cursor = begin;
+
+    auto* output = result.data();
+    auto* outputEnd = result.data() + result.size();
+
+    constexpr size_t stride = 16;
+    constexpr size_t halfStride = stride / 2;
+    if (span.size() >= stride) {
+        auto doStridedDecode = [&]() ALWAYS_INLINE_LAMBDA {
+            if constexpr (sizeof(CharacterType) == 1) {
+                for (; cursor + (stride - 1) < end; cursor += stride, output += halfStride) {
+                    if (!vectorDecode8(SIMD::load(bitwise_cast<const uint8_t*>(cursor)), output))
+                        return false;
+                }
+                if (cursor < end) {
+                    if (!vectorDecode8(SIMD::load(bitwise_cast<const uint8_t*>(end - stride)), outputEnd - halfStride))
+                        return false;
+                }
+                return true;
+            } else {
+                auto vectorDecode16 = [&](simde_uint8x16x2_t input, uint8_t* output) ALWAYS_INLINE_LAMBDA {
+                    if (UNLIKELY(SIMD::isNonZero(input.val[1])))
+                        return false;
+                    return vectorDecode8(input.val[0], output);
+                };
+
+                for (; cursor + (stride - 1) < end; cursor += stride, output += halfStride) {
+                    if (!vectorDecode16(simde_vld2q_u8(bitwise_cast<const uint8_t*>(cursor)), output))
+                        return false;
+                }
+                if (cursor < end) {
+                    if (!vectorDecode16(simde_vld2q_u8(bitwise_cast<const uint8_t*>(end - stride)), outputEnd - halfStride))
+                        return false;
+                }
+                return true;
+            }
+        };
+
+        if (doStridedDecode())
+            return WTF::notFound;
+    }
+
+    // 1. For small strings less than stride.
+    // 2. Vector decoding failed due to incorrect character. Now, we do decoding character by character to decode up to the incorrect character position.
+    for (; cursor < end; cursor += 2, output += 1) {
+        int tens = parseDigit(*cursor, 16);
+        if (UNLIKELY(tens == -1))
+            return cursor - begin;
+        int ones = parseDigit(*(cursor + 1), 16);
+        if (UNLIKELY(ones == -1))
+            return (cursor + 1) - begin;
+        *output = (tens * 16) + ones;
+    }
+    return WTF::notFound;
+}
+
+WARN_UNUSED_RETURN size_t decodeHex(std::span<const LChar> span, std::span<uint8_t> result)
+{
+    return decodeHexImpl(span, result);
+}
+
+WARN_UNUSED_RETURN size_t decodeHex(std::span<const UChar> span, std::span<uint8_t> result)
+{
+    return decodeHexImpl(span, result);
+}
+
 JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromHex, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -111,24 +217,18 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromHex, (JSGlobalObject* globalOb
     RETURN_IF_EXCEPTION(scope, { });
 
     size_t count = static_cast<size_t>(view.length() / 2);
-    for (size_t i = 0; i < count * 2; ++i) {
-        int digit = parseDigit(view[i], 16);
-        if (UNLIKELY(digit == -1))
-            return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.prototype.fromHex requires a string containing only \"0123456789abcdefABCDEF\""_s));
-    }
-
-    JSUint8Array* uint8Array = JSUint8Array::create(globalObject, globalObject->typedArrayStructure(TypeUint8, false), count);
+    JSUint8Array* uint8Array = JSUint8Array::createUninitialized(globalObject, globalObject->typedArrayStructure(TypeUint8, false), count);
     uint8_t* data = uint8Array->typedVector();
+    auto result = std::span { data, data + count };
 
-    size_t read = 0;
-    size_t written = 0;
-    for (size_t i = 0; i < count; ++i) {
-        int tens = parseDigit(view[read++], 16);
-        int ones = parseDigit(view[read++], 16);
-        data[written++] = (tens * 16) + ones;
-    }
-    ASSERT(read == count * 2);
-    ASSERT(written == count);
+    bool success = false;
+    if (view.is8Bit())
+        success = decodeHex(view.span8(), result) == WTF::notFound;
+    else
+        success = decodeHex(view.span16(), result) == WTF::notFound;
+
+    if (UNLIKELY(!success))
+        return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.prototype.fromHex requires a string containing only \"0123456789abcdefABCDEF\""_s));
 
     return JSValue::encode(uint8Array);
 }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h
@@ -144,4 +144,7 @@ private:
 JSC_DECLARE_HOST_FUNCTION(uint8ArrayConstructorFromBase64);
 JSC_DECLARE_HOST_FUNCTION(uint8ArrayConstructorFromHex);
 
+WARN_UNUSED_RETURN size_t decodeHex(std::span<const LChar>, std::span<uint8_t> result);
+WARN_UNUSED_RETURN size_t decodeHex(std::span<const UChar>, std::span<uint8_t> result);
+
 } // namespace JSC


### PR DESCRIPTION
#### 2a040cbef4c2e759a20508e0e32170a86f72d9ab
<pre>
[JSC] Implement fromHex and setFromHex in SIMD
<a href="https://bugs.webkit.org/show_bug.cgi?id=276705">https://bugs.webkit.org/show_bug.cgi?id=276705</a>
<a href="https://rdar.apple.com/131903377">rdar://131903377</a>

Reviewed by Keith Miller and Justin Michaud.

This patch implements fromHex / setFromHex in SIMD. The new implementation is roughly 17x faster.
We use <a href="http://0x80.pl/notesen/2022-01-17-validating-hex-parse.html">http://0x80.pl/notesen/2022-01-17-validating-hex-parse.html</a> &apos;s algorithm 3 approach to decode hex in SIMD with validation.
For 16bit string, we load high and low bytes separately, checking high bytes are all zero, and decoding low bytes as the same to
8bit string with validation.

                               ToT                     Patched

    from-hex             46.8263+-0.1123     ^      2.7441+-0.0149        ^ definitely 17.0641x faster

* JSTests/microbenchmarks/from-hex.js: Added.
(test):
* JSTests/stress/uint8array-fromHex.js:
(shouldBeArray.Uint8Array.fromHex):
(shouldBeArray):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp:
(JSC::decodeHexImpl):
(JSC::decodeHex):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/281053@main">https://commits.webkit.org/281053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c13071fa90a125da615bc67b578b84446f79f5ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62181 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8999 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9197 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/6413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60586 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/50627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/28256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/32209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/7929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8003 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51646 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/8201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63884 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57797 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2468 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2476 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/50653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/54806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/2087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79558 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8729 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33711 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/13249 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34797 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34542 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->