### PR TITLE
Remove non-standard `TextTrack.regions`

### DIFF
--- a/LayoutTests/fast/dom/collection-iterators-expected.txt
+++ b/LayoutTests/fast/dom/collection-iterators-expected.txt
@@ -183,14 +183,6 @@ PASS 'keys' in obj is false
 PASS 'forEach' in obj is false
 PASS 'values' in obj is false
 
-* VTTRegionList
-PASS Symbol.iterator in obj is true
-PASS for..of did not throw an exception
-PASS 'entries' in obj is false
-PASS 'keys' in obj is false
-PASS 'forEach' in obj is false
-PASS 'values' in obj is false
-
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/collection-iterators.html
+++ b/LayoutTests/fast/dom/collection-iterators.html
@@ -64,7 +64,6 @@ checkHasIterator("StyleSheetList", document.styleSheets);
 checkHasIterator("TextTrackCueList", document.createElement("video").addTextTrack("subtitles").cues);
 checkHasIterator("TextTrackList", media.textTracks);
 checkHasIterator("VideoTrackList", media.videoTracks);
-checkHasIterator("VTTRegionList", document.createElement("video").addTextTrack("subtitles").regions);
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/historical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/historical-expected.txt
@@ -1,6 +1,6 @@
 
 PASS VTTCue regionId member must be nuked
-FAIL TextTrack regions member must be nuked assert_false: expected false got true
+PASS TextTrack regions member must be nuked
 PASS TextTrack addRegion member must be nuked
 PASS TextTrack removeRegion member must be nuked
 PASS VTTRegion track member must be nuked

--- a/Source/WebCore/html/track/TextTrack.idl
+++ b/Source/WebCore/html/track/TextTrack.idl
@@ -53,7 +53,4 @@ enum TextTrackKind { "subtitles", "captions", "descriptions", "chapters", "metad
     undefined removeCue(TextTrackCue cue);
 
     attribute EventHandler oncuechange;
-
-    // FIXME: Remove 'non-standard'. See: https://bugs.webkit.org/show_bug.cgi?id=260767 
-    readonly attribute VTTRegionList regions;
 };


### PR DESCRIPTION
#### 8fc251fc41a328ec2536894428dc388c41587b22
<pre>
Remove non-standard `TextTrack.regions`
<a href="https://bugs.webkit.org/show_bug.cgi?id=269660">https://bugs.webkit.org/show_bug.cgi?id=269660</a>
&lt;<a href="https://rdar.apple.com/problem/123580142">rdar://problem/123580142</a>&gt;

Reviewed by Eric Carlson.

Revise our TextTrack.idl to match the standard. This allows us to pass a WPT test,
and remove a place where our implementation differs from the standard.

* LayoutTests/fast/dom/collection-iterators-expected.txt:
* LayoutTests/fast/dom/collection-iterators.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/historical-expected.txt:
* Source/WebCore/html/track/TextTrack.idl:

Canonical link: <a href="https://commits.webkit.org/281427@main">https://commits.webkit.org/281427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3e52187927a95ad310ef5b728682fe79c76b621

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62985 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48011 "") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6824 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8417 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8550 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64701 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8656 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55344 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55460 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2535 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8966 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34260 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35345 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->