### PR TITLE
Web Inspector: Console: add internal properties for registrations of a `FinalizationRegistry`

### DIFF
--- a/LayoutTests/inspector/model/remote-object/finalizationregistry-expected.txt
+++ b/LayoutTests/inspector/model/remote-object/finalizationregistry-expected.txt
@@ -1,0 +1,357 @@
+
+-----------------------------------------------------
+EXPRESSION: new FinalizationRegistry((a) => {})
+{
+  "_type": "object",
+  "_objectId": "<filtered>",
+  "_description": "FinalizationRegistry",
+  "_preview": {
+    "_type": "object",
+    "_description": "FinalizationRegistry",
+    "_lossless": false,
+    "_overflow": false,
+    "_properties": [
+      {
+        "_name": "live",
+        "_type": "object",
+        "_subtype": "array",
+        "_valuePreview": {
+          "_type": "object",
+          "_subtype": "array",
+          "_description": "Array",
+          "_lossless": true,
+          "_overflow": false,
+          "_size": 0,
+          "_properties": [],
+          "_entries": null
+        },
+        "_internal": true
+      },
+      {
+        "_name": "dead",
+        "_type": "object",
+        "_subtype": "array",
+        "_valuePreview": {
+          "_type": "object",
+          "_subtype": "array",
+          "_description": "Array",
+          "_lossless": true,
+          "_overflow": false,
+          "_size": 0,
+          "_properties": [],
+          "_entries": null
+        },
+        "_internal": true
+      }
+    ],
+    "_entries": null
+  }
+}
+{
+  "_name": "cleanupCallback",
+  "_value": {
+    "_type": "function",
+    "_objectId": "<filtered>",
+    "_description": "(a) => {}"
+  },
+  "_hasValue": true,
+  "_writable": false,
+  "_configurable": false,
+  "_enumerable": false,
+  "_own": true,
+  "_wasThrown": false,
+  "_nativeGetterValue": false,
+  "_private": false,
+  "_internal": true
+}
+{
+  "_name": "live",
+  "_value": {
+    "_type": "object",
+    "_subtype": "array",
+    "_objectId": "<filtered>",
+    "_description": "Array",
+    "_size": 0,
+    "_preview": {
+      "_type": "object",
+      "_subtype": "array",
+      "_description": "Array",
+      "_lossless": true,
+      "_overflow": false,
+      "_size": 0,
+      "_properties": [],
+      "_entries": null
+    }
+  },
+  "_hasValue": true,
+  "_writable": false,
+  "_configurable": false,
+  "_enumerable": false,
+  "_own": true,
+  "_wasThrown": false,
+  "_nativeGetterValue": false,
+  "_private": false,
+  "_internal": true
+}
+{
+  "_name": "dead",
+  "_value": {
+    "_type": "object",
+    "_subtype": "array",
+    "_objectId": "<filtered>",
+    "_description": "Array",
+    "_size": 0,
+    "_preview": {
+      "_type": "object",
+      "_subtype": "array",
+      "_description": "Array",
+      "_lossless": true,
+      "_overflow": false,
+      "_size": 0,
+      "_properties": [],
+      "_entries": null
+    }
+  },
+  "_hasValue": true,
+  "_writable": false,
+  "_configurable": false,
+  "_enumerable": false,
+  "_own": true,
+  "_wasThrown": false,
+  "_nativeGetterValue": false,
+  "_private": false,
+  "_internal": true
+}
+
+-----------------------------------------------------
+EXPRESSION: var finalizationRegistry = new FinalizationRegistry((b) => {}); finalizationRegistry.register(live1, heldValue1); finalizationRegistry.register(live2, heldValue1, unregisterToken1); finalizationRegistry
+{
+  "_type": "object",
+  "_objectId": "<filtered>",
+  "_description": "FinalizationRegistry",
+  "_preview": {
+    "_type": "object",
+    "_description": "FinalizationRegistry",
+    "_lossless": false,
+    "_overflow": false,
+    "_properties": [
+      {
+        "_name": "live",
+        "_type": "object",
+        "_subtype": "array",
+        "_value": "Array",
+        "_internal": true
+      },
+      {
+        "_name": "dead",
+        "_type": "object",
+        "_subtype": "array",
+        "_valuePreview": {
+          "_type": "object",
+          "_subtype": "array",
+          "_description": "Array",
+          "_lossless": true,
+          "_overflow": false,
+          "_size": 0,
+          "_properties": [],
+          "_entries": null
+        },
+        "_internal": true
+      }
+    ],
+    "_entries": null
+  }
+}
+{
+  "_name": "cleanupCallback",
+  "_value": {
+    "_type": "function",
+    "_objectId": "<filtered>",
+    "_description": "(b) => {}"
+  },
+  "_hasValue": true,
+  "_writable": false,
+  "_configurable": false,
+  "_enumerable": false,
+  "_own": true,
+  "_wasThrown": false,
+  "_nativeGetterValue": false,
+  "_private": false,
+  "_internal": true
+}
+{
+  "_name": "live",
+  "_value": {
+    "_type": "object",
+    "_subtype": "array",
+    "_objectId": "<filtered>",
+    "_description": "Array",
+    "_size": 2,
+    "_preview": {
+      "_type": "object",
+      "_subtype": "array",
+      "_description": "Array",
+      "_lossless": true,
+      "_overflow": false,
+      "_size": 2,
+      "_properties": [
+        {
+          "_name": "0",
+          "_type": "object",
+          "_valuePreview": {
+            "_type": "object",
+            "_description": "Object",
+            "_lossless": true,
+            "_overflow": false,
+            "_properties": [
+              {
+                "_name": "target",
+                "_type": "object",
+                "_valuePreview": {
+                  "_type": "object",
+                  "_description": "Object",
+                  "_lossless": true,
+                  "_overflow": false,
+                  "_properties": [
+                    {
+                      "_name": "live",
+                      "_type": "number",
+                      "_value": "1"
+                    }
+                  ],
+                  "_entries": null
+                }
+              },
+              {
+                "_name": "heldValue",
+                "_type": "object",
+                "_valuePreview": {
+                  "_type": "object",
+                  "_description": "Object",
+                  "_lossless": true,
+                  "_overflow": false,
+                  "_properties": [
+                    {
+                      "_name": "heldValue",
+                      "_type": "number",
+                      "_value": "1"
+                    }
+                  ],
+                  "_entries": null
+                }
+              }
+            ],
+            "_entries": null
+          }
+        },
+        {
+          "_name": "1",
+          "_type": "object",
+          "_valuePreview": {
+            "_type": "object",
+            "_description": "Object",
+            "_lossless": true,
+            "_overflow": false,
+            "_properties": [
+              {
+                "_name": "target",
+                "_type": "object",
+                "_valuePreview": {
+                  "_type": "object",
+                  "_description": "Object",
+                  "_lossless": true,
+                  "_overflow": false,
+                  "_properties": [
+                    {
+                      "_name": "live",
+                      "_type": "number",
+                      "_value": "2"
+                    }
+                  ],
+                  "_entries": null
+                }
+              },
+              {
+                "_name": "heldValue",
+                "_type": "object",
+                "_valuePreview": {
+                  "_type": "object",
+                  "_description": "Object",
+                  "_lossless": true,
+                  "_overflow": false,
+                  "_properties": [
+                    {
+                      "_name": "heldValue",
+                      "_type": "number",
+                      "_value": "1"
+                    }
+                  ],
+                  "_entries": null
+                }
+              },
+              {
+                "_name": "unregisterToken",
+                "_type": "object",
+                "_valuePreview": {
+                  "_type": "object",
+                  "_description": "Object",
+                  "_lossless": true,
+                  "_overflow": false,
+                  "_properties": [
+                    {
+                      "_name": "unregisterToken",
+                      "_type": "number",
+                      "_value": "1"
+                    }
+                  ],
+                  "_entries": null
+                }
+              }
+            ],
+            "_entries": null
+          }
+        }
+      ],
+      "_entries": null
+    }
+  },
+  "_hasValue": true,
+  "_writable": false,
+  "_configurable": false,
+  "_enumerable": false,
+  "_own": true,
+  "_wasThrown": false,
+  "_nativeGetterValue": false,
+  "_private": false,
+  "_internal": true
+}
+{
+  "_name": "dead",
+  "_value": {
+    "_type": "object",
+    "_subtype": "array",
+    "_objectId": "<filtered>",
+    "_description": "Array",
+    "_size": 0,
+    "_preview": {
+      "_type": "object",
+      "_subtype": "array",
+      "_description": "Array",
+      "_lossless": true,
+      "_overflow": false,
+      "_size": 0,
+      "_properties": [],
+      "_entries": null
+    }
+  },
+  "_hasValue": true,
+  "_writable": false,
+  "_configurable": false,
+  "_enumerable": false,
+  "_own": true,
+  "_wasThrown": false,
+  "_nativeGetterValue": false,
+  "_private": false,
+  "_internal": true
+}
+

