### PR TITLE
[popover] Improve tab navigation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
@@ -3,8 +3,8 @@ Invoker  after
 Show popover
 Toggle popover Other focusable element
 
-FAIL Popover focus navigation assert_true: popover1 should be invoked by invoker1 expected true got false
-FAIL Circular reference tab navigation assert_equals: circular reference: Step 1 (backwards) expected Element node <button id="circular0" popovertarget="popover4" tabindex=... but got Element node <button id="button4" tabindex="0">Button4</button>
+PASS Popover focus navigation
+PASS Circular reference tab navigation
 PASS Popover focus returns when popover is hidden by invoker
 PASS Popover focus only returns to invoker when focus is within the popover
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -412,10 +412,15 @@ void Element::setTabIndexForBindings(int value)
 
 bool Element::isKeyboardFocusable(KeyboardEvent*) const
 {
-    if (!(isFocusable() && !shouldBeIgnoredInSequentialFocusNavigation() && tabIndexSetExplicitly().value_or(0) >= 0))
+    if (!isFocusable() || shouldBeIgnoredInSequentialFocusNavigation() || tabIndexSetExplicitly().value_or(0) < 0)
         return false;
     if (RefPtr root = shadowRoot()) {
         if (root->delegatesFocus())
+            return false;
+    }
+    // Popovers with invokers delegate focus.
+    if (RefPtr popover = dynamicDowncast<HTMLElement>(*this)) {
+        if (popover->isPopoverShowing() && popover->popoverData()->invoker())
             return false;
     }
     return true;

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -104,6 +104,8 @@ public:
 
     RefPtr<Element> invokeTargetElement() const;
 
+    bool isKeyboardFocusable(KeyboardEvent*) const override;
+
     using Node::ref;
     using Node::deref;
 
@@ -121,7 +123,6 @@ protected:
     void readOnlyStateChanged() override;
     virtual void requiredStateChanged();
 
-    bool isKeyboardFocusable(KeyboardEvent*) const override;
     bool isMouseFocusable() const override;
 
     void didRecalcStyle(Style::Change) override;


### PR DESCRIPTION
#### 6e3d19b20a3743ff9679d3362dd577ce21838f4f
<pre>
[popover] Improve tab navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=276843">https://bugs.webkit.org/show_bug.cgi?id=276843</a>
<a href="https://rdar.apple.com/132129060">rdar://132129060</a>

Reviewed by Darin Adler.

This change:
- Changes the scope owner to be the popover rather than the invoker
- Makes popovers with invokers themselves not focusable, since they delegate focus
- In backwards navigation, makes the popover return to its invoker, rather than the node preceding the invoker
- In the nested popovers case, ensures popovers without focusable contents are ignored from backwards tab navigation

Test: LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2.html

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isKeyboardFocusable const):
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/page/FocusController.cpp:
(WebCore::invokerForOpenPopover):
(WebCore::openPopoverForInvoker):
(WebCore::isFocusScopeOwner):
(WebCore::FocusNavigationScope::firstChildInScope const):
(WebCore::FocusNavigationScope::lastChildInScope const):
(WebCore::FocusNavigationScope::nextSiblingInScope const):
(WebCore::FocusNavigationScope::previousSiblingInScope const):
(WebCore::FocusNavigationScope::firstNodeInScope const):
(WebCore::FocusNavigationScope::lastNodeInScope const):
(WebCore::FocusNavigationScope::previousInScope const):
(WebCore::FocusNavigationScope::owner const):
(WebCore::FocusNavigationScope::scopeOf):
(WebCore::FocusNavigationScope::scopeOwnedByScopeOwner):
(WebCore::FocusController::findFocusableElementAcrossFocusScope):
(WebCore::isOpenPopoverWithInvoker): Deleted.
(WebCore::invokerForPopoverShowingState): Deleted.
(WebCore::FocusNavigationScope::scopeOwnedByPopoverInvoker): Deleted.

Canonical link: <a href="https://commits.webkit.org/281167@main">https://commits.webkit.org/281167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41fa1dc3a51c30cff8d63fdd983273f5fb57bfae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62611 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9421 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47685 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6706 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28544 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8301 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8425 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64310 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8537 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55008 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55111 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13058 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2426 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34135 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35219 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36304 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->