### PR TITLE
Add Take Observable operator

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-take.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-take.any-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL take(): Takes the first N values from the source observable, then completes source.take is not a function. (In 'source.take(2)', 'source.take' is undefined)
-FAIL take(): Forwards complete()s that happen before the take count is met, and unsubscribes from source Observable source.take is not a function. (In 'source.take(5)', 'source.take' is undefined)
-FAIL take(): Should forward errors from the source observable source.take is not a function. (In 'source.take(100)', 'source.take' is undefined)
-FAIL take(): take(0) should not subscribe to the source observable, and should return an observable that immediately completes source.take is not a function. (In 'source.take(0)', 'source.take' is undefined)
-FAIL take(): Negative count is treated as maximum value source.take is not a function. (In 'source.take(-1)', 'source.take' is undefined)
+PASS take(): Takes the first N values from the source observable, then completes
+PASS take(): Forwards complete()s that happen before the take count is met, and unsubscribes from source Observable
+PASS take(): Should forward errors from the source observable
+PASS take(): take(0) should not subscribe to the source observable, and should return an observable that immediately completes
+PASS take(): Negative count is treated as maximum value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-take.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-take.any.worker-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL take(): Takes the first N values from the source observable, then completes source.take is not a function. (In 'source.take(2)', 'source.take' is undefined)
-FAIL take(): Forwards complete()s that happen before the take count is met, and unsubscribes from source Observable source.take is not a function. (In 'source.take(5)', 'source.take' is undefined)
-FAIL take(): Should forward errors from the source observable source.take is not a function. (In 'source.take(100)', 'source.take' is undefined)
-FAIL take(): take(0) should not subscribe to the source observable, and should return an observable that immediately completes source.take is not a function. (In 'source.take(0)', 'source.take' is undefined)
-FAIL take(): Negative count is treated as maximum value source.take is not a function. (In 'source.take(-1)', 'source.take' is undefined)
+PASS take(): Takes the first N values from the source observable, then completes
+PASS take(): Forwards complete()s that happen before the take count is met, and unsubscribes from source Observable
+PASS take(): Should forward errors from the source observable
+PASS take(): take(0) should not subscribe to the source observable, and should return an observable that immediately completes
+PASS take(): Negative count is treated as maximum value
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1178,6 +1178,7 @@ dom/InlineStyleSheetOwner.cpp
 dom/InputEvent.cpp
 dom/InternalObserver.cpp
 dom/InternalObserverFromScript.cpp
+dom/InternalObserverTake.cpp
 dom/KeyboardEvent.cpp
 dom/LiveNodeList.cpp
 dom/LoadableClassicScript.cpp

--- a/Source/WebCore/bindings/js/JSSubscriberCustom.cpp
+++ b/Source/WebCore/bindings/js/JSSubscriberCustom.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "JSSubscriber.h"
 
