### PR TITLE
SVGInlineTextBox: DisplayList on SVGTextFragment

### DIFF
--- a/Source/WebCore/rendering/GlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.cpp
@@ -32,6 +32,7 @@
 #include "PaintInfo.h"
 #include "RenderLayer.h"
 #include "RenderStyleInlines.h"
+#include "SVGTextFragment.h"
 
 namespace WebCore {
 
@@ -144,6 +145,11 @@ DisplayList::DisplayList* GlyphDisplayListCache::get(const InlineDisplay::Box& r
     return getDisplayList(run, font, context, textRun, paintInfo);
 }
 
+DisplayList::DisplayList* GlyphDisplayListCache::get(const SVGTextFragment& run, const FontCascade& font, GraphicsContext& context, const TextRun& textRun, const PaintInfo& paintInfo)
+{
+    return getDisplayList(run, font, context, textRun, paintInfo);
+}
+
 template<typename LayoutRun>
 DisplayList::DisplayList* GlyphDisplayListCache::getIfExistsImpl(const LayoutRun& run)
 {
@@ -160,6 +166,11 @@ DisplayList::DisplayList* GlyphDisplayListCache::getIfExists(const LegacyInlineT
 }
 
 DisplayList::DisplayList* GlyphDisplayListCache::getIfExists(const InlineDisplay::Box& run)
+{
+    return getIfExistsImpl(run);
+}
+
+DisplayList::DisplayList* GlyphDisplayListCache::getIfExists(const SVGTextFragment& run)
 {
     return getIfExistsImpl(run);
 }

--- a/Source/WebCore/rendering/GlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.h
@@ -40,6 +40,8 @@ namespace WebCore {
 
 class LegacyInlineTextBox;
 
+struct SVGTextFragment;
+
 namespace InlineDisplay {
 struct Box;
 }
@@ -109,12 +111,15 @@ public:
 
     DisplayList::DisplayList* get(const LegacyInlineTextBox&, const FontCascade&, GraphicsContext&, const TextRun&, const PaintInfo&);
     DisplayList::DisplayList* get(const InlineDisplay::Box&, const FontCascade&, GraphicsContext&, const TextRun&, const PaintInfo&);
+    DisplayList::DisplayList* get(const SVGTextFragment&, const FontCascade&, GraphicsContext&, const TextRun&, const PaintInfo&);
 
     DisplayList::DisplayList* getIfExists(const LegacyInlineTextBox&);
     DisplayList::DisplayList* getIfExists(const InlineDisplay::Box&);
+    DisplayList::DisplayList* getIfExists(const SVGTextFragment&);
 
     void remove(const LegacyInlineTextBox& run) { remove(&run); }
     void remove(const InlineDisplay::Box& run) { remove(&run); }
+    void remove(const SVGTextFragment& run) { remove(&run); }
 
     void clear();
     unsigned size() const;

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
@@ -44,6 +44,7 @@
 #include "SVGRenderingContext.h"
 #include "SVGResourcesCache.h"
 #include "SVGRootInlineBox.h"
+#include "SVGTextFragment.h"
 #include "TextBoxSelectableRange.h"
 #include "TextPainter.h"
 #include <wtf/IsoMallocInlines.h>
@@ -58,6 +59,7 @@ struct ExpectedSVGInlineTextBoxSize : public LegacyInlineTextBox {
     void* pointer;
     SVGPaintServerOrColor paintServerOrColor;
     Vector<SVGTextFragment> vector;
+    void* displayList;
 };
 
 static_assert(sizeof(SVGInlineTextBox) == sizeof(ExpectedSVGInlineTextBoxSize), "SVGInlineTextBox is not of expected size");
@@ -296,14 +298,14 @@ void SVGInlineTextBox::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
                     continue;
                 setPaintingResourceMode({ RenderSVGResourceMode::ApplyToFill, RenderSVGResourceMode::ApplyToText });
                 ASSERT(selectionStyle);
-                paintText(paintInfo.context(), style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
+                paintText(paintInfo, paintInfo.context(), style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
                 break;
             case PaintType::Stroke:
                 if (!hasVisibleStroke)
                     continue;
                 setPaintingResourceMode({ RenderSVGResourceMode::ApplyToStroke, RenderSVGResourceMode::ApplyToText});
                 ASSERT(selectionStyle);
-                paintText(paintInfo.context(), style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
+                paintText(paintInfo, paintInfo.context(), style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
                 break;
             case PaintType::Markers:
                 continue;
@@ -602,7 +604,7 @@ void SVGInlineTextBox::paintDecorationWithStyle(GraphicsContext& context, Option
         releaseLegacyPaintingResource(usedContext, &path);
 }
 
-void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const RenderStyle& style, TextRun& textRun, const SVGTextFragment& fragment, unsigned startPosition, unsigned endPosition)
+void SVGInlineTextBox::paintTextWithShadows(const PaintInfo& paintInfo, GraphicsContext& context, const RenderStyle& style, TextRun& textRun, SVGTextFragment& fragment, unsigned startPosition, unsigned endPosition)
 {
     float scalingFactor = renderer().scalingFactor();
     ASSERT(scalingFactor);
@@ -622,6 +624,8 @@ void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const Rend
 
     GraphicsContext* usedContext = &context;
     SVGPaintServerHandling paintServerHandling { context };
+
+    setGlyphDisplayListIfNeeded(fragment, scaledFont, context, paintInfo, textRun);
 
     auto prepareGraphicsContext = [&]() -> bool {
         if (renderer().document().settings().layerBasedSVGEngineEnabled())
@@ -682,7 +686,8 @@ void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const Rend
                 usedContext->save();
 
             usedContext->scale(1 / scalingFactor);
-            scaledFont.drawText(*usedContext, textRun, textOrigin + shadowApplier.extraOffset(), startPosition, endPosition);
+            // scaledFont.drawText(*usedContext, textRun, textOrigin + shadowApplier.extraOffset(), startPosition, endPosition);
+            drawText(*usedContext, scaledFont, textRun, textOrigin + shadowApplier.extraOffset(), startPosition, endPosition);
 
             if (!shadowApplier.didSaveContext())
                 usedContext->restore();
@@ -700,7 +705,7 @@ void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const Rend
     } while (shadow);
 }
 
-void SVGInlineTextBox::paintText(GraphicsContext& context, const RenderStyle& style, const RenderStyle& selectionStyle, const SVGTextFragment& fragment, bool hasSelection, bool paintSelectedTextOnly)
+void SVGInlineTextBox::paintText(const PaintInfo& paintInfo, GraphicsContext& context, const RenderStyle& style, const RenderStyle& selectionStyle, SVGTextFragment& fragment, bool hasSelection, bool paintSelectedTextOnly)
 {
     unsigned startPosition = 0;
     unsigned endPosition = 0;
@@ -712,23 +717,23 @@ void SVGInlineTextBox::paintText(GraphicsContext& context, const RenderStyle& st
     // Fast path if there is no selection, just draw the whole chunk part using the regular style
     TextRun textRun = constructTextRun(style, fragment);
     if (!hasSelection || startPosition >= endPosition) {
-        paintTextWithShadows(context, style, textRun, fragment, 0, fragment.length);
+        paintTextWithShadows(paintInfo, context, style, textRun, fragment, 0, fragment.length);
         return;
     }
 
     // Eventually draw text using regular style until the start position of the selection
     if (startPosition > 0 && !paintSelectedTextOnly)
-        paintTextWithShadows(context, style, textRun, fragment, 0, startPosition);
+        paintTextWithShadows(paintInfo, context, style, textRun, fragment, 0, startPosition);
 
     // Draw text using selection style from the start to the end position of the selection
     {
         SVGResourcesCache::SetStyleForScope temporaryStyleChange(parent()->renderer(), style, selectionStyle);
-        paintTextWithShadows(context, selectionStyle, textRun, fragment, startPosition, endPosition);
+        paintTextWithShadows(paintInfo, context, selectionStyle, textRun, fragment, startPosition, endPosition);
     }
 
     // Eventually draw text using regular style from the end position of the selection to the end of the current chunk part
     if (endPosition < fragment.length && !paintSelectedTextOnly)
-        paintTextWithShadows(context, style, textRun, fragment, endPosition, fragment.length);
+        paintTextWithShadows(paintInfo, context, style, textRun, fragment, endPosition, fragment.length);
 }
 
 FloatRect SVGInlineTextBox::calculateBoundaries() const
@@ -791,6 +796,28 @@ bool SVGInlineTextBox::nodeAtPoint(const HitTestRequest& request, HitTestResult&
         }
     }
     return false;
+}
+
+bool SVGInlineTextBox::shouldUseGlyphDisplayList(const PaintInfo& paintInfo)
+{
+    return !paintInfo.context().paintingDisabled() && paintInfo.enclosingSelfPaintingLayer();
+}
+
+void SVGInlineTextBox::setGlyphDisplayListIfNeeded(SVGTextFragment& textFragment, const FontCascade& fontCascade, GraphicsContext& context, const PaintInfo& paintInfo, const TextRun& textRun)
+{
+    if (!SVGInlineTextBox::shouldUseGlyphDisplayList(paintInfo))
+        textFragment.removeFromGlyphDisplayListCache();
+    else
+        m_glyphDisplayList = GlyphDisplayListCache::singleton().get(textFragment, fontCascade, context, textRun, paintInfo);
+}
+
+void SVGInlineTextBox::drawText(GraphicsContext& context, const FontCascade& fontCascade, const TextRun& textRun, const FloatPoint& textOrigin, unsigned startOffset, unsigned endOffset)
+{
+    if (startOffset || endOffset < textRun.length() || !m_glyphDisplayList)
+        fontCascade.drawText(context, textRun, textOrigin, startOffset, endOffset);
+    else
+        context.drawDisplayListItems(m_glyphDisplayList->items(), m_glyphDisplayList->resourceHeap(), textOrigin);
+    m_glyphDisplayList = nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.h
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.h
@@ -83,10 +83,16 @@ private:
 
     void paintDecoration(GraphicsContext&, OptionSet<TextDecorationLine>, const SVGTextFragment&);
     void paintDecorationWithStyle(GraphicsContext&, OptionSet<TextDecorationLine>, const SVGTextFragment&, RenderBoxModelObject& decorationRenderer);
-    void paintTextWithShadows(GraphicsContext&, const RenderStyle&, TextRun&, const SVGTextFragment&, unsigned startPosition, unsigned endPosition);
-    void paintText(GraphicsContext&, const RenderStyle&, const RenderStyle& selectionStyle, const SVGTextFragment&, bool hasSelection, bool paintSelectedTextOnly);
+    void paintTextWithShadows(const PaintInfo&, GraphicsContext&, const RenderStyle&, TextRun&, SVGTextFragment&, unsigned startPosition, unsigned endPosition);
+    void paintText(const PaintInfo&, GraphicsContext&, const RenderStyle&, const RenderStyle& selectionStyle, SVGTextFragment&, bool hasSelection, bool paintSelectedTextOnly);
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, LayoutUnit lineTop, LayoutUnit lineBottom, HitTestAction) override;
+
+    static bool shouldUseGlyphDisplayList(const PaintInfo&);
+    void setGlyphDisplayListIfNeeded(SVGTextFragment&, const FontCascade&, GraphicsContext&, const PaintInfo&, const TextRun&);
+    // void getGlyphDisplayList(TextFragment*, const FontCascade&, GraphicsContext&, const PaintInfo&, const TextRun&);
+
+    void drawText(GraphicsContext&, const FontCascade&, const TextRun&, const FloatPoint& textOrigin, unsigned startOffset, unsigned endOffset);
 
 private:
     float m_logicalHeight { 0 };
@@ -96,6 +102,8 @@ private:
     SVGPaintServerOrColor m_paintServerOrColor { };
 
     Vector<SVGTextFragment> m_textFragments;
+
+    DisplayList::DisplayList* m_glyphDisplayList { nullptr };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGTextFragment.h
+++ b/Source/WebCore/rendering/svg/SVGTextFragment.h
@@ -21,6 +21,7 @@
 
 #include "AffineTransform.h"
 
+#include "GlyphDisplayListCache.h"
 namespace WebCore {
 
 // A SVGTextFragment describes a text fragment of a RenderSVGInlineText which can be rendered at once.
@@ -35,6 +36,12 @@ struct SVGTextFragment {
         , width(0)
         , height(0)
     {
+    }
+
+    ~SVGTextFragment()
+    {
+        if (inGlyphDisplayListCache)
+            removeFromGlyphDisplayListCache();
     }
 
     enum TransformType {
@@ -74,7 +81,19 @@ struct SVGTextFragment {
     // Contains lengthAdjust related transformations, which are not allowd to influence the SVGTextQuery code.
     AffineTransform lengthAdjustTransform;
 
+    bool isInGlyphDisplayListCache() const { return inGlyphDisplayListCache; }
+    void setIsInGlyphDisplayListCache(bool inCache = true) { inGlyphDisplayListCache = inCache; }
+    void removeFromGlyphDisplayListCache()
+    {
+        if (inGlyphDisplayListCache) {
+            GlyphDisplayListCache::singleton().remove(*this);
+            setIsInGlyphDisplayListCache(false);
+        }
+    }
+
 private:
+    bool inGlyphDisplayListCache = false;
+
     void transformAroundOrigin(AffineTransform& result) const
     {
         // Returns (translate(x, y) * result) * translate(-x, -y).


### PR DESCRIPTION
#### 95ef1785487c37ab37fbe4ec7d255c980b93df41
<pre>
SVGInlineTextBox: DisplayList on SVGTextFragment
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::displayListForTextRun const):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::FontCascade::hasOTSVGGlyph const):
* Source/WebCore/rendering/GlyphDisplayListCache.cpp:
(WebCore::GlyphDisplayListCache::get):
(WebCore::GlyphDisplayListCache::getIfExists):
* Source/WebCore/rendering/GlyphDisplayListCache.h:
(WebCore::GlyphDisplayListCache::remove):
* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::paint):
(WebCore::SVGInlineTextBox::paintTextWithShadows):
(WebCore::SVGInlineTextBox::paintText):
(WebCore::SVGInlineTextBox::shouldUseGlyphDisplayList):
(WebCore::SVGInlineTextBox::setGlyphDisplayListIfNeeded):
(WebCore::SVGInlineTextBox::drawText):
* Source/WebCore/rendering/svg/SVGInlineTextBox.h:
* Source/WebCore/rendering/svg/SVGTextFragment.h:
(WebCore::SVGTextFragment::~SVGTextFragment):
(WebCore::SVGTextFragment::isInGlyphDisplayListCache const):
(WebCore::SVGTextFragment::setIsInGlyphDisplayListCache):
(WebCore::SVGTextFragment::removeFromGlyphDisplayListCache):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95ef1785487c37ab37fbe4ec7d255c980b93df41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62672 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9460 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47742 "") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6749 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28600 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32593 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8336 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8464 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54545 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8616 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64368 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2929 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8573 "Found 2 new test failures: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55062 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2939 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55165 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2458 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34174 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35258 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36343 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->