### PR TITLE
The preconnect to an HTTP/1.1 origin blocks a main resource request.

### DIFF
--- a/Source/WebKit/NetworkProcess/PreconnectTask.cpp
+++ b/Source/WebKit/NetworkProcess/PreconnectTask.cpp
@@ -82,6 +82,10 @@ void PreconnectTask::willSendRedirectedRequest(ResourceRequest&&, ResourceReques
 
 void PreconnectTask::didReceiveResponse(ResourceResponse&& response, PrivateRelayed, ResponseCompletionHandler&& completionHandler)
 {
+#if !USE(CURL)
+    ASSERT_NOT_REACHED();
+#endif
+
     completionHandler(PolicyAction::Ignore);
     didFinish(ResourceError { ResourceError::Type::Cancellation }, NetworkLoadMetrics::emptyMetrics());
 }

--- a/Source/WebKit/NetworkProcess/PreconnectTask.cpp
+++ b/Source/WebKit/NetworkProcess/PreconnectTask.cpp
@@ -82,8 +82,8 @@ void PreconnectTask::willSendRedirectedRequest(ResourceRequest&&, ResourceReques
 
 void PreconnectTask::didReceiveResponse(ResourceResponse&& response, PrivateRelayed, ResponseCompletionHandler&& completionHandler)
 {
-    ASSERT_NOT_REACHED();
     completionHandler(PolicyAction::Ignore);
+    didFinish(ResourceError { ResourceError::Type::Cancellation }, NetworkLoadMetrics::emptyMetrics());
 }
 
 void PreconnectTask::didReceiveBuffer(const FragmentedSharedBuffer&, uint64_t reportedEncodedDataLength)


### PR DESCRIPTION
#### e3442d872260cfae9378878e3e895e7fe36a9557
<pre>
The preconnect to an HTTP/1.1 origin blocks a main resource request.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275467">https://bugs.webkit.org/show_bug.cgi?id=275467</a>

Reviewed by NOBODY (OOPS!).

The root cause of this issue is that the curl request had been canceled
but the PreconnectTask was still in running till the time out (10
seconds), which blocked the main resource request.

* Source/WebKit/NetworkProcess/PreconnectTask.cpp:
(WebKit::PreconnectTask::didReceiveResponse):
</pre>
----------------------------------------------------------------------
#### e8f523fdb41ebade4a15f77d8bb6f4ebd8344d93
<pre>
Exit preconnect task if the request has been canceled.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275467">https://bugs.webkit.org/show_bug.cgi?id=275467</a>

Reviewed by NOBODY (OOPS!).

The root cause of this issue is that the curl request had been canceled
but the PreconnectTask was still in running till the time out (10
seconds), which blocked the main resource request.

* Source/WebKit/NetworkProcess/PreconnectTask.cpp:
(WebKit::PreconnectTask::didReceiveResponse):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3442d872260cfae9378878e3e895e7fe36a9557

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65637 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12207 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49741 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8471 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30573 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34767 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11138 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56570 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67368 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5605 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57119 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5630 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57345 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4610 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36816 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37900 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38996 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37645 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->