+#include "VoidCallback.h"
+
 namespace WebCore {
 
 template<typename Visitor>

--- a/Source/WebCore/dom/InternalObserverFromScript.cpp
+++ b/Source/WebCore/dom/InternalObserverFromScript.cpp
@@ -27,6 +27,7 @@
 #include "InternalObserverFromScript.h"
 
 #include "JSSubscriptionObserverCallback.h"
+#include "ScriptExecutionContext.h"
 #include "SubscriptionObserver.h"
 
 namespace WebCore {

--- a/Source/WebCore/dom/InternalObserverTake.cpp
+++ b/Source/WebCore/dom/InternalObserverTake.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InternalObserverTake.h"
+
+#include "InternalObserver.h"
+#include "Observable.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include "Subscriber.h"
+#include "SubscriberCallback.h"
+
+namespace WebCore {
+
+class InternalObserverTake final : public InternalObserver {
+public:
+    static Ref<InternalObserverTake> create(ScriptExecutionContext& context, Ref<Subscriber> subscriber, uint64_t amount)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverTake(context, subscriber, amount));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+    class SubscriberCallbackTake final : public SubscriberCallback {
+    public:
+        static Ref<SubscriberCallbackTake> create(ScriptExecutionContext& context, Ref<Observable> source, uint64_t amount)
+        {
+            return adoptRef(*new InternalObserverTake::SubscriberCallbackTake(context, source, amount));
+        }
+
+        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        {
+            auto context = scriptExecutionContext();
+
+            if (!context || !m_amount) {
+                subscriber.complete();
+                return { };
+            }
+
+            SubscribeOptions options;
+            options.signal = &subscriber.signal();
+            m_sourceObservable->subscribeInternal(*context, InternalObserverTake::create(*context, subscriber, m_amount), options);
+
+            return { };
+        }
+
+    private:
+        Ref<Observable> m_sourceObservable;
+        uint64_t m_amount;
+
+        SubscriberCallbackTake(ScriptExecutionContext& context, Ref<Observable> source, uint64_t amount)
+            : SubscriberCallback(&context)
+            , m_sourceObservable(source)
+            , m_amount(amount)
+        { }
+
+        bool hasCallback() const final { return true; }
+    };
+
+private:
+    Ref<Subscriber> m_subscriber;
+    uint64_t m_amount;
+
+    void next(JSC::JSValue value) final
+    {
+        if (!m_amount)
+            return;
+
+        m_subscriber->next(value);
+        m_amount -= 1;
+        if (!m_amount)
+            m_subscriber->complete();
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        m_subscriber->error(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+        m_subscriber->complete();
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    {
+        m_subscriber->visitAdditionalChildren(visitor);
+    }
+
+    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
+    {
+        m_subscriber->visitAdditionalChildren(visitor);
+    }
+
+    InternalObserverTake(ScriptExecutionContext& context, Ref<Subscriber> subscriber, uint64_t amount)
+        : InternalObserver(context)
+        , m_subscriber(subscriber)
+        , m_amount(amount)
+    { }
+
+};
+
+Ref<SubscriberCallback> createSubscriberCallbackTake(ScriptExecutionContext& context, Ref<Observable> observable, uint64_t amount)
+{
+    return InternalObserverTake::SubscriberCallbackTake::create(context, observable, amount);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverTake.h
+++ b/Source/WebCore/dom/InternalObserverTake.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class Observable;
+class ScriptExecutionContext;
+class SubscriberCallback;
+
+Ref<SubscriberCallback> createSubscriberCallbackTake(ScriptExecutionContext&, Ref<Observable>, uint64_t);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -31,6 +31,7 @@
 #include "Exception.h"
 #include "ExceptionCode.h"
 #include "InternalObserverFromScript.h"
+#include "InternalObserverTake.h"
 #include "JSSubscriptionObserverCallback.h"
 #include "SubscribeOptions.h"
 #include "Subscriber.h"
@@ -42,7 +43,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(Observable);
 
-ExceptionOr<Ref<Observable>> Observable::create(Ref<SubscriberCallback> callback)
+Ref<Observable> Observable::create(Ref<SubscriberCallback> callback)
 {
     return adoptRef(*new Observable(callback));
 }
@@ -91,6 +92,11 @@ void Observable::subscribeInternal(ScriptExecutionContext& context, Ref<Internal
             subscriber->error(previousException->value());
         }
     }
+}
+
+Ref<Observable> Observable::take(ScriptExecutionContext& context, uint64_t amount)
+{
+    return create(createSubscriberCallbackTake(context, *this, amount));
 }
 
 Observable::Observable(Ref<SubscriberCallback> callback)

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -36,7 +36,6 @@ namespace WebCore {
 class InternalObserver;
 class ScriptExecutionContext;
 class JSSubscriptionObserverCallback;
-class SubscriptionObserverCallback;
 struct SubscriptionObserver;
 struct SubscribeOptions;
 
@@ -46,12 +45,14 @@ class Observable final : public ScriptWrappable, public RefCounted<Observable> {
 public:
     using ObserverUnion = std::variant<RefPtr<JSSubscriptionObserverCallback>, SubscriptionObserver>;
 
-    static ExceptionOr<Ref<Observable>> create(Ref<SubscriberCallback>);
+    static Ref<Observable> create(Ref<SubscriberCallback>);
 
     explicit Observable(Ref<SubscriberCallback>);
 
     void subscribe(ScriptExecutionContext&, std::optional<ObserverUnion>, SubscribeOptions);
     void subscribeInternal(ScriptExecutionContext&, Ref<InternalObserver>, SubscribeOptions);
+
+    Ref<Observable> take(ScriptExecutionContext&, uint64_t);
 
 private:
     Ref<SubscriberCallback> m_subscriberCallback;

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -30,6 +30,8 @@ typedef (SubscriptionObserverCallback or SubscriptionObserver) ObserverUnion;
   EnabledBySetting=ObservableEnabled
 ]
 interface Observable {
-  [RaisesException] constructor(SubscriberCallback callback);
+  constructor(SubscriberCallback callback);
   [CallWith=CurrentScriptExecutionContext, RaisesException] undefined subscribe(optional ObserverUnion observer = {}, optional SubscribeOptions options = {});
+
+  [CallWith=CurrentScriptExecutionContext] Observable take(unsigned long long amount);
 };

--- a/Source/WebCore/dom/Subscriber.h
+++ b/Source/WebCore/dom/Subscriber.h
@@ -28,13 +28,13 @@
 #include "AbortController.h"
 #include "ActiveDOMObject.h"
 #include "InternalObserver.h"
-#include "ScriptExecutionContext.h"
 #include "ScriptWrappable.h"
-#include "SubscriptionObserverCallback.h"
-#include "VoidCallback.h"
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
+
+class ScriptExecutionContext;
+class VoidCallback;
 
 class Subscriber final : public ActiveDOMObject, public ScriptWrappable, public RefCounted<Subscriber> {
     WTF_MAKE_ISO_ALLOCATED(Subscriber);
@@ -55,15 +55,10 @@ public:
     void reportErrorObject(JSC::JSValue);
 
     // JSCustomMarkFunction; for JSSubscriberCustom
-    Vector<VoidCallback*> teardownCallbacksConcurrently()
-    {
-        Locker locker { m_teardownsLock };
-        return m_teardowns.map([](auto& callback) { return callback.ptr(); });
-    }
-    InternalObserver* observerConcurrently()
-    {
-        return &m_observer.get();
-    }
+    Vector<VoidCallback*> teardownCallbacksConcurrently();
+    InternalObserver* observerConcurrently();
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor&);
+    void visitAdditionalChildren(JSC::SlotVisitor&);
 
     // ActiveDOMObject
     void ref() const final { RefCounted::ref(); }


### PR DESCRIPTION
#### 8bf6f2dcf6ac23fbdbc04fe01f6f0d60d035d35f
<pre>
Add Take Observable operator
<a href="https://bugs.webkit.org/show_bug.cgi?id=277103">https://bugs.webkit.org/show_bug.cgi?id=277103</a>

Reviewed by Darin Adler.

This adds the .take(amount) operator for Observables; implementing this
behind a InternalObserverTake backing class and subsequent
SubscribeCallback specialisation.

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-take.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-take.any.worker-expected.txt:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSSubscriberCustom.cpp:
* Source/WebCore/dom/InternalObserverFromScript.cpp:
* Source/WebCore/dom/InternalObserverTake.cpp: Added.
  Implements createSubscriberCallbackTake as well as the
  InternalObserverTake and SubscribeCallbackTake classes.
(WebCore::createSubscriberCallbackTake):
* Source/WebCore/dom/InternalObserverTake.h: Copied from Source/WebCore/dom/Observable.idl.
  Adds the createSubscriberCallbackTake function which creates a callback to
  handle the logic for `take()`.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::create):
  Drop `ExceptionOr&lt;&gt;` which was unused, and made it difficult to easily
  create new operators (which also don&apos;t need `ExceptionOr&lt;&gt;`).
(WebCore::Observable::take):
  Implement the take() operator.
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.idl:
* Source/WebCore/dom/Subscriber.cpp:
(WebCore::Subscriber::observerConcurrently):
  Moved out of the header file during refactor to add
  visitAdditionalChildren.
(WebCore::Subscriber::visitAdditionalChildren):
  Added to traverse into InternalObserver to allow for objects in
  InternalObserver to be marked.
* Source/WebCore/dom/Subscriber.h:

Canonical link: <a href="https://commits.webkit.org/281460@main">https://commits.webkit.org/281460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3d1fe37bcd027df2f395ca178302803ddf9089c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63898 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10510 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62109 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48604 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7331 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29446 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9182 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9430 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65630 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55962 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56102 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13296 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3242 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35141 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37311 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35967 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->