### PR TITLE
[JSC] Implement `firstDayOfWeek` for `Intl.Locale` info API

### DIFF
--- a/JSTests/stress/intl-locale-info-firstDayOfWeek.js
+++ b/JSTests/stress/intl-locale-info-firstDayOfWeek.js
@@ -1,0 +1,51 @@
+function sameValue(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(callback, errorConstructor) {
+    try {
+        callback();
+    } catch (e) {
+        if (!(e instanceof errorConstructor))
+            throw new Error(`Expected ${errorConstructor.prototype.name} but got ${e.name}`);
+        return;
+    }
+    throw new Error(`Expected ${errorConstructor.prototype.name} but got no error`);
+}
+
+{
+    const loc = new Intl.Locale("en");
+    sameValue(loc.firstDayOfWeek, undefined);
+}
+
+{
+    const loc = new Intl.Locale("en", { firstDayOfWeek: "mon" });
+    sameValue(loc.firstDayOfWeek, "mon");
+}
+
+{
+    const weekdaysStrings = [
+        ["0", "sun"],
+        ["1", "mon"],
+        ["2", "tue"],
+        ["3", "wed"],
+        ["4", "thu"],
+        ["5", "fri"],
+        ["6", "sat"],
+        ["7", "sun"],
+    ];
+    for (const [weekday, string] of weekdaysStrings) {
+        const loc = new Intl.Locale("en", { firstDayOfWeek: weekday });
+        sameValue(loc.firstDayOfWeek, string);
+    }
+}
+
+{
+    const invalidFirstDayOfWeekOptions = ["", "m", "mo", "longerThan8Chars"];
+    for (const firstDayOfWeek of invalidFirstDayOfWeekOptions) {
+        shouldThrow(() => {
+            new Intl.Locale("en", { firstDayOfWeek });
+        }, RangeError);
+    }
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1105,30 +1105,9 @@ test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values
 test/intl402/DurationFormat/prototype/format/rounding-mode-trunc-for-seconds.js:
   default: 'Test262Error: Intl.DurationFormat should format seconds, milliseconds and microseconds with `roundingMode: "trunc"` Expected SameValue(«2», «1») to be true'
   strict mode: 'Test262Error: Intl.DurationFormat should format seconds, milliseconds and microseconds with `roundingMode: "trunc"` Expected SameValue(«2», «1») to be true'
-test/intl402/Locale/constructor-options-firstDayOfWeek-invalid.js:
-  default: 'Test262Error: new Intl.Locale("en", {firstDayOfWeek: ""}) throws RangeError Expected a RangeError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: new Intl.Locale("en", {firstDayOfWeek: ""}) throws RangeError Expected a RangeError to be thrown but no exception was thrown at all'
-test/intl402/Locale/constructor-options-firstDayOfWeek-valid.js:
-  default: 'Test262Error: new Intl.Locale("en", { firstDayOfWeek: mon }).toString() returns "en-u-fw-mon" Expected SameValue(«en», «en-u-fw-mon») to be true'
-  strict mode: 'Test262Error: new Intl.Locale("en", { firstDayOfWeek: mon }).toString() returns "en-u-fw-mon" Expected SameValue(«en», «en-u-fw-mon») to be true'
 test/intl402/Locale/extensions-grandfathered.js:
   default: 'Test262Error: Expected SameValue(«fr-Cyrl-FR-gaulish-u-nu-latn», «fr-Cyrl-FR-u-nu-latn») to be true'
   strict mode: 'Test262Error: Expected SameValue(«fr-Cyrl-FR-gaulish-u-nu-latn», «fr-Cyrl-FR-u-nu-latn») to be true'
-test/intl402/Locale/prototype/firstDayOfWeek/name.js:
-  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(Intl.Locale.prototype, \"firstDayOfWeek\").get')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(Intl.Locale.prototype, \"firstDayOfWeek\").get')"
-test/intl402/Locale/prototype/firstDayOfWeek/prop-desc.js:
-  default: "TypeError: undefined is not an object (evaluating 'propdesc.set')"
-  strict mode: "TypeError: undefined is not an object (evaluating 'propdesc.set')"
-test/intl402/Locale/prototype/firstDayOfWeek/valid-id.js:
-  default: 'Test262Error: new Intl.Locale(en-u-fw-mon).firstDayOfWeek returns "mon" Expected SameValue(«undefined», «mon») to be true'
-  strict mode: 'Test262Error: new Intl.Locale(en-u-fw-mon).firstDayOfWeek returns "mon" Expected SameValue(«undefined», «mon») to be true'
-test/intl402/Locale/prototype/firstDayOfWeek/valid-options.js:
-  default: 'Test262Error: new Intl.Locale("en", { firstDayOfWeek: mon }).firstDayOfWeek returns "mon" Expected SameValue(«undefined», «mon») to be true'
-  strict mode: 'Test262Error: new Intl.Locale("en", { firstDayOfWeek: mon }).firstDayOfWeek returns "mon" Expected SameValue(«undefined», «mon») to be true'
-test/intl402/Locale/prototype/getWeekInfo/firstDay-by-option.js:
-  default: 'Test262Error: new Intl.Locale("en", { firstDayOfWeek: mon }).getWeekInfo().firstDay returns "1" Expected SameValue(«7», «1») to be true'
-  strict mode: 'Test262Error: new Intl.Locale("en", { firstDayOfWeek: mon }).getWeekInfo().firstDay returns "1" Expected SameValue(«7», «1») to be true'
 test/intl402/NumberFormat/prototype/format/useGrouping-extended-en-IN.js:
   default: 'Test262Error: notation: "compact" Expected SameValue(«1K», «1T») to be true'
   strict mode: 'Test262Error: notation: "compact" Expected SameValue(«1K», «1T») to be true'

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -128,6 +128,7 @@
     macro(exports) \
     macro(fallback) \
     macro(flags) \
+    macro(firstDayOfWeek) \
     macro(forEach) \
     macro(formatMatcher) \
     macro(formatToParts) \

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -226,6 +226,28 @@ void IntlLocale::initializeLocale(JSGlobalObject* globalObject, JSValue tagValue
     initializeLocale(globalObject, tag, optionsValue);
 }
 
+// https://tc39.es/proposal-intl-locale-info/#sec-weekday-to-string
+static StringView weekdayToString(StringView fw)
+{
+    if (fw == "0"_s)
+        return "sun"_s;
+    if (fw == "1"_s)
+        return "mon"_s;
+    if (fw == "2"_s)
+        return "tue"_s;
+    if (fw == "3"_s)
+        return "wed"_s;
+    if (fw == "4"_s)
+        return "thu"_s;
+    if (fw == "5"_s)
+        return "fri"_s;
+    if (fw == "6"_s)
+        return "sat"_s;
+    if (fw == "7"_s)
+        return "sun"_s;
+    return fw;
+}
+
 // https://tc39.es/ecma402/#sec-Intl.Locale
 void IntlLocale::initializeLocale(JSGlobalObject* globalObject, const String& tag, JSValue optionsValue)
 {
@@ -279,6 +301,16 @@ void IntlLocale::initializeLocale(JSGlobalObject* globalObject, const String& ta
     if (!collation.isNull()) {
         if (!isUnicodeLocaleIdentifierType(collation) || !localeID.setKeywordValue("collation"_s, collation)) {
             throwRangeError(globalObject, scope, "collation is not a well-formed collation value"_s);
+            return;
+        }
+    }
+
+    String firstDayOfWeek = intlStringOption(globalObject, options, vm.propertyNames->firstDayOfWeek, { }, { }, { });
+    RETURN_IF_EXCEPTION(scope, void());
+    if (!firstDayOfWeek.isNull()) {
+        auto fw = weekdayToString(firstDayOfWeek);
+        if (!isUnicodeLocaleIdentifierType(fw) || !localeID.setKeywordValue("fw"_s, fw)) {
+            throwRangeError(globalObject, scope, "firstDayOfWeek is not a well-formed firstDayOfWeek value"_s);
             return;
         }
     }
@@ -507,6 +539,14 @@ const String& IntlLocale::collation()
     if (!m_collation)
         m_collation = keywordValue("collation"_s);
     return m_collation.value();
+}
+
+// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.firstDayOfWeek
+const String& IntlLocale::firstDayOfWeek()
+{
+    if (!m_firstDayOfWeek)
+        m_firstDayOfWeek = keywordValue("fw"_s);
+    return m_firstDayOfWeek.value();
 }
 
 // https://tc39.es/ecma402/#sec-Intl.Locale.prototype.hourCycle

--- a/Source/JavaScriptCore/runtime/IntlLocale.h
+++ b/Source/JavaScriptCore/runtime/IntlLocale.h
@@ -65,6 +65,7 @@ public:
     const String& calendar();
     const String& caseFirst();
     const String& collation();
+    const String& firstDayOfWeek();
     const String& hourCycle();
     const String& numberingSystem();
     TriState numeric();
@@ -96,6 +97,7 @@ private:
     std::optional<String> m_calendar;
     std::optional<String> m_caseFirst;
     std::optional<String> m_collation;
+    std::optional<String> m_firstDayOfWeek;
     std::optional<String> m_hourCycle;
     std::optional<String> m_numberingSystem;
     TriState m_numeric { TriState::Indeterminate };

--- a/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
@@ -47,6 +47,7 @@ static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterBaseName);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterCalendar);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterCaseFirst);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterCollation);
+static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterFirstDayOfWeek);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterHourCycle);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterNumeric);
 static JSC_DECLARE_CUSTOM_GETTER(intlLocalePrototypeGetterNumberingSystem);
