### PR TITLE
[Text Directionality] Implement behavior for `<slot>` elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7751,10 +7751,9 @@ webkit.org/b/261557 media/video-remove-insert-repaints.html [ Pass Crash ]
 [ Debug ] fast/text/remove-renderer-and-select-crash.html [ Skip ]
 
 # web-platform-tests/html/dom/elements/global-attributes failures
-webkit.org/b/267951 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-06.html [ ImageOnlyFailure ]
-webkit.org/b/267951 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-36.html [ ImageOnlyFailure ]
-webkit.org/b/267951 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-38.html [ ImageOnlyFailure ]
-webkit.org/b/267951 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-39.html [ ImageOnlyFailure ]
+# webkit.org/b/267951 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-36.html [ ImageOnlyFailure ]
+# webkit.org/b/267951 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-38.html [ ImageOnlyFailure ]
+# webkit.org/b/267951 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-39.html [ ImageOnlyFailure ]
 
 webkit.org/b/250795 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focusability.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window-expected.txt
@@ -1,8 +1,8 @@
 
 PASS dynamic insertion of RTL text in a child element
 PASS dir=auto changes for content insertion and removal, in and out of document
-FAIL dir=auto changes for slot reassignment assert_true: #one with LTR child span expected true got false
-FAIL text changes affecting both slot and ancestor with dir=auto assert_false: slot after first text change expected false got true
+PASS dir=auto changes for slot reassignment
+FAIL text changes affecting both slot and ancestor with dir=auto assert_true: slot after second text change expected true got false
 PASS dynamic changes to subtrees excluded as a result of the dir attribute
 FAIL dynamic changes inside of non-HTML elements assert_true: after dynamic change expected true got false
 FAIL slotted non-HTML elements assert_true: initial state (slot) expected true got false
@@ -15,8 +15,7 @@ PASS Child directionality gets updated when dir=auto is set on parent
 FAIL dir=auto slot is updated by text in value of input element children assert_equals: expected "rtl" but got "ltr"
 FAIL dir=auto slot is updated if input stops being auto-directionality form-associated assert_equals: expected "rtl" but got "ltr"
 PASS slot provides updated directionality from host to a dir=auto container
-A א
-א
+A
 A
 A א
 A א

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2907,6 +2907,9 @@ TextDirection Node::effectiveTextDirection() const
 
 void Node::setEffectiveTextDirection(TextDirection direction)
 {
+    // ALWAYS_LOG_WITH_STREAM(stream << *this << "setting effective text direction " << (direction == TextDirection::RTL));
+    // WTFReportBacktrace();
+    // ALWAYS_LOG_WITH_STREAM(stream << "--\n");
     auto bitfields = rareDataBitfields();
     bitfields.effectiveTextDirection = enumToUnderlyingType(direction);
     setRareDataBitfields(bitfields);

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -330,7 +330,15 @@ void ShadowRoot::slotFallbackDidChange(HTMLSlotElement& slot)
 
 const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* ShadowRoot::assignedNodesForSlot(const HTMLSlotElement& slot)
 {
-    return m_slotAssignment ? m_slotAssignment->assignedNodesForSlot(slot, *this) : nullptr;
+    ALWAYS_LOG_WITH_STREAM(stream << "m_slotAssignment -- " << !!m_slotAssignment);
+
+    if (m_slotAssignment) {
+
+        auto nodes = m_slotAssignment->assignedNodesForSlot(slot, *this);
+        ALWAYS_LOG_WITH_STREAM(stream << " --- assigned nodes for slot end");
+        return nodes;
+    }
+    return nullptr;
 }
 
 static std::optional<std::pair<AtomString, AtomString>> parsePartMapping(StringView mappingString)

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -102,6 +102,7 @@ public:
     bool hasDirectionAuto() const;
 
     std::optional<TextDirection> directionalityIfDirIsAuto() const;
+    void updateEffectiveDirectionalityOfDirAuto();
 
     virtual bool isTextControlInnerTextElement() const { return false; }
     virtual bool isSearchFieldResultsButtonElement() const { return false; }
@@ -196,7 +197,6 @@ protected:
 
     void childrenChanged(const ChildChange&) override;
     void updateTextDirectionalityAfterInputTypeChange();
-    void updateEffectiveDirectionalityOfDirAuto();
 
     virtual void effectiveSpellcheckAttributeChanged(bool);
 

--- a/Source/WebCore/html/HTMLSlotElement.h
+++ b/Source/WebCore/html/HTMLSlotElement.h
@@ -59,6 +59,7 @@ private:
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;
+    void didFinishInsertingNode() final;
     void childrenChanged(const ChildChange&) final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 


### PR DESCRIPTION
#### eb818ade84ed926e30c5a1d9c00aa6b3f16c4dfd
<pre>
[Text Directionality] Implement behavior for `&lt;slot&gt;` elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=267951">https://bugs.webkit.org/show_bug.cgi?id=267951</a>
<a href="https://rdar.apple.com/121958890">rdar://121958890</a>

Reviewed by NOBODY (OOPS!).

(WIP, invalidation on slot change/assignment does not work)

Slots should check the directionality of their first assigned node that has a directionality.

<a href="https://html.spec.whatwg.org/#auto-directionality">https://html.spec.whatwg.org/#auto-directionality</a>

* LayoutTests/TestExpectations:
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesDirPseudoClass):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::setEffectiveTextDirection):
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::NamedSlotAssignment::didChangeSlot):
(WebCore::ManualSlotAssignment::slotManualAssignmentDidChange):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::computeDirectionalityFromText const):
(WebCore::HTMLElement::adjustDirectionalityIfNeededAfterChildrenChanged):
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLSlotElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb818ade84ed926e30c5a1d9c00aa6b3f16c4dfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59743 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63659 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10428 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48453 "Found 5 new test failures: imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-36.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-38.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-39.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-42.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7179 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61773 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36473 "Found 1 new test failure: fast/shadow-dom/host-child-append-performance.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51727 "Found 1 new API test failure: TestWebKitAPI.WebKit.InjectedBundleMakeAllShadowRootOpenTest (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29293 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33179 "Exiting early after 10 failures. 14 tests run. 3 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8970 "Found 9 new test failures: fast/shadow-dom/host-child-append-performance.html imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-36.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-38.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-39.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-42.html imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-001.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9190 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55113 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9249 "Found 7 new test failures: fast/shadow-dom/host-child-append-performance.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-36.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-38.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-39.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-42.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65390 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3671 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9121 "Found 7 new test failures: fast/shadow-dom/host-child-append-performance.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-36.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-38.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-39.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-42.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55793 "Found 6 new test failures: fast/shadow-dom/host-child-append-performance.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-36.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-38.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-39.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-shadow-42.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3682 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51711 "Exiting early after 10 failures. 14 tests run. 3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55930 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3051 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34902 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35985 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->