### PR TITLE
Gardening: `seeking-events-1` and `seeking-events-4` tests are passing now

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2087,7 +2087,6 @@ imported/w3c/web-platform-tests/svg/animations/seeking-events-2.html [ Failure P
 imported/w3c/web-platform-tests/svg/animations/dependent-begin-on-syncbase.html [ Failure Pass ]
 imported/w3c/web-platform-tests/svg/animations/dependent-end-on-syncbase.html [ Failure Pass ]
 imported/w3c/web-platform-tests/svg/path/distance/pathlength-rect-mutating.svg [ Failure Pass ]
-imported/w3c/web-platform-tests/svg/animations/seeking-events-1.html [ Failure Pass ]
 imported/w3c/web-platform-tests/svg/animations/pruning-first-interval.html [ Failure Pass ]
 imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-scale-scroll.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-with-position-under-clip-path.html [ ImageOnlyFailure ]
@@ -4861,8 +4860,6 @@ webkit.org/b/214299 imported/w3c/web-platform-tests/css/css-ui/text-overflow-021
 webkit.org/b/214299 imported/w3c/web-platform-tests/css/css-ui/webkit-appearance-menulist-button-002.tentative.html [ ImageOnlyFailure ]
 webkit.org/b/214299 imported/w3c/web-platform-tests/css/css-ui/resize-child-will-change-transform.html [ ImageOnlyFailure ]
 webkit.org/b/214299 imported/w3c/web-platform-tests/css/css-ui/resize-generated-content.html [ ImageOnlyFailure ]
-
-webkit.org/b/214387 imported/w3c/web-platform-tests/svg/animations/seeking-events-4.html [ Pass Failure ]
 
 webkit.org/b/214453 imported/w3c/web-platform-tests/css/css-align/baseline-of-scrollable-1b.html [ ImageOnlyFailure ]
 webkit.org/b/214453 imported/w3c/web-platform-tests/css/css-align/baseline-rules/grid-item-input-type-number.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/seeking-events-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/seeking-events-1-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Seeking forwards does not dispatch events for skipped elements assert_true: Not expecting event, but got endEvent event expected true got false
+PASS Seeking forwards does not dispatch events for skipped elements
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/seeking-events-4-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/seeking-events-4-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Seeking forwards dispatches 'endEvent' if the element is not active at the seeked-to time assert_true: Not expecting event, but got endEvent event expected true got false
+PASS Seeking forwards dispatches 'endEvent' if the element is not active at the seeked-to time
 


### PR DESCRIPTION
<pre>
Gardening: `seeking-events-1` and `seeking-events-4` tests are passing now
<a href="https://bugs.webkit.org/show_bug.cgi?id=276851">https://bugs.webkit.org/show_bug.cgi?id=276851</a>

Unreviewed test gardening.

It seems that these tests are passing since past few STP releases, so
this patch is to update 'test expectations' to reflect it.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/seeking-events-1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/seeking-events-4-expected.txt:
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf5cf1873ae85d613b0eebd4c0d56b528e8bd004

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62644 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9446 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47718 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6740 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28576 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32584 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8327 "44 flakes 2 failures") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8450 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54536 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64342 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2915 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8562 "Exiting early after 10 failures. 19 tests run. 2 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55039 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2925 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51064 "Exiting early after 10 failures. 23 tests run. 2 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55142 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2449 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34160 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35244 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36329 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34990 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->