### PR TITLE
Make RemoteLayerBackingStore::m_layer a reference

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -85,10 +85,10 @@ class RemoteLayerBackingStore : public CanMakeWeakPtr<RemoteLayerBackingStore> {
     WTF_MAKE_NONCOPYABLE(RemoteLayerBackingStore);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    RemoteLayerBackingStore(PlatformCALayerRemote*);
+    RemoteLayerBackingStore(PlatformCALayerRemote&);
     virtual ~RemoteLayerBackingStore();
 
-    static std::unique_ptr<RemoteLayerBackingStore> createForLayer(PlatformCALayerRemote*);
+    static std::unique_ptr<RemoteLayerBackingStore> createForLayer(PlatformCALayerRemote&);
 
     enum class Type : bool {
         IOSurface,
@@ -104,7 +104,7 @@ public:
 
     enum class ProcessModel : uint8_t { InProcess, Remote };
     virtual ProcessModel processModel() const = 0;
-    static ProcessModel processModelForLayer(PlatformCALayerRemote*);
+    static ProcessModel processModelForLayer(PlatformCALayerRemote&);
 
     struct Parameters {
         Type type { Type::Bitmap };
@@ -152,7 +152,7 @@ public:
     bool supportsPartialRepaint() const;
     bool drawingRequiresClearedPixels() const;
 
-    PlatformCALayerRemote* layer() const { return m_layer; }
+    PlatformCALayerRemote& layer() const { return m_layer; }
 
     void encode(IPC::Encoder&) const;
 
@@ -199,7 +199,7 @@ protected:
 
     WebCore::IntRect layerBounds() const;
 
-    PlatformCALayerRemote* m_layer;
+    PlatformCALayerRemote& m_layer;
 
     Parameters m_parameters;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -64,8 +64,8 @@ void RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay(RemoteLay
     auto& remoteRenderingBackend = layerTreeContext().ensureRemoteRenderingBackendProxy();
 
     for (auto& backingStore : m_backingStoresNeedingDisplay) {
-        backingStore.layer()->properties().notePropertiesChanged(LayerChange::BackingStoreChanged);
-        transaction.layerPropertiesChanged(*backingStore.layer());
+        backingStore.layer().properties().notePropertiesChanged(LayerChange::BackingStoreChanged);
+        transaction.layerPropertiesChanged(backingStore.layer());
 
         if (auto* remoteBackingStore = dynamicDowncast<RemoteLayerWithRemoteRenderingBackingStore>(&backingStore)) {
             if (remoteBackingStore->performDelegatedLayerDisplay())
@@ -134,7 +134,7 @@ void RemoteLayerBackingStoreCollection::willCommitLayerTree(RemoteLayerTreeTrans
     Vector<WebCore::PlatformLayerIdentifier> newlyUnreachableLayerIDs;
     for (auto& backingStore : m_liveBackingStore) {
         if (!m_reachableBackingStoreInLatestFlush.contains(backingStore))
-            newlyUnreachableLayerIDs.append(backingStore.layer()->layerID());
+            newlyUnreachableLayerIDs.append(backingStore.layer().layerID());
     }
 
     transaction.setLayerIDsWithNewlyUnreachableBackingStore(newlyUnreachableLayerIDs);
@@ -300,8 +300,6 @@ bool RemoteLayerBackingStoreCollection::markInProcessBackingStoreVolatile(Remote
 
 void RemoteLayerBackingStoreCollection::backingStoreBecameUnreachable(RemoteLayerBackingStore& backingStore)
 {
-    ASSERT(backingStore.layer());
-
     auto backingStoreIter = m_liveBackingStore.find(backingStore);
     if (backingStoreIter == m_liveBackingStore.end())
         return;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -103,7 +103,7 @@ DynamicContentScalingResourceCache RemoteLayerWithInProcessRenderingBackingStore
 void RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContents()
 {
     if (!m_frontBuffer.imageBuffer) {
-        ASSERT(m_layer->owner()->platformCALayerDelegatesDisplay(m_layer));
+        ASSERT(m_layer.owner()->platformCALayerDelegatesDisplay(&m_layer));
         return;
     }
 
@@ -194,7 +194,7 @@ SwapBuffersDisplayRequirement RemoteLayerWithInProcessRenderingBackingStore::pre
     if (!hasFrontBuffer() || result == SetNonVolatileResult::Empty)
         displayRequirement = SwapBuffersDisplayRequirement::NeedsFullDisplay;
 
-    LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer->layerID() << " prepareBuffers() - " << displayRequirement);
+    LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer.layerID() << " prepareBuffers() - " << displayRequirement);
     return displayRequirement;
 }
 
@@ -262,7 +262,7 @@ static RefPtr<ImageBuffer> allocateBufferInternal(RemoteLayerBackingStore::Type 
 
 RefPtr<WebCore::ImageBuffer> RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer()
 {
-    auto purpose = m_layer->containsBitmapOnly() ? WebCore::RenderingPurpose::BitmapOnlyLayerBacking : WebCore::RenderingPurpose::LayerBacking;
+    auto purpose = m_layer.containsBitmapOnly() ? WebCore::RenderingPurpose::BitmapOnlyLayerBacking : WebCore::RenderingPurpose::LayerBacking;
     ImageBufferCreationContext creationContext;
     creationContext.surfacePool = &WebCore::IOSurfacePool::sharedPool();
 
@@ -295,7 +295,7 @@ void RemoteLayerWithInProcessRenderingBackingStore::prepareToDisplay()
         return;
     }
 
-    LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer->layerID() << " prepareToDisplay()");
+    LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStore " << m_layer.layerID() << " prepareToDisplay()");
 
     if (performDelegatedLayerDisplay())
         return;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
@@ -43,7 +43,7 @@ class RemoteImageBufferSetProxy;
 
 class RemoteLayerWithRemoteRenderingBackingStore : public RemoteLayerBackingStore {
 public:
-    RemoteLayerWithRemoteRenderingBackingStore(PlatformCALayerRemote*);
+    RemoteLayerWithRemoteRenderingBackingStore(PlatformCALayerRemote&);
     ~RemoteLayerWithRemoteRenderingBackingStore();
 
     bool isRemoteLayerWithRemoteRenderingBackingStore() const final { return true; }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -38,7 +38,7 @@ namespace WebKit {
 
 using namespace WebCore;
 
-RemoteLayerWithRemoteRenderingBackingStore::RemoteLayerWithRemoteRenderingBackingStore(PlatformCALayerRemote* layer)
+RemoteLayerWithRemoteRenderingBackingStore::RemoteLayerWithRemoteRenderingBackingStore(PlatformCALayerRemote& layer)
     : RemoteLayerBackingStore(layer)
 {
     auto* collection = backingStoreCollection();
@@ -109,7 +109,7 @@ void RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore(const Parame
     m_parameters = parameters;
     clearBackingStore();
     if (m_bufferSet)
-        m_bufferSet->setConfiguration(size(), scale(), colorSpace(), pixelFormat(), type() == RemoteLayerBackingStore::Type::IOSurface ? RenderingMode::Accelerated : RenderingMode::Unaccelerated, m_layer->containsBitmapOnly() ? WebCore::RenderingPurpose::BitmapOnlyLayerBacking : WebCore::RenderingPurpose::LayerBacking);
+        m_bufferSet->setConfiguration(size(), scale(), colorSpace(), pixelFormat(), type() == RemoteLayerBackingStore::Type::IOSurface ? RenderingMode::Accelerated : RenderingMode::Unaccelerated, m_layer.containsBitmapOnly() ? WebCore::RenderingPurpose::BitmapOnlyLayerBacking : WebCore::RenderingPurpose::LayerBacking);
 }
 
 void RemoteLayerWithRemoteRenderingBackingStore::encodeBufferAndBackendInfos(IPC::Encoder& encoder) const

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -273,14 +273,14 @@ void PlatformCALayerRemote::ensureBackingStore()
             return true;
 
         // A layer pulled out of a pool may have existing backing store which we mustn't reuse if it lives in the wrong process.
-        if (m_properties.backingStoreOrProperties.store->processModel() != RemoteLayerBackingStore::processModelForLayer(this))
+        if (m_properties.backingStoreOrProperties.store->processModel() != RemoteLayerBackingStore::processModelForLayer(*this))
             return true;
 
         return false;
     }();
 
     if (needsNewBackingStore)
-        m_properties.backingStoreOrProperties.store = RemoteLayerBackingStore::createForLayer(this);
+        m_properties.backingStoreOrProperties.store = RemoteLayerBackingStore::createForLayer(*this);
 
     updateBackingStore();
 }


### PR DESCRIPTION
#### ec7b70f81292aa1f739bc9adf1af7f0954c89003
<pre>
Make RemoteLayerBackingStore::m_layer a reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=276354">https://bugs.webkit.org/show_bug.cgi?id=276354</a>
<a href="https://rdar.apple.com/problem/131391538">rdar://problem/131391538</a>

Reviewed by Simon Fraser.

m_layer is never null, this removes the cognitive load
of wondering whether it could be. Some pointer checks
were then removed.

Related functions were also changed to accept or
return references instead of pointers.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
(WebKit::RemoteLayerBackingStore::layer const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::createForLayer):
(WebKit::RemoteLayerBackingStore::RemoteLayerBackingStore):
(WebKit::RemoteLayerBackingStore::~RemoteLayerBackingStore):
(WebKit::RemoteLayerBackingStore::backingStoreCollection const):
(WebKit::RemoteLayerBackingStore::processModelForLayer):
(WebKit::RemoteLayerBackingStore::encode const):
(WebKit::RemoteLayerBackingStore::drawingRequiresClearedPixels const):
(WebKit::RemoteLayerBackingStore::needsDisplay const):
(WebKit::RemoteLayerBackingStore::performDelegatedLayerDisplay):
(WebKit::RemoteLayerBackingStore::dirtyRepaintCounterIfNecessary):
(WebKit::RemoteLayerBackingStore::paintContents):
(WebKit::RemoteLayerBackingStore::drawInContext):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay):
(WebKit::RemoteLayerBackingStoreCollection::willCommitLayerTree):
(WebKit::RemoteLayerBackingStoreCollection::backingStoreBecameUnreachable):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContents):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::prepareBuffers):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::prepareToDisplay):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::RemoteLayerWithRemoteRenderingBackingStore):
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::ensureBackingStore):

Canonical link: <a href="https://commits.webkit.org/281170@main">https://commits.webkit.org/281170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9466e1d2511f6f8683866bd9a1af2e16ec70ffc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62609 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9419 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47683 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6708 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61006 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35834 "Found 1 new test failure: http/wpt/service-workers/fetch-service-worker-preload-cache.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28542 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32559 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8423 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54508 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64308 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2888 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55006 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55109 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13059 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2423 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34133 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35217 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36302 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34963 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->