### PR TITLE
AX: Adopt text-related BrowserEngineKit APIs

### DIFF
--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -1542,6 +1542,37 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     return nil;
 }
 
+- (NSString *)browserAccessibilityValueInRange:(NSRange)range
+{
+    if (![self _prepareAccessibilityCall])
+        return nil;
+
+    NSString *value = [self accessibilityValue];
+    if (value == nil)
+        return nil;
+
+    NSRange intersection = NSIntersectionRange(range, NSMakeRange(0, [value length]));
+    if (!intersection.length)
+        return nil;
+    return [value substringWithRange:intersection];
+}
+
+- (NSAttributedString *)browserAccessibilityAttributedValueInRange:(NSRange)range
+{
+    if (![self _prepareAccessibilityCall])
+        return nil;
+
+    NSRange elementRange = [self elementTextRange];
+    if (elementRange.location != NSNotFound)
+        range.location += elementRange.location;
+
+    NSAttributedString *attributedString = [self attributedStringForRange:range];
+    if (![attributedString length])
+        return adoptNS([[NSAttributedString alloc] initWithString:[self browserAccessibilityValueInRange:range]]).autorelease();
+
+    return attributedString;
+}
+
 - (BOOL)accessibilityIsIndeterminate
 {
     if (![self _prepareAccessibilityCall])
@@ -2358,7 +2389,7 @@ static RenderObject* rendererForView(WAKView* view)
     return self.axBackingObject->attributedStringForTextMarkerRange({ [markers.firstObject textMarkerData], [markers.lastObject textMarkerData] }).autorelease();
 }
 
-- (NSRange)_accessibilitySelectedTextRange
+- (NSRange)browserAccessibilitySelectedTextRange
 {
     if (![self _prepareAccessibilityCall] || !self.axBackingObject->isTextControl())
         return NSMakeRange(NSNotFound, 0);
@@ -2369,12 +2400,22 @@ static RenderObject* rendererForView(WAKView* view)
     return textRange;
 }
 
-- (void)_accessibilitySetSelectedTextRange:(NSRange)range
+- (NSRange)_accessibilitySelectedTextRange
+{
+    return [self browserAccessibilitySelectedTextRange];
+}
+
+- (void)browserAccessibilitySetSelectedTextRange:(NSRange)range
 {
     if (![self _prepareAccessibilityCall])
         return;
 
     self.axBackingObject->setSelectedTextRange(range);
+}
+
+- (void)_accessibilitySetSelectedTextRange:(NSRange)range
+{
+    [self browserAccessibilitySetSelectedTextRange:range];
 }
 
 - (BOOL)accessibilityReplaceRange:(NSRange)range withText:(NSString *)string
@@ -2391,6 +2432,43 @@ static RenderObject* rendererForView(WAKView* view)
         return NO;
 
     return self.axBackingObject->insertText(text);
+}
+
+- (void)browserAccessibilityInsertTextAtCursor:(NSString *)text
+{
+    if (![self _prepareAccessibilityCall])
+        return;
+
+    self.axBackingObject->insertText(text);
+}
+
+- (void)browserAccessibilityDeleteTextAtCursor:(NSInteger)numberOfCharacters
+{
+    if (![self _prepareAccessibilityCall] || numberOfCharacters <= 0)
+        return;
+
+    // Start the deletion range from the current selection.
+    NSRange rangeToDelete = [self browserAccessibilitySelectedTextRange];
+
+    // If this is a secure field, we will get a {0, 0} selected text range. But we're
+    // operating under the assumption that we always want to delete all the characters
+    // from a secure field, so the next lines assume we are at the end and deleting everything.
+    BOOL isSecureField = [self accessibilityTraits] & self._axSecureTextFieldTrait;
+    if (isSecureField)
+        rangeToDelete = NSMakeRange([self accessibilityValue].length, 0);
+
+    if (!rangeToDelete.length) {
+        NSUInteger charactersToDelete = std::min(rangeToDelete.location, (NSUInteger)numberOfCharacters);
+        rangeToDelete.length = charactersToDelete;
+        rangeToDelete.location -= charactersToDelete;
+    }
+    [self accessibilityReplaceRange:rangeToDelete withText:@""];
+
+    if (isSecureField) {
+        // Replacing the entire range (like we do unconditionally for secure fields) can result
+        // in the selected text range being set, which we don't want. Undo that here.
+        [self browserAccessibilitySetSelectedTextRange:NSMakeRange([self accessibilityValue].length, 0)];
+    }
 }
 
 - (NSString *)selectionRangeString


### PR DESCRIPTION
#### d75cb52708fcda86e090e6eef7141cb21df83bd7
<pre>
AX: Adopt text-related BrowserEngineKit APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=276789">https://bugs.webkit.org/show_bug.cgi?id=276789</a>
<a href="https://rdar.apple.com/132025063">rdar://132025063</a>

Reviewed by Chris Fleizach.

* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper browserAccessibilityValueInRange:]):
(-[WebAccessibilityObjectWrapper browserAccessibilityAttributedValueInRange:]):
(-[WebAccessibilityObjectWrapper browserAccessibilitySelectedTextRange]):
(-[WebAccessibilityObjectWrapper _accessibilitySelectedTextRange]):
(-[WebAccessibilityObjectWrapper browserAccessibilitySetSelectedTextRange:]):
(-[WebAccessibilityObjectWrapper _accessibilitySetSelectedTextRange:]):
(-[WebAccessibilityObjectWrapper browserAccessibilityInsertTextAtCursor:]):
(-[WebAccessibilityObjectWrapper browserAccessibilityDeleteTextAtCursor:]):

Canonical link: <a href="https://commits.webkit.org/281137@main">https://commits.webkit.org/281137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/692557366de41b9dc7b36b9f0dc6d8352bf30337

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9233 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47556 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6571 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50837 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28409 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8132 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8237 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54357 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64122 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54876 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54966 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13020 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2269 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33947 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35031 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->