### PR TITLE
[GTK][WPE] Constant high idle CPU usage in front of any logged in page on Trello.com

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -143,8 +143,7 @@ public:
     PlatformLayer* platformLayer() const override;
 #endif
 
-    bool checkPendingStateChangesIncludingSubLayers();
-    void updateContentBuffersIncludingSubLayers();
+    std::pair<bool, bool> finalizeCompositingStateFlush();
 
     FloatPoint computePositionRelativeToBase();
     void computePixelAlignment(FloatPoint& position, FloatSize&, FloatPoint3D& anchorPoint, FloatSize& alignmentOffset);
@@ -210,6 +209,9 @@ private:
     void computeTransformedVisibleRect();
     void updateContentBuffers();
 
+    bool checkPendingStateChanges();
+    bool checkContentLayerUpdated();
+
     Ref<Nicosia::Buffer> paintTile(const IntRect&, const IntRect& mappedTileRect, float contentsScale);
     Ref<Nicosia::Buffer> paintImage(Image&);
 
@@ -273,6 +275,7 @@ private:
         Nicosia::CompositionLayer::LayerState::RepaintCounter repaintCounter;
         Nicosia::CompositionLayer::LayerState::DebugBorder debugBorder;
         bool performLayerSync { false };
+        bool contentLayerUpdated { false };
 
         RefPtr<Nicosia::BackingStore> backingStore;
         RefPtr<Nicosia::ContentLayer> contentLayer;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
@@ -82,9 +82,7 @@ public:
     WebCore::GraphicsLayer* rootLayer() const { return m_rootLayer.get(); }
     WebCore::GraphicsLayer* rootCompositingLayer() const { return m_rootCompositingLayer; }
 
-#if !HAVE(DISPLAY_LINK)
     void forceFrameSync() { m_forceFrameSync = true; }
-#endif
 
     bool flushPendingLayerChanges(OptionSet<WebCore::FinalizeRenderingUpdateFlags>);
     void syncDisplayState();
@@ -148,9 +146,7 @@ private:
     WebCore::FloatRect m_visibleContentsRect;
 
     double m_lastAnimationServiceTime { 0 };
-#if !HAVE(DISPLAY_LINK)
     bool m_forceFrameSync { false };
-#endif
 };
 
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -163,12 +163,10 @@ void LayerTreeHost::layerFlushTimerFired()
     if (m_isWaitingForRenderer)
         return;
 
-#if !HAVE(DISPLAY_LINK)
     // If a force-repaint callback was registered, we should force a 'frame sync' that
     // will guarantee us a call to renderNextFrame() once the update is complete.
     if (m_forceRepaintAsync.callback)
         m_coordinator.forceFrameSync();
-#endif
 
     OptionSet<FinalizeRenderingUpdateFlags> flags;
 #if PLATFORM(GTK)
@@ -218,6 +216,7 @@ void LayerTreeHost::forceRepaint()
     m_coordinator.syncDisplayState();
 
     // We need to schedule another flush, otherwise the forced paint might cancel a later expected flush.
+    m_coordinator.forceFrameSync();
     scheduleLayerFlush();
 
     if (!m_isWaitingForRenderer) {
@@ -504,10 +503,8 @@ void LayerTreeHost::renderNextFrame(bool forceRepaint)
 
     if (scheduledWhileWaitingForRenderer || m_layerFlushTimer.isActive() || forceRepaint) {
         m_layerFlushTimer.stop();
-#if !HAVE(DISPLAY_LINK)
         if (forceRepaint)
             m_coordinator.forceFrameSync();
-#endif
         layerFlushTimerFired();
     }
 }


### PR DESCRIPTION
#### 18a0d3296eb321ab479d1438b0f8863b9d13ae14
<pre>
[GTK][WPE] Constant high idle CPU usage in front of any logged in page on Trello.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=252545">https://bugs.webkit.org/show_bug.cgi?id=252545</a>

Reviewed by Miguel Gomez.

Do not schedule a composition if layers haven&apos;t changed and it&apos;s not a
force repaint. To know whether platform layer changed, we need to also
track the updates during layer flush and add a way to check the status.
This patch merges updateContentBuffersIncludingSubLayers() and
checkPendingStateChanges() into finalizeCompositingStateFlush() to
upadate the backing stores and check the frame sync and platform updates
in a single layer iteration.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::updatePlatformLayer):
(WebCore::CoordinatedGraphicsLayer::checkContentLayerUpdated):
(WebCore::CoordinatedGraphicsLayer::checkPendingStateChanges):
(WebCore::CoordinatedGraphicsLayer::finalizeCompositingStateFlush):
(WebCore::CoordinatedGraphicsLayer::checkPendingStateChangesIncludingSubLayers): Deleted.
(WebCore::CoordinatedGraphicsLayer::updateContentBuffersIncludingSubLayers): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::flushPendingLayerChanges):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::layerFlushTimerFired):
(WebKit::LayerTreeHost::forceRepaint):
(WebKit::LayerTreeHost::renderNextFrame):

Canonical link: <a href="https://commits.webkit.org/281288@main">https://commits.webkit.org/281288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfcb16f8740f539004dc38ef3fc5620744358cf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63321 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/9917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48230 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/9917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29055 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32902 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8673 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8854 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65054 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3335 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8866 "layout-tests (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55573 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55677 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2771 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8867 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34566 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36735 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->