### PR TITLE
Add indexInWindowForWebExtensionContext: to _WKWebExtensionTab.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
@@ -82,6 +82,15 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
 - (nullable id <_WKWebExtensionWindow>)windowForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
+ @abstract Called when the index of the tab in the window is needed.
+ @param context The context in which the web extension is running.
+ @return The index of the tab in the window, or `NSNotFound` if the tab is not currently in a window.
+ @discussion This method should be implemented for better performance. Defaults to the window's
+ `tabsForWebExtensionContext:` method to find the index if not implemented.
+ */
+- (NSUInteger)indexInWindowForWebExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
  @abstract Called when the parent tab for the tab is needed.
  @param context The context in which the web extension is running.
  @return The parent tab of the tab, if the tab was opened from another tab.

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -55,6 +55,7 @@ WebExtensionTab::WebExtensionTab(const WebExtensionContext& context, _WKWebExten
     : m_extensionContext(context)
     , m_delegate(delegate)
     , m_respondsToWindow([delegate respondsToSelector:@selector(windowForWebExtensionContext:)])
+    , m_respondsToIndex([delegate respondsToSelector:@selector(indexInWindowForWebExtensionContext:)])
     , m_respondsToParentTab([delegate respondsToSelector:@selector(parentTabForWebExtensionContext:)])
     , m_respondsToSetParentTab([delegate respondsToSelector:@selector(setParentTab:forWebExtensionContext:completionHandler:)])
     , m_respondsToMainWebView([delegate respondsToSelector:@selector(mainWebViewForWebExtensionContext:)])
@@ -276,14 +277,16 @@ RefPtr<WebExtensionWindow> WebExtensionTab::window() const
 
 size_t WebExtensionTab::index() const
 {
-    if (!isValid() || !m_respondsToWindow)
+    if (!isValid())
         return notFound;
+
+    if (m_respondsToIndex) {
+        auto index = [m_delegate indexInWindowForWebExtensionContext:m_extensionContext->wrapper()];
+        return index != NSNotFound ? index : notFound;
+    }
 
     RefPtr window = this->window();
-    if (!window)
-        return notFound;
-
-    return window->tabs().find(*this);
+    return window ? window->tabs().find(*this) : notFound;
 }
 
 RefPtr<WebExtensionTab> WebExtensionTab::parentTab() const

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -207,6 +207,7 @@ private:
     mutable bool m_private : 1 { false };
     mutable bool m_cachedPrivate : 1 { false };
     bool m_respondsToWindow : 1 { false };
+    bool m_respondsToIndex : 1 { false };
     bool m_respondsToParentTab : 1 { false };
     bool m_respondsToSetParentTab : 1 { false };
     bool m_respondsToMainWebView : 1 { false };

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -366,6 +366,11 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     return _window;
 }
 
+- (NSUInteger)indexInWindowForWebExtensionContext:(_WKWebExtensionContext *)context
+{
+    return _window ? [_window.tabs indexOfObject:self] : NSNotFound;
+}
+
 - (void)changeWebViewIfNeededForURL:(NSURL *)url forExtensionContext:(_WKWebExtensionContext *)context
 {
     BOOL usingPrivateBrowsing = _window.usingPrivateBrowsing;


### PR DESCRIPTION
#### 8c332e12731bb524cc6691613c29f703b65182ca
<pre>
Add indexInWindowForWebExtensionContext: to _WKWebExtensionTab.
<a href="https://webkit.org/b/276793">https://webkit.org/b/276793</a>
<a href="https://rdar.apple.com/problem/132029062">rdar://problem/132029062</a>

Reviewed by Brady Eidson.

Getting the tabs and converting them all to `WebExtensionTab` can be expensive
when the user has hundreds of tabs open in a window. Often the browser can quickly
answer what the index in the window is more efficiently. This adds a new optional
protocol method to `_WKWebExtensionTab` for getting the index in the window. If it
is not implement, fallback to asking the window for all tabs and finding the index
from that tabs Vector like before.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::WebExtensionTab): Cache responds to selector for new method.
(WebKit::WebExtensionTab::index const): Use new index method, fallback to tabs.
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionTab indexInWindowForWebExtensionContext:]): Added.

Canonical link: <a href="https://commits.webkit.org/281115@main">https://commits.webkit.org/281115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c3cf1b1bc229a3bb67430d6dbfe5b199a40f693

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62387 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9200 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47544 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6560 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60787 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28397 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8106 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8204 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54334 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64089 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54865 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54955 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2239 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8772 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33914 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34998 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36083 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34744 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->