### PR TITLE
Teach CCallCustom::isValidForm about TmpPair

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirCustom.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCustom.cpp
@@ -60,6 +60,18 @@ bool PatchCustom::isValidForm(Inst& inst)
     return ok;
 }
 
+#if USE(JSVALUE32_64)
+bool CCallCustom::isValidArg(Arg& arg)
+{
+    return arg.isTmp() || arg.isTmpPair() || arg.isStackMemory() || arg.isSomeImm();
+}
+#else
+bool CCallCustom::isValidArg(Arg& arg)
+{
+    return arg.isTmp() || arg.isStackMemory() || arg.isSomeImm();
+}
+#endif
+
 bool CCallCustom::isValidForm(Inst& inst)
 {
     CCallValue* value = inst.origin->as<CCallValue>();
@@ -85,7 +97,7 @@ bool CCallCustom::isValidForm(Inst& inst)
     // The arguments can only refer to the stack, tmps, or immediates.
     for (unsigned i = inst.args.size() - 1; i; --i) {
         Arg arg = inst.args[i];
-        if (!arg.isTmp() && !arg.isStackMemory() && !arg.isSomeImm())
+        if (!isValidArg(arg))
             return false;
     }
 

--- a/Source/JavaScriptCore/b3/air/AirCustom.h
+++ b/Source/JavaScriptCore/b3/air/AirCustom.h
@@ -174,6 +174,7 @@ struct CCallCustom : public CommonCustomBase<CCallCustom> {
         return false;
     }
 
+    static bool isValidArg(Arg&);
     static bool isValidForm(Inst&);
 
     static bool admitsStack(Inst&, unsigned)


### PR DESCRIPTION
#### 42492e3efc310e75270fb1d0bac243e7d2a483ea
<pre>
Teach CCallCustom::isValidForm about TmpPair
<a href="https://bugs.webkit.org/show_bug.cgi?id=276951">https://bugs.webkit.org/show_bug.cgi?id=276951</a>

Reviewed by NOBODY (OOPS!).

Add missing isTmpPair check.

* Source/JavaScriptCore/b3/air/AirCustom.cpp:
(JSC::B3::Air::CCallCustom::isValidForm):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19838fd733c95b066c53d260b48955257cdddb21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63724 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10331 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48504 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7228 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29348 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33232 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9025 "Found 2 new test failures: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9254 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/52901 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55162 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65454 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59052 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55844 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55984 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3105 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80810 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34966 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14025 "Found 1 new JSC stress test failure: stress/proxy-set.js.default (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36049 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->