### PR TITLE
[text-underline-position] Parse `from-font | under` combined with `left | right`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-underline-position-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-underline-position-computed-expected.txt
@@ -4,6 +4,6 @@ PASS Property text-underline-position value 'under'
 PASS Property text-underline-position value 'from-font'
 PASS Property text-underline-position value 'left'
 PASS Property text-underline-position value 'right'
-FAIL Property text-underline-position value 'under left' assert_true: 'under left' is a supported value for text-underline-position. expected true got false
-FAIL Property text-underline-position value 'from-font left' assert_true: 'from-font left' is a supported value for text-underline-position. expected true got false
+PASS Property text-underline-position value 'under left'
+PASS Property text-underline-position value 'from-font left'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-underline-position-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-underline-position-valid-expected.txt
@@ -4,8 +4,8 @@ PASS e.style['text-underline-position'] = "under" should set the property value
 PASS e.style['text-underline-position'] = "from-font" should set the property value
 PASS e.style['text-underline-position'] = "left" should set the property value
 PASS e.style['text-underline-position'] = "right" should set the property value
-FAIL e.style['text-underline-position'] = "under left" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['text-underline-position'] = "from-font left" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['text-underline-position'] = "right under" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['text-underline-position'] = "right from-font" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['text-underline-position'] = "under left" should set the property value
+PASS e.style['text-underline-position'] = "from-font left" should set the property value
+PASS e.style['text-underline-position'] = "right under" should set the property value
+PASS e.style['text-underline-position'] = "right from-font" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-position-expected.txt
@@ -34,6 +34,6 @@ PASS Setting 'text-underline-position' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'text-underline-position' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'text-underline-position' to a transform: perspective(10em) throws TypeError
 PASS Setting 'text-underline-position' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'text-underline-position' does not support 'under left' assert_not_equals: Unsupported value must not be null got disallowed value null
-FAIL 'text-underline-position' does not support 'right under' assert_not_equals: Unsupported value must not be null got disallowed value null
+PASS 'text-underline-position' does not support 'under left'
+PASS 'text-underline-position' does not support 'right under'
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2488,6 +2488,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/style/TextDecorationThickness.h
     rendering/style/TextSizeAdjustment.h
     rendering/style/TextUnderlineOffset.h
+    rendering/style/TextUnderlinePosition.h
     rendering/style/WillChangeData.h
 
     rendering/svg/legacy/LegacyRenderSVGModelObject.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2849,6 +2849,7 @@ rendering/style/StyleTextBoxEdge.cpp
 rendering/style/StyleTransformData.cpp
 rendering/style/StyleVisitedLinkColorData.cpp
 rendering/style/TextSizeAdjustment.cpp
+rendering/style/TextUnderlinePosition.cpp
 rendering/style/WillChangeData.cpp
 rendering/svg/legacy/LegacyRenderSVGContainer.cpp
 rendering/svg/legacy/LegacyRenderSVGEllipse.cpp

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -44,6 +44,7 @@
 #include "ScrollAxis.h"
 #include "ScrollTypes.h"
 #include "TextFlags.h"
+#include "TextUnderlinePosition.h"
 #include "ThemeTypes.h"
 #include "TouchAction.h"
 #include "UnicodeBidi.h"
@@ -1238,9 +1239,14 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
-// FIXME: Implement support for 'under left' and 'under right' values.
-#define TYPE TextUnderlinePosition
-#define FOR_EACH(CASE) CASE(Auto) CASE(Under) CASE(FromFont) CASE(Left) CASE(Right)
+#define TYPE TextUnderlinePosition::Metric
+#define FOR_EACH(CASE) CASE(Auto) CASE(FromFont) CASE(Under)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
+#define TYPE TextUnderlinePosition::Side
+#define FOR_EACH(CASE) CASE(Auto) CASE(Left) CASE(Right)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8321,28 +8321,23 @@
                 "auto",
                 "under",
                 "from-font",
