### PR TITLE
[Navigation] Implement history handling steps from the navigate algorithm

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-navigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-navigate-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigate event for navigation.navigate() assert_equals: expected "replace" but got "push"
+PASS navigate event for navigation.navigate()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/same-url-replace-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/same-url-replace-cross-document-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigate() to the current URL cross document should replace assert_equals: expected "replace" but got "push"
+PASS navigate() to the current URL cross document should replace
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/same-url-replace-same-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/same-url-replace-same-document-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigate() to the current URL same document should replace assert_equals: expected "replace" but got "push"
+PASS navigate() to the current URL same document should replace
 


### PR DESCRIPTION
#### 8047924d30e0f6ec3785d815be4737f1ad0bcdf2
<pre>
[Navigation] Implement history handling steps from the navigate algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=276785">https://bugs.webkit.org/show_bug.cgi?id=276785</a>

Reviewed by Darin Adler.

Implement history handling steps from the navigate algorithm [1].

[1] <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a> (Steps 11, 12)

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-navigate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/same-url-replace-cross-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/same-url-replace-same-document-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::changeLocation):
(WebCore::FrameLoader::loadURL):

Canonical link: <a href="https://commits.webkit.org/281135@main">https://commits.webkit.org/281135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69f6d07bdeee91db5127eb05e4447610a6da6e40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62482 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9294 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47600 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6621 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60881 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35723 "Found 2 new test failures: fast/forms/datalist/datalist-option-labels.html fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28457 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8183 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8298 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64183 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54926 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55021 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13018 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2318 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34008 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35092 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->