@@ -78,6 +79,7 @@ const ClassInfo IntlLocalePrototype::s_info = { "Intl.Locale"_s, &Base::s_info, 
   calendar            intlLocalePrototypeGetterCalendar          DontEnum|ReadOnly|CustomAccessor
   caseFirst           intlLocalePrototypeGetterCaseFirst         DontEnum|ReadOnly|CustomAccessor
   collation           intlLocalePrototypeGetterCollation         DontEnum|ReadOnly|CustomAccessor
+  firstDayOfWeek      intlLocalePrototypeGetterFirstDayOfWeek    DontEnum|ReadOnly|CustomAccessor
   hourCycle           intlLocalePrototypeGetterHourCycle         DontEnum|ReadOnly|CustomAccessor
   numeric             intlLocalePrototypeGetterNumeric           DontEnum|ReadOnly|CustomAccessor
   numberingSystem     intlLocalePrototypeGetterNumberingSystem   DontEnum|ReadOnly|CustomAccessor
@@ -237,6 +239,20 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetCollations, (JSGlobalObject* 
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getCollations called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->collations(globalObject)));
+}
+
+// https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.firstDayOfWeek
+JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterFirstDayOfWeek, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
+    if (UNLIKELY(!locale))
+        return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.firstDayOfWeek called on value that's not a Locale"_s);
+
+    const String& firstDayOfWeek = locale->firstDayOfWeek();
+    RELEASE_AND_RETURN(scope, JSValue::encode(firstDayOfWeek.isNull() ? jsUndefined() : jsString(vm, firstDayOfWeek)));
 }
 
 // https://tc39.es/ecma402/#sec-Intl.Locale.prototype.hourCycle


