### PR TITLE
text-transform:uppercase in SVG causes misplaced letters

### DIFF
--- a/LayoutTests/svg/text/text-transform-whitespace-rules-expected.svg
+++ b/LayoutTests/svg/text/text-transform-whitespace-rules-expected.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<text>
+<tspan x="0" y="1em">WORD1
+</tspan><tspan x="0" dy="1em">WORD2</tspan>
+</text>
+</svg>

--- a/LayoutTests/svg/text/text-transform-whitespace-rules.svg
+++ b/LayoutTests/svg/text/text-transform-whitespace-rules.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<style>
+svg {
+    text-transform: uppercase;
+}
+</style>
+<text>
+<tspan x="0" y="1em">Word1 
+</tspan><tspan x="0" dy="1em">Word2</tspan>
+</text>
+</svg>

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2006 Oliver Hunt <ojh16@student.canterbury.ac.nz>
- * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  * Copyright (C) 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2008 Rob Buis <buis@kde.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
@@ -84,7 +85,10 @@ RenderSVGInlineText::~RenderSVGInlineText() = default;
 
 String RenderSVGInlineText::originalText() const
 {
-    return textNode().data();
+    auto result = textNode().data();
+    if (!result)
+        return { };
+    return applySVGWhitespaceRules(result, style().whiteSpace() == WhiteSpace::Pre);
 }
 
 void RenderSVGInlineText::setRenderedText(const String& text)
@@ -101,13 +105,8 @@ void RenderSVGInlineText::styleDidChange(StyleDifference diff, const RenderStyle
 
     bool newPreserves = style().whiteSpaceCollapse() == WhiteSpaceCollapse::Preserve;
     bool oldPreserves = oldStyle ? oldStyle->whiteSpaceCollapse() == WhiteSpaceCollapse::Preserve : false;
-    if (oldPreserves && !newPreserves) {
-        setText(applySVGWhitespaceRules(originalText(), false), true);
-        return;
-    }
-
-    if (!oldPreserves && newPreserves) {
-        setText(applySVGWhitespaceRules(originalText(), true), true);
+    if (oldPreserves != newPreserves) {
+        setText(originalText(), true);
         return;
     }
 


### PR DESCRIPTION
<pre>
text-transform:uppercase in SVG causes misplaced letters
<a href="https://bugs.webkit.org/show_bug.cgi?id=171664">https://bugs.webkit.org/show_bug.cgi?id=171664</a>
rdar://problem/31989978

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge: <a href="https://github.com/chromium/chromium/commit/829357862f40854d617b4b8640cbe526e6792db3">https://github.com/chromium/chromium/commit/829357862f40854d617b4b8640cbe526e6792db3</a>

The `originalText` function was added in 143476@main to account for any
text changes and then changed into map. This patch leverages it to apply
SVG whitespace rules as stated in web specification [1], which suggests to
look for CSS Whitespace handling [2] except when it is legacy cases (i.e.,
xml:space) [3]. Previously, we were not applying SVG whitespace rules to
account for `pre` whitespace as a result, when `text-transform` was used,
the transform text operations needs to follow [4] order, where `uppercase`
is first and it should happen after `white space` processing [5]
(Phase I: Collapsing and Transformation):

Additionally, it simplifies `styleDidChange` to ‘setText’ only
when `old` and `new` differ.

In future, we can simplify `applySVGWhitespaceRules` rules further as part
of bug 278524.

[1] <a href="https://svgwg.org/svg2-draft/text.html#TextWhiteSpace">https://svgwg.org/svg2-draft/text.html#TextWhiteSpace</a>
[2] <a href="https://drafts.csswg.org/css-text-3/#white-space-processing">https://drafts.csswg.org/css-text-3/#white-space-processing</a>
[3] <a href="https://svgwg.org/svg2-draft/text.html#LegacyXMLSpace">https://svgwg.org/svg2-draft/text.html#LegacyXMLSpace</a>
[4] <a href="https://drafts.csswg.org/css-text-3/#text-transform-order">https://drafts.csswg.org/css-text-3/#text-transform-order</a>
[5] <a href="https://drafts.csswg.org/css-text-3/#white-space-phase-1">https://drafts.csswg.org/css-text-3/#white-space-phase-1</a>

* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::originalText const):
(WebCore::RenderSVGInlineText::styleDidChange):
* LayoutTests/svg/text/text-transform-whitespace-rules.svg: Add Test Case
* LayoutTests/svg/text/text-transform-whitespace-rules-expected.svg: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/748f1c8c5d72c6b1031517a6064d176a8152f6f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67860 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14447 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65959 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50886 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51439 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9989 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32056 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12652 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13320 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58658 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69556 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58762 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58908 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6475 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39016 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->