### PR TITLE
[mac] WebDriver sometimes taking screenshots with transparent grey line at the top and no rounded corners

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -2400,7 +2400,7 @@ void WebAutomationSession::takeScreenshot(const Inspector::Protocol::Automation:
 #if PLATFORM(GTK) || PLATFORM(COCOA)
     Function<void(WebPageProxy&, std::optional<WebCore::IntRect>&&, Ref<TakeScreenshotCallback>&&)> takeViewSnapsot = [](WebPageProxy& page, std::optional<WebCore::IntRect>&& rect, Ref<TakeScreenshotCallback>&& callback) {
         page.callAfterNextPresentationUpdate([page = Ref { page }, rect = WTFMove(rect), callback = WTFMove(callback)] () mutable {
-            auto snapshot = page->takeViewSnapshot(WTFMove(rect));
+            RefPtr snapshot = page->takeViewSnapshot(WTFMove(rect), ForceSoftwareCapturingViewportSnapshot::Yes);
             if (!snapshot)
                 ASYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -83,6 +83,8 @@ class WebOpenPanelResultListenerProxy;
 class WebPageProxy;
 class WebProcessPool;
 
+enum class ForceSoftwareCapturingViewportSnapshot : bool;
+
 class AutomationCommandError {
 public:
     Inspector::Protocol::Automation::ErrorMessage type;

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -177,6 +177,7 @@ using SessionID = WTF::UUID;
 namespace WebKit {
 
 enum class UndoOrRedo : bool;
+enum class ForceSoftwareCapturingViewportSnapshot : bool;
 enum class TapHandlingResult : uint8_t;
 
 class ContextMenuContextData;
@@ -375,6 +376,10 @@ public:
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)
     virtual RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&) = 0;
+#endif
+
+#if PLATFORM(MAC)
+    virtual RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&, ForceSoftwareCapturingViewportSnapshot) = 0;
 #endif
 
 #if USE(APPKIT)

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.h
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.h
@@ -50,6 +50,8 @@ namespace WebKit {
 class WebBackForwardListItem;
 class WebPageProxy;
 
+enum class ForceSoftwareCapturingViewportSnapshot : bool { No, Yes };
+
 class ViewSnapshot : public RefCounted<ViewSnapshot>, public CanMakeWeakPtr<ViewSnapshot> {
 public:
 #if HAVE(IOSURFACE)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11678,7 +11678,16 @@ RefPtr<ViewSnapshot> WebPageProxy::takeViewSnapshot(std::optional<WebCore::IntRe
     return protectedPageClient()->takeViewSnapshot(WTFMove(clipRect));
 }
 
+RefPtr<ViewSnapshot> WebPageProxy::takeViewSnapshot(std::optional<WebCore::IntRect>&& clipRect, ForceSoftwareCapturingViewportSnapshot forceSoftwareCapturing)
+{
+#if PLATFORM(MAC)
+    return protectedPageClient()->takeViewSnapshot(WTFMove(clipRect), forceSoftwareCapturing);
+#else
+    return protectedPageClient()->takeViewSnapshot(WTFMove(clipRect));
 #endif
+}
+
+#endif // PLATFORM(COCOA) || PLATFORM(GTK)
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -528,6 +528,7 @@ enum class ContentAsStringIncludesChildFrames : bool;
 enum class DragControllerAction : uint8_t;
 enum class FindDecorationStyle : uint8_t;
 enum class FindOptions : uint16_t;
+enum class ForceSoftwareCapturingViewportSnapshot : bool;
 enum class GestureRecognizerState : uint8_t;
 enum class GestureType : uint8_t;
 enum class LoadedWebArchive : bool;
@@ -1767,6 +1768,7 @@ public:
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)
     RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&);
+    RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&, ForceSoftwareCapturingViewportSnapshot);
 #endif
 
     void wrapCryptoKey(Vector<uint8_t>&&, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -171,6 +171,7 @@ private:
     void didFirstLayerFlush(const LayerTreeContext&) override;
 
     RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&) override;
+    RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&, ForceSoftwareCapturingViewportSnapshot) override;
     void wheelEventWasNotHandledByWebCore(const NativeWebWheelEvent&) override;
 #if ENABLE(MAC_GESTURE_EVENTS)
     void gestureEventWasNotHandledByWebCore(const NativeWebGestureEvent&) override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -644,6 +644,11 @@ RefPtr<ViewSnapshot> PageClientImpl::takeViewSnapshot(std::optional<WebCore::Int
     return m_impl->takeViewSnapshot();
 }
 
