### PR TITLE
Single layer SVGGlyphDisplayListCache

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2656,6 +2656,7 @@ rendering/GridLayoutFunctions.cpp
 rendering/GridMasonryLayout.cpp
 rendering/GridTrackSizingAlgorithm.cpp
 rendering/GlyphDisplayListCache.cpp
+rendering/SVGGlyphDisplayListCache.cpp
 rendering/GlyphDisplayListCacheRemoval.cpp
 rendering/HitTestLocation.cpp
 rendering/HitTestResult.cpp

--- a/Source/WebCore/rendering/SVGGlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/SVGGlyphDisplayListCache.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SVGGlyphDisplayListCache.h"
+
+#include "DisplayListItems.h"
+#include "InlineDisplayBox.h"
+#include "LegacyInlineTextBox.h"
+#include "PaintInfo.h"
+#include "RenderLayer.h"
+#include "RenderStyleInlines.h"
+#include "SVGTextFragment.h"
+#include "svg/SVGTextFragment.h"
+
+namespace WebCore {
+
+SVGGlyphDisplayListCache& SVGGlyphDisplayListCache::singleton()
+{
+    static NeverDestroyed<SVGGlyphDisplayListCache> cache;
+    return cache;
+}
+
+void SVGGlyphDisplayListCache::clear()
+{
+    m_entriesForLayoutRun.clear();
+}
+
+unsigned SVGGlyphDisplayListCache::size() const
+{
+    return m_entriesForLayoutRun.size();
+}
+
+DisplayList::DisplayList* SVGGlyphDisplayListCache::getDisplayList(SVGTextFragment& run, const FontCascade& font, GraphicsContext& context, const TextRun& textRun, const PaintInfo& paintInfo)
+{
+    if (MemoryPressureHandler::singleton().isUnderMemoryPressure()) {
+        if (!m_entriesForLayoutRun.isEmpty()) {
+            LOG(MemoryPressure, "SVGGlyphDisplayListCache::%s - Under memory pressure - size: %d", __FUNCTION__, size());
+            clear();
+        }
+        return nullptr;
+    }
+
+    if (font.isLoadingCustomFonts() || !font.fonts())
+        return nullptr;
+
+    if (auto* result = getIfExists(run))
+        return result;
+
+    bool isFrequentlyPainted = paintInfo.enclosingSelfPaintingLayer()->paintingFrequently();
+    if (!isFrequentlyPainted && !m_forceUseSVGGlyphDisplayListForTesting) {
+        // Now, all cache entries are actively used.
+        constexpr size_t maximumCacheSize = 2048;
+        if (m_entriesForLayoutRun.size() >= maximumCacheSize)
+            return nullptr;
+    }
+
+    if (auto displayList = font.displayListForTextRun(context, textRun)) {
+        run.setIsInSVGGlyphDisplayListCache();
+        auto result = m_entriesForLayoutRun.add(&run, WTFMove(displayList));
+        return result.iterator->value.get();
+    }
+
+    return nullptr;
+}
+
+DisplayList::DisplayList* SVGGlyphDisplayListCache::getIfExists(const SVGTextFragment& run)
+{
+    if (!run.isInSVGGlyphDisplayListCache())
+        return nullptr;
+    if (auto entry = m_entriesForLayoutRun.get(&run))
+        return entry;
+    return nullptr;
+}
+
+void SVGGlyphDisplayListCache::remove(const SVGTextFragment& run)
+{
+    m_entriesForLayoutRun.remove(&run);
+}
+} // namespace WebCore

