### PR TITLE
[build.webkit.org] Remove AppleWin code (part 2)

### DIFF
--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -44,8 +44,6 @@ class Factory(factory.BuildFactory):
         if platform.startswith('mac'):
             self.addStep(PruneCoreSymbolicationdCacheIfTooLarge())
         if self.shouldInstallDependencies:
-            if platform == "win":
-                self.addStep(InstallWin32Dependencies())
             if platform.startswith("gtk"):
                 self.addStep(InstallGtkDependencies())
             if platform == "wpe":
@@ -59,7 +57,7 @@ class BuildFactory(Factory):
     def __init__(self, platform, configuration, architectures, triggers=None, additionalArguments=None, device_model=None):
         Factory.__init__(self, platform, configuration, architectures, True, additionalArguments, device_model, triggers=triggers)
 
-        if platform == "win" or platform.startswith("playstation"):
+        if platform.startswith("playstation"):
             self.addStep(CompileWebKit(timeout=2 * 60 * 60))
         else:
             self.addStep(CompileWebKit())

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -291,12 +291,6 @@ class CheckOutSpecificRevision(shell.ShellCommandNewStyle):
         return super().run()
 
 
-class InstallWin32Dependencies(shell.Compile):
-    description = ["installing dependencies"]
-    descriptionDone = ["installed dependencies"]
-    command = ["perl", "Tools/Scripts/update-webkit-auxiliary-libs"]
-
-
 class KillOldProcesses(shell.Compile):
     name = "kill-old-processes"
     description = ["killing old processes"]
@@ -887,9 +881,6 @@ class RunWebKitTests(shell.TestNewStyle, CustomFlagsMixin):
 
         self.command += ["--results-directory", self.resultDirectory]
         self.command += ['--debug-rwt-logging']
-
-        if platform == "win":
-            self.command += ['--batch-size', '100', '--root=' + os.path.join("WebKitBuild", self.getProperty('configuration'), "bin64")]
 
         if platform in ['gtk', 'wpe']:
             self.command += ['--enable-core-dumps-nolimit']

--- a/Tools/CISupport/build-webkit-org/wkbuild.py
+++ b/Tools/CISupport/build-webkit-org/wkbuild.py
@@ -47,7 +47,6 @@ def _should_file_trigger_build(target_platform, file):
         "mac-monterey",
         "mac-ventura",
         "mac-sonoma",
-        "win",
         "ios-17",
         "ios-simulator-17",
         "visionos-1",
@@ -88,10 +87,10 @@ def _should_file_trigger_build(target_platform, file):
         ("LayoutTests/platform/mac-sonoma", ["mac-ventura", "mac-sonoma"]),
         ("LayoutTests/platform/mac-wk2", ["mac"]),
         ("LayoutTests/platform/mac-wk1", ["mac"]),
-        ("LayoutTests/platform/mac", ["mac", "win"]),
+        ("LayoutTests/platform/mac", ["mac"]),
         ("LayoutTests/platform/wk2", ["mac", "ios", "visionos"]),
         ("cairo", ["gtk", "wincairo"]),
-        ("cf", ["mac", "win", "ios", "visionos", "tvos", "watchos"]),
+        ("cf", ["mac", "ios", "visionos", "tvos", "watchos"]),
         ("cocoa", ["mac", "ios", "visionos", "tvos", "watchos"]),
         ("curl", ["gtk", "wincairo"]),
         ("gobject", ["gtk"]),
@@ -101,7 +100,6 @@ def _should_file_trigger_build(target_platform, file):
         ("mac", ["mac"]),
         ("objc", ["mac", "ios", "visionos", "tvos", "watchos"]),
         ("soup", ["gtk"]),
-        ("win", ["win"]),
     ]
     patterns = [
         # Patterns that shouldn't trigger builds on any bots.
@@ -117,10 +115,8 @@ def _should_file_trigger_build(target_platform, file):
         (r"(?:^|/)PlatformGTK\.cmake$", ["gtk"]),
         (r"Mac\.(?:cpp|h|mm)$", ["mac"]),
         (r"IOS\.(?:cpp|h|mm)$", ["ios", "visionos", "tvos", "watchos"]),
-        (r"\.(?:vcproj|vsprops|sln|vcxproj|props|filters)$", ["win"]),
         (r"\.exp(?:\.in)?$", ["mac", "ios", "visionos", "tvos", "watchos"]),
         (r"\.order$", ["mac", "ios", "visionos", "tvos", "watchos"]),
-        (r"\.(?:vcproj|vcxproj)/", ["win"]),
         (r"\.xcconfig$", ["mac", "ios", "visionos", "tvos", "watchos"]),
         (r"\.xcodeproj/", ["mac", "ios", "visionos", "tvos", "watchos"]),
     ]

