### PR TITLE
[Pointer Events] Add a stub implementation for the `getCoalescedEvents` function of the PointerEvent interface

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2829,6 +2829,20 @@ GenericCueAPIEnabled:
     WebCore:
       default: false
 
+GetCoalescedEventsEnabled:
+  type: bool
+  status: unstable
+  category: dom
+  humanReadableName: "Pointer Events getCoalescedEvents API"
+  humanReadableDescription: "Enable the `getCoalescedEvents` function of the Pointer Events API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 GetUserMediaRequiresFocus:
   type: bool
   status: internal

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -68,7 +68,12 @@ RefPtr<PointerEvent> PointerEvent::create(MouseButton button, const MouseEvent& 
 
 Ref<PointerEvent> PointerEvent::create(const AtomString& type, MouseButton button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
 {
-    return adoptRef(*new PointerEvent(type, button, mouseEvent, pointerId, pointerType));
+    return create(type, button, mouseEvent, pointerId, pointerType, typeCanBubble(type), typeIsCancelable(type));
+}
+
+Ref<PointerEvent> PointerEvent::create(const AtomString& type, MouseButton button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType, CanBubble canBubble, IsCancelable isCancelable)
+{
+    return adoptRef(*new PointerEvent(type, button, mouseEvent, pointerId, pointerType, canBubble, isCancelable));
 }
 
 Ref<PointerEvent> PointerEvent::create(const AtomString& type, PointerID pointerId, const String& pointerType, IsPrimary isPrimary)
@@ -93,11 +98,12 @@ PointerEvent::PointerEvent(const AtomString& type, Init&& initializer)
     , m_twist(initializer.twist)
     , m_pointerType(initializer.pointerType)
     , m_isPrimary(initializer.isPrimary)
+    , m_coalescedEvents(initializer.coalescedEvents)
 {
 }
 
-PointerEvent::PointerEvent(const AtomString& type, MouseButton button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
-    : MouseEvent(EventInterfaceType::PointerEvent, type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), mouseEvent.timeStamp(), mouseEvent.view(), mouseEvent.detail(), mouseEvent.screenLocation(),
+PointerEvent::PointerEvent(const AtomString& type, MouseButton button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType, CanBubble canBubble, IsCancelable isCancelable)
+    : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), mouseEvent.timeStamp(), mouseEvent.view(), mouseEvent.detail(), mouseEvent.screenLocation(),
         { mouseEvent.clientX(), mouseEvent.clientY() }, mouseEvent.movementX(), mouseEvent.movementY(), mouseEvent.modifierKeys(), button, mouseEvent.buttons(),
         mouseEvent.syntheticClickType(), mouseEvent.relatedTarget())
     , m_pointerId(pointerId)
@@ -121,5 +127,10 @@ PointerEvent::PointerEvent(const AtomString& type, PointerID pointerId, const St
 }
 
 PointerEvent::~PointerEvent() = default;
+
+Vector<Ref<PointerEvent>> PointerEvent::getCoalescedEvents()
+{
+    return m_coalescedEvents;
+}
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -58,6 +58,7 @@ public:
         long twist { 0 };
         String pointerType { mousePointerEventType() };
         bool isPrimary { false };
+        Vector<Ref<PointerEvent>> coalescedEvents;
     };
 
     enum class IsPrimary : bool { No, Yes };
@@ -84,6 +85,7 @@ public:
 
     static RefPtr<PointerEvent> create(MouseButton, const MouseEvent&, PointerID, const String& pointerType);
     static Ref<PointerEvent> create(const AtomString& type, MouseButton, const MouseEvent&, PointerID, const String& pointerType);
+    static Ref<PointerEvent> create(const AtomString& type, MouseButton, const MouseEvent&, PointerID, const String& pointerType, CanBubble, IsCancelable);
     static Ref<PointerEvent> create(const AtomString& type, PointerID, const String& pointerType, IsPrimary = IsPrimary::No);
 
 #if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
@@ -103,6 +105,8 @@ public:
     long twist() const { return m_twist; }
     String pointerType() const { return m_pointerType; }
     bool isPrimary() const { return m_isPrimary; }
