### PR TITLE
Error in run-safari when build is unavailable is quite obtuse

### DIFF
--- a/Tools/Scripts/run-mangleme-tests
+++ b/Tools/Scripts/run-mangleme-tests
@@ -61,7 +61,7 @@ my $productDir = productDir();
 
 chdirWebKit();
 
-checkFrameworks();
+checkBuild();
 
 mkdir "WebKitBuild/mangleme";
 (system "/usr/bin/make", "-C", "Tools/mangleme") == 0 or die;

--- a/Tools/Scripts/run-pageloadtest
+++ b/Tools/Scripts/run-pageloadtest
@@ -67,7 +67,7 @@ my $safariExecutablePath = safariPath();
 my $safariResourcePath = File::Spec->catdir(dirname(dirname($safariExecutablePath)), "Resources");
 
 # Check to see that all the frameworks are built.
-checkFrameworks();
+checkBuild();
 
 chdirWebKit();
 

--- a/Tools/Scripts/run-qt-wpe-minibrowser
+++ b/Tools/Scripts/run-qt-wpe-minibrowser
@@ -51,7 +51,7 @@ my @command = (File::Spec->catfile(sourceDir(), "Tools", "Scripts", "run-qt-wpe-
 runInFlatpakIfAvailable(@command);
 
 # Check to see that all the frameworks are built.
-checkFrameworks();
+checkBuild();
 
 if (!inFlatpakSandbox()) {
     if ($productDir) {

--- a/Tools/Scripts/run-safari
+++ b/Tools/Scripts/run-safari
@@ -39,6 +39,6 @@ printHelpAndExitForRunAndDebugWebKitAppIfNeeded();
 setConfiguration();
 
 # Check to see that all the frameworks are built.
-checkFrameworks();
+checkBuild();
 
 exit exitStatus(runSafari());

--- a/Tools/Scripts/run-webkit-app
+++ b/Tools/Scripts/run-webkit-app
@@ -42,7 +42,7 @@ setUpGuardMallocIfNeeded();
 die "Did not specify an application to open (e.g. run-webkit-app AppName).\n" unless length($ARGV[0]) > 0;
 
 # Check to see that all the frameworks are built.
-checkFrameworks();
+checkBuild();
 
 my $appPath = shift(@ARGV);
 if (isIOSWebKit()) {


### PR DESCRIPTION
#### b9a1d40b83d224955402d7a49e2fb5e6c96fb32a
<pre>
Error in run-safari when build is unavailable is quite obtuse
<a href="https://bugs.webkit.org/show_bug.cgi?id=276968">https://bugs.webkit.org/show_bug.cgi?id=276968</a>

Reviewed by Elliott Williams.

- Adds an additional check to see if the build products directory for the
  specified configuration is available, and fails with a specific message
  if it is not.

- Adds information about the configuration being used with explanatory text
  about how that configuration got selected, when a build product is not
  available or a dylib couldn&apos;t be found.

- Adds a suggestion to run `build-webkit` as a next step.

New error experience looks like:

```
    &gt; Tools/Scripts/run-safari --release
    No build products could be found for specified build:
      configuration: &quot;Release&quot; [via argument, `--release`]
      products:      /Users/person/Code/WebKit/WebKitBuild/Release

    To build this configuration, use the command `Tools/Scripts/build-webkit --release`.

    Once that completes, re-run this command.
```

* Tools/Scripts/run-mangleme-tests:
* Tools/Scripts/run-pageloadtest:
* Tools/Scripts/run-qt-wpe-minibrowser:
* Tools/Scripts/run-safari:
* Tools/Scripts/run-webkit-app:
    Update for rename from checkFrameworks to checkBuild.

* Tools/Scripts/webkitdirs.pm:
(determineConfiguration):
(determineXcodeSDKPlatformName):
(determinePassedConfiguration):
(setConfiguration):
    Track how configuration and xcode platform got selected so
    it can be used in case of an error.
(scriptPathForName):
    Helper to get path for script name.
(launcherPath):
    Use new scriptPathForName() helper.
(debugSafari):
    Update for rename.
(checkBuild):
    Adds check for products directory existing and expands error text.

Canonical link: <a href="https://commits.webkit.org/281270@main">https://commits.webkit.org/281270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25c76472bebd92672c2f8fe756818f0f536d7450

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63196 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9725 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48158 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6934 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28980 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8564 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8729 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/52374 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54767 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64928 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58525 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8786 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55508 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3221 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55596 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13142 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2681 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80284 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34441 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13909 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35524 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36610 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->