### PR TITLE
Ensure unique preheaders for loops in B3

### DIFF
--- a/Source/JavaScriptCore/b3/B3EnsureLoopPreHeaders.cpp
+++ b/Source/JavaScriptCore/b3/B3EnsureLoopPreHeaders.cpp
@@ -25,6 +25,8 @@
 
 #include "config.h"
 #include "B3EnsureLoopPreHeaders.h"
+#include <wtf/BitVector.h>
+#include <wtf/IndexSet.h>
 
 #if ENABLE(B3_JIT)
 
@@ -40,34 +42,126 @@ bool ensureLoopPreHeaders(Procedure& proc)
     NaturalLoops& loops = proc.naturalLoops();
     
     BlockInsertionSet insertionSet(proc);
-    
+
+    // In order to ensure that every loop has a unique preheader, we first need
+    // to guarantee that every loop has a unique header. This involves finding
+    // headers shared by more than one loop and replacing the headers of outer
+    // loops with new blocks. These will generally become the preheaders of
+    // enclosed loops in the subsequent pass.
+
+    BitVector visitedLoops(loops.numLoops());
+    Vector<BasicBlock*, 4> inBodyPredecessors;
+
+    for (unsigned loopIndex = 0; loopIndex < loops.numLoops(); loopIndex ++) {
+        if (visitedLoops.contains(loopIndex))
+            continue;
+        visitedLoops.set(loopIndex);
+
+        const NaturalLoop& loop = loops.loop(loopIndex);
+        auto header = loop.header();
+
+        // If there are no enclosing loops other than the current one, we have
+        // no additional work to do.
+
+        auto enclosingLoops = loops.loopsOf(header);
+        if (enclosingLoops.size() == 1)
+            continue;
+
+        // Otherwise, we must have multiple loops - for each of these loops
+        // with the same header as the current one, create a new unique header
+        // and fix up its predecessors and successors. We'll use enclosedHeader
+        // to track the header block of the next innermost loop - this will be
+        // the successor of any new header we insert.
+
+        BasicBlock* enclosedHeader = nullptr;
+
+        // We also need to track the visited backedges because if multiple
+        // loops share a header, then predecessors of the header that are
+        // within the loop applies to not only the current loop's backedges,
+        // but the backedges of any loop contained within it. We use this set
+        // to remember which backedges belonged to inner loops, so we don't
+        // retarget them to the inserted headers of outer loops.
+
+        IndexSet<BasicBlock*> visitedBackedges;
+
+        for (auto enclosingLoop : enclosingLoops) {
+            if (enclosingLoop->header() != header)
+                break;
+            visitedLoops.set(enclosingLoop->index());
+
+            inBodyPredecessors.clear();
+            for (BasicBlock* predecessor : header->predecessors()) {
+                if (loops.belongsTo(predecessor, *enclosingLoop) && !visitedBackedges.contains(predecessor)) {
+                    inBodyPredecessors.append(predecessor);
+                    visitedBackedges.add(predecessor);
+                }
+            }
+
+            // For the innermost loop, we reuse the existing header, so we
+            // don't do anything other than visit our backedges and tell
+            // the outer loops what our header is.
+
+            if (enclosingLoop == enclosingLoops[0]) {
+                enclosedHeader = header;
+                continue;
+            }
+
+            BasicBlock* newHeader = insertionSet.insertBefore(header, header->frequency());
+            newHeader->appendNew<Value>(proc, Jump, enclosedHeader->at(0)->origin());
+            newHeader->setSuccessors(FrequentedBlock(enclosedHeader));
+
+            for (BasicBlock* predecessor : inBodyPredecessors) {
+                predecessor->replaceSuccessor(header, newHeader);
+                newHeader->addPredecessor(predecessor);
+                header->removePredecessor(predecessor);
+            }
+
+            enclosedHeader->addPredecessor(newHeader);
+
+            // Since we added a new header, we should tell other new headers to
+            // point to this new block, instead of creating more predecessors
+            // of the original header block.
+
+            enclosedHeader = newHeader;
+        }
+    }
+
+    bool uniqueHeadersChangedGraph = false;
+    if (insertionSet.execute()) {
+        proc.invalidateCFG();
+        uniqueHeadersChangedGraph = true;
+    }
+
+    // Now, we find or create unique preheaders for each loop.
+
     for (unsigned loopIndex = loops.numLoops(); loopIndex--;) {
         const NaturalLoop& loop = loops.loop(loopIndex);
-        
+        BasicBlock* header = loop.header();
+
         Vector<BasicBlock*, 4> outOfBodyPredecessors;
         double totalFrequency = 0;
-        for (BasicBlock* predecessor : loop.header()->predecessors()) {
+        for (BasicBlock* predecessor : header->predecessors()) {
             if (loops.belongsTo(predecessor, loop))
                 continue;
             
             outOfBodyPredecessors.append(predecessor);
             totalFrequency += predecessor->frequency();
         }
-        
+
         if (outOfBodyPredecessors.size() <= 1)
             continue;
         
-        BasicBlock* preHeader = insertionSet.insertBefore(loop.header(), totalFrequency);
-        preHeader->appendNew<Value>(proc, Jump, loop.header()->at(0)->origin());
-        preHeader->setSuccessors(FrequentedBlock(loop.header()));
+        BasicBlock* preHeader = insertionSet.insertBefore(header, totalFrequency);
+        preHeader->appendNew<Value>(proc, Jump, header->at(0)->origin());
+        preHeader->setSuccessors(FrequentedBlock(header));
         
         for (BasicBlock* predecessor : outOfBodyPredecessors) {
-            predecessor->replaceSuccessor(loop.header(), preHeader);
+            predecessor->replaceSuccessor(header, preHeader);
             preHeader->addPredecessor(predecessor);
-            loop.header()->removePredecessor(predecessor);
+            header->removePredecessor(predecessor);
         }
-        
-        loop.header()->addPredecessor(preHeader);
+
+        header->addPredecessor(preHeader);
     }
     
     if (insertionSet.execute()) {
@@ -75,7 +169,7 @@ bool ensureLoopPreHeaders(Procedure& proc)
         return true;
     }
     
-    return false;
+    return uniqueHeadersChangedGraph;
 }
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3EnsureLoopPreHeaders.h
+++ b/Source/JavaScriptCore/b3/B3EnsureLoopPreHeaders.h
@@ -31,9 +31,10 @@ namespace JSC { namespace B3 {
 
 class Procedure;
 
-// Creates a pre-header for any loop that don't already have one. A loop has a pre-header if its header has
-// exactly one predecessor that isn't in the loop body. If a loop header has more than one out-of-body
-// predecessor, then this creates a new block and rewires those predecessors to it.
+// Creates a unique pre-header for any loop that don't already have one. A loop has a pre-header if its
+// header has exactly one predecessor that isn't in the loop body. If a loop header has more than one
+// out-of-body predecessor, or if its current pre-header is already used by a contained loop, then this
+// creates a new block and rewires those predecessors to it.
 
 bool ensureLoopPreHeaders(Procedure&);
 


### PR DESCRIPTION
#### 59e96879235bad99712dce2eb9a532d61b93080f
<pre>
Ensure unique preheaders for loops in B3
<a href="https://bugs.webkit.org/show_bug.cgi?id=276970">https://bugs.webkit.org/show_bug.cgi?id=276970</a>
<a href="https://rdar.apple.com/problem/132338867">rdar://problem/132338867</a>

Reviewed by NOBODY (OOPS!).

Expands the ensureLoopPreHeaders phase of B3 to ensure that the
preheader of each natural loop is unique to that loop, in order to
avoid unnecessary dependencies when hoisting. This requires that
loops also have unique headers, so for each loop we iterate the
enclosing loops and create new headers if needed.

* Source/JavaScriptCore/b3/B3EnsureLoopPreHeaders.cpp:
(JSC::B3::ensureLoopPreHeaders):
* Source/JavaScriptCore/b3/B3EnsureLoopPreHeaders.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59e96879235bad99712dce2eb9a532d61b93080f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63220 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9749 "Hash 59e96879 for PR 31123 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48167 "Passed tests") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/9749 "Hash 59e96879 for PR 31123 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28989 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8583 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8753 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/52398 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64953 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58549 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3234 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8799 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55517 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55606 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2697 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80308 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34465 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13913 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35548 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36634 "Hash 59e96879 for PR 31123 does not build (failure)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->