### PR TITLE
[JSC] `Uint8Array#setFromBase64` should decode and write chunks which occur prior to bad data

### DIFF
--- a/JSTests/stress/uint8array-setFromBase64-write-up-to-error.js
+++ b/JSTests/stress/uint8array-setFromBase64-write-up-to-error.js
@@ -1,0 +1,38 @@
+//@ requireOptions("--useUint8ArrayBase64Methods=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.toString(), expected.toString());
+}
+
+function shouldThrow(callback, errorConstructor) {
+    try {
+        callback();
+    } catch (e) {
+        shouldBe(e instanceof errorConstructor, true);
+        return;
+    }
+    throw new Error('FAIL: should have thrown');
+}
+
+var target = new Uint8Array([255, 255, 255, 255, 255]);
+shouldThrow(() => {
+    target.setFromBase64("ABCD=EFG");
+}, SyntaxError);
+shouldBeArray(target, [0, 16, 131, 255, 255]);
+
+target = new Uint8Array([255, 255, 255, 255, 255]);
+shouldThrow(() => {
+    target.setFromBase64("ABCD$EFGH");
+}, SyntaxError);
+shouldBeArray(target, [0, 16, 131, 255, 255]);
+
+target = new Uint8Array([255, 255, 255, 255, 255]);
+shouldThrow(() => {
+    target.setFromBase64("ABCD==FG");
+}, SyntaxError);
+shouldBeArray(target, [0, 16, 131, 255, 255]);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1069,9 +1069,6 @@ test/built-ins/TypedArray/prototype/includes/index-compared-against-initial-leng
 test/built-ins/TypedArrayConstructors/ctors/object-arg/iterated-array-changed-by-tonumber.js:
   default: 'Test262Error: Expected SameValue(«NaN», «2») to be true (Testing with Float64Array.)'
   strict mode: 'Test262Error: Expected SameValue(«NaN», «2») to be true (Testing with Float64Array.)'
-test/built-ins/Uint8Array/prototype/setFromBase64/writes-up-to-error.js:
-  default: 'Test262Error: Expected [255, 255, 255, 255, 255] and [50, 54, 50, 255, 255] to have the same contents. decoding from MjYyZm.9v should only write the valid chunks'
-  strict mode: 'Test262Error: Expected [255, 255, 255, 255, 255] and [50, 54, 50, 255, 255] to have the same contents. decoding from MjYyZm.9v should only write the valid chunks'
 test/intl402/DateTimeFormat/canonicalize-calendar.js:
   default: 'Test262Error: calendar ID is canonicalized (option) Expected SameValue(«islamicc», «islamic-civil») to be true'
   strict mode: 'Test262Error: calendar ID is canonicalized (option) Expected SameValue(«islamicc», «islamic-civil») to be true'

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -230,6 +230,7 @@ template<typename Adaptor> inline RefPtr<typename Adaptor::ViewType> toUnsharedN
 
 enum class Alphabet : uint8_t { Base64, Base64URL };
 enum class LastChunkHandling : uint8_t { Loose, Strict, StopBeforePartial };
-std::optional<std::pair<size_t, Vector<uint8_t>>> fromBase64(StringView, size_t, Alphabet, LastChunkHandling);
+enum class FromBase64ShouldThrowError: bool { Yes, No };
+std::tuple<FromBase64ShouldThrowError, size_t, Vector<uint8_t>> fromBase64(StringView, size_t, Alphabet, LastChunkHandling);
 
 } // namespace JSC


### PR DESCRIPTION
#### 77046030809c04655dc91b43a43715b43235033e
<pre>
[JSC] `Uint8Array#setFromBase64` should decode and write chunks which occur prior to bad data
<a href="https://bugs.webkit.org/show_bug.cgi?id=276859">https://bugs.webkit.org/show_bug.cgi?id=276859</a>

Reviewed by Yusuke Suzuki.

According to the spec[1][2] and the test[3], Uint8Array.prototype.setFromBase64 throws a SyntaxError
when encountering bad data but writes the decoded chunks prior to bad data.

However, the current JSC discards the decoded data upon encountering bad data and throws an error.

The fromBase64 internal function returns a value of type
std::optional&lt;std::pair&lt;size_t, Vector&lt;uint8_t&gt;&gt;&gt;. Returning std::nullopt indicates a decoding
failure. This patch changes it to return a tuple of std::tuple&lt;bool, size_t, Vector&lt;uint8_t&gt;&gt;,
where the initial bool determines whether to throw an error.

[1]: <a href="https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.setfrombase64">https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.setfrombase64</a>
[2]: <a href="https://tc39.es/proposal-arraybuffer-base64/spec/#sec-frombase64">https://tc39.es/proposal-arraybuffer-base64/spec/#sec-frombase64</a>
[3]: <a href="https://github.com/tc39/test262/blob/main/test/built-ins/Uint8Array/prototype/setFromBase64/writes-up-to-error.js">https://github.com/tc39/test262/blob/main/test/built-ins/Uint8Array/prototype/setFromBase64/writes-up-to-error.js</a>

* JSTests/stress/uint8array-setFromBase64-write-up-to-error.js: Added.
(shouldBe):
(shouldThrow):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.cpp:
(JSC::fromBase64):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/281174@main">https://commits.webkit.org/281174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbb97e65cf17726e12a0ceec9ada8142a89a8715

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62693 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9466 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47764 "") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6756 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28622 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8343 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8470 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/52115 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64392 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58264 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55085 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55189 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2465 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80025 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8818 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34180 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13846 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36349 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35010 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->