### PR TITLE
[iOS] Expand Web process cache capacity on some devices

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -199,18 +199,18 @@ void WebProcessCache::updateCapacity(WebProcessPool& processPool)
     } else {
 #if PLATFORM(IOS_FAMILY)
         constexpr unsigned maxProcesses = 10;
-        size_t memorySize = WTF::ramSizeDisregardingJetsamLimit() / GB;
+        size_t memorySize = WTF::ramSizeDisregardingJetsamLimit();
 #else
         constexpr unsigned maxProcesses = 30;
-        size_t memorySize = WTF::ramSize() / GB;
+        size_t memorySize = WTF::ramSize();
 #endif
-        WEBPROCESSCACHE_RELEASE_LOG("memory size %zu GB", 0, memorySize);
-        if (memorySize < 3) {
+        WEBPROCESSCACHE_RELEASE_LOG("memory size %zu bytes", 0, memorySize);
+        if (memorySize < 2 * GB) {
             m_capacity = 0;
             WEBPROCESSCACHE_RELEASE_LOG("updateCapacity: Cache is disabled because device does not have enough RAM", 0);
         } else {
             // Allow 4 processes in the cache per GB of RAM, up to maxProcesses.
-            m_capacity = std::min<unsigned>(memorySize * 4, maxProcesses);
+            m_capacity = std::min<unsigned>(memorySize / (256 * MB), maxProcesses);
             WEBPROCESSCACHE_RELEASE_LOG("updateCapacity: Cache has a capacity of %u processes", 0, capacity());
         }
     }


### PR DESCRIPTION
#### 065317811b09165c62483eb7f1a95e748cf3a4c5
<pre>
[iOS] Expand Web process cache capacity on some devices
<a href="https://bugs.webkit.org/show_bug.cgi?id=276797">https://bugs.webkit.org/show_bug.cgi?id=276797</a>
<a href="https://rdar.apple.com/132513081">rdar://132513081</a>

Reviewed by Chris Dumez.

Expand Web process cache capacity on some iOS devices. Devices are not normally reporting memory capacity in GB multiples. This patch
is using a more fine grained computation of the cache size, instead of basing it on GB multiples. This will effectively enable the Web
process cache for some devices. We still have the upper limit of 10 Web processes in the cache on iOS, so the cache will never be
bigger than that. On memory pressure, we still shut down the processes in the Web process cache. I have been validating this change on
a device affected by this patch, and so far the testing looks good.

* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::updateCapacity):

Canonical link: <a href="https://commits.webkit.org/281675@main">https://commits.webkit.org/281675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0315dc23d8effbfc0ee4269fd659b98af1192a38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64452 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11068 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48964 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7694 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29796 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33839 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55711 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66182 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56331 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56502 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3703 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9116 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35688 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36770 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37861 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->