### PR TITLE
Unconditionally set macOS UA string version to 10_15_7

### DIFF
--- a/Source/WebCore/platform/mac/UserAgentMac.mm
+++ b/Source/WebCore/platform/mac/UserAgentMac.mm
@@ -28,20 +28,15 @@
 
 #if PLATFORM(MAC)
 
-#import "SystemVersion.h"
 #import <wtf/text/MakeString.h>
 
 namespace WebCore {
 
 String standardUserAgentWithApplicationName(const String& applicationName, const String&, UserAgentType)
 {
-    String osVersion = systemMarketingVersionForUserAgentString();
-    if (!osVersion.startsWith("10"_s))
-        osVersion = "10_15_7"_s;
-    
     String appNameSuffix = applicationName.isEmpty() ? emptyString() : makeString(' ', applicationName);
 
-    return makeString("Mozilla/5.0 (Macintosh; Intel Mac OS X "_s, osVersion, ") AppleWebKit/605.1.15 (KHTML, like Gecko)"_s, appNameSuffix);
+    return makeString("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)"_s, appNameSuffix);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 49a2b0400d3f6a16e8d604e112da4b38d22cbd02
<pre>
Unconditionally set macOS UA string version to 10_15_7
<a href="https://bugs.webkit.org/show_bug.cgi?id=276718">https://bugs.webkit.org/show_bug.cgi?id=276718</a>

Reviewed by Abrar Rahman Protyasha.

With versions of macOS prior to macOS 11 unsupported, this branch is
never taken.

* Source/WebCore/platform/mac/UserAgentMac.mm:
(WebCore::standardUserAgentWithApplicationName):

Canonical link: <a href="https://commits.webkit.org/281530@main">https://commits.webkit.org/281530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26ce469a8e4d0b68545d4a606e16b5c3b7494afb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62186 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47406 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6418 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50630 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28258 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7932 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8008 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63889 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2473 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8216 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/URL-createObjectURL-null.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54728 "Found 1 new test failure: imported/w3c/web-platform-tests/server-timing/server_timing_header-parsing.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54811 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13353 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2090 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33716 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34802 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->