### PR TITLE
[CSS] Fix :not(:has(...)) invalidation

### DIFF
--- a/LayoutTests/fast/css/invalidation-not-has-expected.txt
+++ b/LayoutTests/fast/css/invalidation-not-has-expected.txt
@@ -1,0 +1,5 @@
+Hello
+Add Child  Remove Child
+
+PASS invalidation :not(:has(> foo))
+

--- a/LayoutTests/fast/css/invalidation-not-has.html
+++ b/LayoutTests/fast/css/invalidation-not-has.html
@@ -1,0 +1,40 @@
+<html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+    <head>
+        <style>
+            div#target:not(:has(> span)) {
+                color: red;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="target">Hello</div>
+        <button onclick="_addChild()">Add Child</button>
+        <button onclick="_removeChild()">Remove Child</button>
+    </body>
+
+    <script>
+        function _addChild() {
+            let targetElement = document.getElementById("target");
+            let newElement = document.createElement("span");
+            newElement.innerText = "I'm a child element";
+            targetElement.appendChild(newElement);
+        }
+
+        function _removeChild() {
+            let targetElement = document.getElementById("target");
+            targetElement.removeChild(targetElement.lastChild);
+        }
+    </script>
+    <script>
+    test(function() {
+        var target = document.getElementById("target");
+        assert_equals(getComputedStyle(target).getPropertyValue("color"), "rgb(255, 0, 0)");
+        _addChild()
+        assert_equals(getComputedStyle(target).getPropertyValue("color"), "rgb(0, 0, 0)");
+        _removeChild()
+        assert_equals(getComputedStyle(target).getPropertyValue("color"), "rgb(255, 0, 0)");
+    }, "invalidation :not(:has(> foo))");
+    </script>
+</html>

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -70,7 +70,7 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
         checkingContext.matchesAllHasScopes = true;
 
         for (auto* selector : invalidationRuleSet.invalidationSelectors) {
-            if (isFirst) {
+            if (isFirst && invalidationRuleSet.isNegation == IsNegation::No) {
                 // If this :has() matches ignoring this mutation, nothing actually changes and we don't need to invalidate.
                 // FIXME: We could cache this state across invalidations instead of just testing a single sibling.
                 auto* sibling = m_childChange.previousSiblingElement ? m_childChange.previousSiblingElement : m_childChange.nextSiblingElement;
@@ -99,7 +99,7 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
                 continue;
             if (!hasMatchingInvalidationSelector(invalidationRuleSet))
                 continue;
-            Invalidator::addToMatchElementRuleSets(matchElementRuleSets, invalidationRuleSet);
+            Invalidator::addToMatchElementRuleSetsRespectingNegation(matchElementRuleSets, invalidationRuleSet);
         }
     };
 

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -454,7 +454,7 @@ std::optional<DynamicMediaQueryEvaluationChanges> RuleSet::evaluateDynamicMediaQ
         return ruleSet;
     }).iterator->value;
 
-    return { { DynamicMediaQueryEvaluationChanges::Type::InvalidateStyle, { ruleSet.copyRef() } } };
+    return { { DynamicMediaQueryEvaluationChanges::Type::InvalidateStyle, { { ruleSet.copyRef() } } } };
 }
 
 RuleSet::CollectedMediaQueryChanges RuleSet::evaluateDynamicMediaQueryRules(const MQ::MediaQueryEvaluator& evaluator, size_t startIndex)

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -50,7 +50,11 @@ class RuleSet;
 
 using CascadeLayerPriority = uint16_t;
 
-using InvalidationRuleSetVector = Vector<RefPtr<const RuleSet>, 1>;
+struct RuleSetAndNegation {
+    RefPtr<const RuleSet> ruleSet;
+    IsNegation isNegation { IsNegation::No };
+};
+using InvalidationRuleSetVector = Vector<RuleSetAndNegation, 1>;
 
 struct DynamicMediaQueryEvaluationChanges {
     enum class Type { InvalidateStyle, ResetStyle };

--- a/Source/WebCore/style/StyleInvalidator.h
+++ b/Source/WebCore/style/StyleInvalidator.h
@@ -65,6 +65,7 @@ public:
 
     using MatchElementRuleSets = UncheckedKeyHashMap<MatchElement, InvalidationRuleSetVector, IntHash<MatchElement>, WTF::StrongEnumHashTraits<MatchElement>>;
     static void addToMatchElementRuleSets(Invalidator::MatchElementRuleSets&, const InvalidationRuleSet&);
+    static void addToMatchElementRuleSetsRespectingNegation(Invalidator::MatchElementRuleSets&, const InvalidationRuleSet&);
     static void invalidateWithMatchElementRuleSets(Element&, const MatchElementRuleSets&);
     static void invalidateAllStyle(Scope&);
     static void invalidateHostAndSlottedStyleIfNeeded(ShadowRoot&);


### PR DESCRIPTION
#### 95ffd81b29e8337bbed14f19e229e5aca0579077
<pre>
[CSS] Fix :not(:has(...)) invalidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=276867">https://bugs.webkit.org/show_bug.cgi?id=276867</a>
<a href="https://rdar.apple.com/122689282">rdar://122689282</a>

Reviewed by Antti Koivisto.

Invalidation of :not(:has(...)) is special because while there can be no
element to actually invalidate, the rule matches.
For ChildChangeInvalidation, we thus propagate the isNegation flag to StyleInvalidator
to invalidate in case of non-matching the :has().
The other *Invalidation classes handle :not() differently, thus the
isNegation flag is purposedly not propagated to StyleInvalidator for them.

* LayoutTests/fast/css/invalidation-not-has-expected.txt: Added.
* LayoutTests/fast/css/invalidation-not-has.html: Added.
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::evaluateDynamicMediaQueryRules):
* Source/WebCore/style/RuleSet.h:
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::Invalidator):
(WebCore::Style::Invalidator::collectRuleInformation):
(WebCore::Style::Invalidator::invalidateIfNeeded):
(WebCore::Style::Invalidator::invalidateUserAgentParts):
(WebCore::Style::Invalidator::addToMatchElementRuleSets):
(WebCore::Style::Invalidator::addToMatchElementRuleSetsRespectingNegation):
(WebCore::Style::Invalidator::invalidateWithScopeBreakingHasPseudoClassRuleSet):
* Source/WebCore/style/StyleInvalidator.h:

Canonical link: <a href="https://commits.webkit.org/285987@main">https://commits.webkit.org/285987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db143f92a09e4919035bcb9410270da20e8c33bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/74373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/53802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27184 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/78753 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/25611 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/76490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/62935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/1587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58463 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/16780 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/77440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/48621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/63968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/38866 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/45617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/21463 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/23944 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67015 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/21810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/80272 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/1690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/978 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/66742 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/1838 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/63986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66026 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16406 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/9962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8118 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/1654 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/4442 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/1683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/1671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/1690 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->