### PR TITLE
[css-overflow] Implement scrollbar-gutter on viewports

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-gutter-root-both-edges-expected.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-gutter-root-both-edges-expected.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Overflow: scrollbar-gutter on the root element</title>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1874093">
+
+<style>
+    html {
+        background-color: blue;
+        margin: 10px;
+        margin-right: 25px;
+        margin-left: 25px;
+        padding: 10px;
+        border: 5px solid black;
+    }
+
+    body{
+        margin: 10px;
+        padding: 10px;
+        border: 5px solid green;
+    }
+
+    div {
+        position:absolute;
+        top:150px;
+        left: 15px;
+        background-color: green;
+        width: 80px;
+        height: 100px;
+        transform: translateZ(0);
+    }
+
+p {
+  background-color: purple;
+  color: white;
+}
+</style>
+<p id="content">Should not have space around me in the inline axis.</p> 
+<div></div>

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-gutter-root-both-edges.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-gutter-root-both-edges.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Overflow: scrollbar-gutter on the root element</title>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1874093">
+
+<style>
+    body,html {
+        background-color: blue;
+        margin: 10px;
+        padding: 10px;
+        border: 5px solid black;
+    }
+
+    body{
+        border: 5px solid green;
+    }
+
+
+:root {
+  scrollbar-gutter: stable both-edges;
+}
+p {
+  background-color: purple;
+  color: white;
+}
+div {
+    position:absolute;
+    left:-20px;
+    top:150px;
+    background-color: green;
+    width: 100px;
+    height: 100px;
+    transform: translateZ(0);
+}
+</style>
+<p id="content">Should not have space around me in the inline axis.</p>
+<div></div>

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-gutter-root-expected.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-gutter-root-expected.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Overflow: scrollbar-gutter on the root element</title>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1874093">
+
+<style>
+    html {
+
+        background-color: blue;
+        margin: 10px;
+        margin-right: 25px;
+        padding: 10px;
+        border: 5px solid black;
+    }
+
+    body{
+        margin: 10px;
+        padding: 10px;
+        border: 5px solid green;
+    }
+
+    div {
+        position:absolute;
+        top:150px;
+        left: 0px;
+        background-color: green;
+        width: 80px;
+        height: 100px;
+        transform: translateZ(0);
+    }
+
+p {
+  background-color: purple;
+  color: white;
+}
+</style>
+<p id="content">Should not have space around me in the inline axis.</p> 
+<div></div>

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-gutter-root.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-gutter-root.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Overflow: scrollbar-gutter on the root element</title>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1874093">
+
+<style>
+    body,html {
+        background-color: blue;
+        margin: 10px;
+        padding: 10px;
+        border: 5px solid black;
+    }
+
+    body{
+        border: 5px solid green;
+    }
+
+
+:root {
+  scrollbar-gutter: stable;
+}
+p {
+  background-color: purple;
+  color: white;
+}
+div {
+    position:absolute;
+    left:-20px;
+    top:150px;
+    background-color: green;
+    width: 100px;
+    height: 100px;
+    transform: translateZ(0);
+}
+</style>
+<p id="content">Should not have space around me in the inline axis.</p>
+<div></div>

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-state-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-state-expected.txt
@@ -11,7 +11,7 @@ PASS verticalScrollbarStateForAuto is "enabled"
 PASS horizontalScrollbarStateForAuto is "none"
 overflow:scroll
 PASS verticalScrollbarStateForScroll is "enabled"
-PASS horizontalScrollbarStateForScroll is "none"
+PASS horizontalScrollbarStateForScroll is "disabled"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-state.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-state.html
@@ -53,7 +53,7 @@
             verticalScrollbarStateForScroll = await UIHelper.verticalScrollbarState(scrollScroller);
             horizontalScrollbarStateForScroll = await UIHelper.horizontalScrollbarState(scrollScroller);
             shouldBeEqualToString('verticalScrollbarStateForScroll', 'enabled');
-            shouldBeEqualToString('horizontalScrollbarStateForScroll', 'none');
+            shouldBeEqualToString('horizontalScrollbarStateForScroll', 'disabled');
 
             finishJSTest();
         }, false);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-001-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL viewport has gutter, others do not assert_less_than: viewport has gutter expected a number less than 800 but got 800
+PASS viewport has gutter, others do not
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-003-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL viewport has gutter, others do not assert_less_than: viewport has gutter expected a number less than 800 but got 800
+PASS viewport has gutter, others do not
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-001-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-001-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL viewport has gutter, others do not assert_less_than: viewport has gutter expected a number less than 800 but got 800
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-003-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-003-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL viewport has gutter, others do not assert_less_than: viewport has gutter expected a number less than 800 but got 800
+

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -675,6 +675,7 @@ public:
     void hide() final;
 
     bool shouldPlaceVerticalScrollbarOnLeft() const final;
+    bool isHorizontalWritingMode() const final;
 
     void didRestoreFromBackForwardCache();
 
@@ -727,6 +728,10 @@ public:
     void scrollbarWidthChanged(ScrollbarWidth) override;
 
     FrameIdentifier rootFrameID() const final;
