### PR TITLE
SVG rendering ignores xml:space="preserve" attribute for text

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/text-tspan-02-b-manual-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/text-tspan-02-b-manual-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
     RenderSVGHiddenContainer {defs} at (0,0) size 0x0
-    RenderSVGContainer {g} at (0,0) size 798x354
+    RenderSVGContainer {g} at (0,0) size 800x354
       RenderSVGText {text} at (-1,83) size 480x117 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (19,0) size 377x57
           chunk 1 text run 1 at (20.00,120.00) startOffset 0 endOffset 1 width 25.20: "N"
@@ -138,85 +138,54 @@ layer at (0,0) size 800x600
           chunk 1 text run 6 at (414.20,180.00) startOffset 5 endOffset 6 width 7.80: "i"
           chunk 1 text run 7 at (422.00,180.00) startOffset 6 endOffset 7 width 19.20: "o"
           chunk 1 text run 8 at (441.20,180.00) startOffset 7 endOffset 8 width 19.20: "n"
-      RenderSVGText {text} at (0,-8) size 439x220 contains 1 chunk(s)
+      RenderSVGText {text} at (0,-8) size 484x220 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 17x9
           chunk 1 text run 1 at (0.00,0.00) startOffset 0 endOffset 7 width 16.80: "       "
-        RenderSVGTSpan {tspan} at (30,135) size 29x9
-          RenderSVGInlineText {#text} at (30,135) size 29x9
-            chunk 1 text run 1 at (30.00,135.00) startOffset 0 endOffset 2 width 6.60: "5 "
-            chunk 1 text run 1 at (36.60,135.00) startOffset 0 endOffset 3 width 10.80: "15 "
-            chunk 1 text run 1 at (47.40,135.00) startOffset 0 endOffset 3 width 10.80: "25 "
-        RenderSVGInlineText {#text} at (58,135) size 17x9
-          chunk 1 text run 1 at (58.20,135.00) startOffset 0 endOffset 7 width 16.80: "       "
-        RenderSVGTSpan {tspan} at (80,130) size 40x9
-          RenderSVGInlineText {#text} at (80,130) size 40x9
-            chunk 1 text run 1 at (80.00,130.00) startOffset 0 endOffset 4 width 13.20: "-10 "
-            chunk 1 text run 1 at (93.20,130.00) startOffset 0 endOffset 8 width 26.40: "-20 -30 "
-        RenderSVGInlineText {#text} at (119,130) size 17x9
-          chunk 1 text run 1 at (119.60,130.00) startOffset 0 endOffset 7 width 16.80: "       "
-        RenderSVGTSpan {tspan} at (125,130) size 132x9
-          RenderSVGInlineText {#text} at (0,7) size 132x9
-            chunk 1 text run 1 at (125.00,130.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-            chunk 1 text run 1 at (138.20,130.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-            chunk 1 text run 1 at (151.40,130.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-            chunk 1 text run 1 at (164.60,130.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-            chunk 1 text run 1 at (177.80,130.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-            chunk 1 text run 1 at (191.00,130.00) startOffset 0 endOffset 12 width 39.60: "-40 -40 -40 "
-            chunk 1 text run 1 at (230.60,130.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-            chunk 1 text run 1 at (243.80,130.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-        RenderSVGInlineText {#text} at (256,130) size 17x9
-          chunk 1 text run 1 at (257.00,130.00) startOffset 0 endOffset 7 width 16.80: "       "
-        RenderSVGTSpan {tspan} at (295,145) size 22x9
-          RenderSVGInlineText {#text} at (295,145) size 22x9
-            chunk 1 text run 1 at (295.00,145.00) startOffset 0 endOffset 3 width 10.80: "70 "
-            chunk 1 text run 1 at (305.80,145.00) startOffset 0 endOffset 3 width 10.80: "60 "
-        RenderSVGInlineText {#text} at (316,145) size 17x9
-          chunk 1 text run 1 at (316.60,145.00) startOffset 0 endOffset 7 width 16.80: "       "
-        RenderSVGTSpan {tspan} at (340,140) size 33x9
-          RenderSVGInlineText {#text} at (340,140) size 33x9
-            chunk 1 text run 1 at (340.00,140.00) startOffset 0 endOffset 3 width 10.80: "40 "
-            chunk 1 text run 1 at (350.80,140.00) startOffset 0 endOffset 3 width 10.80: "30 "
-            chunk 1 text run 1 at (361.60,140.00) startOffset 0 endOffset 3 width 10.80: "20 "
-        RenderSVGInlineText {#text} at (372,140) size 17x9
-          chunk 1 text run 1 at (372.40,140.00) startOffset 0 endOffset 7 width 16.80: "       "
-        RenderSVGTSpan {tspan} at (15,190) size 119x9
-          RenderSVGInlineText {#text} at (15,190) size 119x9
-            chunk 1 text run 1 at (15.00,190.00) startOffset 0 endOffset 8 width 26.40: "-40 -40 "
-            chunk 1 text run 1 at (41.40,190.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-            chunk 1 text run 1 at (54.60,190.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-            chunk 1 text run 1 at (67.80,190.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-            chunk 1 text run 1 at (81.00,190.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-            chunk 1 text run 1 at (94.20,190.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-            chunk 1 text run 1 at (107.40,190.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-            chunk 1 text run 1 at (120.60,190.00) startOffset 0 endOffset 4 width 13.20: "-40 "
-        RenderSVGInlineText {#text} at (133,190) size 17x9
-          chunk 1 text run 1 at (133.80,190.00) startOffset 0 endOffset 7 width 16.80: "       "
-        RenderSVGTSpan {tspan} at (190,200) size 106x9
-          RenderSVGInlineText {#text} at (0,7) size 106x9
-            chunk 1 text run 1 at (190.00,200.00) startOffset 0 endOffset 4 width 13.20: "-10 "
-            chunk 1 text run 1 at (203.20,200.00) startOffset 0 endOffset 4 width 13.20: "-10 "
-            chunk 1 text run 1 at (216.40,200.00) startOffset 0 endOffset 4 width 13.20: "-10 "
-            chunk 1 text run 1 at (229.60,200.00) startOffset 0 endOffset 8 width 26.40: "-10 -10 "
-            chunk 1 text run 1 at (256.00,200.00) startOffset 0 endOffset 8 width 26.40: "-10 -10 "
-            chunk 1 text run 1 at (282.40,200.00) startOffset 0 endOffset 4 width 13.20: "-10 "
-        RenderSVGInlineText {#text} at (295,200) size 17x9
-          chunk 1 text run 1 at (295.60,200.00) startOffset 0 endOffset 7 width 16.80: "       "
-        RenderSVGTSpan {tspan} at (275,190) size 14x9
-          RenderSVGInlineText {#text} at (275,190) size 14x9
-            chunk 1 text run 1 at (275.00,190.00) startOffset 0 endOffset 4 width 13.20: "-10 "
-        RenderSVGInlineText {#text} at (288,190) size 17x9
-          chunk 1 text run 1 at (288.20,190.00) startOffset 0 endOffset 7 width 16.80: "       "
-        RenderSVGTSpan {tspan} at (340,210) size 87x9
-          RenderSVGInlineText {#text} at (0,7) size 87x9
-            chunk 1 text run 1 at (340.00,210.00) startOffset 0 endOffset 3 width 10.80: "55 "
-            chunk 1 text run 1 at (350.80,210.00) startOffset 0 endOffset 3 width 10.80: "55 "
-            chunk 1 text run 1 at (361.60,210.00) startOffset 0 endOffset 3 width 10.80: "55 "
-            chunk 1 text run 1 at (372.40,210.00) startOffset 0 endOffset 3 width 10.80: "55 "
-            chunk 1 text run 1 at (383.20,210.00) startOffset 0 endOffset 6 width 21.60: "55 55 "
-            chunk 1 text run 1 at (404.80,210.00) startOffset 0 endOffset 3 width 10.80: "55 "
-            chunk 1 text run 1 at (415.60,210.00) startOffset 0 endOffset 3 width 10.80: "55 "
-        RenderSVGInlineText {#text} at (426,210) size 12x9
-          chunk 1 text run 1 at (426.40,210.00) startOffset 0 endOffset 5 width 12.00: "     "
+        RenderSVGTSpan {tspan} at (30,135) size 62x9
+          RenderSVGInlineText {#text} at (30,135) size 62x9
+            chunk 1 text run 1 at (30.00,135.00) startOffset 0 endOffset 22 width 61.80: " 5      15   25       "
+        RenderSVGInlineText {#text} at (91,135) size 17x9
+          chunk 1 text run 1 at (91.80,135.00) startOffset 0 endOffset 7 width 16.80: "       "
+        RenderSVGTSpan {tspan} at (80,130) size 59x9
+          RenderSVGInlineText {#text} at (80,130) size 59x9
+            chunk 1 text run 1 at (80.00,130.00) startOffset 0 endOffset 20 width 58.80: " -10  -20 -30       "
+        RenderSVGInlineText {#text} at (138,130) size 17x9
+          chunk 1 text run 1 at (138.80,130.00) startOffset 0 endOffset 7 width 16.80: "       "
+        RenderSVGTSpan {tspan} at (125,130) size 171x9
+          RenderSVGInlineText {#text} at (125,130) size 171x9
+            chunk 1 text run 1 at (125.00,130.00) startOffset 0 endOffset 56 width 170.40: "  -40  -40  -40  -40  -40   -40 -40 -40  -40  -40       "
+        RenderSVGInlineText {#text} at (295,130) size 17x9
+          chunk 1 text run 1 at (295.40,130.00) startOffset 0 endOffset 7 width 16.80: "       "
+        RenderSVGTSpan {tspan} at (295,145) size 44x9
+          RenderSVGInlineText {#text} at (295,145) size 44x9
+            chunk 1 text run 1 at (295.00,145.00) startOffset 0 endOffset 15 width 43.20: " 70   60       "
+        RenderSVGInlineText {#text} at (338,145) size 17x9
+          chunk 1 text run 1 at (338.20,145.00) startOffset 0 endOffset 7 width 16.80: "       "
+        RenderSVGTSpan {tspan} at (340,140) size 62x9
+          RenderSVGInlineText {#text} at (340,140) size 62x9
+            chunk 1 text run 1 at (340.00,140.00) startOffset 0 endOffset 21 width 61.20: " 40   30    20       "
+        RenderSVGInlineText {#text} at (401,140) size 17x9
+          chunk 1 text run 1 at (401.20,140.00) startOffset 0 endOffset 7 width 16.80: "       "
+        RenderSVGTSpan {tspan} at (15,190) size 174x9
+          RenderSVGInlineText {#text} at (15,190) size 174x9
+            chunk 1 text run 1 at (15.00,190.00) startOffset 0 endOffset 59 width 174.00: " -40 -40  -40  -40    -40  -40   -40   -40       -40       "
+        RenderSVGInlineText {#text} at (188,190) size 17x9
+          chunk 1 text run 1 at (189.00,190.00) startOffset 0 endOffset 7 width 16.80: "       "
+        RenderSVGTSpan {tspan} at (190,200) size 159x9
+          RenderSVGInlineText {#text} at (190,200) size 159x9
+            chunk 1 text run 1 at (190.00,200.00) startOffset 0 endOffset 54 width 158.40: "    -10   -10    -10   -10 -10   -10 -10    -10       "
+        RenderSVGInlineText {#text} at (348,200) size 17x9
+          chunk 1 text run 1 at (348.40,200.00) startOffset 0 endOffset 7 width 16.80: "       "
+        RenderSVGTSpan {tspan} at (275,190) size 30x9
+          RenderSVGInlineText {#text} at (275,190) size 30x9
+            chunk 1 text run 1 at (275.00,190.00) startOffset 0 endOffset 11 width 30.00: " -10       "
+        RenderSVGInlineText {#text} at (304,190) size 17x9
+          chunk 1 text run 1 at (305.00,190.00) startOffset 0 endOffset 7 width 16.80: "       "
+        RenderSVGTSpan {tspan} at (340,210) size 132x9
+          RenderSVGInlineText {#text} at (340,210) size 132x9
+            chunk 1 text run 1 at (340.00,210.00) startOffset 0 endOffset 43 width 132.00: "   55    55  55  55   55 55  55   55       "
+        RenderSVGInlineText {#text} at (471,210) size 12x9
+          chunk 1 text run 1 at (472.00,210.00) startOffset 0 endOffset 5 width 12.00: "     "
     RenderSVGContainer {g} at (16,518) size 414x60
       RenderSVGText {text} at (10,311) size 248x36 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 248x36

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/import/text-tspan-02-b-manual-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/import/text-tspan-02-b-manual-expected.txt
@@ -138,85 +138,54 @@ layer at (0,0) size 800x600
           chunk 1 text run 6 at (418.84,180.00) startOffset 5 endOffset 6 width 7.78: "i"
           chunk 1 text run 7 at (426.62,180.00) startOffset 6 endOffset 7 width 19.47: "o"
           chunk 1 text run 8 at (446.08,180.00) startOffset 7 endOffset 8 width 19.47: "n"
-      RenderSVGText {text} at (0,-8) size 441x221 contains 1 chunk(s)
+      RenderSVGText {text} at (0,-8) size 483x221 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 16x10
           chunk 1 text run 1 at (0.00,0.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (30,135) size 29x10
-          RenderSVGInlineText {#text} at (30,135) size 29x10
-            chunk 1 text run 1 at (30.00,135.00) startOffset 0 endOffset 2 width 6.67: "5 "
-            chunk 1 text run 1 at (36.67,135.00) startOffset 0 endOffset 3 width 11.12: "15 "
-            chunk 1 text run 1 at (47.79,135.00) startOffset 0 endOffset 3 width 11.12: "25 "
-        RenderSVGInlineText {#text} at (58,135) size 16x10
-          chunk 1 text run 1 at (58.91,135.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (80,130) size 42x10
-          RenderSVGInlineText {#text} at (80,130) size 42x10
-            chunk 1 text run 1 at (80.00,130.00) startOffset 0 endOffset 4 width 13.79: "-10 "
-            chunk 1 text run 1 at (93.79,130.00) startOffset 0 endOffset 8 width 27.57: "-20 -30 "
-        RenderSVGInlineText {#text} at (121,130) size 16x10
-          chunk 1 text run 1 at (121.36,130.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (125,130) size 138x10
-          RenderSVGInlineText {#text} at (0,7) size 138x10
-            chunk 1 text run 1 at (125.00,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (138.79,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (152.57,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (166.36,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (180.14,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (193.93,130.00) startOffset 0 endOffset 12 width 41.36: "-40 -40 -40 "
-            chunk 1 text run 1 at (235.28,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (249.07,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-        RenderSVGInlineText {#text} at (262,130) size 16x10
-          chunk 1 text run 1 at (262.85,130.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (295,145) size 23x10
-          RenderSVGInlineText {#text} at (295,145) size 23x10
-            chunk 1 text run 1 at (295.00,145.00) startOffset 0 endOffset 3 width 11.12: "70 "
-            chunk 1 text run 1 at (306.12,145.00) startOffset 0 endOffset 3 width 11.12: "60 "
-        RenderSVGInlineText {#text} at (317,145) size 16x10
-          chunk 1 text run 1 at (317.24,145.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (340,140) size 34x10
-          RenderSVGInlineText {#text} at (340,140) size 34x10
-            chunk 1 text run 1 at (340.00,140.00) startOffset 0 endOffset 3 width 11.12: "40 "
-            chunk 1 text run 1 at (351.12,140.00) startOffset 0 endOffset 3 width 11.12: "30 "
-            chunk 1 text run 1 at (362.24,140.00) startOffset 0 endOffset 3 width 11.12: "20 "
-        RenderSVGInlineText {#text} at (373,140) size 16x10
-          chunk 1 text run 1 at (373.36,140.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (15,190) size 125x10
-          RenderSVGInlineText {#text} at (15,190) size 125x10
-            chunk 1 text run 1 at (15.00,190.00) startOffset 0 endOffset 8 width 27.57: "-40 -40 "
-            chunk 1 text run 1 at (42.57,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (56.36,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (70.14,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (83.93,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (97.71,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (111.50,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (125.28,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-        RenderSVGInlineText {#text} at (139,190) size 16x10
-          chunk 1 text run 1 at (139.07,190.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (190,200) size 111x10
-          RenderSVGInlineText {#text} at (0,7) size 111x10
-            chunk 1 text run 1 at (190.00,200.00) startOffset 0 endOffset 4 width 13.79: "-10 "
-            chunk 1 text run 1 at (203.79,200.00) startOffset 0 endOffset 4 width 13.79: "-10 "
-            chunk 1 text run 1 at (217.57,200.00) startOffset 0 endOffset 4 width 13.79: "-10 "
-            chunk 1 text run 1 at (231.36,200.00) startOffset 0 endOffset 8 width 27.57: "-10 -10 "
-            chunk 1 text run 1 at (258.93,200.00) startOffset 0 endOffset 8 width 27.57: "-10 -10 "
-            chunk 1 text run 1 at (286.50,200.00) startOffset 0 endOffset 4 width 13.79: "-10 "
-        RenderSVGInlineText {#text} at (300,200) size 16x10
-          chunk 1 text run 1 at (300.28,200.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (275,190) size 14x10
-          RenderSVGInlineText {#text} at (275,190) size 14x10
-            chunk 1 text run 1 at (275.00,190.00) startOffset 0 endOffset 4 width 13.79: "-10 "
-        RenderSVGInlineText {#text} at (288,190) size 16x10
-          chunk 1 text run 1 at (288.79,190.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (340,210) size 89x10
-          RenderSVGInlineText {#text} at (0,7) size 89x10
-            chunk 1 text run 1 at (340.00,210.00) startOffset 0 endOffset 3 width 11.12: "55 "
-            chunk 1 text run 1 at (351.12,210.00) startOffset 0 endOffset 3 width 11.12: "55 "
-            chunk 1 text run 1 at (362.24,210.00) startOffset 0 endOffset 3 width 11.12: "55 "
-            chunk 1 text run 1 at (373.36,210.00) startOffset 0 endOffset 3 width 11.12: "55 "
-            chunk 1 text run 1 at (384.48,210.00) startOffset 0 endOffset 6 width 22.24: "55 55 "
-            chunk 1 text run 1 at (406.73,210.00) startOffset 0 endOffset 3 width 11.12: "55 "
-            chunk 1 text run 1 at (417.85,210.00) startOffset 0 endOffset 3 width 11.12: "55 "
-        RenderSVGInlineText {#text} at (428,210) size 12x10
-          chunk 1 text run 1 at (428.97,210.00) startOffset 0 endOffset 5 width 11.11: "     "
+        RenderSVGTSpan {tspan} at (30,135) size 61x10
+          RenderSVGInlineText {#text} at (30,135) size 61x10
+            chunk 1 text run 1 at (30.00,135.00) startOffset 0 endOffset 22 width 60.03: " 5      15   25       "
+        RenderSVGInlineText {#text} at (90,135) size 16x10
+          chunk 1 text run 1 at (90.03,135.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (80,130) size 60x10
+          RenderSVGInlineText {#text} at (80,130) size 60x10
+            chunk 1 text run 1 at (80.00,130.00) startOffset 0 endOffset 20 width 59.14: " -10  -20 -30       "
+        RenderSVGInlineText {#text} at (139,130) size 16x10
+          chunk 1 text run 1 at (139.14,130.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (125,130) size 174x10
+          RenderSVGInlineText {#text} at (125,130) size 174x10
+            chunk 1 text run 1 at (125.00,130.00) startOffset 0 endOffset 56 width 173.41: "  -40  -40  -40  -40  -40   -40 -40 -40  -40  -40       "
+        RenderSVGInlineText {#text} at (298,130) size 16x10
+          chunk 1 text run 1 at (298.41,130.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (295,145) size 43x10
+          RenderSVGInlineText {#text} at (295,145) size 43x10
+            chunk 1 text run 1 at (295.00,145.00) startOffset 0 endOffset 15 width 42.25: " 70   60       "
+        RenderSVGInlineText {#text} at (337,145) size 16x10
+          chunk 1 text run 1 at (337.25,145.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (340,140) size 61x10
+          RenderSVGInlineText {#text} at (340,140) size 61x10
+            chunk 1 text run 1 at (340.00,140.00) startOffset 0 endOffset 21 width 60.04: " 40   30    20       "
+        RenderSVGInlineText {#text} at (400,140) size 16x10
+          chunk 1 text run 1 at (400.04,140.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (15,190) size 176x10
+          RenderSVGInlineText {#text} at (15,190) size 176x10
+            chunk 1 text run 1 at (15.00,190.00) startOffset 0 endOffset 59 width 175.19: " -40 -40  -40  -40    -40  -40   -40   -40       -40       "
+        RenderSVGInlineText {#text} at (190,190) size 16x10
+          chunk 1 text run 1 at (190.19,190.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (190,200) size 160x10
+          RenderSVGInlineText {#text} at (190,200) size 160x10
+            chunk 1 text run 1 at (190.00,200.00) startOffset 0 endOffset 54 width 159.18: "    -10   -10    -10   -10 -10   -10 -10    -10       "
+        RenderSVGInlineText {#text} at (349,200) size 16x10
+          chunk 1 text run 1 at (349.18,200.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (275,190) size 30x10
+          RenderSVGInlineText {#text} at (275,190) size 30x10
+            chunk 1 text run 1 at (275.00,190.00) startOffset 0 endOffset 11 width 29.34: " -10       "
+        RenderSVGInlineText {#text} at (304,190) size 16x10
+          chunk 1 text run 1 at (304.34,190.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (340,210) size 132x10
+          RenderSVGInlineText {#text} at (340,210) size 132x10
+            chunk 1 text run 1 at (340.00,210.00) startOffset 0 endOffset 43 width 131.20: "   55    55  55  55   55 55  55   55       "
+        RenderSVGInlineText {#text} at (471,210) size 12x10
+          chunk 1 text run 1 at (471.20,210.00) startOffset 0 endOffset 5 width 11.11: "     "
     RenderSVGContainer {g} at (16,516) size 413x64
       RenderSVGText {text} at (10,310) size 248x38 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 248x38

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/text-tspan-02-b-manual-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/text-tspan-02-b-manual-expected.txt
@@ -138,85 +138,54 @@ layer at (0,0) size 800x600
           chunk 1 text run 6 at (418.84,180.00) startOffset 5 endOffset 6 width 7.78: "i"
           chunk 1 text run 7 at (426.62,180.00) startOffset 6 endOffset 7 width 19.47: "o"
           chunk 1 text run 8 at (446.08,180.00) startOffset 7 endOffset 8 width 19.47: "n"
-      RenderSVGText {text} at (0,-8) size 441x220 contains 1 chunk(s)
+      RenderSVGText {text} at (0,-8) size 483x220 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 16x10
           chunk 1 text run 1 at (0.00,0.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (30,135) size 29x10
-          RenderSVGInlineText {#text} at (30,135) size 29x10
-            chunk 1 text run 1 at (30.00,135.00) startOffset 0 endOffset 2 width 6.67: "5 "
-            chunk 1 text run 1 at (36.67,135.00) startOffset 0 endOffset 3 width 11.12: "15 "
-            chunk 1 text run 1 at (47.79,135.00) startOffset 0 endOffset 3 width 11.12: "25 "
-        RenderSVGInlineText {#text} at (58,135) size 16x10
-          chunk 1 text run 1 at (58.91,135.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (80,130) size 42x10
-          RenderSVGInlineText {#text} at (80,130) size 42x10
-            chunk 1 text run 1 at (80.00,130.00) startOffset 0 endOffset 4 width 13.79: "-10 "
-            chunk 1 text run 1 at (93.79,130.00) startOffset 0 endOffset 8 width 27.57: "-20 -30 "
-        RenderSVGInlineText {#text} at (121,130) size 16x10
-          chunk 1 text run 1 at (121.36,130.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (125,130) size 138x10
-          RenderSVGInlineText {#text} at (0,7) size 138x10
-            chunk 1 text run 1 at (125.00,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (138.79,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (152.57,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (166.36,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (180.14,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (193.93,130.00) startOffset 0 endOffset 12 width 41.36: "-40 -40 -40 "
-            chunk 1 text run 1 at (235.28,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (249.07,130.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-        RenderSVGInlineText {#text} at (262,130) size 16x10
-          chunk 1 text run 1 at (262.85,130.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (295,145) size 23x10
-          RenderSVGInlineText {#text} at (295,145) size 23x10
-            chunk 1 text run 1 at (295.00,145.00) startOffset 0 endOffset 3 width 11.12: "70 "
-            chunk 1 text run 1 at (306.12,145.00) startOffset 0 endOffset 3 width 11.12: "60 "
-        RenderSVGInlineText {#text} at (317,145) size 16x10
-          chunk 1 text run 1 at (317.24,145.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (340,140) size 34x10
-          RenderSVGInlineText {#text} at (340,140) size 34x10
-            chunk 1 text run 1 at (340.00,140.00) startOffset 0 endOffset 3 width 11.12: "40 "
-            chunk 1 text run 1 at (351.12,140.00) startOffset 0 endOffset 3 width 11.12: "30 "
-            chunk 1 text run 1 at (362.24,140.00) startOffset 0 endOffset 3 width 11.12: "20 "
-        RenderSVGInlineText {#text} at (373,140) size 16x10
-          chunk 1 text run 1 at (373.36,140.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (15,190) size 125x10
-          RenderSVGInlineText {#text} at (15,190) size 125x10
-            chunk 1 text run 1 at (15.00,190.00) startOffset 0 endOffset 8 width 27.57: "-40 -40 "
-            chunk 1 text run 1 at (42.57,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (56.36,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (70.14,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (83.93,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (97.71,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (111.50,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-            chunk 1 text run 1 at (125.28,190.00) startOffset 0 endOffset 4 width 13.79: "-40 "
-        RenderSVGInlineText {#text} at (139,190) size 16x10
-          chunk 1 text run 1 at (139.07,190.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (190,200) size 111x10
-          RenderSVGInlineText {#text} at (0,7) size 111x10
-            chunk 1 text run 1 at (190.00,200.00) startOffset 0 endOffset 4 width 13.79: "-10 "
-            chunk 1 text run 1 at (203.79,200.00) startOffset 0 endOffset 4 width 13.79: "-10 "
-            chunk 1 text run 1 at (217.57,200.00) startOffset 0 endOffset 4 width 13.79: "-10 "
-            chunk 1 text run 1 at (231.36,200.00) startOffset 0 endOffset 8 width 27.57: "-10 -10 "
-            chunk 1 text run 1 at (258.93,200.00) startOffset 0 endOffset 8 width 27.57: "-10 -10 "
-            chunk 1 text run 1 at (286.50,200.00) startOffset 0 endOffset 4 width 13.79: "-10 "
-        RenderSVGInlineText {#text} at (300,200) size 16x10
-          chunk 1 text run 1 at (300.28,200.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (275,190) size 14x10
-          RenderSVGInlineText {#text} at (275,190) size 14x10
-            chunk 1 text run 1 at (275.00,190.00) startOffset 0 endOffset 4 width 13.79: "-10 "
-        RenderSVGInlineText {#text} at (288,190) size 16x10
-          chunk 1 text run 1 at (288.79,190.00) startOffset 0 endOffset 7 width 15.56: "       "
-        RenderSVGTSpan {tspan} at (340,210) size 89x10
-          RenderSVGInlineText {#text} at (0,7) size 89x10
-            chunk 1 text run 1 at (340.00,210.00) startOffset 0 endOffset 3 width 11.12: "55 "
-            chunk 1 text run 1 at (351.12,210.00) startOffset 0 endOffset 3 width 11.12: "55 "
-            chunk 1 text run 1 at (362.24,210.00) startOffset 0 endOffset 3 width 11.12: "55 "
-            chunk 1 text run 1 at (373.36,210.00) startOffset 0 endOffset 3 width 11.12: "55 "
-            chunk 1 text run 1 at (384.48,210.00) startOffset 0 endOffset 6 width 22.24: "55 55 "
-            chunk 1 text run 1 at (406.73,210.00) startOffset 0 endOffset 3 width 11.12: "55 "
-            chunk 1 text run 1 at (417.85,210.00) startOffset 0 endOffset 3 width 11.12: "55 "
-        RenderSVGInlineText {#text} at (428,210) size 12x10
-          chunk 1 text run 1 at (428.97,210.00) startOffset 0 endOffset 5 width 11.11: "     "
+        RenderSVGTSpan {tspan} at (30,135) size 61x10
+          RenderSVGInlineText {#text} at (30,135) size 61x10
+            chunk 1 text run 1 at (30.00,135.00) startOffset 0 endOffset 22 width 60.03: " 5      15   25       "
+        RenderSVGInlineText {#text} at (90,135) size 16x10
+          chunk 1 text run 1 at (90.03,135.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (80,130) size 60x10
+          RenderSVGInlineText {#text} at (80,130) size 60x10
+            chunk 1 text run 1 at (80.00,130.00) startOffset 0 endOffset 20 width 59.14: " -10  -20 -30       "
+        RenderSVGInlineText {#text} at (139,130) size 16x10
+          chunk 1 text run 1 at (139.14,130.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (125,130) size 174x10
+          RenderSVGInlineText {#text} at (125,130) size 174x10
+            chunk 1 text run 1 at (125.00,130.00) startOffset 0 endOffset 56 width 173.41: "  -40  -40  -40  -40  -40   -40 -40 -40  -40  -40       "
+        RenderSVGInlineText {#text} at (298,130) size 16x10
+          chunk 1 text run 1 at (298.41,130.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (295,145) size 43x10
+          RenderSVGInlineText {#text} at (295,145) size 43x10
+            chunk 1 text run 1 at (295.00,145.00) startOffset 0 endOffset 15 width 42.25: " 70   60       "
+        RenderSVGInlineText {#text} at (337,145) size 16x10
+          chunk 1 text run 1 at (337.25,145.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (340,140) size 61x10
+          RenderSVGInlineText {#text} at (340,140) size 61x10
+            chunk 1 text run 1 at (340.00,140.00) startOffset 0 endOffset 21 width 60.04: " 40   30    20       "
+        RenderSVGInlineText {#text} at (400,140) size 16x10
+          chunk 1 text run 1 at (400.04,140.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (15,190) size 176x10
+          RenderSVGInlineText {#text} at (15,190) size 176x10
+            chunk 1 text run 1 at (15.00,190.00) startOffset 0 endOffset 59 width 175.19: " -40 -40  -40  -40    -40  -40   -40   -40       -40       "
+        RenderSVGInlineText {#text} at (190,190) size 16x10
+          chunk 1 text run 1 at (190.19,190.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (190,200) size 160x10
+          RenderSVGInlineText {#text} at (190,200) size 160x10
+            chunk 1 text run 1 at (190.00,200.00) startOffset 0 endOffset 54 width 159.18: "    -10   -10    -10   -10 -10   -10 -10    -10       "
+        RenderSVGInlineText {#text} at (349,200) size 16x10
+          chunk 1 text run 1 at (349.18,200.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (275,190) size 30x10
+          RenderSVGInlineText {#text} at (275,190) size 30x10
+            chunk 1 text run 1 at (275.00,190.00) startOffset 0 endOffset 11 width 29.34: " -10       "
+        RenderSVGInlineText {#text} at (304,190) size 16x10
+          chunk 1 text run 1 at (304.34,190.00) startOffset 0 endOffset 7 width 15.56: "       "
+        RenderSVGTSpan {tspan} at (340,210) size 132x10
+          RenderSVGInlineText {#text} at (340,210) size 132x10
+            chunk 1 text run 1 at (340.00,210.00) startOffset 0 endOffset 43 width 131.20: "   55    55  55  55   55 55  55   55       "
+        RenderSVGInlineText {#text} at (471,210) size 12x10
+          chunk 1 text run 1 at (471.20,210.00) startOffset 0 endOffset 5 width 11.11: "     "
     RenderSVGContainer {g} at (16,517) size 413x62
       RenderSVGText {text} at (10,310) size 248x38 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 248x37

--- a/Source/WebCore/css/svg.css
+++ b/Source/WebCore/css/svg.css
@@ -61,8 +61,12 @@ text, foreignObject {
     display: block
 }
 
-text, tspan, textPath {
-   white-space: nowrap
+text {
+    white-space: nowrap;
+}
+
+tspan, textPath {
+    white-space: inherit;
 }
 
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY


### PR DESCRIPTION
#### e4359d3e33a4927ce8c7164b4d277693ddfa1806
<pre>
SVG rendering ignores xml:space=&quot;preserve&quot; attribute for text

<a href="https://bugs.webkit.org/show_bug.cgi?id=112032">https://bugs.webkit.org/show_bug.cgi?id=112032</a>
<a href="https://rdar.apple.com/problem/19164263">rdar://problem/19164263</a>

Reviewed by Nikolas Zimmermann.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/66a66b7e89c9cb4d2f0579354f8f84a202dce332">https://source.chromium.org/chromium/chromium/src/+/66a66b7e89c9cb4d2f0579354f8f84a202dce332</a>

Web Specification: <a href="https://svgwg.org/svg2-draft/text.html#LegacyXMLSpace">https://svgwg.org/svg2-draft/text.html#LegacyXMLSpace</a>

It landed in past 255917@main but led to regression and was reverted in 258905@main.
Prior to relanding, I tested the regression `chart testcase` attached on
bug 250603 and it was working as intended and didn&apos;t had &apos;garbled&apos; text
anymore.

&quot;It will convert all newline and tab characters into space characters. Then,
it will draw all space characters, including leading, trailing and
multiple contiguous space characters...&quot;

* Source/WebCore/css/svg.css:
(text):
(tspan, textPath):
(text, tspan, textPath): Deleted.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/import/text-tspan-02-b-manual-expected.txt:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/text-tspan-02-b-manual-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/text-tspan-02-b-manual-expected.txt:

Canonical link: <a href="https://commits.webkit.org/281364@main">https://commits.webkit.org/281364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a01dcc2a3e136b2acf2af78ae46bf8d80045f5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63117 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9598 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48104 "") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6859 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28929 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8462 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8602 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64822 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55432 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55530 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2574 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34314 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35397 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->