### PR TITLE
[WebAuthn] Fully form largeBlob before setting on ASAuthorizationPlatformPublicKeyCredentialAssertion.

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -413,9 +413,10 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForAssertion(const 
             ASSERT(!options.extensions->largeBlob->support);
             ASSERT(!(options.extensions->largeBlob->read && options.extensions->largeBlob->write));
             auto largeBlob = options.extensions->largeBlob;
-            request.get().largeBlob = adoptNS([allocASAuthorizationPublicKeyCredentialLargeBlobAssertionInputInstance() initWithOperation:(largeBlob->read && *largeBlob->read) ? ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperationRead : ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperationWrite]).get();
+            RetainPtr asLargeBlob = adoptNS([allocASAuthorizationPublicKeyCredentialLargeBlobAssertionInputInstance() initWithOperation:(largeBlob->read && *largeBlob->read) ? ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperationRead : ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperationWrite]);
             if (largeBlob->write)
-                request.get().largeBlob.dataToWrite = WebCore::toNSData(*largeBlob->write).get();
+                asLargeBlob.get().dataToWrite = WebCore::toNSData(*largeBlob->write).get();
+            request.get().largeBlob = asLargeBlob.get();
         }
 
         request.get().userVerificationPreference = toASUserVerificationPreference(options.userVerification).get();


### PR DESCRIPTION
#### 7ab47afe1deadce14c18851f5d23eaf1cdd9a1b2
<pre>
[WebAuthn] Fully form largeBlob before setting on ASAuthorizationPlatformPublicKeyCredentialAssertion.
<a href="https://rdar.apple.com/132344331">rdar://132344331</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=276961">https://bugs.webkit.org/show_bug.cgi?id=276961</a>

Reviewed by Aditya Keerthi.

Setting the member largeBlob on ASAuthorizationPlatformPublicKeyCredentialAssertion relies on the
ASAuthorizationPublicKeyCredentialLargeBlobAssertionInput being fully formed by the time setLargeBlob
is called. The dataToWrite member must already be set by the time setLargeBlob is called, so we first
fully construct the ASAuthorizationPublicKeyCredentialLargeBlobAssertionInput before setting it on the
request.

* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForAssertion):

Canonical link: <a href="https://commits.webkit.org/281310@main">https://commits.webkit.org/281310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35de64940859107632efa076110cad6e2dbc427b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63222 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9751 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48168 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6941 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36112 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28990 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32823 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8755 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64955 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8801 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55518 "Found 1 new test failure: webgl/2.0.0/conformance/canvas/rapid-resizing.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55616 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2695 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80310 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34467 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/80310 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35550 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->