### PR TITLE
Use dirty bits to only traverse the unchanged subtrees with recursiveUpdateLayerPositions.

### DIFF
--- a/LayoutTests/svg/compositing/transform-change-repainting-no-viewBox.html
+++ b/LayoutTests/svg/compositing/transform-change-repainting-no-viewBox.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=26; totalPixels=4" />
+    <meta name="fuzzy" content="maxDifference=0-26; totalPixels=0-4" />
     <title>Tests that SVG documents without viewBox don't trigger unnecessary repaints during animations.</title>
     <style>
         svg { border: 1px solid black; }

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -769,6 +769,11 @@ static constexpr bool unreachableForValue = false;
         CRASH_UNDER_CONSTEXPR_CONTEXT(); \
     } \
 } while (0)
+#define RELEASE_ASSERT_IMPLIES(condition, assertion) do { \
+    if (UNLIKELY((condition) && !(assertion))) { \
+        CRASH(); \
+    } \
+} while (0)
 
 #else /* ASSERT_ENABLED */
 
@@ -778,6 +783,7 @@ static constexpr bool unreachableForValue = false;
 #define RELEASE_ASSERT_NOT_REACHED(...) ASSERT_NOT_REACHED(__VA_ARGS__)
 #define RELEASE_ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT() ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT()
 #define RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(assertion) ASSERT_UNDER_CONSTEXPR_CONTEXT(assertion)
+#define RELEASE_ASSERT_IMPLIES(condition, assertion) ASSERT_IMPLIES(condition, assertion)
 
 #endif /* ASSERT_ENABLED */
 
@@ -805,8 +811,13 @@ static constexpr bool unreachableForValue = false;
         if (UNLIKELY(wtfConjectureAssertIsEnabled && !(assertion))) \
             WTFCrashDueToConjectureAssert(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #assertion); \
     } while (false)
+#define CONJECTURE_ASSERT_IMPLIES(condition, assertion)  do { \
+        if (UNLIKELY(wtfConjectureAssertIsEnabled && (condition) && !(assertion))) \
+            WTFCrashDueToConjectureAssert(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #assertion); \
+    } while (false)
 #else
 #define CONJECTURE_ASSERT(assertion, ...)
+#define CONJECTURE_ASSERT_IMPLIES(condition, assertion)
 #endif
 
 #ifdef __cplusplus

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -1040,19 +1040,13 @@ private:
     std::unique_ptr<SingleThreadWeakHashSet<RenderLayerModelObject>> m_viewportConstrainedObjects;
 
     struct UpdateLayerPositions {
-        bool merge(const UpdateLayerPositions& other)
+        void merge(const UpdateLayerPositions& other)
         {
-            // FIXME: If one is an ancestor of the other we can also probably combine them.
-            if (layoutRoot != other.layoutRoot)
-                return false;
-
             needsFullRepaint |= other.needsFullRepaint;
             if (!other.didRunSimplifiedLayout)
                 didRunSimplifiedLayout = false;
-            return true;
         }
 
-        SingleThreadWeakPtr<RenderElement> layoutRoot;
         RenderElement::LayoutIdentifier layoutIdentifier : 12 { 0 };
         bool needsFullRepaint { false };
         bool didRunSimplifiedLayout { true };

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -597,7 +597,7 @@ void RenderElement::didAttachChild(RenderObject& child, RenderObject*)
     // To avoid the problem alltogether, detect early if we're inside a hidden SVG subtree
     // and stop creating layers at all for these cases - they're not used anyways.
     if (child.hasLayer() && !layerCreationAllowedForSubtree())
-        downcast<RenderLayerModelObject>(child).checkedLayer()->removeOnlyThisLayer(RenderLayer::LayerChangeTiming::RenderTreeConstruction);
+        downcast<RenderLayerModelObject>(child).checkedLayer()->removeOnlyThisLayer();
 }
 
 RenderObject* RenderElement::attachRendererInternal(RenderPtr<RenderObject> child, RenderObject* beforeChild)
@@ -2295,6 +2295,7 @@ void RenderElement::repaintOldAndNewPositionsForSVGRenderer() const
     // LBSE: Instead of repainting the current boundaries, utilize RenderLayer::updateLayerPositionsAfterStyleChange() to repaint
     // the old and the new repaint boundaries, if they differ -- instead of just the new boundaries.
     if (auto layer = useUpdateLayerPositionsLogic()) {
+        (*layer.value()).setSelfAndDescendantsNeedPositionUpdate();
         (*layer.value()).updateLayerPositionsAfterStyleChange();
         return;
     }

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -63,6 +63,8 @@ namespace WTF {
 class TextStream;
 }
 