### PR DESCRIPTION
#### 8cd1f6cc395ca82effa2968efe87339d54be2b66
<pre>
[JSC] Implement `firstDayOfWeek` for `Intl.Locale` info API
<a href="https://bugs.webkit.org/show_bug.cgi?id=276943">https://bugs.webkit.org/show_bug.cgi?id=276943</a>

Reviewed by Ross Kirsling.

JSC has implemented the Stage 3 Intl.Locale Info API[1][2]. The proposal includes support for the
&quot;fw&quot; (First day of the week) Unicode extension[3], but it is not currently implemented in JSC.

This patch implements support for the &quot;fw&quot; extension in the Intl.Locale Info API.

[1]: <a href="https://github.com/tc39/proposal-intl-locale-info">https://github.com/tc39/proposal-intl-locale-info</a>
[2]: <a href="https://tc39.es/proposal-intl-locale-info">https://tc39.es/proposal-intl-locale-info</a>
[3]: <a href="https://unicode.org/reports/tr35/#Key_Type_Definitions">https://unicode.org/reports/tr35/#Key_Type_Definitions</a>

* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::weekDayToString):
(JSC::IntlLocale::initializeLocale):
(JSC::IntlLocale::firstDayOfWeek):
* Source/JavaScriptCore/runtime/IntlLocale.h:
* Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):

Canonical link: <a href="https://commits.webkit.org/281510@main">https://commits.webkit.org/281510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/429f0c1c5ea239229d260b661bdbe80a6c7f8ad7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63310 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9909 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48226 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6976 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29051 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8662 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8843 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/52488 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65043 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58641 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55565 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55669 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13330 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2761 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80398 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34555 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13934 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35638 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36724 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->