### PR TITLE
[iOS] WebKit XPC services are not always considered managed by RunningBoard

### DIFF
--- a/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUService/Info-iOS.plist
+++ b/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUService/Info-iOS.plist
@@ -28,16 +28,26 @@
 	<string>NSApplication</string>
 	<key>LSUIElement</key>
 	<true/>
-    <key>_STAttributionDisplayName</key>
-    <string>Website</string>
+	<key>_STAttributionDisplayName</key>
+	<string>Website</string>
 	<key>XPCService</key>
 	<dict>
 		<key>ServiceType</key>
 		<string>Application</string>
 		<key>RunLoopType</key>
 		<string>NSRunLoop</string>
-                <key>_ProcessType</key>
-                <string>App</string>
+		<key>_AdditionalProperties</key>
+		<dict>
+			<key>RunningBoard</key>
+			<dict>
+				<key>Managed</key>
+				<true/>
+				<key>Reported</key>
+				<true/>
+			</dict>
+		</dict>
+		<key>_ProcessType</key>
+		<string>App</string>
 		<key>_MultipleInstances</key>
 		<true/>
 	</dict>

--- a/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelService/Info-embedded.plist
+++ b/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelService/Info-embedded.plist
@@ -36,6 +36,16 @@
 		<string>Application</string>
 		<key>RunLoopType</key>
 		<string>NSRunLoop</string>
+		<key>_AdditionalProperties</key>
+		<dict>
+			<key>RunningBoard</key>
+			<dict>
+				<key>Managed</key>
+				<true/>
+				<key>Reported</key>
+				<true/>
+			</dict>
+		</dict>
 		<key>_ProcessType</key>
 		<string>App</string>
 		<key>_MultipleInstances</key>

--- a/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkService/Info-iOS.plist
+++ b/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkService/Info-iOS.plist
@@ -34,8 +34,18 @@
 		<string>Application</string>
 		<key>RunLoopType</key>
 		<string>NSRunLoop</string>
-                <key>_ProcessType</key>
-                <string>App</string>
+		<key>_AdditionalProperties</key>
+		<dict>
+			<key>RunningBoard</key>
+			<dict>
+				<key>Managed</key>
+				<true/>
+				<key>Reported</key>
+				<true/>
+			</dict>
+		</dict>
+		<key>_ProcessType</key>
+		<string>App</string>
 		<key>_MultipleInstances</key>
 		<true/>
 	</dict>

--- a/Source/WebKit/WebProcess/EntryPoint/Cocoa/XPCService/WebContentService/Info-iOS.plist
+++ b/Source/WebKit/WebProcess/EntryPoint/Cocoa/XPCService/WebContentService/Info-iOS.plist
@@ -34,8 +34,18 @@
 		<string>Application</string>
 		<key>RunLoopType</key>
 		<string>NSRunLoop</string>
-                <key>_ProcessType</key>
-                <string>App</string>
+		<key>_AdditionalProperties</key>
+		<dict>
+			<key>RunningBoard</key>
+			<dict>
+				<key>Managed</key>
+				<true/>
+				<key>Reported</key>
+				<true/>
+			</dict>
+		</dict>
+		<key>_ProcessType</key>
+		<string>App</string>
 		<key>_MultipleInstances</key>
 		<true/>
 		<key>_HighBitsASLR</key>


### PR DESCRIPTION
#### 8c6a0b63833a0fd180e5e0b7b5f05fbb560244fa
<pre>
[iOS] WebKit XPC services are not always considered managed by RunningBoard
<a href="https://bugs.webkit.org/show_bug.cgi?id=276834">https://bugs.webkit.org/show_bug.cgi?id=276834</a>
<a href="https://rdar.apple.com/132063557">rdar://132063557</a>

Reviewed by Per Arne Vollan.

Whether or not RunningBoard manages an XPC service depends on the type of its host process. While
XPC services hosted by UI applications are managed by default, XPC services hosted by launchd
daemons are not managed even if the daemon itself is managed by RunningBoard and can show UI.
Some bugs are introduced when WebKit XPC services are not managed by RunningBoard, such as:
1. Some parts of iOS not considering the XPC service to be in the foreground even though it is
   running and has propagated visibility.
2. RunningBoard not suspending/freezing XPC services it does not manage.

Resolved this by opting WebKit XPC services into RunningBoard management on iOS using the same
Info.plist key we use on macOS.

* Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUService/Info-iOS.plist:
* Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelService/Info-embedded.plist:
* Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkService/Info-iOS.plist:
* Source/WebKit/WebProcess/EntryPoint/Cocoa/XPCService/WebContentService/Info-iOS.plist:

Canonical link: <a href="https://commits.webkit.org/281165@main">https://commits.webkit.org/281165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0b39e734512a02ca787339ed4aa9021f23ba6cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62592 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9403 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47673 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6694 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50992 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28532 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32539 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8407 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64292 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54996 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55099 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2404 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34117 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35201 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->