### PR TITLE
Avoid calling recursiveUpdateLayerPositions for subtrees that have no visible content.

### DIFF
--- a/LayoutTests/compositing/contents-opaque/hidden-with-visible-text-expected.txt
+++ b/LayoutTests/compositing/contents-opaque/hidden-with-visible-text-expected.txt
@@ -8,13 +8,8 @@
       (children 1
         (GraphicsLayer
           (position 8.00 13.00)
-          (preserves3D 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 200.00 100.00)
-              (contentsVisible 0)
-            )
-          )
+          (bounds 200.00 100.00)
+          (contentsVisible 0)
         )
       )
     )

--- a/LayoutTests/compositing/contents-opaque/visibility-hidden-expected.txt
+++ b/LayoutTests/compositing/contents-opaque/visibility-hidden-expected.txt
@@ -7,7 +7,6 @@
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (position 8.00 20.00)
           (bounds 200.00 50.00)
           (contentsVisible 0)
         )

--- a/LayoutTests/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
+++ b/LayoutTests/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
@@ -29,8 +29,8 @@ layer at (0,0) size 800x424
       RenderBlock {PRE} at (0,413) size 784x0
 layer at (18,10) size 764x144
   RenderBlock (relative positioned) {DIV} at (10,0) size 764x144
-layer at (38,30) size 100x100
+layer at (18,10) size 0x0
   RenderImage {IMG} at (20,20) size 100x100
-layer at (38,184) size 100x100
+layer at (0,0) size 0x0
   RenderImage {IMG} at (20,20) size 100x100
 

