### PR TITLE
[Flex] Try to use cached logical height for flex item's hypothetical cross size.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/percent-height-flex-items-cross-sizes-with-mutations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/percent-height-flex-items-cross-sizes-with-mutations-expected.txt
@@ -1,0 +1,35 @@
+a a a a
+a
+a a a a
+a
+a a a
+a a
+a a a
+a a a
+a
+a a a
+a a a
+a a a
+
+PASS percent-height-flex-items-cross-sizes-with-mutations
+PASS percent-height-flex-items-cross-sizes-with-mutations 1
+PASS percent-height-flex-items-cross-sizes-with-mutations 2
+PASS percent-height-flex-items-cross-sizes-with-mutations 3
+PASS percent-height-flex-items-cross-sizes-with-mutations 4
+PASS percent-height-flex-items-cross-sizes-with-mutations 5
+PASS percent-height-flex-items-cross-sizes-with-mutations 6
+PASS percent-height-flex-items-cross-sizes-with-mutations 7
+PASS percent-height-flex-items-cross-sizes-with-mutations 8
+PASS percent-height-flex-items-cross-sizes-with-mutations 9
+PASS percent-height-flex-items-cross-sizes-with-mutations 10
+PASS percent-height-flex-items-cross-sizes-with-mutations 11
+PASS percent-height-flex-items-cross-sizes-with-mutations 12
+PASS percent-height-flex-items-cross-sizes-with-mutations 13
+PASS percent-height-flex-items-cross-sizes-with-mutations 14
+PASS percent-height-flex-items-cross-sizes-with-mutations 15
+PASS percent-height-flex-items-cross-sizes-with-mutations 16
+PASS percent-height-flex-items-cross-sizes-with-mutations 17
+PASS percent-height-flex-items-cross-sizes-with-mutations 18
+PASS percent-height-flex-items-cross-sizes-with-mutations 19
+PASS percent-height-flex-items-cross-sizes-with-mutations 20
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/percent-height-flex-items-cross-sizes-with-mutations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/percent-height-flex-items-cross-sizes-with-mutations.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="Tests that the cross size of flexboxes and flex items with % height are computed correctly with various mutations."
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#layout-algorithm">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+.flexbox {
+  display: flex;
+  font: 10px Ahem;
+  outline: 1px solid black;
+}
+.grid {
+  display: grid;
+  outline: 1px solid magenta;
+}
+.flexbox > div {
+  width: min-content;
+  outline: 1px solid blue;
+}
+.percent-height {
+  min-height: 100%;
+}
+.fixed-height {
+  height: 100px;
+}
+.align-start {
+  align-items: start;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+function mutateContent() {
+  document.querySelectorAll("#one, #two, #three").forEach((element) => {
+    element.innerHTML += " a";
+  });
+
+  document.querySelector("#four").style.width = "auto";
+  document.querySelector("#five").style.height = "auto";
+  document.querySelector("#six").style.height = "100px";
+
+  document.querySelectorAll("#seven, #eight").forEach((element) => {
+    element.style.alignItems = "start";
+  });
+}
+</script>
+</head>
+<body>
+
+<!-- Non-percent height flex item is mutated and percent height flex item should be 
+     stretched up. -->
+<div class="flexbox test" data-expected-height="40">
+  <div id="one" class="test" data-expected-height="40">a a a</div>
+  <div class="percent-height test" data-expected-height="40">a</div>
+</div>
+
+<!-- Non-percent height flex item content is mutated and should be stretched to percent 
+     height flex item's size. -->
+<div class="flexbox test" data-expected-height="40">
+  <div id="two" class="min-content percent-height test" data-expected-height="40">a a a</div>
+  <div class="test" data-expected-height="40">a</div>
+</div>
+
+<!-- Percent height flex item content is mutated and increased flexbox's cross axis size. -->
+<div class="flexbox test" data-expected-height="30">
+  <div class="min-content percent-height test" data-expected-height="30">a a a</div>
+  <div id="three" data-expected-height="30">a</div>
+</div>
+
+<!-- Percent height flex item's main axis size changes from min-content to auto which 
+     should result in different cross size. -->
+<div class="flexbox test" data-expected-height="10">
+  <div class="min-content percent-height test" id="four" data-expected-height="10">a a a</div>
+</div>
+
+<!-- Flexbox with align-items: flex-start changes from definite to indefinite cross size 
+     which results in different hypothetical cross size for flex item.-->
+<div class="flexbox fixed-height align-start test" id="five" data-expected-height="30">
+  <div class="min-content percent-height test" data-expected-height="30">a a a</div>
+  <div class="test" data-expected-height="10">a</div>
+</div>
+
+
+<!-- Flexbox with align-items: flex-start changes from indefinite to definite cross size 
+     which results in different hypothetical cross size for the flex item. -->
+<div class="flexbox align-start test" id="six" data-expected-height="100">
+  <div class="min-content percent-height test" data-expected-height="100">a a a</div>
+</div>
+
+<!-- Outer flexbox goes from stretching its content to no longer stretching with a
+     definite cross size. The inner flexbox is no longer stretching which affects the
+     hypothetical cross axis size of its flex item. -->
+<div class="flexbox fixed-height test" id="seven" data-expected-height="100"">
+  <div class="flexbox align-start test" data-expected-height="30">
+    <div class="min-content percent-height test" data-expected-height="30">a a a</div>
+  </div>
+</div>
+
+<!-- Grid goes from stretching its content to no longer stretching with a definite cross
+     size. The flexbox is no longer stretching which affects the hypothetical cross axis
+     size of tis flex item.-->
+<div class="grid fixed-height test" id="eight" data-expected-height="100">
+  <div class="flexbox align-start test" data-expected-height="30">
+    <div class="min-content percent-height test" data-expected-height="30">a a a</div>
+  </div>
+</div>
+
+</body>
+<script>
+document.body.offsetHeight;
+mutateContent();
+document.body.offsetHeight;
+
+let tests = document.querySelectorAll(".test");
+tests.forEach((element) => {
+  test(function() {
+    let expectedHeight = element.getAttribute("data-expected-height");
+    assert_equals(element.offsetHeight, Number(expectedHeight), "height");
+  });
+});
+</script>
+</html>
+

--- a/PerformanceTests/Layout/flexbox-percent-height-cross-size-caching.html
+++ b/PerformanceTests/Layout/flexbox-percent-height-cross-size-caching.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<script src="../resources/runner.js"></script>
+<div style="display: flex;">
+  <div style="display: flex; flex-direction: column; height: 100%; visibility: hidden" id="column"></div>
+  <div id="second"></div>
+</div>
+<script>
+for (var i = 0; i < 5000; i++)
+    document.querySelector("#column").innerHTML += "<div>a</div>";
+document.body.offsetHeight;
+
+var index = 0;
+
+PerfTestRunner.measureRunsPerSecond({run: function() {
+  document.querySelector("#second").style.width = ++index % 2 ? "1px" : "2px";
+  document.body.offsetHeight;
+}, done: function() {
+  document.querySelector("#column").style.display = "none";
+}});
+</script>
+</html>
+

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -52,6 +52,8 @@ public:
 
     using Direction = FlowDirection;
 
+    enum class Damage : uint8_t { NoLongerStretching = 1 << 0 };
+
     ASCIILiteral renderName() const override;
 
     bool canDropAnonymousBlockChild() const final { return false; }
@@ -106,6 +108,7 @@ public:
     LayoutUnit cachedFlexItemIntrinsicContentLogicalHeight(const RenderBox& flexItem) const;
     void setCachedFlexItemIntrinsicContentLogicalHeight(const RenderBox& flexItem, LayoutUnit);
     void clearCachedFlexItemIntrinsicContentLogicalHeight(const RenderBox& flexItem);
+    void removePercentLogicalHeightFlexItemsFromIntrinsicLogicalHeightCache();
 
     LayoutUnit staticMainAxisPositionForPositionedFlexItem(const RenderBox&);
     LayoutUnit staticCrossAxisPositionForPositionedFlexItem(const RenderBox&);
@@ -125,6 +128,9 @@ public:
     bool isComputingFlexBaseSizes() const { return m_isComputingFlexBaseSizes; }
 
     static std::optional<TextDirection> leftRightAxisDirectionFromStyle(const RenderStyle&);
+
+    void clearNeedsLayout();
+    void setNoLongerStretching();
 
     bool hasModernLayout() const { return m_hasFlexFormattingContextLayout && *m_hasFlexFormattingContextLayout; }
 
@@ -307,6 +313,8 @@ private:
     bool m_shouldResetFlexItemLogicalHeightBeforeLayout { false };
     bool m_isComputingFlexBaseSizes { false };
     std::optional<bool> m_hasFlexFormattingContextLayout;
+
+    OptionSet<Damage> m_flexLayoutDamage;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -35,6 +35,7 @@
 #include "LayoutRepainter.h"
 #include "RenderChildIterator.h"
 #include "RenderElementInlines.h"
+#include "RenderFlexibleBox.h"
 #include "RenderLayer.h"
 #include "RenderLayoutState.h"
 #include "RenderTreeBuilder.h"
@@ -110,11 +111,13 @@ void RenderGrid::styleDidChange(StyleDifference diff, const RenderStyle* oldStyl
         for (auto& gridItem : childrenOfType<RenderBox>(*this)) {
             if (gridItem.isOutOfFlowPositioned())
                 continue;
-            if (selfAlignmentChangedToStretch(GridAxis::GridRowAxis, *oldStyle, newStyle, gridItem)
-                || selfAlignmentChangedFromStretch(GridAxis::GridRowAxis, *oldStyle, newStyle, gridItem)
-                || selfAlignmentChangedToStretch(GridAxis::GridColumnAxis, *oldStyle, newStyle, gridItem)
-                || selfAlignmentChangedFromStretch(GridAxis::GridColumnAxis, *oldStyle, newStyle, gridItem)) {
+            if (selfAlignmentChangedToStretch(GridAxis::GridRowAxis, *oldStyle, newStyle, gridItem) || selfAlignmentChangedToStretch(GridAxis::GridColumnAxis, *oldStyle, newStyle, gridItem))
                 gridItem.setNeedsLayout();
+
+            if (selfAlignmentChangedFromStretch(GridAxis::GridRowAxis, *oldStyle, newStyle, gridItem) || selfAlignmentChangedFromStretch(GridAxis::GridColumnAxis, *oldStyle, newStyle, gridItem)) {
+                gridItem.setNeedsLayout();
+                if (auto* renderFleixbleBox = dynamicDowncast<RenderFlexibleBox>(gridItem))
+                    renderFleixbleBox->setNoLongerStretching();
             }
         }
     }


### PR DESCRIPTION
#### 8e50dd5daa89220c06096dc5961f86e225c165f7
<pre>
[Flex] Try to use cached logical height for flex item&apos;s hypothetical cross size.
<a href="https://rdar.apple.com/132034177">rdar://132034177</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=276796">https://bugs.webkit.org/show_bug.cgi?id=276796</a>

Reviewed by Alan Baradlay.

Currently, in RenderFlexibleBox::layoutAndPlaceFlexItems, we currently
call setNeedsLayout on a flex item if it has a relative logical height
(e.g. % min-height). In some cases, this can result in us doing some extra
work on subsequent layouts when we may not need to. Consider the
following piece of content:

&lt;div style=&quot;display: flex;&quot;&gt;
  &lt;some-potentially-expensive-flex-item style=&quot;height: 100%;&quot;&gt;&lt;/some-potentially-expensive-flex-item&gt;
  &lt;div&gt;foobar&lt;/div&gt;
&lt;/div&gt;

In this example, when we run flex layout, we do the following for each of
the flex items:

1.) Compute the main axis size
2.) Compute the hypothetical cross size
3.) Perform stretch alignment