-                {
-                    "value": "left",
-                    "settings-flag": "cssTextUnderlinePositionLeftRightEnabled"
-
-                },
-                {
-                    "value": "right",
-                    "settings-flag": "cssTextUnderlinePositionLeftRightEnabled"
-                }
+                "left",
+                "right"
             ],
             "codegen-properties": {
                 "aliases": [
                     "-webkit-text-underline-position"
                 ],
-                "parser-grammar": "<<values>>",
+                "converter": "TextUnderlinePosition",
+                "parser-function": "consumeTextUnderlinePosition",
+                "parser-function-requires-context": true,
                 "parser-grammar-unused": "auto | [ [ under | from-font ] || [ left | right ] ]",
                 "parser-grammar-unused-reason": "Needs support for '||' groups.",
                 "comment": "Grammar is 'auto | [ [ under | from-font ] || [ left | right ] ]', but we only support 'auto | under | from-font | left | right'."
             },
             "specification": {
                 "category": "css-text-decor",
-                "url": "https://www.w3.org/TR/css-text-decor-3/#text-underline-position-property"
+                "url": "https://drafts.csswg.org/css-text-decor-4/#text-underline-position-property"
             }
         },
         "text-underline-offset": {

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3977,8 +3977,16 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         return renderTextDecorationSkipToCSSValue(style.textDecorationSkipInk());
     case CSSPropertyTextDecorationSkipInk:
         return createConvertingToCSSValueID(style.textDecorationSkipInk());
-    case CSSPropertyTextUnderlinePosition:
-        return createConvertingToCSSValueID(style.textUnderlinePosition());
+    case CSSPropertyTextUnderlinePosition: {
+        auto value = style.textUnderlinePosition();
+        if (value.isAuto())
+            return CSSPrimitiveValue::create(CSSValueAuto);
+        if (value.metric == TextUnderlinePosition::Metric::Auto)
+            return createConvertingToCSSValueID(value.side);
+        if (value.side == TextUnderlinePosition::Side::Auto)
+            return createConvertingToCSSValueID(value.metric);
+        return CSSValuePair::create(createConvertingToCSSValueID(value.metric), createConvertingToCSSValueID(value.side));
+    }
     case CSSPropertyTextUnderlineOffset:
         return textUnderlineOffsetToCSSValue(style.textUnderlineOffset());
     case CSSPropertyTextDecorationThickness:

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -1319,6 +1319,31 @@ RefPtr<CSSValue> consumeTextIndent(CSSParserTokenRange& range, CSSParserMode mod
         CSSPrimitiveValue::create(CSSValueHanging), CSSPrimitiveValue::create(CSSValueEachLine));
 }
 
