### PR TITLE
Support QU and SP break-class in fast path

### DIFF
--- a/Source/WebCore/rendering/BreakLines.h
+++ b/Source/WebCore/rendering/BreakLines.h
@@ -76,7 +76,8 @@ private:
 
     // Data types.
     enum BreakClass : uint16_t {
-        // See UAX14
+        // See UAX14 and LineBreak.txt
+        // https://www.unicode.org/Public/UCD/latest/ucd/LineBreak.txt
         kIndeterminate = 0,
         kAL = 1,
         kID = 1 << 1,
@@ -85,9 +86,13 @@ private:
         kCP = 1 << 4,
         kCL = 1 << 5,
         kGL = 1 << 6,
+        kQU = 1 << 7,
+        kSP = 1 << 8,
         kNU = kAL,
         kWeird = 1 << 15,
-        // Currently we map HL to AL and H2 and H3 to ID.
+        // Currently we map
+        //     1. HL to AL
+        //     2. H2 and H3 to ID
         // We also don't distinguish AL and NU.
         // If we pull more logic into isBreakable, these may need to be distinguished.
     };
@@ -168,8 +173,7 @@ inline size_t BreakLines::nextBreakablePosition(CachedLineBreakIteratorFactory& 
             return i;
 
         // ASCII rapid lookup.
-        if (shortcutRules == LineBreakRules::Normal) { // Not valid for 'loose' line-breaking.
-
+        if constexpr (shortcutRules == LineBreakRules::Normal) { // Not valid for 'loose' line-breaking.
             // Don't allow line breaking between '-' and a digit if the '-' may mean a minus sign in the context,
             // while allow breaking in 'ABCD-1234' and '1234-5678' which may be in long URLs.
             if (before == '-' && isASCIIDigit(after)) {
@@ -190,36 +194,41 @@ inline size_t BreakLines::nextBreakablePosition(CachedLineBreakIteratorFactory& 
         }
 
         // Non-ASCII rapid lookup.
-        if (words != WordBreakBehavior::AutoPhrase) {
+        if constexpr (words != WordBreakBehavior::AutoPhrase) {
             if (!before.type)
                 before.type = classify<shortcutRules, nonBreakingSpaceBehavior>(before);
             after.type = classify<shortcutRules, nonBreakingSpaceBehavior>(after);
             // Short-circuit the commonest cases: letter + letter.
-            int pair = before.type | after.type;
-            if (pair == (kAL | kAL)) {
-                if (words == WordBreakBehavior::BreakAll)
-                    return i;
+            unsigned pair = before.type | after.type;
+            // AL+AL SP+AL SP+QU AL+QU QU+QU QU+AL (after's SP is already filtered out).
+            if (!(pair & ~(kSP | kAL | kQU))) {
+                if constexpr (words == WordBreakBehavior::BreakAll) {
+                    if (pair == kAL)
+                        return i;
+                }
                 continue;
             }
             if ((pair | kAL) == (kID | kAL)) {
-                if (words == WordBreakBehavior::KeepAll)
+                if constexpr (words == WordBreakBehavior::KeepAll)
                     continue;
                 return i;
             }
             // Handle special cases.
-            if (pair & kGL && !(pair & kWeird)) // Keep nbsp high in our list.
+            if (pair & (kGL | kQU) && !(pair & kWeird)) // Keep nbsp high in our list.
                 continue;
             if (after.type == kCM) {
                 after.type = before.type;
                 continue;
             }
-            if (shortcutRules == LineBreakRules::Normal && !(pair & kWeird)) {
-                // Handle some common and obvious punctuation behaviors.
-                if (pair & (kCL | kCP | kOP)) {
-                    if (after.type == kCL || after.type == kCP || before.type == kOP)
-                        continue;
-                    if (pair & kID)
-                        return i;
+            if constexpr (shortcutRules == LineBreakRules::Normal) {
+                if (!(pair & kWeird)) {
+                    // Handle some common and obvious punctuation behaviors.
+                    if (pair & (kCL | kCP | kOP)) {
+                        if (after.type == kCL || after.type == kCP || before.type == kOP)
+                            continue;
+                        if (pair & kID)
+                            return i;
+                    }
                 }
             }
         }
@@ -318,6 +327,7 @@ template<BreakLines::LineBreakRules rules, BreakLines::NoBreakSpaceBehavior nonB
 inline BreakLines::BreakClass BreakLines::classify(UChar character)
 {
     // This function is optimized for letters and NBSP.
+    // See LineBreak.txt for classification.
 
     static constexpr UChar blockLast3 = ~0x07;
     static constexpr UChar blockLast4 = ~0x0F;
@@ -334,6 +344,10 @@ inline BreakLines::BreakClass BreakLines::classify(UChar character)
         case 0x0010 / 0x10:
             return kCM;
         case 0x0020 / 0x10:
+            if (character == 0x0020) // space
+                return kSP;
+            if (character == 0x0022 || character == 0x0027)
+                return kQU;
             if (character == 0x0028)
                 return kOP;
             if (character == 0x0029)
@@ -367,12 +381,14 @@ inline BreakLines::BreakClass BreakLines::classify(UChar character)
             return kWeird;
         }
     case 0x0080 / 0x80: // Latin-1
-        if (nonBreakingSpaceBehavior == NoBreakSpaceBehavior::Normal && character == 0xA0)
-            return kGL;
+        if (character == 0x00A0) // noBreakSpace
+            return nonBreakingSpaceBehavior == NoBreakSpaceBehavior::Normal ? kGL : kSP;
         if (character > 0x00C0)
             return kAL;
         if (character == 0x00A1 || character == 0x00BF)
             return kOP;
+        if (character == 0x00AB || character == 0x00BB)
+            return kQU;
         return kWeird;
     case 0x0100 / 0x80:
     case 0x0180 / 0x80:
@@ -421,6 +437,39 @@ inline BreakLines::BreakClass BreakLines::classify(UChar character)
         default:
             return kWeird;
         }
+    case 0x0600 / 0x80:
+    case 0x0680 / 0x80:
+    case 0x0700 / 0x80:
+    case 0x0780 / 0x80:
+    case 0x0800 / 0x80:
+    case 0x0880 / 0x80:
+    case 0x0900 / 0x80:
+    case 0x0980 / 0x80:
+    case 0x1000 / 0x80:
+    case 0x1080 / 0x80:
+    case 0x1100 / 0x80:
+    case 0x1180 / 0x80:
+    case 0x1200 / 0x80:
+    case 0x1280 / 0x80:
+    case 0x1300 / 0x80:
+    case 0x1380 / 0x80:
+    case 0x1400 / 0x80:
+    case 0x1480 / 0x80:
+    case 0x1500 / 0x80:
+    case 0x1580 / 0x80:
+    case 0x1600 / 0x80:
+    case 0x1680 / 0x80:
+    case 0x1700 / 0x80:
+    case 0x1780 / 0x80:
+    case 0x1800 / 0x80:
+    case 0x1880 / 0x80:
+    case 0x1900 / 0x80:
+    case 0x1980 / 0x80:
+        return kWeird;
+    case 0x2000 / 0x80:
+        if (character == 0x2018 || character == 0x2019)
+            return kQU;
+        return kWeird;
     // FIXME: Continue bitmask switch up to 2E80.
     }
 


### PR DESCRIPTION
#### 52e12b92108758547e05df45cc8e8a439b2135df
<pre>
Support QU and SP break-class in fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=276765">https://bugs.webkit.org/show_bug.cgi?id=276765</a>
<a href="https://rdar.apple.com/131982061">rdar://131982061</a>

Reviewed by Alan Baradlay.

This patch adds QU and SP break-class support in BreakLines.
We intentionally do not categorize u201c u201d as QU since they sometimes are categorized into open/close punctuations.

* Source/WebCore/rendering/BreakLines.h:
(WebCore::BreakLines::nextBreakablePosition):
(WebCore::BreakLines::classify):

Canonical link: <a href="https://commits.webkit.org/281122@main">https://commits.webkit.org/281122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/546c2ea77c92ee4ef008d6cee59c76e6d99e5785

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58814 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62446 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9258 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47572 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6590 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28428 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32421 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8149 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8262 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64147 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54896 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54989 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2286 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8777 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33972 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36141 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/34802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->