--- a/LayoutTests/inspector/model/remote-object/finalizationregistry.html
+++ b/LayoutTests/inspector/model/remote-object/finalizationregistry.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/remote-object-utilities.js"></script>
+<script>
+window.live1 = {live: 1};
+window.live2 = {live: 2};
+
+window.heldValue1 = {heldValue: 1};
+window.heldValue2 = {heldValue: 2};
+
+window.unregisterToken1 = {unregisterToken: 1};
+window.unregisterToken2 = {unregisterToken: 2};
+
+function test()
+{
+    const deep = ["cleanupCallback", "live", "dead"];
+
+    let steps = [
+        {expression: `new FinalizationRegistry((a) => {})`, deep},
+        {expression: `var finalizationRegistry = new FinalizationRegistry((b) => {}); finalizationRegistry.register(live1, heldValue1); finalizationRegistry.register(live2, heldValue1, unregisterToken1); finalizationRegistry`, deep},
+        // {expression: `var finalizationRegistry = new FinalizationRegistry((c) => {}); finalizationRegistry.register({}, heldValue1); finalizationRegistry.register({}, heldValue1, unregisterToken1); GCController.collect(); finalizationRegistry`, deep},
+        // {expression: `var finalizationRegistry = new FinalizationRegistry((d) => {}); finalizationRegistry.register(live1, heldValue1, unregisterToken1); finalizationRegistry.register({}, heldValue2, unregisterToken2); GCController.collect(); finalizationRegistry`, deep},
+    ];
+
+    if (!window.WI) {
+        window.steps = steps;
+        return;
+    }
+
+    runSteps(steps);
+}
+</script>
+</head>
+<body onload="runTest(); runInBrowserTest();"></body>
+</html>

