### PR TITLE
Remove libwebrtc network thread with socket server from NetworkRTCProvider

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -42,17 +42,15 @@
 #include <wtf/MainThread.h>
 #include <wtf/text/WTFString.h>
 
-#if !PLATFORM(COCOA)
-ALLOW_COMMA_BEGIN
-#include <webrtc/rtc_base/async_packet_socket.h>
-ALLOW_COMMA_END
-#endif
-
 #if PLATFORM(COCOA)
 #include "NetworkRTCTCPSocketCocoa.h"
 #include "NetworkRTCUDPSocketCocoa.h"
 #include "NetworkSessionCocoa.h"
-#endif
+#else // PLATFORM(COCOA)
+ALLOW_COMMA_BEGIN
+#include <webrtc/rtc_base/async_packet_socket.h>
+ALLOW_COMMA_END
+#endif // PLATFORM(COCOA)
 
 namespace WebKit {
 using namespace WebCore;
@@ -60,28 +58,14 @@ using namespace WebCore;
 #define RTC_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - NetworkRTCProvider::" fmt, this, ##__VA_ARGS__)
 #define RTC_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(Network, "%p - NetworkRTCProvider::" fmt, this, ##__VA_ARGS__)
 
-rtc::Thread& NetworkRTCProvider::rtcNetworkThread()
-{
-    static NeverDestroyed<std::unique_ptr<rtc::Thread>> networkThread;
-    static std::once_flag onceKey;
-    std::call_once(onceKey, [] {
-        networkThread.get() = rtc::Thread::CreateWithSocketServer();
-        networkThread.get()->SetName("RTC Network Thread", nullptr);
-
-        auto result = networkThread.get()->Start();
-        ASSERT_UNUSED(result, result);
-    });
-    return *networkThread.get();
-}
-
 NetworkRTCProvider::NetworkRTCProvider(NetworkConnectionToWebProcess& connection)
     : m_connection(&connection)
     , m_ipcConnection(connection.connection())
     , m_rtcMonitor(*this)
 #if PLATFORM(COCOA)
     , m_sourceApplicationAuditToken(connection.networkProcess().sourceApplicationAuditToken())
-#endif
-#if !PLATFORM(COCOA)
+    , m_rtcNetworkThreadQueue(WorkQueue::create("NetworkRTCProvider Queue"_s, WorkQueue::QOS::UserInitiated))
+#else
     , m_packetSocketFactory(makeUniqueRefWithoutFastMallocCheck<rtc::BasicPacketSocketFactory>(rtcNetworkThread().socketserver()))
 #endif
 {
@@ -125,81 +109,9 @@ void NetworkRTCProvider::close()
     });
 }
 
