### PR TITLE
[Grid][Cleanup] Factor out some logic used in intrinsic track sizing to standalone functions

### DIFF
--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -219,6 +219,9 @@ private:
     void computeFlexSizedTracksGrowth(double flexFraction, Vector<LayoutUnit>& increments, LayoutUnit& totalGrowth) const;
     double findFrUnitSize(const GridSpan& tracksSpan, LayoutUnit leftOverSpace) const;
 
+
+    void computeIndefiniteItemsForMasonry(MasonryIndefiniteItems&) const;
+    bool shouldExcludeGridItemForMasonryTrackSizing(const RenderBox& gridItem, unsigned trackIndex, GridSpan itemSpan) const;
     // Track sizing algorithm steps. Note that the "Maximize Tracks" step is done
     // entirely inside the strategies, that's why we don't need an additional
     // method at this level.


### PR DESCRIPTION
#### 8ffc3352b0699dc3457f2cff6b0154879c48247f
<pre>
[Grid][Cleanup] Factor out some logic used in intrinsic track sizing to standalone functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=276798">https://bugs.webkit.org/show_bug.cgi?id=276798</a>
<a href="https://rdar.apple.com/132040421">rdar://132040421</a>

Reviewed by Ryan Reno.

This is an initial patch aimed to help slightly improve the readability
of the intrinsic track sizing logic by first moving some logic into
their own standalone functions. I think we can continue to improve the
code in this area but this is just a first step.

1.) Change extraMarginFromSubgridAncestorGutters in
accumulateIntrinsicSizesForTrack from being a lambda to a static function.

2.) Move the logic in accumulateIntrinsicSizesForTrack that determines
whether we should consider an item for sizing in this track for masonry
to shouldExcludeGridItemForMasonryTrackSizing

3.) Change the computeIndefiniteItems lambda in resolveIntrinsicTrackSizes
to a standalone method and renamed it to computeIndefiniteItemsForMasonry
to help distinguish it is for masonry layout.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::extraMarginFromSubgridAncestorGutters):
(WebCore::GridTrackSizingAlgorithm::shouldExcludeGridItemForMasonryTrackSizing const):
(WebCore::GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack):
(WebCore::GridTrackSizingAlgorithm::computeIndefiniteItemsForMasonry const):
(WebCore::GridTrackSizingAlgorithm::resolveIntrinsicTrackSizes):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:

Canonical link: <a href="https://commits.webkit.org/281141@main">https://commits.webkit.org/281141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bcd3ea4245631cb4ca4476db1c03ce1e2db05b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9238 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47557 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6576 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28412 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32406 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8131 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8242 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64127 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8400 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54879 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2716 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54988 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13033 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2262 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33952 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35036 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34782 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->