+RefPtr<ViewSnapshot> PageClientImpl::takeViewSnapshot(std::optional<WebCore::IntRect>&&, ForceSoftwareCapturingViewportSnapshot forceSoftwareCapturing)
+{
+    return m_impl->takeViewSnapshot(forceSoftwareCapturing);
+}
+
 void PageClientImpl::selectionDidChange()
 {
     m_impl->selectionDidChange();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -190,6 +190,7 @@ class WebProcessProxy;
 struct WebHitTestResultData;
 
 enum class ContinueUnsafeLoad : bool;
+enum class ForceSoftwareCapturingViewportSnapshot : bool;
 enum class UndoOrRedo : bool;
 
 typedef id <NSValidatedUserInterfaceItem> ValidationItem;
@@ -535,6 +536,7 @@ public:
     NSArray *namesOfPromisedFilesDroppedAtDestination(NSURL *dropDestination);
 
     RefPtr<ViewSnapshot> takeViewSnapshot();
+    RefPtr<ViewSnapshot> takeViewSnapshot(ForceSoftwareCapturingViewportSnapshot);
     void saveBackForwardSnapshotForCurrentItem();
     void saveBackForwardSnapshotForItem(WebBackForwardListItem&);
 


### PR DESCRIPTION
#### bdd0eaf1d28f834bdc3fab3e656486522f3b301f
<pre>
[mac] WebDriver sometimes taking screenshots with transparent grey line at the top and no rounded corners
<a href="https://rdar.apple.com/116020785">rdar://116020785</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=262078">https://bugs.webkit.org/show_bug.cgi?id=262078</a>

Reviewed by Aditya Keerthi, Abrar Rahman Protyasha and BJ Burg.

Our WebDriver currently takes viewport screenshots with the
`static takeWindowSnapshot` function in WebViewImpl. What that function
currently does is:

   1. Try taking a screenshot using the hardware capture path, with the
      CGSHWCaptureWindowList function and the
      kCGSCaptureIgnoreGlobalClipShape option to avoid the rounded
      corners.
   2. The above function may fail (e.g. due to the window being off-
      screen, as noted in the code comments), and if it does, take
      a screenshot using the non-hardware capture path with
      CGWindowListCreateImage and kCGWindowImageBoundsIgnoreFraming.

Due to the kCGSCaptureIgnoreGlobalClipShape option currently bugged
and having no effect, if hardware capturing does succeed, we get a
screenshot with the rounded corners, and if it fails we get no
rounded corners, which contributes toward the tests&apos; flakiness.

   - This inconsistency is also observable from the screenshots taken
     when performing a swipe to go back/forward in the browser, though
     the consequence there is less severe than failing WPT tests.

To address that, we force WebDriver to always fall back to the non-
hardware capture path, taking viewport screenshots with
CGWindowListCreateImage, to rule out any flakiness caused by
CGSHWCaptureWindowList occasionally failing.

   - The reason we began to prefer the hardware capture path with
     CGSHWCaptureWindowList is because CGWindowListCreateImage had a
     performance issue where it might hang. Source: <a href="https://github.com/WebKit/WebKit/commit/8f81edf40d069cacf6107254a535a812d5978dea">https://github.com/WebKit/WebKit/commit/8f81edf40d069cacf6107254a535a812d5978dea</a>
   - However, the hang has been addressed internally and no longer
     occurs today. My local testing instead shows no noticeable
     difference in speed between CGWindowListCreateImage and
     CGSHWCaptureWindowList.
   - Though, CGWindowListCreateImage has been deprecated in favor of the
     ScreenCaptureKit, but it&apos;s still functional for now. So, I believe
     this patch is a reasonable workaround at least until the hardware
     capturing bug gets fixed, in exchange for a more consistent
     performance in WPT.

Despite this patch aims to improve WPT results, it&apos;s hard to pinpoint
which specific tests will progress, as all tests that take viewport
screenshots are currently flaky due to the bug. However, I can observe
some tests progressing locally. With this command inside the WPT repo:

    ./wpt run safari ./css/css-contain --webdriver-binary=&quot;...&quot;

556 tests were run, where 140-150 tests fail without this patch, and
this patch makes it so that exactly 51 tests were still failing (about
90 tests progressed) and no tests regressed.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::takeViewSnapshot):
   - Add the option to always use the non-hardware screen capture path
     when taking a window snapshot.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::takeScreenshot):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/ViewSnapshotStore.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::takeViewSnapshot):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::takeViewSnapshot):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::takeWindowSnapshot):
   - Allow WebDriver to make use of this change when taking a viewport
     screenshot.

Canonical link: <a href="https://commits.webkit.org/281887@main">https://commits.webkit.org/281887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b838dd5bf845a6bd4f6ae3a6d913859cd40acd63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65212 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11811 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12086 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49506 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8210 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53079 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30338 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34455 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10724 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66943 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5209 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10396 "Found 1 new test failure: fast/forms/form-submission-crash-4.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56879 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57101 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13671 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4304 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36427 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37510 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->