+void outputLayerPositionTreeRecursive(TextStream&, const WebCore::RenderLayer&, unsigned);
+
 namespace WebCore {
 
 class CSSFilter;
@@ -160,6 +162,7 @@ public:
     friend class RenderLayerBacking;
     friend class RenderLayerCompositor;
     friend class RenderLayerScrollableArea;
+    friend void ::outputLayerPositionTreeRecursive(TextStream&, const WebCore::RenderLayer&, unsigned);
 
     explicit RenderLayer(RenderLayerModelObject&);
     ~RenderLayer();
@@ -193,12 +196,8 @@ public:
     void addChild(RenderLayer& newChild, RenderLayer* beforeChild = nullptr);
     void removeChild(RenderLayer&);
 
-    enum class LayerChangeTiming {
-        StyleChange,
-        RenderTreeConstruction,
-    };
-    void insertOnlyThisLayer(LayerChangeTiming);
-    void removeOnlyThisLayer(LayerChangeTiming);
+    void insertOnlyThisLayer();
+    void removeOnlyThisLayer();
 
     bool isNormalFlowOnly() const { return m_isNormalFlowOnly; }
 
@@ -241,6 +240,23 @@ public:
 
     // Convert a point in absolute coords into layer coords, taking transforms into account
     LayoutPoint absoluteToContents(const LayoutPoint&) const;
+
+    void setNeedsPositionUpdate();
+    void setSelfAndChildrenNeedPositionUpdate();
+    void setSelfAndDescendantsNeedPositionUpdate();
+
+private:
+    enum class LayerPositionUpdates {
+        NeedsPositionUpdate  = 1 << 0,
+        DescendantNeedsPositionUpdate = 1 << 1,
+        AllChildrenNeedPositionUpdate = 1 << 2,
+        AllDescendantsNeedPositionUpdate = 1 << 3,
+    };
+
+    bool needsPositionUpdate() const;
+    void clearLayerPositionDirtyBits() { m_layerPositionDirtyBits = { }; }
+
+    OptionSet<LayerPositionUpdates> m_layerPositionDirtyBits;
 
 protected:
     void destroy();
@@ -500,7 +516,7 @@ public:
 
     void updateLayerPositionsAfterStyleChange();
     enum class CanUseSimplifiedRepaintPass : uint8_t { No, Yes };
-    void updateLayerPositionsAfterLayout(RenderElement::LayoutIdentifier, bool isRelayoutingSubtree, bool didFullRepaint, CanUseSimplifiedRepaintPass);
+    void updateLayerPositionsAfterLayout(RenderElement::LayoutIdentifier, bool didFullRepaint, CanUseSimplifiedRepaintPass);
     void updateLayerPositionsAfterOverflowScroll();
     void updateLayerPositionsAfterDocumentScroll();
 
@@ -654,11 +670,14 @@ public:
             : rootLayer(inRootLayer)
             , clipRectsType(inClipRectsType)
             , options(inOptions)
-        { }
+        {
+            if (inClipRectsType == RootRelativeClipRects)
+                options.add(ClipRectsOption::IncludeOverlayScrollbarSize);
+        }
         const RenderLayer* rootLayer;
         ClipRectsType clipRectsType;
         OptionSet<ClipRectsOption> options;
-        
+
         bool respectOverflowClip() const { return options.contains(ClipRectsOption::RespectOverflowClip); }
         OverlayScrollbarSizeRelevancy overlayScrollbarSizeRelevancy() const { return options.contains(ClipRectsOption::IncludeOverlayScrollbarSize) ? IncludeOverlayScrollbarSize : IgnoreOverlayScrollbarSize; }
     };
@@ -977,6 +996,8 @@ private:
     void computeRepaintRects(const RenderLayerModelObject* repaintContainer);
     void computeRepaintRectsIncludingDescendants();
 
+    void compositingStatusChanged(LayoutUpToDate);
+
     void setRepaintRects(const RenderObject::RepaintRects&);
     void clearRepaintRects();
 
@@ -1000,13 +1021,31 @@ private:
         SeenTransformedLayer                = 1 << 6,
         Seen3DTransformedLayer              = 1 << 7,
         SeenCompositedScrollingLayer        = 1 << 8,
