### PR TITLE
[JSC] Prevent GC from collecting plan dependencies while inside B3::generate()

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2273,12 +2273,6 @@ JSGlobalObject* CodeBlock::globalObjectFor(CodeOrigin codeOrigin)
     auto* inlineCallFrame = codeOrigin.inlineCallFrame();
     if (!inlineCallFrame)
         return globalObject();
-    // It is possible that the global object and/or other data relating to this origin
-    // was collected by GC, but we are still asking for this (ex: in a patchpoint generate() function).
-    // Plan::cancel should have cleared this in that case.
-    // Let's make sure we can continue to execute safely, even though we don't have a global object to give.
-    if (!inlineCallFrame->baselineCodeBlock)
-        return nullptr;
     return inlineCallFrame->baselineCodeBlock->globalObject();
 }
 

--- a/Source/JavaScriptCore/dfg/DFGGraphSafepoint.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraphSafepoint.cpp
@@ -33,11 +33,11 @@
 
 namespace JSC { namespace DFG {
 
-GraphSafepoint::GraphSafepoint(Graph& graph, Safepoint::Result& result)
+GraphSafepoint::GraphSafepoint(Graph& graph, Safepoint::Result& result, bool keepDependencesLive)
     : m_safepoint(graph.m_plan, result)
 {
     m_safepoint.add(&graph);
-    m_safepoint.begin();
+    m_safepoint.begin(keepDependencesLive);
 }
 
 GraphSafepoint::~GraphSafepoint() = default;

--- a/Source/JavaScriptCore/dfg/DFGGraphSafepoint.h
+++ b/Source/JavaScriptCore/dfg/DFGGraphSafepoint.h
@@ -35,7 +35,7 @@ class Graph;
 
 class GraphSafepoint {
 public:
-    GraphSafepoint(Graph&, Safepoint::Result&);
+    GraphSafepoint(Graph&, Safepoint::Result&, bool keepDependenciesLive = false);
     ~GraphSafepoint();
     
 private:

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -176,10 +176,7 @@ void Plan::cancel()
     m_mustHandleValues.clear();
     m_compilation = nullptr;
     m_finalizer = nullptr;
-    if (m_inlineCallFrames) {
-        for (auto i : *m_inlineCallFrames)
-            i->baselineCodeBlock.clear();
-    }
+    m_inlineCallFrames = nullptr;
     m_watchpoints = DesiredWatchpoints();
     m_identifiers = DesiredIdentifiers();
     m_weakReferences = DesiredWeakReferences();
@@ -689,6 +686,9 @@ bool Plan::checkLivenessAndVisitChildren(AbstractSlotVisitor& visitor)
 
 bool Plan::isKnownToBeLiveDuringGC(AbstractSlotVisitor& visitor)
 {
+    if (safepointKeepsDependenciesLive())
+        return true;
+
     if (!Base::isKnownToBeLiveDuringGC(visitor))
         return false;
     if (!visitor.isMarked(m_codeBlock->alternative()))
@@ -700,6 +700,9 @@ bool Plan::isKnownToBeLiveDuringGC(AbstractSlotVisitor& visitor)
 
 bool Plan::isKnownToBeLiveAfterGC()
 {
+    if (safepointKeepsDependenciesLive())
+        return true;
+
     if (!Base::isKnownToBeLiveAfterGC())
         return false;
     if (!m_vm->heap.isMarked(m_codeBlock->alternative()))

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -127,7 +127,7 @@ void compile(State& state, Safepoint::Result& safepointResult)
     CCallHelpers jit(codeBlock);
     {
         SetForScope disallowFreeze { state.graph.m_frozenValuesAreFinalized, true };
-        GraphSafepoint safepoint(state.graph, safepointResult);
+        GraphSafepoint safepoint(state.graph, safepointResult, true);
         B3::generate(*state.proc, jit);
     }
     if (safepointResult.didGetCancelled())

--- a/Source/JavaScriptCore/jit/BaselineJITPlan.cpp
+++ b/Source/JavaScriptCore/jit/BaselineJITPlan.cpp
@@ -45,7 +45,7 @@ auto BaselineJITPlan::compileInThreadImpl(JITCompilationEffort effort) -> Compil
     Safepoint::Result result;
     {
         Safepoint safepoint(*this, result);
-        safepoint.begin();
+        safepoint.begin(false);
 
         JIT jit(*m_vm, *this, m_codeBlock);
         auto jitCode = jit.compileAndLinkWithoutFinalizing(effort);

--- a/Source/JavaScriptCore/jit/JITPlan.h
+++ b/Source/JavaScriptCore/jit/JITPlan.h
@@ -96,6 +96,8 @@ public:
     virtual bool iterateCodeBlocksForGC(AbstractSlotVisitor&, const Function<void(CodeBlock*)>&);
     virtual bool checkLivenessAndVisitChildren(AbstractSlotVisitor&);
 
+    bool safepointKeepsDependenciesLive() const;
+
     template<typename Functor>
     void addMainThreadFinalizationTask(const Functor& functor)
     {

--- a/Source/JavaScriptCore/jit/JITSafepoint.cpp
+++ b/Source/JavaScriptCore/jit/JITSafepoint.cpp
@@ -73,10 +73,11 @@ void Safepoint::add(Scannable* scannable)
     m_scannables.append(scannable);
 }
 
-void Safepoint::begin() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+void Safepoint::begin(bool keepDependenciesLive) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     RELEASE_ASSERT(!m_didCallBegin);
     m_didCallBegin = true;
+    m_keepDependenciesLive = keepDependenciesLive;
     if (JITWorklistThread* data = m_plan.thread()) {
         RELEASE_ASSERT(!data->m_safepoint);
         data->m_safepoint = this;
@@ -109,7 +110,7 @@ bool Safepoint::isKnownToBeLiveDuringGC(Visitor& visitor)
     
     if (m_result.m_didGetCancelled)
         return true; // We were cancelled during a previous GC, so let's not mess with it this time around - pretend it's live and move on.
-    
+
     return m_plan.isKnownToBeLiveDuringGC(visitor);
 }
 
@@ -134,6 +135,11 @@ void Safepoint::cancel()
     RELEASE_ASSERT(m_plan.stage() == JITPlanStage::Canceled);
     m_result.m_didGetCancelled = true;
     m_vm = nullptr;
+}
+
+bool Safepoint::keepDependenciesLive() const
+{
+    return m_keepDependenciesLive;
 }
 
 VM* Safepoint::vm() const

--- a/Source/JavaScriptCore/jit/JITSafepoint.h
+++ b/Source/JavaScriptCore/jit/JITSafepoint.h
@@ -54,6 +54,7 @@ public:
         
         bool m_didGetCancelled;
         bool m_wasChecked;
+        bool m_keepDependenciesLive;
     };
     
     Safepoint(JITPlan&, Result&);
@@ -61,12 +62,13 @@ public:
     
     void add(Scannable*);
     
-    void begin();
+    void begin(bool keepDependenciesLive);
 
     template<typename Visitor> void checkLivenessAndVisitChildren(Visitor&);
     template<typename Visitor> bool isKnownToBeLiveDuringGC(Visitor&);
     bool isKnownToBeLiveAfterGC();
     void cancel();
+    bool keepDependenciesLive() const;
     
     VM* vm() const; // May return null if we've been cancelled.
 
@@ -75,6 +77,7 @@ private:
     JITPlan& m_plan;
     Vector<Scannable*> m_scannables;
     bool m_didCallBegin;
+    bool m_keepDependenciesLive;
     Result& m_result;
 };
 

--- a/Source/JavaScriptCore/jit/JITWorklistThread.h
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.h
@@ -53,6 +53,7 @@ public:
     ASCIILiteral name() const final;
 
     State state() const { return m_state; }
+    const Safepoint* safepoint() const { return m_safepoint; }
 
 private:
     PollResult poll(const AbstractLocker&) final;


### PR DESCRIPTION
#### cf8997ca4715f44b3a402db14914b720c29772c9
<pre>
[JSC] Prevent GC from collecting plan dependencies while inside B3::generate()
<a href="https://bugs.webkit.org/show_bug.cgi?id=276911">https://bugs.webkit.org/show_bug.cgi?id=276911</a>
<a href="https://rdar.apple.com/122517397">rdar://122517397</a>

Reviewed by Yusuke Suzuki.

B3::generate() is executed inside a safepoint, meaning the GC is allowed
to run concurrently. However, patchpoint generation may reference GCed
objects, potentially leading to UAF.

Change 272710@main reduced the race window between GC and patchpoint
generation for a known case, however the window was not eliminated.

In order to elminate this race, extend the Safepoint mechanism to
include a mode where GC is allowed to run but the current plan&apos;s
dependencies are kept live during the safepoint. Then use this in
the safepoint around B3::generate() so that patchpoints can safely
access dependencies of the plan while the GC is still allowed to
collect/cancel other plans and unrelated objects.

Note that in practice, marking the plan&apos;s dependencies as live also
means that this plan will not be canceled during this safepoint,
since the liveness predicates for determining whether a plan can be
canceled are themselves dependencies of the plan. So the tradeoff to
allowing B3::generate() to run inside a safepoint is that the current
plan cannot be canceled during a GC cycle that completes during the
B3::generate() safepoint. Make this implication explicit with some asserts.

Revert most of 272710@main except for its test case which continues to
be the regression test for this race.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::globalObjectFor):
* Source/JavaScriptCore/dfg/DFGGraphSafepoint.cpp:
(JSC::DFG::GraphSafepoint::GraphSafepoint):
* Source/JavaScriptCore/dfg/DFGGraphSafepoint.h:
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::cancel):
(JSC::DFG::Plan::isKnownToBeLiveDuringGC):
(JSC::DFG::Plan::isKnownToBeLiveAfterGC):
* Source/JavaScriptCore/ftl/FTLCompile.cpp:
(JSC::FTL::compile):
* Source/JavaScriptCore/jit/BaselineJITPlan.cpp:
(JSC::BaselineJITPlan::compileInThreadImpl):
* Source/JavaScriptCore/jit/JITPlan.cpp:
(JSC::JITPlan::cancel):
(JSC::JITPlan::safepointKeepsDependenciesLive const):
* Source/JavaScriptCore/jit/JITPlan.h:
* Source/JavaScriptCore/jit/JITSafepoint.cpp:
(JSC::Safepoint::isKnownToBeLiveDuringGC):
(JSC::Safepoint::keepDependenciesLive const):
* Source/JavaScriptCore/jit/JITSafepoint.h:
* Source/JavaScriptCore/jit/JITWorklistThread.h:

Canonical link: <a href="https://commits.webkit.org/281300@main">https://commits.webkit.org/281300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cabd1ab0fced7ed30ffff0b62010b9243cd0ae77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63265 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9794 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48192 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6956 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29016 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32860 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8625 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8798 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/52443 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54819 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64998 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58595 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55538 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55646 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2728 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80353 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8874 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34510 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13927 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35593 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36679 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->