### PR TITLE
Support parsing hsl() colors on the fast path

### DIFF
--- a/LayoutTests/fast/css/invalid-color-parsing-hsl-expected.txt
+++ b/LayoutTests/fast/css/invalid-color-parsing-hsl-expected.txt
@@ -1,0 +1,93 @@
+Test parsing various invalid hsl colors
+Parsing hsl(0, 10%, 20%)
+PASS expectedStyle is actualStyle
+Parsing hsl(0, -10%, 20%)
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 20%, -12%)
+PASS expectedStyle is actualStyle
+Parsing hsl(.7deg, 10%, 20%)
+PASS expectedStyle is actualStyle
+Parsing hsl(0., 10%, 20%)
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10.%, 20%)
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 20.%)
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10% 20%)
+PASS expectedStyle is actualStyle
+Parsing hsl(0,10%
+PASS expectedStyle is actualStyle
+Parsing hsl(0,10%)
+PASS expectedStyle is actualStyle
+Parsing hsl(0,10)
+PASS expectedStyle is actualStyle
+Parsing hsl(20deg, 10%,20%
+PASS expectedStyle is actualStyle
+Parsing hsl(20deg, 10%20%
+PASS expectedStyle is actualStyle
+Parsing hsl(20degg,10)
+PASS expectedStyle is actualStyle
+Parsing hsl(20degg,10%,20%)
+PASS expectedStyle is actualStyle
+Parsing hsl(20degg, 10%,20%
+PASS expectedStyle is actualStyle
+Parsing hsl(20de, 10%,20%
+PASS expectedStyle is actualStyle
+Parsing hsl(20d, 10%,20%
+PASS expectedStyle is actualStyle
+Parsing hsl(20ra, 10%,20%
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 20%,.2)
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 20%,.2
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 20%,.
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 20%,
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 20%
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 20
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 2
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%,
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%,
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 1
+PASS expectedStyle is actualStyle
+Parsing hsl(0,
+PASS expectedStyle is actualStyle
+Parsing hsl(0,
+PASS expectedStyle is actualStyle
+Parsing hsl(0
+PASS expectedStyle is actualStyle
+Parsing hsl(
+PASS expectedStyle is actualStyle
+Parsing hsla(
+PASS expectedStyle is actualStyle
+Parsing hsl()
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 20%,)
+PASS expectedStyle is actualStyle
+Parsing hsla(0, 10%, 20%,)
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 20%,0.)
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 20%,0.  )
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 20%,0.%  )
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10%, 20%,0.  %)
+PASS expectedStyle is actualStyle
+Parsing hsl(0, 10, 20%,0.1)
+PASS expectedStyle is actualStyle
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/invalid-color-parsing-hsl.html
+++ b/LayoutTests/fast/css/invalid-color-parsing-hsl.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    let expectedStyle;
+    let actualStyle;
+    
+    function test()
+    {
+        debug('Test parsing various invalid hsl colors');
+        const tests = [
+            { test: "hsl(0, 10%, 20%)", expected: "rgba(56, 46, 46, 1)" },
+            { test: "hsl(0, -10%, 20%)", expected: "rgb(51, 51, 51)" },
+            { test: "hsl(0, 10%, 20%, -12%)", expected: "rgba(56, 46, 46, 0)" },
+            { test: "hsl(.7deg, 10%, 20%)", expected: "rgba(56, 46, 46, 1)" },
+            { test: "hsl(0., 10%, 20%)", expected: "transparent" },
+            { test: "hsl(0, 10.%, 20%)", expected: "transparent" },
+            { test: "hsl(0, 10%, 20.%)", expected: "transparent" },
+            { test: "hsl(0, 10% 20%)", expected: "transparent" },
+            { test: "hsl(0,10% ", expected: "transparent" },
+            { test: "hsl(0,10%)", expected: "transparent" },
+            { test: "hsl(0,10)", expected: "transparent" },
+
+            { test: "hsl(20deg, 10%,20%", expected: "rgb(56, 49, 46)" }, // CSS allows a missing bracket at the end of the token stream.
+            { test: "hsl(20deg, 10%20%", expected: "transparent" },
+
+            { test: "hsl(20degg,10)", expected: "transparent" },
+            { test: "hsl(20degg,10%,20%)", expected: "transparent" },
+            { test: "hsl(20degg, 10%,20%", expected: "transparent" },
+            { test: "hsl(20de, 10%,20%", expected: "transparent" },
+            { test: "hsl(20d, 10%,20%", expected: "transparent" },
+            { test: "hsl(20ra, 10%,20%", expected: "transparent" },
+
+            { test: "hsl(0, 10%, 20%,.2)", expected: "rgba(56, 46, 46, 0.2)" },
+            { test: "hsl(0, 10%, 20%,.2", expected: "rgba(56, 46, 46, 0.2)" }, // Ditto.
+            { test: "hsl(0, 10%, 20%,.", expected: "transparent" },
+            { test: "hsl(0, 10%, 20%,", expected: "transparent" },
+            { test: "hsl(0, 10%, 20%", expected: "rgb(56, 46, 46)" }, // Ditto.
+            { test: "hsl(0, 10%, 20", expected: "transparent" },
+            { test: "hsl(0, 10%, 2", expected: "transparent" },
+            { test: "hsl(0, 10%, ", expected: "transparent" },
+            { test: "hsl(0, 10%,", expected: "transparent" },
+            { test: "hsl(0, 10%", expected: "transparent" },
+            { test: "hsl(0, 10", expected: "transparent" },
+            { test: "hsl(0, 1", expected: "transparent" },
+            { test: "hsl(0, ", expected: "transparent" },
+            { test: "hsl(0,", expected: "transparent" },
+            { test: "hsl(0", expected: "transparent" },
+            { test: "hsl(", expected: "transparent" },
+            { test: "hsla(", expected: "transparent" },
+
+            { test: "hsl()", expected: "transparent" },
+            { test: "hsl(0, 10%, 20%,)", expected: "transparent" },
+            { test: "hsla(0, 10%, 20%,)", expected: "transparent" },
+            { test: "hsl(0, 10%, 20%,0.)", expected: "transparent" },
+            { test: "hsl(0, 10%, 20%,0.  )", expected: "transparent" },
+            { test: "hsl(0, 10%, 20%,0.%  )", expected: "transparent" },
+            { test: "hsl(0, 10%, 20%,0.  %)", expected: "transparent" },
+            { test: "hsl(0, 10, 20%,0.1)", expected: "transparent" },
+        ];
+
+        const expectedResultDiv = document.createElement('div');
+        const actualResultDiv = document.createElement('div');
+
+        for (const test of tests) {
+            expectedResultDiv.style.color = 'transparent';
+            actualResultDiv.style.color = 'transparent';
+
+            expectedResultDiv.style.color = test.test;
+            actualResultDiv.style.color = test.expected;
+            
+            expectedStyle = expectedResultDiv.style.color;
+            actualStyle = actualResultDiv.style.color;
+
+            debug(`Parsing ${test.test}`)
+            shouldBe('expectedStyle', 'actualStyle');
+        }
+    }
+
+    test();
+</script>    
+</body>
+</html>

--- a/LayoutTests/fast/css/invalid-color-parsing-rgb-expected.txt
+++ b/LayoutTests/fast/css/invalid-color-parsing-rgb-expected.txt
@@ -1,0 +1,11 @@
+Test parsing various invalid rgb colors
+Parsing rgb(128, 123, 255, 0.2%)
+PASS expectedStyle is actualStyle
+Parsing rgb(128, 123, 255, 2.%)
+PASS expectedStyle is actualStyle
+Parsing rgb(128, 123, 255, 20.)
+PASS expectedStyle is actualStyle
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/invalid-color-parsing-rgb.html
+++ b/LayoutTests/fast/css/invalid-color-parsing-rgb.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    let expectedStyle;
+    let actualStyle;
+    
+    function test()
+    {
+        debug('Test parsing various invalid rgb colors');
+        const tests = [
+            { test: "rgb(128, 123, 255, 0.2%)", expected: "rgba(128, 123, 255, 0.004)" },
+            { test: "rgb(128, 123, 255, 2.%)", expected: "transparent" },
+            { test: "rgb(128, 123, 255, 20.)", expected: "transparent" },
+        ];
+
+        const expectedResultDiv = document.createElement('div');
+        const actualResultDiv = document.createElement('div');
+
+        for (const test of tests) {
+            expectedResultDiv.style.color = 'transparent';
+            actualResultDiv.style.color = 'transparent';
+
+            expectedResultDiv.style.color = test.test;
+            actualResultDiv.style.color = test.expected;
+            
+            expectedStyle = expectedResultDiv.style.color;
+            actualStyle = actualResultDiv.style.color;
+
+            debug(`Parsing ${test.test}`)
+            shouldBe('expectedStyle', 'actualStyle');
+        }
+    }
+
+    test();
+</script>    
+</body>
+</html>


### PR DESCRIPTION
#### 9599027820b8f3dce4f1d40182cb32021563202e
<pre>
Support parsing hsl() colors on the fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=276836">https://bugs.webkit.org/show_bug.cgi?id=276836</a>
<a href="https://rdar.apple.com/132110971">rdar://132110971</a>

Reviewed by Tim Nguyen.

Add support to CSSParserFastPaths for parsing `hsl()` and `hsla()` colors.

`parseSimpleAngle()` is enhanced to allow for optional units, which these colors allow.
Fix `checkForValidDouble()` to disallow a value with a trailing decimal point, since
CSS doesn&apos;t allow this.

Add some tests for invalid color parsing, to ensure we don&apos;t hit any of the `span&lt;&gt;` bounds
checks.

* LayoutTests/fast/css/invalid-color-parsing-hsl-expected.txt: Added.
* LayoutTests/fast/css/invalid-color-parsing-hsl.html: Added.
* LayoutTests/fast/css/invalid-color-parsing-rgb-expected.txt: Added.
* LayoutTests/fast/css/invalid-color-parsing-rgb.html: Added.
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseSimpleAngle):
(WebCore::checkForValidDouble):
(WebCore::parseRGBAlphaValue):
(WebCore::mightBeHSLA):
(WebCore::mightBeHSL):
(WebCore::parseLegacyHSL):
(WebCore::parseNumericColor):
(WebCore::parseTransformAngleArgument):
(WebCore::parseAlphaValue): Deleted.

Canonical link: <a href="https://commits.webkit.org/281160@main">https://commits.webkit.org/281160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d0e59a8055e549abe78c8b701ae8420d3ab588a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62593 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47674 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6690 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28533 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8270 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8399 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64284 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54992 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55095 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13055 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2398 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34109 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->