+        SubtreeNeedsUpdate                  = 1 << 9,
     };
     static OptionSet<UpdateLayerPositionsFlag> flagsForUpdateLayerPositions(RenderLayer& startingLayer);
 
-    // Returns true if the position changed.
-    bool updateLayerPosition(OptionSet<UpdateLayerPositionsFlag>* = nullptr);
+    // UpdateLayerPositionsFlags that describe changes to the layer tree
+    static constexpr OptionSet<UpdateLayerPositionsFlag> invalidationLayerPositionsFlags()
+    {
+        return {
+            UpdateLayerPositionsFlag::NeedsFullRepaintInBacking,
+            UpdateLayerPositionsFlag::ContainingClippingLayerChangedSize,
+            UpdateLayerPositionsFlag::SubtreeNeedsUpdate,
+        };
+    }
 
+    enum UpdateLayerPositionsMode {
+        Write,
+        Verify,
+    };
+
+    // Returns true if the position changed.
+    bool updateLayerPosition(OptionSet<UpdateLayerPositionsFlag>* = nullptr, UpdateLayerPositionsMode = Write);
+
+    template<UpdateLayerPositionsMode = Write>
     void recursiveUpdateLayerPositions(RenderElement::LayoutIdentifier, OptionSet<UpdateLayerPositionsFlag>, CanUseSimplifiedRepaintPass = CanUseSimplifiedRepaintPass::No);
+    bool ancestorLayerPositionStateChanged(OptionSet<UpdateLayerPositionsFlag>);
 
     enum UpdateLayerPositionsAfterScrollFlag {
         IsOverflowScroll                        = 1 << 0,
@@ -1157,10 +1196,13 @@ private:
     bool has3DTransformedDescendant() const { return m_has3DTransformedDescendant; }
     bool has3DTransformedAncestor() const { return m_has3DTransformedAncestor; }
 
+    bool hasFixedAncestor() const { return m_hasFixedAncestor; }
+    bool hasPaginatedAncestor() const { return m_hasPaginatedAncestor; }
+
     void dirty3DTransformedDescendantStatus();
     // Both updates the status, and returns true if descendants of this have 3d.
     bool update3DTransformedDescendantStatus();
-    
+
     bool isInsideSVGForeignObject() const { return m_insideSVGForeignObject; }
 
     void createReflection();
@@ -1196,6 +1238,9 @@ private:
     void setWasIncludedInZOrderTree() { m_wasOmittedFromZOrderTree = false; }
     void removeSelfFromCompositor();
     void removeDescendantsFromCompositor();
+
+    void verifyClipRects();
+    void verifyClipRect(const ClipRectsContext&);
 
     void setHasCompositingDescendant(bool b)  { m_hasCompositingDescendant = b; }
     void setHasCompositedNonContainedDescendants(bool value) { m_hasCompositedNonContainedDescendants = value; }
@@ -1267,6 +1312,9 @@ private:
     bool m_hasTransformedAncestor : 1;
     bool m_has3DTransformedAncestor : 1;
 
+    bool m_hasFixedAncestor : 1 { false };
+    bool m_hasPaginatedAncestor : 1 { false };
+
     bool m_insideSVGForeignObject : 1;
     bool m_isHiddenByOverflowTruncation : 1 { false };
     bool m_isPaintingSVGResourceLayer : 1 { false };
@@ -1301,6 +1349,10 @@ private:
     RenderLayer* m_last { nullptr };
 
     SingleThreadWeakPtr<RenderLayer> m_backingProviderLayer;
+
+#if ASSERT_ENABLED || ENABLE(CONJECTURE_ASSERT)
+    SingleThreadWeakPtr<RenderObject> m_repaintContainer;
+#endif
 
     // For layers that establish stacking contexts, m_posZOrderList holds a sorted list of all the
     // descendant layers within the stacking context that have z-indices of 0 or greater
@@ -1383,6 +1435,7 @@ inline void RenderLayer::setIsHiddenByOverflowTruncation(bool isHidden)
         return;
     m_isHiddenByOverflowTruncation = isHidden;
     m_visibleContentStatusDirty = true;
+    setNeedsPositionUpdate();
 }
 
 #if ASSERT_ENABLED
