### PR TITLE
Wrong collapsing border resolution on RTL table cells

### DIFF
--- a/LayoutTests/fast/table/border-collapsing/table-rtl-row-mixed-direction-expected.html
+++ b/LayoutTests/fast/table/border-collapsing/table-rtl-row-mixed-direction-expected.html
@@ -8,7 +8,7 @@ table {
 }
 
 td {
-    height: 100px;
+    height: 50px;
     width: 100px;
 }
 </style>
@@ -19,6 +19,22 @@ td {
 <p>The table below should have a 3px green outer border.</p>
 <table>
     <tbody>
+        <tr>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td></td>
+        </tr>
         <tr>
             <td></td>
             <td></td>

--- a/LayoutTests/fast/table/border-collapsing/table-rtl-row-mixed-direction.html
+++ b/LayoutTests/fast/table/border-collapsing/table-rtl-row-mixed-direction.html
@@ -34,16 +34,32 @@ td {
             <td></td>
             <td class="leftGreenBorder"></td>
         </tr>
+        <tr dir="ltr">
+            <td></td>
+            <td dir="rtl" class="leftGreenBorder"></td>
+        </tr>
         <tr dir="rtl">
             <td></td>
             <td class="leftGreenBorder"></td>
+        </tr>
+        <tr dir="rtl">
+            <td></td>
+            <td dir="ltr" class="leftGreenBorder"></td>
         </tr>
         <tr dir="ltr" class="leftGreenBorder">
             <td></td>
             <td></td>
         </tr>
+        <tr dir="rtl">
+            <td></td>
+            <td dir="ltr" class="leftGreenBorder"></td>
+        </tr>
         <tr dir="rtl" class="leftGreenBorder">
             <td></td>
+            <td></td>
+        </tr>
+        <tr dir="rtl" class="leftGreenBorder">
+            <td dir="ltr"></td>
             <td></td>
         </tr>
     </tbody>

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -417,7 +417,7 @@ auto RenderTableCell::localRectsForRepaint(RepaintOutlineBounds repaintOutlineBo
     if (!table()->collapseBorders() || table()->needsSectionRecalc())
         return RenderBlockFlow::localRectsForRepaint(repaintOutlineBounds);
 
-    bool rtl = !styleForCellFlow().isLeftToRightDirection();
+    bool rtl = !style().isLeftToRightDirection();
     LayoutUnit outlineSize { style().outlineSize() };
     LayoutUnit left = std::max(borderHalfLeft(true), outlineSize);
     LayoutUnit right = std::max(borderHalfRight(true), outlineSize);
@@ -629,8 +629,8 @@ CollapsedBorderValue RenderTableCell::computeCollapsedStartBorder(IncludeBorderC
 {
     // For the start border, we need to check, in order of precedence:
     // (1) Our start border.
-    CSSPropertyID startColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineStartColor, styleForCellFlow().direction(), styleForCellFlow().writingMode()) : CSSPropertyInvalid;
-    CSSPropertyID endColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineEndColor, styleForCellFlow().direction(), styleForCellFlow().writingMode()) : CSSPropertyInvalid;
+    CSSPropertyID startColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineStartColor, style().direction(), style().writingMode()) : CSSPropertyInvalid;
+    CSSPropertyID endColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineEndColor, style().direction(), style().writingMode()) : CSSPropertyInvalid;
     CollapsedBorderValue result(style().borderStart(), includeColor ? style().visitedDependentColorWithColorFilter(startColorProperty) : Color(), BorderPrecedence::Cell);
 
     RenderTable* table = this->table();
@@ -740,8 +740,8 @@ CollapsedBorderValue RenderTableCell::computeCollapsedEndBorder(IncludeBorderCol
 {
     // For end border, we need to check, in order of precedence:
     // (1) Our end border.
-    CSSPropertyID startColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineStartColor, styleForCellFlow().direction(), styleForCellFlow().writingMode()) : CSSPropertyInvalid;
-    CSSPropertyID endColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineEndColor, styleForCellFlow().direction(), styleForCellFlow().writingMode()) : CSSPropertyInvalid;
+    CSSPropertyID startColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineStartColor, style().direction(), style().writingMode()) : CSSPropertyInvalid;
+    CSSPropertyID endColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderInlineEndColor, style().direction(), style().writingMode()) : CSSPropertyInvalid;
     CollapsedBorderValue result = CollapsedBorderValue(style().borderEnd(), includeColor ? style().visitedDependentColorWithColorFilter(endColorProperty) : Color(), BorderPrecedence::Cell);
 
     RenderTable* table = this->table();