+
+    Vector<Ref<PointerEvent>> getCoalescedEvents();
 
     bool isPointerEvent() const final { return true; }
 
@@ -138,7 +142,7 @@ private:
 
     PointerEvent();
     PointerEvent(const AtomString&, Init&&);
-    PointerEvent(const AtomString& type, MouseButton, const MouseEvent&, PointerID, const String& pointerType);
+    PointerEvent(const AtomString& type, MouseButton, const MouseEvent&, PointerID, const String& pointerType, CanBubble, IsCancelable);
     PointerEvent(const AtomString& type, PointerID, const String& pointerType, IsPrimary);
 #if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
     PointerEvent(const AtomString& type, const PlatformTouchEvent&, IsCancelable isCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
@@ -154,6 +158,7 @@ private:
     long m_twist { 0 };
     String m_pointerType { mousePointerEventType() };
     bool m_isPrimary { false };
+    Vector<Ref<PointerEvent>> m_coalescedEvents;
 };
 
 inline bool PointerEvent::typeIsEnterOrLeave(const AtomString& type)

--- a/Source/WebCore/dom/PointerEvent.idl
+++ b/Source/WebCore/dom/PointerEvent.idl
@@ -34,11 +34,14 @@ dictionary PointerEventInit : MouseEventInit {
     long twist = 0;
     DOMString pointerType = "";
     boolean isPrimary = false;
+    sequence<PointerEvent> coalescedEvents = [];
 };
 
 [
     DisabledByQuirk=shouldDisablePointerEvents,
-    Exposed=Window
+    Exposed=Window,
+    JSGenerateToNativeObject,
+    ExportToWrappedFunction
 ] interface PointerEvent : MouseEvent {
     constructor([AtomString] DOMString type, optional PointerEventInit eventInitDict);
 
@@ -52,5 +55,7 @@ dictionary PointerEventInit : MouseEventInit {
     readonly attribute long twist;
     readonly attribute DOMString pointerType;
     readonly attribute boolean isPrimary;
+
+    [SecureContext, EnabledBySetting=GetCoalescedEventsEnabled] sequence<PointerEvent> getCoalescedEvents();
 };
 


### PR DESCRIPTION
#### 5da0cb3702d0173c3dff499c70c8af3e6c416a06
<pre>
[Pointer Events] Add a stub implementation for the `getCoalescedEvents` function of the PointerEvent interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=276832">https://bugs.webkit.org/show_bug.cgi?id=276832</a>
<a href="https://rdar.apple.com/132105605">rdar://132105605</a>

Reviewed by Tim Nguyen.

Add a stub implementation for the `getCoalescedEvents` function of the `PointerEvent` interface,
as per the corresponding UI events specification (<a href="https://w3c.github.io/pointerevents/#dom-pointerevent-getcoalescedevents).">https://w3c.github.io/pointerevents/#dom-pointerevent-getcoalescedevents).</a>

Also slightly refactor the `PointerEvent` constructors to allow for explicitly setting the value of
`bubbles` and `isCancelable`, which must be set to `false` for the coalesced events.

Also adds a runtime feature flag to control its enablement.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::create):
(WebCore::PointerEvent::PointerEvent):
(WebCore::PointerEvent::getCoalescedEvents):
* Source/WebCore/dom/PointerEvent.h:
* Source/WebCore/dom/PointerEvent.idl:

Canonical link: <a href="https://commits.webkit.org/281173@main">https://commits.webkit.org/281173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f86630044e9d561e3aba54b08c4c667a4d660f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59027 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62702 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9470 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9675 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47771 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6759 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8348 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8474 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/52119 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64401 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58268 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8584 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55093 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51085 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/55197 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13060 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2469 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80029 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34184 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13847 "Found 12 new JSC stress test failures: stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.default, stress/proxy-set.js.dfg-eager, stress/proxy-set.js.dfg-eager-no-cjit-validate, stress/proxy-set.js.eager-jettison-no-cjit, stress/proxy-set.js.mini-mode, stress/proxy-set.js.no-cjit-collect-continuously ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35268 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->