### PR TITLE
[Site Isolation] Replace WKBundleFrameIsRemote call with keeping state in UI process

### DIFF
--- a/LayoutTests/http/tests/navigation/sec-fetch-site-header-expected.txt
+++ b/LayoutTests/http/tests/navigation/sec-fetch-site-header-expected.txt
@@ -8,3 +8,8 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 
+
+============== Back Forward List ==============
+        http://127.0.0.1:8000/navigation/sec-fetch-site-header.html
+curr->  https://localhost:8443/referrer-policy/resources/check-sec-fetch-site.py?expected=none  **nav target**
+===============================================

--- a/LayoutTests/http/tests/navigation/sec-fetch-site-header-on-crossorigin-redirection-expected.txt
+++ b/LayoutTests/http/tests/navigation/sec-fetch-site-header-on-crossorigin-redirection-expected.txt
@@ -8,3 +8,8 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 
+
+============== Back Forward List ==============
+        http://127.0.0.1:8000/navigation/sec-fetch-site-header-on-crossorigin-redirection.html
+curr->  http://127.0.0.1:8000/referrer-policy/resources/check-sec-fetch-site.py?expected=none  **nav target**
+===============================================

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -317,9 +317,6 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "DumpBackForwardList"))
-        return m_testRunner->dumpBackForwardList();
-
     postPageMessage("Error", "Unknown");
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -2126,10 +2126,12 @@ void TestRunner::getAndClearReportedWindowProxyAccessDomains(JSContextRef contex
 
 void TestRunner::dumpBackForwardList()
 {
-    m_shouldDumpBackForwardListsForAllWindows = true;
-    auto& injectedBundle = InjectedBundle::singleton();
-    if (WKBundleFrameIsRemote(WKBundlePageGetMainFrame(injectedBundle.pageRef())))
-        postPageMessage("DumpBackForwardList");
+    postSynchronousPageMessage("DumpBackForwardList");
+}
+
+bool TestRunner::shouldDumpBackForwardListsForAllWindows() const
+{
+    return postSynchronousPageMessageReturningBoolean("ShouldDumpBackForwardListsForAllWindows");
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_END

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -211,7 +211,7 @@ public:
     void setWhatToDump(WhatToDump);
 
     bool shouldDumpAllFrameScrollPositions() const { return m_shouldDumpAllFrameScrollPositions; }
-    bool shouldDumpBackForwardListsForAllWindows() const { return m_shouldDumpBackForwardListsForAllWindows; }
+    bool shouldDumpBackForwardListsForAllWindows() const;
     bool shouldDumpEditingCallbacks() const { return m_dumpEditingCallbacks; }
     bool shouldDumpMainFrameScrollPosition() const { return whatToDump() == WhatToDump::RenderTree; }
     bool shouldDumpStatusCallbacks() const { return m_dumpStatusCallbacks; }
@@ -588,7 +588,6 @@ private:
 
     unsigned m_renderTreeDumpOptions { 0 };
     bool m_shouldDumpAllFrameScrollPositions { false };
-    bool m_shouldDumpBackForwardListsForAllWindows { false };
     bool m_shouldAllowEditing { true };
 
     bool m_dumpEditingCallbacks { false };

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -690,9 +690,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "DumpBackForwardList"))
-        return postPageMessage("DumpBackForwardList");
-
     if (WKStringIsEqualToUTF8CString(messageName, "StopLoading"))
         return WKPageStopLoading(TestController::singleton().mainWebView()->page());
 
@@ -1415,6 +1412,14 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
 
     if (WKStringIsEqualToUTF8CString(messageName, "IsCommandEnabled"))
         return adoptWK(WKBooleanCreate(WKPageIsEditingCommandEnabledForTesting(TestController::singleton().mainWebView()->page(), stringValue(messageBody))));
+
+    if (WKStringIsEqualToUTF8CString(messageName, "DumpBackForwardList")) {
+        m_shouldDumpBackForwardListsForAllWindows = true;
+        return nullptr;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "ShouldDumpBackForwardListsForAllWindows"))
+        return adoptWK(WKBooleanCreate(m_shouldDumpBackForwardListsForAllWindows));
 
     ASSERT_NOT_REACHED();
     return nullptr;

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -149,6 +149,7 @@ private:
     bool m_shouldDumpResourceLoadStatistics { false };
     bool m_canOpenWindows { true };
     bool m_shouldDumpPrivateClickMeasurement { false };
+    bool m_shouldDumpBackForwardListsForAllWindows { false };
     WhatToDump m_whatToDump { WhatToDump::RenderTree };
 
     StringBuilder m_textOutput;


### PR DESCRIPTION
#### cbecaea6c6d4dd99f1813be4ff165124abdcaf60
<pre>
[Site Isolation] Replace WKBundleFrameIsRemote call with keeping state in UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=276912">https://bugs.webkit.org/show_bug.cgi?id=276912</a>
<a href="https://rdar.apple.com/132273884">rdar://132273884</a>

Reviewed by Charlie Wolfe.

WKBundleFrameIsRemote is a function we need to remove.  It can be replaced in a way that works
with site isolation by keeping state in the UI process instead of the web content processes.

Two tests call testRunner.dumpBackForwardList() then call testRunner.queueLoad with a cross-site
URL, which used to load the second URL in a new process that doesn&apos;t have the dumpBackForwardList
state, but moving the state to the UI process causes the state to be remembered.  Adding some
back/forward list contents to the test expectations makes the test deterministically pass and
continue to test what it used to test.

* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::dumpBackForwardList):
(WTR::TestRunner::shouldDumpBackForwardListsForAllWindows const):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
(WTR::TestRunner::shouldDumpBackForwardListsForAllWindows const): Deleted.
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/TestInvocation.h:

Canonical link: <a href="https://commits.webkit.org/281242@main">https://commits.webkit.org/281242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c783245daa836c471cadce99e6681362c351564e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63145 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9656 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48126 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6883 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28948 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8509 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8660 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64879 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3141 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8728 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 11 flakes 3 failures; Uploaded test results; 10 flakes 2 failures; Compiled WebKit (warnings); layout-tests; Running analyze-layout-tests-results") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51251 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/55570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2618 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8847 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34372 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35455 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36541 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->