--- a/Source/WebCore/rendering/SVGGlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/SVGGlyphDisplayListCache.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DisplayList.h"
+#include "FloatSizeHash.h"
+#include "FontCascade.h"
+#include "Logging.h"
+#include "TextRun.h"
+#include "TextRunHash.h"
+#include <wtf/HashMap.h>
+#include <wtf/MemoryPressureHandler.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/WeakRef.h>
+
+namespace WebCore {
+
+struct SVGTextFragment;
+
+class SVGGlyphDisplayListCache {
+    WTF_MAKE_FAST_ALLOCATED;
+    friend class SVGGlyphDisplayListCacheEntry;
+public:
+    SVGGlyphDisplayListCache() = default;
+
+    static SVGGlyphDisplayListCache& singleton();
+
+    DisplayList::DisplayList* getIfExists(const SVGTextFragment&);
+
+    void remove(const SVGTextFragment& run);
+    void clear();
+    unsigned size() const;
+
+    DisplayList::DisplayList* getDisplayList(SVGTextFragment&, const FontCascade&, GraphicsContext&, const TextRun&, const PaintInfo&);
+
+private:
+    HashMap<const SVGTextFragment*, std::unique_ptr<DisplayList::DisplayList>> m_entriesForLayoutRun;
+    bool m_forceUseSVGGlyphDisplayListForTesting { false };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
@@ -38,12 +38,14 @@
 #include "RenderSVGText.h"
 #include "RenderStyleInlines.h"
 #include "RenderView.h"
+#include "SVGGlyphDisplayListCache.h"
 #include "SVGInlineTextBoxInlines.h"
 #include "SVGPaintServerHandling.h"
 #include "SVGRenderStyle.h"
 #include "SVGRenderingContext.h"
 #include "SVGResourcesCache.h"
 #include "SVGRootInlineBox.h"
+#include "SVGTextFragment.h"
 #include "TextBoxSelectableRange.h"
 #include "TextPainter.h"
 #include <wtf/IsoMallocInlines.h>
@@ -58,6 +60,7 @@ struct ExpectedSVGInlineTextBoxSize : public LegacyInlineTextBox {
     void* pointer;
     SVGPaintServerOrColor paintServerOrColor;
     Vector<SVGTextFragment> vector;
+    void* displayList;
 };
 
 static_assert(sizeof(SVGInlineTextBox) == sizeof(ExpectedSVGInlineTextBoxSize), "SVGInlineTextBox is not of expected size");
@@ -296,14 +299,14 @@ void SVGInlineTextBox::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
                     continue;
                 setPaintingResourceMode({ RenderSVGResourceMode::ApplyToFill, RenderSVGResourceMode::ApplyToText });
                 ASSERT(selectionStyle);
-                paintText(paintInfo.context(), style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
+                paintText(paintInfo, paintInfo.context(), style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
                 break;
             case PaintType::Stroke:
                 if (!hasVisibleStroke)
                     continue;
                 setPaintingResourceMode({ RenderSVGResourceMode::ApplyToStroke, RenderSVGResourceMode::ApplyToText});
                 ASSERT(selectionStyle);
-                paintText(paintInfo.context(), style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
+                paintText(paintInfo, paintInfo.context(), style, *selectionStyle, fragment, hasSelection, paintSelectedTextOnly);
                 break;
             case PaintType::Markers:
                 continue;
@@ -602,7 +605,7 @@ void SVGInlineTextBox::paintDecorationWithStyle(GraphicsContext& context, Option
         releaseLegacyPaintingResource(usedContext, &path);
 }
 
-void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const RenderStyle& style, TextRun& textRun, const SVGTextFragment& fragment, unsigned startPosition, unsigned endPosition)
+void SVGInlineTextBox::paintTextWithShadows(const PaintInfo& paintInfo, GraphicsContext& context, const RenderStyle& style, TextRun& textRun, SVGTextFragment& fragment, unsigned startPosition, unsigned endPosition)
 {
     float scalingFactor = renderer().scalingFactor();
     ASSERT(scalingFactor);
@@ -622,6 +625,8 @@ void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const Rend
 
     GraphicsContext* usedContext = &context;
     SVGPaintServerHandling paintServerHandling { context };
+
+    setGlyphDisplayListIfNeeded(fragment, scaledFont, context, paintInfo, textRun);
 
     auto prepareGraphicsContext = [&]() -> bool {
         if (renderer().document().settings().layerBasedSVGEngineEnabled())
@@ -682,7 +687,8 @@ void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const Rend
                 usedContext->save();
 
             usedContext->scale(1 / scalingFactor);
-            scaledFont.drawText(*usedContext, textRun, textOrigin + shadowApplier.extraOffset(), startPosition, endPosition);
+            // scaledFont.drawText(*usedContext, textRun, textOrigin + shadowApplier.extraOffset(), startPosition, endPosition);
+            drawText(*usedContext, scaledFont, textRun, textOrigin + shadowApplier.extraOffset(), startPosition, endPosition);
 
             if (!shadowApplier.didSaveContext())
                 usedContext->restore();
@@ -700,7 +706,7 @@ void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const Rend
     } while (shadow);
 }
 
-void SVGInlineTextBox::paintText(GraphicsContext& context, const RenderStyle& style, const RenderStyle& selectionStyle, const SVGTextFragment& fragment, bool hasSelection, bool paintSelectedTextOnly)
+void SVGInlineTextBox::paintText(const PaintInfo& paintInfo, GraphicsContext& context, const RenderStyle& style, const RenderStyle& selectionStyle, SVGTextFragment& fragment, bool hasSelection, bool paintSelectedTextOnly)
 {
     unsigned startPosition = 0;
     unsigned endPosition = 0;
@@ -712,23 +718,23 @@ void SVGInlineTextBox::paintText(GraphicsContext& context, const RenderStyle& st
     // Fast path if there is no selection, just draw the whole chunk part using the regular style
     TextRun textRun = constructTextRun(style, fragment);
     if (!hasSelection || startPosition >= endPosition) {
-        paintTextWithShadows(context, style, textRun, fragment, 0, fragment.length);
+        paintTextWithShadows(paintInfo, context, style, textRun, fragment, 0, fragment.length);
         return;
     }
 
     // Eventually draw text using regular style until the start position of the selection
     if (startPosition > 0 && !paintSelectedTextOnly)
-        paintTextWithShadows(context, style, textRun, fragment, 0, startPosition);
+        paintTextWithShadows(paintInfo, context, style, textRun, fragment, 0, startPosition);
 
     // Draw text using selection style from the start to the end position of the selection
     {
         SVGResourcesCache::SetStyleForScope temporaryStyleChange(parent()->renderer(), style, selectionStyle);
-        paintTextWithShadows(context, selectionStyle, textRun, fragment, startPosition, endPosition);
+        paintTextWithShadows(paintInfo, context, selectionStyle, textRun, fragment, startPosition, endPosition);
     }
 
     // Eventually draw text using regular style from the end position of the selection to the end of the current chunk part
     if (endPosition < fragment.length && !paintSelectedTextOnly)
-        paintTextWithShadows(context, style, textRun, fragment, endPosition, fragment.length);
+        paintTextWithShadows(paintInfo, context, style, textRun, fragment, endPosition, fragment.length);
 }
 
 FloatRect SVGInlineTextBox::calculateBoundaries() const
@@ -791,6 +797,28 @@ bool SVGInlineTextBox::nodeAtPoint(const HitTestRequest& request, HitTestResult&
         }
     }
     return false;
+}
+
+bool SVGInlineTextBox::shouldUseGlyphDisplayList(const PaintInfo& paintInfo)
+{
+    return !paintInfo.context().paintingDisabled() && paintInfo.enclosingSelfPaintingLayer();
+}
+
+void SVGInlineTextBox::setGlyphDisplayListIfNeeded(SVGTextFragment& textFragment, const FontCascade& fontCascade, GraphicsContext& context, const PaintInfo& paintInfo, const TextRun& textRun)
+{
+    if (!SVGInlineTextBox::shouldUseGlyphDisplayList(paintInfo))
+        textFragment.removeFromGlyphDisplayListCache();
+    else
+        m_glyphDisplayList = SVGGlyphDisplayListCache::singleton().getDisplayList(textFragment, fontCascade, context, textRun, paintInfo);
+}
+
+void SVGInlineTextBox::drawText(GraphicsContext& context, const FontCascade& fontCascade, const TextRun& textRun, const FloatPoint& textOrigin, unsigned startOffset, unsigned endOffset)
+{
+    if (startOffset || endOffset < textRun.length() || !m_glyphDisplayList)
+        fontCascade.drawText(context, textRun, textOrigin, startOffset, endOffset);
+    else
+        context.drawDisplayListItems(m_glyphDisplayList->items(), m_glyphDisplayList->resourceHeap(), textOrigin);
+    m_glyphDisplayList = nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.h
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.h
@@ -83,10 +83,16 @@ private:
 
     void paintDecoration(GraphicsContext&, OptionSet<TextDecorationLine>, const SVGTextFragment&);
     void paintDecorationWithStyle(GraphicsContext&, OptionSet<TextDecorationLine>, const SVGTextFragment&, RenderBoxModelObject& decorationRenderer);
-    void paintTextWithShadows(GraphicsContext&, const RenderStyle&, TextRun&, const SVGTextFragment&, unsigned startPosition, unsigned endPosition);
-    void paintText(GraphicsContext&, const RenderStyle&, const RenderStyle& selectionStyle, const SVGTextFragment&, bool hasSelection, bool paintSelectedTextOnly);
+    void paintTextWithShadows(const PaintInfo&, GraphicsContext&, const RenderStyle&, TextRun&, SVGTextFragment&, unsigned startPosition, unsigned endPosition);
+    void paintText(const PaintInfo&, GraphicsContext&, const RenderStyle&, const RenderStyle& selectionStyle, SVGTextFragment&, bool hasSelection, bool paintSelectedTextOnly);
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, LayoutUnit lineTop, LayoutUnit lineBottom, HitTestAction) override;
+
+    static bool shouldUseGlyphDisplayList(const PaintInfo&);
+    void setGlyphDisplayListIfNeeded(SVGTextFragment&, const FontCascade&, GraphicsContext&, const PaintInfo&, const TextRun&);
+    // void getGlyphDisplayList(TextFragment*, const FontCascade&, GraphicsContext&, const PaintInfo&, const TextRun&);
+
+    void drawText(GraphicsContext&, const FontCascade&, const TextRun&, const FloatPoint& textOrigin, unsigned startOffset, unsigned endOffset);
 
 private:
     float m_logicalHeight { 0 };
@@ -96,6 +102,8 @@ private:
     SVGPaintServerOrColor m_paintServerOrColor { };
 
     Vector<SVGTextFragment> m_textFragments;
+
+    DisplayList::DisplayList* m_glyphDisplayList { nullptr };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGTextFragment.h
+++ b/Source/WebCore/rendering/svg/SVGTextFragment.h
@@ -21,6 +21,7 @@
 
 #include "AffineTransform.h"
 
+#include "SVGGlyphDisplayListCache.h"
 namespace WebCore {
 
 // A SVGTextFragment describes a text fragment of a RenderSVGInlineText which can be rendered at once.
@@ -35,6 +36,12 @@ struct SVGTextFragment {
         , width(0)
         , height(0)
     {
+    }
+
+    ~SVGTextFragment()
+    {
+        if (inSVGGlyphDisplayListCache)
+            removeFromGlyphDisplayListCache();
     }
 
     enum TransformType {
@@ -74,7 +81,19 @@ struct SVGTextFragment {
     // Contains lengthAdjust related transformations, which are not allowd to influence the SVGTextQuery code.
     AffineTransform lengthAdjustTransform;
 
+    bool isInSVGGlyphDisplayListCache() const { return inSVGGlyphDisplayListCache; }
+    void setIsInSVGGlyphDisplayListCache(bool inCache = true) { inSVGGlyphDisplayListCache = inCache; }
+    void removeFromGlyphDisplayListCache()
+    {
+        if (inSVGGlyphDisplayListCache) {
+            SVGGlyphDisplayListCache::singleton().remove(*this);
+            setIsInSVGGlyphDisplayListCache(false);
+        }
+    }
+
 private:
+    bool inSVGGlyphDisplayListCache = false;
+
     void transformAroundOrigin(AffineTransform& result) const
     {
         // Returns (translate(x, y) * result) * translate(-x, -y).


### PR DESCRIPTION
#### 0dcd46f8780d153a4eb49675d7d400d4c4a76716
<pre>
Single layer SVGGlyphDisplayListCache
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/SVGGlyphDisplayListCache.cpp: Added.
(WebCore::SVGGlyphDisplayListCache::singleton):
(WebCore::SVGGlyphDisplayListCache::clear):
(WebCore::SVGGlyphDisplayListCache::size const):
(WebCore::SVGGlyphDisplayListCache::getDisplayList):
(WebCore::SVGGlyphDisplayListCache::getIfExists):
(WebCore::SVGGlyphDisplayListCache::remove):
* Source/WebCore/rendering/SVGGlyphDisplayListCache.h: Added.
* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::paint):
(WebCore::SVGInlineTextBox::paintTextWithShadows):
(WebCore::SVGInlineTextBox::paintText):
(WebCore::SVGInlineTextBox::shouldUseGlyphDisplayList):
(WebCore::SVGInlineTextBox::setGlyphDisplayListIfNeeded):
(WebCore::SVGInlineTextBox::drawText):
* Source/WebCore/rendering/svg/SVGInlineTextBox.h:
* Source/WebCore/rendering/svg/SVGTextFragment.h:
(WebCore::SVGTextFragment::~SVGTextFragment):
(WebCore::SVGTextFragment::isInSVGGlyphDisplayListCache const):
(WebCore::SVGTextFragment::setIsInSVGGlyphDisplayListCache):
(WebCore::SVGTextFragment::removeFromGlyphDisplayListCache):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dcd46f8780d153a4eb49675d7d400d4c4a76716

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63107 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9608 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48092 "") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6860 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28917 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32721 "Found 2 new test failures: imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html imported/w3c/web-platform-tests/websockets/basic-auth.any.html?wss (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8464 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8612 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54678 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8744 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64817 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3093 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8705 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55429 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55529 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2586 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34324 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35407 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36493 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->