### PR TITLE
[WPE] WPE Platform: add window minimization to WPEToplevel

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
@@ -463,6 +463,22 @@ gboolean wpe_toplevel_unmaximize(WPEToplevel* toplevel)
 }
 
 /**
+ * wpe_toplevel_minimize:
+ * @toplevel: a #WPEToplevel
+ *
+ * Request that the @toplevel is minimized.
+ *
+ * Returns: %TRUE if minimize is supported, otherwise %FALSE
+ */
+gboolean wpe_toplevel_minimize(WPEToplevel* toplevel)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), FALSE);
+
+    auto* toplevelClass = WPE_TOPLEVEL_GET_CLASS(toplevel);
+    return toplevelClass->set_minimized ? toplevelClass->set_minimized(toplevel) : FALSE;
+}
+
+/**
  * wpe_toplevel_get_preferred_dma_buf_formats:
  * @toplevel: a #WPEToplevel
  *

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.h
@@ -58,6 +58,7 @@ struct _WPEToplevelClass
                                                                gboolean     fullscreen);
     gboolean                (* set_maximized)                 (WPEToplevel *toplevel,
                                                                gboolean     maximized);
+    gboolean                (* set_minimized)                 (WPEToplevel *toplevel);
     WPEBufferDMABufFormats *(* get_preferred_dma_buf_formats) (WPEToplevel *toplevel);
 
     gpointer padding[32];
@@ -123,6 +124,7 @@ WPE_API gboolean                wpe_toplevel_fullscreen                        (
 WPE_API gboolean                wpe_toplevel_unfullscreen                      (WPEToplevel               *toplevel);
 WPE_API gboolean                wpe_toplevel_maximize                          (WPEToplevel               *toplevel);
 WPE_API gboolean                wpe_toplevel_unmaximize                        (WPEToplevel               *toplevel);
+WPE_API gboolean                wpe_toplevel_minimize                          (WPEToplevel               *toplevel);
 WPE_API WPEBufferDMABufFormats *wpe_toplevel_get_preferred_dma_buf_formats     (WPEToplevel               *toplevel);
 WPE_API void                    wpe_toplevel_preferred_dma_buf_formats_changed (WPEToplevel               *toplevel);
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
@@ -638,6 +638,16 @@ static gboolean wpeToplevelWaylandSetMaximized(WPEToplevel* toplevel, gboolean m
     return TRUE;
 }
 
+static gboolean wpeToplevelWaylandSetMinimized(WPEToplevel* toplevel)
+{
+    auto* priv = WPE_TOPLEVEL_WAYLAND(toplevel)->priv;
+    if (!priv->xdgToplevel)
+        return FALSE;
+
+    xdg_toplevel_set_minimized(priv->xdgToplevel);
+    return TRUE;
+}
+
 static WPEBufferDMABufFormats* wpeToplevelWaylandGetPreferredDMABufFormats(WPEToplevel* toplevel)
 {
     auto* priv = WPE_TOPLEVEL_WAYLAND(toplevel)->priv;
@@ -705,6 +715,7 @@ static void wpe_toplevel_wayland_class_init(WPEToplevelWaylandClass* toplevelWay
     toplevelClass->resize = wpeToplevelWaylandResize;
     toplevelClass->set_fullscreen = wpeToplevelWaylandSetFullscreen;
     toplevelClass->set_maximized = wpeToplevelWaylandSetMaximized;
+    toplevelClass->set_minimized = wpeToplevelWaylandSetMinimized;
     toplevelClass->get_preferred_dma_buf_formats = wpeToplevelWaylandGetPreferredDMABufFormats;
     toplevelClass->set_title = wpeToplevelWaylandSetTitle;
 }

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -213,6 +213,13 @@ static gboolean wpeViewEventCallback(WPEView* view, WPEEvent* event, WebKitWebVi
                 return TRUE;
             }
         }
+
+        if (keyval == WPE_KEY_Down) {
+            if (auto* toplevel = wpe_view_get_toplevel(view)) {
+                wpe_toplevel_minimize(toplevel);
+                return TRUE;
+            }
+        }
     }
 
     if (keyval == WPE_KEY_F11) {


### PR DESCRIPTION
#### 1951f6a96e1b0f426ebb12f9f688e6eb428b6280
<pre>
[WPE] WPE Platform: add window minimization to WPEToplevel
<a href="https://bugs.webkit.org/show_bug.cgi?id=276905">https://bugs.webkit.org/show_bug.cgi?id=276905</a>

Reviewed by Carlos Garcia Campos.

This is to implement minimization support for the toplevel in WPE
Platform; we would like to add a keyboard shortcut to the minibrowser.

* Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp:
(wpe_toplevel_minimize):
* Source/WebKit/WPEPlatform/wpe/WPEToplevel.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp:
(wpeToplevelWaylandSetMinimized):
(wpe_toplevel_wayland_class_init):
* Tools/MiniBrowser/wpe/main.cpp:

Canonical link: <a href="https://commits.webkit.org/281230@main">https://commits.webkit.org/281230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/867ee32e4c880fb1c3d567a3f6ff544312c229db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63061 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9574 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48059 "") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6845 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35975 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28886 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8439 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8578 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54653 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8720 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64768 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3050 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8677 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/URL-createObjectURL-null.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3061 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51176 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/55506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2561 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8840 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34290 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35373 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36459 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35118 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->