For this type of content, we need to call layout() on each of the flex
items during both 2 and 3, and we should also note that calling layout on
&lt;some-potentially-expensive-flex-item&gt; may be &quot;expensive,&quot; for a variety
of reasons. On a subsequent layout, for example, if we change the content
inside the &lt;div&gt;, we end up calling setNeedsLayout() on the first flex
item due to its % logical height and perform layout on it in order to
compute its hypothetical cross axis size again. During this process, we
unfortunately end up losing the item&apos;s stretched size and so must
stretch it again, which requires calling layout() on it one final time.

This patch attempts to mitigate this less than ideal behavior by
attempting to reuse a previously stored hypothetical cross axis size on
a subsequent layout. Rather than invalidating the flex item and
attempting to recompute it due to the % logical height, we can use the
previous value because the flexbox itself has an indefinite logical
height. This causes the flex items&apos; % logical height to behave as auto,
and the resulting size will be based just off of its content.

RenderFlexibleBox already seems to cache the logical heights for its
flex items within a map called m_intrinsicContentLogicalHeights. This
cache is populated when a renderer goes through layout as one of its
first steps inside of updateLogicalHeight(). Inside of
RenderFlexibleBox::layoutAndPlaceItems: we will try not to invalidate the
flex item if the following are true for flex items with a relative
logical height:

