### PR TITLE
Update compare-static-analysis-results for better readability and EWS support

### DIFF
--- a/Tools/Scripts/compare-static-analysis-results
+++ b/Tools/Scripts/compare-static-analysis-results
@@ -136,18 +136,13 @@ def compare_project_results_to_expectations(args, new_path, project):
         with open(f'{new_path}/{project}/UnexpectedIssues{checker}', 'a') as f:
             f.write('\n'.join(unexpected_issues))
 
-        no_unexpected = True
         print(f'\n{checker}:')
-        for type, type_list in {
-            'Unexpected passing files': clean_files,
-            'Unexpected failing files': buggy_files,
-            'Unexpected issues': unexpected_issues
-        }.items():
-            if len(type_list):
-                no_unexpected = False
-                print(f'    {type}: {len(type_list)}')
-        if no_unexpected:
-            print(f'    No unexpected results!')
+        if clean_files or buggy_files or unexpected_issues:
+            print(f'    Unexpected passing files: {len(clean_files)}')
+            print(f'    Unexpected failing files: {len(buggy_files)}')
+            print(f'    Unexpected issues: {len(unexpected_issues)}')
+        else:
+            print('    No unexpected results')
 
     if unexpected_issues_total and args.scan_build:
         create_filtered_results_dir(args, project, unexpected_result_paths_total, STATIC_ANALYZER_UNEXPECTED)
@@ -160,9 +155,10 @@ def compare_project_results_by_run(args, archive_path, new_path, project):
     new_files_total = set()
     fixed_issues_total = set()
     fixed_files_total = set()
+    project_results_passes = {}
+    project_results_failures = {}
 
     for checker in CHECKERS:
-        print(f'{checker}:')
         new_issues, fixed_issues = find_diff(args, f'{archive_path}/{checker}Issues', f'{new_path}/{project}/{checker}Issues')
         new_files, fixed_files = find_diff(args, f'{archive_path}/{checker}Files', f'{new_path}/{project}/{checker}Files')
         fixed_issues_total.update(fixed_issues)
@@ -170,21 +166,29 @@ def compare_project_results_by_run(args, archive_path, new_path, project):
         new_issues_total.update(new_issues)
         new_files_total.update(new_files)
 
-        print(f'    Issues fixed: {len(fixed_issues)}')
-        print(f'    Files fixed: {len(fixed_files)}')
-        print(f'    New issues: {len(new_issues)}')
-        print(f'    New files with issues: {len(new_files)}\n')
+        project_results_passes[checker] = list(fixed_files)
+        project_results_failures[checker] = list(new_files)
+
+        print(f'{checker}:')
+        if fixed_issues or fixed_files or new_issues or new_files:
+            print(f'    Issues fixed: {len(fixed_issues)}')
+            print(f'    Files fixed: {len(fixed_files)}')
+            print(f'    Unexpected issues: {len(new_issues)}')
+            print(f'    Unexpected failing files: {len(new_files)}\n')
+        else:
+            print('    No unexpected results')
 
     if new_issues_total and args.scan_build:
         create_filtered_results_dir(args, project, new_issues_total, 'StaticAnalyzerRegressions')
 
-    return new_issues_total, new_files_total
+    return new_issues_total, new_files_total, fixed_files_total, project_results_passes, project_results_failures
 
 
 def main():
     args = parser()
     new_issues_total = set()
     new_files_total = set()
+    fixed_files_total = set()
     unexpected_passes_total = set()
     unexpected_failures_total = set()
     unexpected_issues_total = set()
@@ -198,14 +202,15 @@ def main():
             unexpected_failures_total.update(unexpected_failures)
             unexpected_passes_total.update(unexpected_passes)
             unexpected_issues_total.update(unexpected_issues)
-            # JSON
-            unexpected_results_data['passes'][project] = project_results_passes
-            unexpected_results_data['failures'][project] = project_results_failures
         else:
             archive_path = os.path.abspath(f'{args.archived_dir}/{project}')
-            new_issues, new_files = compare_project_results_by_run(args, archive_path, new_path, project)
+            new_issues, new_files, fixed_files, project_results_passes, project_results_failures = compare_project_results_by_run(args, archive_path, new_path, project)
             new_issues_total.update(new_issues)
             new_files_total.update(new_files)
+            fixed_files_total.update(fixed_files)
+        # JSON
+        unexpected_results_data['passes'][project] = project_results_passes
+        unexpected_results_data['failures'][project] = project_results_failures
 
     results_data_file = os.path.abspath(f'{args.build_output}/unexpected_results.json')
     with open(results_data_file, "w") as f:
@@ -216,6 +221,7 @@ def main():
     for type, type_total in {
         'new issues': new_issues_total,
         'new files': new_files_total,
+        'fixed files': fixed_files_total,
         'unexpected failing files': unexpected_failures_total,
         'unexpected passing files': unexpected_passes_total,
         'unexpected issues': unexpected_issues_total


### PR DESCRIPTION
#### bff30458ca217d2d653f52f8ee29fda881c08337
<pre>
Update compare-static-analysis-results for better readability and EWS support
<a href="https://bugs.webkit.org/show_bug.cgi?id=276783">https://bugs.webkit.org/show_bug.cgi?id=276783</a>
<a href="https://rdar.apple.com/132017828">rdar://132017828</a>

Reviewed by Ryosuke Niwa.

Generate an unexpected_results.json when comparing results by run.
Update logging to use clearer wording and less unnecessary output.

* Tools/Scripts/compare-static-analysis-results:
(compare_project_results_to_expectations):
(compare_project_results_by_run):
(main):

Canonical link: <a href="https://commits.webkit.org/281096@main">https://commits.webkit.org/281096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb30de398f7ab418fd1cd069ce08d73ab93da808

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11230 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/62371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/9184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9384 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/62371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/9184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60771 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50797 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/62371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/32371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/8093 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/8188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/8371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/64073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2653 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/64073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50821 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/64073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2228 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8754 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/33898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/34982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/36067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/34728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->