+
+    IntSize totalScrollbarSpace() const final;
+    int scrollbarGutterWidth(bool isHorizontalWritingMode = true) const;
+    int insetForLeftScrollbarSpace() const final;
 
 private:
     explicit LocalFrameView(LocalFrame&);

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -36,6 +36,7 @@
 #include "PlatformWheelEvent.h"
 #include "ScrollAnimator.h"
 #include "Scrollbar.h"
+#include "ScrollbarGutter.h"
 #include "ScrollbarTheme.h"
 #include <wtf/HexNumber.h>
 #include <wtf/SetForScope.h>
@@ -295,7 +296,9 @@ IntSize ScrollView::sizeForVisibleContent(VisibleContentRectIncludesScrollbars s
 #endif
 
     IntSize scrollbarSpace;
-    if (scrollbarInclusion == VisibleContentRectIncludesScrollbars::No)
+    if (!scrollbarGutterStyle().isAuto && scrollbarInclusion == VisibleContentRectIncludesScrollbars::No)
+        scrollbarSpace = totalScrollbarSpace();
+    else if (scrollbarInclusion == VisibleContentRectIncludesScrollbars::No)
         scrollbarSpace = scrollbarIntrusion();
 
     return IntSize(width() - scrollbarSpace.width(), height() - scrollbarSpace.height()).expandedTo(IntSize());
@@ -441,8 +444,7 @@ void ScrollView::cacheCurrentScrollState()
 
 ScrollPosition ScrollView::documentScrollPositionRelativeToViewOrigin() const
 {
-    return scrollPosition() - IntSize(
-        shouldPlaceVerticalScrollbarOnLeft() && m_verticalScrollbar ? m_verticalScrollbar->occupiedWidth() : 0,
+    return scrollPosition() - IntSize(insetForLeftScrollbarSpace(),
         headerHeight() + topContentInset(TopContentInsetType::WebCoreOrPlatformContentInset));
 }
 
@@ -1617,8 +1619,7 @@ void ScrollView::styleAndRenderTreeDidChange()
 IntPoint ScrollView::locationOfContents() const
 {
     IntPoint result = location();
-    if (shouldPlaceVerticalScrollbarOnLeft() && m_verticalScrollbar)
-        result.move(m_verticalScrollbar->occupiedWidth(), 0);
+    result.move(insetForLeftScrollbarSpace(), 0);
     return result;
 }
 

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -414,6 +414,8 @@ public:
 
     virtual bool shouldPlaceVerticalScrollbarOnLeft() const = 0;
     
+    virtual bool isHorizontalWritingMode() const { return false; }
+
     virtual String debugDescription() const = 0;
 
     virtual float pageScaleFactor() const
@@ -439,6 +441,9 @@ public:
 
     WEBCORE_EXPORT void setScrollbarsController(std::unique_ptr<ScrollbarsController>&&);
     WEBCORE_EXPORT virtual void scrollbarWidthChanged(ScrollbarWidth) { }
+
+    virtual IntSize totalScrollbarSpace() const { return { }; }
+    virtual int insetForLeftScrollbarSpace() const { return 0; }
 
 protected:
     WEBCORE_EXPORT ScrollableArea();

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2675,8 +2675,7 @@ FloatPoint RenderLayerCompositor::positionForClipLayer() const
 {
     auto& frameView = m_renderView.frameView();
 
-    return FloatPoint(
-        frameView.shouldPlaceVerticalScrollbarOnLeft() ? frameView.horizontalScrollbarIntrusion() : 0,
+    return FloatPoint(frameView.insetForLeftScrollbarSpace(),
         LocalFrameView::yPositionForInsetClipLayer(frameView.scrollPosition(), frameView.topContentInset()));
 }
 


### PR DESCRIPTION
#### c94f5d66b46909bb9cc72345adf97a6739f36f90
<pre>
[css-overflow] Implement scrollbar-gutter on viewports
<a href="https://bugs.webkit.org/show_bug.cgi?id=257606">https://bugs.webkit.org/show_bug.cgi?id=257606</a>
<a href="https://rdar.apple.com/110468611">rdar://110468611</a>

Reviewed by Simon Fraser.

Updates scrollbar gutter implementation to work for viewports. When setting scrollbar gutter
on the viewport, shrink the size of the visible content rect, and when both-edges is present,
shift the clip layer over like we do when placing the scrollbar on the left.

* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::documentScrollPositionRelativeToViewOrigin const):
(WebCore::ScrollView::verticalScrollbarWidth const):
(WebCore::ScrollView::horizontalScrollbarHeight const):
(WebCore::ScrollView::locationOfContents const):
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::includeVerticalScrollbarSize const):
(WebCore::RenderBox::verticalScrollbarWidth const):

Canonical link: <a href="https://commits.webkit.org/282661@main">https://commits.webkit.org/282661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b53a882270e22083db47bb6e373bd4a37dd71e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67837 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14424 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51423 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9971 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32040 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12628 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13297 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58642 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69533 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58745 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58887 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6457 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9651 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38993 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40072 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41255 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->