### PR TITLE
Potential UI hang under IPC::Connection::dispatchIncomingMessages()

### DIFF
--- a/Source/WTF/wtf/Lock.h
+++ b/Source/WTF/wtf/Lock.h
@@ -124,6 +124,11 @@ public:
         return isHeld();
     }
 
+    void assertIsOwner() const
+    {
+        ASSERT(isHeld());
+    }
+
 private:
     friend struct TestWebKitAPI::LockInspector;
     
@@ -161,12 +166,18 @@ public:
     {
         os_unfair_lock_unlock(&m_lock);
     }
+    void assertIsOwner() const
+    {
+        os_unfair_lock_assert_owner(&m_lock);
+    }
 
     UnfairLock() = default;
 
 private:
     os_unfair_lock m_lock = OS_UNFAIR_LOCK_INIT;
 };
+
+inline void assertIsHeld(const UnfairLock& lock) WTF_ASSERTS_ACQUIRED_LOCK(lock) { lock.assertIsOwner(); }
 #endif // ENABLE(UNFAIR_LOCK)
 
 // Locker specialization to use with Lock and UnfairLock that integrates with thread safety analysis.

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -580,7 +580,11 @@ private:
     std::optional<uint8_t> m_incomingMessagesThrottlingLevel;
 
     // Incoming messages.
+#if ENABLE(UNFAIR_LOCK)
+    mutable UnfairLock m_incomingMessagesLock;
+#else
     mutable Lock m_incomingMessagesLock;
+#endif
     Deque<UniqueRef<Decoder>> m_incomingMessages WTF_GUARDED_BY_LOCK(m_incomingMessagesLock);
     MessageReceiveQueueMap m_receiveQueues WTF_GUARDED_BY_LOCK(m_incomingMessagesLock);
 


### PR DESCRIPTION
#### 07cee55ea03c872b72d82ca0c736cf298d602cf6
<pre>
Potential UI hang under IPC::Connection::dispatchIncomingMessages()
<a href="https://bugs.webkit.org/show_bug.cgi?id=276900">https://bugs.webkit.org/show_bug.cgi?id=276900</a>
<a href="https://rdar.apple.com/132123087">rdar://132123087</a>

Reviewed by Brady Eidson.

Use an UnfairLock for IPC::Connection::m_incomingMessagesLock instead
of a WTF::Lock to get priority inheritance.

* Source/WTF/wtf/Lock.h:
(WTF::WTF_ASSERTS_ACQUIRED_LOCK):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::SyncMessageState::processIncomingMessage):
(IPC::Connection::enqueueIncomingMessage):
(IPC::Connection::dispatcher):
* Source/WebKit/Platform/IPC/Connection.h:

Canonical link: <a href="https://commits.webkit.org/281223@main">https://commits.webkit.org/281223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb3960e9f9e84b0054b481504e9c462ba3b15c38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63039 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9567 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9783 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6840 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51172 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/28878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8435 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8571 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/52216 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64731 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58367 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8670 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51172 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/55488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2554 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80126 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8836 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34283 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13872 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35366 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->