### PR TITLE
[WPE] Add explicit fence support for wayland

### DIFF
--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -332,8 +332,11 @@ struct WebPageCreationParameters {
     SandboxExtension::Handle machBootstrapHandle;
 #endif
 
-#if (PLATFORM(GTK) || PLATFORM(WPE)) && USE(GBM)
+#if PLATFORM(GTK) || PLATFORM(WPE)
+#if USE(GBM)
     Vector<DMABufRendererBufferFormat> preferredBufferFormats;
+#endif
+    bool useExplicitSync { false };
 #endif
 
 #if PLATFORM(VISION) && ENABLE(GAMEPAD)

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -256,8 +256,11 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     WebKit::SandboxExtensionHandle machBootstrapHandle;
 #endif
 
-#if (PLATFORM(GTK) || PLATFORM(WPE)) && USE(GBM)
+#if PLATFORM(GTK) || PLATFORM(WPE)
+#if USE(GBM)
     Vector<WebKit::DMABufRendererBufferFormat> preferredBufferFormats;
+#endif
+    bool useExplicitSync;
 #endif
 
 #if PLATFORM(VISION) && ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10613,6 +10613,11 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.preferredBufferFormats = preferredBufferFormats();
 #endif
 #endif
+
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    parameters.useExplicitSync = useExplicitSync();
+#endif
+
     return parameters;
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2730,6 +2730,7 @@ private:
 #if PLATFORM(GTK) || PLATFORM(WPE)
     void bindAccessibilityTree(const String&);
     OptionSet<WebCore::PlatformEventModifier> currentStateOfModifierKeys();
+    bool useExplicitSync() const;
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in
+++ b/Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in
@@ -24,5 +24,5 @@ messages -> AcceleratedBackingStoreDMABuf NotRefCounted {
     DidCreateBuffer(uint64_t id, WebCore::IntSize size, uint32_t format, Vector<UnixFileDescriptor> fds, Vector<uint32_t> offsets, Vector<uint32_t> strides, uint64_t modifier, WebKit::DMABufRendererBufferFormat::Usage usage)
     DidCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle handle)
     DidDestroyBuffer(uint64_t id)
-    Frame(uint64_t id, WebCore::Region damage)
+    Frame(uint64_t id, WebCore::Region damage, UnixFileDescriptor syncFD)
 }

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -548,7 +548,7 @@ void AcceleratedBackingStoreDMABuf::didDestroyBuffer(uint64_t id)
     m_buffers.remove(id);
 }
 
-void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID, WebCore::Region&& damageRegion)
+void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID, WebCore::Region&& damageRegion, WTF::UnixFileDescriptor&&)
 {
     ASSERT(!m_pendingBuffer);
     auto* buffer = m_buffers.get(bufferID);
@@ -631,7 +631,8 @@ bool AcceleratedBackingStoreDMABuf::prepareForRendering()
         m_pendingDamageRegion = { };
 
         if (m_committedBuffer)
-            m_webPage.legacyMainFrameProcess().send(Messages::AcceleratedSurfaceDMABuf::ReleaseBuffer(m_committedBuffer->id()), m_surfaceID);
+            m_webPage.legacyMainFrameProcess().send(Messages::AcceleratedSurfaceDMABuf::ReleaseBuffer(m_committedBuffer->id(), { }), m_surfaceID);
+
         m_committedBuffer = WTFMove(m_pendingBuffer);
     }
 

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -80,7 +80,7 @@ private:
     void didCreateBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage);
     void didCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle&&);
     void didDestroyBuffer(uint64_t id);
-    void frame(uint64_t id, WebCore::Region&&);
+    void frame(uint64_t id, WebCore::Region&&, WTF::UnixFileDescriptor&&);
     void frameDone();
     void ensureGLContext();
     bool prepareForRendering();

--- a/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
@@ -151,4 +151,10 @@ void WebPageProxy::callAfterNextPresentationUpdate(CompletionHandler<void()>&& c
     webkitWebViewBaseCallAfterNextPresentationUpdate(WEBKIT_WEB_VIEW_BASE(viewWidget()), WTFMove(callback));
 }
 
+bool WebPageProxy::useExplicitSync() const
+{
+    // FIXME: implement explicit sync.
+    return false;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
@@ -68,7 +68,7 @@ private:
     void didCreateBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage);
     void didCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle&&);
     void didDestroyBuffer(uint64_t id);
