### PR TITLE
[web-animations] Support discrete animations on `text-underline-position`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/animations/discrete-no-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/animations/discrete-no-interpolation-expected.txt
@@ -209,16 +209,16 @@ PASS Web Animations: property <text-emphasis-style> from [initial] to [dot] at (
 PASS Web Animations: property <text-emphasis-style> from [initial] to [dot] at (0.6) should be [dot]
 PASS Web Animations: property <text-emphasis-style> from [initial] to [dot] at (1) should be [dot]
 PASS Web Animations: property <text-emphasis-style> from [initial] to [dot] at (1.5) should be [dot]
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <text-underline-position> from [initial] to [under] at (-0.3) should be [initial] assert_equals: expected "auto " but got "under "
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <text-underline-position> from [initial] to [under] at (0) should be [initial] assert_equals: expected "auto " but got "under "
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <text-underline-position> from [initial] to [under] at (0.3) should be [initial] assert_equals: expected "auto " but got "under "
+PASS CSS Transitions with transition-behavior:allow-discrete: property <text-underline-position> from [initial] to [under] at (-0.3) should be [initial]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <text-underline-position> from [initial] to [under] at (0) should be [initial]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <text-underline-position> from [initial] to [under] at (0.3) should be [initial]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <text-underline-position> from [initial] to [under] at (0.5) should be [under]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <text-underline-position> from [initial] to [under] at (0.6) should be [under]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <text-underline-position> from [initial] to [under] at (1) should be [under]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <text-underline-position> from [initial] to [under] at (1.5) should be [under]
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <text-underline-position> from [initial] to [under] at (-0.3) should be [initial] assert_equals: expected "auto " but got "under "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <text-underline-position> from [initial] to [under] at (0) should be [initial] assert_equals: expected "auto " but got "under "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <text-underline-position> from [initial] to [under] at (0.3) should be [initial] assert_equals: expected "auto " but got "under "
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <text-underline-position> from [initial] to [under] at (-0.3) should be [initial]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <text-underline-position> from [initial] to [under] at (0) should be [initial]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <text-underline-position> from [initial] to [under] at (0.3) should be [initial]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <text-underline-position> from [initial] to [under] at (0.5) should be [under]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <text-underline-position> from [initial] to [under] at (0.6) should be [under]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <text-underline-position> from [initial] to [under] at (1) should be [under]
@@ -240,15 +240,15 @@ PASS CSS Transitions with transition: all: property <text-underline-position> fr
 PASS CSS Animations: property <text-underline-position> from [initial] to [under] at (-0.3) should be [initial]
 PASS CSS Animations: property <text-underline-position> from [initial] to [under] at (0) should be [initial]
 PASS CSS Animations: property <text-underline-position> from [initial] to [under] at (0.3) should be [initial]
-FAIL CSS Animations: property <text-underline-position> from [initial] to [under] at (0.5) should be [under] assert_equals: expected "under " but got "auto "
-FAIL CSS Animations: property <text-underline-position> from [initial] to [under] at (0.6) should be [under] assert_equals: expected "under " but got "auto "
-FAIL CSS Animations: property <text-underline-position> from [initial] to [under] at (1) should be [under] assert_equals: expected "under " but got "auto "
-FAIL CSS Animations: property <text-underline-position> from [initial] to [under] at (1.5) should be [under] assert_equals: expected "under " but got "auto "
+PASS CSS Animations: property <text-underline-position> from [initial] to [under] at (0.5) should be [under]
+PASS CSS Animations: property <text-underline-position> from [initial] to [under] at (0.6) should be [under]
+PASS CSS Animations: property <text-underline-position> from [initial] to [under] at (1) should be [under]
+PASS CSS Animations: property <text-underline-position> from [initial] to [under] at (1.5) should be [under]
 PASS Web Animations: property <text-underline-position> from [initial] to [under] at (-0.3) should be [initial]
 PASS Web Animations: property <text-underline-position> from [initial] to [under] at (0) should be [initial]
 PASS Web Animations: property <text-underline-position> from [initial] to [under] at (0.3) should be [initial]
-FAIL Web Animations: property <text-underline-position> from [initial] to [under] at (0.5) should be [under] assert_equals: expected "under " but got "auto "
-FAIL Web Animations: property <text-underline-position> from [initial] to [under] at (0.6) should be [under] assert_equals: expected "under " but got "auto "
-FAIL Web Animations: property <text-underline-position> from [initial] to [under] at (1) should be [under] assert_equals: expected "under " but got "auto "
-FAIL Web Animations: property <text-underline-position> from [initial] to [under] at (1.5) should be [under] assert_equals: expected "under " but got "auto "
+PASS Web Animations: property <text-underline-position> from [initial] to [under] at (0.5) should be [under]
+PASS Web Animations: property <text-underline-position> from [initial] to [under] at (0.6) should be [under]
+PASS Web Animations: property <text-underline-position> from [initial] to [under] at (1) should be [under]
+PASS Web Animations: property <text-underline-position> from [initial] to [under] at (1.5) should be [under]
 

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3983,6 +3983,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<OverflowAnchor>(CSSPropertyOverflowAnchor, &RenderStyle::overflowAnchor, &RenderStyle::setOverflowAnchor),
         new DiscretePropertyWrapper<TextSpacingTrim>(CSSPropertyTextSpacingTrim, &RenderStyle::textSpacingTrim, &RenderStyle::setTextSpacingTrim),
         new DiscretePropertyWrapper<TextAutospace>(CSSPropertyTextAutospace, &RenderStyle::textAutospace, &RenderStyle::setTextAutospace),
+        new DiscretePropertyWrapper<TextUnderlinePosition>(CSSPropertyTextUnderlinePosition, &RenderStyle::textUnderlinePosition, &RenderStyle::setTextUnderlinePosition),
 
         new DiscretePropertyWrapper<BoxDecorationBreak>(CSSPropertyWebkitBoxDecorationBreak, &RenderStyle::boxDecorationBreak, &RenderStyle::setBoxDecorationBreak),
         new DiscretePropertyWrapper<Isolation>(CSSPropertyIsolation, &RenderStyle::isolation, &RenderStyle::setIsolation),
@@ -4249,7 +4250,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyTextCombineUpright:
         case CSSPropertyTextDecoration:
         case CSSPropertyTextDecorationSkip:
-        case CSSPropertyTextUnderlinePosition:
         case CSSPropertyTransition:
         case CSSPropertyTransitionBehavior:
         case CSSPropertyTransitionDelay:

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2067,6 +2067,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyScrollbarColor);
         if (first.listStyleType != second.listStyleType)
             changingProperties.m_properties.set(CSSPropertyListStyleType);