--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
@@ -234,6 +234,21 @@ size_t JSFinalizationRegistry::liveCount(const Locker<JSCellLock>&)
     return count;
 }
 
+Vector<JSFinalizationRegistry::LiveRegistration> JSFinalizationRegistry::liveRegistrations(const Locker<JSCellLock>&) const
+{
+    Vector<LiveRegistration> liveRegistrations;
+
+    for (const auto& registration : m_noUnregistrationLive)
+        liveRegistrations.append({ registration.target, registration.holdings.get() });
+
+    for (const auto& [unregisterToken, registrations] : m_liveRegistrations) {
+        for (const auto& registration : registrations)
+            liveRegistrations.append({ registration.target, registration.holdings.get(), unregisterToken });
+    }
+
+    return liveRegistrations;
+}
+
 size_t JSFinalizationRegistry::deadCount(const Locker<JSCellLock>&)
 {
     size_t count = m_noUnregistrationDead.size();
@@ -241,6 +256,21 @@ size_t JSFinalizationRegistry::deadCount(const Locker<JSCellLock>&)
         count += iter.value.size();
 
     return count;
+}
+
+Vector<JSFinalizationRegistry::DeadRegistration> JSFinalizationRegistry::deadRegistrations(const Locker<JSCellLock>&) const
+{
+    Vector<DeadRegistration> deadRegistrations;
+
+    for (const auto& heldValue : m_noUnregistrationDead)
+        deadRegistrations.append({ heldValue.get() });
+
+    for (const auto& [unregisterToken, heldValues] : m_deadRegistrations) {
+        for (const auto& heldValue : heldValues)
+            deadRegistrations.append({ heldValue.get(), unregisterToken });
+    }
+
+    return deadRegistrations;
 }
 
 }

--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
@@ -80,8 +80,20 @@ public:
     // token should be a JSObject, Symbol, or undefined.
     void registerTarget(VM&, JSCell* target, JSValue holdings, JSValue token);
 
+    struct LiveRegistration {
+        JSCell* target;
+        JSValue heldValue;
+        JSCell* unregisterToken = nullptr;
+    };
     JS_EXPORT_PRIVATE size_t liveCount(const Locker<JSCellLock>&);
+    Vector<LiveRegistration> liveRegistrations(const Locker<JSCellLock>&) const;
+
+    struct DeadRegistration {
+        JSValue heldValue;
+        JSCell* unregisterToken = nullptr;
+    };
     JS_EXPORT_PRIVATE size_t deadCount(const Locker<JSCellLock>&);
+    Vector<DeadRegistration> deadRegistrations(const Locker<JSCellLock>&) const;
 
 private:
     JSFinalizationRegistry(VM& vm, Structure* structure)


### PR DESCRIPTION
#### 626aa2207e3e6402daa4dfd62a02b6cf29ab8683
<pre>
Web Inspector: Console: add internal properties for registrations of a `FinalizationRegistry`
<a href="https://bugs.webkit.org/show_bug.cgi?id=276719">https://bugs.webkit.org/show_bug.cgi?id=276719</a>

Reviewed by Yusuke Suzuki.

Add special handling for `FinalizationRegistry` to make it easier for developers to understand its state (e.g. what is still alive vs what is dead but not yet notified vs etc.).

* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
(Inspector::JSInjectedScriptHost::getInternalProperties):
Add internal properties for
- `cleanupCallback` to help the developer know what the `FinalizationRegistry` is for if the grab it via some general means (e.g. `queryInstances`).
- `live` is the list of objects that have not been GCd, each showing the `target`, `heldValue`, and (if provided) `unregisterToken`.
- `dead` is the list of metadata for objects that have been GCd (but not yet notified), each showing the `heldValue` and (if provided) `unregisterToken`.

* Source/JavaScriptCore/runtime/JSFinalizationRegistry.h:
* Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp:
(JSC::JSFinalizationRegistry::forEachLive const): Added.
(JSC::JSFinalizationRegistry::forEachDead const): Added.
Expose ways for callers to get the above data.

* LayoutTests/inspector/model/remote-object/resources/remote-object-utilities.js:
* LayoutTests/inspector/model/remote-object/finalizationregistry.html: Added.
* LayoutTests/inspector/model/remote-object/finalizationregistry-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/282000@main">https://commits.webkit.org/282000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2c664f65aff8be64cd565e0a4b378445a2eb0d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65677 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12243 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12514 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8506 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30599 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10679 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11174 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54793 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67405 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60939 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57142 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5666 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57368 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13737 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4641 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82701 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14465 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37936 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39032 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37681 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->