### PR TITLE
[WebGPU] synchronizeResource: calls are missing for non-UMA platforms

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -105,6 +105,8 @@ public:
     void onCommandBufferCompletion(Function<void()>&&);
     bool encoderIsCurrent(id<MTLCommandEncoder>) const;
     bool submitWillBeInvalid() const;
+    void addBuffer(id<MTLBuffer>);
+    void addTexture(id<MTLTexture>);
 
 private:
     CommandEncoder(id<MTLCommandBuffer>, id<MTLSharedEvent>, Device&);
@@ -138,6 +140,10 @@ private:
     int m_bufferMapCount { 0 };
     bool m_makeSubmitInvalid { false };
 
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+    NSMutableSet<id<MTLTexture>> *m_managedTextures { nil };
+    NSMutableSet<id<MTLBuffer>> *m_managedBuffers { nil };
+#endif
     const Ref<Device> m_device;
 };
 

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -197,7 +197,11 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
     desc.mipmapLevelCount = 1;
     desc.pixelFormat = MTLPixelFormatBGRA8Unorm;
     desc.textureType = MTLTextureType2D;
+#if PLATFORM(MAC)
+    desc.storageMode = hasUnifiedMemory() ? MTLStorageModeShared : MTLStorageModeManaged;
+#else
     desc.storageMode = MTLStorageModeShared;
+#endif
     desc.usage = MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget;
     m_placeholderTexture = [m_device newTextureWithDescriptor:desc];
     desc.pixelFormat = MTLPixelFormatDepth32Float_Stencil8;

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -49,7 +49,11 @@ static constexpr auto multipleOf4(auto input)
 }
 static uint64_t maxBufferSize(id<MTLDevice> device)
 {
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+    auto result = std::max<uint64_t>(std::min<uint64_t>(device.maxBufferLength, GB), std::min<uint64_t>(INT_MAX, device.maxBufferLength / 10));
+#else
     auto result = std::max<uint64_t>(defaultMaxBufferSize, std::min<uint64_t>(INT_MAX, device.maxBufferLength / 10));
+#endif
     return multipleOf4(result);
 }
 

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -119,6 +119,7 @@ void QuerySet::setOverrideLocation(QuerySet&, uint32_t, uint32_t)
 void QuerySet::setCommandEncoder(CommandEncoder& commandEncoder) const
 {
     m_commandEncoders.add(commandEncoder);
+    commandEncoder.addBuffer(m_visibilityBuffer);
     if (isDestroyed())
         commandEncoder.makeSubmitInvalid();
 }

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3012,6 +3012,7 @@ void Texture::onCommandBufferCompletion(Function<void()>&& completion)
 void Texture::setCommandEncoder(CommandEncoder& commandEncoder) const
 {
     m_commandEncoders.add(commandEncoder);
+    commandEncoder.addTexture(m_texture);
     if (!m_canvasBacking && isDestroyed())
         commandEncoder.makeSubmitInvalid();
 }

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -179,6 +179,7 @@ void TextureView::destroy()
 void TextureView::setCommandEncoder(CommandEncoder& commandEncoder) const
 {
     m_commandEncoders.add(commandEncoder);
+    commandEncoder.addTexture(m_parentTexture->texture());
     if (isDestroyed() && !m_parentTexture->isCanvasBacking())
         commandEncoder.makeSubmitInvalid();
 }


### PR DESCRIPTION
#### 0f9c15e7690c41a7c3a439871eb3d1684813a70c
<pre>
[WebGPU] synchronizeResource: calls are missing for non-UMA platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=276910">https://bugs.webkit.org/show_bug.cgi?id=276910</a>
&lt;radar://131950319&gt;

Reviewed by Tadeu Zagallo.

Make sure sychronizeResource: and didModifyRange: calls occur when
needed for non-UMA platforms.

* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::storageMode):
(WebGPU::Buffer::setCommandEncoder const):
(WebGPU::Buffer::unmap):
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::CommandEncoder):
(WebGPU::CommandEncoder::addBuffer):
(WebGPU::CommandEncoder::addTexture):
(WebGPU::CommandEncoder::finish):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::maxBufferSize):
* Source/WebGPU/WebGPU/QuerySet.mm:
(WebGPU::QuerySet::setCommandEncoder const):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::setCommandEncoder const):
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::setCommandEncoder const):

Canonical link: <a href="https://commits.webkit.org/281255@main">https://commits.webkit.org/281255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/756b6b8ea9c40a96d6106de5191a519039db5205

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63144 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9638 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48124 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6875 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28946 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8642 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64847 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8718 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55456 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55548 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13130 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2607 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34354 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36523 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35182 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->