-    void frame(uint64_t bufferID, WebCore::Region&&);
+    void frame(uint64_t bufferID, WebCore::Region&&, WTF::UnixFileDescriptor&&);
     void frameDone();
     void bufferRendered();
     void bufferReleased(WPEBuffer*);

--- a/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
@@ -192,6 +192,15 @@ OptionSet<WebCore::PlatformEvent::Modifier> WebPageProxy::currentStateOfModifier
 #endif
 }
 
+bool WebPageProxy::useExplicitSync() const
+{
+#if ENABLE(WPE_PLATFORM)
+    if (auto* view = wpeView())
+        return wpe_display_use_explicit_sync(wpe_view_get_display(view));
+#endif
+    return false;
+}
+
 void WebPageProxy::callAfterNextPresentationUpdate(CompletionHandler<void()>&& callback)
 {
     if (!hasRunningProcess() || !m_drawingArea) {

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.h
@@ -57,6 +57,14 @@ WPE_API guint32          wpe_buffer_dma_buf_get_offset   (WPEBufferDMABuf *buffe
 WPE_API guint32          wpe_buffer_dma_buf_get_stride   (WPEBufferDMABuf *buffer,
                                                           guint32          plane);
 WPE_API guint64          wpe_buffer_dma_buf_get_modifier (WPEBufferDMABuf *buffer);
+WPE_API void             wpe_buffer_dma_buf_set_rendering_fence  (WPEBufferDMABuf *buffer,
+                                                                  int              fd);
+WPE_API int              wpe_buffer_dma_buf_get_rendering_fence  (WPEBufferDMABuf *buffer);
+WPE_API int              wpe_buffer_dma_buf_take_rendering_fence (WPEBufferDMABuf *buffer);
+WPE_API void             wpe_buffer_dma_buf_set_release_fence    (WPEBufferDMABuf *buffer,
+                                                                  int              fd);
+WPE_API int              wpe_buffer_dma_buf_get_release_fence    (WPEBufferDMABuf *buffer);
+WPE_API int              wpe_buffer_dma_buf_take_release_fence   (WPEBufferDMABuf *buffer);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -538,3 +538,23 @@ const char* wpe_display_get_drm_render_node(WPEDisplay* display)
     return wpeDisplayClass->get_drm_render_node ? wpeDisplayClass->get_drm_render_node(display) : nullptr;
 }
 
+/**
+ * wpe_display_use_explicit_sync:
+ * @display: a #WPEDisplay
+ *
+ * Get whether explicit sync should be used with @display for
+ * supported buffers.
+ *
+ * Returns: %TRUE if explicit sync should be used, or %FALSE otherwise
+ */
+gboolean wpe_display_use_explicit_sync(WPEDisplay* display)
+{
+    g_return_val_if_fail(WPE_IS_DISPLAY(display), FALSE);
+
+    static const char* envExplicitSync = getenv("WPE_USE_EXPLICIT_SYNC");
+    if (envExplicitSync && !strcmp(envExplicitSync, "0"))
+        return false;
+
+    auto* wpeDisplayClass = WPE_DISPLAY_GET_CLASS(display);
+    return wpeDisplayClass->use_explicit_sync ? wpeDisplayClass->use_explicit_sync(display) : FALSE;
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -62,6 +62,7 @@ struct _WPEDisplayClass
                                                                guint       index);
     const char             *(* get_drm_device)                (WPEDisplay *display);
     const char             *(* get_drm_render_node)           (WPEDisplay *display);
+    gboolean                (* use_explicit_sync)             (WPEDisplay *display);
 
     WPEInputMethodContext   *(* create_input_method_context)    (WPEDisplay *display);
 
@@ -102,6 +103,7 @@ WPE_API void                    wpe_display_monitor_removed               (WPEDi
                                                                            WPEMonitor *monitor);
 WPE_API const char             *wpe_display_get_drm_device                (WPEDisplay *display);
 WPE_API const char             *wpe_display_get_drm_render_node           (WPEDisplay *display);
+WPE_API gboolean                wpe_display_use_explicit_sync             (WPEDisplay *display);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
@@ -15,6 +15,7 @@ set(WPEPlatformWayland_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/linux-dmabuf-unstable-v1-protocol.c
+    ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/linux-explicit-synchronization-unstable-v1-protocol.c
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v1-protocol.c
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v3-protocol.c
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/xdg-shell-protocol.c
@@ -107,6 +108,19 @@ add_custom_command(
     OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v3-client-protocol.h
     MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/text-input/text-input-unstable-v3.xml
     COMMAND ${WAYLAND_SCANNER} client-header ${WAYLAND_PROTOCOLS_DATADIR}/unstable/text-input/text-input-unstable-v3.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v3-client-protocol.h
+    VERBATIM)
+
+add_custom_command(
+    OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/linux-explicit-synchronization-unstable-v1-protocol.c
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/linux-explicit-synchronization/linux-explicit-synchronization-unstable-v1.xml
+    DEPENDS ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/linux-explicit-synchronization-unstable-v1-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} private-code ${WAYLAND_PROTOCOLS_DATADIR}/unstable/linux-explicit-synchronization/linux-explicit-synchronization-unstable-v1.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/linux-explicit-synchronization-unstable-v1-protocol.c
+    VERBATIM)
+
+add_custom_command(
+    OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/linux-explicit-synchronization-unstable-v1-client-protocol.h
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/linux-explicit-synchronization/linux-explicit-synchronization-unstable-v1.xml
+    COMMAND ${WAYLAND_SCANNER} client-header ${WAYLAND_PROTOCOLS_DATADIR}/unstable/linux-explicit-synchronization/linux-explicit-synchronization-unstable-v1.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/linux-explicit-synchronization-unstable-v1-client-protocol.h
     VERBATIM)
 
 add_library(WPEPlatformWayland OBJECT ${WPEPlatformWayland_SOURCES})

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h
@@ -35,5 +35,6 @@ WPE::WaylandSeat* wpeDisplayWaylandGetSeat(WPEDisplayWayland*);
 WPE::WaylandCursor* wpeDisplayWaylandGetCursor(WPEDisplayWayland*);
 WPEMonitor* wpeDisplayWaylandFindMonitor(WPEDisplayWayland*, struct wl_output*);
 struct zwp_linux_dmabuf_v1* wpeDisplayWaylandGetLinuxDMABuf(WPEDisplayWayland*);
+struct zwp_linux_explicit_synchronization_v1* wpeDisplayWaylandGetLinuxExplicitSync(WPEDisplayWayland*);
 struct zwp_text_input_v1* wpeDisplayWaylandGetTextInputV1(WPEDisplayWayland*);
 struct zwp_text_input_v3* wpeDisplayWaylandGetTextInputV3(WPEDisplayWayland*);

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWaylandPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWaylandPrivate.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "WPEToplevelWayland.h"
+#include "linux-explicit-synchronization-unstable-v1-client-protocol.h"
 
 void wpeToplevelWaylandSetOpaqueRectangles(WPEToplevelWayland*, WPERectangle*, unsigned);
 void wpeToplevelWaylandUpdateOpaqueRegion(WPEToplevelWayland*);
@@ -36,3 +37,4 @@ WPEView* wpeToplevelWaylandGetVisibleFocusedView(WPEToplevelWayland*);
 void wpeToplevelWaylandSetIsUnderTouch(WPEToplevelWayland*, bool);
 WPEView* wpeToplevelWaylandGetVisibleViewUnderTouch(WPEToplevelWayland*);
 void wpeToplevelWaylandViewVisibilityChanged(WPEToplevelWayland*, WPEView*);
+struct zwp_linux_surface_synchronization_v1* wpeToplevelWaylandGetSurfaceSync(WPEToplevelWayland*);

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -121,6 +121,31 @@ static void wpeViewWaylandDispose(GObject* object)
     G_OBJECT_CLASS(wpe_view_wayland_parent_class)->dispose(object);
 }
 
+struct DMABufBuffer {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+    explicit DMABufBuffer(wl_buffer* buffer)
+        : wlBuffer(buffer)
+    {
+    }
+
+    ~DMABufBuffer()
+    {
+        if (wlBuffer)
+            wl_buffer_destroy(wlBuffer);
+        if (release)
+            zwp_linux_buffer_release_v1_destroy(release);
+    }
+
+    struct wl_buffer* wlBuffer { nullptr };
+    struct zwp_linux_buffer_release_v1* release { nullptr };
+};
+
+static void dmaBufBufferDestroy(DMABufBuffer* buffer)
+{
+    delete buffer;
+}
+
 static const struct wl_buffer_listener bufferListener = {
     // release
     [](void* userData, struct wl_buffer*)
@@ -130,7 +155,7 @@ static const struct wl_buffer_listener bufferListener = {
     }
 };
 
-static struct wl_buffer* createWaylandBufferFromEGLImage(WPEView* view, WPEBuffer* buffer, GError** error)
+static DMABufBuffer* createWaylandBufferFromEGLImage(WPEView* view, WPEBuffer* buffer, GError** error)
 {
     GUniqueOutPtr<GError> bufferError;
     auto* eglDisplay = wpe_display_get_egl_display(wpe_view_get_display(view), &bufferError.outPtr());
@@ -156,7 +181,7 @@ static struct wl_buffer* createWaylandBufferFromEGLImage(WPEView* view, WPEBuffe
     }
 
     if (auto* wlBuffer = s_eglCreateWaylandBufferFromImageWL(eglDisplay, eglImage))
-        return wlBuffer;
+        return new DMABufBuffer(wlBuffer);
 
     g_set_error(error, WPE_VIEW_ERROR, WPE_VIEW_ERROR_RENDER_FAILED, "Failed to render buffer: eglCreateWaylandBufferFromImageWL failed with error %#04x", eglGetError());
     return nullptr;
@@ -164,12 +189,12 @@ static struct wl_buffer* createWaylandBufferFromEGLImage(WPEView* view, WPEBuffe
 
 static struct wl_buffer* createWaylandBufferFromDMABuf(WPEView* view, WPEBuffer* buffer, GError** error)
 {
-    if (auto* wlBuffer = static_cast<struct wl_buffer*>(wpe_buffer_get_user_data(buffer)))
-        return wlBuffer;
+    if (auto* dmaBufBuffer = static_cast<DMABufBuffer*>(wpe_buffer_get_user_data(buffer)))
+        return dmaBufBuffer->wlBuffer;
 
-    struct wl_buffer* wlBuffer = nullptr;
+    auto* bufferDMABuf = WPE_BUFFER_DMA_BUF(buffer);
+    DMABufBuffer* dmaBufBuffer = nullptr;
     if (auto* dmabuf = wpeDisplayWaylandGetLinuxDMABuf(WPE_DISPLAY_WAYLAND(wpe_view_get_display(view)))) {
-        auto* bufferDMABuf = WPE_BUFFER_DMA_BUF(buffer);
         auto modifier = wpe_buffer_dma_buf_get_modifier(bufferDMABuf);
         auto* params = zwp_linux_dmabuf_v1_create_params(dmabuf);
         auto planeCount = wpe_buffer_dma_buf_get_n_planes(bufferDMABuf);
@@ -177,7 +202,7 @@ static struct wl_buffer* createWaylandBufferFromDMABuf(WPEView* view, WPEBuffer*
             zwp_linux_buffer_params_v1_add(params, wpe_buffer_dma_buf_get_fd(bufferDMABuf, i), i, wpe_buffer_dma_buf_get_offset(bufferDMABuf, i),
                 wpe_buffer_dma_buf_get_stride(bufferDMABuf, i), modifier >> 32, modifier & 0xffffffff);
         }
-        wlBuffer = zwp_linux_buffer_params_v1_create_immed(params, wpe_buffer_get_width(buffer), wpe_buffer_get_height(buffer),
+        auto* wlBuffer = zwp_linux_buffer_params_v1_create_immed(params, wpe_buffer_get_width(buffer), wpe_buffer_get_height(buffer),
             wpe_buffer_dma_buf_get_format(bufferDMABuf), 0);
         zwp_linux_buffer_params_v1_destroy(params);
 
@@ -185,20 +210,36 @@ static struct wl_buffer* createWaylandBufferFromDMABuf(WPEView* view, WPEBuffer*
             g_set_error_literal(error, WPE_VIEW_ERROR, WPE_VIEW_ERROR_RENDER_FAILED, "Failed to render buffer: failed to create Wayland buffer from DMABuf");
             return nullptr;
         }
+
+        dmaBufBuffer = new DMABufBuffer(wlBuffer);
     } else {
-        wlBuffer = createWaylandBufferFromEGLImage(view, buffer, error);
-        if (!wlBuffer)
+        dmaBufBuffer = createWaylandBufferFromEGLImage(view, buffer, error);
+        if (!dmaBufBuffer)
             return nullptr;
     }
 
-    wl_buffer_add_listener(wlBuffer, &bufferListener, buffer);
+    auto* toplevel = wpe_view_get_toplevel(WPE_VIEW(view));
+    if (!wpeToplevelWaylandGetSurfaceSync(WPE_TOPLEVEL_WAYLAND(toplevel)) || wpe_buffer_dma_buf_get_rendering_fence(bufferDMABuf) == -1)
+        wl_buffer_add_listener(dmaBufBuffer->wlBuffer, &bufferListener, buffer);
 
-    wpe_buffer_set_user_data(buffer, wlBuffer, reinterpret_cast<GDestroyNotify>(wl_buffer_destroy));
-    return wlBuffer;
+    wpe_buffer_set_user_data(buffer, dmaBufBuffer, reinterpret_cast<GDestroyNotify>(dmaBufBufferDestroy));
+    return dmaBufBuffer->wlBuffer;
 }
 
 struct SharedMemoryBuffer {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+    SharedMemoryBuffer(std::unique_ptr<WPE::WaylandSHMPool>&& pool, uint32_t offset, uint32_t width, uint32_t height, uint32_t stride)
+        : wlPool(WTFMove(pool))
+        , wlBuffer(wlPool->createBuffer(offset, width, height, stride))
+    {
+    }
+
+    ~SharedMemoryBuffer()
+    {
+        if (wlBuffer)
+            wl_buffer_destroy(wlBuffer);
+    }
 
     std::unique_ptr<WPE::WaylandSHMPool> wlPool;
     struct wl_buffer* wlBuffer;
@@ -206,7 +247,6 @@ struct SharedMemoryBuffer {
 
 static void sharedMemoryBufferDestroy(SharedMemoryBuffer* buffer)
 {
-    g_clear_pointer(&buffer->wlBuffer, wl_buffer_destroy);
     delete buffer;
 }
 
@@ -223,10 +263,7 @@ static SharedMemoryBuffer* sharedMemoryBufferCreate(WPEDisplayWayland* display, 
 
     memcpy(reinterpret_cast<char*>(wlPool->data()) + offset, g_bytes_get_data(bytes, nullptr), size);
 
-    auto* sharedMemoryBuffer = new SharedMemoryBuffer();
-    sharedMemoryBuffer->wlPool = WTFMove(wlPool);
-    sharedMemoryBuffer->wlBuffer = sharedMemoryBuffer->wlPool->createBuffer(offset, width, height, stride);
-    return sharedMemoryBuffer;
+    return new SharedMemoryBuffer(WTFMove(wlPool), offset, width, height, stride);
 }
 
 static struct wl_buffer* createWaylandBufferSHM(WPEView* view, WPEBuffer* buffer, GError** error)
@@ -284,6 +321,28 @@ const struct wl_callback_listener frameListener = {
     }
 };
 
+static void bufferReleased(WPEBuffer* buffer)
+{
+    wpe_view_buffer_released(wpe_buffer_get_view(buffer), buffer);
+    if (auto* dmaBufBuffer = static_cast<DMABufBuffer*>(wpe_buffer_get_user_data(buffer)))
+        g_clear_pointer(&dmaBufBuffer->release, zwp_linux_buffer_release_v1_destroy);
+}
+
+const struct zwp_linux_buffer_release_v1_listener bufferReleaseListener = {
+    // fenced_release
+    [](void* userData, struct zwp_linux_buffer_release_v1*, int32_t fence)
+    {
+        auto* buffer = WPE_BUFFER(userData);
+        wpe_buffer_dma_buf_set_release_fence(WPE_BUFFER_DMA_BUF(buffer), fence);
+        bufferReleased(buffer);
+    },
+    // immediate_release
+    [](void* userData, struct zwp_linux_buffer_release_v1*)
+    {
+        bufferReleased(WPE_BUFFER(userData));
+    }
+};
+
 static gboolean wpeViewWaylandRenderBuffer(WPEView* view, WPEBuffer* buffer, const WPERectangle* damageRects, guint nDamageRects, GError** error)
 {
     auto* wlBuffer = createWaylandBuffer(view, buffer, error);
@@ -297,6 +356,16 @@ static gboolean wpeViewWaylandRenderBuffer(WPEView* view, WPEBuffer* buffer, con
 
     auto* wlSurface = wpe_view_wayland_get_wl_surface(WPE_VIEW_WAYLAND(view));
     wl_surface_attach(wlSurface, wlBuffer, 0, 0);
+
+    auto* surfaceSync = wpeToplevelWaylandGetSurfaceSync(WPE_TOPLEVEL_WAYLAND(wpe_view_get_toplevel(view)));
+    auto renderingFence = UnixFileDescriptor { wpe_buffer_dma_buf_take_rendering_fence(WPE_BUFFER_DMA_BUF(buffer)), UnixFileDescriptor::Adopt };
+    if (renderingFence) {
+        zwp_linux_surface_synchronization_v1_set_acquire_fence(surfaceSync, renderingFence.value());
+
+        auto* dmaBufBuffer = static_cast<DMABufBuffer*>(wpe_buffer_get_user_data(buffer));
+        dmaBufBuffer->release = zwp_linux_surface_synchronization_v1_get_release(surfaceSync);
+        zwp_linux_buffer_release_v1_add_listener(dmaBufBuffer->release, &bufferReleaseListener, buffer);
+    }
 
     auto* display = WPE_DISPLAY_WAYLAND(wpe_view_get_display(view));
     auto* wlCompositor = wpe_display_wayland_get_wl_compositor(display);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -620,8 +620,11 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 #endif
     , m_overriddenMediaType(parameters.overriddenMediaType)
     , m_processDisplayName(parameters.processDisplayName)
-#if (PLATFORM(GTK) || PLATFORM(WPE)) && USE(GBM)
+#if PLATFORM(GTK) || PLATFORM(WPE)
+#if USE(GBM)
     , m_preferredBufferFormats(WTFMove(parameters.preferredBufferFormats))
+#endif
+    , m_useExplicitSync(parameters.useExplicitSync)
 #endif
 #if ENABLE(APP_BOUND_DOMAINS)
     , m_limitsNavigationsToAppBoundDomains(parameters.limitsNavigationsToAppBoundDomains)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1757,8 +1757,11 @@ public:
     const Logger& logger() const;
     const void* logIdentifier() const;
 
-#if (PLATFORM(GTK) || PLATFORM(WPE)) && USE(GBM)
+#if PLATFORM(GTK) || PLATFORM(WPE)
+#if USE(GBM)
     const Vector<DMABufRendererBufferFormat>& preferredBufferFormats() const { return m_preferredBufferFormats; }
+#endif
+    bool useExplicitSync() const { return m_useExplicitSync; }
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
@@ -2779,8 +2782,11 @@ private:
     WebCore::Color m_accentColor;
 #endif
 
-#if (PLATFORM(GTK) || PLATFORM(WPE)) && USE(GBM)
+#if PLATFORM(GTK) || PLATFORM(WPE)
+#if USE(GBM)
     Vector<DMABufRendererBufferFormat> m_preferredBufferFormats;
+#endif
+    bool m_useExplicitSync { false };
 #endif
 
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -44,6 +44,7 @@ struct gbm_bo;
 #endif
 
 namespace WebCore {
+class GLFence;
 class Region;
 class ShareableBitmap;
 class ShareableBitmapHandle;
@@ -90,7 +91,7 @@ private:
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    void releaseBuffer(uint64_t);
+    void releaseBuffer(uint64_t, WTF::UnixFileDescriptor&&);
     void frameDone();
     void releaseUnusedBuffersTimerFired();
 
@@ -104,12 +105,19 @@ private:
         virtual void willRenderFrame() const;
         virtual void didRenderFrame() { }
 
+        std::unique_ptr<WebCore::GLFence> createRenderingFence(bool) const;
+        void setReleaseFenceFD(UnixFileDescriptor&&);
+        void waitRelease();
+
     protected:
         RenderTarget(uint64_t, const WebCore::IntSize&);
+
+        virtual bool supportsExplicitSync() const = 0;
 
         uint64_t m_id { 0 };
         uint64_t m_surfaceID { 0 };
         unsigned m_depthStencilBuffer { 0 };
+        UnixFileDescriptor m_releaseFenceFD;
     };
 
     class RenderTargetColorBuffer : public RenderTarget {
@@ -161,6 +169,8 @@ private:
         ~RenderTargetEGLImage();
 
     private:
+        bool supportsExplicitSync() const override { return true; }
+
         EGLImage m_image { nullptr };
     };
 #endif
@@ -172,6 +182,7 @@ private:
         ~RenderTargetSHMImage() = default;
 
     private:
+        bool supportsExplicitSync() const override { return false; }
         void didRenderFrame() override;
 
         Ref<WebCore::ShareableBitmap> m_bitmap;
@@ -184,6 +195,7 @@ private:
         ~RenderTargetTexture();
 
     private:
+        bool supportsExplicitSync() const override { return true; }
         void willRenderFrame() const override;
 
         unsigned m_texture { 0 };
@@ -207,7 +219,7 @@ private:
         Type type() const { return m_type; }
         void resize(const WebCore::IntSize&);
         RenderTarget* nextTarget();
-        void releaseTarget(uint64_t);
+        void releaseTarget(uint64_t, UnixFileDescriptor&& releaseFence);
         void reset();
         void releaseUnusedBuffers();
 
@@ -239,6 +251,7 @@ private:
     SwapChain m_swapChain;
     RenderTarget* m_target { nullptr };
     bool m_isVisible { false };
+    bool m_useExplicitSync { false };
     std::unique_ptr<RunLoop::Timer> m_releaseUnusedBuffersTimer;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.messages.in
@@ -21,6 +21,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 messages -> AcceleratedSurfaceDMABuf NotRefCounted {
-    ReleaseBuffer(uint64_t id)
+    ReleaseBuffer(uint64_t id, UnixFileDescriptor releaseFence)
     FrameDone()
 }


### PR DESCRIPTION
#### 863d0f1f6ab1bcfdbc47b4a689af051c337576ad
<pre>
[WPE] Add explicit fence support for wayland
<a href="https://bugs.webkit.org/show_bug.cgi?id=276818">https://bugs.webkit.org/show_bug.cgi?id=276818</a>

Reviewed by Miguel Gomez.

We are adding support to pass fence from the WebProcess to the wayland
server to avoid stopping the pipeline in the CPU. This is the initial
implementation, we are using the protocol
linux-explicit-synchronization-unstable-v1 and we plan to add support
for new protocols and DRM fences in the future.

The compositor generates a fence for the frame that is used to create a
synchronization point in the command queue and passed to the wayland
server. Also we receive the fence for the buffer usage from the wayland
server that we associate to the buffer and pused to the command queue
before using the buffer.

The patch adds the parameters to the messages in the IPC communication
between WebProcess and UIProces and methods to handle both fences.

Co-authored-by: Carlos Garcia Campos &lt;cgarcia@igalia.com&gt;

* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in:
* Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp:
(WebKit::WebPageProxy::useExplicitSync const):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::frame):
(WebKit::AcceleratedBackingStoreDMABuf::bufferReleased):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp:
(WebKit::WebPageProxy::useExplicitSync const):
* Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp:
(wpe_buffer_dma_buf_set_rendering_fence):
(wpe_buffer_dma_buf_get_rendering_fence):
(wpe_buffer_dma_buf_take_rendering_fence):
(wpe_buffer_dma_buf_set_release_fence):
(wpe_buffer_dma_buf_get_release_fence):
(wpe_buffer_dma_buf_take_release_fence):
* Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.h:
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpe_display_use_explicit_sync):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.h:
* Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandDispose):
(wpeDisplayWaylandUseExplicitSync):
(wpeDisplayWaylandGetLinuxExplicitSync):
(wpe_display_wayland_class_init):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp:
(wpeToplevelWaylandConstructed):
(wpeToplevelWaylandDispose):
(wpeToplevelWaylandHasSyncObject):
(wpeToplevelWaylandGetSyncListener):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWaylandPrivate.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(DMABufBuffer::DMABufBuffer):
(DMABufBuffer::~DMABufBuffer):
(dmaBufBufferDestroy):
(createWaylandBufferFromDMABuf):
(SharedMemoryBuffer::SharedMemoryBuffer):
(sharedMemoryBufferCreate):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::useExplicitSync const):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::setReleaseFence):
(WebKit::AcceleratedSurfaceDMABuf::SwapChain::releaseTarget):
(WebKit::AcceleratedSurfaceDMABuf::willRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::releaseBuffer):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.messages.in:

Canonical link: <a href="https://commits.webkit.org/281640@main">https://commits.webkit.org/281640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56454007168bcd0c93f050bee3293bae50cda766

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64263 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10875 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48857 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7574 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29704 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33696 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9792 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55580 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65995 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56216 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4295 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56384 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3564 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9102 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35505 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36586 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->