@@ -1424,5 +1477,6 @@ void showLayerTree(const WebCore::RenderLayer*);
 void showLayerTree(const WebCore::RenderObject*);
 void showPaintOrderTree(const WebCore::RenderLayer*);
 void showPaintOrderTree(const WebCore::RenderObject*);
+void showLayerPositionTree(const WebCore::RenderLayer*);
 #endif
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -320,7 +320,7 @@ void RenderLayerBacking::setBackingSharingLayers(SingleThreadWeakListHashSet<Ren
         if (!sharingLayers.contains(oldSharingLayer)) {
             sharingLayersChanged = true;
             if (!oldSharingLayer.isComposited())
-                oldSharingLayer.computeRepaintRectsIncludingDescendants();
+                oldSharingLayer.compositingStatusChanged(LayoutUpToDate::Yes);
         }
     }
 
@@ -341,7 +341,7 @@ void RenderLayerBacking::setBackingSharingLayers(SingleThreadWeakListHashSet<Ren
         // For layers that are newly sharing, recompute repaint rects.
         for (auto& currentSharingLayer : m_backingSharingLayers) {
             if (!oldSharingLayers.contains(currentSharingLayer))
-                currentSharingLayer.computeRepaintRectsIncludingDescendants();
+                currentSharingLayer.compositingStatusChanged(LayoutUpToDate::Yes);
         }
     }
 }
@@ -3403,9 +3403,8 @@ void RenderLayerBacking::setRequiresOwnBackingStore(bool requiresOwnBacking)
     m_requiresOwnBackingStore = requiresOwnBacking;
 
     // This affects the answer to paintsIntoCompositedAncestor(), which in turn affects
