### PR TITLE
Only set JIT_OPERATION_VALIDATION_ASSERT_ENABLED when JIT_OPERATION_VALIDATION is enabled

### DIFF
--- a/Source/JavaScriptCore/assembler/JITOperationList.cpp
+++ b/Source/JavaScriptCore/assembler/JITOperationList.cpp
@@ -54,7 +54,7 @@ void JITOperationList::initialize()
 
 #if ENABLE(JIT_OPERATION_VALIDATION)
 
-#if JIT_OPERATION_VALIDATION_ASSERT_ENABLED
+#if ENABLE(JIT_OPERATION_VALIDATION_ASSERT)
 void JITOperationList::addInverseMap(void* validationEntry, void* pointer)
 {
     m_validatedOperationsInverseMap.add(validationEntry, pointer);
@@ -64,7 +64,7 @@ void JITOperationList::addInverseMap(void* validationEntry, void* pointer)
     addInverseMap(validationEntry, pointer)
 #else
 #define JSC_REGISTER_INVERSE_JIT_CAGED_POINTER_FOR_DEBUG(validationEntry, pointer)
-#endif // JIT_OPERATION_VALIDATION_ASSERT_ENABLED
+#endif // ENABLE(JIT_OPERATION_VALIDATION_ASSERT)
 
 SUPPRESS_ASAN ALWAYS_INLINE void JITOperationList::addPointers(const JITOperationAnnotation* begin, const JITOperationAnnotation* end)
 {
@@ -75,7 +75,7 @@ SUPPRESS_ASAN ALWAYS_INLINE void JITOperationList::addPointers(const JITOperatio
         return;
     }
 #endif
-    if constexpr (JIT_OPERATION_VALIDATION_ASSERT_ENABLED) {
+#if ENABLE(JIT_OPERATION_VALIDATION_ASSERT)
         for (const auto* current = begin; current != end; ++current) {
             void* operation = removeCodePtrTag(current->operation);
             if (operation) {
@@ -85,7 +85,7 @@ SUPPRESS_ASAN ALWAYS_INLINE void JITOperationList::addPointers(const JITOperatio
                 JSC_REGISTER_INVERSE_JIT_CAGED_POINTER_FOR_DEBUG(validator, operation);
             }
         }
-    }
+#endif
 }
 
 void JITOperationList::populatePointersInJavaScriptCore()

--- a/Source/JavaScriptCore/assembler/JITOperationList.h
+++ b/Source/JavaScriptCore/assembler/JITOperationList.h
@@ -36,7 +36,9 @@ namespace JSC {
 
 // This indirection is provided so that we can manually force on assertions for
 // testing even on release builds.
-#define JIT_OPERATION_VALIDATION_ASSERT_ENABLED ASSERT_ENABLED
+#if ENABLE(JIT_OPERATION_VALIDATION) && ASSERT_ENABLED
+#define ENABLE_JIT_OPERATION_VALIDATION_ASSERT 1
+#endif
 
 struct JITOperationAnnotation;
 
@@ -52,7 +54,7 @@ public:
         return m_validatedOperations.get(removeCodePtrTag(bitwise_cast<void*>(pointer)));
     }
 
-#if JIT_OPERATION_VALIDATION_ASSERT_ENABLED
+#if ENABLE(JIT_OPERATION_VALIDATION_ASSERT)
     template<typename PtrType>
     void* inverseMap(PtrType pointer) const
     {
@@ -73,7 +75,7 @@ public:
     template<typename T> static void assertIsJITOperation(T function)
     {
         UNUSED_PARAM(function);
-#if JIT_OPERATION_VALIDATION_ASSERT_ENABLED
+#if ENABLE(JIT_OPERATION_VALIDATION_ASSERT)
         RELEASE_ASSERT(!Options::useJIT() || JITOperationList::instance().map(function));
 #endif
     }
@@ -81,7 +83,7 @@ public:
     template<typename T> static void assertIsJITOperationWithValidation(T function)
     {
         UNUSED_PARAM(function);
-#if JIT_OPERATION_VALIDATION_ASSERT_ENABLED
+#if ENABLE(JIT_OPERATION_VALIDATION_ASSERT)
         RELEASE_ASSERT(!Options::useJIT() || JITOperationList::instance().inverseMap(function));
 #endif
     }
@@ -96,12 +98,12 @@ private:
 #if ENABLE(JIT_OPERATION_VALIDATION)
     ALWAYS_INLINE void addPointers(const JITOperationAnnotation* begin, const JITOperationAnnotation* end);
 
-#if JIT_OPERATION_VALIDATION_ASSERT_ENABLED
+#if ENABLE(JIT_OPERATION_VALIDATION_ASSERT)
     void addInverseMap(void* validationEntry, void* pointer);
 #endif
 
     HashMap<void*, void*> m_validatedOperations;
-#if JIT_OPERATION_VALIDATION_ASSERT_ENABLED
+#if ENABLE(JIT_OPERATION_VALIDATION_ASSERT)
     HashMap<void*, void*> m_validatedOperationsInverseMap;
 #endif
 #endif // ENABLE(JIT_OPERATION_VALIDATION)


### PR DESCRIPTION
#### 292ee2d452dae53bcbcc4bff0a103f363f573afb
<pre>
Only set JIT_OPERATION_VALIDATION_ASSERT_ENABLED when JIT_OPERATION_VALIDATION is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=276734">https://bugs.webkit.org/show_bug.cgi?id=276734</a>
<a href="https://rdar.apple.com/131950848">rdar://131950848</a>

Reviewed by Alexey Shvayka and Keith Miller.

This prevents the problematic pieces of code from being compiled when
they&apos;re not wanted, while not changing the behavior of
JITOperationValidation otherwise.

* Source/JavaScriptCore/assembler/JITOperationList.h:

Canonical link: <a href="https://commits.webkit.org/281070@main">https://commits.webkit.org/281070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ed4bfa7c3d0190ad0daad3fe1cd28c8269c4c38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62256 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9074 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9272 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6466 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60661 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/50701 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28308 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/32279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/8002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8078 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/51721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/8274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63959 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57872 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2543 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54771 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54855 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12939 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2142 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79633 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/13270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/34872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/34617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->