### PR TITLE
[Text Directionality] Fix directionality of non-HTML elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-assorted.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-assorted.window-expected.txt
@@ -1,9 +1,9 @@
 
 PASS Root element has a direction
 PASS Element outside the document tree has a direction
-FAIL Non-HTML element outside the document tree has a direction assert_true: expected true got false
+PASS Non-HTML element outside the document tree has a direction
 PASS Element without direction has parent element direction
-FAIL Non-HTML element without direction has parent element direction assert_true: expected true got false
+PASS Non-HTML element without direction has parent element direction
 PASS dir inheritance is correct after insertion and removal from document
 FAIL Non-HTML element text contents influence dir=auto assert_true: is RTL before change expected true got false
 PASS style element text contents do not influence dir=auto

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -252,10 +252,6 @@ ALWAYS_INLINE bool matchesLangPseudoClass(const Element& element, const FixedVec
 
 ALWAYS_INLINE bool matchesDirPseudoClass(const Element& element, const AtomString& argument)
 {
-    // FIXME: Add support for non-HTML elements.
-    if (!is<HTMLElement>(element))
-        return false;
-
     switch (element.effectiveTextDirection()) {
     case TextDirection::LTR:
         return equalIgnoringASCIICase(argument, "ltr"_s);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2833,6 +2833,14 @@ Node::InsertedIntoAncestorResult Element::insertedIntoAncestor(InsertionType ins
     } else if (!hasLanguageAttribute())
         updateEffectiveLangStateFromParent();
 
+    if (RefPtr parent = parentOrShadowHostElement(); parent && UNLIKELY(parent->usesEffectiveTextDirection())) {
+        auto* input = dynamicDowncast<HTMLInputElement>(*this);
+        if (!elementAffectsDirectionality() && !(input && input->isTelephoneField())) {
+            setUsesEffectiveTextDirection(true);
+            setEffectiveTextDirection(parent->effectiveTextDirection());
+        }
+    }
+
     return InsertedIntoAncestorResult::Done;
 }
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -334,6 +334,8 @@ public:
     bool usesEffectiveTextDirection() const { return rareDataBitfields().usesEffectiveTextDirection; }
     void setUsesEffectiveTextDirection(bool);
 
+    virtual bool elementAffectsDirectionality() const { return false; }
+
     // Returns the enclosing event parent Element (or self) that, when clicked, would trigger a navigation.
     WEBCORE_EXPORT Element* enclosingLinkEventParentOrSelf();
 

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -212,6 +212,7 @@ private:
     void updateEffectiveDirectionality(std::optional<TextDirection>);
     void adjustDirectionalityIfNeededAfterChildAttributeChanged(Element* child);
     void adjustDirectionalityIfNeededAfterChildrenChanged(Element* beforeChange, ChildChange::Type);
+    bool elementAffectsDirectionality() const override;
 
     struct TextDirectionWithStrongDirectionalityNode {
         TextDirection direction;


### PR DESCRIPTION
#### 3b98d7d0dd7c59cf450ce41e16c944253903ed2e
<pre>
[Text Directionality] Fix directionality of non-HTML elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=276871">https://bugs.webkit.org/show_bug.cgi?id=276871</a>
<a href="https://rdar.apple.com/132210868">rdar://132210868</a>

Reviewed by NOBODY (OOPS!).

(WIP, needs to implement invalidation when text content of non-HTML node changes)

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-assorted.window-expected.txt:
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesDirPseudoClass):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::insertedIntoAncestor):
* Source/WebCore/dom/Node.h:
(WebCore::Node::elementAffectsDirectionality const):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::insertedIntoAncestor):
(WebCore::setHasDirAutoFlagRecursively):
(WebCore::HTMLElement::elementAffectsDirectionality const):
(WebCore::HTMLElement::computeDirectionalityFromText const):
(WebCore::HTMLElement::updateEffectiveDirectionality):
(WebCore::HTMLElement::adjustDirectionalityIfNeededAfterChildAttributeChanged):
(WebCore::HTMLElement::adjustDirectionalityIfNeededAfterChildrenChanged):
(WebCore::elementAffectsDirectionality): Deleted.
* Source/WebCore/html/HTMLElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b98d7d0dd7c59cf450ce41e16c944253903ed2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59047 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62772 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9490 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47833 "") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6778 "Found 1 new test failure: imported/w3c/web-platform-tests/css/selectors/dir-style-02b.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28691 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32622 "Found 2 new test failures: imported/w3c/web-platform-tests/css/selectors/dir-style-02b.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8368 "Found 3 new test failures: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html imported/w3c/web-platform-tests/css/selectors/dir-style-02b.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8494 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54576 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8648 "Found 2 new test failures: imported/w3c/web-platform-tests/css/selectors/dir-style-02b.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64466 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2959 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8602 "Found 2 new test failures: imported/w3c/web-platform-tests/css/selectors/dir-style-02b.html imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55150 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2969 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55255 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2486 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34204 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35288 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->