### PR TITLE
Transform-origin on SVG breaks when zoom in or out

### DIFF
--- a/LayoutTests/svg/zoom/page/transform-origin-and-zoom-expected.html
+++ b/LayoutTests/svg/zoom/page/transform-origin-and-zoom-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+        rect {
+            transform-box: fill-box;
+        }
+    </style>
+    <script>
+        function doTest()
+        {
+            const zoomCount = 2;
+            for (let i = 0; i < zoomCount; ++i)
+                eventSender.zoomPageIn();
+        }
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <svg width="500" height="400" viewBox="0 0 500 400">
+        <rect x="50" y="50" width="80" height="80" fill="gray"/>
+        <rect x="130" y="50" width="80" height="80" fill="green"/>
+
+        <rect x="250" y="100" width="80" height="80" fill="gray"/>
+        <rect x="330" y="60" width="120" height="120" fill="green"/>
+
+        <rect x="50" y="250" width="80" height="80" fill="gray"/>
+        <rect x="130" y="250" width="80" height="80" fill="green"/>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/zoom/page/transform-origin-and-zoom.html
+++ b/LayoutTests/svg/zoom/page/transform-origin-and-zoom.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+        rect {
+            transform-box: fill-box;
+        }
+    </style>
+    <script>
+        function doTest()
+        {
+            const zoomCount = 2;
+            for (let i = 0; i < zoomCount; ++i)
+                eventSender.zoomPageIn();
+        }
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <svg width="500" height="400" viewBox="0 0 500 400">
+        <rect x="50" y="50" width="80" height="80" fill="gray"/>
+        <rect x="50" y="50" width="80" height="80" fill="green" style="transform: rotate(90deg); transform-origin: bottom right"/>
+
+        <rect x="250" y="100" width="80" height="80" fill="gray"/>
+        <rect x="250" y="100" width="80" height="80" fill="green" style="transform: rotate(90deg) scale(1.5); transform-origin: bottom right"/>
+
+        <rect x="50" y="250" width="80" height="80" fill="gray"/>
+        <rect x="50" y="250" width="80" height="80" fill="green" style="transform: translate(100%, 0);"/>
+    </svg>
+</body>
+</html>

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -559,7 +559,10 @@ inline ImageOrientation BuilderConverter::convertImageOrientation(BuilderState&,
 
 inline TransformOperations BuilderConverter::convertTransform(BuilderState& builderState, const CSSValue& value)
 {
-    auto operations = transformsForValue(value, builderState.cssToLengthConversionData());
+    CSSToLengthConversionData conversionData = builderState.useSVGZoomRulesForLength() ?
+        builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
+        : builderState.cssToLengthConversionData();
+    auto operations = transformsForValue(value, conversionData);
     if (!operations)
         return TransformOperations { };
     return *operations;
@@ -567,7 +570,10 @@ inline TransformOperations BuilderConverter::convertTransform(BuilderState& buil
 
 inline RefPtr<TranslateTransformOperation> BuilderConverter::convertTranslate(BuilderState& builderState, const CSSValue& value)
 {
-    return translateForValue(value, builderState.cssToLengthConversionData());
+    CSSToLengthConversionData conversionData = builderState.useSVGZoomRulesForLength() ?
+        builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
+        : builderState.cssToLengthConversionData();
+    return translateForValue(value, conversionData);
 }
 
 inline RefPtr<RotateTransformOperation> BuilderConverter::convertRotate(BuilderState&, const CSSValue& value)

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -109,13 +109,6 @@ AffineTransform SVGGraphicsElement::animatedLocalTransform() const
 
         // Flatten any 3D transform.
         matrix = transform.toAffineTransform();
-        // CSS bakes the zoom factor into lengths, including translation components.
-        // In order to align CSS & SVG transforms, we need to invert this operation.
-        float zoom = style->usedZoom();
-        if (zoom != 1) {
-            matrix.setE(matrix.e() / zoom);
-            matrix.setF(matrix.f() / zoom);
-        }
     }
 
     // If we didn't have the CSS "transform" property set, we must account for the "transform" attribute.


### PR DESCRIPTION
#### c78d507eeee2bb3be38e5f5129c3af9f497bbd71
<pre>
Transform-origin on SVG breaks when zoom in or out
<a href="https://bugs.webkit.org/show_bug.cgi?id=194903">https://bugs.webkit.org/show_bug.cgi?id=194903</a>

Reviewed by Simon Fraser.

Since &lt;<a href="https://commits.webkit.org/24834@main">https://commits.webkit.org/24834@main</a>&gt;, WebKit handles page
zoom and zoom CSS property by embedding them into CSS length. However,
WebKit doesn&apos;t do that for SVG. So, WebKit should resolve length
properties differently for HTML and SVG.

However, transform property was resolved by taking zoom factor into
account even for SVG. &lt;<a href="https://commits.webkit.org/149452@main">https://commits.webkit.org/149452@main</a>&gt; was a
previous attempt to fix the bug. But, it was wrong because it just
clobbered the translation in the matrix.

Style::BuilderConverter should use a different
CSSToLengthConversionData for SVG elements.

* LayoutTests/svg/zoom/page/transform-origin-and-zoom-expected.html: Added.
* LayoutTests/svg/zoom/page/transform-origin-and-zoom.html: Added.
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertTransform):
(WebCore::Style::BuilderConverter::convertTranslate):
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::animatedLocalTransform const):

Canonical link: <a href="https://commits.webkit.org/281265@main">https://commits.webkit.org/281265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adb966cb1d8dbe2be845254d85b7b894b3304711

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63127 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9647 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48112 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6881 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32743 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8498 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8651 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54700 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64864 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8722 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55468 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51240 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55560 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13138 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2613 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34363 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35446 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36532 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35191 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->