@@ -853,8 +853,8 @@ CollapsedBorderValue RenderTableCell::computeCollapsedBeforeBorder(IncludeBorder
 {
     // For before border, we need to check, in order of precedence:
     // (1) Our before border.
-    CSSPropertyID beforeColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockStartColor, styleForCellFlow().direction(), styleForCellFlow().writingMode()) : CSSPropertyInvalid;
-    CSSPropertyID afterColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockEndColor, styleForCellFlow().direction(), styleForCellFlow().writingMode()) : CSSPropertyInvalid;
+    CSSPropertyID beforeColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockStartColor, style().direction(), style().writingMode()) : CSSPropertyInvalid;
+    CSSPropertyID afterColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockEndColor, style().direction(), style().writingMode()) : CSSPropertyInvalid;
     CollapsedBorderValue result = CollapsedBorderValue(style().borderBefore(), includeColor ? style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::Cell);
     
     RenderTable* table = this->table();
@@ -950,8 +950,8 @@ CollapsedBorderValue RenderTableCell::computeCollapsedAfterBorder(IncludeBorderC
 {
     // For after border, we need to check, in order of precedence:
     // (1) Our after border.
-    CSSPropertyID beforeColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockStartColor, styleForCellFlow().direction(), styleForCellFlow().writingMode()) : CSSPropertyInvalid;
-    CSSPropertyID afterColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockEndColor, styleForCellFlow().direction(), styleForCellFlow().writingMode()) : CSSPropertyInvalid;
+    CSSPropertyID beforeColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockStartColor, style().direction(), style().writingMode()) : CSSPropertyInvalid;
+    CSSPropertyID afterColorProperty = includeColor ? CSSProperty::resolveDirectionAwareProperty(CSSPropertyBorderBlockEndColor, style().direction(), style().writingMode()) : CSSPropertyInvalid;
     CollapsedBorderValue result = CollapsedBorderValue(style().borderAfter(), includeColor ? style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::Cell);
     
     RenderTable* table = this->table();
@@ -1016,32 +1016,32 @@ CollapsedBorderValue RenderTableCell::computeCollapsedAfterBorder(IncludeBorderC
     return result;    
 }
 
-inline CollapsedBorderValue RenderTableCell::cachedCollapsedLeftBorder(const RenderStyle& styleForCellFlow) const
+inline CollapsedBorderValue RenderTableCell::cachedCollapsedLeftBorder(const RenderStyle& style) const
 {
-    if (styleForCellFlow.isHorizontalWritingMode())
-        return styleForCellFlow.isLeftToRightDirection() ? section()->cachedCollapsedBorder(*this, CBSStart) : section()->cachedCollapsedBorder(*this, CBSEnd);
-    return styleForCellFlow.isFlippedBlocksWritingMode() ? section()->cachedCollapsedBorder(*this, CBSAfter) : section()->cachedCollapsedBorder(*this, CBSBefore);
+    if (style.isHorizontalWritingMode())
+        return style.isLeftToRightDirection() ? section()->cachedCollapsedBorder(*this, CBSStart) : section()->cachedCollapsedBorder(*this, CBSEnd);
+    return style.isFlippedBlocksWritingMode() ? section()->cachedCollapsedBorder(*this, CBSAfter) : section()->cachedCollapsedBorder(*this, CBSBefore);
 }
 