--- a/LayoutTests/css3/filters/backdrop/backdrop-with-visibility-hidden-expected.txt
+++ b/LayoutTests/css3/filters/backdrop/backdrop-with-visibility-hidden-expected.txt
@@ -7,11 +7,10 @@
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (position 0.00 150.00)
           (bounds 402.00 52.00)
           (contentsVisible 0)
           (structural layer
-            (position 201.00 176.00)
+            (position 201.00 26.00)
             (bounds 402.00 52.00)
           )
           (backdrop layer

--- a/LayoutTests/fast/repaint/incorrect-repaint-when-child-layer-overflows-expected.txt
+++ b/LayoutTests/fast/repaint/incorrect-repaint-when-child-layer-overflows-expected.txt
@@ -1,5 +1,6 @@
 (repaint rects
   (rect 0 0 200 200)
   (rect 0 0 50 50)
+  (rect 0 0 200 200)
 )
 

--- a/LayoutTests/platform/glib/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
+++ b/LayoutTests/platform/glib/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
@@ -29,8 +29,8 @@ layer at (0,0) size 800x422
       RenderBlock {PRE} at (0,411) size 784x0
 layer at (18,10) size 764x144
   RenderBlock (relative positioned) {DIV} at (10,0) size 764x144
-layer at (38,30) size 100x100
+layer at (18,10) size 0x0
   RenderImage {IMG} at (20,20) size 100x100
-layer at (38,184) size 100x100
+layer at (0,0) size 0x0
   RenderImage {IMG} at (20,20) size 100x100
 

--- a/LayoutTests/platform/glib/css3/filters/backdrop/backdrop-with-visibility-hidden-expected.txt
+++ b/LayoutTests/platform/glib/css3/filters/backdrop/backdrop-with-visibility-hidden-expected.txt
@@ -7,7 +7,6 @@
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (position 0.00 150.00)
           (bounds 402.00 52.00)
           (contentsVisible 0)
           (backdrop layer 0.00, 0.00 402.00 x 52.00 hidden)

--- a/LayoutTests/platform/glib/fast/overflow/hidden-scrollbar-resize-expected.txt
+++ b/LayoutTests/platform/glib/fast/overflow/hidden-scrollbar-resize-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 623x17
           text run at (0,0) width 623: "This tests that the scrollbar and resize corner are not visible on an element that has visibility:hidden."
-layer at (8,26) size 50x70 clip at (8,26) size 35x55 scrollWidth 42 scrollHeight 108
+layer at (0,0) size 0x0 scrollWidth 42 scrollHeight 108
   RenderBlock {DIV} at (0,18) size 50x70
     RenderText {#text} at (0,0) size 42x107
       text run at (0,0) width 27: "You"

--- a/LayoutTests/platform/ios/compositing/visibility/visibility-composited-expected.txt
+++ b/LayoutTests/platform/ios/compositing/visibility/visibility-composited-expected.txt
@@ -13,9 +13,9 @@ layer at (8,8) size 100x300
     RenderBlock {DIV} at (0,0) size 100x100
     RenderBlock {DIV} at (0,100) size 100x100
     RenderBlock {DIV} at (0,200) size 100x100
-layer at (8,8) size 100x100
+layer at (8,8) size 0x0
   RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#FF0000]
-layer at (8,108) size 100x100
+layer at (8,8) size 0x0
   RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#FF0000]
 layer at (8,208) size 100x100
   RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#008000]

--- a/LayoutTests/platform/ios/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
+++ b/LayoutTests/platform/ios/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
@@ -29,8 +29,8 @@ layer at (0,0) size 800x430
       RenderBlock {PRE} at (0,419) size 784x0
 layer at (18,10) size 764x145
   RenderBlock (relative positioned) {DIV} at (10,0) size 764x145
-layer at (38,30) size 100x100
+layer at (18,10) size 0x0
   RenderImage {IMG} at (20,20) size 100x100
-layer at (38,185) size 100x100
+layer at (0,0) size 0x0
   RenderImage {IMG} at (20,20) size 100x100
 

--- a/LayoutTests/platform/ios/compositing/visibility/visibility-image-layers-dynamic-expected.txt
+++ b/LayoutTests/platform/ios/compositing/visibility/visibility-image-layers-dynamic-expected.txt
@@ -16,7 +16,6 @@ Initial
           (bounds 764.00 145.00)
           (children 1
             (GraphicsLayer
-              (position 20.00 20.00)
               (bounds 100.00 100.00)
               (drawsContent 1)
               (contentsVisible 0)
@@ -25,12 +24,12 @@ Initial
         )
         (GraphicsLayer
           (offsetFromRenderer width=-4 height=-4)
-          (position 14.00 161.00)
+          (position -4.00 -4.00)
           (bounds 772.00 153.00)
           (contentsVisible 0)
           (children 1
             (GraphicsLayer
-              (position 24.00 24.00)
+              (position 4.00 4.00)
               (bounds 100.00 100.00)
               (drawsContent 1)
               (contentsVisible 0)
@@ -58,10 +57,10 @@ After step 1
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 800.00 1369.00)
+  (bounds 800.00 1355.00)
   (children 1
     (GraphicsLayer
-      (bounds 800.00 1369.00)
+      (bounds 800.00 1355.00)
       (contentsOpaque 1)
       (children 3
         (GraphicsLayer
@@ -77,12 +76,12 @@ After step 1
         )
         (GraphicsLayer
           (offsetFromRenderer width=-4 height=-4)
-          (position 14.00 161.00)
+          (position -4.00 4.00)
           (bounds 772.00 153.00)
           (contentsVisible 0)
           (children 1
             (GraphicsLayer
-              (position 24.00 24.00)
+              (position 4.00 4.00)
               (bounds 100.00 100.00)
               (drawsContent 1)
               (contentsVisible 0)
@@ -110,10 +109,10 @@ After step 2
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 800.00 2088.00)
+  (bounds 800.00 2074.00)
   (children 1
     (GraphicsLayer
-      (bounds 800.00 2088.00)
+      (bounds 800.00 2074.00)
       (contentsOpaque 1)
       (children 3
         (GraphicsLayer

--- a/LayoutTests/platform/ios/fast/overflow/hidden-scrollbar-resize-expected.txt
+++ b/LayoutTests/platform/ios/fast/overflow/hidden-scrollbar-resize-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x20
         RenderText {#text} at (0,0) size 641x19
           text run at (0,0) width 641: "This tests that the scrollbar and resize corner are not visible on an element that has visibility:hidden."
-layer at (8,28) size 50x70 clip at (8,28) size 35x55 scrollWidth 43 scrollHeight 120
+layer at (0,0) size 0x0 scrollWidth 43 scrollHeight 120
   RenderBlock {DIV} at (0,20) size 50x70
     RenderText {#text} at (0,0) size 43x119
       text run at (0,0) width 26: "You"

--- a/LayoutTests/platform/mac-ventura-wk2/compositing/visibility/visibility-image-layers-dynamic-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk2/compositing/visibility/visibility-image-layers-dynamic-expected.txt
@@ -17,7 +17,6 @@ Initial
           (bounds 749.00 144.00)
           (children 1
             (GraphicsLayer
-              (position 20.00 20.00)
               (bounds 100.00 100.00)
               (contentsVisible 0)
             )
@@ -25,13 +24,13 @@ Initial
         )
         (GraphicsLayer
           (offsetFromRenderer width=-4 height=-4)
-          (position 14.00 160.00)
+          (position -4.00 -4.00)
           (anchor 0.50 0.50)
           (bounds 757.00 152.00)
           (contentsVisible 0)
           (children 1
             (GraphicsLayer
-              (position 24.00 24.00)
+              (position 4.00 4.00)
               (bounds 100.00 100.00)
               (contentsVisible 0)
             )
@@ -58,10 +57,10 @@ After step 1
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 785.00 1411.00)
+  (bounds 785.00 1396.00)
   (children 1
     (GraphicsLayer
-      (bounds 785.00 1411.00)
+      (bounds 785.00 1396.00)
       (contentsOpaque 1)
       (children 3
         (GraphicsLayer
@@ -77,13 +76,13 @@ After step 1
         )
         (GraphicsLayer
           (offsetFromRenderer width=-4 height=-4)
-          (position 14.00 160.00)
+          (position -4.00 -4.00)
           (anchor 0.50 0.50)
           (bounds 757.00 152.00)
           (contentsVisible 0)
           (children 1
             (GraphicsLayer
-              (position 24.00 24.00)
+              (position 4.00 4.00)
               (bounds 100.00 100.00)
               (contentsVisible 0)
             )
@@ -110,10 +109,10 @@ After step 2
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 785.00 2180.00)
+  (bounds 785.00 2165.00)
   (children 1
     (GraphicsLayer
-      (bounds 785.00 2180.00)
+      (bounds 785.00 2165.00)
       (contentsOpaque 1)
       (children 3
         (GraphicsLayer

--- a/LayoutTests/platform/mac-wk2/compositing/visibility/visibility-image-layers-dynamic-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/visibility/visibility-image-layers-dynamic-expected.txt
@@ -17,7 +17,6 @@ Initial
           (bounds 749.00 144.00)
           (children 1
             (GraphicsLayer
-              (position 20.00 20.00)
               (bounds 100.00 100.00)
               (drawsContent 1)
               (contentsVisible 0)
@@ -26,13 +25,13 @@ Initial
         )
         (GraphicsLayer
           (offsetFromRenderer width=-4 height=-4)
-          (position 14.00 160.00)
+          (position -4.00 -4.00)
           (anchor 0.50 0.50)
           (bounds 757.00 152.00)
           (contentsVisible 0)
           (children 1
             (GraphicsLayer
-              (position 24.00 24.00)
+              (position 4.00 4.00)
               (bounds 100.00 100.00)
               (drawsContent 1)
               (contentsVisible 0)
@@ -61,10 +60,10 @@ After step 1
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 785.00 1456.00)
+  (bounds 785.00 1441.00)
   (children 1
     (GraphicsLayer
-      (bounds 785.00 1456.00)
+      (bounds 785.00 1441.00)
       (contentsOpaque 1)
       (children 3
         (GraphicsLayer
@@ -81,13 +80,13 @@ After step 1
         )
         (GraphicsLayer
           (offsetFromRenderer width=-4 height=-4)
-          (position 14.00 160.00)
+          (position -4.00 -4.00)
           (anchor 0.50 0.50)
           (bounds 757.00 152.00)
           (contentsVisible 0)
           (children 1
             (GraphicsLayer
-              (position 24.00 24.00)
+              (position 4.00 4.00)
               (bounds 100.00 100.00)
               (drawsContent 1)
               (contentsVisible 0)
@@ -116,10 +115,10 @@ After step 2
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 785.00 2270.00)
+  (bounds 785.00 2255.00)
   (children 1
     (GraphicsLayer
-      (bounds 785.00 2270.00)
+      (bounds 785.00 2255.00)
       (contentsOpaque 1)
       (children 3
         (GraphicsLayer

--- a/LayoutTests/platform/mac/compositing/visibility/visibility-composited-expected.txt
+++ b/LayoutTests/platform/mac/compositing/visibility/visibility-composited-expected.txt
@@ -13,9 +13,9 @@ layer at (8,8) size 100x300
     RenderBlock {DIV} at (0,0) size 100x100
     RenderBlock {DIV} at (0,100) size 100x100
     RenderBlock {DIV} at (0,200) size 100x100
-layer at (8,8) size 100x100
+layer at (8,8) size 0x0
   RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#FF0000]
-layer at (8,108) size 100x100
+layer at (8,8) size 0x0
   RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#FF0000]
 layer at (8,208) size 100x100
   RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#008000]

--- a/LayoutTests/platform/mac/compositing/visibility/visibility-image-layers-dynamic-expected.txt
+++ b/LayoutTests/platform/mac/compositing/visibility/visibility-image-layers-dynamic-expected.txt
@@ -17,7 +17,6 @@ Initial
           (bounds 749.00 144.00)
           (children 1
             (GraphicsLayer
-              (position 20.00 20.00)
               (bounds 100.00 100.00)
               (contentsVisible 0)
             )
@@ -25,13 +24,13 @@ Initial
         )
         (GraphicsLayer
           (offsetFromRenderer width=-4 height=-4)
-          (position 14.00 160.00)
+          (position -4.00 -4.00)
           (anchor 0.50 0.50)
           (bounds 757.00 152.00)
           (contentsVisible 0)
           (children 1
             (GraphicsLayer
-              (position 24.00 24.00)
+              (position 4.00 4.00)
               (bounds 100.00 100.00)
               (contentsVisible 0)
             )
@@ -58,10 +57,10 @@ After step 1
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 785.00 1411.00)
+  (bounds 785.00 1396.00)
   (children 1
     (GraphicsLayer
-      (bounds 785.00 1411.00)
+      (bounds 785.00 1396.00)
       (contentsOpaque 1)
       (children 3
         (GraphicsLayer
@@ -77,13 +76,13 @@ After step 1
         )
         (GraphicsLayer
           (offsetFromRenderer width=-4 height=-4)
-          (position 14.00 160.00)
+          (position -4.00 -4.00)
           (anchor 0.50 0.50)
           (bounds 757.00 152.00)
           (contentsVisible 0)
           (children 1
             (GraphicsLayer
-              (position 24.00 24.00)
+              (position 4.00 4.00)
               (bounds 100.00 100.00)
               (contentsVisible 0)
             )
@@ -110,10 +109,10 @@ After step 2
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 785.00 2180.00)
+  (bounds 785.00 2165.00)
   (children 1
     (GraphicsLayer
-      (bounds 785.00 2180.00)
+      (bounds 785.00 2165.00)
       (contentsOpaque 1)
       (children 3
         (GraphicsLayer

--- a/LayoutTests/platform/mac/fast/overflow/hidden-scrollbar-resize-expected.txt
+++ b/LayoutTests/platform/mac/fast/overflow/hidden-scrollbar-resize-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 641x18
           text run at (0,0) width 641: "This tests that the scrollbar and resize corner are not visible on an element that has visibility:hidden."
-layer at (8,26) size 50x70 clip at (8,26) size 35x55 scrollWidth 43 scrollHeight 108
+layer at (0,0) size 0x0 scrollWidth 43 scrollHeight 108
   RenderBlock {DIV} at (0,18) size 50x70
     RenderText {#text} at (0,0) size 43x108
       text run at (0,0) width 26: "You"

--- a/LayoutTests/platform/win/compositing/visibility/visibility-composited-expected.txt
+++ b/LayoutTests/platform/win/compositing/visibility/visibility-composited-expected.txt
@@ -13,9 +13,9 @@ layer at (8,8) size 100x300
     RenderBlock {DIV} at (0,0) size 100x100
     RenderBlock {DIV} at (0,100) size 100x100
     RenderBlock {DIV} at (0,200) size 100x100
-layer at (8,8) size 100x100
+layer at (8,8) size 0x0
   RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#FF0000]
-layer at (8,108) size 100x100
+layer at (8,8) size 0x0
   RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#FF0000]
 layer at (8,208) size 100x100
   RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#008000]

--- a/LayoutTests/platform/win/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
+++ b/LayoutTests/platform/win/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
@@ -29,8 +29,8 @@ layer at (0,0) size 800x422
       RenderBlock {PRE} at (0,411) size 784x0
 layer at (18,10) size 764x144
   RenderBlock (relative positioned) {DIV} at (10,0) size 764x144
-layer at (38,30) size 100x100
+layer at (18,10) size 0x0
   RenderImage {IMG} at (20,20) size 100x100
-layer at (38,184) size 100x100
+layer at (0,0) size 0x0
   RenderImage {IMG} at (20,20) size 100x100
 

--- a/LayoutTests/platform/wpe/compositing/visibility/visibility-composited-expected.txt
+++ b/LayoutTests/platform/wpe/compositing/visibility/visibility-composited-expected.txt
@@ -13,9 +13,9 @@ layer at (8,8) size 100x300
     RenderBlock {DIV} at (0,0) size 100x100
     RenderBlock {DIV} at (0,100) size 100x100
     RenderBlock {DIV} at (0,200) size 100x100
-layer at (8,8) size 100x100
+layer at (8,8) size 0x0
   RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#FF0000]
-layer at (8,108) size 100x100
+layer at (8,8) size 0x0
   RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#FF0000]
 layer at (8,208) size 100x100
   RenderBlock {DIV} at (0,0) size 100x100 [bgcolor=#008000]

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -131,6 +131,7 @@ public:
 
     bool hasPendingUpdateLayerPositions() const;
     void flushUpdateLayerPositions();
+    void scheduleUpdateLayerPositions();
 
     WEBCORE_EXPORT bool didFirstLayout() const;
 
@@ -1026,22 +1027,12 @@ private:
     std::unique_ptr<SingleThreadWeakHashSet<RenderLayerModelObject>> m_viewportConstrainedObjects;
 
     struct UpdateLayerPositions {
-        bool merge(const UpdateLayerPositions& other)
-        {
-            // FIXME: If one is an ancestor of the other we can also probably combine them.
-            if (layoutRoot != other.layoutRoot)
-                return false;
-
-            needsFullRepaint |= other.needsFullRepaint;
-            if (!other.didRunSimplifiedLayout)
-                didRunSimplifiedLayout = false;
-            return true;
-        }
+        void merge(const UpdateLayerPositions& other);
 
         SingleThreadWeakPtr<RenderElement> layoutRoot;
         RenderElement::LayoutIdentifier layoutIdentifier : 12 { 0 };
         bool needsFullRepaint { false };
-        bool didRunSimplifiedLayout { true };
+        bool didRunSimplifiedLayout { false };
     };
     std::optional<UpdateLayerPositions> m_pendingUpdateLayerPositions;
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -880,6 +880,11 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
         if (wasVisible != willBeVisible) {
             if (CheckedPtr layer = enclosingLayer()) {
                 if (willBeVisible) {
+                    // Visibility changes don't trigger layout, but layer positions won't have been updated within hidden
+                    // subtrees, so ensure that there's an update scheduled if this newly became visible.
+                    if (!layer->hasVisibleContent())
+                        view().protectedFrameView()->scheduleUpdateLayerPositions();
+
                     if (m_style.hasSkippedContent() && isSkippedContentRoot())
                         layer->dirtyVisibleContentStatus();
                     else

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -992,6 +992,12 @@ void RenderLayer::updateLayerPositionsAfterLayout(RenderElement::LayoutIdentifie
 
 void RenderLayer::recursiveUpdateLayerPositions(RenderElement::LayoutIdentifier layoutIdentifier, OptionSet<UpdateLayerPositionsFlag> flags, CanUseSimplifiedRepaintPass canUseSimplifiedRepaintPass)
 {
+    updateDescendantDependentFlags();
+    if (!m_hasVisibleDescendant && !m_hasVisibleContent && !m_hasSkippedContentDescendant && !m_hasSkippedContent) {
+        clearRepaintRects();
+        return;
+    }
+
     updateLayerPosition(&flags);
     if (m_scrollableArea)
         m_scrollableArea->applyPostLayoutScrollPositionIfNeeded();
@@ -1005,8 +1011,6 @@ void RenderLayer::recursiveUpdateLayerPositions(RenderElement::LayoutIdentifier 
         auto offsetFromRoot = offsetFromAncestor(root());
         m_scrollableArea->positionOverflowControls(roundedIntSize(offsetFromRoot));
     }
-
-    updateDescendantDependentFlags();
 
     if (flags & UpdatePagination)
         updatePagination();
@@ -1626,6 +1630,7 @@ void RenderLayer::updateDescendantDependentFlags()
         bool hasSelfPaintingLayerDescendant = false;
         bool hasNotIsolatedBlendingDescendants = false;
         bool hasIntrinsicallyCompositedDescendants = false;
+        bool hasSkippedContentDescendant = false;
 
         auto firstLayerChild = [&] () -> RenderLayer* {
             if (renderer().isSkippedContentRoot())
@@ -1636,6 +1641,7 @@ void RenderLayer::updateDescendantDependentFlags()
             child->updateDescendantDependentFlags();
 
             hasVisibleDescendant |= child->m_hasVisibleContent || child->m_hasVisibleDescendant;
+            hasSkippedContentDescendant |= child->m_hasSkippedContent;
             hasSelfPaintingLayerDescendant |= child->isSelfPaintingLayer() || child->hasSelfPaintingLayerDescendant();
             hasNotIsolatedBlendingDescendants |= child->hasBlendMode() || (child->hasNotIsolatedBlendingDescendants() && !child->isolatesBlending());
             hasIntrinsicallyCompositedDescendants |= child->isIntrinsicallyComposited() || child->m_hasIntrinsicallyCompositedDescendants;
@@ -1647,6 +1653,7 @@ void RenderLayer::updateDescendantDependentFlags()
         }
 
         m_hasVisibleDescendant = hasVisibleDescendant;
+        m_hasSkippedContentDescendant = hasSkippedContentDescendant;
         m_visibleDescendantStatusDirty = false;
         m_hasSelfPaintingLayerDescendant = hasSelfPaintingLayerDescendant;
         m_hasSelfPaintingLayerDescendantDirty = false;
@@ -5550,6 +5557,11 @@ void RenderLayer::styleChanged(StyleDifference diff, const RenderStyle* oldStyle
             if (visibilityChanged || oldStyle->isOverflowVisible() != renderer().style().isOverflowVisible())
                 m_scrollableArea->computeHasCompositedScrollableOverflow(diff <= StyleDifference::RepaintLayer ? LayoutUpToDate::Yes : LayoutUpToDate::No);
         }
+    }
+
+    if (m_hasSkippedContent != renderer().style().hasSkippedContent()) {
+        m_hasSkippedContent = renderer().style().hasSkippedContent();
+        dirtyAncestorChainVisibleDescendantStatus();
     }
 
     if (m_scrollableArea) {

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1276,6 +1276,9 @@ private:
     bool m_hasIntrinsicallyCompositedDescendants : 1;
     bool m_hasIntrinsicallyCompositedDescendantsStatusDirty : 1;
 
+    bool m_hasSkippedContent : 1 { false };
+    bool m_hasSkippedContentDescendant : 1 { false };
+
     RenderLayerModelObject& m_renderer;
 
     RenderLayer* m_parent { nullptr };


### PR DESCRIPTION
#### 273c51835481bff8b30856d4765d99bf072b819d
<pre>
Avoid calling recursiveUpdateLayerPositions for subtrees that have no visible content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276973">https://bugs.webkit.org/show_bug.cgi?id=276973</a>
&lt;<a href="https://rdar.apple.com/132355228">rdar://132355228</a>&gt;

Reviewed by NOBODY (OOPS!).

Subtrees of the RenderLayer tree that are entirely hidden by visibility:hidden
don&apos;t paint or hit-test, so we should be able to avoid updating the layer
positions every layout and defer it until they get made visible.

This is already the case for recursiveUpdateLayerPositionsAfterScroll, so this
change extends it for the post-layout version.

Changes to visibility don&apos;t trigger layout (which would implicitly update layer
positions), so we also need to explictly request the layer position update when
a layer newly becomes visible.

* LayoutTests/compositing/contents-opaque/hidden-with-visible-text-expected.txt:
* LayoutTests/compositing/contents-opaque/visibility-hidden-expected.txt:
* LayoutTests/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt:
* LayoutTests/css3/filters/backdrop/backdrop-with-visibility-hidden-expected.txt:
* LayoutTests/fast/repaint/incorrect-repaint-when-child-layer-overflows-expected.txt:
* LayoutTests/platform/glib/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt:
* LayoutTests/platform/glib/css3/filters/backdrop/backdrop-with-visibility-hidden-expected.txt:
* LayoutTests/platform/glib/fast/overflow/hidden-scrollbar-resize-expected.txt:
* LayoutTests/platform/ios/compositing/visibility/visibility-composited-expected.txt:
* LayoutTests/platform/ios/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt:
* LayoutTests/platform/ios/compositing/visibility/visibility-image-layers-dynamic-expected.txt:
* LayoutTests/platform/ios/fast/overflow/hidden-scrollbar-resize-expected.txt:
* LayoutTests/platform/mac-ventura-wk2/compositing/visibility/visibility-image-layers-dynamic-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/visibility/visibility-image-layers-dynamic-expected.txt:
* LayoutTests/platform/mac/compositing/visibility/visibility-composited-expected.txt:
* LayoutTests/platform/mac/compositing/visibility/visibility-image-layers-dynamic-expected.txt:
* LayoutTests/platform/mac/fast/overflow/hidden-scrollbar-resize-expected.txt:
* LayoutTests/platform/win/compositing/visibility/visibility-composited-expected.txt:
* LayoutTests/platform/win/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt:
* LayoutTests/platform/wpe/compositing/visibility/visibility-composited-expected.txt:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::UpdateLayerPositions::merge):
(WebCore::LocalFrameView::scheduleUpdateLayerPositions):
(WebCore::LocalFrameView::didLayout):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleWillChange):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::recursiveUpdateLayerPositions):
(WebCore::RenderLayer::updateDescendantDependentFlags):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/273c51835481bff8b30856d4765d99bf072b819d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63475 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10083 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48330 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7060 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61590 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36319 "Found 1 new test failure: compositing/visibility/visibility-image-layers-dynamic.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29165 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8813 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9007 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54971 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65207 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3488 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8981 "Found 1 new test failure: http/tests/media/media-element-frame-destroyed-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55670 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55790 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2897 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34719 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35802 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->