### PR TITLE
SVGInlineTextBox: Adding DisplayList caching for glyphs

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -235,6 +235,13 @@ std::unique_ptr<DisplayList::DisplayList> FontCascade::displayListForTextRun(Gra
     if (glyphBuffer.isEmpty())
         return nullptr;
 
+#if PLATFORM(COCOA)
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=252347
+    // DisplayLists don't handle OTSVG glyphs correctly. From LayoutTests it seems to affect only Cocoa (rdar://105515478).
+    if (hasOTSVGGlyph(glyphBuffer))
+        return nullptr;
+#endif
+
     std::unique_ptr<DisplayList::DisplayList> displayList = makeUnique<DisplayList::DisplayList>();
     DisplayList::RecorderImpl recordingContext(*displayList, context.state().clone(GraphicsContextState::Purpose::Initial), { },
         context.getCTM(GraphicsContext::DefinitelyIncludeDeviceScale), context.colorSpace(),

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -247,6 +247,8 @@ private:
     static bool canReturnFallbackFontsForComplexText();
     static bool canExpandAroundIdeographsInComplexText();
 
+    bool hasOTSVGGlyph(const GlyphBuffer&) const;
+
     GlyphBuffer layoutComplexText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
     float widthForComplexText(const TextRun&, SingleThreadWeakHashSet<const Font>* fallbackFonts = nullptr, GlyphOverflow* = nullptr) const;
     int offsetForPositionForComplexText(const TextRun&, float position, bool includePartialGlyphs) const;

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -514,4 +514,13 @@ ResolvedEmojiPolicy FontCascade::resolveEmojiPolicy(FontVariantEmoji fontVariant
     }
 }
 
+bool FontCascade::hasOTSVGGlyph(const GlyphBuffer& glyphBuffer) const
+{
+    for (unsigned i = 0; i < glyphBuffer.size(); ++i) {
+        if (glyphBuffer.fontAt(i).findOTSVGGlyphs(glyphBuffer.glyphs(i), 1))
+            return true;
+    }
+    return false;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.h
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.h
@@ -22,9 +22,11 @@
 
 #pragma once
 
+#include "GlyphDisplayListCache.h"
 #include "LegacyInlineTextBox.h"
 #include "LegacyRenderSVGResource.h"
 #include "RenderSVGResourcePaintServer.h"
+// #include "SVGGlyphDisplayListCache.h"
 #include "SVGTextFragment.h"
 
 namespace WebCore {
@@ -83,10 +85,15 @@ private:
 
     void paintDecoration(GraphicsContext&, OptionSet<TextDecorationLine>, const SVGTextFragment&);
     void paintDecorationWithStyle(GraphicsContext&, OptionSet<TextDecorationLine>, const SVGTextFragment&, RenderBoxModelObject& decorationRenderer);
-    void paintTextWithShadows(GraphicsContext&, const RenderStyle&, TextRun&, const SVGTextFragment&, unsigned startPosition, unsigned endPosition);
-    void paintText(GraphicsContext&, const RenderStyle&, const RenderStyle& selectionStyle, const SVGTextFragment&, bool hasSelection, bool paintSelectedTextOnly);
+    void paintTextWithShadows(const PaintInfo&, GraphicsContext&, const RenderStyle&, TextRun&, const SVGTextFragment&, unsigned startPosition, unsigned endPosition);
+    void paintText(const PaintInfo&, GraphicsContext&, const RenderStyle&, const RenderStyle& selectionStyle, const SVGTextFragment&, bool hasSelection, bool paintSelectedTextOnly);
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, LayoutUnit lineTop, LayoutUnit lineBottom, HitTestAction) override;
+
+    static bool shouldUseGlyphDisplayList(const PaintInfo&);
+    void setGlyphDisplayListIfNeeded(const FontCascade&, GraphicsContext&, const PaintInfo&, const TextRun&);
+
+    void drawText(GraphicsContext&, const FontCascade&, const TextRun&, const FloatPoint& textOrigin, unsigned startOffset, unsigned endOffset);
 
 private:
     float m_logicalHeight { 0 };
@@ -96,6 +103,8 @@ private:
     SVGPaintServerOrColor m_paintServerOrColor { };
 
     Vector<SVGTextFragment> m_textFragments;
+
+    DisplayList::DisplayList* m_glyphDisplayList { nullptr };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 48d3dac410c95b388f3b5ead4dc8af70f7e4f58b
<pre>
SVGInlineTextBox: Adding DisplayList caching for glyphs
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::paint):
(WebCore::SVGInlineTextBox::paintTextWithShadows):
(WebCore::SVGInlineTextBox::paintText):
(WebCore::SVGInlineTextBox::shouldUseGlyphDisplayList):
(WebCore::SVGInlineTextBox::setGlyphDisplayListIfNeeded):
(WebCore::SVGInlineTextBox::drawText):
* Source/WebCore/rendering/svg/SVGInlineTextBox.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48d3dac410c95b388f3b5ead4dc8af70f7e4f58b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62447 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9259 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9459 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47579 "Found 25 new test failures: imported/blink/svg/text/obb-paintserver.html imported/blink/svg/text/selection-partial-gradient.html imported/mozilla/svg/dynamic-textPath-02.svg imported/mozilla/svg/text-gradient-01.svg imported/mozilla/svg/text-layout-08.svg imported/mozilla/svg/text-scale-02.svg imported/mozilla/svg/text/multiple-chunks-directions-and-anchor-multiple-dx.svg imported/mozilla/svg/text/multiple-chunks-multiple-dx-different-anchor.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-end.svg ... (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6593 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60846 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35689 "Found 20 new test failures: imported/mozilla/svg/text-layout-08.svg imported/mozilla/svg/text/multiple-chunks-directions-and-anchor-multiple-dx.svg imported/mozilla/svg/text/multiple-chunks-multiple-dx-different-anchor.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle-bidi.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle.svg imported/mozilla/svg/text/textpath-anchor-end.svg imported/mozilla/svg/text/textpath-anchor-middle.svg imported/mozilla/svg/text/textpath-multiline.svg ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28435 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32422 "Found 2 new test failures: imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html imported/w3c/web-platform-tests/websockets/basic-auth.any.html?wss (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8153 "Found 21 new test failures: imported/mozilla/svg/text-layout-08.svg imported/mozilla/svg/text/multiple-chunks-directions-and-anchor-multiple-dx.svg imported/mozilla/svg/text/multiple-chunks-multiple-dx-different-anchor.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle-bidi.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle.svg imported/mozilla/svg/text/textpath-anchor-end.svg imported/mozilla/svg/text/textpath-anchor-middle.svg imported/mozilla/svg/text/textpath-multiline.svg ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8263 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54377 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8433 "Found 22 new test failures: imported/mozilla/svg/text-layout-08.svg imported/mozilla/svg/text/multiple-chunks-directions-and-anchor-multiple-dx.svg imported/mozilla/svg/text/multiple-chunks-multiple-dx-different-anchor.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle-bidi.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle.svg imported/mozilla/svg/text/textpath-anchor-end.svg imported/mozilla/svg/text/textpath-anchor-middle.svg imported/mozilla/svg/text/textpath-multiline.svg ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64148 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2728 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8414 "Found 23 new test failures: fast/text/glyph-display-lists/glyph-display-list-svg-unshared.html imported/mozilla/svg/text-layout-08.svg imported/mozilla/svg/text/multiple-chunks-directions-and-anchor-multiple-dx.svg imported/mozilla/svg/text/multiple-chunks-multiple-dx-different-anchor.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle-bidi.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle.svg imported/mozilla/svg/text/textpath-anchor-end.svg imported/mozilla/svg/text/textpath-anchor-middle.svg ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54897 "Found 25 new test failures: imported/blink/svg/text/obb-paintserver.html imported/blink/svg/text/selection-partial-gradient.html imported/mozilla/svg/dynamic-textPath-02.svg imported/mozilla/svg/text-gradient-01.svg imported/mozilla/svg/text-layout-08.svg imported/mozilla/svg/text-scale-02.svg imported/mozilla/svg/text/multiple-chunks-directions-and-anchor-multiple-dx.svg imported/mozilla/svg/text/multiple-chunks-multiple-dx-different-anchor.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-end.svg ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54990 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2285 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33973 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35057 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36142 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34803 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->