-inline CollapsedBorderValue RenderTableCell::cachedCollapsedRightBorder(const RenderStyle& styleForCellFlow) const
+inline CollapsedBorderValue RenderTableCell::cachedCollapsedRightBorder(const RenderStyle& style) const
 {
-    if (styleForCellFlow.isHorizontalWritingMode())
-        return styleForCellFlow.isLeftToRightDirection() ? section()->cachedCollapsedBorder(*this, CBSEnd) : section()->cachedCollapsedBorder(*this, CBSStart);
-    return styleForCellFlow.isFlippedBlocksWritingMode() ? section()->cachedCollapsedBorder(*this, CBSBefore) : section()->cachedCollapsedBorder(*this, CBSAfter);
+    if (style.isHorizontalWritingMode())
+        return style.isLeftToRightDirection() ? section()->cachedCollapsedBorder(*this, CBSEnd) : section()->cachedCollapsedBorder(*this, CBSStart);
+    return style.isFlippedBlocksWritingMode() ? section()->cachedCollapsedBorder(*this, CBSBefore) : section()->cachedCollapsedBorder(*this, CBSAfter);
 }
 
-inline CollapsedBorderValue RenderTableCell::cachedCollapsedTopBorder(const RenderStyle& styleForCellFlow) const
+inline CollapsedBorderValue RenderTableCell::cachedCollapsedTopBorder(const RenderStyle& style) const
 {
-    if (styleForCellFlow.isHorizontalWritingMode())
-        return styleForCellFlow.isFlippedBlocksWritingMode() ? section()->cachedCollapsedBorder(*this, CBSAfter) : section()->cachedCollapsedBorder(*this, CBSBefore);
-    return styleForCellFlow.isLeftToRightDirection() ? section()->cachedCollapsedBorder(*this, CBSStart) : section()->cachedCollapsedBorder(*this, CBSEnd);
+    if (style.isHorizontalWritingMode())
+        return style.isFlippedBlocksWritingMode() ? section()->cachedCollapsedBorder(*this, CBSAfter) : section()->cachedCollapsedBorder(*this, CBSBefore);
+    return style.isLeftToRightDirection() ? section()->cachedCollapsedBorder(*this, CBSStart) : section()->cachedCollapsedBorder(*this, CBSEnd);
 }
 
-inline CollapsedBorderValue RenderTableCell::cachedCollapsedBottomBorder(const RenderStyle& styleForCellFlow) const
+inline CollapsedBorderValue RenderTableCell::cachedCollapsedBottomBorder(const RenderStyle& style) const
 {
-    if (styleForCellFlow.isHorizontalWritingMode())
-        return styleForCellFlow.isFlippedBlocksWritingMode() ? section()->cachedCollapsedBorder(*this, CBSBefore) : section()->cachedCollapsedBorder(*this, CBSAfter);
-    return styleForCellFlow.isLeftToRightDirection() ? section()->cachedCollapsedBorder(*this, CBSEnd) : section()->cachedCollapsedBorder(*this, CBSStart);
+    if (style.isHorizontalWritingMode())
+        return style.isFlippedBlocksWritingMode() ? section()->cachedCollapsedBorder(*this, CBSBefore) : section()->cachedCollapsedBorder(*this, CBSAfter);
+    return style.isLeftToRightDirection() ? section()->cachedCollapsedBorder(*this, CBSEnd) : section()->cachedCollapsedBorder(*this, CBSStart);
 }
 
 RectEdges<LayoutUnit> RenderTableCell::borderWidths() const
