### PR TITLE
Digital Credential API needs a CredentialRequestCoordinator and clients skeletons

### DIFF
--- a/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html
+++ b/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html
@@ -78,13 +78,5 @@
             navigator.identity.get(options),
             "navigator.identity.get() with abort signal set"
         );
-
-        assert_equals(
-            await navigator.identity.get({
-                digital: { providers: [{ protocol: "mdoc", request: {} }] },
-            }),
-            null,
-            "navigator.identity.get() with a valid provider"
-        );
     }, "navigator.identity.get() default behavior checks.");
 </script>

--- a/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html
+++ b/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html
@@ -18,8 +18,8 @@
         }
     });
 
-    promise_test(async function (test) {
-        this.add_cleanup(() => {
+    promise_test(async (t) => {
+        t.add_cleanup(() => {
             testRunner.setPageVisibility("visible");
         });
 
@@ -36,10 +36,21 @@
             "User activation should be active after test_driver.bless()."
         );
 
-        await promise_rejects_dom(
-            test,
-            "NotAllowedError",
-            navigator.identity.get({ digital: { providers: [] } })
-        );
+        const p = navigator.identity.get({
+            digital: {
+              providers: [],
+            },
+        });
+
+        await promise_rejects_dom(t, "NotAllowedError", p);
+
+        try {
+            await p;
+        } catch (error) {
+            assert_equals(
+                error.message,
+                "The document is not visible."
+            );
+        }
     }, "navigator.identity.get() can't be used with hidden documents.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https.html
@@ -79,14 +79,15 @@
                     iframe.allow = policy;
                 }
 
-                iframe.src = new URL(
-                    "/digital-credentials/support/iframe.html",
-                    crossOrigin ? hostInfo.HTTPS_REMOTE_ORIGIN : location.origin
-                ).href;
-                iframe.dataset.isAllowed = isAllowed;
-
                 await new Promise((resolve) => {
                     iframe.onload = resolve;
+                    iframe.src = new URL(
+                        "/digital-credentials/support/iframe.html",
+                        crossOrigin
+                            ? hostInfo.HTTPS_REMOTE_ORIGIN
+                            : location.origin
+                    ).href;
+                    iframe.dataset.isAllowed = isAllowed;
                     document.body.appendChild(iframe);
                 });
                 iframe.focus();
@@ -100,13 +101,19 @@
                         const { isAllowed } = details;
                         const action = "get";
                         const options = {
-                            digital: { providers: [] },
+                            digital: {
+                                // Results in TypeError when allowed, NotAllowedError when disallowed
+                                providers: [],
+                            },
                         };
                         const { data } = await new Promise((resolve) => {
                             window.addEventListener("message", resolve, {
                                 once: true,
                             });
-                            iframe.contentWindow.postMessage({ action, options }, "*");
+                            iframe.contentWindow.postMessage(
+                                { action, options, needsActivation: true },
+                                "*"
+                            );
                         });
                         const { name, messsage } = data;
                         assert_equals(

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html
@@ -15,7 +15,7 @@
     const cross_origin_src = new URL(same_origin_src, HTTPS_REMOTE_ORIGIN).href;
 
     promise_test(async (test) => {
-        await test_driver.bless("use activation");
+        await test_driver.bless("user activation");
         await promise_rejects_js(
             test,
             TypeError,

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/iframe.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<script src="/resources/testharness.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <body></body>
@@ -27,33 +26,39 @@
       }
       data.options.signal = abortController.signal;
     }
+    if (data.needsActivation) {
+      await test_driver.bless("user activation", null, window);
+    }
     let result;
     try {
-      /** @type {CrendetialManager} */
-      const { identity } = navigator;
-      if (abortController && data.abort === "before") {
+      /** @type {CredentialsContainer} */
+      const identity = navigator.identity;
+      if (data.abort === "before") {
         abortController.abort();
       }
+      let promise;
       switch (data.action) {
         case "ping":
-          result = "pong";
+          promise = Promise.resolve("pong");
           break;
         case "create":
-          result = await identity.create(data.options);
+          promise = identity.create(data.options);
           break;
         case "get":
-          await test_driver.bless("user activation", null, window);
-          assert_true(navigator.userActivation.isActive, "user activation must be active");
-          result = await identity.get(data.options);
+          promise = identity.get(data.options);
           break;
         case "preventSilentAccess":
-          result = await identity.preventSilentAccess();
+          promise = identity.preventSilentAccess();
           break;
         default:
           throw new Error(
             `Unsupported action in ${window.location}: ${data.action}`
           );
       }
+      if (data.abort === "after") {
+        abortController.abort();
+      }
+      result = await promise;
     } catch (error) {
       result = {
         constructor: error.constructor.name,

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -393,7 +393,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/highlight/HighlightRegistry.h
     Modules/highlight/HighlightVisibility.h
 
+    Modules/identity/CredentialRequestCoordinator.h
+    Modules/identity/CredentialRequestCoordinatorClient.h
     Modules/identity/DigitalCredentialRequestOptions.h
+    Modules/identity/IdentityCredentialsContainer.h
 
     Modules/indexeddb/IDBActiveDOMObject.h
     Modules/indexeddb/IDBDatabaseIdentifier.h

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CredentialRequestCoordinator.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#include "AbortSignal.h"
+#include "CredentialRequestCoordinatorClient.h"
+#include "CredentialRequestOptions.h"
+#include "Document.h"
+#include "JSDOMPromiseDeferred.h"
+#include <wtf/Logger.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+CredentialRequestCoordinator::CredentialRequestCoordinator(std::unique_ptr<CredentialRequestCoordinatorClient>&& client)
+    : m_client(WTFMove(client))
+{
+}
+
+void CredentialRequestCoordinator::discoverFromExternalSource(const Document& document, CredentialRequestOptions&& requestOptions, CredentialPromise&& promise)
+{
+    if (!m_client) {
+        LOG_ERROR("No client found");
+        promise.reject(Exception { ExceptionCode::UnknownError, "Unknown internal error."_s });
+        return;
+    }
+
+    const auto& options = requestOptions.digital.value();
+
+    if (requestOptions.signal) {
+        requestOptions.signal->addAlgorithm([weakThis = WeakPtr { *this }](JSC::JSValue) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis || !protectedThis->m_client)
+                return;
+
+            ASSERT(!protectedThis->m_isCancelling);
+
+            protectedThis->m_isCancelling = true;
+            protectedThis->m_client->cancel([protectedThis = WTFMove(protectedThis)]() mutable {
+                if (!protectedThis)
+                    return;
+                protectedThis->m_isCancelling = false;
+                if (auto queuedRequest = WTFMove(protectedThis->m_queuedRequest))
+                    queuedRequest();
+            });
+        });
+    }
+
+    auto callback = [promise = WTFMove(promise), abortSignal = WTFMove(requestOptions.signal)](ExceptionData&& exception) mutable {
+        if (abortSignal && abortSignal->aborted()) {
+            LOG_ERROR("Request aborted by AbortSignal");
+            promise.reject(Exception { ExceptionCode::AbortError, "Aborted by AbortSignal."_s });
+            return;
+        }
+        ASSERT(!exception.message.isNull());
+        LOG_ERROR("Exception occurred: %s", exception.message.utf8().data());
+        promise.reject(exception.toException());
+    };
+
+    RefPtr frame = document.frame();
+    ASSERT(frame);
+
+    if (m_isCancelling) {
+        m_queuedRequest = [weakThis = WeakPtr { *this }, weakFrame = WeakPtr { *frame }, requestOptions = WTFMove(requestOptions), callback = WTFMove(callback)]() mutable {
+            RefPtr protectedThis = weakThis.get();
+            RefPtr protectedFrame = weakFrame.get();
+            if (!protectedThis || !protectedFrame || !protectedThis->m_client) {
+                LOG_ERROR("No this, or no frame, or no client found");
+                return;
+            }
+            const auto options = requestOptions.digital.value();
+            protectedThis->m_client->requestDigitalCredential(*protectedFrame, options, WTFMove(callback));
+        };
+        return;
+    }
+
+    m_client->requestDigitalCredential(*frame, options, WTFMove(callback));
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_AUTHN)
+
+#include "CredentialRequestCoordinatorClient.h"
+#include "IDLTypes.h"
+#include <wtf/CompletionHandler.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class AbortSignal;
+class BasicCredential;
+class CredentialRequestCoordinatorClient;
+class Document;
+struct CredentialRequestOptions;
+
+template<typename IDLType> class DOMPromiseDeferred;
+
+using CredentialPromise = DOMPromiseDeferred<IDLNullable<IDLInterface<BasicCredential>>>;
+
+class CredentialRequestCoordinator final : public RefCounted<CredentialRequestCoordinator>, public CanMakeWeakPtr<CredentialRequestCoordinator> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(CredentialRequestCoordinator);
+
+public:
+    WEBCORE_EXPORT explicit CredentialRequestCoordinator(std::unique_ptr<CredentialRequestCoordinatorClient>&&);
+    void discoverFromExternalSource(const Document&, CredentialRequestOptions&&, CredentialPromise&&);
+
+private:
+    CredentialRequestCoordinator() = default;
+
+    std::unique_ptr<CredentialRequestCoordinatorClient> m_client;
+    bool m_isCancelling = false;
+    CompletionHandler<void()> m_queuedRequest;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinatorClient.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinatorClient.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+
+#if ENABLE(WEB_AUTHN)
+
+#include "CredentialRequestCoordinator.h"
+#include "ExceptionData.h"
+#include <wtf/CompletionHandler.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+struct DigitalCredentialRequestOptions;
+class LocalFrame;
+
+using DigitalCredentialRequestCompletionHandler = CompletionHandler<void(WebCore::ExceptionData&&)>;
+
+class CredentialRequestCoordinatorClient : public CanMakeWeakPtr<CredentialRequestCoordinatorClient> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(CredentialRequestCoordinatorClient);
+
+public:
+    CredentialRequestCoordinatorClient() = default;
+    virtual ~CredentialRequestCoordinatorClient() = default;
+
+    virtual void requestDigitalCredential(const LocalFrame&, const DigitalCredentialRequestOptions&, DigitalCredentialRequestCompletionHandler&&) = 0;
+    virtual void cancel(CompletionHandler<void()>&&) = 0;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/identity/IdentityCredentialProtocol.h
+++ b/Source/WebCore/Modules/identity/IdentityCredentialProtocol.h
@@ -27,6 +27,6 @@
 
 namespace WebCore {
 
-enum class IdentityCredentialProtocol : uint8_t { Mdoc };
+enum class IdentityCredentialProtocol : uint8_t { Openid4vp };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/IdentityCredentialProtocol.idl
+++ b/Source/WebCore/Modules/identity/IdentityCredentialProtocol.idl
@@ -24,5 +24,5 @@
  */
 
 enum IdentityCredentialProtocol {
-    "mdoc",
+    "openid4vp",
 };

--- a/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
+++ b/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
@@ -37,6 +37,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSDigitalCredential.h"
 #include "LocalDOMWindow.h"
+#include "Page.h"
 #include "VisibilityState.h"
 
 namespace WebCore {
@@ -50,8 +51,14 @@ void IdentityCredentialsContainer::get(CredentialRequestOptions&& options, Crede
     if (!performCommonChecks(options, promise))
         return;
 
+    if (!options.digital || options.publicKey) {
+        promise.reject(Exception { ExceptionCode::NotSupportedError, "Only digital member is supported."_s });
+        return;
+    }
+
     RefPtr document = this->document();
     ASSERT(document);
+
     if (!PermissionsPolicy::isFeatureEnabled(PermissionsPolicy::Feature::DigitalCredentialsGetRule, *document, PermissionsPolicy::ShouldReportViolation::No)) {
         promise.reject(Exception { ExceptionCode::NotAllowedError, "Third-party iframes are not allowed to call .get() unless explicitly allowed via Permissions Policy (digital-credentials-get)"_s });
         return;
@@ -73,21 +80,15 @@ void IdentityCredentialsContainer::get(CredentialRequestOptions&& options, Crede
         return;
     }
 
-    if (!options.digital) {
-        promise.reject(Exception { ExceptionCode::NotSupportedError, "Only digital member is supported."_s });
-        return;
-    }
-
     if (options.digital->providers.isEmpty()) {
         promise.reject(Exception { ExceptionCode::TypeError, "At least one provider must be specified."_s });
         return;
     }
 
-    // FIXME: Implement the actual get logic.
+    // FIXME: <https://webkit.org/b/277322> mediation requirement,
+    // which is waiting on https://github.com/WICG/digital-credentials/pull/149
 
-    // Default as per Cred Man spec is to resolve with null.
-    // https://www.w3.org/TR/credential-management-1/#algorithm-discover-creds
-    promise.resolve(nullptr);
+    document->page()->credentialRequestCoordinator().discoverFromExternalSource(*document, WTFMove(options), WTFMove(promise));
 }
 
 void IdentityCredentialsContainer::isCreate(CredentialCreationOptions&& options, CredentialPromise&& promise)

--- a/Source/WebCore/Modules/identity/IdentityCredentialsContainer.h
+++ b/Source/WebCore/Modules/identity/IdentityCredentialsContainer.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEB_AUTHN)
 
+#include "CredentialRequestCoordinator.h"
 #include "CredentialsContainer.h"
 #include "DigitalCredential.h"
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -145,6 +145,7 @@ Modules/highlight/AppHighlightRangeData.cpp
 Modules/highlight/AppHighlightStorage.cpp
 Modules/highlight/HighlightRegistry.cpp
 Modules/highlight/Highlight.cpp
+Modules/identity/CredentialRequestCoordinator.cpp
 Modules/identity/DigitalCredential.cpp
 Modules/identity/IdentityCredentialsContainer.cpp
 Modules/identity/NavigatorIdentity.cpp

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -46,6 +46,7 @@
 #include "ContextMenuClient.h"
 #include "ContextMenuController.h"
 #include "CookieJar.h"
+#include "CredentialRequestCoordinator.h"
 #include "CryptoClient.h"
 #include "DOMRect.h"
 #include "DOMRectList.h"
@@ -398,6 +399,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
 #endif
 #if ENABLE(WEB_AUTHN)
     , m_authenticatorCoordinator(makeUniqueRef<AuthenticatorCoordinator>(WTFMove(pageConfiguration.authenticatorCoordinatorClient)))
+    , m_credentialRequestCoordinator(makeUniqueRef<CredentialRequestCoordinator>(WTFMove(pageConfiguration.credentialRequestCoordinatorClient)))
 #endif
 #if ENABLE(APPLICATION_MANIFEST)
     , m_applicationManifest(pageConfiguration.applicationManifest)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -112,6 +112,7 @@ class DOMRectList;
 class DatabaseProvider;
 class DeviceOrientationUpdateProvider;
 class DiagnosticLoggingClient;
+class CredentialRequestCoordinator;
 class DragCaretController;
 class DragController;
 class EditorClient;
@@ -676,6 +677,7 @@ public:
 
 #if ENABLE(WEB_AUTHN)
     AuthenticatorCoordinator& authenticatorCoordinator() { return m_authenticatorCoordinator.get(); }
+    CredentialRequestCoordinator& credentialRequestCoordinator() { return m_credentialRequestCoordinator.get(); }
 #endif
 
 #if ENABLE(APPLICATION_MANIFEST)
@@ -1514,6 +1516,7 @@ private:
 
 #if ENABLE(WEB_AUTHN)
     UniqueRef<AuthenticatorCoordinator> m_authenticatorCoordinator;
+    UniqueRef<CredentialRequestCoordinator> m_credentialRequestCoordinator;
 #endif
 
 #if ENABLE(APPLICATION_MANIFEST)

--- a/Source/WebCore/page/PageConfiguration.cpp
+++ b/Source/WebCore/page/PageConfiguration.cpp
@@ -63,6 +63,7 @@
 #include "WebRTCProvider.h"
 #if ENABLE(WEB_AUTHN)
 #include "AuthenticatorCoordinatorClient.h"
+#include "CredentialRequestCoordinatorClient.h"
 #endif
 #if ENABLE(APPLE_PAY)
 #include "PaymentCoordinatorClient.h"

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -64,6 +64,7 @@ class CacheStorageProvider;
 class ChromeClient;
 class ContextMenuClient;
 class CookieJar;
+class CredentialRequestCoordinatorClient;
 class CryptoClient;
 class DatabaseProvider;
 class DiagnosticLoggingClient;
@@ -149,6 +150,7 @@ public:
 
 #if ENABLE(WEB_AUTHN)
     std::unique_ptr<AuthenticatorCoordinatorClient> authenticatorCoordinatorClient;
+    std::unique_ptr<CredentialRequestCoordinatorClient> credentialRequestCoordinatorClient;
 #endif
 
 #if ENABLE(APPLICATION_MANIFEST)


### PR DESCRIPTION
#### 01e05cb09f9e7ce8b24e917384f9b0c750d0b4ed
<pre>
Digital Credential API needs a CredentialRequestCoordinator and clients skeletons
<a href="https://bugs.webkit.org/show_bug.cgi?id=270778">https://bugs.webkit.org/show_bug.cgi?id=270778</a>
<a href="https://rdar.apple.com/124874018">rdar://124874018</a>

Reviewed by Abrar Rahman Protyasha.

Implements CredentialRequestCoordinator and clients skeletons.

* LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html:
* LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/enabled-on-self-origin-by-permissions-policy.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/iframe.html:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp: Added.
(WebCore::CredentialRequestCoordinator::CredentialRequestCoordinator):
(WebCore::CredentialRequestCoordinator::discoverFromExternalSource):
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.h: Copied from Source/WebCore/Modules/identity/IdentityCredentialsContainer.h.
* Source/WebCore/Modules/identity/CredentialRequestCoordinatorClient.h: Copied from Source/WebCore/Modules/identity/IdentityCredentialsContainer.h.
* Source/WebCore/Modules/identity/IdentityCredentialProtocol.h:
* Source/WebCore/Modules/identity/IdentityCredentialProtocol.idl:
* Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp:
(WebCore::IdentityCredentialsContainer::get):
* Source/WebCore/Modules/identity/IdentityCredentialsContainer.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/Page.cpp:
* Source/WebCore/page/Page.h:
(WebCore::Page::credentialRequestCoordinator):
* Source/WebCore/page/PageConfiguration.cpp:
* Source/WebCore/page/PageConfiguration.h:

Canonical link: <a href="https://commits.webkit.org/281646@main">https://commits.webkit.org/281646@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed222c1d4b7c4388401b0ca380fd58accc83b3b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11020 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48944 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7657 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9620 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9935 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55686 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66137 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4421 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9745 "Found 60 new test failures: accessibility/mac/replace-text-with-empty-range.html accessibility/mac/replace-text-with-range-value-change-notification.html accessibility/mac/replace-text-with-range.html animations/cross-fade-border-image-source.html css3/blending/background-blend-mode-svg.html css3/color/backgrounds-and-borders.html css3/color/box-shadows.html css3/color/canvas.html css3/color/composited-solid-backgrounds.html css3/color/gradients.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56307 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4440 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56474 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13472 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3670 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35646 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36728 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37819 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36473 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->