### PR TITLE
[GTK][X11] Improve pointer lock

### DIFF
--- a/Source/WebKit/UIProcess/gtk/PointerLockManagerX11.h
+++ b/Source/WebKit/UIProcess/gtk/PointerLockManagerX11.h
@@ -43,8 +43,6 @@ private:
     bool lock() override;
     bool unlock() override;
     void didReceiveMotionEvent(const WebCore::FloatPoint&) override;
-
-    WebCore::IntPoint m_x11RootInitialPoint;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### c99908cf384c4b39b49eec744d35f86c6e681227
<pre>
[GTK][X11] Improve pointer lock
<a href="https://bugs.webkit.org/show_bug.cgi?id=276659">https://bugs.webkit.org/show_bug.cgi?id=276659</a>

Reviewed by Carlos Garcia Campos.

My previous attempt in 280623@main had an issue where if the mouse was
moving while pointer lock was started, the movementX/Y values would be
offset because m_initialPoint and m_x11RootInitialPoint disagreed.

I now switched to using XWarpPointer in the relative mode (src_w and
dst_w are None). The relative warp is easier to calculate than the
absolute one as GTK3 and GTK4 use different coordinates for
m_initialPoint.

An added benefit is that subpixel offsets and movement that happened
after the event are preserved. The feel is better, but it&apos;s still
possible for a delta to be &quot;double counted&quot; if a new event happens
before the warp is processed.

It seems like some other implementations warp the pointer to the center of
the window, so there is space for the pointer to move even if started
at the edge of the window. I didn&apos;t attempt that now.

Tested on GTK3 &amp; GTK4 at various DPI scales.

* Source/WebKit/UIProcess/gtk/PointerLockManagerX11.cpp:
(WebKit::PointerLockManagerX11::lock):
(WebKit::PointerLockManagerX11::didReceiveMotionEvent):
* Source/WebKit/UIProcess/gtk/PointerLockManagerX11.h:

Canonical link: <a href="https://commits.webkit.org/281232@main">https://commits.webkit.org/281232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60493d7097a2bb64ee28fc7676eafc17fb5ebf43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62812 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9509 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47871 "") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6792 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28729 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32639 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8513 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64523 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2978 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8620 "Found 1 new test failure: media/video-playsinline.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55205 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55311 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2502 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8842 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34223 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35307 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36392 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->