@@ -1129,41 +1129,41 @@ LayoutUnit RenderTableCell::borderAfter() const
 
 LayoutUnit RenderTableCell::borderHalfLeft(bool outer) const
 {
-    const RenderStyle& styleForCellFlow = this->styleForCellFlow();
-    if (styleForCellFlow.isHorizontalWritingMode())
-        return styleForCellFlow.isLeftToRightDirection() ? borderHalfStart(outer) : borderHalfEnd(outer);
-    return styleForCellFlow.isFlippedBlocksWritingMode() ? borderHalfAfter(outer) : borderHalfBefore(outer);
+    const RenderStyle& style = this->style();
+    if (style.isHorizontalWritingMode())
+        return style.isLeftToRightDirection() ? borderHalfStart(outer) : borderHalfEnd(outer);
+    return style.isFlippedBlocksWritingMode() ? borderHalfAfter(outer) : borderHalfBefore(outer);
 }
 
 LayoutUnit RenderTableCell::borderHalfRight(bool outer) const
 {
-    const RenderStyle& styleForCellFlow = this->styleForCellFlow();
-    if (styleForCellFlow.isHorizontalWritingMode())
-        return styleForCellFlow.isLeftToRightDirection() ? borderHalfEnd(outer) : borderHalfStart(outer);
-    return styleForCellFlow.isFlippedBlocksWritingMode() ? borderHalfBefore(outer) : borderHalfAfter(outer);
+    const RenderStyle& style = this->style();
+    if (style.isHorizontalWritingMode())
+        return style.isLeftToRightDirection() ? borderHalfEnd(outer) : borderHalfStart(outer);
+    return style.isFlippedBlocksWritingMode() ? borderHalfBefore(outer) : borderHalfAfter(outer);
 }
 
 LayoutUnit RenderTableCell::borderHalfTop(bool outer) const
 {
-    const RenderStyle& styleForCellFlow = this->styleForCellFlow();
-    if (styleForCellFlow.isHorizontalWritingMode())
-        return styleForCellFlow.isFlippedBlocksWritingMode() ? borderHalfAfter(outer) : borderHalfBefore(outer);
-    return styleForCellFlow.isLeftToRightDirection() ? borderHalfStart(outer) : borderHalfEnd(outer);
+    const RenderStyle& style = this->style();
+    if (style.isHorizontalWritingMode())
+        return style.isFlippedBlocksWritingMode() ? borderHalfAfter(outer) : borderHalfBefore(outer);
+    return style.isLeftToRightDirection() ? borderHalfStart(outer) : borderHalfEnd(outer);
 }
 
 LayoutUnit RenderTableCell::borderHalfBottom(bool outer) const
 {
-    const RenderStyle& styleForCellFlow = this->styleForCellFlow();
-    if (styleForCellFlow.isHorizontalWritingMode())
-        return styleForCellFlow.isFlippedBlocksWritingMode() ? borderHalfBefore(outer) : borderHalfAfter(outer);
-    return styleForCellFlow.isLeftToRightDirection() ? borderHalfEnd(outer) : borderHalfStart(outer);
+    const RenderStyle& style = this->style();
+    if (style.isHorizontalWritingMode())
+        return style.isFlippedBlocksWritingMode() ? borderHalfBefore(outer) : borderHalfAfter(outer);
+    return style.isLeftToRightDirection() ? borderHalfEnd(outer) : borderHalfStart(outer);
 }
 
 LayoutUnit RenderTableCell::borderHalfStart(bool outer) const
 {
     CollapsedBorderValue border = collapsedStartBorder(DoNotIncludeBorderColor);
     if (border.exists())
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), styleForCellFlow().isLeftToRightDirection() ^ outer);
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), style().isLeftToRightDirection() ^ outer);
     return 0;
 }
     
@@ -1171,7 +1171,7 @@ LayoutUnit RenderTableCell::borderHalfEnd(bool outer) const
 {
     CollapsedBorderValue border = collapsedEndBorder(DoNotIncludeBorderColor);
     if (border.exists())
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), !(styleForCellFlow().isLeftToRightDirection() ^ outer));
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), !(style().isLeftToRightDirection() ^ outer));
     return 0;
 }
 
@@ -1179,7 +1179,7 @@ LayoutUnit RenderTableCell::borderHalfBefore(bool outer) const
 {
     CollapsedBorderValue border = collapsedBeforeBorder(DoNotIncludeBorderColor);
     if (border.exists())
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), !(styleForCellFlow().isFlippedBlocksWritingMode() ^ outer));
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), !(style().isFlippedBlocksWritingMode() ^ outer));
     return 0;
 }
 