--- a/Tools/CISupport/build-webkit-org/wkbuild_unittest.py
+++ b/Tools/CISupport/build-webkit-org/wkbuild_unittest.py
@@ -31,7 +31,6 @@ class ShouldBuildTest(unittest.TestCase):
         (["Websites/bugs.webkit.org/foo"], []),
         (["Source/JavaScriptCore/JavaScriptCore.xcodeproj/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-17", "ios-simulator-17", "visionos-1", "visionos-simulator-1", "tvos-17", "tvos-simulator-17", "watchos-10", "watchos-simulator-10"]),
         (["Source/JavaScriptCore/Configurations/Base.xcconfig"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-17", "ios-simulator-17", "visionos-1", "visionos-simulator-1", "tvos-17", "tvos-simulator-17", "watchos-10", "watchos-simulator-10"]),
-        (["Source/JavaScriptCore/JavaScriptCore.vcproj/foo", "Source/WebKit/win/WebKit2.vcproj", "Source/WebKitLegacy/win/WebKit.sln", "Tools/WebKitTestRunner/Configurations/WebKitTestRunnerCommon.vsprops"], ["win"]),
         (["LayoutTests/platform/mac/foo", "Source/WebCore/bar"], ["*"]),
         (["LayoutTests/foo"], ["*"]),
         (["LayoutTests/canvas/philip/tests/size.attributes.parse.exp-expected.txt", "LayoutTests/canvas/philip/tests/size.attributes.parse.exp.html"], ["*"]),
@@ -50,19 +49,15 @@ class ShouldBuildTest(unittest.TestCase):
         (["LayoutTests/platform/wk2/Skipped"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-17", "ios-simulator-17", "visionos-1", "visionos-simulator-1"]),
         (["LayoutTests/platform/mac-wk2/Skipped"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave"]),
         (["LayoutTests/platform/mac-wk1/compositing/tiling/transform-origin-tiled-expected.txt"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave"]),
-        (["LayoutTests/platform/mac/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "win"]),
+        (["LayoutTests/platform/mac/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave"]),
         (["LayoutTests/platform/mac-wk2/platform/mac/editing/spelling/autocorrection-contraction-expected.txt"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave"]),
-        (["LayoutTests/platform/win-xp/foo"], ["win"]),
-        (["LayoutTests/platform/win-wk1/foo"], ["win"]),
-        (["LayoutTests/platform/win/foo"], ["win"]),
         (["LayoutTests/platform/spi/cocoa/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-17", "ios-simulator-17", "visionos-1", "visionos-simulator-1", "tvos-17", "tvos-simulator-17", "watchos-10", "watchos-simulator-10"]),
-        (["LayoutTests/platform/spi/cf/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "win", "ios-17", "ios-simulator-17", "visionos-1", "visionos-simulator-1", "tvos-17", "tvos-simulator-17", "watchos-10", "watchos-simulator-10"]),
+        (["LayoutTests/platform/spi/cf/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-17", "ios-simulator-17", "visionos-1", "visionos-simulator-1", "tvos-17", "tvos-simulator-17", "watchos-10", "watchos-simulator-10"]),
         (["Source/WebKitLegacy/mac/WebKit.mac.exp"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave"]),
         (["Source/WebKitLegacy/ios/WebKit.iOS.exp"], ["ios-17", "ios-simulator-17", "visionos-1", "visionos-simulator-1", "tvos-17", "tvos-simulator-17", "watchos-10", "watchos-simulator-10"]),
         (["Source/Dummy/foo.exp"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-17", "ios-simulator-17", "visionos-1", "visionos-simulator-1", "tvos-17", "tvos-simulator-17", "watchos-10", "watchos-simulator-10"]),
         (["Source/WebCore/ios/foo"], ["ios-17", "ios-simulator-17", "visionos-1", "visionos-simulator-1", "tvos-17", "tvos-simulator-17", "watchos-10", "watchos-simulator-10"]),
         (["Source/WebCore/mac/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave"]),
-        (["Source/WebCore/win/foo"], ["win"]),
         (["Source/WebCore/bridge/objc/objc_class.mm"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-17", "ios-simulator-17", "visionos-1", "visionos-simulator-1", "tvos-17", "tvos-simulator-17", "watchos-10", "watchos-simulator-10"]),
         (["Source/WebCore/platform/wx/wxcode/win/foo"], []),
         (["Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm"], ["ios-17", "ios-simulator-17", "visionos-1", "visionos-simulator-1", "tvos-17", "tvos-simulator-17", "watchos-10", "watchos-simulator-10"]),
@@ -75,7 +70,7 @@ class ShouldBuildTest(unittest.TestCase):
         for files, platforms in self._should_build_tests:
             # FIXME: We should test more platforms here once
             # wkbuild._should_file_trigger_build is implemented for them.
-            for platform in ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "win", "ios-17", "ios-simulator-17", "visionos-1", "visionos-simulator-1", "tvos-17", "tvos-simulator-17", "watchos-10", "watchos-simulator-10"]:
+            for platform in ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-17", "ios-simulator-17", "visionos-1", "visionos-simulator-1", "tvos-17", "tvos-simulator-17", "watchos-10", "watchos-simulator-10"]:
                 should_build = platform in platforms or "*" in platforms
                 self.assertEqual(wkbuild.should_build(platform, files), should_build, "%s should%s have built but did%s (files: %s)" % (platform, "" if should_build else "n't", "n't" if should_build else "", str(files)))
 


### PR DESCRIPTION
#### d206ccabcf6740bfaaba9d6d204aa00a24780685
<pre>
[build.webkit.org] Remove AppleWin code (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=276738">https://bugs.webkit.org/show_bug.cgi?id=276738</a>

Reviewed by Ross Kirsling.

It turned out that &lt;<a href="https://commits.webkit.org/281034@main">https://commits.webkit.org/281034@main</a>&gt; wasn&apos;t
enough. Removed more Apple Windows port code.

* Tools/CISupport/build-webkit-org/factories.py:
* Tools/CISupport/build-webkit-org/steps.py:
* Tools/CISupport/build-webkit-org/wkbuild.py:
* Tools/CISupport/build-webkit-org/wkbuild_unittest.py:

Canonical link: <a href="https://commits.webkit.org/281069@main">https://commits.webkit.org/281069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20d9151ac4779d262a3085836dd747f8f9aca2f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62241 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9059 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9257 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47446 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6463 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60646 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28298 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32270 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7987 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8063 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63944 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2528 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8264 "Build is in progress. Recent messages:") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/58306 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54850 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2137 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8736 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/34857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/35941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->