-    // cached clip rects, so when it changes we have to clear clip rects on descendants.
-    m_owningLayer.clearClipRectsIncludingDescendants(PaintingClipRects);
-    m_owningLayer.computeRepaintRectsIncludingDescendants();
+    // cached clip rects, so we have to notify the layer.
+    m_owningLayer.compositingStatusChanged(LayoutUpToDate::Yes);
 
     compositor().repaintInCompositedAncestor(m_owningLayer, compositedBounds());
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -541,7 +541,7 @@ void RenderLayerCompositor::BackingSharingState::issuePendingRepaints()
 {
     for (auto& layer : m_layersPendingRepaint) {
         LOG_WITH_STREAM(Compositing, stream << "Issuing postponed repaint of layer " << &layer);
-        layer.computeRepaintRectsIncludingDescendants();
+        layer.compositingStatusChanged(LayoutUpToDate::Yes);
         layer.compositor().repaintOnCompositingChange(layer);
     }
     
@@ -2273,8 +2273,7 @@ bool RenderLayerCompositor::updateBacking(RenderLayer& layer, RequiresCompositin
 
             // This layer and all of its descendants have cached repaints rects that are relative to
             // the repaint container, so change when compositing changes; we need to update them here.
-            if (layer.parent())
-                layer.computeRepaintRectsIncludingDescendants();
+            layer.compositingStatusChanged(queryData.layoutUpToDate);
 
             layer.setNeedsCompositingGeometryUpdate();
             layer.setNeedsCompositingConfigurationUpdate();
@@ -2302,7 +2301,7 @@ bool RenderLayerCompositor::updateBacking(RenderLayer& layer, RequiresCompositin
             // the repaint container, so change when compositing changes; we need to update them here,
             // as long as shared backing isn't going to change our repaint container.
             if (!repaintTargetsSharedBacking(layer))
-                layer.computeRepaintRectsIncludingDescendants();
+                layer.compositingStatusChanged(queryData.layoutUpToDate);
 
             // If we need to repaint, do so now that we've removed the backing.
             repaintLayer(layer);

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -109,7 +109,7 @@ void RenderLayerModelObject::createLayer()
     ASSERT(!m_layer);
     m_layer = makeUnique<RenderLayer>(*this);
     setHasLayer(true);
-    m_layer->insertOnlyThisLayer(RenderLayer::LayerChangeTiming::StyleChange);
+    m_layer->insertOnlyThisLayer();
 }
 
 bool RenderLayerModelObject::hasSelfPaintingLayer() const
@@ -173,7 +173,7 @@ void RenderLayerModelObject::styleDidChange(StyleDifference diff, const RenderSt
         if (layer()->isSelfPaintingLayer() && layer()->repaintStatus() == RepaintStatus::NeedsFullRepaint && layer()->cachedClippedOverflowRect())
             repaintUsingContainer(containerForRepaint().renderer.get(), *(layer()->cachedClippedOverflowRect()));
 
-        layer()->removeOnlyThisLayer(RenderLayer::LayerChangeTiming::StyleChange); // calls destroyLayer() which clears m_layer
+        layer()->removeOnlyThisLayer(); // calls destroyLayer() which clears m_layer
         if (s_wasFloating && isFloating())
             setChildNeedsLayout();
         if (s_wasTransformed)

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1049,31 +1049,43 @@ bool RenderLayerScrollableArea::hasOverflowControls() const
     return m_hBar || m_vBar || m_scrollCorner || m_layer.renderer().style().resize() != Resize::None;
 }
 
-void RenderLayerScrollableArea::positionOverflowControls(const IntSize& offsetFromRoot)
+bool RenderLayerScrollableArea::positionOverflowControls(const IntSize& offsetFromRoot)
 {
     if (!m_hBar && !m_vBar && !m_layer.canResize())
-        return;
+        return false;
 
     if (!m_layer.renderBox())
-        return;
+        return false;
 
     auto rects = overflowControlsRects();
+    bool changed = false;
 
     if (m_vBar) {
         rects.verticalScrollbar.move(offsetFromRoot);
-        m_vBar->setFrameRect(rects.verticalScrollbar);
+        if (m_vBar->frameRect() != rects.verticalScrollbar) {
+            m_vBar->setFrameRect(rects.verticalScrollbar);
+            changed = true;
+        }
     }
 
     if (m_hBar) {
         rects.horizontalScrollbar.move(offsetFromRoot);
-        m_hBar->setFrameRect(rects.horizontalScrollbar);
+        if (m_hBar->frameRect() != rects.horizontalScrollbar) {
+            m_hBar->setFrameRect(rects.horizontalScrollbar);
+            changed = true;
+        }
     }
 
-    if (m_scrollCorner)
+    if (m_scrollCorner && m_scrollCorner->frameRect() != rects.scrollCorner) {
         m_scrollCorner->setFrameRect(rects.scrollCorner);
+        changed = true;
+    }
 
-    if (m_resizer)
+    if (m_resizer && m_resizer->frameRect() != rects.resizer) {
         m_resizer->setFrameRect(rects.resizer);
+        changed = true;
+    }
+    return changed;
 }
 
 LayoutUnit RenderLayerScrollableArea::overflowTop() const

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -82,6 +82,7 @@ public:
 
     void setPostLayoutScrollPosition(std::optional<ScrollPosition>);
     void applyPostLayoutScrollPositionIfNeeded();
+    bool hasPostLayoutScrollPosition() { return !!m_postLayoutScrollPosition; }
 
     int scrollWidth() const;
     int scrollHeight() const;
@@ -233,7 +234,7 @@ public:
     void updateScrollbarsAfterStyleChange(const RenderStyle* oldStyle);
     void updateScrollbarsAfterLayout();
 
-    void positionOverflowControls(const IntSize&);
+    bool positionOverflowControls(const IntSize&);
 
     void updateAllScrollbarRelatedStyle();
 

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -573,8 +573,12 @@ void RenderObject::clearNeedsLayout(HadSkippedLayout hadSkippedLayout)
     setEverHadLayout();
     setHadSkippedLayout(hadSkippedLayout == HadSkippedLayout::Yes);
 
-    if (auto* renderElement = dynamicDowncast<RenderElement>(*this))
+    if (auto* renderElement = dynamicDowncast<RenderElement>(*this)) {
         renderElement->setLayoutIdentifier(renderElement->view().frameView().layoutContext().layoutIdentifier());
+
+        if (hasLayer())
+            downcast<RenderLayerModelObject>(*this).layer()->setSelfAndChildrenNeedPositionUpdate();
+    }
     m_stateBitfields.clearFlag(StateFlag::NeedsLayout);
     setPosChildNeedsLayoutBit(false);
     setNeedsSimplifiedNormalFlowLayoutBit(false);
@@ -2818,6 +2822,14 @@ bool RenderObject::isSkippedContentForLayout() const
 TextStream& operator<<(TextStream& ts, const RenderObject& renderer)
 {
     ts << renderer.debugDescription();
+    return ts;
+}
+
+TextStream& operator<<(TextStream& ts, const RenderObject::RepaintRects& repaintRects)
+{
+    ts << " (clipped overflow " << repaintRects.clippedOverflowRect << ")";
+    if (repaintRects.outlineBoundsRect && repaintRects.outlineBoundsRect != repaintRects.clippedOverflowRect)
+        ts << " (outline bounds " << repaintRects.outlineBoundsRect << ")";
     return ts;
 }
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1602,6 +1602,7 @@ inline bool RenderObject::usesBoundaryCaching() const
 }
 
 WTF::TextStream& operator<<(WTF::TextStream&, const RenderObject&);
+WTF::TextStream& operator<<(WTF::TextStream&, const RenderObject::RepaintRects&);
 
 #if ENABLE(TREE_DEBUGGING)
 void printPaintOrderTreeForLiveDocuments();

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -664,6 +664,7 @@ static void writeLayers(TextStream& ts, const RenderLayer& rootLayer, RenderLaye
         paintDirtyRect.setWidth(std::max<LayoutUnit>(paintDirtyRect.width(), rootLayer.renderBox()->layoutOverflowRect().maxX()));
         paintDirtyRect.setHeight(std::max<LayoutUnit>(paintDirtyRect.height(), rootLayer.renderBox()->layoutOverflowRect().maxY()));
         layer.setSize(layer.size().expandedTo(snappedIntSize(maxLayoutOverflow(layer.renderBox()), LayoutPoint(0, 0))));
+        layer.setNeedsPositionUpdate();
     }
     
     // Calculate the clip rects we should use.

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -1069,24 +1069,6 @@ unsigned RenderView::pageCount() const
     return 0;
 }
 
