### PR TITLE
ShadowBlur::blurLayerImage: fix out-of-bounds subspan creation and wrong comparison

### DIFF
--- a/LayoutTests/css3/filters/svg-filter-on-1px-element-expected.txt
+++ b/LayoutTests/css3/filters/svg-filter-on-1px-element-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash

--- a/LayoutTests/css3/filters/svg-filter-on-1px-element.html
+++ b/LayoutTests/css3/filters/svg-filter-on-1px-element.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <svg>
+        <filter id="f" x="0px">
+            <feDropShadow color="white">
+        </filter>
+    </svg>
+    <div style="filter: url(#f); width: 1px; height: 1px"></div>
+    <p>This test passes if it does not crash</p>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            testRunner.dumpAsText();
+
+            // Let the test run for a bit so WebKitTestRunner could
+            // catch the GPU process crash.
+            setInterval(() => testRunner.notifyDone(), 1000);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
#### 7bc1ae1abbb9794991b86c7f21ee09a6a694691d
<pre>
ShadowBlur::blurLayerImage: fix out-of-bounds subspan creation and wrong comparison
<a href="https://rdar.apple.com/130755880">rdar://130755880</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=276976">https://bugs.webkit.org/show_bug.cgi?id=276976</a>

Reviewed by Chris Dumez.

If the input image is 1 pixel long on either dimension, the offset of `prev` subspan
is outside the bounds of `pixels`. If the input image is smaller than the box kernel
size, the offset of `next` subspan is outside the bounds of `pixels`. Catch either
case and treat the subspan as empty span to avoid crashing within std::span::subspan().

Also fixed a wrong comparison sign (&lt;= is used instead of &gt;=)

Tested by fuzzing the routine with input images and blur width/height between 1x1
and 100x100.

* LayoutTests/css3/filters/svg-filter-on-1px-element-expected.txt: Added.
* LayoutTests/css3/filters/svg-filter-on-1px-element.html: Added.
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
(WebCore::ShadowBlur::blurLayerImage):

Canonical link: <a href="https://commits.webkit.org/281274@main">https://commits.webkit.org/281274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6a428026167c463f32ebf879251604c2865398d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63268 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48193 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6958 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29017 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8630 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8801 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65001 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55543 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55635 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13149 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2730 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34513 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36682 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->