@@ -1187,7 +1187,7 @@ LayoutUnit RenderTableCell::borderHalfAfter(bool outer) const
 {
     CollapsedBorderValue border = collapsedAfterBorder(DoNotIncludeBorderColor);
     if (border.exists())
-        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), styleForCellFlow().isFlippedBlocksWritingMode() ^ outer);
+        return CollapsedBorderValue::adjustedCollapsedBorderWidth(border.width(), document().deviceScaleFactor(), style().isFlippedBlocksWritingMode() ^ outer);
     return 0;
 }
 
@@ -1301,11 +1301,11 @@ void RenderTableCell::paintCollapsedBorders(PaintInfo& paintInfo, const LayoutPo
     if (!table()->currentBorderValue() || graphicsContext.paintingDisabled())
         return;
 
-    const RenderStyle& styleForCellFlow = this->styleForCellFlow();
-    CollapsedBorderValue leftVal = cachedCollapsedLeftBorder(styleForCellFlow);
-    CollapsedBorderValue rightVal = cachedCollapsedRightBorder(styleForCellFlow);
-    CollapsedBorderValue topVal = cachedCollapsedTopBorder(styleForCellFlow);
-    CollapsedBorderValue bottomVal = cachedCollapsedBottomBorder(styleForCellFlow);
+    const RenderStyle& style = this->style();
+    CollapsedBorderValue leftVal = cachedCollapsedLeftBorder(style);
+    CollapsedBorderValue rightVal = cachedCollapsedRightBorder(style);
+    CollapsedBorderValue topVal = cachedCollapsedTopBorder(style);
+    CollapsedBorderValue bottomVal = cachedCollapsedBottomBorder(style);
      
     // Adjust our x/y/width/height so that we paint the collapsed borders at the correct location.
     LayoutUnit topWidth = topVal.width();

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -116,13 +116,6 @@ public:
     static RenderPtr<RenderTableCell> createAnonymousWithParentRenderer(const RenderTableRow&);
     RenderPtr<RenderBox> createAnonymousBoxWithSameTypeAs(const RenderBox&) const override;
 
-    // This function is used to unify which table part's style we use for computing direction and
-    // writing mode. Writing modes are not allowed on row group and row but direction is.
-    // This means we can safely use the same style in all cases to simplify our code.
-    // FIXME: Eventually this function should replaced by style() once we support direction
-    // on all table parts and writing-mode on cells.
-    const RenderStyle& styleForCellFlow() const { return row()->style(); }
-
     inline const BorderValue& borderAdjoiningTableStart() const;
     inline const BorderValue& borderAdjoiningTableEnd() const;
     inline const BorderValue& borderAdjoiningCellBefore(const RenderTableCell&);

--- a/Source/WebCore/rendering/RenderTableCellInlines.h
+++ b/Source/WebCore/rendering/RenderTableCellInlines.h
@@ -26,16 +26,14 @@ namespace WebCore {
 
 inline const BorderValue& RenderTableCell::borderAdjoiningCellAfter(const RenderTableCell& cell)
 {
-    ASSERT_UNUSED(cell, table()->cellBefore(&cell) == this);
-    // FIXME: https://webkit.org/b/79272 - Add support for mixed directionality at the cell level.
-    return style().borderEnd();
+    ASSERT(table()->cellAfter(cell) == this);
+    return isDirectionSame(this, &cell) ? style().borderStart() : style().borderEnd();
 }
 
 inline const BorderValue& RenderTableCell::borderAdjoiningCellBefore(const RenderTableCell& cell)
 {
-    ASSERT_UNUSED(cell, table()->cellAfter(&cell) == this);
-    // FIXME: https://webkit.org/b/79272 - Add support for mixed directionality at the cell level.
-    return style().borderStart();
+    ASSERT(table()->cellBefore(cell) == this);
+    return isDirectionSame(this, &cell) ? style().borderEnd() : style().borderStart();
 }
 
 inline const BorderValue& RenderTableCell::borderAdjoiningTableEnd() const

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -114,16 +114,14 @@ void RenderTableRow::styleDidChange(StyleDifference diff, const RenderStyle* old
 
 const BorderValue& RenderTableRow::borderAdjoiningStartCell(const RenderTableCell& cell) const
 {
-    ASSERT_UNUSED(cell, cell.isFirstOrLastCellInRow());
-    // FIXME: https://webkit.org/b/79272 - Add support for mixed directionality at the cell level.
-    return style().borderStart();
+    ASSERT(cell->isFirstOrLastCellInRow());
+    return isDirectionSame(this, &cell) ? style().borderStart() : style().borderEnd();
 }
 
 const BorderValue& RenderTableRow::borderAdjoiningEndCell(const RenderTableCell& cell) const
 {
-    ASSERT_UNUSED(cell, cell.isFirstOrLastCellInRow());
-    // FIXME: https://webkit.org/b/79272 - Add support for mixed directionality at the cell level.
-    return style().borderEnd();
+    ASSERT(cell->isFirstOrLastCellInRow());
+    return isDirectionSame(this, &cell) ? style().borderEnd() : style().borderStart();
 }
 
 void RenderTableRow::didInsertTableCell(RenderTableCell& child, RenderObject* beforeChild)


### PR DESCRIPTION
Wrong collapsing border resolution on RTL table cells
https://bugs.webkit.org/show_bug.cgi?id=79272
    
This change makes us abide by 'direction' on cells - we were
artificially ignoring it. Most of the scaffolding code was introduced
in previous refactorings and we just had to pipe it through.
    
This is revival of Julien Chaffraix <jchaffraix@webkit.org> patch in
https://bug-79272-attachments.webkit.org/attachment.cgi?id=172290
    
* LayoutTests/fast/table/border-collapsing/table-rtl-row-mixed-direction-expected.html:
* LayoutTests/fast/table/border-collapsing/table-rtl-row-mixed-direction.html:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::localRectsForRepaint const):
(WebCore::RenderTableCell::computeCollapsedStartBorder const):
(WebCore::RenderTableCell::computeCollapsedEndBorder const):
(WebCore::RenderTableCell::computeCollapsedBeforeBorder const):
(WebCore::RenderTableCell::computeCollapsedAfterBorder const):
(WebCore::RenderTableCell::cachedCollapsedLeftBorder const):
(WebCore::RenderTableCell::cachedCollapsedRightBorder const):
(WebCore::RenderTableCell::cachedCollapsedTopBorder const):
(WebCore::RenderTableCell::cachedCollapsedBottomBorder const):
(WebCore::RenderTableCell::borderHalfLeft const):
(WebCore::RenderTableCell::borderHalfRight const):
(WebCore::RenderTableCell::borderHalfTop const):
(WebCore::RenderTableCell::borderHalfBottom const):
(WebCore::RenderTableCell::borderHalfStart const):
(WebCore::RenderTableCell::borderHalfEnd const):
(WebCore::RenderTableCell::borderHalfBefore const):
(WebCore::RenderTableCell::borderHalfAfter const):
(WebCore::RenderTableCell::paintCollapsedBorders):
* Source/WebCore/rendering/RenderTableCell.h:
* Source/WebCore/rendering/RenderTableCellInlines.h:
(WebCore::RenderTableCell::borderAdjoiningCellAfter):
(WebCore::RenderTableCell::borderAdjoiningCellBefore):
* Source/WebCore/rendering/RenderTableRow.cpp:
(WebCore::RenderTableRow::borderAdjoiningStartCell const):
(WebCore::RenderTableRow::borderAdjoiningEndCell const):<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7be3bd9529402f2117c64a9087923e794258ef22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9300 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60986 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45821 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9501 "Hash 7be3bd95 for PR 30950 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47607 "Found 23 new test failures: css2.1/20110323/border-conflict-element-029.htm css2.1/20110323/border-conflict-element-038.htm fast/css/border-conflict-element-002.htm fast/table/border-collapsing/cached-cell-append.html fast/table/border-collapsing/cached-cell-remove.html fast/table/border-collapsing/equal-precedence-resolution-vertical.html fast/table/border-collapsing/equal-precedence-resolution.html fast/table/border-collapsing/first-cell-left-border-hidden-table-ltr-section-rtl.html fast/table/border-collapsing/last-cell-left-border-hidden-table-ltr-section-rtl.html fast/table/border-collapsing/left-border-table-ltr-section-rtl.html ... (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6628 "Found 1 new test failure: fast/css/border-conflict-element-002.htm (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60887 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35727 "Found 18 new test failures: css2.1/20110323/border-conflict-element-029.htm css2.1/20110323/border-conflict-element-038.htm fast/css/border-conflict-element-002.htm fast/table/border-collapsing/cached-cell-append.html fast/table/border-collapsing/cached-cell-remove.html fast/table/border-collapsing/equal-precedence-resolution-vertical.html fast/table/border-collapsing/equal-precedence-resolution.html fast/table/border-collapsing/first-cell-left-border-hidden-table-ltr-section-rtl.html fast/table/border-collapsing/last-cell-left-border-hidden-table-ltr-section-rtl.html fast/table/border-collapsing/left-border-table-ltr-section-rtl.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28464 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32460 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-tables/border-conflict-resolution.html imported/w3c/web-platform-tests/css/css-writing-modes/border-conflict-element-vlr-003.xht imported/w3c/web-platform-tests/css/css-writing-modes/border-conflict-element-vrl-002.xht (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8189 "Found 60 new test failures: css2.1/20110323/border-conflict-element-029.htm css2.1/20110323/border-conflict-element-038.htm fast/css/border-conflict-element-002.htm fast/repaint/inline-box-with-self-paint-layer.html fast/table/border-collapsing/cached-cell-append.html fast/table/border-collapsing/cached-cell-remove.html fast/table/border-collapsing/equal-precedence-resolution-vertical.html fast/table/border-collapsing/equal-precedence-resolution.html fast/table/border-collapsing/first-cell-left-border-hidden-table-ltr-section-rtl.html fast/table/border-collapsing/last-cell-left-border-hidden-table-ltr-section-rtl.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8304 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54415 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8469 "Found 23 new test failures: css2.1/20110323/border-conflict-element-029.htm css2.1/20110323/border-conflict-element-038.htm fast/css/border-conflict-element-002.htm fast/table/border-collapsing/cached-cell-append.html fast/table/border-collapsing/cached-cell-remove.html fast/table/border-collapsing/equal-precedence-resolution-vertical.html fast/table/border-collapsing/equal-precedence-resolution.html fast/table/border-collapsing/first-cell-left-border-hidden-table-ltr-section-rtl.html fast/table/border-collapsing/last-cell-left-border-hidden-table-ltr-section-rtl.html fast/table/border-collapsing/left-border-table-ltr-section-rtl.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64189 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2769 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/9501 "Hash 7be3bd95 for PR 30950 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54930 "Found 23 new test failures: css2.1/20110323/border-conflict-element-029.htm css2.1/20110323/border-conflict-element-038.htm fast/css/border-conflict-element-002.htm fast/table/border-collapsing/cached-cell-append.html fast/table/border-collapsing/cached-cell-remove.html fast/table/border-collapsing/equal-precedence-resolution-vertical.html fast/table/border-collapsing/equal-precedence-resolution.html fast/table/border-collapsing/first-cell-left-border-hidden-table-ltr-section-rtl.html fast/table/border-collapsing/last-cell-left-border-hidden-table-ltr-section-rtl.html fast/table/border-collapsing/left-border-table-ltr-section-rtl.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2778 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50925 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55025 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2323 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34014 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35098 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36183 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->