+        if (first.textUnderlinePosition != second.textUnderlinePosition)
+            changingProperties.m_properties.set(CSSPropertyTextUnderlinePosition);
 
         // customProperties is handled separately.
         // Non animated styles are followings.
@@ -2101,7 +2103,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // touchCalloutEnabled
         // lineGrid
         // imageRendering
-        // textUnderlinePosition
         // textZoom
         // lineSnap
         // lineAlign


### PR DESCRIPTION
#### 0797bbb8c4f2c293d56e455a2ca63b05214ef128
<pre>
[web-animations] Support discrete animations on `text-underline-position`
<a href="https://bugs.webkit.org/show_bug.cgi?id=241177">https://bugs.webkit.org/show_bug.cgi?id=241177</a>
<a href="https://rdar.apple.com/94615165">rdar://94615165</a>

Reviewed by Darin Adler.

It should be animatable according to <a href="https://drafts.csswg.org/css-text-decor/#text-underline-position-property">https://drafts.csswg.org/css-text-decor/#text-underline-position-property</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/animations/discrete-no-interpolation-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):

Canonical link: <a href="https://commits.webkit.org/281245@main">https://commits.webkit.org/281245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e44dfe40120cf5a65ea109e81a2bca990b67159f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11777 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/63172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9931 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/63172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/6919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61288 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/36075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/51293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/63172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/32788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/8550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8705 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/8830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/64889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3186 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/64889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3197 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/51292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/64889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/2660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8849 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/34417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/36586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->