### PR TITLE
No transforms experiment

### DIFF
--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -301,9 +301,9 @@ void WidthIterator::commitCurrentFontRange(AdvanceInternalState& advanceInternal
         ASSERT(&advanceInternalState.glyphBuffer.fontAt(i) == advanceInternalState.rangeFont);
 #endif
 
-    auto applyFontTransformsResult = applyFontTransforms(advanceInternalState.glyphBuffer, advanceInternalState.lastGlyphCount, *advanceInternalState.rangeFont, advanceInternalState.charactersTreatedAsSpace);
-    m_runWidthSoFar += applyFontTransformsResult.additionalAdvance;
-    applyInitialAdvance(advanceInternalState.glyphBuffer, applyFontTransformsResult.initialAdvance, advanceInternalState.lastGlyphCount);
+    // auto applyFontTransformsResult = applyFontTransforms(advanceInternalState.glyphBuffer, advanceInternalState.lastGlyphCount, *advanceInternalState.rangeFont, advanceInternalState.charactersTreatedAsSpace);
+    // m_runWidthSoFar += applyFontTransformsResult.additionalAdvance;
+    // applyInitialAdvance(advanceInternalState.glyphBuffer, applyFontTransformsResult.initialAdvance, advanceInternalState.lastGlyphCount);
     m_currentCharacterIndex = advanceInternalState.currentCharacterIndex;
 
     if (advanceInternalState.widthOfCurrentFontRange && m_fallbackFonts && advanceInternalState.rangeFont != advanceInternalState.primaryFont.ptr())


### PR DESCRIPTION
#### a16396ab4ba7925c19e026c78cf269e2efc564dd
<pre>
No transforms experiment
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::commitCurrentFontRange):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a16396ab4ba7925c19e026c78cf269e2efc564dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63194 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9723 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48157 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6933 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61310 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36091 "Found 60 new test failures: accessibility/mixed-contenteditable-double-br-visible-character-range-hang.html css1/box_properties/border.html css1/box_properties/float_margin.html css1/color_and_background/background_attachment.html css1/font_properties/font.html css1/pseudo/firstline.html css1/pseudo/multiple_pseudo_elements.html css1/pseudo/pseudo_elements_in_selectors.html css1/text_properties/letter_spacing.html css1/text_properties/text_decoration.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51315 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28979 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32804 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/css3-border-image-repeat-repeat.html imported/w3c/web-platform-tests/css/css-color/t421-rgb-clip-outside-gamut-b.xht imported/w3c/web-platform-tests/css/css-color/t422-rgba-clip-outside-device-gamut-b.xht imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-removed.html imported/w3c/web-platform-tests/css/css-contain/contain-layout-001.html imported/w3c/web-platform-tests/css/css-contain/contain-layout-018.html imported/w3c/web-platform-tests/css/css-contain/contain-paint-025.html imported/w3c/web-platform-tests/css/css-contain/contain-size-002.html imported/w3c/web-platform-tests/css/css-contain/contain-size-003.html imported/w3c/web-platform-tests/css/css-contain/contain-size-004.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8571 "Found 60 new test failures: css1/box_properties/float_margin.html css1/box_properties/float_on_text_elements.html css1/color_and_background/background_attachment.html css1/font_properties/font.html css1/pseudo/firstline.html css1/pseudo/multiple_pseudo_elements.html css1/pseudo/pseudo_elements_in_selectors.html css1/text_properties/letter_spacing.html css1/text_properties/text_decoration.html css1/text_properties/text_transform.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8727 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54763 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8851 "Found 60 new test failures: css1/box_properties/float_margin.html css1/box_properties/float_on_text_elements.html css1/color_and_background/background_attachment.html css1/font_properties/font.html css1/pseudo/firstline.html css1/pseudo/multiple_pseudo_elements.html css1/pseudo/pseudo_elements_in_selectors.html css1/text_properties/letter_spacing.html css1/text_properties/text_decoration.html css1/text_properties/text_transform.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64926 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3208 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8785 "Found 60 new test failures: css1/box_properties/float_margin.html css1/box_properties/float_on_text_elements.html css1/color_and_background/background_attachment.html css1/font_properties/font.html css1/pseudo/firstline.html css1/pseudo/multiple_pseudo_elements.html css1/pseudo/pseudo_elements_in_selectors.html css1/text_properties/letter_spacing.html css1/text_properties/text_decoration.html css1/text_properties/text_transform.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55507 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55595 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2678 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34439 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35522 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36608 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->