-void RenderView::layerChildrenChangedDuringStyleChange(RenderLayer& layer)
-{
-    if (!m_styleChangeLayerMutationRoot) {
-        m_styleChangeLayerMutationRoot = layer;
-        return;
-    }
-
-    RenderLayer* commonAncestor = m_styleChangeLayerMutationRoot->commonAncestorWithLayer(layer);
-    m_styleChangeLayerMutationRoot = commonAncestor;
-}
-
-RenderLayer* RenderView::takeStyleChangeLayerTreeMutationRoot()
-{
-    auto* result = m_styleChangeLayerMutationRoot.get();
-    m_styleChangeLayerMutationRoot.clear();
-    return result;
-}
-
 void RenderView::registerBoxWithScrollSnapPositions(const RenderBox& box)
 {
     m_boxesWithScrollSnapPositions.add(box);

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -200,9 +200,6 @@ public:
         bool m_wasAccumulatingRepaintRegion { false };
     };
 
-    void layerChildrenChangedDuringStyleChange(RenderLayer&);
-    RenderLayer* takeStyleChangeLayerTreeMutationRoot();
-
     void registerBoxWithScrollSnapPositions(const RenderBox&);
     void unregisterBoxWithScrollSnapPositions(const RenderBox&);
     const SingleThreadWeakHashSet<const RenderBox>& boxesWithScrollSnapPositions() { return m_boxesWithScrollSnapPositions; }
@@ -246,8 +243,6 @@ private:
 
     mutable std::unique_ptr<Region> m_accumulatedRepaintRegion;
     RenderSelection m_selection;
-
-    SingleThreadWeakPtr<RenderLayer> m_styleChangeLayerMutationRoot;
 
     // FIXME: Only used by embedded WebViews inside AppKit NSViews.  Find a way to remove.
     struct LegacyPrinting {


### PR DESCRIPTION
#### 0ef1fec1cdce7a5dd3007976f09afdf302267593
<pre>
Use dirty bits to only traverse the unchanged subtrees with recursiveUpdateLayerPositions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276706">https://bugs.webkit.org/show_bug.cgi?id=276706</a>
&lt;<a href="https://rdar.apple.com/131903605">rdar://131903605</a>&gt;

Reviewed by Alan Baradlay.

Adds a set of dirty bits to mark which RenderLayers need their position updates,
and makes recursiveUpdateLayerPositions only walk the dirty subset of the tree.

With a debug build, the full traversal still gets completed, and it verifies
that all computed values would have been a no-op had they been skipped.

recursiveUpdateLayerPositions gets a templated &apos;mode&apos; parameter so that the
compiled code in release should be mostly identical to before (except the flag
checks). Each block of state changes handles the write/verify branches, to keep
these together and hopefully keep them in sync.

Also adds a new tree dump to &apos;Compositing&apos; logging, showing the RenderLayer tree
and its dirty bits before/after the recursiveUpdateLayerPositions.

The general approach is that we mark layers (and their ancestors) that we know
to be changed), and then descend into children of those to check if any ancestor
state that they depend on has changed.

