### PR TITLE
[webkitbugspy] Support adding keywords during bug creation

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -350,6 +350,17 @@ class Bugzilla(Base, mocks.Requests):
             url=url,
         )
 
+    def _fields(self, url, id):
+        return mocks.Response.fromJson(
+            dict(fields=[dict(
+                id=10,
+                name='keywords',
+                type=8,
+                display_name='Keywords',
+                values=[dict(name='InRadar')]
+            )]), url=url
+        )
+
     def _create(self, url, credentials, data):
         user = self._user_for_credentials(credentials)
         assignee = self.users.get(data['assigned_to']) if 'assigned_to' in data else None
@@ -379,7 +390,7 @@ class Bugzilla(Base, mocks.Requests):
             project=data.get('product'),
             component=data.get('component'),
             version=data.get('version'),
-            keywords=[],
+            keywords=data.get('keywords'),
             comments=[], watchers=[user, assignee] if assignee else [user],
         )
 
@@ -463,6 +474,10 @@ class Bugzilla(Base, mocks.Requests):
         match = re.match(r'{}/rest/product/(?P<id>\d+)(?P<credentials>\?login=\S+\&password=\S+)?$'.format(self.hosts[0]), stripped_url)
         if match and method == 'GET':
             return self._product_details(url, int(match.group('id')))
+
+        match = re.match(r'{}/rest/field/bug/(?P<id>\w+)(?P<credentials>\?login=\S+\&password=\S+)?$'.format(self.hosts[0]), stripped_url)
+        if match and method == 'GET':
+            return self._fields(url, match.group('id'))
 
         match = re.match(r'{}/rest/bug(?P<credentials>\?login=\S+\&password=\S+)?$'.format(self.hosts[0]), stripped_url)
         if match and method == 'POST':

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -321,7 +321,7 @@ class TestBugzilla(unittest.TestCase):
         ), projects=mocks.PROJECTS, issues=mocks.ISSUES):
             created = bugzilla.Tracker(self.URL).create(
                 'New bug', 'Creating new bug',
-                project='WebKit', component='Tables', version='Other',
+                project='WebKit', component='Tables', version='Other', keywords=['InRadar']
             )
             self.assertEqual(created.id, 4)
             self.assertEqual(created.title, 'New bug')
@@ -339,6 +339,7 @@ class TestBugzilla(unittest.TestCase):
             self.assertEqual(created.project, 'WebKit')
             self.assertEqual(created.component, 'Tables')
             self.assertEqual(created.version, 'Other')
+            self.assertEqual(created.keywords, ['InRadar'])
 
     def test_create_prompt(self):
         with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(
@@ -383,6 +384,19 @@ What component in 'WebKit' should the bug be associated with?:
             self.assertEqual(issue.project, 'WebKit')
             self.assertEqual(issue.component, 'Text')
             self.assertEqual(issue.version, 'Other')
+
+    def test_invalid_keyword(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+        ), projects=mocks.PROJECTS, issues=mocks.ISSUES):
+
+            with self.assertRaises(ValueError) as e:
+                bugzilla.Tracker(self.URL).create(
+                    'New bug', 'Creating new bug',
+                    project='WebKit', component='Tables', version='Other', keywords=['InvalidKeyword']
+                )
+            self.assertEqual(f"'InvalidKeyword' is not a valid keyword for 'WebKit'", str(e.exception))
 
     def test_set_component(self):
         with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(


### PR DESCRIPTION
#### 587755c4264c6184dffe5d3e3588913cb2c18728
<pre>
[webkitbugspy] Support adding keywords during bug creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=276730">https://bugs.webkit.org/show_bug.cgi?id=276730</a>
<a href="https://rdar.apple.com/131946982">rdar://131946982</a>

Reviewed by Jonathan Bedard.

Add keywords field to bug creation.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.valid_keywords): Fetches all valid keywords for the project.
(Tracker.create): Adds keywords argument and creates bug with desired keyword.
(Tracker):

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
(Bugzilla._fields): Added.
(Bugzilla.request): Add mock request for fields.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
(TestBugzilla.test_create): Add check for keywords.
(TestBugzilla.test_invalid_keyword): Added.

Canonical link: <a href="https://commits.webkit.org/281066@main">https://commits.webkit.org/281066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d28efb6475d4d8160abdbe1d10b73b686601098

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58633 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/37960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/11118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/62259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/9077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60762 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/45597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/9275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/62259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/9077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/60664 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/45597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/11118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/62259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/58160 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/45597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/11118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/8081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/45597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/11118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/63962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/2546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/9275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/63962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/2555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/11118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/63962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8734 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/34875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/34620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->