+// auto | [ [ under | from-font ] || [ left | right ] ]
+RefPtr<CSSValue> consumeTextUnderlinePosition(CSSParserTokenRange& range, const CSSParserContext& context)
+{
+    if (auto ident = consumeIdent<CSSValueAuto>(range))
+        return ident;
+
+    auto metric = consumeIdentRaw<CSSValueUnder, CSSValueFromFont>(range);
+
+    std::optional<CSSValueID> side;
+    if (context.cssTextUnderlinePositionLeftRightEnabled)
+        side = consumeIdentRaw<CSSValueLeft, CSSValueRight>(range);
+
+    if (side && !metric)
+        metric = consumeIdentRaw<CSSValueUnder, CSSValueFromFont>(range);
+
+    if (metric && side)
+        return CSSValuePair::create(CSSPrimitiveValue::create(*metric), CSSPrimitiveValue::create(*side));
+    if (metric)
+        return CSSPrimitiveValue::create(*metric);
+    if (side)
+        return CSSPrimitiveValue::create(*side);
+
+    return nullptr;
+}
+
 static bool validWidthOrHeightKeyword(CSSValueID id)
 {
     switch (id) {

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -216,6 +216,7 @@ RefPtr<CSSValue> consumeColorScheme(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeOffsetRotate(CSSParserTokenRange&, CSSParserMode);
 RefPtr<CSSValue> consumeTextSpacingTrim(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeTextAutospace(CSSParserTokenRange&);
+RefPtr<CSSValue> consumeTextUnderlinePosition(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeAnimationTimeline(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeSingleAnimationTimeline(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeAnimationTimelineScroll(CSSParserTokenRange&);

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -115,7 +115,7 @@ void LegacyInlineFlowBox::addToLine(LegacyInlineBox* child)
         bool hasMarkers = false;
         if (auto* textBox = dynamicDowncast<LegacyInlineTextBox>(*child))
             hasMarkers = textBox->hasMarkers();
-        if (childStyle->letterSpacing() < 0 || childStyle->textShadow() || childStyle->textEmphasisMark() != TextEmphasisMark::None || childStyle->hasPositiveStrokeWidth() || hasMarkers || !childStyle->textUnderlineOffset().isAuto() || !childStyle->textDecorationThickness().isAuto() || childStyle->textUnderlinePosition() != TextUnderlinePosition::Auto)
+        if (childStyle->letterSpacing() < 0 || childStyle->textShadow() || childStyle->textEmphasisMark() != TextEmphasisMark::None || childStyle->hasPositiveStrokeWidth() || hasMarkers || !childStyle->textUnderlineOffset().isAuto() || !childStyle->textDecorationThickness().isAuto() || !childStyle->textUnderlinePosition().isAuto())
             child->clearKnownToHaveNoOverflow();
     } else if (child->boxModelObject()->hasSelfPaintingLayer())
         child->clearKnownToHaveNoOverflow();

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -221,7 +221,6 @@ enum class TextOrientation : uint8_t;
 enum class TextOverflow : bool;
 enum class TextSecurity : uint8_t;
 enum class TextTransform : uint8_t;
-enum class TextUnderlinePosition : uint8_t;
 enum class TextWrapMode : bool;
 enum class TextWrapStyle : uint8_t;
 enum class TextZoom : bool;
@@ -268,6 +267,7 @@ struct TabSize;
 struct TextAutospace;
 struct TextBoxEdge;
 struct TextSpacingTrim;
+struct TextUnderlinePosition;
 struct TransformOperationData;
 
 template<typename> class FontTaggedSettings;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1186,18 +1186,6 @@ TextStream& operator<<(TextStream& ts, TextTransform textTransform)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, TextUnderlinePosition underlinePosition)
-{
-    switch (underlinePosition) {
-    case TextUnderlinePosition::Auto: ts << "Auto"; break;
-    case TextUnderlinePosition::Under: ts << "Under"; break;
-    case TextUnderlinePosition::FromFont: ts << "FromFont"; break;
-    case TextUnderlinePosition::Left: ts << "Left"; break;
-    case TextUnderlinePosition::Right: ts << "Right"; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, TextWrapMode wrap)
 {
     switch (wrap) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -702,15 +702,6 @@ enum class TextGroupAlign : uint8_t {
     Center
 };
 
-enum class TextUnderlinePosition : uint8_t {
-    // FIXME: Implement support for 'under left' and 'under right' values.
-    Auto,
-    Under,
-    FromFont,
-    Left,
-    Right
-};
-
 enum class TextBoxTrim : uint8_t {
     None,
     Start,
@@ -1304,7 +1295,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, TextOrientation);
 WTF::TextStream& operator<<(WTF::TextStream&, TextOverflow);
 WTF::TextStream& operator<<(WTF::TextStream&, TextSecurity);
 WTF::TextStream& operator<<(WTF::TextStream&, TextTransform);
-WTF::TextStream& operator<<(WTF::TextStream&, TextUnderlinePosition);
 WTF::TextStream& operator<<(WTF::TextStream&, TextWrapMode);
 WTF::TextStream& operator<<(WTF::TextStream&, TextWrapStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, TextBoxTrim);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -54,6 +54,7 @@
 #include "StyleSurroundData.h"
 #include "StyleTransformData.h"
 #include "StyleVisitedLinkColorData.h"
+#include "TextUnderlinePosition.h"
 #include "UnicodeBidi.h"
 #include "ViewTimeline.h"
 
@@ -485,7 +486,7 @@ constexpr TextSecurity RenderStyle::initialTextSecurity() { return TextSecurity:
 inline StyleColor RenderStyle::initialTextStrokeColor() { return StyleColor::currentColor(); }
 constexpr OptionSet<TextTransform> RenderStyle::initialTextTransform() { return { }; }
 constexpr TextUnderlineOffset RenderStyle::initialTextUnderlineOffset() { return TextUnderlineOffset::createWithAuto(); }
-constexpr TextUnderlinePosition RenderStyle::initialTextUnderlinePosition() { return TextUnderlinePosition::Auto; }
+constexpr TextUnderlinePosition RenderStyle::initialTextUnderlinePosition() { return { TextUnderlinePosition::Metric::Auto, TextUnderlinePosition::Side::Auto }; }
 constexpr TextWrapMode RenderStyle::initialTextWrapMode() { return TextWrapMode::Wrap; }
 constexpr TextWrapStyle RenderStyle::initialTextWrapStyle() { return TextWrapStyle::Auto; }
 constexpr TextZoom RenderStyle::initialTextZoom() { return TextZoom::Normal; }
@@ -705,7 +706,7 @@ inline const StyleColor& RenderStyle::textStrokeColor() const { return m_rareInh
 inline float RenderStyle::textStrokeWidth() const { return m_rareInheritedData->textStrokeWidth; }
 inline OptionSet<TextTransform> RenderStyle::textTransform() const { return OptionSet<TextTransform>::fromRaw(m_inheritedFlags.textTransform); }
 inline TextUnderlineOffset RenderStyle::textUnderlineOffset() const { return m_rareInheritedData->textUnderlineOffset; }
-inline TextUnderlinePosition RenderStyle::textUnderlinePosition() const { return static_cast<TextUnderlinePosition>(m_rareInheritedData->textUnderlinePosition); }
+inline TextUnderlinePosition RenderStyle::textUnderlinePosition() const { return m_rareInheritedData->textUnderlinePosition; }
 inline TextZoom RenderStyle::textZoom() const { return static_cast<TextZoom>(m_rareInheritedData->textZoom); }
 inline const Length& RenderStyle::top() const { return m_nonInheritedData->surroundData->offset.top(); }
 inline OptionSet<TouchAction> RenderStyle::touchActions() const { return m_nonInheritedData->rareData->touchActions; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -314,7 +314,7 @@ inline void RenderStyle::setTextStrokeColor(const StyleColor& c) { SET(m_rareInh
 inline void RenderStyle::setTextStrokeWidth(float value) { SET(m_rareInheritedData, textStrokeWidth, value); }
 inline void RenderStyle::setTextTransform(OptionSet<TextTransform> value) { m_inheritedFlags.textTransform = value.toRaw(); }
 inline void RenderStyle::setTextUnderlineOffset(TextUnderlineOffset textUnderlineOffset) { SET(m_rareInheritedData, textUnderlineOffset, textUnderlineOffset); }
-inline void RenderStyle::setTextUnderlinePosition(TextUnderlinePosition position) { SET(m_rareInheritedData, textUnderlinePosition, static_cast<unsigned>(position)); }
+inline void RenderStyle::setTextUnderlinePosition(TextUnderlinePosition position) { SET(m_rareInheritedData, textUnderlinePosition, position); }
 inline void RenderStyle::setTextZoom(TextZoom zoom) { SET(m_rareInheritedData, textZoom, static_cast<unsigned>(zoom)); }
 inline void RenderStyle::setTop(Length&& length) { SET_NESTED(m_nonInheritedData, surroundData, offset.top(), WTFMove(length)); }
 inline void RenderStyle::setTouchActions(OptionSet<TouchAction> actions) { SET_NESTED(m_nonInheritedData, rareData, touchActions, actions); }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -119,7 +119,6 @@ StyleRareInheritedData::StyleRareInheritedData()
     , textAlignLast(static_cast<unsigned>(RenderStyle::initialTextAlignLast()))
     , textJustify(static_cast<unsigned>(RenderStyle::initialTextJustify()))
     , textDecorationSkipInk(static_cast<unsigned>(RenderStyle::initialTextDecorationSkipInk()))
-    , textUnderlinePosition(static_cast<unsigned>(RenderStyle::initialTextUnderlinePosition()))
     , rubyPosition(static_cast<unsigned>(RenderStyle::initialRubyPosition()))
     , textZoom(static_cast<unsigned>(RenderStyle::initialTextZoom()))
 #if PLATFORM(IOS_FAMILY)
@@ -155,6 +154,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , tapHighlightColor(RenderStyle::initialTapHighlightColor())
 #endif
     , listStyleType(RenderStyle::initialListStyleType())
+    , textUnderlinePosition(RenderStyle::initialTextUnderlinePosition())
     , scrollbarColor(RenderStyle::initialScrollbarColor())
 {
 }
@@ -211,7 +211,6 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , textAlignLast(o.textAlignLast)
     , textJustify(o.textJustify)
     , textDecorationSkipInk(o.textDecorationSkipInk)
-    , textUnderlinePosition(o.textUnderlinePosition)
     , rubyPosition(o.rubyPosition)
     , textZoom(o.textZoom)
 #if PLATFORM(IOS_FAMILY)
@@ -254,6 +253,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , tapHighlightColor(o.tapHighlightColor)
 #endif
     , listStyleType(o.listStyleType)
+    , textUnderlinePosition(o.textUnderlinePosition)
     , scrollbarColor(o.scrollbarColor)
 {
 }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -33,6 +33,7 @@
 #include "StyleTextBoxEdge.h"
 #include "TabSize.h"
 #include "TextUnderlineOffset.h"
+#include "TextUnderlinePosition.h"
 #include "TouchAction.h"
 #include <wtf/DataRef.h>
 #include <wtf/OptionSet.h>
@@ -137,7 +138,6 @@ public:
     unsigned textAlignLast : 3; // TextAlignLast
     unsigned textJustify : 2; // TextJustify
     unsigned textDecorationSkipInk : 2; // TextDecorationSkipInk
-    unsigned textUnderlinePosition : 3; // TextUnderlinePosition
     unsigned rubyPosition : 2; // RubyPosition
     unsigned textZoom: 1; // TextZoom
 
@@ -200,6 +200,7 @@ public:
 #endif
 
     ListStyleType listStyleType;
+    TextUnderlinePosition textUnderlinePosition;
 
     Markable<ScrollbarColor> scrollbarColor;
 

--- a/Source/WebCore/rendering/style/TextUnderlinePosition.cpp
+++ b/Source/WebCore/rendering/style/TextUnderlinePosition.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TextUnderlinePosition.h"
+
+#include "CSSPrimitiveValueMappings.h"
+
+namespace WebCore {
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, TextUnderlinePosition underlinePosition)
+{
+    if (underlinePosition.isAuto()) {
+        ts << "auto"_s;
+        return ts;
+    }
+
+    bool metricIsAuto = underlinePosition.metric == TextUnderlinePosition::Metric::Auto;
+    bool sideIsAuto = underlinePosition.side == TextUnderlinePosition::Side::Auto;
+    if (!metricIsAuto)
+        ts << nameLiteral(toCSSValueID(underlinePosition.metric)).characters();
+
+    if (!sideIsAuto) {
+        ts << (!metricIsAuto ? " "_s : ""_s);
+        ts << nameLiteral(toCSSValueID(underlinePosition.side)).characters();
+    }
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/style/TextUnderlinePosition.h
+++ b/Source/WebCore/rendering/style/TextUnderlinePosition.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+// FIXME: This could fit in 4 bits as a single enum.
+// Tweaking values to use 2 bits to represent each of Metric and Side would allow for easy helper functions.
+struct TextUnderlinePosition {
+    enum class Metric : uint8_t {
+        Auto,
+        Under,
+        FromFont
+    };
+    enum class Side : uint8_t {
+        Auto,
+        Left,
+        Right
+    };
+
+    Metric metric;
+    Side side;
+
+    constexpr bool isAuto()
+    {
+        return metric == Metric::Auto && side == Side::Auto;
+    }
+
+    bool operator==(const TextUnderlinePosition&) const = default;
+};
+
+WTF::TextStream& operator<<(WTF::TextStream&, TextUnderlinePosition);
+
+} // namespace WebCore

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -144,7 +144,7 @@ static float computedUnderlineOffset(const UnderlineOffsetArguments& context)
     // FIXME: The code for visual overflow detection passes in a null inline text box. This means it is now
     // broken for the case where auto needs to behave like "under".
     
-    // According to the specification TextUnderlinePosition::Auto should avoid drawing through glyphs in
+    // According to the specification `text-underline-position: auto` should avoid drawing through glyphs in
     // scripts where it would not be appropriate (e.g., ideographs).
     // Strictly speaking this can occur whenever the line contains ideographs
     // even if it is horizontal, but detecting this has performance implications. For now we only work with
@@ -157,7 +157,7 @@ static float computedUnderlineOffset(const UnderlineOffsetArguments& context)
     if (isAlignedForUnder(styleToUse)) {
         ASSERT(context.textUnderlinePositionUnder);
         // FIXME: This needs to be flipped for sideways-lr.
-        if (textUnderlinePosition == TextUnderlinePosition::Right) {
+        if (textUnderlinePosition.side == TextUnderlinePosition::Side::Right) {
             // In vertical typographic modes, the underline is aligned as for under, except it is always aligned to the right edge of the text.
             underlineOffset = 0.f - (styleToUse.textUnderlineOffset().lengthOr(0.f) + defaultGap(styleToUse));
         } else {
@@ -167,16 +167,12 @@ static float computedUnderlineOffset(const UnderlineOffsetArguments& context)
             underlineOffset = std::max<float>(desiredOffset, fontMetrics.intAscent());
         }
     } else {
-        switch (styleToUse.textUnderlinePosition()) {
-        case TextUnderlinePosition::Left:
-        case TextUnderlinePosition::Right:
-            // In horizontal typographic modes, both 'left' and 'right' values are treated as auto.
-            ASSERT(styleToUse.isHorizontalWritingMode());
-            FALLTHROUGH;
-        case TextUnderlinePosition::Auto:
+        switch (styleToUse.textUnderlinePosition().metric) {
+        case TextUnderlinePosition::Metric::Auto:
             underlineOffset = fontMetrics.intAscent() + styleToUse.textUnderlineOffset().lengthOr(defaultGap(styleToUse));
             break;
-        case TextUnderlinePosition::FromFont:
+        case TextUnderlinePosition::Metric::FromFont:
+            // FIXME: Does it make sense to apply the underline position font metric in a vertical typographic mode?
             underlineOffset = fontMetrics.intAscent() + fontMetrics.underlinePosition().value_or(0) + styleToUse.textUnderlineOffset().lengthOr(0.f);
             break;
         default:
@@ -264,19 +260,20 @@ static GlyphOverflow computedVisualOverflowForDecorations(const RenderStyle& lin
     return overflowResult;
 }
 
+// FIXME: Rename this method as this is really about visual overflow.
 bool isAlignedForUnder(const RenderStyle& decoratingBoxStyle)
 {
     auto underlinePosition = decoratingBoxStyle.textUnderlinePosition();
-    if (underlinePosition == TextUnderlinePosition::Under)
+    if (underlinePosition.metric == TextUnderlinePosition::Metric::Under)
         return true;
     if (decoratingBoxStyle.isHorizontalWritingMode())
         return false;
-    if (underlinePosition == TextUnderlinePosition::Left || underlinePosition == TextUnderlinePosition::Right) {
+    if (underlinePosition.side == TextUnderlinePosition::Side::Left || underlinePosition.side == TextUnderlinePosition::Side::Right) {
         // In vertical typographic modes, the underline is aligned as for under for 'left' and 'right'.
         return true;
     }
     // When left/right support is not enabled.
-    return underlinePosition == TextUnderlinePosition::Auto && decoratingBoxStyle.textUnderlineOffset().isAuto();
+    return underlinePosition.isAuto() && decoratingBoxStyle.textUnderlineOffset().isAuto();
 }
 
 GlyphOverflow visualOverflowForDecorations(const InlineIterator::LineBoxIterator& lineBox, const RenderText& renderer, float textBoxLogicalTop, float textBoxLogicalBottom)
@@ -336,14 +333,14 @@ float overlineOffsetForTextBoxPainting(const InlineIterator::InlineBox& inlineBo
     if (style.isHorizontalWritingMode())
         return { };
 
-    auto underlinePosition = style.textUnderlinePosition();
+    auto underlinePositionSide = style.textUnderlinePosition().side;
     auto overBecomesUnder = [&] {
         auto typographicMode = style.typographicMode();
         // If 'right' causes the underline to be drawn on the "over" side of the text, then an overline also switches sides and is drawn on the "under" side.
-        if (underlinePosition == TextUnderlinePosition::Right)
+        if (underlinePositionSide == TextUnderlinePosition::Side::Right)
             return typographicMode == TypographicMode::Vertical || style.blockFlowDirection() == BlockFlowDirection::RightToLeft;
         // If 'left' causes the underline to be drawn on the "over" side of the text, then an overline also switches sides and is drawn on the "under" side.
-        if (underlinePosition == TextUnderlinePosition::Left)
+        if (underlinePositionSide == TextUnderlinePosition::Side::Left)
             return typographicMode == TypographicMode::Horizontal && style.blockFlowDirection() == BlockFlowDirection::LeftToRight;
         return false;
     };

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -875,7 +875,30 @@ inline RefPtr<QuotesData> BuilderConverter::convertQuotes(BuilderState&, const C
 
 inline TextUnderlinePosition BuilderConverter::convertTextUnderlinePosition(BuilderState&, const CSSValue& value)
 {
-    return fromCSSValue<TextUnderlinePosition>(value);
+    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
+    if (primitiveValue) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueFromFont:
+        case CSSValueUnder:
+            return { fromCSSValueID<TextUnderlinePosition::Metric>(primitiveValue->valueID()), TextUnderlinePosition::Side::Auto };
+
+        case CSSValueLeft:
+        case CSSValueRight:
+            return { TextUnderlinePosition::Metric::Auto, fromCSSValueID<TextUnderlinePosition::Side>(primitiveValue->valueID()) };
+
+        default:
+            return { TextUnderlinePosition::Metric::Auto, TextUnderlinePosition::Side::Auto };
+        }
+    }
+
+    auto* pair = dynamicDowncast<CSSValuePair>(value);
+    if (!pair)
+        return { TextUnderlinePosition::Metric::Auto, TextUnderlinePosition::Side::Auto };
+
+    return {
+        fromCSSValueID<TextUnderlinePosition::Metric>(downcast<CSSPrimitiveValue>(pair->first()).valueID()),
+        fromCSSValueID<TextUnderlinePosition::Side>(downcast<CSSPrimitiveValue>(pair->second()).valueID()),
+    };
 }
 
 inline TextUnderlineOffset BuilderConverter::convertTextUnderlineOffset(BuilderState& builderState, const CSSValue& value)


### PR DESCRIPTION
#### 3bbfe9b1ec474ad7874249db7d0678cef813f048
<pre>
[text-underline-position] Parse `from-font | under` combined with `left | right`
<a href="https://bugs.webkit.org/show_bug.cgi?id=276922">https://bugs.webkit.org/show_bug.cgi?id=276922</a>
<a href="https://rdar.apple.com/132292219">rdar://132292219</a>

Reviewed by Darin Adler.

Allow chaining `from-font | under` before or after `left | right`.

Spec: <a href="https://drafts.csswg.org/css-text-decor-4/#text-underline-position-property">https://drafts.csswg.org/css-text-decor-4/#text-underline-position-property</a>

This only implements parsing and does not change painting when combinations are used.

* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-underline-position-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-underline-position-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-underline-position-expected.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeTextUnderlinePosition):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::LegacyInlineFlowBox::addToLine):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::initialTextUnderlinePosition):
(WebCore::RenderStyle::textUnderlinePosition const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setTextUnderlinePosition):
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/rendering/style/TextUnderlinePosition.cpp: Added.
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/TextUnderlinePosition.h: Added.
(WebCore::TextUnderlinePosition::isAuto):
* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::computedUnderlineOffset):
(WebCore::isAlignedForUnder):
(WebCore::overlineOffsetForTextBoxPainting):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertTextUnderlinePosition):

Canonical link: <a href="https://commits.webkit.org/281260@main">https://commits.webkit.org/281260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16f612d9edf6f68f29a712b8d3f8a73ddb227c09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11849 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/63243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/9772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10003 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/63243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/9772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61359 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/36129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/51353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/63243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/32840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/8608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/8776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/8888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/64976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/3257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/64976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/3268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/51350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/64976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8860 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/34488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/36657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->