### PR TITLE
Implement getPushPermissionState in webpushd

### DIFF
--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -166,7 +166,9 @@ void NetworkNotificationManager::getPushPermissionState(URL&& scopeURL, Completi
         return;
     }
 
-    m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushPermissionState(WTFMove(scopeURL)), WTFMove(completionHandler));
+    m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushPermissionState(WTFMove(scopeURL)), [completionHandler = WTFMove(completionHandler)](WebCore::PushPermissionState state) mutable {
+        completionHandler(static_cast<uint8_t>(state));
+    });
 }
 
 void NetworkNotificationManager::incrementSilentPushCount(WebCore::SecurityOriginData&& origin, CompletionHandler<void(unsigned)>&& completionHandler)

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -148,6 +148,7 @@
 @interface UIWebClip : NSObject
 + (UIWebClip *)webClipWithIdentifier:(NSString *)identifier;
 @property (nonatomic, copy) NSString *title;
+@property (nonatomic, retain) NSURL *pageURL;
 @end
 
 #if ENABLE(DRAG_SUPPORT)

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
@@ -34,6 +34,7 @@ namespace WebKit::WebPushD {
 struct WebPushDaemonConnectionConfiguration {
     bool useMockBundlesForTesting { false };
     std::optional<Vector<uint8_t>> hostAppAuditTokenData;
+    String bundleIdentifierOverride;
     String pushPartitionString;
     std::optional<WTF::UUID> dataStoreIdentifier;
 };

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
@@ -25,6 +25,7 @@ webkit_platform_headers: "ArgumentCoders.h" "WebPushDaemonConnectionConfiguratio
 [CustomHeader, WebKitPlatform] struct WebKit::WebPushD::WebPushDaemonConnectionConfiguration {
     bool useMockBundlesForTesting;
     std::optional<Vector<uint8_t>> hostAppAuditTokenData;
+    String bundleIdentifierOverride;
     String pushPartitionString;
     std::optional<WTF::UUID> dataStoreIdentifier;
 };

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -178,7 +178,7 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
 
 WebPushD::WebPushDaemonConnectionConfiguration WebsiteDataStoreConfiguration::webPushDaemonConnectionConfiguration() const
 {
-    return { m_webPushDaemonUsesMockBundlesForTesting, { }, m_webPushPartitionString, m_identifier };
+    return { m_webPushDaemonUsesMockBundlesForTesting, { }, { }, m_webPushPartitionString, m_identifier };
 }
 
 WebsiteDataStoreConfiguration::Directories WebsiteDataStoreConfiguration::Directories::isolatedCopy() const &

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -32,6 +32,7 @@
 #include "WebPushMessage.h"
 #include <WebCore/ExceptionData.h>
 #include <WebCore/NotificationResources.h>
+#include <WebCore/PushPermissionState.h>
 #include <WebCore/PushSubscriptionData.h>
 #include <WebCore/PushSubscriptionIdentifier.h>
 #include <WebCore/SecurityOriginData.h>
@@ -111,7 +112,7 @@ private:
     void removePushSubscriptionsForOrigin(WebCore::SecurityOriginData&&, CompletionHandler<void(unsigned)>&&);
     void setPublicTokenForTesting(const String& publicToken, CompletionHandler<void()>&&);
     void updateConnectionConfiguration(WebPushDaemonConnectionConfiguration&&);
-    void getPushPermissionState(URL&& scopeURL, CompletionHandler<void(const Expected<uint8_t, WebCore::ExceptionData>&)>&&);
+    void getPushPermissionState(URL&& scopeURL, CompletionHandler<void(WebCore::PushPermissionState)>&&);
     void setHostAppAuditTokenData(const Vector<uint8_t>&);
     void getPushTopicsForTesting(CompletionHandler<void(Vector<String>, Vector<String>)>&&);
     void didShowNotificationForTesting(URL&& scopeURL, CompletionHandler<void()>&&);
@@ -132,6 +133,7 @@ private:
     std::optional<String> m_hostAppCodeSigningIdentifier;
     std::optional<bool> m_hostAppHasPushEntitlement;
 
+    String m_bundleIdentifierOverride;
     String m_pushPartitionString;
     Markable<WTF::UUID> m_dataStoreIdentifier;
 

--- a/Source/WebKit/webpushd/PushClientConnection.messages.in
+++ b/Source/WebKit/webpushd/PushClientConnection.messages.in
@@ -32,7 +32,7 @@ messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     SubscribeToPushService(URL scopeURL, Vector<uint8_t> vapidPublicKey) -> (Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData> result)
     UnsubscribeFromPushService(URL scopeURL, std::optional<WebCore::PushSubscriptionIdentifier> identifier) -> (Expected<bool, WebCore::ExceptionData> result)
     GetPushSubscription(URL scopeURL) -> (Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData> result)
-    GetPushPermissionState(URL scopeURL) -> (Expected<uint8_t, WebCore::ExceptionData> result)
+    GetPushPermissionState(URL scopeURL) -> (enum:uint8_t WebCore::PushPermissionState result)
     IncrementSilentPushCount(WebCore::SecurityOriginData origin) -> (unsigned newCount)
     RemoveAllPushSubscriptions()  -> (unsigned removed)
     RemovePushSubscriptionsForOrigin(WebCore::SecurityOriginData origin) -> (unsigned removed)

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -34,6 +34,7 @@
 #include "WebPushDaemonConstants.h"
 #include "WebPushMessage.h"
 #include <WebCore/ExceptionData.h>
+#include <WebCore/PushPermissionState.h>
 #include <WebCore/PushSubscriptionData.h>
 #include <WebCore/Timer.h>
 #include <span>
@@ -93,6 +94,8 @@ public:
 
     void showNotification(PushClientConnection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>, CompletionHandler<void()>&&);
     void getNotifications(PushClientConnection&, const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&&);
+
+    void getPushPermissionState(PushClientConnection&, const URL& scopeURL, CompletionHandler<void(WebCore::PushPermissionState)>&&);
 
 private:
     WebPushDaemon();

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -41,9 +41,9 @@
 
 namespace WebPushTool {
 
-std::unique_ptr<Connection> Connection::create(std::optional<Action> action, PreferTestService preferTestService, Reconnect reconnect)
+std::unique_ptr<Connection> Connection::create(PreferTestService preferTestService, String bundleIdentifier, String pushPartition)
 {
-    return makeUnique<Connection>(action, preferTestService, reconnect);
+    return makeUnique<Connection>(preferTestService, bundleIdentifier, pushPartition);
 }
 
 static mach_port_t maybeConnectToService(const char* serviceName)
@@ -60,9 +60,9 @@ static mach_port_t maybeConnectToService(const char* serviceName)
     return MACH_PORT_NULL;
 }
 
-Connection::Connection(std::optional<Action> action, PreferTestService preferTestService, Reconnect reconnect)
-    : m_action(action)
-    , m_reconnect(reconnect == Reconnect::Yes)
+Connection::Connection(PreferTestService preferTestService, String bundleIdentifier, String pushPartition)
+    : m_bundleIdentifier(bundleIdentifier)
+    , m_pushPartition(pushPartition)
 {
     if (preferTestService == PreferTestService::Yes)
         m_serviceName = "org.webkit.webpushtestdaemon.service";
@@ -72,31 +72,12 @@ Connection::Connection(std::optional<Action> action, PreferTestService preferTes
 
 void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
 {
-    if (m_connection)
-        return;
 
     m_connection = adoptNS(xpc_connection_create_mach_service(m_serviceName, dispatch_get_main_queue(), 0));
 
-    xpc_connection_set_event_handler(m_connection.get(), [this, weakThis = WeakPtr { *this }](xpc_object_t event) {
-        if (!weakThis)
-            return;
-
-        if (event == XPC_ERROR_CONNECTION_INVALID) {
-            printf("Failed to start listening for connections to mach service\n");
-            connectionDropped();
-            return;
-        }
-
-        if (event == XPC_ERROR_CONNECTION_INTERRUPTED) {
-            printf("Connection closed\n");
-            if (m_reconnect)
-                printf("===============\nReconnecting...\n");
-            connectionDropped();
-            return;
-        }
-
-        if (xpc_get_type(event) == XPC_TYPE_DICTIONARY) {
-            messageReceived(event);
+    xpc_connection_set_event_handler(m_connection.get(), [](xpc_object_t event) {
+        if (event == XPC_ERROR_CONNECTION_INVALID || event == XPC_ERROR_CONNECTION_INTERRUPTED) {
+            fprintf(stderr, "Unexpected XPC connection issue: %s\n", event.debugDescription.UTF8String);
             return;
         }
 
@@ -118,44 +99,20 @@ void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
     xpc_connection_activate(m_connection.get());
 
     sendAuditToken();
-    startAction();
 }
 
-void Connection::startAction()
+void Connection::sendPushMessage(PushMessageForTesting&& message, CompletionHandler<void(String)>&& completionHandler)
 {
-    if (m_action) {
-        switch (*m_action) {
-        case Action::StreamDebugMessages:
-            startDebugStreamAction();
-            break;
-        };
-    }
-
-    if (m_pushMessage)
-        sendPushMessage();
-}
-
-void Connection::sendPushMessage()
-{
-    ASSERT(m_pushMessage);
-
     printf("Injecting push message\n");
 
-    sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::InjectPushMessageForTesting(*m_pushMessage), [shouldExitAfterInject = !m_action] (const String& error) {
-        if (!error.isEmpty())
-            printf("Push message injected. Error: %s\n", error.utf8().data());
-        else
-            printf("Push message injected.\n");
-
-        if (shouldExitAfterInject)
-            CFRunLoopStop(CFRunLoopGetMain());
-    });
+    sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::InjectPushMessageForTesting(WTFMove(message)), WTFMove(completionHandler));
 }
 
-void Connection::startDebugStreamAction()
+void Connection::getPushPermissionState(const String& scope, CompletionHandler<void(WebCore::PushPermissionState)>&& completionHandler)
 {
-    printf("Now streaming debug messages via: log stream --debug --info --process webpushd");
-    system("log stream --debug --info --process webpushd");
+    printf("Getting push permission state\n");
+
+    sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushPermissionState(URL(scope)), WTFMove(completionHandler));
 }
 
 void Connection::sendAuditToken()
@@ -170,6 +127,8 @@ void Connection::sendAuditToken()
 
     WebKit::WebPushD::WebPushDaemonConnectionConfiguration configuration;
     configuration.useMockBundlesForTesting = true;
+    configuration.bundleIdentifierOverride = m_bundleIdentifier;
+    configuration.pushPartitionString = m_pushPartition;
 
     Vector<uint8_t> tokenVector;
     tokenVector.resize(32);
@@ -177,29 +136,6 @@ void Connection::sendAuditToken()
     configuration.hostAppAuditTokenData = WTFMove(tokenVector);
 
     sendWithoutUsingIPCConnection(Messages::PushClientConnection::UpdateConnectionConfiguration(WTFMove(configuration)));
-}
-
-void Connection::connectionDropped()
-{
-    m_connection = nullptr;
-    if (m_reconnect) {
-        callOnMainRunLoop([this, weakThis = WeakPtr { this }] {
-            if (weakThis)
-                connectToService(WaitForServiceToExist::Yes);
-        });
-        return;
-    }
-
-    CFRunLoopStop(CFRunLoopGetCurrent());
-}
-
-void Connection::messageReceived(xpc_object_t message)
-{
-    const char* debugMessage = xpc_dictionary_get_string(message, "debug message");
-    if (!debugMessage)
-        return;
-
-    printf("%s\n", debugMessage);
 }
 
 static OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)


### PR DESCRIPTION
#### aa9297075ed0cd9f3731773954d4ce506658e308
<pre>
Implement getPushPermissionState in webpushd
<a href="https://bugs.webkit.org/show_bug.cgi?id=276929">https://bugs.webkit.org/show_bug.cgi?id=276929</a>
<a href="https://rdar.apple.com/132296992">rdar://132296992</a>

Reviewed by Brady Eidson.

This implements the getPushPermissionState IPC in webpushd, which is part of a larger project in
which we are moving push and notifications permissions management from the embedder to webpushd.

Testing is currently via a new webpushtool command. We&apos;ll add integration tests in the future once
Brady commits UserNotifications mocks in a future patch.

I also had to do some webpushtool cleanup to make that possible, and a lot more webpushtool cleanup
should probably occur, but I&apos;ll defer that work to a future patch.

* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::getPushPermissionState):
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h:
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::webPushDaemonConnectionConfiguration const):
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/PushClientConnection.messages.in:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::updateConnectionConfiguration):
(WebPushD::PushClientConnection::hostAppCodeSigningIdentifier):
(WebPushD::PushClientConnection::getPushPermissionState):
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::getPushPermissionState):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::create):
(WebPushTool::Connection::Connection):
(WebPushTool::Connection::connectToService):
(WebPushTool::Connection::sendPushMessage):
(WebPushTool::Connection::getPushPermissionState):
(WebPushTool::Connection::sendAuditToken):
(WebPushTool::Connection::startAction): Deleted.
(WebPushTool::Connection::startDebugStreamAction): Deleted.
(WebPushTool::Connection::connectionDropped): Deleted.
(WebPushTool::Connection::messageReceived): Deleted.
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
(printUsageAndTerminate):
(WebKit::WebPushToolMain):

Canonical link: <a href="https://commits.webkit.org/281258@main">https://commits.webkit.org/281258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17ad0577ebc3272d0125079ff17283c4a35c45e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63206 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9735 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48163 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6936 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28985 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32814 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8739 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64939 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8792 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51319 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/55602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13131 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2688 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34451 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35534 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36620 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->