### PR TITLE
Remove trusted types enforcement from DOM node APIs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-expected.txt
@@ -22,11 +22,13 @@
 'mixed';
 'mixed';
 'mixed';
+'mixed';
 'mixed';'script';
 'mixed';'script';
 'mixed';'script';
 'mixed';'script';
 'mixed';'script';
+'script';
 'script';
 'script';
 'script';

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-tt-enforced-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-tt-enforced-expected.txt
@@ -1,0 +1,202 @@
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+'createScript';
+'createScript';
+'createScript';
+'createScript';
+'createScript';
+'createScript #1';'#2;'
+'createScript #1';'#2;'
+'createScript #1';'#2;'
+'createScript #1';'#2;'
+'createScript #1';'#2;'
+'plain text';
+'plain text';
+'plain text';
+'plain text';
+'plain text';
+'plain text #1';'plain text #2';
+'plain text #1';'plain text #2';
+'plain text #1';'plain text #2';
+'plain text #1';'plain text #2';
+'plain text #1';'plain text #2';
+'mixed';
+'mixed';
+'mixed';
+'mixed';
+'mixed';
+'mixed';'script';
+'mixed';'script';
+'mixed';'script';
+'mixed';'script';
+'mixed';'script';
+'script';
+'script';
+'script';
+'script';
+'script';
+
+PASS replaceWith('createScript';) on <div> should pass
+PASS after('createScript';) on <div> should pass
+PASS before('createScript';) on <div> should pass
+PASS append('createScript';) on <div> should pass
+PASS prepend('createScript';) on <div> should pass
+PASS replaceWith('createScript #1';,'#2;') on <div> should pass
+PASS after('createScript #1';,'#2;') on <div> should pass
+PASS before('createScript #1';,'#2;') on <div> should pass
+PASS append('createScript #1';,'#2;') on <div> should pass
+PASS prepend('createScript #1';,'#2;') on <div> should pass
+PASS replaceWith('plain text';) on <div> should pass
+PASS after('plain text';) on <div> should pass
+PASS before('plain text';) on <div> should pass
+PASS append('plain text';) on <div> should pass
+PASS prepend('plain text';) on <div> should pass
+PASS replaceWith('plain text #1';,'plain text #2';) on <div> should pass
+PASS after('plain text #1';,'plain text #2';) on <div> should pass
+PASS before('plain text #1';,'plain text #2';) on <div> should pass
+PASS append('plain text #1';,'plain text #2';) on <div> should pass
+PASS prepend('plain text #1';,'plain text #2';) on <div> should pass
+PASS replaceWith([object Text]) on <div> should pass
+PASS after([object Text]) on <div> should pass
+PASS before([object Text]) on <div> should pass
+PASS append([object Text]) on <div> should pass
+PASS prepend([object Text]) on <div> should pass
+PASS replaceWith([object Text],[object Text]) on <div> should pass
+PASS after([object Text],[object Text]) on <div> should pass
+PASS before([object Text],[object Text]) on <div> should pass
+PASS append([object Text],[object Text]) on <div> should pass
+PASS prepend([object Text],[object Text]) on <div> should pass
+PASS replaceWith('mixed';,[object Text]) on <div> should pass
+PASS after('mixed';,[object Text]) on <div> should pass
+PASS before('mixed';,[object Text]) on <div> should pass
+PASS append('mixed';,[object Text]) on <div> should pass
+PASS prepend('mixed';,[object Text]) on <div> should pass
+PASS replaceWith('mixed';,'script';) on <div> should pass
+PASS after('mixed';,'script';) on <div> should pass
+PASS before('mixed';,'script';) on <div> should pass
+PASS append('mixed';,'script';) on <div> should pass
+PASS prepend('mixed';,'script';) on <div> should pass
+PASS replaceWith([object Text],'script';) on <div> should pass
+PASS after([object Text],'script';) on <div> should pass
+PASS before([object Text],'script';) on <div> should pass
+PASS append([object Text],'script';) on <div> should pass
+PASS prepend([object Text],'script';) on <div> should pass
+PASS replaceWith('createScript';) on <script> should pass
+PASS after('createScript';) on <script> should pass
+PASS before('createScript';) on <script> should pass
+PASS append('createScript';) on <script> should pass
+PASS prepend('createScript';) on <script> should pass
+PASS replaceWith('createScript #1';,'#2;') on <script> should pass
+PASS after('createScript #1';,'#2;') on <script> should pass
+PASS before('createScript #1';,'#2;') on <script> should pass
+PASS append('createScript #1';,'#2;') on <script> should pass
+PASS prepend('createScript #1';,'#2;') on <script> should pass
+PASS replaceWith('plain text';) on <script> should pass
+PASS after('plain text';) on <script> should pass
+PASS before('plain text';) on <script> should pass
+PASS append('plain text';) on <script> should pass
+PASS prepend('plain text';) on <script> should pass
+PASS replaceWith('plain text #1';,'plain text #2';) on <script> should pass
+PASS after('plain text #1';,'plain text #2';) on <script> should pass
+PASS before('plain text #1';,'plain text #2';) on <script> should pass
+PASS append('plain text #1';,'plain text #2';) on <script> should pass
+PASS prepend('plain text #1';,'plain text #2';) on <script> should pass
+PASS replaceWith([object Text]) on <script> should pass
+PASS after([object Text]) on <script> should pass
+PASS before([object Text]) on <script> should pass
+PASS append([object Text]) on <script> should pass
+PASS prepend([object Text]) on <script> should pass
+PASS replaceWith([object Text],[object Text]) on <script> should pass
+PASS after([object Text],[object Text]) on <script> should pass
+PASS before([object Text],[object Text]) on <script> should pass
+PASS append([object Text],[object Text]) on <script> should pass
+PASS prepend([object Text],[object Text]) on <script> should pass
+PASS replaceWith('mixed';,[object Text]) on <script> should pass
+PASS after('mixed';,[object Text]) on <script> should pass
+PASS before('mixed';,[object Text]) on <script> should pass
+PASS append('mixed';,[object Text]) on <script> should pass
+PASS prepend('mixed';,[object Text]) on <script> should pass
+PASS replaceWith('mixed';,'script';) on <script> should pass
+PASS after('mixed';,'script';) on <script> should pass
+PASS before('mixed';,'script';) on <script> should pass
+PASS append('mixed';,'script';) on <script> should pass
+PASS prepend('mixed';,'script';) on <script> should pass
+PASS replaceWith([object Text],'script';) on <script> should pass
+PASS after([object Text],'script';) on <script> should pass
+PASS before([object Text],'script';) on <script> should pass
+PASS append([object Text],'script';) on <script> should pass
+PASS prepend([object Text],'script';) on <script> should pass
+

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-tt-enforced.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-tt-enforced.html
@@ -30,23 +30,21 @@
   const pass_args = [
     [ policy.createScript("'createScript';") ],
     [ policy.createScript("'createScript #1';"), policy.createScript("'#2;'") ],
-  ];
-  const fail_args = [
     [ "'plain text';" ],
     [ "'plain text #1';", "'plain text #2';" ],
     [ document.createTextNode("'node';") ],
     [ document.createTextNode("'node #1';"),
-      document.createTextNode("'node #2';") ],
+        document.createTextNode("'node #2';") ],
     [ "'mixed';", document.createTextNode("'node';") ],
     [ "'mixed';", policy.createScript("'script';") ],
     [ document.createTextNode("'node';"),
-      policy.createScript("'script';") ],
+        policy.createScript("'script';") ],
   ];
