### PR TITLE
Manifest v2 web_accessible_resources are not working.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -350,7 +350,8 @@ bool WebExtension::isWebAccessibleResource(const URL& resourceURL, const URL& pa
     resourcePath = resourcePath.substring(1);
 
     for (auto& data : m_webAccessibleResources) {
-        bool allowed = false;
+        // If matchPatterns is empty, these resources are allowed on any page.
+        bool allowed = data.matchPatterns.isEmpty();
         for (auto& matchPattern : data.matchPatterns) {
             if (matchPattern->matchesURL(pageURL)) {
                 allowed = true;
@@ -433,10 +434,8 @@ void WebExtension::populateWebAccessibleResourcesIfNeeded()
                 return !!string.length;
             });
 
-            if (resourcesArray.count) {
-                MatchPatternSet matchPatterns { WebExtensionMatchPattern::allHostsAndSchemesMatchPattern() };
-                m_webAccessibleResources.append({ WTFMove(matchPatterns), makeVector<String>(resourcesArray) });
-            }
+            if (resourcesArray.count)
+                m_webAccessibleResources.append({ { }, makeVector<String>(resourcesArray) });
         } else if ([m_manifest objectForKey:webAccessibleResourcesManifestKey])
             recordError(createError(Error::InvalidWebAccessibleResources));
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
@@ -777,6 +777,76 @@ TEST(WKWebExtensionController, WebAccessibleResources)
     [manager loadAndRun];
 }
 
+TEST(WKWebExtensionController, WebAccessibleResourcesV2)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *contentScript = Util::constructScript(@[
+        @"var imgGood = document.createElement('img')",
+        @"imgGood.src = browser.runtime.getURL('good.svg')",
+
+        @"var imgBad = document.createElement('img')",
+        @"imgBad.src = browser.runtime.getURL('bad.svg')",
+
+        @"var goodLoaded = false",
+        @"var badFailed = false",
+
+        @"imgGood.onload = () => {",
+        @"  goodLoaded = true",
+        @"  if (badFailed)",
+        @"    browser.test.notifyPass()",
+        @"}",
+
+        @"imgGood.onerror = () => {",
+        @"  browser.test.notifyFail('The good image should load')",
+        @"}",
+
+        @"imgBad.onload = () => {",
+        @"  browser.test.notifyFail('The bad image should not load')",
+        @"}",
+
+        @"imgBad.onerror = () => {",
+        @"  badFailed = true",
+        @"  if (goodLoaded)",
+        @"    browser.test.notifyPass()",
+        @"}",
+
+        @"document.body.appendChild(imgGood)",
+        @"document.body.appendChild(imgBad)"
+    ]);
+
+    auto *manifest = @{
+        @"manifest_version": @2,
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+
+        @"content_scripts": @[ @{
+            @"js": @[ @"content.js" ],
+            @"matches": @[ @"*://localhost/*" ],
+        } ],
+
+        @"web_accessible_resources": @[ @"good.svg" ]
+    };
+
+    auto *resources = @{
+        @"content.js": contentScript,
+        @"good.svg": @"<svg xmlns='http://www.w3.org/2000/svg'></svg>",
+        @"bad.svg": @"<svg xmlns='http://www.w3.org/2000/svg'></svg>"
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+
+    [manager loadAndRun];
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 10f17092d03f8a428e17db665bada7c87010ee2d
<pre>
Manifest v2 web_accessible_resources are not working.
<a href="https://webkit.org/b/276835">https://webkit.org/b/276835</a>
<a href="https://rdar.apple.com/131750151">rdar://131750151</a>

Reviewed by Brian Weinstein.

Manifest v2 web accessible resources don’t restrict the page URLs they can load from. Therefore,
any page should be able to load them. However, the previous code was using a `*://*/*` pattern,
which was too restrictive to allow URLs like `about:srcdoc`. Even the `&lt;all_urls&gt;` pattern was
too restrictive, as it only allowed supported schemes.

To fix this, allow an empty match patterns set to allow any URL. This is only supported on
Manifest v2, as an empty patterns array is an error in Manifest v3.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::isWebAccessibleResource): Default to allowed if the patterns are empty.
(WebKit::WebExtension::populateWebAccessibleResourcesIfNeeded): Use an empty patterns set.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm:
(TestWebKitAPI::TEST(WKWebExtensionController, WebAccessibleResourcesV2)): Added.

Canonical link: <a href="https://commits.webkit.org/281157@main">https://commits.webkit.org/281157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26efa144a25589a55db6fbe7e8794387ff9f7c1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47660 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6685 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50973 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8264 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8385 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64270 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8505 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54984 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2860 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55086 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2388 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8810 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34095 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36264 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->