### PR TITLE
Implement InternalObserver for Observable

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1176,6 +1176,8 @@ dom/InlineClassicScript.cpp
 dom/InlineStyleSheetOwner.cpp
 dom/InputEvent.cpp
 dom/InvokeEvent.cpp
+dom/InternalObserver.cpp
+dom/InternalObserverFromScript.cpp
 dom/KeyboardEvent.cpp
 dom/LiveNodeList.cpp
 dom/LoadableClassicScript.cpp

--- a/Source/WebCore/bindings/js/JSSubscriberCustom.cpp
+++ b/Source/WebCore/bindings/js/JSSubscriberCustom.cpp
@@ -31,14 +31,10 @@ namespace WebCore {
 template<typename Visitor>
 void JSSubscriber::visitAdditionalChildren(Visitor& visitor)
 {
-    if (auto* next = wrapped().nextCallbackConcurrently())
-        next->visitJSFunction(visitor);
-    if (auto* error = wrapped().errorCallbackConcurrently())
-        error->visitJSFunction(visitor);
-    if (auto* complete = wrapped().completeCallbackConcurrently())
-        complete->visitJSFunction(visitor);
     for (auto* teardown : wrapped().teardownCallbacksConcurrently())
         teardown->visitJSFunction(visitor);
+
+    wrapped().observerConcurrently()->visitAdditionalChildren(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSSubscriber);

--- a/Source/WebCore/dom/InternalObserver.cpp
+++ b/Source/WebCore/dom/InternalObserver.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InternalObserver.h"
+
+namespace WebCore {
+
+void InternalObserver::error(JSC::JSValue value)
+{
+    auto* context = scriptExecutionContext();
+    if (!context)
+        return;
+
+    auto* globalObject = context->globalObject();
+    if (!globalObject)
+        return;
+
+    Ref vm = globalObject->vm();
+    JSC::JSLockHolder lock(vm);
+
+    reportException(globalObject, JSC::Exception::create(vm, value));
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserver.h
+++ b/Source/WebCore/dom/InternalObserver.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ActiveDOMObject.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class InternalObserver : public ActiveDOMObject, public RefCounted<InternalObserver> {
+public:
+    virtual ~InternalObserver() = default;
+
+    virtual void next(JSC::JSValue) = 0;
+    virtual void complete()
+    {
+        m_active = false;
+    }
+
+    virtual void error(JSC::JSValue);
+
+    // ActiveDOMObject
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+    virtual void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const = 0;
+    virtual void visitAdditionalChildren(JSC::SlotVisitor&) const = 0;
+
+protected:
+    bool m_active { true };
+
+    InternalObserver(ScriptExecutionContext& context)
+        : ActiveDOMObject(&context)
+    {
+    }
+
+    // ActiveDOMObject
+    void stop() override { }
+    bool virtualHasPendingActivity() const override { return m_active; }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverFromScript.cpp
+++ b/Source/WebCore/dom/InternalObserverFromScript.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InternalObserverFromScript.h"
+
+#include "JSSubscriptionObserverCallback.h"
+#include "SubscriptionObserver.h"
+
+namespace WebCore {
+
+Ref<InternalObserverFromScript> InternalObserverFromScript::create(ScriptExecutionContext& context, RefPtr<JSSubscriptionObserverCallback> callback)
+{
+    Ref internalObserver = adoptRef(*new InternalObserverFromScript(context, callback));
+    internalObserver->suspendIfNeeded();
+    return internalObserver;
+}
+
+Ref<InternalObserverFromScript> InternalObserverFromScript::create(ScriptExecutionContext& context, SubscriptionObserver& subscription)
+{
+    Ref internalObserver = adoptRef(*new InternalObserverFromScript(context, subscription));
+    internalObserver->suspendIfNeeded();
+    return internalObserver;
+}
+
+void InternalObserverFromScript::next(JSC::JSValue value)
+{
+    if (m_next)
+        m_next->handleEvent(value);
+}
+
+void InternalObserverFromScript::error(JSC::JSValue error)
+{
+    if (m_error) {
+        m_error->handleEvent(error);
+        return;
+    }
+
+    InternalObserver::error(error);
+}
+
+void InternalObserverFromScript::complete()
+{
+    if (m_complete)
+        m_complete->handleEvent();
+
+    m_active = false;
+}
+
+void InternalObserverFromScript::visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const
+{
+    if (m_next)
+        m_next->visitJSFunction(visitor);
+
+    if (m_error)
+        m_error->visitJSFunction(visitor);
+
+    if (m_complete)
+        m_complete->visitJSFunction(visitor);
+}
+
+void InternalObserverFromScript::visitAdditionalChildren(JSC::SlotVisitor& visitor) const
+{
+    if (m_next)
+        m_next->visitJSFunction(visitor);
+
+    if (m_error)
+        m_error->visitJSFunction(visitor);
+
+    if (m_complete)
+        m_complete->visitJSFunction(visitor);
+}
+
+InternalObserverFromScript::InternalObserverFromScript(ScriptExecutionContext& context, RefPtr<JSSubscriptionObserverCallback> callback)
+    : InternalObserver(context)
+    , m_next(callback)
+    , m_error(nullptr)
+    , m_complete(nullptr) { }
+
+InternalObserverFromScript::InternalObserverFromScript(ScriptExecutionContext& context, SubscriptionObserver& subscription)
+    : InternalObserver(context)
+    , m_next(subscription.next)
+    , m_error(subscription.error)
+    , m_complete(subscription.complete) { }
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverFromScript.h
+++ b/Source/WebCore/dom/InternalObserverFromScript.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InternalObserver.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class ScriptExecutionContext;
+class JSSubscriptionObserverCallback;
+class SubscriptionObserverCallback;
+struct SubscriptionObserver;
+
+class InternalObserverFromScript final : public InternalObserver {
+public:
+    static Ref<InternalObserverFromScript> create(ScriptExecutionContext&, RefPtr<JSSubscriptionObserverCallback>);
+    static Ref<InternalObserverFromScript> create(ScriptExecutionContext&, SubscriptionObserver&);
+
+    explicit InternalObserverFromScript(ScriptExecutionContext&, RefPtr<JSSubscriptionObserverCallback>);
+    explicit InternalObserverFromScript(ScriptExecutionContext&, SubscriptionObserver&);
+
+    void next(JSC::JSValue) final;
+    void error(JSC::JSValue) final;
+    void complete() final;
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const final;
+    void visitAdditionalChildren(JSC::SlotVisitor&) const final;
+
+protected:
+    // ActiveDOMObject
+    void stop() final
+    {
+        m_next = nullptr;
+        m_error = nullptr;
+        m_complete = nullptr;
+    }
+
+private:
+    RefPtr<SubscriptionObserverCallback> m_next;
+    RefPtr<SubscriptionObserverCallback> m_error;
+    RefPtr<VoidCallback> m_complete;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "AbortSignal.h"
 #include "ScriptWrappable.h"
 #include "SubscriberCallback.h"
 #include "VoidCallback.h"
@@ -33,6 +32,7 @@
 
 namespace WebCore {
 
+class InternalObserver;
 class ScriptExecutionContext;
 class JSSubscriptionObserverCallback;
 class SubscriptionObserverCallback;
@@ -50,11 +50,10 @@ public:
     explicit Observable(Ref<SubscriberCallback>);
 
     void subscribe(ScriptExecutionContext&, std::optional<ObserverUnion>, SubscribeOptions);
+    void subscribeInternal(ScriptExecutionContext&, Ref<InternalObserver>, SubscribeOptions);
 
 private:
-    Ref<SubscriberCallback> m_subscriber;
-
-    Ref<Subscriber> makeSubscriber(ScriptExecutionContext&, std::optional<ObserverUnion>);
+    Ref<SubscriberCallback> m_subscriberCallback;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 14125a03f1ad98b91fbe1d65d46c6f15c36e421b
<pre>
Implement InternalObserver for Observable
<a href="https://bugs.webkit.org/show_bug.cgi?id=276839">https://bugs.webkit.org/show_bug.cgi?id=276839</a>

Reviewed by Ryan Reno.

This implements `InternalObserver` for the `Observable` and
`Subscriber` classes, simplifying their functionality by
using a delegate class to manage some of the different types
of Observers. This will make it much easier to implement
operators (e.g. take, map, filter).

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSSubscriberCustom.cpp:
(WebCore::JSSubscriber::visitAdditionalChildren):
* Source/WebCore/dom/InternalObserver.cpp: Copied from Source/WebCore/dom/Observable.h.
(WebCore::InternalObserver::error):
* Source/WebCore/dom/InternalObserver.h: Copied from Source/WebCore/dom/Observable.h.
(WebCore::InternalObserver::complete):
(WebCore::InternalObserver::InternalObserver):
  The point of this class is to act as a base for further operators which will
  require mapping observables by creating intermediary subsribers, each which
  need an Observer. The spec describes these as Internal Observer.
  (<a href="https://wicg.github.io/observable/#internal-observer)">https://wicg.github.io/observable/#internal-observer)</a>
* Source/WebCore/dom/InternalObserverFromScript.cpp: Added.
(WebCore::InternalObserverFromScript::create):
(WebCore::InternalObserverFromScript::next):
(WebCore::InternalObserverFromScript::error):
(WebCore::InternalObserverFromScript::complete):
(WebCore::InternalObserverFromScript::visitAdditionalChildren const):
(WebCore::InternalObserverFromScript::InternalObserverFromScript):
  This class allows us to simpify Subscriber so that it only ever takes
  InternalObservers, by taking the existing way Subscriber consumes a
  SubscriptionObserver and mapping that to an InternalObserver delegate instead.
  I called this InternalObserverFromScript as it&apos;s InternalObserver that will
  only be created from the Observer#subscribe() IDL calls.
* Source/WebCore/dom/InternalObserverFromScript.h: Copied from Source/WebCore/dom/Observable.h.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::subscribe):
(WebCore::Observable::subscribeInternal):
(WebCore::Observable::Observable):
(WebCore::Observable::makeSubscriber): Deleted.
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Subscriber.cpp:
(WebCore::Subscriber::create):
(WebCore::Subscriber::Subscriber):
(WebCore::Subscriber::next):
(WebCore::Subscriber::error):
(WebCore::Subscriber::complete):
* Source/WebCore/dom/Subscriber.h:

Canonical link: <a href="https://commits.webkit.org/281278@main">https://commits.webkit.org/281278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/224499025d374806bfc09e81df3ffab528d2e02d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63237 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9766 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61452 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48175 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6948 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28998 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32834 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8600 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8770 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64970 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55526 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55617 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13151 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2705 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34482 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35565 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36651 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->