### PR TITLE
Test fixes for wasm llint on Windows

### DIFF
--- a/JSTests/wasm/lowExecutableMemory/exports-oom.js
+++ b/JSTests/wasm/lowExecutableMemory/exports-oom.js
@@ -6,7 +6,7 @@ import Builder from '../Builder.js'
 
 const verbose = false;
 const numFunctions = 2;
-const maxParams = 128;
+const maxParams = 16;
 
 // This test starts running with a few bytes of executable memory available. Try
 // to create and instantiate modules which have way more exports than anything

--- a/JSTests/wasm/stress/funcref-validation.js
+++ b/JSTests/wasm/stress/funcref-validation.js
@@ -1,3 +1,4 @@
+//@ skip if !$isSIMDPlatform
 (async function () {
   let bytes = readFile('./resources/funcref-validation.wasm', 'binary');
   let importObject = {

--- a/JSTests/wasm/stress/referenced-function.js
+++ b/JSTests/wasm/stress/referenced-function.js
@@ -1,3 +1,4 @@
+//@ skip if !$isSIMDPlatform
 let bytes = readFile('./resources/funcref-race.wasm', 'binary');
 (async function () {
     let importObject = {

--- a/JSTests/wasm/stress/try-and-block-with-v128-results.js
+++ b/JSTests/wasm/stress/try-and-block-with-v128-results.js
@@ -1,3 +1,4 @@
+//@ skip if !$isSIMDPlatform
 let tools;
 if (globalThis.callerIsBBQOrOMGCompiled) {
   function instantiateJsc(filename, importObject) {

--- a/JSTests/wasm/stress/tuple-and-v128.js
+++ b/JSTests/wasm/stress/tuple-and-v128.js
@@ -1,3 +1,4 @@
+//@ skip if !$isSIMDPlatform
 let bytes = readFile('./resources/tuple-and-v128.wasm', 'binary');
 let importObject = {
   m: {

--- a/JSTests/wasm/v8/shared-memory-gc-stress.js
+++ b/JSTests/wasm/v8/shared-memory-gc-stress.js
@@ -1,3 +1,4 @@
+//@ skip if $hostOS == "windows"
 //@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be


### PR DESCRIPTION
#### 6ede3d217aa2205dd63fbe3888fec49642d55e02
<pre>
Test fixes for wasm llint on Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=276837">https://bugs.webkit.org/show_bug.cgi?id=276837</a>

Reviewed by Yusuke Suzuki.

Four tests skipped as they rely on SIMD wasm instructions, and without
BBQ or OMG those tests fail.

exports-oom.js intermittedly fails depending on the number of arguments,
a different code path is taken in WasmLLIntPlan if the function exceeds
16 arguments. imports-oom.js previously had issues as well:
<a href="https://bugs.webkit.org/show_bug.cgi?id=196373">https://bugs.webkit.org/show_bug.cgi?id=196373</a>

shared-memomry-gc-stress.js puts enough memory pressure on my system
that it&apos;ll fail and also cause surrounding tests to fail. Skipping on
Windows.

* JSTests/wasm/lowExecutableMemory/exports-oom.js:
* JSTests/wasm/stress/funcref-validation.js:
* JSTests/wasm/stress/referenced-function.js:
* JSTests/wasm/stress/try-and-block-with-v128-results.js:
* JSTests/wasm/stress/tuple-and-v128.js:
* JSTests/wasm/v8/shared-memory-gc-stress.js:

Canonical link: <a href="https://commits.webkit.org/281164@main">https://commits.webkit.org/281164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fc81133e6c43ac9f501cb3326b90a1010ab5a25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62574 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9385 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47663 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6682 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28521 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32525 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8389 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/52034 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64274 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58183 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54987 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55089 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2392 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79944 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8815 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34099 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13824 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35183 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->