### PR TITLE
SVGInlineTextBox: Adding DisplayList caching for glyphs

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2760,6 +2760,7 @@ rendering/RenderVideo.cpp
 rendering/RenderView.cpp
 rendering/RenderViewTransitionCapture.cpp
 rendering/RenderWidget.cpp
+rendering/SVGGlyphDisplayListCache.cpp
 rendering/StyledMarkedText.cpp
 rendering/TableLayout.cpp
 rendering/TextBoxPainter.cpp

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -235,6 +235,13 @@ std::unique_ptr<DisplayList::DisplayList> FontCascade::displayListForTextRun(Gra
     if (glyphBuffer.isEmpty())
         return nullptr;
 
+// #if PLATFORM(COCOA)
+//     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=252347
+//     // DisplayLists don't handle OTSVG glyphs correctly. From LayoutTests it seems to affect only Cocoa (rdar://105515478).
+//     if (hasOTSVGGlyph(glyphBuffer))
+//         return nullptr;
+// #endif
+
     std::unique_ptr<DisplayList::DisplayList> displayList = makeUnique<DisplayList::DisplayList>();
     DisplayList::RecorderImpl recordingContext(*displayList, context.state().clone(GraphicsContextState::Purpose::Initial), { },
         context.getCTM(GraphicsContext::DefinitelyIncludeDeviceScale), context.colorSpace(),

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -247,6 +247,8 @@ private:
     static bool canReturnFallbackFontsForComplexText();
     static bool canExpandAroundIdeographsInComplexText();
 
+    bool hasOTSVGGlyph(const GlyphBuffer&) const;
+
     GlyphBuffer layoutComplexText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
     float widthForComplexText(const TextRun&, SingleThreadWeakHashSet<const Font>* fallbackFonts = nullptr, GlyphOverflow* = nullptr) const;
     int offsetForPositionForComplexText(const TextRun&, float position, bool includePartialGlyphs) const;

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -514,4 +514,13 @@ ResolvedEmojiPolicy FontCascade::resolveEmojiPolicy(FontVariantEmoji fontVariant
     }
 }
 
+bool FontCascade::hasOTSVGGlyph(const GlyphBuffer& glyphBuffer) const
+{
+    for (unsigned i = 0; i < glyphBuffer.size(); ++i) {
+        if (glyphBuffer.fontAt(i).findOTSVGGlyphs(glyphBuffer.glyphs(i), 1))
+            return true;
+    }
+    return false;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/SVGGlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/SVGGlyphDisplayListCache.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SVGGlyphDisplayListCache.h"
+
+#include "DisplayListItems.h"
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+SVGGlyphDisplayListCache& SVGGlyphDisplayListCache::singleton()
+{
+    static NeverDestroyed<SVGGlyphDisplayListCache> cache;
+    return cache;
+}
+
+void SVGGlyphDisplayListCache::clear()
+{
+    m_entries.clear();
+}
+
+unsigned SVGGlyphDisplayListCache::size() const
+{
+    return m_entries.size();
+}
+
+DisplayList::DisplayList* SVGGlyphDisplayListCache::getDisplayList(const FontCascade& font, GraphicsContext& context, const TextRun& textRun, const PaintInfo& paintInfo)
+{
+    if (MemoryPressureHandler::singleton().isUnderMemoryPressure()) {
+        if (!m_entries.isEmpty()) {
+            LOG(MemoryPressure, "SVGGlyphDisplayListCache::%s - Under memory pressure - size: %d", __FUNCTION__, size());
+            clear();
+        }
+        return nullptr;
+    }
+
+    if (font.isLoadingCustomFonts() || !font.fonts())
+        return nullptr;
+
+    if (auto entry = m_entries.find(SVGGlyphDisplayListCacheKey { textRun, font, context }); entry != m_entries.end())
+        return entry->value.get();
+
+    bool isFrequentlyPainted = paintInfo.enclosingSelfPaintingLayer()->paintingFrequently();
+    if (!isFrequentlyPainted) {
+        // Now, all cache entries are actively used.
+        constexpr size_t maximumCacheSize = 2048;
+        if (m_entries.size() >= maximumCacheSize)
+            return nullptr;
+    }
+
+    if (auto displayList = font.displayListForTextRun(context, textRun)) {
+        SVGGlyphDisplayListCacheKey key { textRun, font, context };
+        if (!canShareDisplayList(*displayList))
+            return nullptr;
+
+        auto addResult = m_entries.add(key, WTFMove(displayList));
+        return addResult.iterator->value.get();
+    }
+
+    return nullptr;
+}
+
+bool SVGGlyphDisplayListCache::canShareDisplayList(const DisplayList::DisplayList& displayList)
+{
+    for (auto& item : displayList.items()) {
+        if (!(std::holds_alternative<DisplayList::Translate>(item)
+            || std::holds_alternative<DisplayList::Scale>(item)
+            || std::holds_alternative<DisplayList::ConcatenateCTM>(item)
+            || std::holds_alternative<DisplayList::DrawDecomposedGlyphs>(item)
+            || std::holds_alternative<DisplayList::DrawImageBuffer>(item)
+            || std::holds_alternative<DisplayList::DrawNativeImage>(item)
+            || std::holds_alternative<DisplayList::BeginTransparencyLayer>(item)
+            || std::holds_alternative<DisplayList::EndTransparencyLayer>(item)))
+            return false;
+    }
+    return true;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/SVGGlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/SVGGlyphDisplayListCache.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DisplayList.h"
+#include "FloatSizeHash.h"
+#include "FontCascade.h"
+#include "Logging.h"
+#include "TextRun.h"
+#include "TextRunHash.h"
+#include <memory>
+#include <wtf/GetPtr.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashTraits.h>
+#include <wtf/MemoryPressureHandler.h>
+#include <wtf/NeverDestroyed.h>
+
+namespace WebCore {
+
+class SVGGlyphDisplayListCacheKey {
+    WTF_MAKE_FAST_ALLOCATED;
+    friend struct SVGGlyphDisplayListCacheEntryHashTraits;
+    friend void add(Hasher&, const SVGGlyphDisplayListCacheKey&);
+public:
+    bool operator==(const SVGGlyphDisplayListCacheKey& other) const
+    {
+        return m_textRun == other.m_textRun
+            && m_scaleFactor == other.m_scaleFactor
+            && m_fontCascadeGeneration == other.m_fontCascadeGeneration
+            && m_shouldSubpixelQuantizeFont == other.m_shouldSubpixelQuantizeFont;
+    }
+
+    SVGGlyphDisplayListCacheKey()
+        : m_textRun(WTF::HashTableEmptyValue)
+    { }
+
+    SVGGlyphDisplayListCacheKey(WTF::HashTableDeletedValueType)
+        : m_textRun(WTF::HashTableDeletedValue)
+    { }
+
+    SVGGlyphDisplayListCacheKey(const TextRun& textRun, const FontCascade& font, GraphicsContext& context)
+        : m_textRun(textRun.isolatedCopy())
+        , m_scaleFactor(context.scaleFactor())
+        , m_fontCascadeGeneration(font.generation())
+        , m_shouldSubpixelQuantizeFont(context.shouldSubpixelQuantizeFonts())
+    {
+    }
+
+private:
+    TextRun m_textRun;
+    FloatSize m_scaleFactor;
+    unsigned m_fontCascadeGeneration;
+    bool m_shouldSubpixelQuantizeFont;
+};
+
+inline void add(Hasher& hasher, const SVGGlyphDisplayListCacheKey& key)
+{
+    add(hasher, key.m_textRun, key.m_scaleFactor.width(), key.m_scaleFactor.height(), key.m_fontCascadeGeneration, key.m_shouldSubpixelQuantizeFont);
+}
+
+struct SVGGlyphDisplayListCacheEntryHash {
+    static unsigned hash(const SVGGlyphDisplayListCacheKey& key) { return computeHash(key); }
+    static bool equal (const SVGGlyphDisplayListCacheKey& a, SVGGlyphDisplayListCacheKey b) { return a == b; }
+    static constexpr bool safeToCompareToEmptyOrDeleted = false;
+};
+
+struct SVGGlyphDisplayListCacheEntryHashTraits : SimpleClassHashTraits<SVGGlyphDisplayListCacheKey> {
+    static const bool emptyValueIsZero = false;
+    static SVGGlyphDisplayListCacheKey emptyValue() { return { }; }
+    static const bool hasIsEmptyValueFunction = true;
+    static bool isEmptyValue(const SVGGlyphDisplayListCacheKey& key) { return key.m_textRun.isHashTableEmptyValue(); }
+
+    static void constructDeletedValue(SVGGlyphDisplayListCacheKey& slot) { new (NotNull, &slot) SVGGlyphDisplayListCacheKey(WTF::HashTableDeletedValue); }
+    static bool isDeletedValue(const SVGGlyphDisplayListCacheKey& key) { return key.m_textRun.isHashTableDeletedValue(); }
+};
+
+class SVGGlyphDisplayListCache {
+    WTF_MAKE_FAST_ALLOCATED;
+    friend class SVGGlyphDisplayListCacheKey;
+public:
+    SVGGlyphDisplayListCache() = default;
+
+    static SVGGlyphDisplayListCache& singleton();
+
+    DisplayList::DisplayList* getDisplayList(const FontCascade&, GraphicsContext&, const TextRun&, const PaintInfo&);
+
+    void clear();
+    unsigned size() const;
+
+private:
+    static bool canShareDisplayList(const DisplayList::DisplayList&);
+    HashMap<SVGGlyphDisplayListCacheKey, std::unique_ptr<DisplayList::DisplayList>, SVGGlyphDisplayListCacheEntryHash, SVGGlyphDisplayListCacheEntryHashTraits> m_entries;
+};
+
+} // namespace WebCore
+
+namespace WTF {
+
+template<> struct DefaultHash<WebCore::SVGGlyphDisplayListCacheKey> : WebCore::SVGGlyphDisplayListCacheEntryHash { };
+
+} // namespace WTF

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
@@ -58,6 +58,7 @@ struct ExpectedSVGInlineTextBoxSize : public LegacyInlineTextBox {
     void* pointer;
     SVGPaintServerOrColor paintServerOrColor;
     Vector<SVGTextFragment> vector;
+    // void* displayList;
 };
 
 static_assert(sizeof(SVGInlineTextBox) == sizeof(ExpectedSVGInlineTextBoxSize), "SVGInlineTextBox is not of expected size");
@@ -296,14 +297,14 @@ void SVGInlineTextBox::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
                     continue;
                 setPaintingResourceMode({ RenderSVGResourceMode::ApplyToFill, RenderSVGResourceMode::ApplyToText });
                 ASSERT(selectionStyle);
-                paintText(paintInfo.context(), style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
+                paintText(paintInfo, paintInfo.context(), style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
                 break;
             case PaintType::Stroke:
                 if (!hasVisibleStroke)
                     continue;
                 setPaintingResourceMode({ RenderSVGResourceMode::ApplyToStroke, RenderSVGResourceMode::ApplyToText});
                 ASSERT(selectionStyle);
-                paintText(paintInfo.context(), style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
+                paintText(paintInfo, paintInfo.context(), style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
                 break;
             case PaintType::Markers:
                 continue;
@@ -602,7 +603,7 @@ void SVGInlineTextBox::paintDecorationWithStyle(GraphicsContext& context, Option
         releaseLegacyPaintingResource(usedContext, &path);
 }
 
-void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const RenderStyle& style, TextRun& textRun, const SVGTextFragment& fragment, unsigned startPosition, unsigned endPosition)
+void SVGInlineTextBox::paintTextWithShadows(const PaintInfo& paintInfo, GraphicsContext& context, const RenderStyle& style, TextRun& textRun, const SVGTextFragment& fragment, unsigned startPosition, unsigned endPosition)
 {
     float scalingFactor = renderer().scalingFactor();
     ASSERT(scalingFactor);
@@ -622,6 +623,8 @@ void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const Rend
 
     GraphicsContext* usedContext = &context;
     SVGPaintServerHandling paintServerHandling { context };
+
+    // setGlyphDisplayListIfNeeded(scaledFont, context, paintInfo, textRun);
 
     auto prepareGraphicsContext = [&]() -> bool {
         if (renderer().document().settings().layerBasedSVGEngineEnabled())
@@ -682,7 +685,8 @@ void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const Rend
                 usedContext->save();
 
             usedContext->scale(1 / scalingFactor);
-            scaledFont.drawText(*usedContext, textRun, textOrigin + shadowApplier.extraOffset(), startPosition, endPosition);
+            // scaledFont.drawText(*usedContext, textRun, textOrigin + shadowApplier.extraOffset(), startPosition, endPosition);
+            drawText(*usedContext, scaledFont, paintInfo, textRun, textOrigin + shadowApplier.extraOffset(), startPosition, endPosition);
 
             if (!shadowApplier.didSaveContext())
                 usedContext->restore();
@@ -700,7 +704,7 @@ void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const Rend
     } while (shadow);
 }
 
-void SVGInlineTextBox::paintText(GraphicsContext& context, const RenderStyle& style, const RenderStyle& selectionStyle, const SVGTextFragment& fragment, bool hasSelection, bool paintSelectedTextOnly)
+void SVGInlineTextBox::paintText(const PaintInfo& paintInfo, GraphicsContext& context, const RenderStyle& style, const RenderStyle& selectionStyle, const SVGTextFragment& fragment, bool hasSelection, bool paintSelectedTextOnly)
 {
     unsigned startPosition = 0;
     unsigned endPosition = 0;
@@ -712,23 +716,23 @@ void SVGInlineTextBox::paintText(GraphicsContext& context, const RenderStyle& st
     // Fast path if there is no selection, just draw the whole chunk part using the regular style
     TextRun textRun = constructTextRun(style, fragment);
     if (!hasSelection || startPosition >= endPosition) {
-        paintTextWithShadows(context, style, textRun, fragment, 0, fragment.length);
+        paintTextWithShadows(paintInfo, context, style, textRun, fragment, 0, fragment.length);
         return;
     }
 
     // Eventually draw text using regular style until the start position of the selection
     if (startPosition > 0 && !paintSelectedTextOnly)
-        paintTextWithShadows(context, style, textRun, fragment, 0, startPosition);
+        paintTextWithShadows(paintInfo, context, style, textRun, fragment, 0, startPosition);
 
     // Draw text using selection style from the start to the end position of the selection
     {
         SVGResourcesCache::SetStyleForScope temporaryStyleChange(parent()->renderer(), style, selectionStyle);
-        paintTextWithShadows(context, selectionStyle, textRun, fragment, startPosition, endPosition);
+        paintTextWithShadows(paintInfo, context, selectionStyle, textRun, fragment, startPosition, endPosition);
     }
 
     // Eventually draw text using regular style from the end position of the selection to the end of the current chunk part
     if (endPosition < fragment.length && !paintSelectedTextOnly)
-        paintTextWithShadows(context, style, textRun, fragment, endPosition, fragment.length);
+        paintTextWithShadows(paintInfo, context, style, textRun, fragment, endPosition, fragment.length);
 }
 
 FloatRect SVGInlineTextBox::calculateBoundaries() const
@@ -791,6 +795,36 @@ bool SVGInlineTextBox::nodeAtPoint(const HitTestRequest& request, HitTestResult&
         }
     }
     return false;
+}
+
+bool SVGInlineTextBox::shouldUseGlyphDisplayList(const PaintInfo& paintInfo)
+{
+    return !paintInfo.context().paintingDisabled() && paintInfo.enclosingSelfPaintingLayer();
+}
+
+// void SVGInlineTextBox::setGlyphDisplayListIfNeeded(const FontCascade& fontCascade, GraphicsContext& context, const PaintInfo& paintInfo, const TextRun& textRun)
+// {
+//     // if (!SVGInlineTextBox::shouldUseGlyphDisplayList(paintInfo))
+//     //     removeFromGlyphDisplayListCache();
+//     if (SVGInlineTextBox::shouldUseGlyphDisplayList(paintInfo))
+//         m_glyphDisplayList = SVGGlyphDisplayListCache::singleton().getDisplayList(fontCascade, context, textRun, paintInfo);
+// }
+
+void SVGInlineTextBox::drawText(GraphicsContext& context, const FontCascade& fontCascade, const PaintInfo& paintInfo, const TextRun& textRun, const FloatPoint& textOrigin, unsigned startOffset, unsigned endOffset)
+{
+    if (startOffset || endOffset < textRun.length() || !shouldUseGlyphDisplayList(paintInfo)) {
+        fontCascade.drawText(context, textRun, textOrigin, startOffset, endOffset);
+        return;
+    }
+
+    auto* glyphDisplayList = SVGGlyphDisplayListCache::singleton().getDisplayList(fontCascade, context, textRun, paintInfo);
+
+    if (!glyphDisplayList) {
+        fontCascade.drawText(context, textRun, textOrigin, startOffset, endOffset);
+        return;
+    }
+
+    context.drawDisplayListItems(glyphDisplayList->items(), glyphDisplayList->resourceHeap(), textOrigin);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.h
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.h
@@ -22,9 +22,11 @@
 
 #pragma once
 
+// #include "GlyphDisplayListCache.h"
 #include "LegacyInlineTextBox.h"
 #include "LegacyRenderSVGResource.h"
 #include "RenderSVGResourcePaintServer.h"
+#include "SVGGlyphDisplayListCache.h"
 #include "SVGTextFragment.h"
 
 namespace WebCore {
@@ -83,10 +85,15 @@ private:
 
     void paintDecoration(GraphicsContext&, OptionSet<TextDecorationLine>, const SVGTextFragment&);
     void paintDecorationWithStyle(GraphicsContext&, OptionSet<TextDecorationLine>, const SVGTextFragment&, RenderBoxModelObject& decorationRenderer);
-    void paintTextWithShadows(GraphicsContext&, const RenderStyle&, TextRun&, const SVGTextFragment&, unsigned startPosition, unsigned endPosition);
-    void paintText(GraphicsContext&, const RenderStyle&, const RenderStyle& selectionStyle, const SVGTextFragment&, bool hasSelection, bool paintSelectedTextOnly);
+    void paintTextWithShadows(const PaintInfo&, GraphicsContext&, const RenderStyle&, TextRun&, const SVGTextFragment&, unsigned startPosition, unsigned endPosition);
+    void paintText(const PaintInfo&, GraphicsContext&, const RenderStyle&, const RenderStyle& selectionStyle, const SVGTextFragment&, bool hasSelection, bool paintSelectedTextOnly);
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, LayoutUnit lineTop, LayoutUnit lineBottom, HitTestAction) override;
+
+    static bool shouldUseGlyphDisplayList(const PaintInfo&);
+    void setGlyphDisplayListIfNeeded(const FontCascade&, GraphicsContext&, const PaintInfo&, const TextRun&);
+
+    void drawText(GraphicsContext&, const FontCascade&, const PaintInfo&, const TextRun&, const FloatPoint& textOrigin, unsigned startOffset, unsigned endOffset);
 
 private:
     float m_logicalHeight { 0 };
@@ -96,6 +103,8 @@ private:
     SVGPaintServerOrColor m_paintServerOrColor { };
 
     Vector<SVGTextFragment> m_textFragments;
+
+    // DisplayList::DisplayList* m_glyphDisplayList { nullptr };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### cb2ca507cb4bc529328878a0d1c3657bec5b4116
<pre>
SVGInlineTextBox: Adding DisplayList caching for glyphs
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::paint):
(WebCore::SVGInlineTextBox::paintTextWithShadows):
(WebCore::SVGInlineTextBox::paintText):
(WebCore::SVGInlineTextBox::shouldUseGlyphDisplayList):
(WebCore::SVGInlineTextBox::setGlyphDisplayListIfNeeded):
(WebCore::SVGInlineTextBox::drawText):
* Source/WebCore/rendering/svg/SVGInlineTextBox.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb2ca507cb4bc529328878a0d1c3657bec5b4116

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62634 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9440 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61126 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9643 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47708 "Found 4 new test failures: imported/blink/svg/text/obb-paintserver.html imported/blink/svg/text/selection-partial-gradient.html imported/mozilla/svg/text-gradient-01.svg imported/mozilla/svg/text-scale-02.svg (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6734 "Passed tests") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61027 "Build is in progress. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7; Running apply-patch; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28566 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8321 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8444 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54530 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64333 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8557 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55031 "Found 3 new test failures: imported/blink/svg/text/obb-paintserver.html imported/mozilla/svg/text-gradient-01.svg imported/mozilla/svg/text-scale-02.svg (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55134 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2444 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34154 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35238 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36323 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34984 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->