We could instead ensure that changes to state that descendants use trigger a
full descendant subtree update, and avoid needing to iterate the child list to
check. Logging of visited vs updated layer counts suggests that this wouldn&apos;t
make much difference. We would likely also need to make sure these extra
triggers are specific (not all style changes for example) to avoid updating too
much.

Layout on a RenderObject with a layer triggers update on the direct children of
that layer, since we can move (but not layout) a descendant renderer, and the
child layer is then a further descendant of the moved renderer. We need to
update the child layer to account for the different offset to parent layer.

ClipRectsContext always (and only) specified
ClipRectsOption::IncludeOverlayScrollbarSize when using RootRelativeClipRects,
so that is now implicit. Clip rect validation now can assert these when adding
to the cache, and verify cached clips using it.

recursiveUpdateLayerPositionsAfterScroll no longer checks isVisuallyNonEmpty()
to clear repaint rects, since this doesn&apos;t match the condition we use any other
time (and changing the others results in lots of test failures).

* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::repaintOldAndNewPositionsForSVGRenderer const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::ClipRectsCache::ClipRectsCache):
(WebCore::ClipRectsCache::getClipRects const):
(WebCore::RenderLayer::RenderLayer):
(WebCore::RenderLayer::addChild):
(WebCore::RenderLayer::isStackingContextChanged):
(WebCore::RenderLayer::setNeedsPositionUpdate):
(WebCore::RenderLayer::setSelfAndChildrenNeedPositionUpdate):
(WebCore::RenderLayer::setSelfAndDescendantsNeedPositionUpdate):
(WebCore::compositingLogEnabledRenderLayer):
(WebCore::RenderLayer::updateLayerPositionsAfterStyleChange):
(WebCore::RenderLayer::updateLayerPositionsAfterLayout):
(WebCore::RenderLayer::ancestorLayerPositionStateChanged):
(WebCore::RenderLayer::recursiveUpdateLayerPositions):
(WebCore::RenderLayer::dirtyAncestorChainHasSelfPaintingLayerDescendantStatus):
(WebCore::RenderLayer::computeRepaintRects):
(WebCore::RenderLayer::computeRepaintRectsIncludingDescendants):
(WebCore::RenderLayer::compositingStatusChanged):
(WebCore::RenderLayer::recursiveUpdateLayerPositionsAfterScroll):
(WebCore::RenderLayer::dirtyAncestorChainHasBlendingDescendants):
(WebCore::RenderLayer::updateTransform):
(WebCore::RenderLayer::setHasVisibleContent):
(WebCore::RenderLayer::dirtyVisibleContentStatus):
(WebCore::RenderLayer::dirtyAncestorChainVisibleDescendantStatus):
(WebCore::RenderLayer::updateLayerPosition):
(WebCore::RenderLayer::hitTestLayer):
(WebCore::RenderLayer::hitTestTransformedLayerInFragments):
(WebCore::RenderLayer::verifyClipRects):
(WebCore::RenderLayer::verifyClipRect):
(WebCore::RenderLayer::updateClipRects):
(WebCore::RenderLayer::clipRects const):
(WebCore::RenderLayer::calculateClipRects const):
(WebCore::outputLayerPositionTreeLegend):
(WebCore::outputLayerPositionTreeRecursive):
(WebCore::showLayerPositionTree):
* Source/WebCore/rendering/RenderLayer.h:
(WebCore::RenderLayer::setIsHiddenByOverflowTruncation):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::setBackingSharingLayers):
(WebCore::RenderLayerBacking::setRequiresOwnBackingStore):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::BackingSharingState::issuePendingRepaints):
(WebCore::RenderLayerCompositor::updateBacking):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::positionOverflowControls):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::clearNeedsLayout):
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/RenderObject.h:

Canonical link: <a href="https://commits.webkit.org/284780@main">https://commits.webkit.org/284780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edc8f1d9900ba87e4b16c5fcb806b7593efb22a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/49928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23287 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/21700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21540 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/74611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/21700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73588 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/45408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/60795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/74611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/42067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/18230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/20061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/63643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/64000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/18585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76330 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/69769 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/14748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/17810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/63602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/14791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/60862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/63537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/5219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/91552 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/10801 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45730 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/19961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/46804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/48081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/46546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->