### PR TITLE
[GStreamer] Add gstStructureGet<bool> helper function and complete migration to gstStructureGet<T> helpers

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1029,6 +1029,12 @@ std::optional<T> gstStructureGet(const GstStructure* structure, ASCIILiteral key
     } else if constexpr(std::is_same_v<T, double>) {
         if (gst_structure_get_double(structure, key.characters(), &value))
             return value;
+    } else if constexpr(std::is_same_v<T, bool>) {
+        gboolean gstValue;
+        if (gst_structure_get_boolean(structure, key.characters(), &gstValue)) {
+            value = gstValue;
+            return value;
+        }
     } else
         static_assert(!std::is_same_v<T, T>, "type not implemented for gstStructureGet");
     return std::nullopt;
@@ -1039,6 +1045,7 @@ template std::optional<int64_t> gstStructureGet(const GstStructure*, ASCIILitera
 template std::optional<unsigned> gstStructureGet(const GstStructure*, ASCIILiteral key);
 template std::optional<uint64_t> gstStructureGet(const GstStructure*, ASCIILiteral key);
 template std::optional<double> gstStructureGet(const GstStructure*, ASCIILiteral key);
+template std::optional<bool> gstStructureGet(const GstStructure*, ASCIILiteral key);
 
 static RefPtr<JSON::Value> gstStructureToJSON(const GstStructure*);
 

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -608,9 +608,9 @@ static void videoEncoderConstructed(GObject* encoder)
         if (GST_EVENT_TYPE(event) == GST_EVENT_CUSTOM_DOWNSTREAM_OOB) {
             const auto* structure = gst_event_get_structure(event);
             if (gst_structure_has_name(structure, "encoder-bitrate-change-request")) {
-                uint32_t bitrate;
-                gst_structure_get_uint(structure, "bitrate", &bitrate);
-                g_object_set(parent, "bitrate", bitrate, nullptr);
+                auto bitrate = gstStructureGet<unsigned>(structure, "bitrate"_s);
+                RELEASE_ASSERT(bitrate);
+                g_object_set(parent, "bitrate", static_cast<uint32_t>(*bitrate), nullptr);
                 return TRUE;
             }
         }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -41,10 +41,8 @@ static gint sortDevices(gconstpointer a, gconstpointer b)
     GstDevice* adev = GST_DEVICE(a), *bdev = GST_DEVICE(b);
     GUniquePtr<GstStructure> aprops(gst_device_get_properties(adev));
     GUniquePtr<GstStructure> bprops(gst_device_get_properties(bdev));
-    gboolean aIsDefault = FALSE, bIsDefault = FALSE;
-
-    gst_structure_get_boolean(aprops.get(), "is-default", &aIsDefault);
-    gst_structure_get_boolean(bprops.get(), "is-default", &bIsDefault);
+    auto aIsDefault = gstStructureGet<bool>(aprops.get(), "is-default"_s).value_or(false);
+    auto bIsDefault = gstStructureGet<bool>(bprops.get(), "is-default"_s).value_or(false);
 
     if (aIsDefault == bIsDefault) {
         GUniquePtr<char> aName(gst_device_get_display_name(adev));
@@ -206,8 +204,7 @@ void GStreamerCaptureDeviceManager::addDevice(GRefPtr<GstDevice>&& device)
     // itself does that at least for pulseaudio devices).
     GUniquePtr<char> deviceName(gst_device_get_display_name(device.get()));
     GST_INFO("Registering device %s", deviceName.get());
-    gboolean isDefault = FALSE;
-    gst_structure_get_boolean(properties.get(), "is-default", &isDefault);
+    auto isDefault = gstStructureGet<bool>(properties.get(), "is-default"_s).value_or(false);
     auto label = makeString(isDefault ? "default: "_s : ""_s, span(deviceName.get()));
 
     auto identifier = label;

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -4055,6 +4055,10 @@ def check_language(filename, clean_lines, line_number, file_extension, include_s
               'Consider using toText helper function in WebCore/dom/Text.h '
               'instead of static_cast<Text*>')
 
+    if filename != 'Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp':
+        if search(r'gst_structure_get_(int|uint|double|boolean)', line):
+            error(line_number, 'readability/check', 4, 'Consider using gstStructureGet<T>() instead')
+
 
 def check_identifier_name_in_declaration(filename, line_number, line, file_state, error):
     """Checks if identifier names contain any anti-patterns like underscores.

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -1038,6 +1038,14 @@ class CppStyleTest(CppStyleTestBase):
             'instead of static_cast<Text*>'
             '  [readability/check] [4]')
 
+    def test_gst_structure_get(self):
+        error_message = 'Consider using gstStructureGet<T>() instead  [readability/check] [4]'
+        self.assert_lint('gst_structure_get_int(s, "foo", &bar)', error_message)
+        self.assert_lint('gst_structure_get_int64(s, "foo", &bar)', error_message)
+        self.assert_lint('gst_structure_get_uint(s, "foo", &bar)', error_message)
+        self.assert_lint('gst_structure_get_double(s, "foo", &bar)', error_message)
+        self.assert_lint('gst_structure_get_boolean(s, "foo", &bar)', error_message)
+
     # We cannot test this functionality because of difference of
     # function definitions.  Anyway, we may never enable this.
     #

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
@@ -52,7 +52,7 @@ void GStreamerTest::TearDownTestSuite()
 
 TEST_F(GStreamerTest, gstStructureGetters)
 {
-    GUniquePtr<GstStructure> structure(gst_structure_new("foo", "int-val", G_TYPE_INT, -5, "int64-val", G_TYPE_INT64, -10, "uint-val", G_TYPE_UINT, 5, "uint64-val", G_TYPE_UINT64, 18014398509481982, "double-val", G_TYPE_DOUBLE, 1.0, nullptr));
+    GUniquePtr<GstStructure> structure(gst_structure_new("foo", "int-val", G_TYPE_INT, -5, "int64-val", G_TYPE_INT64, -10, "uint-val", G_TYPE_UINT, 5, "uint64-val", G_TYPE_UINT64, 18014398509481982, "double-val", G_TYPE_DOUBLE, 1.0, "bool-val", G_TYPE_BOOLEAN, TRUE, nullptr));
     ASSERT_EQ(gstStructureGet<int>(structure.get(), "int-val"_s), -5);
     ASSERT_TRUE(!gstStructureGet<int>(structure.get(), "int-val-noexist"_s).has_value());
     ASSERT_EQ(gstStructureGet<int64_t>(structure.get(), "int64-val"_s), -10);
@@ -63,6 +63,8 @@ TEST_F(GStreamerTest, gstStructureGetters)
     ASSERT_TRUE(!gstStructureGet<uint64_t>(structure.get(), "uint64-val-noexist"_s).has_value());
     ASSERT_EQ(gstStructureGet<double>(structure.get(), "double-val"_s), 1.0);
     ASSERT_TRUE(!gstStructureGet<double>(structure.get(), "double-val-noexist"_s).has_value());
+    ASSERT_EQ(gstStructureGet<bool>(structure.get(), "bool-val"_s), true);
+    ASSERT_TRUE(!gstStructureGet<bool>(structure.get(), "bool-val-noexist"_s).has_value());
 
     // webkit.org/b/276224
     auto emptyIntOpt = gstStructureGet<int>(structure.get(), "int-val-noexist2"_s);


### PR DESCRIPTION
#### 6d494648332fbd981645653e77709213ff89532e
<pre>
[GStreamer] Add gstStructureGet&lt;bool&gt; helper function and complete migration to gstStructureGet&lt;T&gt; helpers
<a href="https://bugs.webkit.org/show_bug.cgi?id=276772">https://bugs.webkit.org/show_bug.cgi?id=276772</a>

Reviewed by Xabier Rodriguez-Calvar.

This new helper makes boolean fields access from GstStructures a bit more idiomatic. The migration
to gstStructureGet&lt;T&gt; helpers is now complete and the coding style checker is now able to detect
cases where the helper functions would be recommended.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::gstStructureGet):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
(WebCore::MediaPlayerPrivateGStreamer::updateVideoSinkStatistics):
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(transformInPlace):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(videoEncoderConstructed):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::sortDevices):
(WebCore::GStreamerCaptureDeviceManager::addDevice):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_language):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(CppStyleTest):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/281187@main">https://commits.webkit.org/281187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8edac0d4197e23be705e33005610b256768915f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62795 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9711 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6788 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28711 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/58588 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8379 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8509 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54589 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64492 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2974 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8615 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55176 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55280 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13064 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2498 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34219 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35303 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36388 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35049 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->