### PR TITLE
[JSC] Extend object-cloning fast path for spread

### DIFF
--- a/JSTests/microbenchmarks/clone-objects-via-spread-first.js
+++ b/JSTests/microbenchmarks/clone-objects-via-spread-first.js
@@ -1,0 +1,24 @@
+function test(object, value)
+{
+    return { ...object, value };
+}
+noInline(test);
+
+var object = {
+    "hello": 1,
+    "world": 2,
+    "this": 3,
+    "is": 4,
+    "a": 5,
+    "test": 6,
+    "for": 7,
+    "super": 8,
+    "fast": 9,
+    "cloning": 10,
+    "via": 11,
+    "spread": 12,
+    "expression": 13,
+};
+
+for (var i = 0; i < 1e6; ++i)
+    test(object, 14);

--- a/JSTests/stress/spread-first.js
+++ b/JSTests/stress/spread-first.js
@@ -1,0 +1,30 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+function test(object, value)
+{
+    return { ...object, value };
+}
+noInline(test);
+
+function test2(object, object2)
+{
+    return { ...object, ...object2 };
+}
+noInline(test2);
+
+function test3(object, key, value)
+{
+    return { ...object, [key]: value };
+}
+noInline(test3);
+
+shouldBe(JSON.stringify(test({ a: 42, b: 43, c: 44 }, 45)), `{"a":42,"b":43,"c":44,"value":45}`);
+shouldBe(JSON.stringify(test({ a: 42, b: 43, value: 42, c: 44 }, 45)), `{"a":42,"b":43,"value":45,"c":44}`);
+shouldBe(JSON.stringify(test2({ a: 42, b: 43, value: 42, c: 44 }, { d: 44 })), `{"a":42,"b":43,"value":42,"c":44,"d":44}`);
+shouldBe(JSON.stringify(test2({ a: 42, b: 43, value: 42, c: 44 }, { c: 45 })), `{"a":42,"b":43,"value":42,"c":45}`);
+shouldBe(JSON.stringify(test3({ a: 42, b: 43, value: 42, c: 44 }, 'd', 44)), `{"a":42,"b":43,"value":42,"c":44,"d":44}`);
+shouldBe(JSON.stringify(test3({ a: 42, b: 43, value: 42, c: 44 }, 'c', 45)), `{"a":42,"b":43,"value":42,"c":45}`);


### PR DESCRIPTION
#### 7445b8e96e6bd57286af9089214d50c69e067f03
<pre>
[JSC] Extend object-cloning fast path for spread
<a href="https://bugs.webkit.org/show_bug.cgi?id=276841">https://bugs.webkit.org/show_bug.cgi?id=276841</a>
<a href="https://rdar.apple.com/132116565">rdar://132116565</a>

Reviewed by Yijia Huang.

If the object literal starts with the spread with simple properties like,

    `{ ...object, value: 42 }`

we can start with object cloning and setting the rest of them to the result.
This improves the above simple pattern&apos;s performance by 5.8x.

                                               ToT                     Patched

    clone-objects-via-spread-first      102.5393+-3.7326     ^     17.5802+-0.1094        ^ definitely 5.8327x faster

* JSTests/microbenchmarks/clone-objects-via-spread-first.js: Added.
(test):
* JSTests/stress/spread-first.js: Added.
(shouldBe):
(test):
(shouldBe.JSON.stringify.test):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ObjectLiteralNode::emitBytecode):

Canonical link: <a href="https://commits.webkit.org/281159@main">https://commits.webkit.org/281159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1acb44132dbda5a65612efe27cf0df05228fc0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62591 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9402 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47671 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6692 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28530 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8283 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8406 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/52051 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54488 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64291 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58200 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54995 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55098 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2403 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79961 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8812 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34116 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13827 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36285 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/34946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->