### PR TITLE
[git-webkit] Support integration PR branches

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py
@@ -31,11 +31,6 @@ from webkitscmpy import ScmBase, Contributor, CommitClassifier
 
 
 class Scm(ScmBase):
-    # Projects can define for themselves what constitutes a development vs a production branch,
-    # the following idioms seem common enough to be shared.
-    DEV_BRANCHES = re.compile(r'.*[(eng)(dev)(bug)]/.+')
-    PROD_BRANCHES = re.compile(r'\S+-[\d+\.]+-branch')
-
     @classmethod
     def executable(cls, program):
         path = shutil.which(program)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
@@ -37,8 +37,8 @@ class ScmBase(object):
 
     # Projects can define for themselves what constitutes a development vs a production branch,
     # the following idioms seem common enough to be shared.
-    DEV_BRANCHES = re.compile(r'.*[(eng)(dev)(bug)]/.+')
-    PROD_BRANCHES = re.compile(r'\S+-[\d+\.]+-branch')
+    DEV_BRANCHES = re.compile(r'^(.+/)?((eng)|(dev)|(bug)|(integration))/.+')
+    PROD_BRANCHES = re.compile(r'^[^-/]+-[\d+\.]+-branch')
     GIT_SVN_REVISION = re.compile(r'^git-svn-id: \S+:\/\/.+@(?P<revision>\d+) .+-.+-.+-.+', flags=re.MULTILINE)
     DEFAULT_BRANCHES = ['main', 'master', 'trunk']
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/scm_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/scm_unittest.py
@@ -58,6 +58,7 @@ class TestScm(testing.PathTestCase):
         self.assertTrue(local.Scm.DEV_BRANCHES.match('jbedard/dev/1234'))
         self.assertTrue(local.Scm.DEV_BRANCHES.match('bug/1234'))
         self.assertTrue(local.Scm.DEV_BRANCHES.match('jbedard/bug/1234'))
+        self.assertTrue(local.Scm.DEV_BRANCHES.match('integration/ci/stuff/safari-606-branch'))
 
         self.assertFalse(local.Scm.DEV_BRANCHES.match('main'))
         self.assertFalse(local.Scm.DEV_BRANCHES.match('random/1234'))
@@ -70,3 +71,4 @@ class TestScm(testing.PathTestCase):
 
         self.assertFalse(local.Scm.PROD_BRANCHES.match('main'))
         self.assertFalse(local.Scm.PROD_BRANCHES.match('eng/1234'))
+        self.assertFalse(local.Scm.PROD_BRANCHES.match('integration/ci/stuff/safari-606-branch'))


### PR DESCRIPTION
#### 803e3c08d48a1202718eeb224d1dcf6c58c8ac4e
<pre>
[git-webkit] Support integration PR branches
<a href="https://bugs.webkit.org/show_bug.cgi?id=276747">https://bugs.webkit.org/show_bug.cgi?id=276747</a>
<a href="https://rdar.apple.com/131963428">rdar://131963428</a>

Reviewed by Aakash Jain.

We have begun using &quot;integration&quot; branches as a special form of dev branch
supporting shared conflict resolution. git-webkit doesn&apos;t handle these branches
well, currently, and is prone to incorrectly categorizing them as canonical branches.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py:
(Scm): Move branch categorization regexes to the base class.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py:
(ScmBase): Exclude branch names with slashes in them from lists of production branches,
treat &quot;integration&quot; branches as dev branches.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/scm_unittest.py:
(TestScm.test_dev_branches):
(TestScm.test_prod_branches):

Canonical link: <a href="https://commits.webkit.org/281081@main">https://commits.webkit.org/281081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d7925b4b6992634e3746803cb753b1fe1117ad0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62280 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9295 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47463 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6478 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28315 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/58180 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32291 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8010 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8101 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54244 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63983 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54787 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/58344 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2575 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54871 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12965 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2155 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34895 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->