-  const all_args = [].concat(pass_args).concat(fail_args);
+  const all_args = [].concat(pass_args);
 
   for (const target of targets) {
     for (const args of all_args) {
-      var should_fail = target == "script" && fail_args.indexOf(args) != -1;
+      var should_fail = false;
       var fail_string = should_fail ? "fail" : "pass";
 
       for (const setter of [container.replaceWith, container.after, container.before]) {

--- a/Source/WebCore/dom/ChildNode.idl
+++ b/Source/WebCore/dom/ChildNode.idl
@@ -20,8 +20,8 @@
 
 // https://dom.spec.whatwg.org/#childnode
 interface mixin ChildNode {
-    [CEReactions=Needed, Unscopable] undefined before((Node or DOMString or TrustedScript)... nodes);
-    [CEReactions=Needed, Unscopable] undefined after((Node or DOMString or TrustedScript)... nodes);
-    [CEReactions=Needed, Unscopable] undefined replaceWith((Node or DOMString or TrustedScript)... nodes);
+    [CEReactions=Needed, Unscopable] undefined before((Node or DOMString)... nodes);
+    [CEReactions=Needed, Unscopable] undefined after((Node or DOMString)... nodes);
+    [CEReactions=Needed, Unscopable] undefined replaceWith((Node or DOMString)... nodes);
     [CEReactions=Needed, Unscopable] undefined remove();
 };

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1164,9 +1164,9 @@ unsigned ContainerNode::childElementCount() const
     return std::distance(children.begin(), { });
 }
 
-ExceptionOr<void> ContainerNode::append(FixedVector<NodeOrStringOrTrustedScript>&& vector)
+ExceptionOr<void> ContainerNode::append(FixedVector<NodeOrString>&& vector)
 {
-    auto result = convertNodesOrStringsOrTrustedScriptsIntoNodeVector(this, WTFMove(vector));
+    auto result = convertNodesOrStringsIntoNodeVector(WTFMove(vector));
     if (result.hasException())
         return result.releaseException();
 
@@ -1185,9 +1185,9 @@ ExceptionOr<void> ContainerNode::append(FixedVector<NodeOrStringOrTrustedScript>
     return { };
 }
 
-ExceptionOr<void> ContainerNode::prepend(FixedVector<NodeOrStringOrTrustedScript>&& vector)
+ExceptionOr<void> ContainerNode::prepend(FixedVector<NodeOrString>&& vector)
 {
-    auto result = convertNodesOrStringsOrTrustedScriptsIntoNodeVector(this, WTFMove(vector));
+    auto result = convertNodesOrStringsIntoNodeVector(WTFMove(vector));
     if (result.hasException())
         return result.releaseException();
 
@@ -1208,9 +1208,9 @@ ExceptionOr<void> ContainerNode::prepend(FixedVector<NodeOrStringOrTrustedScript
 }
 
 // https://dom.spec.whatwg.org/#dom-parentnode-replacechildren
-ExceptionOr<void> ContainerNode::replaceChildren(FixedVector<NodeOrStringOrTrustedScript>&& vector)
+ExceptionOr<void> ContainerNode::replaceChildren(FixedVector<NodeOrString>&& vector)
 {
-    auto result = convertNodesOrStringsOrTrustedScriptsIntoNodeVector(this, WTFMove(vector));
+    auto result = convertNodesOrStringsIntoNodeVector(WTFMove(vector));
     if (result.hasException())
         return result.releaseException();
     auto newChildren = result.releaseReturnValue();

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -135,10 +135,10 @@ public:
     WEBCORE_EXPORT Element* firstElementChild() const;
     WEBCORE_EXPORT Element* lastElementChild() const;
     WEBCORE_EXPORT unsigned childElementCount() const;
-    ExceptionOr<void> append(FixedVector<NodeOrStringOrTrustedScript>&&);
-    ExceptionOr<void> prepend(FixedVector<NodeOrStringOrTrustedScript>&&);
+    ExceptionOr<void> append(FixedVector<NodeOrString>&&);
+    ExceptionOr<void> prepend(FixedVector<NodeOrString>&&);
 
-    ExceptionOr<void> replaceChildren(FixedVector<NodeOrStringOrTrustedScript>&&);
+    ExceptionOr<void> replaceChildren(FixedVector<NodeOrString>&&);
 
     ExceptionOr<void> ensurePreInsertionValidity(Node& newChild, Node* refChild);
     ExceptionOr<void> ensurePreInsertionValidityForPhantomDocumentFragment(NodeVector& newChildren, Node* refChild = nullptr);

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -49,7 +49,6 @@
 #include "HTMLDialogElement.h"
 #include "HTMLElement.h"
 #include "HTMLImageElement.h"
-#include "HTMLScriptElement.h"
 #include "HTMLSlotElement.h"
 #include "HTMLStyleElement.h"
 #include "InputEvent.h"
@@ -83,8 +82,7 @@
 #include "TemplateContentDocumentFragment.h"
 #include "TextEvent.h"
 #include "TextManipulationController.h"
-#include "TouchEvent.h"
-#include "TrustedType.h"
+#include "WebCoreOpaqueRoot.h"
 #include "WebCoreOpaqueRoot.h"
 #include "WheelEvent.h"
 #include "XMLNSNames.h"
@@ -568,14 +566,13 @@ ExceptionOr<void> Node::appendChild(Node& newChild)
     return Exception { ExceptionCode::HierarchyRequestError };
 }
 
-static HashSet<RefPtr<Node>> nodeSetPreTransformedFromNodeOrStringOrTrustedScriptVector(const FixedVector<NodeOrStringOrTrustedScript>& vector)
+static HashSet<RefPtr<Node>> nodeSetPreTransformedFromNodeOrStringVector(const FixedVector<NodeOrString>& vector)
 {
     HashSet<RefPtr<Node>> nodeSet;
     for (const auto& variant : vector) {
         WTF::switchOn(variant,
             [&] (const RefPtr<Node>& node) { nodeSet.add(const_cast<Node*>(node.get())); },
-            [] (const String&) { },
-            [] (const RefPtr<TrustedScript>&) { }
+            [] (const String&) { }
         );
     }
     return nodeSet;
@@ -600,34 +597,18 @@ static RefPtr<Node> firstFollowingSiblingNotInNodeSet(Node& context, const HashS
 }
 
 // https://dom.spec.whatwg.org/#converting-nodes-into-a-node
-ExceptionOr<RefPtr<Node>> Node::convertNodesOrStringsOrTrustedScriptsIntoNode(RefPtr<Node> parent, FixedVector<NodeOrStringOrTrustedScript>&& vector)
+ExceptionOr<RefPtr<Node>> Node::convertNodesOrStringsIntoNode(FixedVector<NodeOrString>&& nodeOrStringVector)
 {
-    if (vector.isEmpty())
+    if (nodeOrStringVector.isEmpty())
         return nullptr;
 
     Ref document = this->document();
-    NodeVector nodes;
-    auto trustedTypesEnabled = document->scriptExecutionContext()->settingsValues().trustedTypesEnabled;
-    for (auto& variant : vector) {
-        if (trustedTypesEnabled) {
-            auto textNodeHolder = processNodeOrStringAsTrustedType(document, parent, variant);
-            if (textNodeHolder.hasException())
-                return textNodeHolder.releaseException();
-
-            if (RefPtr textNode = textNodeHolder.releaseReturnValue()) {
-                nodes.append(textNode.releaseNonNull());
-                continue;
-            }
-        } else if (std::holds_alternative<String>(variant)) {
-            nodes.append(Text::create(document, WTFMove(std::get<String>(variant))));
-            continue;
-        }
-
-        ASSERT(std::holds_alternative<RefPtr<Node>>(variant));
-        RefPtr node = WTFMove(std::get<RefPtr<Node>>(variant));
-        ASSERT(node);
-        nodes.append(node.releaseNonNull());
-    }
+    auto nodes = WTF::map(WTFMove(nodeOrStringVector), [&](auto&& variant) -> Ref<Node> {
+        return WTF::switchOn(WTFMove(variant),
+            [&](RefPtr<Node>&& node) { return node.releaseNonNull(); },
+            [&](String&& string) -> Ref<Node> { return Text::create(document, WTFMove(string)); }
+        );
+    });
 
     if (nodes.size() == 1)
         return RefPtr<Node> { WTFMove(nodes.first()) };
@@ -642,26 +623,16 @@ ExceptionOr<RefPtr<Node>> Node::convertNodesOrStringsOrTrustedScriptsIntoNode(Re
 }
 
 // https://dom.spec.whatwg.org/#converting-nodes-into-a-node except this returns a NodeVector
-ExceptionOr<NodeVector> Node::convertNodesOrStringsOrTrustedScriptsIntoNodeVector(RefPtr<Node> parent, FixedVector<NodeOrStringOrTrustedScript>&& vector)
+ExceptionOr<NodeVector> Node::convertNodesOrStringsIntoNodeVector(FixedVector<NodeOrString>&& nodeOrStringVector)
 {
-    if (vector.isEmpty())
+    if (nodeOrStringVector.isEmpty())
         return NodeVector { };
 
     Ref document = this->document();
     NodeVector nodeVector;
-    nodeVector.reserveInitialCapacity(vector.size());
-    auto trustedTypesEnabled = document->scriptExecutionContext()->settingsValues().trustedTypesEnabled;
-    for (auto& variant : vector) {
-        if (trustedTypesEnabled) {
-            auto textNodeHolder = processNodeOrStringAsTrustedType(document, parent, variant);
-            if (textNodeHolder.hasException())
-                return textNodeHolder.releaseException();
-
-            if (RefPtr textNode = textNodeHolder.releaseReturnValue()) {
-                nodeVector.append(textNode.releaseNonNull());
-                continue;
-            }
-        } else if (std::holds_alternative<String>(variant)) {
+    nodeVector.reserveInitialCapacity(nodeOrStringVector.size());
+    for (auto& variant : nodeOrStringVector) {
+        if (std::holds_alternative<String>(variant)) {
             nodeVector.append(Text::create(document, WTFMove(std::get<String>(variant))));
             continue;
         }
@@ -688,16 +659,16 @@ ExceptionOr<NodeVector> Node::convertNodesOrStringsOrTrustedScriptsIntoNodeVecto
     return nodeVector;
 }
 
-ExceptionOr<void> Node::before(FixedVector<NodeOrStringOrTrustedScript>&& vector)
+ExceptionOr<void> Node::before(FixedVector<NodeOrString>&& nodeOrStringVector)
 {
     RefPtr parent = parentNode();
     if (!parent)
         return { };
 
-    auto nodeSet = nodeSetPreTransformedFromNodeOrStringOrTrustedScriptVector(vector);
+    auto nodeSet = nodeSetPreTransformedFromNodeOrStringVector(nodeOrStringVector);
     RefPtr viablePreviousSibling = firstPrecedingSiblingNotInNodeSet(*this, nodeSet);
 
-    auto result = convertNodesOrStringsOrTrustedScriptsIntoNodeVector(parent, WTFMove(vector));
+    auto result = convertNodesOrStringsIntoNodeVector(WTFMove(nodeOrStringVector));
     if (result.hasException())
         return result.releaseException();
 
@@ -709,16 +680,16 @@ ExceptionOr<void> Node::before(FixedVector<NodeOrStringOrTrustedScript>&& vector
     return parent->insertChildrenBeforeWithoutPreInsertionValidityCheck(WTFMove(newChildren), viableNextSibling.get());
 }
 
-ExceptionOr<void> Node::after(FixedVector<NodeOrStringOrTrustedScript>&& vector)
+ExceptionOr<void> Node::after(FixedVector<NodeOrString>&& nodeOrStringVector)
 {
     RefPtr parent = parentNode();
     if (!parent)
         return { };
 
-    auto nodeSet = nodeSetPreTransformedFromNodeOrStringOrTrustedScriptVector(vector);
+    auto nodeSet = nodeSetPreTransformedFromNodeOrStringVector(nodeOrStringVector);
     RefPtr viableNextSibling = firstFollowingSiblingNotInNodeSet(*this, nodeSet);
 
-    auto result = convertNodesOrStringsOrTrustedScriptsIntoNodeVector(parent, WTFMove(vector));
+    auto result = convertNodesOrStringsIntoNodeVector(WTFMove(nodeOrStringVector));
     if (result.hasException())
         return result.releaseException();
 
@@ -729,16 +700,16 @@ ExceptionOr<void> Node::after(FixedVector<NodeOrStringOrTrustedScript>&& vector)
     return parent->insertChildrenBeforeWithoutPreInsertionValidityCheck(WTFMove(newChildren), viableNextSibling.get());
 }
 
-ExceptionOr<void> Node::replaceWith(FixedVector<NodeOrStringOrTrustedScript>&& vector)
+ExceptionOr<void> Node::replaceWith(FixedVector<NodeOrString>&& nodeOrStringVector)
 {
     RefPtr parent = parentNode();
     if (!parent)
         return { };
 
-    auto nodeSet = nodeSetPreTransformedFromNodeOrStringOrTrustedScriptVector(vector);
+    auto nodeSet = nodeSetPreTransformedFromNodeOrStringVector(nodeOrStringVector);
     RefPtr viableNextSibling = firstFollowingSiblingNotInNodeSet(*this, nodeSet);
 
-    auto result = convertNodesOrStringsOrTrustedScriptsIntoNode(parent, WTFMove(vector));
+    auto result = convertNodesOrStringsIntoNode(WTFMove(nodeOrStringVector));
     if (result.hasException())
         return result.releaseException();
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -72,7 +72,6 @@ class RenderStyle;
 class SVGQualifiedName;
 class ShadowRoot;
 class TouchEvent;
-class TrustedScript;
 class WebCoreOpaqueRoot;
 
 namespace Style {
@@ -91,7 +90,7 @@ enum class MutationObserverOptionType : uint8_t;
 using MutationObserverOptions = OptionSet<MutationObserverOptionType>;
 using MutationRecordDeliveryOptions = OptionSet<MutationObserverOptionType>;
 
-using NodeOrStringOrTrustedScript = std::variant<RefPtr<Node>, String, RefPtr<TrustedScript>>;
+using NodeOrString = std::variant<RefPtr<Node>, String>;
 
 const int initialNodeVectorSize = 11; // Covers 99.5%. See webkit.org/b/80706
 typedef Vector<Ref<Node>, initialNodeVectorSize> NodeVector;
@@ -218,9 +217,9 @@ public:
     WEBCORE_EXPORT Element* nextElementSibling() const;
 
     // From the ChildNode - https://dom.spec.whatwg.org/#childnode
-    ExceptionOr<void> before(FixedVector<NodeOrStringOrTrustedScript>&&);
-    ExceptionOr<void> after(FixedVector<NodeOrStringOrTrustedScript>&&);
-    ExceptionOr<void> replaceWith(FixedVector<NodeOrStringOrTrustedScript>&&);
+    ExceptionOr<void> before(FixedVector<NodeOrString>&&);
+    ExceptionOr<void> after(FixedVector<NodeOrString>&&);
+    ExceptionOr<void> replaceWith(FixedVector<NodeOrString>&&);
     WEBCORE_EXPORT ExceptionOr<void> remove();
 
     // Other methods (not part of DOM)
@@ -767,9 +766,9 @@ protected:
     template<typename NodeClass>
     static NodeClass& traverseToRootNodeInternal(const NodeClass&);
 
-    // FIXME: Replace all uses of convertNodesOrStringsOrTrustedScriptsIntoNode by convertNodesOrStringsOrTrustedScriptsIntoNodeVector.
-    ExceptionOr<RefPtr<Node>> convertNodesOrStringsOrTrustedScriptsIntoNode(RefPtr<Node>, FixedVector<NodeOrStringOrTrustedScript>&&);
-    ExceptionOr<NodeVector> convertNodesOrStringsOrTrustedScriptsIntoNodeVector(RefPtr<Node>, FixedVector<NodeOrStringOrTrustedScript>&&);
+    // FIXME: Replace all uses of convertNodesOrStringsIntoNode by convertNodesOrStringsIntoNodeVector.
+    ExceptionOr<RefPtr<Node>> convertNodesOrStringsIntoNode(FixedVector<NodeOrString>&&);
+    ExceptionOr<NodeVector> convertNodesOrStringsIntoNodeVector(FixedVector<NodeOrString>&&);
 
 private:
     virtual PseudoId customPseudoId() const

--- a/Source/WebCore/dom/ParentNode.idl
+++ b/Source/WebCore/dom/ParentNode.idl
@@ -31,9 +31,9 @@ interface mixin ParentNode {
     readonly attribute Element? lastElementChild;
     readonly attribute unsigned long childElementCount;
 
-    [CEReactions=Needed, Unscopable] undefined prepend((Node or DOMString or TrustedScript)... nodes);
-    [CEReactions=Needed, Unscopable] undefined append((Node or DOMString or TrustedScript)... nodes);
-    [CEReactions=Needed, Unscopable] undefined replaceChildren((Node or DOMString or TrustedScript)... nodes);
+    [CEReactions=Needed, Unscopable] undefined prepend((Node or DOMString)... nodes);
+    [CEReactions=Needed, Unscopable] undefined append((Node or DOMString)... nodes);
+    [CEReactions=Needed, Unscopable] undefined replaceChildren((Node or DOMString)... nodes);
 
     Element? querySelector(DOMString selectors);
     [NewObject] NodeList querySelectorAll(DOMString selectors);

--- a/Source/WebCore/dom/TrustedType.cpp
+++ b/Source/WebCore/dom/TrustedType.cpp
@@ -28,13 +28,11 @@
 
 #include "ContentSecurityPolicy.h"
 #include "Document.h"
-#include "HTMLScriptElement.h"
+#include "HTMLElement.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSTrustedScript.h"
 #include "LocalDOMWindow.h"
-#include "Node.h"
 #include "SVGNames.h"
-#include "Text.h"
 #include "TrustedTypePolicy.h"
 #include "TrustedTypePolicyFactory.h"
 #include "WindowOrWorkerGlobalScopeTrustedTypes.h"
@@ -302,30 +300,6 @@ ExceptionOr<String> requireTrustedTypesForPreNavigationCheckPasses(ScriptExecuti
     return String(newURL.isValid()
         ? newURL.string()
         : nullString());
-}
-
-ExceptionOr<RefPtr<Text>> processNodeOrStringAsTrustedType(Ref<Document> document, RefPtr<Node> parent, std::variant<RefPtr<Node>, String, RefPtr<TrustedScript>> variant)
-{
-    RefPtr<Text> text;
-    if (std::holds_alternative<String>(variant))
-        text = Text::create(document, WTFMove(std::get<String>(variant)));
-    else if (std::holds_alternative<RefPtr<Node>>(variant)) {
-        if (RefPtr textNode = dynamicDowncast<Text>(std::get<RefPtr<Node>>(variant)))
-            text = textNode;
-    }
-
-    if (text) {
-        if (UNLIKELY(is<HTMLScriptElement>(parent))) {
-            auto holder = trustedTypeCompliantString(TrustedType::TrustedScript, *document->scriptExecutionContext(), text->wholeText(), "HTMLScriptElement text"_s);
-            if (holder.hasException())
-                return holder.releaseException();
-
-            text->replaceWholeText(holder.releaseReturnValue());
-        }
-    } else if (std::holds_alternative<RefPtr<TrustedScript>>(variant))
-        text = Text::create(document, std::get<RefPtr<TrustedScript>>(variant)->toString());
-
-    return text;
 }
 
 ExceptionOr<bool> canCompile(ScriptExecutionContext& scriptExecutionContext, JSC::CompilationType compilationType, String codeString, JSC::JSValue bodyArgument)

--- a/Source/WebCore/dom/TrustedType.h
+++ b/Source/WebCore/dom/TrustedType.h
@@ -40,11 +40,8 @@ enum class CompilationType;
 
 namespace WebCore {
 
-class Document;
 class Exception;
-class Node;
 class ScriptExecutionContext;
-class Text;
 
 enum class TrustedType : int8_t {
     TrustedHTML,
@@ -72,8 +69,6 @@ ExceptionOr<String> trustedTypeCompliantString(ScriptExecutionContext&, std::var
 ExceptionOr<String> trustedTypeCompliantString(ScriptExecutionContext&, std::variant<RefPtr<TrustedScript>, String>&&, const String& sink);
 
 ExceptionOr<String> trustedTypeCompliantString(ScriptExecutionContext&, std::variant<RefPtr<TrustedScriptURL>, String>&&, const String& sink);
-
-ExceptionOr<RefPtr<Text>> processNodeOrStringAsTrustedType(Ref<Document>, RefPtr<Node> parent, std::variant<RefPtr<Node>, String, RefPtr<TrustedScript>>);
 
 WEBCORE_EXPORT AttributeTypeAndSink trustedTypeForAttribute(const String& elementName, const String& attributeName, const String& elementNamespace, const String& attributeNamespace);
 


### PR DESCRIPTION
#### 10507bcb292c24fee4a4dee3fd04edb3a338fe83
<pre>
Remove trusted types enforcement from DOM node APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=276881">https://bugs.webkit.org/show_bug.cgi?id=276881</a>

Reviewed by Ryosuke Niwa.

The enforcement of Trusted Types in various node manipulation APIs in DOM
was based on a previous model for protecting script elements.

This patch removes it as its not needed.

See <a href="https://github.com/whatwg/dom/pull/1299">https://github.com/whatwg/dom/pull/1299</a> and <a href="https://github.com/w3c/trusted-types/issues/537">https://github.com/w3c/trusted-types/issues/537</a>

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-tt-enforced-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-tt-enforced.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-Node-multiple-arguments.html.
* Source/WebCore/dom/ChildNode.idl:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::append):
(WebCore::ContainerNode::prepend):
(WebCore::ContainerNode::replaceChildren):
* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::nodeSetPreTransformedFromNodeOrStringVector):
(WebCore::Node::convertNodesOrStringsIntoNode):
(WebCore::Node::convertNodesOrStringsIntoNodeVector):
(WebCore::Node::before):
(WebCore::Node::after):
(WebCore::Node::replaceWith):
(WebCore::nodeSetPreTransformedFromNodeOrStringOrTrustedScriptVector): Deleted.
(WebCore::Node::convertNodesOrStringsOrTrustedScriptsIntoNode): Deleted.
(WebCore::Node::convertNodesOrStringsOrTrustedScriptsIntoNodeVector): Deleted.
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/ParentNode.idl:
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::processNodeOrStringAsTrustedType): Deleted.
* Source/WebCore/dom/TrustedType.h:

Canonical link: <a href="https://commits.webkit.org/281285@main">https://commits.webkit.org/281285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4aae90bebe65d6a9a48d32e98ea58fe83b24620e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9518 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9724 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47945 "") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6802 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28789 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32649 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8393 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8522 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64582 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8744 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55268 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51130 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55382 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13156 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2512 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34232 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36401 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->