-#if !PLATFORM(COCOA)
-void NetworkRTCProvider::createSocket(LibWebRTCSocketIdentifier identifier, std::unique_ptr<rtc::AsyncPacketSocket>&& socket, Socket::Type type, Ref<IPC::Connection>&& connection)
-{
-    ASSERT(rtcNetworkThread().IsCurrent());
-    if (!socket) {
-        RTC_RELEASE_LOG_ERROR("createSocket with %lu sockets is unable to create a new socket", m_sockets.size());
-        connection->send(Messages::LibWebRTCNetwork::SignalClose(identifier, 1), 0);
-        return;
-    }
-    addSocket(identifier, makeUnique<LibWebRTCSocketClient>(identifier, *this, WTFMove(socket), type, WTFMove(connection)));
-}
-#endif
-
-#if PLATFORM(COCOA)
-const String& NetworkRTCProvider::attributedBundleIdentifierFromPageIdentifier(WebPageProxyIdentifier pageIdentifier)
-{
-    return m_attributedBundleIdentifiers.ensure(pageIdentifier, [&]() -> String {
-        String value;
-        callOnMainRunLoopAndWait([&] {
-            auto* session = m_connection ? m_connection->networkSession() : nullptr;
-            if (session)
-                value = session->attributedBundleIdentifierFromPageIdentifier(pageIdentifier).isolatedCopy();
-        });
-        return value;
-    }).iterator->value;
-}
-#endif
-
-void NetworkRTCProvider::createUDPSocket(LibWebRTCSocketIdentifier identifier, const RTCNetwork::SocketAddress& address, uint16_t minPort, uint16_t maxPort, WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain&& domain)
-{
-    ASSERT(rtcNetworkThread().IsCurrent());
-
-#if PLATFORM(COCOA)
-    auto socket = makeUnique<NetworkRTCUDPSocketCocoa>(identifier, *this, address.rtcAddress(), m_ipcConnection.copyRef(), String(attributedBundleIdentifierFromPageIdentifier(pageIdentifier)), isFirstParty, isRelayDisabled, WTFMove(domain));
-    addSocket(identifier, WTFMove(socket));
-#else
-    std::unique_ptr<rtc::AsyncPacketSocket> socket(m_packetSocketFactory->CreateUdpSocket(address.rtcAddress(), minPort, maxPort));
-    createSocket(identifier, WTFMove(socket), Socket::Type::UDP, m_ipcConnection.copyRef());
-#endif
-}
-
-void NetworkRTCProvider::createClientTCPSocket(LibWebRTCSocketIdentifier identifier, const RTCNetwork::SocketAddress& localAddress, const RTCNetwork::SocketAddress& remoteAddress, String&& userAgent, int options, WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain&& domain)
-{
-    ASSERT(rtcNetworkThread().IsCurrent());
-
-#if PLATFORM(COCOA)
-    auto socket = NetworkRTCTCPSocketCocoa::createClientTCPSocket(identifier, *this, remoteAddress.rtcAddress(), options, attributedBundleIdentifierFromPageIdentifier(pageIdentifier), isFirstParty, isRelayDisabled, domain, m_ipcConnection.copyRef());
-    if (socket)
-        addSocket(identifier, WTFMove(socket));
-    else
-        signalSocketIsClosed(identifier);
-#else
-    callOnMainRunLoop([this, protectedThis = Ref { *this }, identifier, localAddress, remoteAddress, userAgent = WTFMove(userAgent).isolatedCopy(), options]() mutable {
-        if (!m_connection)
-            return;
-
-        auto* session = m_connection->networkSession();
-        if (!session) {
-            signalSocketIsClosed(identifier);
-            return;
-        }
-        callOnRTCNetworkThread([this, protectedThis = Ref { *this }, identifier, localAddress = RTC::Network::SocketAddress::isolatedCopy(localAddress.rtcAddress()), remoteAddress = RTC::Network::SocketAddress::isolatedCopy(remoteAddress.rtcAddress()), options]() mutable {
-
-            rtc::PacketSocketTcpOptions tcpOptions;
-            tcpOptions.opts = options;
-            std::unique_ptr<rtc::AsyncPacketSocket> socket(m_packetSocketFactory->CreateClientTcpSocket(localAddress, remoteAddress, tcpOptions));
-            createSocket(identifier, WTFMove(socket), Socket::Type::ClientTCP, m_ipcConnection.copyRef());
-        });
-    });
-#endif
-}
-
 void NetworkRTCProvider::sendToSocket(LibWebRTCSocketIdentifier identifier, std::span<const uint8_t> data, RTCNetwork::SocketAddress&& address, RTCPacketOptions&& options)
 {
-    ASSERT(rtcNetworkThread().IsCurrent());
+    assertIsRTCNetworkThread();
     auto iterator = m_sockets.find(identifier);
     if (iterator == m_sockets.end())
         return;
@@ -208,7 +120,7 @@ void NetworkRTCProvider::sendToSocket(LibWebRTCSocketIdentifier identifier, std:
 
 void NetworkRTCProvider::closeSocket(LibWebRTCSocketIdentifier identifier)
 {
-    ASSERT(rtcNetworkThread().IsCurrent());
+    assertIsRTCNetworkThread();
     auto iterator = m_sockets.find(identifier);
     if (iterator == m_sockets.end())
         return;
@@ -227,7 +139,7 @@ void NetworkRTCProvider::doSocketTaskOnRTCNetworkThread(LibWebRTCSocketIdentifie
 
 void NetworkRTCProvider::setSocketOption(LibWebRTCSocketIdentifier identifier, int option, int value)
 {
-    ASSERT(rtcNetworkThread().IsCurrent());
+    assertIsRTCNetworkThread();
     auto iterator = m_sockets.find(identifier);
     if (iterator == m_sockets.end())
         return;
@@ -236,7 +148,7 @@ void NetworkRTCProvider::setSocketOption(LibWebRTCSocketIdentifier identifier, i
 
 void NetworkRTCProvider::addSocket(LibWebRTCSocketIdentifier identifier, std::unique_ptr<Socket>&& socket)
 {
-    ASSERT(rtcNetworkThread().IsCurrent());
+    assertIsRTCNetworkThread();
     ASSERT(socket);
     m_sockets.emplace(identifier, WTFMove(socket));
 
@@ -251,7 +163,7 @@ void NetworkRTCProvider::addSocket(LibWebRTCSocketIdentifier identifier, std::un
 
 std::unique_ptr<NetworkRTCProvider::Socket> NetworkRTCProvider::takeSocket(LibWebRTCSocketIdentifier identifier)
 {
-    ASSERT(rtcNetworkThread().IsCurrent());
+    assertIsRTCNetworkThread();
     auto iterator = m_sockets.find(identifier);
     if (iterator == m_sockets.end())
         return nullptr;
@@ -327,6 +239,38 @@ void NetworkRTCProvider::stopResolver(LibWebRTCResolverIdentifier identifier)
 }
 
 #if PLATFORM(COCOA)
+const String& NetworkRTCProvider::attributedBundleIdentifierFromPageIdentifier(WebPageProxyIdentifier pageIdentifier)
+{
+    return m_attributedBundleIdentifiers.ensure(pageIdentifier, [&]() -> String {
+        String value;
+        callOnMainRunLoopAndWait([&] {
+            auto* session = m_connection ? m_connection->networkSession() : nullptr;
+            if (session)
+                value = session->attributedBundleIdentifierFromPageIdentifier(pageIdentifier).isolatedCopy();
+        });
+        return value;
+    }).iterator->value;
+}
+
+void NetworkRTCProvider::createUDPSocket(LibWebRTCSocketIdentifier identifier, const RTCNetwork::SocketAddress& address, uint16_t minPort, uint16_t maxPort, WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain&& domain)
+{
+    assertIsRTCNetworkThread();
+
+    auto socket = makeUnique<NetworkRTCUDPSocketCocoa>(identifier, *this, address.rtcAddress(), m_ipcConnection.copyRef(), String(attributedBundleIdentifierFromPageIdentifier(pageIdentifier)), isFirstParty, isRelayDisabled, WTFMove(domain));
+    addSocket(identifier, WTFMove(socket));
+}
+
+void NetworkRTCProvider::createClientTCPSocket(LibWebRTCSocketIdentifier identifier, const RTCNetwork::SocketAddress& localAddress, const RTCNetwork::SocketAddress& remoteAddress, String&& userAgent, int options, WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain&& domain)
+{
+    assertIsRTCNetworkThread();
+
+    auto socket = NetworkRTCTCPSocketCocoa::createClientTCPSocket(identifier, *this, remoteAddress.rtcAddress(), options, attributedBundleIdentifierFromPageIdentifier(pageIdentifier), isFirstParty, isRelayDisabled, domain, m_ipcConnection.copyRef());
+    if (socket)
+        addSocket(identifier, WTFMove(socket));
+    else
+        signalSocketIsClosed(identifier);
+}
+
 void NetworkRTCProvider::getInterfaceName(URL&& url, WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain&& domain, CompletionHandler<void(String&&)>&& completionHandler)
 {
     if (!url.protocolIsInHTTPFamily()) {
@@ -336,12 +280,84 @@ void NetworkRTCProvider::getInterfaceName(URL&& url, WebPageProxyIdentifier page
 
     NetworkRTCTCPSocketCocoa::getInterfaceName(*this, url, attributedBundleIdentifierFromPageIdentifier(pageIdentifier), isFirstParty, isRelayDisabled, domain, WTFMove(completionHandler));
 }
-#endif
+
+void NetworkRTCProvider::callOnRTCNetworkThread(Function<void()>&& callback)
+{
+    m_rtcNetworkThreadQueue->dispatch(WTFMove(callback));
+}
+
+void NetworkRTCProvider::assertIsRTCNetworkThread()
+{
+    ASSERT(m_rtcNetworkThreadQueue->isCurrent());
+}
+
+#else // PLATFORM(COCOA)
+rtc::Thread& NetworkRTCProvider::rtcNetworkThread()
+{
+    static NeverDestroyed<std::unique_ptr<rtc::Thread>> networkThread;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [] {
+        networkThread.get() = rtc::Thread::CreateWithSocketServer();
+        networkThread.get()->SetName("RTC Network Thread", nullptr);
+
+        auto result = networkThread.get()->Start();
+        ASSERT_UNUSED(result, result);
+    });
+    return *networkThread.get();
+}
+
+void NetworkRTCProvider::createUDPSocket(LibWebRTCSocketIdentifier identifier, const RTCNetwork::SocketAddress& address, uint16_t minPort, uint16_t maxPort, WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain&& domain)
+{
+    assertIsRTCNetworkThread();
+
+    std::unique_ptr<rtc::AsyncPacketSocket> socket(m_packetSocketFactory->CreateUdpSocket(address.rtcAddress(), minPort, maxPort));
+    createSocket(identifier, WTFMove(socket), Socket::Type::UDP, m_ipcConnection.copyRef());
+}
+
+void NetworkRTCProvider::createClientTCPSocket(LibWebRTCSocketIdentifier identifier, const RTCNetwork::SocketAddress& localAddress, const RTCNetwork::SocketAddress& remoteAddress, String&& userAgent, int options, WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain&& domain)
+{
+    assertIsRTCNetworkThread();
+
+    callOnMainRunLoop([this, protectedThis = Ref { *this }, identifier, localAddress, remoteAddress, userAgent = WTFMove(userAgent).isolatedCopy(), options]() mutable {
+        if (!m_connection)
+            return;
+
+        auto* session = m_connection->networkSession();
+        if (!session) {
+            signalSocketIsClosed(identifier);
+            return;
+        }
+        callOnRTCNetworkThread([this, protectedThis = Ref { *this }, identifier, localAddress = RTC::Network::SocketAddress::isolatedCopy(localAddress.rtcAddress()), remoteAddress = RTC::Network::SocketAddress::isolatedCopy(remoteAddress.rtcAddress()), options]() mutable {
+
+            rtc::PacketSocketTcpOptions tcpOptions;
+            tcpOptions.opts = options;
+            std::unique_ptr<rtc::AsyncPacketSocket> socket(m_packetSocketFactory->CreateClientTcpSocket(localAddress, remoteAddress, tcpOptions));
+            createSocket(identifier, WTFMove(socket), Socket::Type::ClientTCP, m_ipcConnection.copyRef());
+        });
+    });
+}
+
+void NetworkRTCProvider::createSocket(LibWebRTCSocketIdentifier identifier, std::unique_ptr<rtc::AsyncPacketSocket>&& socket, Socket::Type type, Ref<IPC::Connection>&& connection)
+{
+    assertIsRTCNetworkThread();
+    if (!socket) {
+        RTC_RELEASE_LOG_ERROR("createSocket with %lu sockets is unable to create a new socket", m_sockets.size());
+        connection->send(Messages::LibWebRTCNetwork::SignalClose(identifier, 1), 0);
+        return;
+    }
+    addSocket(identifier, makeUnique<LibWebRTCSocketClient>(identifier, *this, WTFMove(socket), type, WTFMove(connection)));
+}
 
 void NetworkRTCProvider::callOnRTCNetworkThread(Function<void()>&& callback)
 {
     rtcNetworkThread().PostTask(WTFMove(callback));
 }
+
+void NetworkRTCProvider::assertIsRTCNetworkThread()
+{
+    ASSERT(rtcNetworkThread().IsCurrent());
+}
+#endif // !PLATFORM(COCOA)
 
 void NetworkRTCProvider::signalSocketIsClosed(LibWebRTCSocketIdentifier identifier)
 {


### PR DESCRIPTION
#### ff2a05f6674c75d2a78a179ca31270c3bd1aa3db
<pre>
Remove libwebrtc network thread with socket server from NetworkRTCProvider
<a href="https://bugs.webkit.org/show_bug.cgi?id=276779">https://bugs.webkit.org/show_bug.cgi?id=276779</a>
<a href="https://rdar.apple.com/132008878">rdar://132008878</a>

Reviewed by Chris Dumez.

We remove the creation of the rtc network thread from NetworkRTCProvider on Cocoa ports.
We no longer need it as we are not using it for sockets nor for monitoring the network.
Some code is being moved to either a Cocoa section or a non Cocoa section.

* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:
(WebKit::NetworkRTCProvider::NetworkRTCProvider):
(WebKit::NetworkRTCProvider::sendToSocket):
(WebKit::NetworkRTCProvider::closeSocket):
(WebKit::NetworkRTCProvider::setSocketOption):
(WebKit::NetworkRTCProvider::addSocket):
(WebKit::NetworkRTCProvider::takeSocket):
(WebKit::NetworkRTCProvider::attributedBundleIdentifierFromPageIdentifier):
(WebKit::NetworkRTCProvider::createUDPSocket):
(WebKit::NetworkRTCProvider::createClientTCPSocket):
(WebKit::NetworkRTCProvider::callOnRTCNetworkThread):
(WebKit::NetworkRTCProvider::assertIsRTCNetworkThread):
(WebKit::NetworkRTCProvider::rtcNetworkThread):
(WebKit::NetworkRTCProvider::createSocket):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:

Canonical link: <a href="https://commits.webkit.org/281248@main">https://commits.webkit.org/281248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0675ceccf5344a6759759be1d675a795e00c50a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62823 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9513 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47881 "") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6796 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32642 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8517 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64532 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55213 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55321 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13128 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2505 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34227 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35311 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36396 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->