1.) The main axis direction is the same as the flex item&apos;s inline direction
2.) The flexbox has an indefinite logical height
3.) We have a previously cached value for the cross size

Note that if the flex item&apos;s content may have been mutated, we will still
call layout on it due to the mutation, but during layout, we will end up
updating the cached value.

When the flexbox code needs the cross size of the flex item, for example,
to determine the size of the line, it will use
crossAxisIntrinsicExtentForFlexItem, which checks to see if it has a
cached cross size to use.

In order to use this cached size correctly we also needed to add some
extra invalidation when certain types of mutations occur. In this patch
we started removing percent logical height items from the cache in two
scenarios:

1.) When the computed logical height of the flexbox changes
2.) When a flexbox goes from being stretched to no longer stretching in
cases where itself participates in a flex or grid formatting context.

In order to accomplish 2 we allow RenderFlexibleBox to keep track of a
new bit that represents this type of damage. This bit will be set by
callers, in this case RenderFlexibleBox and RenderGrid, to inform the
flexbox that it is no longer being stretched. During flex layout it will
check to see if this bit is set and prune from the cache if it is.

On my M4 Max the included performance test went from ~590 runs/s to ~87K
runs/s.

I also included a new testcase which attempts to exercise this logic to
make sure we are computing the correct sizes and invalidating the cache
properly. This testcase includes a variety of subtests in which the
content is mutated in different ways.

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/percent-height-flex-items-cross-sizes-with-mutations-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/percent-height-flex-items-cross-sizes-with-mutations.html: Added.
* PerformanceTests/Layout/flexbox-percent-height-cross-size-caching.html: Added.
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::styleDidChange):
(WebCore::RenderFlexibleBox::layoutBlock):
(WebCore::RenderFlexibleBox::removePercentLogicalHeightFlexItemsFromIntrinsicLogicalHeightCache):
(WebCore::RenderFlexibleBox::layoutAndPlaceFlexItems):
(WebCore::RenderFlexibleBox::clearNeedsLayout):
(WebCore::RenderFlexibleBox::setNoLongerStretching):
(WebCore::updateFlexItemDirtyBitsBeforeLayout): Deleted.
* Source/WebCore/rendering/RenderFlexibleBox.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::styleDidChange):

Canonical link: <a href="https://commits.webkit.org/292314@main">https://commits.webkit.org/292314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5ae2d2e503e53fddf181ac811757b03b3809aa2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72668 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29941 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98299 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11409 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53063 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11053 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3759 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45136 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102378 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81666 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81066 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20370 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25637 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3036 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15597 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27450 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21973 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25447 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23712 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->