### PR TITLE
[Grid] Rename child/children references to gridItem/gridItems.

### DIFF
--- a/Source/WebCore/rendering/AncestorSubgridIterator.cpp
+++ b/Source/WebCore/rendering/AncestorSubgridIterator.cpp
@@ -71,7 +71,7 @@ AncestorSubgridIterator& AncestorSubgridIterator::operator++()
 
     if (m_firstAncestorSubgrid && m_currentAncestorSubgrid && m_direction) {
         auto nextAncestor = RenderTraversal::findAncestorOfType<RenderGrid>(*m_currentAncestorSubgrid);
-        m_currentAncestorSubgrid = (nextAncestor && nextAncestor->isSubgrid(GridLayoutFunctions::flowAwareDirectionForChild(*nextAncestor, *m_firstAncestorSubgrid, m_direction.value()))) ? nextAncestor : nullptr;
+        m_currentAncestorSubgrid = (nextAncestor && nextAncestor->isSubgrid(GridLayoutFunctions::flowAwareDirectionForGridItem(*nextAncestor, *m_firstAncestorSubgrid, m_direction.value()))) ? nextAncestor : nullptr;
     }
     return *this;
 }

--- a/Source/WebCore/rendering/Grid.h
+++ b/Source/WebCore/rendering/Grid.h
@@ -136,7 +136,7 @@ private:
     GridTrackSizingDirection m_direction;
     unsigned m_rowIndex;
     unsigned m_columnIndex;
-    unsigned m_childIndex;
+    unsigned m_gridItemIndex;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/GridBaselineAlignment.cpp
+++ b/Source/WebCore/rendering/GridBaselineAlignment.cpp
@@ -39,10 +39,10 @@
 
 namespace WebCore {
 
-LayoutUnit GridBaselineAlignment::logicalAscentForChild(const RenderBox& child, GridAxis alignmentAxis, ItemPosition position) const
+LayoutUnit GridBaselineAlignment::logicalAscentForGridItem(const RenderBox& gridItem, GridAxis alignmentAxis, ItemPosition position) const
 {
     auto hasOrthogonalAncestorSubgrids = [&] {
-        for (auto& currentAncestorSubgrid : ancestorSubgridsOfGridItem(child, GridTrackSizingDirection::ForRows)) {
+        for (auto& currentAncestorSubgrid : ancestorSubgridsOfGridItem(gridItem, GridTrackSizingDirection::ForRows)) {
             if (currentAncestorSubgrid.isHorizontalWritingMode() != currentAncestorSubgrid.parent()->isHorizontalWritingMode())
                 return true;
         }
@@ -51,60 +51,60 @@ LayoutUnit GridBaselineAlignment::logicalAscentForChild(const RenderBox& child, 
 
     ExtraMarginsFromSubgrids extraMarginsFromAncestorSubgrids;
     if (alignmentAxis == GridAxis::GridColumnAxis && !hasOrthogonalAncestorSubgrids())
-        extraMarginsFromAncestorSubgrids = GridLayoutFunctions::extraMarginForSubgridAncestors(GridTrackSizingDirection::ForRows, child);
+        extraMarginsFromAncestorSubgrids = GridLayoutFunctions::extraMarginForSubgridAncestors(GridTrackSizingDirection::ForRows, gridItem);
 
-    LayoutUnit ascent = ascentForChild(child, alignmentAxis, position) + extraMarginsFromAncestorSubgrids.extraTrackStartMargin();
-    return (isDescentBaselineForChild(child, alignmentAxis) || position == ItemPosition::LastBaseline) ? descentForChild(child, ascent, alignmentAxis, extraMarginsFromAncestorSubgrids) : ascent;
+    LayoutUnit ascent = ascentForGridItem(gridItem, alignmentAxis, position) + extraMarginsFromAncestorSubgrids.extraTrackStartMargin();
+    return (isDescentBaselineForGridItem(gridItem, alignmentAxis) || position == ItemPosition::LastBaseline) ? descentForGridItem(gridItem, ascent, alignmentAxis, extraMarginsFromAncestorSubgrids) : ascent;
 }
 
-LayoutUnit GridBaselineAlignment::ascentForChild(const RenderBox& child, GridAxis alignmentAxis, ItemPosition position) const
+LayoutUnit GridBaselineAlignment::ascentForGridItem(const RenderBox& gridItem, GridAxis alignmentAxis, ItemPosition position) const
 {
     static const LayoutUnit noValidBaseline = LayoutUnit(-1);
 
     ASSERT(position == ItemPosition::Baseline || position == ItemPosition::LastBaseline);
     auto baseline = 0_lu;
-    auto gridItemMargin = alignmentAxis == GridAxis::GridColumnAxis ? child.marginBlockStart(m_writingMode) : child.marginInlineStart(m_writingMode);
-    auto& parentStyle = child.parent()->style();
+    auto gridItemMargin = alignmentAxis == GridAxis::GridColumnAxis ? gridItem.marginBlockStart(m_writingMode) : gridItem.marginInlineStart(m_writingMode);
+    auto& parentStyle = gridItem.parent()->style();
 
     if (alignmentAxis == GridAxis::GridColumnAxis) {
         auto alignmentContextDirection = [&] {
             return parentStyle.isHorizontalWritingMode() ? LineDirectionMode::HorizontalLine : LineDirectionMode::VerticalLine;
         };
 
-        if (!isParallelToAlignmentAxisForChild(child, alignmentAxis))
-            return gridItemMargin + synthesizedBaseline(child, parentStyle, alignmentContextDirection(), BaselineSynthesisEdge::BorderBox);
-        auto ascent = position == ItemPosition::Baseline ? child.firstLineBaseline() : child.lastLineBaseline();
+        if (!isParallelToAlignmentAxisForGridItem(gridItem, alignmentAxis))
+            return gridItemMargin + synthesizedBaseline(gridItem, parentStyle, alignmentContextDirection(), BaselineSynthesisEdge::BorderBox);
+        auto ascent = position == ItemPosition::Baseline ? gridItem.firstLineBaseline() : gridItem.lastLineBaseline();
         if (!ascent)
-            return gridItemMargin + synthesizedBaseline(child, parentStyle, alignmentContextDirection(), BaselineSynthesisEdge::BorderBox);
+            return gridItemMargin + synthesizedBaseline(gridItem, parentStyle, alignmentContextDirection(), BaselineSynthesisEdge::BorderBox);
         baseline = ascent.value();
     } else {
-        auto computedBaselineValue = position == ItemPosition::Baseline ? child.firstLineBaseline() : child.lastLineBaseline();
-        baseline = isParallelToAlignmentAxisForChild(child, alignmentAxis) ? computedBaselineValue.value_or(noValidBaseline) : noValidBaseline;
+        auto computedBaselineValue = position == ItemPosition::Baseline ? gridItem.firstLineBaseline() : gridItem.lastLineBaseline();
+        baseline = isParallelToAlignmentAxisForGridItem(gridItem, alignmentAxis) ? computedBaselineValue.value_or(noValidBaseline) : noValidBaseline;
         // We take border-box's under edge if no valid baseline.
         if (baseline == noValidBaseline) {
-            ASSERT(!child.needsLayout());
+            ASSERT(!gridItem.needsLayout());
             if (isVerticalAlignmentContext(alignmentAxis))
-                return isFlippedWritingMode(m_writingMode) ? gridItemMargin + child.size().width().toInt() : gridItemMargin;
-            return gridItemMargin + synthesizedBaseline(child, parentStyle, LineDirectionMode::HorizontalLine, BaselineSynthesisEdge::BorderBox);
+                return isFlippedWritingMode(m_writingMode) ? gridItemMargin + gridItem.size().width().toInt() : gridItemMargin;
+            return gridItemMargin + synthesizedBaseline(gridItem, parentStyle, LineDirectionMode::HorizontalLine, BaselineSynthesisEdge::BorderBox);
         }
     }
 
     return gridItemMargin + baseline;
 }
 
-LayoutUnit GridBaselineAlignment::descentForChild(const RenderBox& child, LayoutUnit ascent, GridAxis alignmentAxis, ExtraMarginsFromSubgrids extraMarginsFromAncestorSubgrids) const
+LayoutUnit GridBaselineAlignment::descentForGridItem(const RenderBox& gridItem, LayoutUnit ascent, GridAxis alignmentAxis, ExtraMarginsFromSubgrids extraMarginsFromAncestorSubgrids) const
 {
-    ASSERT(!child.needsLayout());
-    if (isParallelToAlignmentAxisForChild(child, alignmentAxis))
-        return extraMarginsFromAncestorSubgrids.extraTotalMargin() + child.marginLogicalHeight() + child.logicalHeight() - ascent;
-    return child.marginLogicalWidth() + child.logicalWidth() - ascent;
+    ASSERT(!gridItem.needsLayout());
+    if (isParallelToAlignmentAxisForGridItem(gridItem, alignmentAxis))
+        return extraMarginsFromAncestorSubgrids.extraTotalMargin() + gridItem.marginLogicalHeight() + gridItem.logicalHeight() - ascent;
+    return gridItem.marginLogicalWidth() + gridItem.logicalWidth() - ascent;
 }
 
-bool GridBaselineAlignment::isDescentBaselineForChild(const RenderBox& child, GridAxis alignmentAxis) const
+bool GridBaselineAlignment::isDescentBaselineForGridItem(const RenderBox& gridItem, GridAxis alignmentAxis) const
 {
     return isVerticalAlignmentContext(alignmentAxis)
-        && ((child.style().isFlippedBlocksWritingMode() && !isFlippedWritingMode(m_writingMode))
-            || (child.style().isFlippedLinesWritingMode() && isFlippedWritingMode(m_writingMode)));
+        && ((gridItem.style().isFlippedBlocksWritingMode() && !isFlippedWritingMode(m_writingMode))
+            || (gridItem.style().isFlippedLinesWritingMode() && isFlippedWritingMode(m_writingMode)));
 }
 
 bool GridBaselineAlignment::isVerticalAlignmentContext(GridAxis alignmentAxis) const
@@ -112,51 +112,51 @@ bool GridBaselineAlignment::isVerticalAlignmentContext(GridAxis alignmentAxis) c
     return alignmentAxis == GridAxis::GridRowAxis ? isHorizontalWritingMode(m_writingMode) : !isHorizontalWritingMode(m_writingMode);
 }
 
-bool GridBaselineAlignment::isOrthogonalChildForBaseline(const RenderBox& child) const
+bool GridBaselineAlignment::isOrthogonalGridItemForBaseline(const RenderBox& gridItem) const
 {
-    return isHorizontalWritingMode(m_writingMode) != child.isHorizontalWritingMode();
+    return isHorizontalWritingMode(m_writingMode) != gridItem.isHorizontalWritingMode();
 }
 
-bool GridBaselineAlignment::isParallelToAlignmentAxisForChild(const RenderBox& child, GridAxis alignmentAxis) const
+bool GridBaselineAlignment::isParallelToAlignmentAxisForGridItem(const RenderBox& gridItem, GridAxis alignmentAxis) const
 {
-    return alignmentAxis == GridAxis::GridColumnAxis ? !isOrthogonalChildForBaseline(child) : isOrthogonalChildForBaseline(child);
+    return alignmentAxis == GridAxis::GridColumnAxis ? !isOrthogonalGridItemForBaseline(gridItem) : isOrthogonalGridItemForBaseline(gridItem);
 }
 
-const BaselineGroup& GridBaselineAlignment::baselineGroupForChild(ItemPosition preference, unsigned sharedContext, const RenderBox& child, GridAxis alignmentAxis) const
+const BaselineGroup& GridBaselineAlignment::baselineGroupForGridItem(ItemPosition preference, unsigned sharedContext, const RenderBox& gridItem, GridAxis alignmentAxis) const
 {
     ASSERT(isBaselinePosition(preference));
     bool isRowAxisContext = alignmentAxis == GridAxis::GridColumnAxis;
     auto& baselineAlignmentStateMap = isRowAxisContext ? m_rowAxisBaselineAlignmentStates : m_colAxisBaselineAlignmentStates;
     auto* baselineAlignmentState = baselineAlignmentStateMap.get(sharedContext);
     ASSERT(baselineAlignmentState);
-    return baselineAlignmentState->sharedGroup(child, preference);
+    return baselineAlignmentState->sharedGroup(gridItem, preference);
 }
 
-void GridBaselineAlignment::updateBaselineAlignmentContext(ItemPosition preference, unsigned sharedContext, const RenderBox& child, GridAxis alignmentAxis)
+void GridBaselineAlignment::updateBaselineAlignmentContext(ItemPosition preference, unsigned sharedContext, const RenderBox& gridItem, GridAxis alignmentAxis)
 {
     ASSERT(isBaselinePosition(preference));
-    ASSERT(!child.needsLayout());
+    ASSERT(!gridItem.needsLayout());
 
-    // Determine Ascent and Descent values of this child with respect to
+    // Determine Ascent and Descent values of this grid item with respect to
     // its grid container.
-    LayoutUnit ascent = logicalAscentForChild(child, alignmentAxis, preference);
+    LayoutUnit ascent = logicalAscentForGridItem(gridItem, alignmentAxis, preference);
     // Looking up for a shared alignment context perpendicular to the
     // alignment axis.
     bool isRowAxisContext = alignmentAxis == GridAxis::GridColumnAxis;
     auto& baselineAlignmentStateMap = isRowAxisContext ? m_rowAxisBaselineAlignmentStates : m_colAxisBaselineAlignmentStates;
     // Looking for a compatible baseline-sharing group.
     if (auto* baselineAlignmentStateSearch = baselineAlignmentStateMap.get(sharedContext))
-        baselineAlignmentStateSearch->updateSharedGroup(child, preference, ascent);
+        baselineAlignmentStateSearch->updateSharedGroup(gridItem, preference, ascent);
     else
-        baselineAlignmentStateMap.add(sharedContext, makeUnique<BaselineAlignmentState>(child, preference, ascent));
+        baselineAlignmentStateMap.add(sharedContext, makeUnique<BaselineAlignmentState>(gridItem, preference, ascent));
 }
 
-LayoutUnit GridBaselineAlignment::baselineOffsetForChild(ItemPosition preference, unsigned sharedContext, const RenderBox& child, GridAxis alignmentAxis) const
+LayoutUnit GridBaselineAlignment::baselineOffsetForGridItem(ItemPosition preference, unsigned sharedContext, const RenderBox& gridItem, GridAxis alignmentAxis) const
 {
     ASSERT(isBaselinePosition(preference));
-    auto& group = baselineGroupForChild(preference, sharedContext, child, alignmentAxis);
+    auto& group = baselineGroupForGridItem(preference, sharedContext, gridItem, alignmentAxis);
     if (group.computeSize() > 1)
-        return group.maxAscent() - logicalAscentForChild(child, alignmentAxis, preference);
+        return group.maxAscent() - logicalAscentForGridItem(gridItem, alignmentAxis, preference);
     return LayoutUnit();
 }
 

--- a/Source/WebCore/rendering/GridBaselineAlignment.h
+++ b/Source/WebCore/rendering/GridBaselineAlignment.h
@@ -53,7 +53,7 @@ public:
 
     // Returns the baseline offset of a particular item, based on the max-ascent for its associated
     // baseline-sharing group
-    LayoutUnit baselineOffsetForChild(ItemPosition, unsigned sharedContext, const RenderBox&, GridAxis) const;
+    LayoutUnit baselineOffsetForGridItem(ItemPosition, unsigned sharedContext, const RenderBox&, GridAxis) const;
 
     // Sets the Grid Container's writing-mode so that we can avoid the dependecy of the LayoutGrid class for
     // determining whether a grid item is orthogonal or not.
@@ -63,16 +63,16 @@ public:
     void clear(GridAxis);
 
 private:
-    const BaselineGroup& baselineGroupForChild(ItemPosition, unsigned sharedContext, const RenderBox&, GridAxis) const;
-    LayoutUnit marginOverForChild(const RenderBox&, GridAxis) const;
-    LayoutUnit marginUnderForChild(const RenderBox&, GridAxis) const;
-    LayoutUnit logicalAscentForChild(const RenderBox&, GridAxis, ItemPosition) const;
-    LayoutUnit ascentForChild(const RenderBox&, GridAxis, ItemPosition) const;
-    LayoutUnit descentForChild(const RenderBox&, LayoutUnit, GridAxis, ExtraMarginsFromSubgrids) const;
-    bool isDescentBaselineForChild(const RenderBox&, GridAxis) const;
+    const BaselineGroup& baselineGroupForGridItem(ItemPosition, unsigned sharedContext, const RenderBox&, GridAxis) const;
+    LayoutUnit marginOverForGridItem(const RenderBox&, GridAxis) const;
+    LayoutUnit marginUnderForGridItem(const RenderBox&, GridAxis) const;
+    LayoutUnit logicalAscentForGridItem(const RenderBox&, GridAxis, ItemPosition) const;
+    LayoutUnit ascentForGridItem(const RenderBox&, GridAxis, ItemPosition) const;
+    LayoutUnit descentForGridItem(const RenderBox&, LayoutUnit, GridAxis, ExtraMarginsFromSubgrids) const;
+    bool isDescentBaselineForGridItem(const RenderBox&, GridAxis) const;
     bool isVerticalAlignmentContext(GridAxis) const;
-    bool isOrthogonalChildForBaseline(const RenderBox&) const;
-    bool isParallelToAlignmentAxisForChild(const RenderBox&, GridAxis) const;
+    bool isOrthogonalGridItemForBaseline(const RenderBox&) const;
+    bool isParallelToAlignmentAxisForGridItem(const RenderBox&, GridAxis) const;
 
     typedef HashMap<unsigned, std::unique_ptr<BaselineAlignmentState>, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> BaselineAlignmentStateMap;
 

--- a/Source/WebCore/rendering/GridLayoutFunctions.cpp
+++ b/Source/WebCore/rendering/GridLayoutFunctions.cpp
@@ -38,44 +38,44 @@ namespace WebCore {
 
 namespace GridLayoutFunctions {
 
-static inline bool marginStartIsAuto(const RenderBox& child, GridTrackSizingDirection direction)
+static inline bool marginStartIsAuto(const RenderBox& gridItem, GridTrackSizingDirection direction)
 {
-    return direction == GridTrackSizingDirection::ForColumns ? child.style().marginStart().isAuto() : child.style().marginBefore().isAuto();
+    return direction == GridTrackSizingDirection::ForColumns ? gridItem.style().marginStart().isAuto() : gridItem.style().marginBefore().isAuto();
 }
 
-static inline bool marginEndIsAuto(const RenderBox& child, GridTrackSizingDirection direction)
+static inline bool marginEndIsAuto(const RenderBox& gridItem, GridTrackSizingDirection direction)
 {
-    return direction == GridTrackSizingDirection::ForColumns ? child.style().marginEnd().isAuto() : child.style().marginAfter().isAuto();
+    return direction == GridTrackSizingDirection::ForColumns ? gridItem.style().marginEnd().isAuto() : gridItem.style().marginAfter().isAuto();
 }
 
-static bool childHasMargin(const RenderBox& child, GridTrackSizingDirection direction)
+static bool gridItemHasMargin(const RenderBox& gridItem, GridTrackSizingDirection direction)
 {
     // Length::IsZero returns true for 'auto' margins, which is aligned with the purpose of this function.
     if (direction == GridTrackSizingDirection::ForColumns)
-        return !child.style().marginStart().isZero() || !child.style().marginEnd().isZero();
-    return !child.style().marginBefore().isZero() || !child.style().marginAfter().isZero();
+        return !gridItem.style().marginStart().isZero() || !gridItem.style().marginEnd().isZero();
+    return !gridItem.style().marginBefore().isZero() || !gridItem.style().marginAfter().isZero();
 }
 
-LayoutUnit computeMarginLogicalSizeForChild(const RenderGrid& grid, GridTrackSizingDirection direction, const RenderBox& child)
+LayoutUnit computeMarginLogicalSizeForGridItem(const RenderGrid& grid, GridTrackSizingDirection direction, const RenderBox& gridItem)
 {
-    GridTrackSizingDirection flowAwareDirection = flowAwareDirectionForChild(grid, child, direction);
-    if (!childHasMargin(child, flowAwareDirection))
+    GridTrackSizingDirection flowAwareDirection = flowAwareDirectionForGridItem(grid, gridItem, direction);
+    if (!gridItemHasMargin(gridItem, flowAwareDirection))
         return 0;
 
     LayoutUnit marginStart;
     LayoutUnit marginEnd;
     if (direction == GridTrackSizingDirection::ForColumns)
-        child.computeInlineDirectionMargins(grid, child.containingBlockLogicalWidthForContentInFragment(nullptr), { }, child.logicalWidth(), marginStart, marginEnd);
+        gridItem.computeInlineDirectionMargins(grid, gridItem.containingBlockLogicalWidthForContentInFragment(nullptr), { }, gridItem.logicalWidth(), marginStart, marginEnd);
     else
-        child.computeBlockDirectionMargins(grid, marginStart, marginEnd);
-    return marginStartIsAuto(child, flowAwareDirection) ? marginEnd : marginEndIsAuto(child, flowAwareDirection) ? marginStart : marginStart + marginEnd;
+        gridItem.computeBlockDirectionMargins(grid, marginStart, marginEnd);
+    return marginStartIsAuto(gridItem, flowAwareDirection) ? marginEnd : marginEndIsAuto(gridItem, flowAwareDirection) ? marginStart : marginStart + marginEnd;
 }
 
-bool hasRelativeOrIntrinsicSizeForChild(const RenderBox& child, GridTrackSizingDirection direction)
+bool hasRelativeOrIntrinsicSizeForGridItem(const RenderBox& gridItem, GridTrackSizingDirection direction)
 {
     if (direction == GridTrackSizingDirection::ForColumns)
-        return child.hasRelativeLogicalWidth() || child.style().logicalWidth().isIntrinsicOrAuto();
-    return child.hasRelativeLogicalHeight() || child.style().logicalHeight().isIntrinsicOrAuto();
+        return gridItem.hasRelativeLogicalWidth() || gridItem.style().logicalWidth().isIntrinsicOrAuto();
+    return gridItem.hasRelativeLogicalHeight() || gridItem.style().logicalHeight().isIntrinsicOrAuto();
 }
 
 static ExtraMarginsFromSubgrids extraMarginForSubgrid(const RenderGrid& parent, unsigned startLine, unsigned endLine, GridTrackSizingDirection direction)
@@ -85,7 +85,7 @@ static ExtraMarginsFromSubgrids extraMarginForSubgrid(const RenderGrid& parent, 
         return { };
 
     std::optional<LayoutUnit> availableSpace;
-    if (!hasRelativeOrIntrinsicSizeForChild(parent, direction))
+    if (!hasRelativeOrIntrinsicSizeForGridItem(parent, direction))
         availableSpace = parent.availableSpaceForGutters(direction);
 
     RenderGrid& grandParent = downcast<RenderGrid>(*parent.parent());
@@ -103,40 +103,40 @@ static ExtraMarginsFromSubgrids extraMarginForSubgrid(const RenderGrid& parent, 
     return extraMargins;
 }
 
-ExtraMarginsFromSubgrids extraMarginForSubgridAncestors(GridTrackSizingDirection direction, const RenderBox& child)
+ExtraMarginsFromSubgrids extraMarginForSubgridAncestors(GridTrackSizingDirection direction, const RenderBox& gridItem)
 {
     ExtraMarginsFromSubgrids extraMargins;
-    for (auto& currentAncestorSubgrid : ancestorSubgridsOfGridItem(child, direction)) {
-        GridSpan span = currentAncestorSubgrid.gridSpanForChild(child, direction);
+    for (auto& currentAncestorSubgrid : ancestorSubgridsOfGridItem(gridItem, direction)) {
+        GridSpan span = currentAncestorSubgrid.gridSpanForGridItem(gridItem, direction);
         extraMargins += extraMarginForSubgrid(currentAncestorSubgrid, span.startLine(), span.endLine(), direction);
     }
     return extraMargins;
 }
 
-LayoutUnit marginLogicalSizeForChild(const RenderGrid& grid, GridTrackSizingDirection direction, const RenderBox& child)
+LayoutUnit marginLogicalSizeForGridItem(const RenderGrid& grid, GridTrackSizingDirection direction, const RenderBox& gridItem)
 {
     LayoutUnit margin;
-    if (child.needsLayout())
-        margin = computeMarginLogicalSizeForChild(grid, direction, child);
+    if (gridItem.needsLayout())
+        margin = computeMarginLogicalSizeForGridItem(grid, direction, gridItem);
     else {
-        GridTrackSizingDirection flowAwareDirection = flowAwareDirectionForChild(grid, child, direction);
+        GridTrackSizingDirection flowAwareDirection = flowAwareDirectionForGridItem(grid, gridItem, direction);
         bool isRowAxis = flowAwareDirection == GridTrackSizingDirection::ForColumns;
-        LayoutUnit marginStart = marginStartIsAuto(child, flowAwareDirection) ? 0_lu : isRowAxis ? child.marginStart() : child.marginBefore();
-        LayoutUnit marginEnd = marginEndIsAuto(child, flowAwareDirection) ? 0_lu : isRowAxis ? child.marginEnd() : child.marginAfter();
+        LayoutUnit marginStart = marginStartIsAuto(gridItem, flowAwareDirection) ? 0_lu : isRowAxis ? gridItem.marginStart() : gridItem.marginBefore();
+        LayoutUnit marginEnd = marginEndIsAuto(gridItem, flowAwareDirection) ? 0_lu : isRowAxis ? gridItem.marginEnd() : gridItem.marginAfter();
         margin = marginStart + marginEnd;
     }
 
-    if (&grid != child.parent()) {
-        GridTrackSizingDirection subgridDirection = flowAwareDirectionForChild(grid, *downcast<RenderGrid>(child.parent()), direction);
-        margin += extraMarginForSubgridAncestors(subgridDirection, child).extraTotalMargin();
+    if (&grid != gridItem.parent()) {
+        GridTrackSizingDirection subgridDirection = flowAwareDirectionForGridItem(grid, *downcast<RenderGrid>(gridItem.parent()), direction);
+        margin += extraMarginForSubgridAncestors(subgridDirection, gridItem).extraTotalMargin();
     }
 
     return margin;
 }
 
-bool isOrthogonalChild(const RenderGrid& grid, const RenderBox& child)
+bool isOrthogonalGridItem(const RenderGrid& grid, const RenderBox& gridItem)
 {
-    return child.isHorizontalWritingMode() != grid.isHorizontalWritingMode();
+    return gridItem.isHorizontalWritingMode() != grid.isHorizontalWritingMode();
 }
 
 bool isOrthogonalParent(const RenderGrid& grid, const RenderElement& parent)
@@ -144,14 +144,14 @@ bool isOrthogonalParent(const RenderGrid& grid, const RenderElement& parent)
     return parent.isHorizontalWritingMode() != grid.isHorizontalWritingMode();
 }
 
-bool isAspectRatioBlockSizeDependentChild(const RenderBox& child)
+bool isAspectRatioBlockSizeDependentGridItem(const RenderBox& gridItem)
 {
-    return (child.style().hasAspectRatio() || child.hasIntrinsicAspectRatio()) && (child.hasRelativeLogicalHeight() || child.hasStretchedLogicalHeight());
+    return (gridItem.style().hasAspectRatio() || gridItem.hasIntrinsicAspectRatio()) && (gridItem.hasRelativeLogicalHeight() || gridItem.hasStretchedLogicalHeight());
 }
 
-GridTrackSizingDirection flowAwareDirectionForChild(const RenderGrid& grid, const RenderBox& child, GridTrackSizingDirection direction)
+GridTrackSizingDirection flowAwareDirectionForGridItem(const RenderGrid& grid, const RenderBox& gridItem, GridTrackSizingDirection direction)
 {
-    return !isOrthogonalChild(grid, child) ? direction : (direction == GridTrackSizingDirection::ForColumns ? GridTrackSizingDirection::ForRows : GridTrackSizingDirection::ForColumns);
+    return !isOrthogonalGridItem(grid, gridItem) ? direction : (direction == GridTrackSizingDirection::ForColumns ? GridTrackSizingDirection::ForRows : GridTrackSizingDirection::ForColumns);
 }
 
 GridTrackSizingDirection flowAwareDirectionForParent(const RenderGrid& grid, const RenderElement& parent, GridTrackSizingDirection direction)
@@ -159,9 +159,9 @@ GridTrackSizingDirection flowAwareDirectionForParent(const RenderGrid& grid, con
     return isOrthogonalParent(grid, parent) ? (direction == GridTrackSizingDirection::ForColumns ? GridTrackSizingDirection::ForRows : GridTrackSizingDirection::ForColumns) : direction;
 }
 
-std::optional<RenderBox::ContainingBlockOverrideValue> overridingContainingBlockContentSizeForChild(const RenderBox& child, GridTrackSizingDirection direction)
+std::optional<RenderBox::ContainingBlockOverrideValue> overridingContainingBlockContentSizeForGridItem(const RenderBox& gridItem, GridTrackSizingDirection direction)
 {
-    return direction == GridTrackSizingDirection::ForColumns ? child.overridingContainingBlockContentLogicalWidth() : child.overridingContainingBlockContentLogicalHeight();
+    return direction == GridTrackSizingDirection::ForColumns ? gridItem.overridingContainingBlockContentLogicalWidth() : gridItem.overridingContainingBlockContentLogicalHeight();
 }
 
 bool isFlippedDirection(const RenderGrid& grid, GridTrackSizingDirection direction)
@@ -173,9 +173,9 @@ bool isFlippedDirection(const RenderGrid& grid, GridTrackSizingDirection directi
 
 bool isSubgridReversedDirection(const RenderGrid& grid, GridTrackSizingDirection outerDirection, const RenderGrid& subgrid)
 {
-    GridTrackSizingDirection childDirection = flowAwareDirectionForChild(grid, subgrid, outerDirection);
-    ASSERT(subgrid.isSubgrid(childDirection));
-    return isFlippedDirection(grid, outerDirection) != isFlippedDirection(subgrid, childDirection);
+    GridTrackSizingDirection subgridDirection = flowAwareDirectionForGridItem(grid, subgrid, outerDirection);
+    ASSERT(subgrid.isSubgrid(subgridDirection));
+    return isFlippedDirection(grid, outerDirection) != isFlippedDirection(subgrid, subgridDirection);
 }
 
 unsigned alignmentContextForBaselineAlignment(const GridSpan& span, const ItemPosition& alignment)

--- a/Source/WebCore/rendering/GridLayoutFunctions.h
+++ b/Source/WebCore/rendering/GridLayoutFunctions.h
@@ -60,19 +60,19 @@ struct ExtraMarginsFromSubgrids {
 
 namespace GridLayoutFunctions {
 
-LayoutUnit computeMarginLogicalSizeForChild(const RenderGrid&, GridTrackSizingDirection, const RenderBox&);
-LayoutUnit marginLogicalSizeForChild(const RenderGrid&, GridTrackSizingDirection, const RenderBox&);
-bool isOrthogonalChild(const RenderGrid&, const RenderBox&);
+LayoutUnit computeMarginLogicalSizeForGridItem(const RenderGrid&, GridTrackSizingDirection, const RenderBox&);
+LayoutUnit marginLogicalSizeForGridItem(const RenderGrid&, GridTrackSizingDirection, const RenderBox&);
+bool isOrthogonalGridItem(const RenderGrid&, const RenderBox&);
 bool isOrthogonalParent(const RenderGrid&, const RenderElement& parent);
-bool isAspectRatioBlockSizeDependentChild(const RenderBox&);
-GridTrackSizingDirection flowAwareDirectionForChild(const RenderGrid&, const RenderBox&, GridTrackSizingDirection);
+bool isAspectRatioBlockSizeDependentGridItem(const RenderBox&);
+GridTrackSizingDirection flowAwareDirectionForGridItem(const RenderGrid&, const RenderBox&, GridTrackSizingDirection);
 GridTrackSizingDirection flowAwareDirectionForParent(const RenderGrid&, const RenderElement& parent, GridTrackSizingDirection);
-std::optional<RenderBox::ContainingBlockOverrideValue> overridingContainingBlockContentSizeForChild(const RenderBox&, GridTrackSizingDirection);
-bool hasRelativeOrIntrinsicSizeForChild(const RenderBox& child, GridTrackSizingDirection);
+std::optional<RenderBox::ContainingBlockOverrideValue> overridingContainingBlockContentSizeForGridItem(const RenderBox&, GridTrackSizingDirection);
+bool hasRelativeOrIntrinsicSizeForGridItem(const RenderBox& gridItem, GridTrackSizingDirection);
 
 bool isFlippedDirection(const RenderGrid&, GridTrackSizingDirection);
 bool isSubgridReversedDirection(const RenderGrid&, GridTrackSizingDirection outerDirection, const RenderGrid& subgrid);
-ExtraMarginsFromSubgrids extraMarginForSubgridAncestors(GridTrackSizingDirection, const RenderBox& child);
+ExtraMarginsFromSubgrids extraMarginForSubgridAncestors(GridTrackSizingDirection, const RenderBox& gridItem);
 
 unsigned alignmentContextForBaselineAlignment(const GridSpan&, const ItemPosition& alignment);
 

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -80,17 +80,17 @@ void GridMasonryLayout::collectMasonryItems()
     m_itemsWithIndefiniteGridAxisPosition.shrink(0);
 
     auto& grid = m_renderGrid.currentGrid();
-    for (auto* child = grid.orderIterator().first(); child; child = grid.orderIterator().next()) {
-        if (grid.orderIterator().shouldSkipChild(*child))
+    for (auto* gridItem = grid.orderIterator().first(); gridItem; gridItem = grid.orderIterator().next()) {
+        if (grid.orderIterator().shouldSkipChild(*gridItem))
             continue;
 
         if (m_renderGrid.style().masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::Ordered)
-            m_itemsWithDefiniteGridAxisPosition.append(child);
+            m_itemsWithDefiniteGridAxisPosition.append(gridItem);
         else if (m_renderGrid.style().masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::DefiniteFirst) {
-            if (hasDefiniteGridAxisPosition(*child, gridAxisDirection()))
-                m_itemsWithDefiniteGridAxisPosition.append(child);
+            if (hasDefiniteGridAxisPosition(*gridItem, gridAxisDirection()))
+                m_itemsWithDefiniteGridAxisPosition.append(gridItem);
             else
-                m_itemsWithIndefiniteGridAxisPosition.append(child);
+                m_itemsWithIndefiniteGridAxisPosition.append(gridItem);
         }
     }
 }
@@ -116,15 +116,15 @@ void GridMasonryLayout::resizeAndResetRunningPositions()
 
 void GridMasonryLayout::placeItemsUsingOrderModifiedDocumentOrder()
 {
-    for (auto* child : m_itemsWithDefiniteGridAxisPosition) {
-        ASSERT(child);
-        if (!child)
+    for (auto* gridItem : m_itemsWithDefiniteGridAxisPosition) {
+        ASSERT(gridItem);
+        if (!gridItem)
             continue;
 
-        if (hasDefiniteGridAxisPosition(*child, gridAxisDirection()))
-            insertIntoGridAndLayoutItem(*child, gridAreaForDefiniteGridAxisItem(*child));
+        if (hasDefiniteGridAxisPosition(*gridItem, gridAxisDirection()))
+            insertIntoGridAndLayoutItem(*gridItem, gridAreaForDefiniteGridAxisItem(*gridItem));
         else
-            insertIntoGridAndLayoutItem(*child, gridAreaForIndefiniteGridAxisItem(*child));
+            insertIntoGridAndLayoutItem(*gridItem, gridAreaForIndefiniteGridAxisItem(*gridItem));
     }   
 }
 
@@ -146,9 +146,9 @@ void GridMasonryLayout::placeItemsWithDefiniteGridAxisPosition()
     }
 }
 
-GridArea GridMasonryLayout::gridAreaForDefiniteGridAxisItem(const RenderBox& child) const
+GridArea GridMasonryLayout::gridAreaForDefiniteGridAxisItem(const RenderBox& gridItem) const
 {
-    auto itemSpan = m_renderGrid.currentGrid().gridItemSpan(child, gridAxisDirection());
+    auto itemSpan = m_renderGrid.currentGrid().gridItemSpan(gridItem, gridAxisDirection());
     ASSERT(!itemSpan.isIndefinite());
     itemSpan.translate(m_renderGrid.currentGrid().explicitGridStart(gridAxisDirection()));
     return masonryGridAreaFromGridAxisSpan(itemSpan);
@@ -164,45 +164,45 @@ void GridMasonryLayout::placeItemsWithIndefiniteGridAxisPosition()
     }
 }
 
-void GridMasonryLayout::setItemGridAxisContainingBlockToGridArea(RenderBox& child)
+void GridMasonryLayout::setItemGridAxisContainingBlockToGridArea(RenderBox& gridItem)
 {
     if (gridAxisDirection() == GridTrackSizingDirection::ForColumns)
-        child.setOverridingContainingBlockContentLogicalWidth(m_renderGrid.m_trackSizingAlgorithm.gridAreaBreadthForChild(child, GridTrackSizingDirection::ForColumns));
+        gridItem.setOverridingContainingBlockContentLogicalWidth(m_renderGrid.m_trackSizingAlgorithm.gridAreaBreadthForGridItem(gridItem, GridTrackSizingDirection::ForColumns));
     else
-        child.setOverridingContainingBlockContentLogicalHeight(m_renderGrid.m_trackSizingAlgorithm.gridAreaBreadthForChild(child, GridTrackSizingDirection::ForRows));
+        gridItem.setOverridingContainingBlockContentLogicalHeight(m_renderGrid.m_trackSizingAlgorithm.gridAreaBreadthForGridItem(gridItem, GridTrackSizingDirection::ForRows));
     
     // FIXME(249230): Try to cache masonry layout sizes
-    child.setChildNeedsLayout(MarkOnlyThis);
+    gridItem.setChildNeedsLayout(MarkOnlyThis);
 }
 
-void GridMasonryLayout::insertIntoGridAndLayoutItem(RenderBox& child, const GridArea& area)
+void GridMasonryLayout::insertIntoGridAndLayoutItem(RenderBox& gridItem, const GridArea& area)
 {
-    m_renderGrid.currentGrid().insert(child, area);
-    setItemGridAxisContainingBlockToGridArea(child);
-    child.layoutIfNeeded();
-    updateRunningPositions(child, area);
+    m_renderGrid.currentGrid().insert(gridItem, area);
+    setItemGridAxisContainingBlockToGridArea(gridItem);
+    gridItem.layoutIfNeeded();
+    updateRunningPositions(gridItem, area);
     m_autoFlowNextCursor = gridAxisSpanFromArea(area).endLine() % m_gridAxisTracksCount;
 }
 
-LayoutUnit GridMasonryLayout::masonryAxisMarginBoxForItem(const RenderBox& child)
+LayoutUnit GridMasonryLayout::masonryAxisMarginBoxForItem(const RenderBox& gridItem)
 {
     LayoutUnit marginBoxSize;
     if (m_masonryAxisDirection == GridTrackSizingDirection::ForRows) {
-        if (GridLayoutFunctions::isOrthogonalChild(m_renderGrid, child))
-            marginBoxSize = child.isHorizontalWritingMode() ? child.width() + child.horizontalMarginExtent() : child.height() + child.verticalMarginExtent();
+        if (GridLayoutFunctions::isOrthogonalGridItem(m_renderGrid, gridItem))
+            marginBoxSize = gridItem.isHorizontalWritingMode() ? gridItem.width() + gridItem.horizontalMarginExtent() : gridItem.height() + gridItem.verticalMarginExtent();
         else
-            marginBoxSize = child.logicalHeight() + child.marginLogicalHeight();
+            marginBoxSize = gridItem.logicalHeight() + gridItem.marginLogicalHeight();
 
     } else {
-        if (GridLayoutFunctions::isOrthogonalChild(m_renderGrid, child))
-            marginBoxSize = child.isHorizontalWritingMode() ? child.height() + child.verticalMarginExtent() : child.width() + child.horizontalMarginExtent();
+        if (GridLayoutFunctions::isOrthogonalGridItem(m_renderGrid, gridItem))
+            marginBoxSize = gridItem.isHorizontalWritingMode() ? gridItem.height() + gridItem.verticalMarginExtent() : gridItem.width() + gridItem.horizontalMarginExtent();
         else
-            marginBoxSize = child.logicalWidth() + child.marginLogicalWidth();
+            marginBoxSize = gridItem.logicalWidth() + gridItem.marginLogicalWidth();
     }
     return marginBoxSize;
 }
 
-void GridMasonryLayout::updateRunningPositions(const RenderBox& child, const GridArea& area)
+void GridMasonryLayout::updateRunningPositions(const RenderBox& gridItem, const GridArea& area)
 {
     auto gridAxisSpan = gridAxisSpanFromArea(area);
     ASSERT(gridAxisSpan.startLine() < m_runningPositions.size() && gridAxisSpan.endLine() <= m_runningPositions.size());
@@ -212,19 +212,19 @@ void GridMasonryLayout::updateRunningPositions(const RenderBox& child, const Gri
     for (auto line : gridAxisSpan)
         previousRunningPosition = std::max(previousRunningPosition, m_runningPositions[line]);
 
-    auto newRunningPosition = masonryAxisMarginBoxForItem(child) + previousRunningPosition + m_masonryAxisGridGap; 
+    auto newRunningPosition = masonryAxisMarginBoxForItem(gridItem) + previousRunningPosition + m_masonryAxisGridGap;
     m_gridContentSize = std::max(m_gridContentSize, newRunningPosition - m_masonryAxisGridGap);
 
     for (auto span : gridAxisSpan)
         m_runningPositions[span] = std::max(m_runningPositions[span], newRunningPosition);
 
-    updateItemOffset(child, previousRunningPosition);
+    updateItemOffset(gridItem, previousRunningPosition);
 }
 
-void GridMasonryLayout::updateItemOffset(const RenderBox& child, LayoutUnit offset)
+void GridMasonryLayout::updateItemOffset(const RenderBox& gridItem, LayoutUnit offset)
 {
-    // We set() and not add() to update the value if the child is already inserted
-    m_itemOffsets.set(child, offset);
+    // We set() and not add() to update the value if the |gridItem| is already inserted
+    m_itemOffsets.set(gridItem, offset);
 }
 
 GridSpan GridMasonryLayout::gridAxisPositionUsingPackAutoFlow(const RenderBox& item) const
@@ -260,9 +260,9 @@ GridArea GridMasonryLayout::gridAreaForIndefiniteGridAxisItem(const RenderBox& i
     return masonryGridAreaFromGridAxisSpan(gridAxisPosition);
 }
 
-LayoutUnit GridMasonryLayout::offsetForChild(const RenderBox& child) const
+LayoutUnit GridMasonryLayout::offsetForGridItem(const RenderBox& gridItem) const
 {
-    const auto& offsetIter = m_itemOffsets.find(child);
+    const auto& offsetIter = m_itemOffsets.find(gridItem);
     if (offsetIter == m_itemOffsets.end())
         return 0_lu;
     return offsetIter->value;
@@ -275,9 +275,9 @@ inline GridTrackSizingDirection GridMasonryLayout::gridAxisDirection() const
     return m_masonryAxisDirection == GridTrackSizingDirection::ForRows ? GridTrackSizingDirection::ForColumns : GridTrackSizingDirection::ForRows;
 }
 
-bool GridMasonryLayout::hasDefiniteGridAxisPosition(const RenderBox& child, GridTrackSizingDirection gridAxisDirection) const 
+bool GridMasonryLayout::hasDefiniteGridAxisPosition(const RenderBox& gridItem, GridTrackSizingDirection gridAxisDirection) const
 {
-    auto itemSpan = GridPositionsResolver::resolveGridPositionsFromStyle(m_renderGrid, child, gridAxisDirection);
+    auto itemSpan = GridPositionsResolver::resolveGridPositionsFromStyle(m_renderGrid, gridItem, gridAxisDirection);
     return !itemSpan.isIndefinite();
 }
 

--- a/Source/WebCore/rendering/GridMasonryLayout.h
+++ b/Source/WebCore/rendering/GridMasonryLayout.h
@@ -42,7 +42,7 @@ public:
 
     void initializeMasonry(unsigned gridAxisTracks, GridTrackSizingDirection masonryAxisDirection);
     void performMasonryPlacement(unsigned gridAxisTracks, GridTrackSizingDirection masonryAxisDirection);
-    LayoutUnit offsetForChild(const RenderBox&) const;
+    LayoutUnit offsetForGridItem(const RenderBox&) const;
     LayoutUnit gridContentSize() const { return m_gridContentSize; };
     LayoutUnit gridGap() const { return m_masonryAxisGridGap; };
 
@@ -61,12 +61,12 @@ private:
 
     void resizeAndResetRunningPositions();
     void allocateCapacityForMasonryVectors();
-    LayoutUnit masonryAxisMarginBoxForItem(const RenderBox& child);
-    void updateRunningPositions(const RenderBox& child, const GridArea&);
-    void updateItemOffset(const RenderBox& child, LayoutUnit offset);
+    LayoutUnit masonryAxisMarginBoxForItem(const RenderBox& gridItem);
+    void updateRunningPositions(const RenderBox& gridItem, const GridArea&);
+    void updateItemOffset(const RenderBox& gridItem, LayoutUnit offset);
     inline GridTrackSizingDirection gridAxisDirection() const;
 
-    bool hasDefiniteGridAxisPosition(const RenderBox& child, GridTrackSizingDirection masonryDirection) const;
+    bool hasDefiniteGridAxisPosition(const RenderBox& gridItem, GridTrackSizingDirection masonryDirection) const;
     GridArea masonryGridAreaFromGridAxisSpan(const GridSpan&) const;
     GridSpan gridAxisSpanFromArea(const GridArea&) const;
     bool hasEnoughSpaceAtPosition(unsigned startingPosition, unsigned spanLength) const;

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -131,36 +131,36 @@ static GridTrackSizingDirection gridDirectionForAxis(GridAxis axis)
     return axis == GridAxis::GridRowAxis ? GridTrackSizingDirection::ForColumns : GridTrackSizingDirection::ForRows;
 }
 
-static bool hasRelativeMarginOrPaddingForChild(const RenderBox& child, GridTrackSizingDirection direction)
+static bool hasRelativeMarginOrPaddingForGridItem(const RenderBox& gridItem, GridTrackSizingDirection direction)
 {
     if (direction == GridTrackSizingDirection::ForColumns)
-        return child.style().marginStart().isPercentOrCalculated() || child.style().marginEnd().isPercentOrCalculated() || child.style().paddingStart().isPercentOrCalculated() || child.style().paddingEnd().isPercentOrCalculated();
-    return child.style().marginBefore().isPercentOrCalculated() || child.style().marginAfter().isPercentOrCalculated() || child.style().paddingBefore().isPercentOrCalculated() || child.style().paddingAfter().isPercentOrCalculated();
+        return gridItem.style().marginStart().isPercentOrCalculated() || gridItem.style().marginEnd().isPercentOrCalculated() || gridItem.style().paddingStart().isPercentOrCalculated() || gridItem.style().paddingEnd().isPercentOrCalculated();
+    return gridItem.style().marginBefore().isPercentOrCalculated() || gridItem.style().marginAfter().isPercentOrCalculated() || gridItem.style().paddingBefore().isPercentOrCalculated() || gridItem.style().paddingAfter().isPercentOrCalculated();
 }
 
-static bool hasRelativeOrIntrinsicSizeForChild(const RenderBox& child, GridTrackSizingDirection direction)
+static bool hasRelativeOrIntrinsicSizeForGridItem(const RenderBox& gridItem, GridTrackSizingDirection direction)
 {
     if (direction == GridTrackSizingDirection::ForColumns)
-        return child.hasRelativeLogicalWidth() || child.style().logicalWidth().isIntrinsicOrAuto();
-    return child.hasRelativeLogicalHeight() || child.style().logicalHeight().isIntrinsicOrAuto();
+        return gridItem.hasRelativeLogicalWidth() || gridItem.style().logicalWidth().isIntrinsicOrAuto();
+    return gridItem.hasRelativeLogicalHeight() || gridItem.style().logicalHeight().isIntrinsicOrAuto();
 }
 
-static bool shouldClearOverridingContainingBlockContentSizeForChild(const RenderBox& child, GridTrackSizingDirection direction)
+static bool shouldClearOverridingContainingBlockContentSizeForGridItem(const RenderBox& gridItem, GridTrackSizingDirection direction)
 {
-    return hasRelativeOrIntrinsicSizeForChild(child, direction) || hasRelativeMarginOrPaddingForChild(child, direction);
+    return hasRelativeOrIntrinsicSizeForGridItem(gridItem, direction) || hasRelativeMarginOrPaddingForGridItem(gridItem, direction);
 }
 
-static void setOverridingContainingBlockContentSizeForChild(const RenderGrid& grid, RenderBox& child, GridTrackSizingDirection direction, std::optional<LayoutUnit> size)
+static void setOverridingContainingBlockContentSizeForGridItem(const RenderGrid& grid, RenderBox& gridItem, GridTrackSizingDirection direction, std::optional<LayoutUnit> size)
 {
     // This function sets the dimension based on the writing mode of the containing block.
     // For subgrids, this might not be the outermost grid, but could be a subgrid. If the
     // writing mode of the CB and the grid for which we're doing sizing don't match, swap
     // the directions.
-    direction = GridLayoutFunctions::flowAwareDirectionForChild(grid, *child.containingBlock(), direction);
+    direction = GridLayoutFunctions::flowAwareDirectionForGridItem(grid, *gridItem.containingBlock(), direction);
     if (direction == GridTrackSizingDirection::ForColumns)
-        child.setOverridingContainingBlockContentLogicalWidth(size);
+        gridItem.setOverridingContainingBlockContentLogicalWidth(size);
     else
-        child.setOverridingContainingBlockContentLogicalHeight(size);
+        gridItem.setOverridingContainingBlockContentLogicalHeight(size);
 }
 
 // GridTrackSizingAlgorithm private.
@@ -298,17 +298,17 @@ void GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem(const GridSpan& spa
     const auto& trackSize = tracks(m_direction)[trackPosition].cachedTrackSize();
 
     if (trackSize.hasMinContentMinTrackBreadth()) {
-        track.setBaseSize(std::max(track.baseSize(), m_strategy->minContentForChild(gridItem)));
+        track.setBaseSize(std::max(track.baseSize(), m_strategy->minContentForGridItem(gridItem)));
     } else if (trackSize.hasMaxContentMinTrackBreadth()) {
-        track.setBaseSize(std::max(track.baseSize(), m_strategy->maxContentForChild(gridItem)));
+        track.setBaseSize(std::max(track.baseSize(), m_strategy->maxContentForGridItem(gridItem)));
     } else if (trackSize.hasAutoMinTrackBreadth()) {
-        track.setBaseSize(std::max(track.baseSize(), m_strategy->minSizeForChild(gridItem)));
+        track.setBaseSize(std::max(track.baseSize(), m_strategy->minSizeForGridItem(gridItem)));
     }
 
     if (trackSize.hasMinContentMaxTrackBreadth()) {
-        track.setGrowthLimit(std::max(track.growthLimit(), m_strategy->minContentForChild(gridItem)));
+        track.setGrowthLimit(std::max(track.growthLimit(), m_strategy->minContentForGridItem(gridItem)));
     } else if (trackSize.hasMaxContentOrAutoMaxTrackBreadth()) {
-        LayoutUnit growthLimit = m_strategy->maxContentForChild(gridItem);
+        LayoutUnit growthLimit = m_strategy->maxContentForGridItem(gridItem);
         if (trackSize.isFitContent())
             growthLimit = std::min(growthLimit, valueForLength(trackSize.fitContentTrackBreadth().length(), availableSpace().value_or(0)));
         track.setGrowthLimit(std::max(track.growthLimit(), growthLimit));
@@ -359,13 +359,13 @@ LayoutUnit GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhase(TrackS
 {
     switch (phase) {
     case TrackSizeComputationPhase::ResolveIntrinsicMinimums:
-        return m_strategy->minSizeForChild(gridItem);
+        return m_strategy->minSizeForGridItem(gridItem);
     case TrackSizeComputationPhase::ResolveContentBasedMinimums:
     case TrackSizeComputationPhase::ResolveIntrinsicMaximums:
-        return m_strategy->minContentForChild(gridItem);
+        return m_strategy->minContentForGridItem(gridItem);
     case TrackSizeComputationPhase::ResolveMaxContentMinimums:
     case TrackSizeComputationPhase::ResolveMaxContentMaximums:
-        return m_strategy->maxContentForChild(gridItem);
+        return m_strategy->maxContentForGridItem(gridItem);
     case TrackSizeComputationPhase::MaximizeTracks:
         ASSERT_NOT_REACHED();
         return 0;
@@ -640,9 +640,9 @@ void GridTrackSizingAlgorithm::distributeSpaceToTracks(Vector<WeakPtr<GridTrack>
         track->setPlannedSize(track->plannedSize() == infinity ? track->tempSize() : std::max(track->plannedSize(), track->tempSize()));
 }
 
-std::optional<LayoutUnit> GridTrackSizingAlgorithm::estimatedGridAreaBreadthForChild(const RenderBox& child, GridTrackSizingDirection direction) const
+std::optional<LayoutUnit> GridTrackSizingAlgorithm::estimatedGridAreaBreadthForGridItem(const RenderBox& gridItem, GridTrackSizingDirection direction) const
 {
-    const GridSpan& span = m_renderGrid->gridSpanForChild(child, direction);
+    const GridSpan& span = m_renderGrid->gridSpanForGridItem(gridItem, direction);
     LayoutUnit gridAreaSize;
     bool gridAreaIsIndefinite = false;
     std::optional<LayoutUnit> availableSize = availableSpace(direction);
@@ -660,9 +660,9 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::estimatedGridAreaBreadthForC
 
     gridAreaSize += m_renderGrid->guttersSize(direction, span.startLine(), span.integerSpan(), availableSize);
 
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*m_renderGrid, child, GridTrackSizingDirection::ForColumns);
+    GridTrackSizingDirection gridItemInlineDirection = GridLayoutFunctions::flowAwareDirectionForGridItem(*m_renderGrid, gridItem, GridTrackSizingDirection::ForColumns);
     if (gridAreaIsIndefinite)
-        return direction == childInlineDirection ? std::make_optional(std::max(child.maxPreferredLogicalWidth(), gridAreaSize)) : std::nullopt;
+        return direction == gridItemInlineDirection ? std::make_optional(std::max(gridItem.maxPreferredLogicalWidth(), gridAreaSize)) : std::nullopt;
     return gridAreaSize;
 }
 
@@ -674,7 +674,7 @@ static LayoutUnit computeGridSpanSize(const Vector<GridTrack>& tracks, const Gri
     return totalTracksSize + totalGuttersSize + ((gridSpan.integerSpan() - 1) * gridItemOffset.value_or(0_lu));
 }
 
-std::optional<LayoutUnit> GridTrackSizingAlgorithm::gridAreaBreadthForChild(const RenderBox& child, GridTrackSizingDirection direction) const
+std::optional<LayoutUnit> GridTrackSizingAlgorithm::gridAreaBreadthForGridItem(const RenderBox& gridItem, GridTrackSizingDirection direction) const
 {
     if (m_renderGrid->areMasonryColumns())
         return m_renderGrid->contentLogicalWidth();
@@ -685,15 +685,15 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::gridAreaBreadthForChild(cons
     // height, which may depend on the row track's size. It's possible that the row tracks sizing
     // logic has not been performed yet, so we will need to do an estimation.
     if (direction == GridTrackSizingDirection::ForRows && (m_sizingState == SizingState::ColumnSizingFirstIteration || m_sizingState == SizingState::ColumnSizingSecondIteration) && !m_renderGrid->areMasonryColumns()) {
-        ASSERT(GridLayoutFunctions::isOrthogonalChild(*m_renderGrid, child));
+        ASSERT(GridLayoutFunctions::isOrthogonalGridItem(*m_renderGrid, gridItem));
         // FIXME (jfernandez) Content Alignment should account for this heuristic.
         // https://github.com/w3c/csswg-drafts/issues/2697
         if (m_sizingState == SizingState::ColumnSizingFirstIteration)
-            return estimatedGridAreaBreadthForChild(child, GridTrackSizingDirection::ForRows);
+            return estimatedGridAreaBreadthForGridItem(gridItem, GridTrackSizingDirection::ForRows);
         addContentAlignmentOffset = true;
     }
 
-    const GridSpan& span = m_renderGrid->gridSpanForChild(child, direction);
+    const GridSpan& span = m_renderGrid->gridSpanForGridItem(gridItem, direction);
     return computeGridSpanSize(tracks(direction), span, addContentAlignmentOffset ? std::make_optional(m_renderGrid->gridItemOffset(direction)) : std::nullopt, m_renderGrid->guttersSize(direction, span.startLine(), span.integerSpan(), availableSpace(direction)));
 }
 
@@ -702,11 +702,11 @@ bool GridTrackSizingAlgorithm::isRelativeGridLengthAsAuto(const GridLength& leng
     return length.isPercentage() && !availableSpace(direction);
 }
 
-bool GridTrackSizingAlgorithm::isIntrinsicSizedGridArea(const RenderBox& child, GridAxis axis) const
+bool GridTrackSizingAlgorithm::isIntrinsicSizedGridArea(const RenderBox& gridItem, GridAxis axis) const
 {
     ASSERT(wasSetup());
     GridTrackSizingDirection direction = gridDirectionForAxis(axis);
-    const GridSpan& span = m_renderGrid->gridSpanForChild(child, direction);
+    const GridSpan& span = m_renderGrid->gridSpanForGridItem(gridItem, direction);
     for (auto trackPosition : span) {
         const auto& trackSize = rawGridTrackSize(direction, trackPosition);
         // We consider fr units as 'auto' for the min sizing function.
@@ -852,96 +852,96 @@ void GridTrackSizingAlgorithm::computeGridContainerIntrinsicSizes()
 }
 
 // GridTrackSizingAlgorithmStrategy.
-LayoutUnit GridTrackSizingAlgorithmStrategy::logicalHeightForChild(RenderBox& child) const
+LayoutUnit GridTrackSizingAlgorithmStrategy::logicalHeightForGridItem(RenderBox& gridItem) const
 {
-    GridTrackSizingDirection childBlockDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForRows);
-    // If |child| has a relative logical height, we shouldn't let it override its intrinsic height, which is
+    GridTrackSizingDirection gridItemBlockDirection = GridLayoutFunctions::flowAwareDirectionForGridItem(*renderGrid(), gridItem, GridTrackSizingDirection::ForRows);
+    // If |gridItem| has a relative logical height, we shouldn't let it override its intrinsic height, which is
     // what we are interested in here. Thus we need to set the block-axis override size to nullopt (no possible resolution).
-    auto hasOverridingContainingBlockContentSizeForChild = [&] {
-        if (auto overridingContainingBlockContentSizeForChild = GridLayoutFunctions::overridingContainingBlockContentSizeForChild(child, GridTrackSizingDirection::ForRows); overridingContainingBlockContentSizeForChild && *overridingContainingBlockContentSizeForChild)
+    auto hasOverridingContainingBlockContentSizeForGridItem = [&] {
+        if (auto overridingContainingBlockContentSizeForGridItem = GridLayoutFunctions::overridingContainingBlockContentSizeForGridItem(gridItem, GridTrackSizingDirection::ForRows); overridingContainingBlockContentSizeForGridItem && *overridingContainingBlockContentSizeForGridItem)
             return true;
         return false;
     };
-    if (hasOverridingContainingBlockContentSizeForChild() && shouldClearOverridingContainingBlockContentSizeForChild(child, GridTrackSizingDirection::ForRows)) {
-        setOverridingContainingBlockContentSizeForChild(*renderGrid(), child, childBlockDirection, std::nullopt);
-        child.setNeedsLayout(MarkOnlyThis);
+    if (hasOverridingContainingBlockContentSizeForGridItem() && shouldClearOverridingContainingBlockContentSizeForGridItem(gridItem, GridTrackSizingDirection::ForRows)) {
+        setOverridingContainingBlockContentSizeForGridItem(*renderGrid(), gridItem, gridItemBlockDirection, std::nullopt);
+        gridItem.setNeedsLayout(MarkOnlyThis);
 
         if (auto* gridLayoutState = m_algorithm.m_gridLayoutState.get()) {
             auto& itemsLayoutRequirements = gridLayoutState->itemsLayoutRequirements();
 
-            if (renderGrid()->canSetColumnAxisStretchRequirementForItem(child))
-                itemsLayoutRequirements.add(child, ItemLayoutRequirement::NeedsColumnAxisStretchAlignment);
+            if (renderGrid()->canSetColumnAxisStretchRequirementForItem(gridItem))
+                itemsLayoutRequirements.add(gridItem, ItemLayoutRequirement::NeedsColumnAxisStretchAlignment);
         }
     }
 
     // We need to clear the stretched content size to properly compute logical height during layout.
-    if (child.needsLayout())
-        child.clearOverridingContentSize();
+    if (gridItem.needsLayout())
+        gridItem.clearOverridingContentSize();
 
-    child.layoutIfNeeded();
-    return child.logicalHeight() + GridLayoutFunctions::marginLogicalSizeForChild(*renderGrid(), childBlockDirection, child) + m_algorithm.baselineOffsetForChild(child, gridAxisForDirection(direction()));
+    gridItem.layoutIfNeeded();
+    return gridItem.logicalHeight() + GridLayoutFunctions::marginLogicalSizeForGridItem(*renderGrid(), gridItemBlockDirection, gridItem) + m_algorithm.baselineOffsetForGridItem(gridItem, gridAxisForDirection(direction()));
 }
 
-LayoutUnit GridTrackSizingAlgorithmStrategy::minContentForChild(RenderBox& child) const
+LayoutUnit GridTrackSizingAlgorithmStrategy::minContentForGridItem(RenderBox& gridItem) const
 {
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForColumns);
-    if (direction() == childInlineDirection) {
+    GridTrackSizingDirection gridItemInlineDirection = GridLayoutFunctions::flowAwareDirectionForGridItem(*renderGrid(), gridItem, GridTrackSizingDirection::ForColumns);
+    if (direction() == gridItemInlineDirection) {
         if (isComputingInlineSizeContainment())
             return { };
         // FIXME: It's unclear if we should return the intrinsic width or the preferred width.
         // See http://lists.w3.org/Archives/Public/www-style/2013Jan/0245.html
-        if (child.needsPreferredWidthsRecalculation())
-            child.setPreferredLogicalWidthsDirty(true);
-        return child.minPreferredLogicalWidth() + GridLayoutFunctions::marginLogicalSizeForChild(*renderGrid(), childInlineDirection, child) + m_algorithm.baselineOffsetForChild(child, gridAxisForDirection(direction()));
+        if (gridItem.needsPreferredWidthsRecalculation())
+            gridItem.setPreferredLogicalWidthsDirty(true);
+        return gridItem.minPreferredLogicalWidth() + GridLayoutFunctions::marginLogicalSizeForGridItem(*renderGrid(), gridItemInlineDirection, gridItem) + m_algorithm.baselineOffsetForGridItem(gridItem, gridAxisForDirection(direction()));
     }
 
-    if (updateOverridingContainingBlockContentSizeForChild(child, childInlineDirection)) {
-        child.setNeedsLayout(MarkOnlyThis);
-        // For a child with relative width constraints to the grid area, such as percentaged paddings, we reset the overridingContainingBlockContentSizeForChild value for columns when we are executing a definite strategy
-        // for columns. Since we have updated the overridingContainingBlockContentSizeForChild inline-axis/width value here, we might need to recompute the child's relative width. For some cases, we probably will not
-        // be able to do it during the RenderGrid::layoutGridItems() function as the grid area does't change there any more. Also, as we are doing a layout inside GridTrackSizingAlgorithmStrategy::logicalHeightForChild()
+    if (updateOverridingContainingBlockContentSizeForGridItem(gridItem, gridItemInlineDirection)) {
+        gridItem.setNeedsLayout(MarkOnlyThis);
+        // For a grid item with relative width constraints to the grid area, such as percentaged paddings, we reset the overridingContainingBlockContentSizeForGridItem value for columns when we are executing a definite strategy
+        // for columns. Since we have updated the overridingContainingBlockContentSizeForGridItem inline-axis/width value here, we might need to recompute the grid item's relative width. For some cases, we probably will not
+        // be able to do it during the RenderGrid::layoutGridItems() function as the grid area does't change there any more. Also, as we are doing a layout inside GridTrackSizingAlgorithmStrategy::logicalHeightForGridItem()
         // function, let's take the advantage and set it here. 
-        if (shouldClearOverridingContainingBlockContentSizeForChild(child, childInlineDirection))
-            child.setPreferredLogicalWidthsDirty(true);
+        if (shouldClearOverridingContainingBlockContentSizeForGridItem(gridItem, gridItemInlineDirection))
+            gridItem.setPreferredLogicalWidthsDirty(true);
     }
-    return logicalHeightForChild(child);
+    return logicalHeightForGridItem(gridItem);
 }
 
-LayoutUnit GridTrackSizingAlgorithmStrategy::maxContentForChild(RenderBox& child) const
+LayoutUnit GridTrackSizingAlgorithmStrategy::maxContentForGridItem(RenderBox& gridItem) const
 {
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForColumns);
-    if (direction() == childInlineDirection) {
+    GridTrackSizingDirection gridItemInlineDirection = GridLayoutFunctions::flowAwareDirectionForGridItem(*renderGrid(), gridItem, GridTrackSizingDirection::ForColumns);
+    if (direction() == gridItemInlineDirection) {
         if (isComputingInlineSizeContainment())
             return { };
         // FIXME: It's unclear if we should return the intrinsic width or the preferred width.
         // See http://lists.w3.org/Archives/Public/www-style/2013Jan/0245.html
-        if (child.needsPreferredWidthsRecalculation())
-            child.setPreferredLogicalWidthsDirty(true);
-        return child.maxPreferredLogicalWidth() + GridLayoutFunctions::marginLogicalSizeForChild(*renderGrid(), childInlineDirection, child) + m_algorithm.baselineOffsetForChild(child, gridAxisForDirection(direction()));
+        if (gridItem.needsPreferredWidthsRecalculation())
+            gridItem.setPreferredLogicalWidthsDirty(true);
+        return gridItem.maxPreferredLogicalWidth() + GridLayoutFunctions::marginLogicalSizeForGridItem(*renderGrid(), gridItemInlineDirection, gridItem) + m_algorithm.baselineOffsetForGridItem(gridItem, gridAxisForDirection(direction()));
     }
 
-    if (updateOverridingContainingBlockContentSizeForChild(child, childInlineDirection))
-        child.setNeedsLayout(MarkOnlyThis);
-    return logicalHeightForChild(child);
+    if (updateOverridingContainingBlockContentSizeForGridItem(gridItem, gridItemInlineDirection))
+        gridItem.setNeedsLayout(MarkOnlyThis);
+    return logicalHeightForGridItem(gridItem);
 }
 
-LayoutUnit GridTrackSizingAlgorithmStrategy::minSizeForChild(RenderBox& child) const
+LayoutUnit GridTrackSizingAlgorithmStrategy::minSizeForGridItem(RenderBox& gridItem) const
 {
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForColumns);
-    bool isRowAxis = direction() == childInlineDirection;
+    GridTrackSizingDirection gridItemInlineDirection = GridLayoutFunctions::flowAwareDirectionForGridItem(*renderGrid(), gridItem, GridTrackSizingDirection::ForColumns);
+    bool isRowAxis = direction() == gridItemInlineDirection;
     if (isRowAxis && isComputingInlineSizeContainment())
         return { };
-    const Length& childSize = isRowAxis ? child.style().logicalWidth() : child.style().logicalHeight();
-    if (!childSize.isAuto() && !childSize.isPercentOrCalculated())
-        return minContentForChild(child);
+    const Length& gridItemSize = isRowAxis ? gridItem.style().logicalWidth() : gridItem.style().logicalHeight();
+    if (!gridItemSize.isAuto() && !gridItemSize.isPercentOrCalculated())
+        return minContentForGridItem(gridItem);
 
-    const Length& childMinSize = isRowAxis ? child.style().logicalMinWidth() : child.style().logicalMinHeight();
-    bool overflowIsVisible = isRowAxis ? child.effectiveOverflowInlineDirection() == Overflow::Visible : child.effectiveOverflowBlockDirection() == Overflow::Visible;
-    LayoutUnit baselineShim = m_algorithm.baselineOffsetForChild(child, gridAxisForDirection(direction()));
+    const Length& gridItemMinSize = isRowAxis ? gridItem.style().logicalMinWidth() : gridItem.style().logicalMinHeight();
+    bool overflowIsVisible = isRowAxis ? gridItem.effectiveOverflowInlineDirection() == Overflow::Visible : gridItem.effectiveOverflowBlockDirection() == Overflow::Visible;
+    LayoutUnit baselineShim = m_algorithm.baselineOffsetForGridItem(gridItem, gridAxisForDirection(direction()));
 
-    if (childMinSize.isAuto() && overflowIsVisible) {
-        auto minSize = minContentForChild(child);
-        const GridSpan& span = m_algorithm.m_renderGrid->gridSpanForChild(child, direction());
+    if (gridItemMinSize.isAuto() && overflowIsVisible) {
+        auto minSize = minContentForGridItem(gridItem);
+        const GridSpan& span = m_algorithm.m_renderGrid->gridSpanForGridItem(gridItem, direction());
 
         LayoutUnit maxBreadth;
         const auto& allTracks = m_algorithm.tracks(direction());
@@ -958,74 +958,74 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minSizeForChild(RenderBox& child) c
         if (!allFixed)
             return minSize;
         if (minSize > maxBreadth) {
-            auto marginAndBorderAndPadding = GridLayoutFunctions::marginLogicalSizeForChild(*renderGrid(), direction(), child);
-            marginAndBorderAndPadding += isRowAxis ? child.borderAndPaddingLogicalWidth() : child.borderAndPaddingLogicalHeight();
+            auto marginAndBorderAndPadding = GridLayoutFunctions::marginLogicalSizeForGridItem(*renderGrid(), direction(), gridItem);
+            marginAndBorderAndPadding += isRowAxis ? gridItem.borderAndPaddingLogicalWidth() : gridItem.borderAndPaddingLogicalHeight();
             minSize = std::max(maxBreadth, marginAndBorderAndPadding + baselineShim);
         }
         return minSize;
     }
 
-    std::optional<LayoutUnit> gridAreaSize = m_algorithm.gridAreaBreadthForChild(child, childInlineDirection);
-    return minLogicalSizeForChild(child, childMinSize, gridAreaSize) + baselineShim;
+    std::optional<LayoutUnit> gridAreaSize = m_algorithm.gridAreaBreadthForGridItem(gridItem, gridItemInlineDirection);
+    return minLogicalSizeForGridItem(gridItem, gridItemMinSize, gridAreaSize) + baselineShim;
 }
 
-bool GridTrackSizingAlgorithm::canParticipateInBaselineAlignment(const RenderBox& child, GridAxis baselineAxis) const
+bool GridTrackSizingAlgorithm::canParticipateInBaselineAlignment(const RenderBox& gridItem, GridAxis baselineAxis) const
 {
-    ASSERT(baselineAxis == GridAxis::GridColumnAxis ? m_columnBaselineItemsMap.contains(&child) : m_rowBaselineItemsMap.contains(&child));
+    ASSERT(baselineAxis == GridAxis::GridColumnAxis ? m_columnBaselineItemsMap.contains(&gridItem) : m_rowBaselineItemsMap.contains(&gridItem));
 
     // Baseline cyclic dependencies only happen with synthesized
     // baselines. These cases include orthogonal or empty grid items
     // and replaced elements.
-    bool isParallelToBaselineAxis = baselineAxis == GridAxis::GridColumnAxis ? !GridLayoutFunctions::isOrthogonalChild(*m_renderGrid, child) : GridLayoutFunctions::isOrthogonalChild(*m_renderGrid, child);
-    if (isParallelToBaselineAxis && child.firstLineBaseline())
+    bool isParallelToBaselineAxis = baselineAxis == GridAxis::GridColumnAxis ? !GridLayoutFunctions::isOrthogonalGridItem(*m_renderGrid, gridItem) : GridLayoutFunctions::isOrthogonalGridItem(*m_renderGrid, gridItem);
+    if (isParallelToBaselineAxis && gridItem.firstLineBaseline())
         return true;
 
     // FIXME: We don't currently allow items within subgrids that need to
     // synthesize a baseline, since we need a layout to have been completed
     // and performPreLayoutForGridItems on the outer grid doesn't layout subgrid
     // items.
-    if (child.parent() != renderGrid())
+    if (gridItem.parent() != renderGrid())
         return false;
 
     // Baseline cyclic dependencies only happen in grid areas with
     // intrinsically-sized tracks. 
-    if (!isIntrinsicSizedGridArea(child, baselineAxis))
+    if (!isIntrinsicSizedGridArea(gridItem, baselineAxis))
         return true;
 
-    return isParallelToBaselineAxis ? !child.hasRelativeLogicalHeight() : !child.hasRelativeLogicalWidth() && !child.style().logicalWidth().isAuto();
+    return isParallelToBaselineAxis ? !gridItem.hasRelativeLogicalHeight() : !gridItem.hasRelativeLogicalWidth() && !gridItem.style().logicalWidth().isAuto();
 }
 
-bool GridTrackSizingAlgorithm::participateInBaselineAlignment(const RenderBox& child, GridAxis baselineAxis) const
+bool GridTrackSizingAlgorithm::participateInBaselineAlignment(const RenderBox& gridItem, GridAxis baselineAxis) const
 {
-    return baselineAxis == GridAxis::GridColumnAxis ? m_columnBaselineItemsMap.get(&child) : m_rowBaselineItemsMap.get(&child);
+    return baselineAxis == GridAxis::GridColumnAxis ? m_columnBaselineItemsMap.get(&gridItem) : m_rowBaselineItemsMap.get(&gridItem);
 }
 
-void GridTrackSizingAlgorithm::updateBaselineAlignmentContext(const RenderBox& child, GridAxis baselineAxis)
+void GridTrackSizingAlgorithm::updateBaselineAlignmentContext(const RenderBox& gridItem, GridAxis baselineAxis)
 {
     ASSERT(wasSetup());
-    ASSERT(canParticipateInBaselineAlignment(child, baselineAxis));
+    ASSERT(canParticipateInBaselineAlignment(gridItem, baselineAxis));
 
-    ItemPosition align = m_renderGrid->selfAlignmentForChild(baselineAxis, child).position();
-    const auto& span = m_renderGrid->gridSpanForChild(child, gridDirectionForAxis(baselineAxis));
+    ItemPosition align = m_renderGrid->selfAlignmentForGridItem(baselineAxis, gridItem).position();
+    const auto& span = m_renderGrid->gridSpanForGridItem(gridItem, gridDirectionForAxis(baselineAxis));
     auto alignmentContext = GridLayoutFunctions::alignmentContextForBaselineAlignment(span, align);
-    m_baselineAlignment.updateBaselineAlignmentContext(align, alignmentContext, child, baselineAxis);
+    m_baselineAlignment.updateBaselineAlignmentContext(align, alignmentContext, gridItem, baselineAxis);
 }
 
-LayoutUnit GridTrackSizingAlgorithm::baselineOffsetForChild(const RenderBox& child, GridAxis baselineAxis) const
+LayoutUnit GridTrackSizingAlgorithm::baselineOffsetForGridItem(const RenderBox& gridItem, GridAxis baselineAxis) const
 {
     // If we haven't yet initialized this axis (which can be the case if we're doing
     // prelayout of a subgrid), then we can't know the baseline offset.
     if (tracks(gridDirectionForAxis(baselineAxis)).isEmpty())
         return LayoutUnit();
 
-    if (!participateInBaselineAlignment(child, baselineAxis))
+    if (!participateInBaselineAlignment(gridItem, baselineAxis))
         return LayoutUnit();
 
     ASSERT_IMPLIES(baselineAxis == GridAxis::GridColumnAxis, !m_renderGrid->isSubgridRows());
-    ItemPosition align = m_renderGrid->selfAlignmentForChild(baselineAxis, child).position();
-    const auto& span = m_renderGrid->gridSpanForChild(child, gridDirectionForAxis(baselineAxis));
+    ItemPosition align = m_renderGrid->selfAlignmentForGridItem(baselineAxis, gridItem).position();
+    const auto& span = m_renderGrid->gridSpanForGridItem(gridItem, gridDirectionForAxis(baselineAxis));
     auto alignmentContext = GridLayoutFunctions::alignmentContextForBaselineAlignment(span, align);
-    return m_baselineAlignment.baselineOffsetForChild(align, alignmentContext, child, baselineAxis);
+    return m_baselineAlignment.baselineOffsetForGridItem(align, alignmentContext, gridItem, baselineAxis);
 }
 
 void GridTrackSizingAlgorithm::clearBaselineItemsCache()
@@ -1036,7 +1036,7 @@ void GridTrackSizingAlgorithm::clearBaselineItemsCache()
 
 void GridTrackSizingAlgorithm::cacheBaselineAlignedItem(const RenderBox& item, GridAxis axis, bool cachingRowSubgridsForRootGrid)
 {
-    ASSERT(downcast<RenderGrid>(item.parent())->isBaselineAlignmentForChild(item, axis));
+    ASSERT(downcast<RenderGrid>(item.parent())->isBaselineAlignmentForGridItem(item, axis));
 
     if (GridLayoutFunctions::isOrthogonalParent(*m_renderGrid, *item.parent()))
         axis = axis == GridAxis::GridColumnAxis ? GridAxis::GridRowAxis : GridAxis::GridColumnAxis;
@@ -1048,7 +1048,7 @@ void GridTrackSizingAlgorithm::cacheBaselineAlignedItem(const RenderBox& item, G
 
     const auto* gridItemParent = dynamicDowncast<RenderGrid>(item.parent());
     if (gridItemParent) {
-        auto gridItemParentIsSubgridRowsOfRootGrid = GridLayoutFunctions::isOrthogonalChild(*m_renderGrid, *gridItemParent) ? gridItemParent->isSubgridColumns() : gridItemParent->isSubgridRows();
+        auto gridItemParentIsSubgridRowsOfRootGrid = GridLayoutFunctions::isOrthogonalGridItem(*m_renderGrid, *gridItemParent) ? gridItemParent->isSubgridColumns() : gridItemParent->isSubgridRows();
         if (cachingRowSubgridsForRootGrid && gridItemParentIsSubgridRowsOfRootGrid)
             m_rowSubgridsWithBaselineAlignedItems.add(*gridItemParent);
     }
@@ -1062,57 +1062,57 @@ void GridTrackSizingAlgorithm::copyBaselineItemsCache(const GridTrackSizingAlgor
         m_rowBaselineItemsMap = source.m_rowBaselineItemsMap;
 }
 
-bool GridTrackSizingAlgorithmStrategy::updateOverridingContainingBlockContentSizeForChild(RenderBox& child, GridTrackSizingDirection direction, std::optional<LayoutUnit> overrideSize) const
+bool GridTrackSizingAlgorithmStrategy::updateOverridingContainingBlockContentSizeForGridItem(RenderBox& gridItem, GridTrackSizingDirection direction, std::optional<LayoutUnit> overrideSize) const
 {
     if (!overrideSize)
-        overrideSize = m_algorithm.gridAreaBreadthForChild(child, direction);
+        overrideSize = m_algorithm.gridAreaBreadthForGridItem(gridItem, direction);
 
-    if (renderGrid() != child.parent()) {
-        // If child is part of a subgrid, find the nearest ancestor this is directly part of this grid
+    if (renderGrid() != gridItem.parent()) {
+        // If |gridItem| is part of a subgrid, find the nearest ancestor this is directly part of this grid
         // (either by being a child of the grid, or via being subgridded in this dimension.
-        RenderGrid* grid = downcast<RenderGrid>(child.parent());
-        GridTrackSizingDirection subgridDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), *grid, direction);
+        RenderGrid* grid = downcast<RenderGrid>(gridItem.parent());
+        GridTrackSizingDirection subgridDirection = GridLayoutFunctions::flowAwareDirectionForGridItem(*renderGrid(), *grid, direction);
         while (grid->parent() != renderGrid() && !grid->isSubgridOf(subgridDirection, *renderGrid())) {
             grid = downcast<RenderGrid>(grid->parent());
-            subgridDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), *grid, direction);
+            subgridDirection = GridLayoutFunctions::flowAwareDirectionForGridItem(*renderGrid(), *grid, direction);
         }
 
-        if (grid == child.parent() && grid->isSubgrid(subgridDirection)) {
+        if (grid == gridItem.parent() && grid->isSubgrid(subgridDirection)) {
             // If the item is subgridded in this direction (and thus the tracks it covers are tracks
             // owned by this sizing algorithm), then we want to take the breadth of the tracks we occupy,
             // and subtract any space occupied by the subgrid itself (and any ancestor subgrids).
-            *overrideSize -= GridLayoutFunctions::extraMarginForSubgridAncestors(subgridDirection, child).extraTotalMargin();
+            *overrideSize -= GridLayoutFunctions::extraMarginForSubgridAncestors(subgridDirection, gridItem).extraTotalMargin();
         } else {
-            // Otherwise the tracks that this child covers (in this non-subgridded axis) are owned
+            // Otherwise the tracks that this grid item covers (in this non-subgridded axis) are owned
             // by one of the intermediate RenderGrids (which are subgrids in the other axis), which may
             // be |grid| or a descendent.
             // Set the override size for |grid| (which is part of the outer grid), and force a layout
             // so that it computes the track sizes for the non-subgridded dimension and makes the size
-            // of |child| available.
+            // of |gridItem| available.
             bool overrideSizeHasChanged =
-                updateOverridingContainingBlockContentSizeForChild(*grid, direction);
+                updateOverridingContainingBlockContentSizeForGridItem(*grid, direction);
             layoutGridItemForMinSizeComputation(*grid, overrideSizeHasChanged);
             return overrideSizeHasChanged;
         }
     }
 
-    if (auto overridingContainingBlockContentSizeForChild = GridLayoutFunctions::overridingContainingBlockContentSizeForChild(child, direction); overridingContainingBlockContentSizeForChild && *overridingContainingBlockContentSizeForChild == overrideSize)
+    if (auto overridingContainingBlockContentSizeForGridItem = GridLayoutFunctions::overridingContainingBlockContentSizeForGridItem(gridItem, direction); overridingContainingBlockContentSizeForGridItem && *overridingContainingBlockContentSizeForGridItem == overrideSize)
         return false;
 
-    setOverridingContainingBlockContentSizeForChild(*renderGrid(), child, direction, overrideSize);
+    setOverridingContainingBlockContentSizeForGridItem(*renderGrid(), gridItem, direction, overrideSize);
     return true;
 }
 
-LayoutUnit GridTrackSizingAlgorithmStrategy::minLogicalSizeForChild(RenderBox& child, const Length& childMinSize, std::optional<LayoutUnit> availableSize) const
+LayoutUnit GridTrackSizingAlgorithmStrategy::minLogicalSizeForGridItem(RenderBox& gridItem, const Length& gridItemMinSize, std::optional<LayoutUnit> availableSize) const
 {
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForColumns);
-    bool isRowAxis = direction() == childInlineDirection;
+    GridTrackSizingDirection gridItemInlineDirection = GridLayoutFunctions::flowAwareDirectionForGridItem(*renderGrid(), gridItem, GridTrackSizingDirection::ForColumns);
+    bool isRowAxis = direction() == gridItemInlineDirection;
     if (isRowAxis)
-        return isComputingInlineSizeContainment() ? 0_lu : child.computeLogicalWidthInFragmentUsing(MinSize, childMinSize, availableSize.value_or(0), *renderGrid(), nullptr) + GridLayoutFunctions::marginLogicalSizeForChild(*renderGrid(), childInlineDirection, child);
-    bool overrideSizeHasChanged = updateOverridingContainingBlockContentSizeForChild(child, childInlineDirection, availableSize);
-    layoutGridItemForMinSizeComputation(child, overrideSizeHasChanged);
-    GridTrackSizingDirection childBlockDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForRows);
-    return child.computeLogicalHeightUsing(MinSize, childMinSize, std::nullopt).value_or(0) + GridLayoutFunctions::marginLogicalSizeForChild(*renderGrid(), childBlockDirection, child);
+        return isComputingInlineSizeContainment() ? 0_lu : gridItem.computeLogicalWidthInFragmentUsing(MinSize, gridItemMinSize, availableSize.value_or(0), *renderGrid(), nullptr) + GridLayoutFunctions::marginLogicalSizeForGridItem(*renderGrid(), gridItemInlineDirection, gridItem);
+    bool overrideSizeHasChanged = updateOverridingContainingBlockContentSizeForGridItem(gridItem, gridItemInlineDirection, availableSize);
+    layoutGridItemForMinSizeComputation(gridItem, overrideSizeHasChanged);
+    GridTrackSizingDirection gridItemBlockDirection = GridLayoutFunctions::flowAwareDirectionForGridItem(*renderGrid(), gridItem, GridTrackSizingDirection::ForRows);
+    return gridItem.computeLogicalHeightUsing(MinSize, gridItemMinSize, std::nullopt).value_or(0) + GridLayoutFunctions::marginLogicalSizeForGridItem(*renderGrid(), gridItemBlockDirection, gridItem);
 }
 
 class IndefiniteSizeStrategy final : public GridTrackSizingAlgorithmStrategy {
@@ -1132,11 +1132,11 @@ private:
     void accumulateFlexFraction(double& flexFraction, GridIterator&, GridTrackSizingDirection outermostDirection, SingleThreadWeakHashSet<RenderBox>& itemsSet) const;
 };
 
-void IndefiniteSizeStrategy::layoutGridItemForMinSizeComputation(RenderBox& child, bool overrideSizeHasChanged) const
+void IndefiniteSizeStrategy::layoutGridItemForMinSizeComputation(RenderBox& gridItem, bool overrideSizeHasChanged) const
 {
     if (overrideSizeHasChanged && direction() != GridTrackSizingDirection::ForColumns)
-        child.setNeedsLayout(MarkOnlyThis);
-    child.layoutIfNeeded();
+        gridItem.setNeedsLayout(MarkOnlyThis);
+    gridItem.layoutIfNeeded();
 }
 
 void IndefiniteSizeStrategy::maximizeTracks(Vector<GridTrack>& tracks, std::optional<LayoutUnit>& freeSpace)
@@ -1158,19 +1158,19 @@ void IndefiniteSizeStrategy::accumulateFlexFraction(double& flexFraction, GridIt
     while (auto* gridItem = iterator.nextGridItem()) {
         if (CheckedPtr inner = dynamicDowncast<RenderGrid>(gridItem); inner && inner->isSubgridInParentDirection(iterator.direction())) {
             const RenderGrid& subgrid = *inner;
-            GridSpan span = downcast<RenderGrid>(subgrid.parent())->gridSpanForChild(subgrid, iterator.direction());
-            GridIterator childIterator = GridIterator::createForSubgrid(*inner, iterator, span);
-            accumulateFlexFraction(flexFraction, childIterator, outermostDirection, itemsSet);
+            GridSpan span = downcast<RenderGrid>(subgrid.parent())->gridSpanForGridItem(subgrid, iterator.direction());
+            GridIterator subgridIterator = GridIterator::createForSubgrid(*inner, iterator, span);
+            accumulateFlexFraction(flexFraction, subgridIterator, outermostDirection, itemsSet);
             continue;
         }
         // Do not include already processed items.
         if (!itemsSet.add(*gridItem).isNewEntry)
             continue;
 
-        GridSpan span = m_algorithm.renderGrid()->gridSpanForChild(*gridItem, outermostDirection);
+        GridSpan span = m_algorithm.renderGrid()->gridSpanForGridItem(*gridItem, outermostDirection);
 
         // Removing gutters from the max-content contribution of the item, so they are not taken into account in FindFrUnitSize().
-        LayoutUnit leftOverSpace = maxContentForChild(*gridItem) - renderGrid()->guttersSize(outermostDirection, span.startLine(), span.integerSpan(), availableSpace());
+        LayoutUnit leftOverSpace = maxContentForGridItem(*gridItem) - renderGrid()->guttersSize(outermostDirection, span.startLine(), span.integerSpan(), availableSpace());
         flexFraction = std::max(flexFraction, findFrUnitSize(span, leftOverSpace));
     }
 }
@@ -1241,8 +1241,8 @@ private:
     double findUsedFlexFraction(Vector<unsigned>& flexibleSizedTracksIndex, GridTrackSizingDirection, std::optional<LayoutUnit> freeSpace) const override;
     bool recomputeUsedFlexFractionIfNeeded(double& flexFraction, LayoutUnit& totalGrowth) const override;
     LayoutUnit freeSpaceForStretchAutoTracksStep() const override;
-    LayoutUnit minContentForChild(RenderBox&) const override;
-    LayoutUnit minLogicalSizeForChild(RenderBox&, const Length& childMinSize, std::optional<LayoutUnit> availableSize) const override;
+    LayoutUnit minContentForGridItem(RenderBox&) const override;
+    LayoutUnit minLogicalSizeForGridItem(RenderBox&, const Length& gridItemMinSize, std::optional<LayoutUnit> availableSize) const override;
     bool isComputingSizeContainment() const override { return false; }
     bool isComputingInlineSizeContainment() const override { return false; }
     bool isComputingSizeOrInlineSizeContainment() const override { return false; }
@@ -1260,15 +1260,15 @@ LayoutUnit IndefiniteSizeStrategy::freeSpaceForStretchAutoTracksStep() const
     return minSize.value() - computeTrackBasedSize();
 }
 
-LayoutUnit DefiniteSizeStrategy::minLogicalSizeForChild(RenderBox& child, const Length& childMinSize, std::optional<LayoutUnit> availableSize) const
+LayoutUnit DefiniteSizeStrategy::minLogicalSizeForGridItem(RenderBox& gridItem, const Length& gridItemMinSize, std::optional<LayoutUnit> availableSize) const
 {
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForColumns);
-    GridTrackSizingDirection flowAwareDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, direction());
-    if (hasRelativeMarginOrPaddingForChild(child, flowAwareDirection) || (direction() != childInlineDirection && hasRelativeOrIntrinsicSizeForChild(child, flowAwareDirection))) {
-        auto indefiniteSize = direction() == childInlineDirection ? std::make_optional(0_lu) : std::nullopt;
-        setOverridingContainingBlockContentSizeForChild(*renderGrid(), child, direction(), indefiniteSize);
+    GridTrackSizingDirection gridItemInlineDirection = GridLayoutFunctions::flowAwareDirectionForGridItem(*renderGrid(), gridItem, GridTrackSizingDirection::ForColumns);
+    GridTrackSizingDirection flowAwareDirection = GridLayoutFunctions::flowAwareDirectionForGridItem(*renderGrid(), gridItem, direction());
+    if (hasRelativeMarginOrPaddingForGridItem(gridItem, flowAwareDirection) || (direction() != gridItemInlineDirection && hasRelativeOrIntrinsicSizeForGridItem(gridItem, flowAwareDirection))) {
+        auto indefiniteSize = direction() == gridItemInlineDirection ? std::make_optional(0_lu) : std::nullopt;
+        setOverridingContainingBlockContentSizeForGridItem(*renderGrid(), gridItem, direction(), indefiniteSize);
     }
-    return GridTrackSizingAlgorithmStrategy::minLogicalSizeForChild(child, childMinSize, availableSize);
+    return GridTrackSizingAlgorithmStrategy::minLogicalSizeForGridItem(gridItem, gridItemMinSize, availableSize);
 }
 
 void DefiniteSizeStrategy::maximizeTracks(Vector<GridTrack>& tracks, std::optional<LayoutUnit>& freeSpace)
@@ -1288,11 +1288,11 @@ void DefiniteSizeStrategy::maximizeTracks(Vector<GridTrack>& tracks, std::option
 }
 
 
-void DefiniteSizeStrategy::layoutGridItemForMinSizeComputation(RenderBox& child, bool overrideSizeHasChanged) const
+void DefiniteSizeStrategy::layoutGridItemForMinSizeComputation(RenderBox& gridItem, bool overrideSizeHasChanged) const
 {
     if (overrideSizeHasChanged)
-        child.setNeedsLayout(MarkOnlyThis);
-    child.layoutIfNeeded();
+        gridItem.setNeedsLayout(MarkOnlyThis);
+    gridItem.layoutIfNeeded();
 }
 
 double DefiniteSizeStrategy::findUsedFlexFraction(Vector<unsigned>&, GridTrackSizingDirection direction, std::optional<LayoutUnit> freeSpace) const
@@ -1307,12 +1307,12 @@ LayoutUnit DefiniteSizeStrategy::freeSpaceForStretchAutoTracksStep() const
     return m_algorithm.freeSpace(direction()).value();
 }
 
-LayoutUnit DefiniteSizeStrategy::minContentForChild(RenderBox& child) const
+LayoutUnit DefiniteSizeStrategy::minContentForGridItem(RenderBox& gridItem) const
 {
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForColumns);
-    if (direction() == childInlineDirection && child.needsLayout() && shouldClearOverridingContainingBlockContentSizeForChild(child, GridTrackSizingDirection::ForColumns))
-        setOverridingContainingBlockContentSizeForChild(*renderGrid(), child, childInlineDirection, LayoutUnit());
-    return GridTrackSizingAlgorithmStrategy::minContentForChild(child);
+    GridTrackSizingDirection gridItemInlineDirection = GridLayoutFunctions::flowAwareDirectionForGridItem(*renderGrid(), gridItem, GridTrackSizingDirection::ForColumns);
+    if (direction() == gridItemInlineDirection && gridItem.needsLayout() && shouldClearOverridingContainingBlockContentSizeForGridItem(gridItem, GridTrackSizingDirection::ForColumns))
+        setOverridingContainingBlockContentSizeForGridItem(*renderGrid(), gridItem, gridItemInlineDirection, LayoutUnit());
+    return GridTrackSizingAlgorithmStrategy::minContentForGridItem(gridItem);
 }
 
 bool DefiniteSizeStrategy::recomputeUsedFlexFractionIfNeeded(double& flexFraction, LayoutUnit& totalGrowth) const
@@ -1381,7 +1381,7 @@ static LayoutUnit computeSubgridMarginBorderPadding(const RenderGrid* outermost,
 {
     // Convert the direction into the coordinate space of subgrid (which may not be a direct child
     // of the outermost grid for which we're running the track sizing algorithm).
-    GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForChild(*outermost, *subgrid, outermostDirection);
+    GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForGridItem(*outermost, *subgrid, outermostDirection);
     bool reversed = GridLayoutFunctions::isSubgridReversedDirection(*outermost, outermostDirection, *subgrid);
 
     LayoutUnit subgridMbp;
@@ -1404,10 +1404,10 @@ static std::optional<LayoutUnit> extraMarginFromSubgridAncestorGutters(const Ren
 
     for (auto& currentAncestorSubgrid : ancestorSubgridsOfGridItem(gridItem, direction)) {
         std::optional<LayoutUnit> availableSpace;
-        if (!GridLayoutFunctions::hasRelativeOrIntrinsicSizeForChild(currentAncestorSubgrid, direction))
+        if (!GridLayoutFunctions::hasRelativeOrIntrinsicSizeForGridItem(currentAncestorSubgrid, direction))
             availableSpace = currentAncestorSubgrid.availableSpaceForGutters(direction);
 
-        auto gridItemSpanInAncestor = currentAncestorSubgrid.gridSpanForChild(gridItem, direction);
+        auto gridItemSpanInAncestor = currentAncestorSubgrid.gridSpanForGridItem(gridItem, direction);
         auto numTracksForCurrentAncestor = currentAncestorSubgrid.numTracks(direction);
 
         const auto* currentAncestorSubgridParent = dynamicDowncast<RenderGrid>(currentAncestorSubgrid.parent());
@@ -1429,7 +1429,7 @@ bool GridTrackSizingAlgorithm::shouldExcludeGridItemForMasonryTrackSizing(const 
     bool shouldExcludeGridItemForMasonryTrackSizing = true;
 
     // Items specifically placed in this track.
-    if (m_renderGrid->gridSpanForChild(gridItem, m_direction).startLine() == trackIndex)
+    if (m_renderGrid->gridSpanForGridItem(gridItem, m_direction).startLine() == trackIndex)
         shouldExcludeGridItemForMasonryTrackSizing = false;
 
     // Items that have an indefinite placement in the grid axis.
@@ -1447,17 +1447,17 @@ void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack(GridTrack& track
 {
     auto accumulateIntrinsicSizes = [&](RenderBox* gridItem) {
         bool isNewEntry = itemsSet.add(*gridItem).isNewEntry;
-        GridSpan span = m_renderGrid->gridSpanForChild(*gridItem, m_direction);
+        GridSpan span = m_renderGrid->gridSpanForGridItem(*gridItem, m_direction);
 
         if (CheckedPtr inner = dynamicDowncast<RenderGrid>(gridItem); inner && inner->isSubgridInParentDirection(iterator.direction())) {
             // Contribute the mbp of wrapper to the first and last tracks that we span.
-            GridSpan subgridSpan = downcast<RenderGrid>(inner->parent())->gridSpanForChild(*inner, iterator.direction());
+            GridSpan subgridSpan = downcast<RenderGrid>(inner->parent())->gridSpanForGridItem(*inner, iterator.direction());
             auto accumulatedMbpWithSubgrid = currentAccumulatedMbp + computeSubgridMarginBorderPadding(m_renderGrid, m_direction, track, trackIndex, span, inner.get());
             track.setBaseSize(std::max(track.baseSize(), accumulatedMbpWithSubgrid + extraMarginFromSubgridAncestorGutters(*gridItem, span, trackIndex, iterator.direction()).value_or(0_lu)));
 
-            GridIterator childIterator = GridIterator::createForSubgrid(*inner, iterator, subgridSpan);
+            GridIterator subgridIterator = GridIterator::createForSubgrid(*inner, iterator, subgridSpan);
 
-            accumulateIntrinsicSizesForTrack(track, trackIndex, childIterator, itemsSortedByIncreasingSpan, itemsCrossingFlexibleTracks, itemsSet, accumulatedMbpWithSubgrid);
+            accumulateIntrinsicSizesForTrack(track, trackIndex, subgridIterator, itemsSortedByIncreasingSpan, itemsCrossingFlexibleTracks, itemsSet, accumulatedMbpWithSubgrid);
             return;
         }
 
@@ -1480,7 +1480,7 @@ void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrackMasonry(GridTrack
 {
     auto accumulateIntrinsicSizes = [&](RenderBox* gridItem) {
         bool isNewEntry = itemsSet.add(*gridItem).isNewEntry;
-        GridSpan span = m_renderGrid->gridSpanForChild(*gridItem, m_direction);
+        GridSpan span = m_renderGrid->gridSpanForGridItem(*gridItem, m_direction);
 
         // Masonry Track Sizing
         // https://drafts.csswg.org/css-grid-3/#track-sizing
@@ -1507,17 +1507,17 @@ void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrackMasonry(GridTrack
             auto accumulatedMbpWithSubgrid = currentAccumulatedMbp + computeSubgridMarginBorderPadding(m_renderGrid, m_direction, track, trackIndex, span, inner.get());
             track.setBaseSize(std::max(track.baseSize(), accumulatedMbpWithSubgrid + extraMarginFromSubgridAncestorGutters(*gridItem, span, trackIndex, iterator.direction()).value_or(0_lu)));
 
-            GridIterator childIterator = GridIterator::createForSubgrid(*inner, iterator, subgridSpan);
+            GridIterator subgridIterator = GridIterator::createForSubgrid(*inner, iterator, subgridSpan);
             MasonryIndefiniteItems subgridMasonryIndefiniteItems;
 
             if (renderGrid()->isMasonry()) {
-                while (CheckedPtr<RenderBox> gridItem = childIterator.nextGridItem()) {
+                while (CheckedPtr<RenderBox> gridItem = subgridIterator.nextGridItem()) {
                     if (GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem, m_direction).isIndefinite())
                         subgridMasonryIndefiniteItems.indefiniteItems.add(*gridItem);
                 }
             }
 
-            accumulateIntrinsicSizesForTrackMasonry(track, trackIndex, childIterator, itemsSortedByIncreasingSpan, itemsCrossingFlexibleTracks, itemsSet, subgridMasonryIndefiniteItems, accumulatedMbpWithSubgrid);
+            accumulateIntrinsicSizesForTrackMasonry(track, trackIndex, subgridIterator, itemsSortedByIncreasingSpan, itemsCrossingFlexibleTracks, itemsSet, subgridMasonryIndefiniteItems, accumulatedMbpWithSubgrid);
             return;
         }
 
@@ -1561,17 +1561,17 @@ void GridTrackSizingAlgorithm::computeIndefiniteItemsForMasonry(MasonryIndefinit
         GridIterator iterator(m_grid, m_direction, trackIndex);
         while (CheckedPtr<RenderBox> gridItem = iterator.nextGridItem()) {
             if (GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem, m_direction).isIndefinite()) {
-                auto spanLength = m_renderGrid->gridSpanForChild(*gridItem, m_direction).integerSpan();
+                auto spanLength = m_renderGrid->gridSpanForGridItem(*gridItem, m_direction).integerSpan();
                 bool isSubgrid = gridItem->isRenderGrid() && downcast<RenderGrid>(gridItem.get())->isSubgridInParentDirection(iterator.direction());
 
                 if (spanLength == 1 && !isSubgrid) {
-                    auto minContentForChild = m_strategy->minContentForChild(*gridItem);
-                    auto maxContentForChild = m_strategy->maxContentForChild(*gridItem);
-                    auto minSizeForChild = m_strategy->minSizeForChild(*gridItem);
+                    auto minContentForGridItem = m_strategy->minContentForGridItem(*gridItem);
+                    auto maxContentForGridItem = m_strategy->maxContentForGridItem(*gridItem);
+                    auto minSizeForGridItem = m_strategy->minSizeForGridItem(*gridItem);
 
-                    masonryIndefiniteItems.largestMinContentSizeForSingleTrackItems = std::max(masonryIndefiniteItems.largestMinContentSizeForSingleTrackItems, minContentForChild);
-                    masonryIndefiniteItems.largestMaxContentSizeForSingleTrackItems = std::max(masonryIndefiniteItems.largestMaxContentSizeForSingleTrackItems, maxContentForChild);
-                    masonryIndefiniteItems.largestMinSizeForSingleTrackItems = std::max(masonryIndefiniteItems.largestMinSizeForSingleTrackItems, minSizeForChild);
+                    masonryIndefiniteItems.largestMinContentSizeForSingleTrackItems = std::max(masonryIndefiniteItems.largestMinContentSizeForSingleTrackItems, minContentForGridItem);
+                    masonryIndefiniteItems.largestMaxContentSizeForSingleTrackItems = std::max(masonryIndefiniteItems.largestMaxContentSizeForSingleTrackItems, maxContentForGridItem);
+                    masonryIndefiniteItems.largestMinSizeForSingleTrackItems = std::max(masonryIndefiniteItems.largestMinSizeForSingleTrackItems, minSizeForGridItem);
 
                     masonryIndefiniteItems.singleTrackIndefiniteItems.add(*gridItem);
                 } else
@@ -1783,7 +1783,7 @@ void GridTrackSizingAlgorithm::setup(GridTrackSizingDirection direction, unsigne
 
     auto resolveAndSetNonAutoRowStartMarginsOnRowSubgrids = [&] {
         for (auto& subgrid : m_rowSubgridsWithBaselineAlignedItems) {
-            const auto subgridSpan = m_renderGrid->gridSpanForChild(subgrid, GridTrackSizingDirection::ForColumns);
+            const auto subgridSpan = m_renderGrid->gridSpanForGridItem(subgrid, GridTrackSizingDirection::ForColumns);
             const auto subgridRowStartMargin = subgrid.style().marginBeforeUsing(&m_renderGrid->style());
             if (!subgridRowStartMargin.isAuto())
                 m_renderGrid->setMarginBeforeForChild(subgrid, minimumValueForLength(subgridRowStartMargin, computeGridSpanSize(tracks(GridTrackSizingDirection::ForColumns), subgridSpan, std::make_optional(m_renderGrid->gridItemOffset(direction)), m_renderGrid->guttersSize(GridTrackSizingDirection::ForColumns, subgridSpan.startLine(), subgridSpan.integerSpan(), this->availableSpace(GridTrackSizingDirection::ForColumns)))));
@@ -1802,15 +1802,15 @@ void GridTrackSizingAlgorithm::computeBaselineAlignmentContext()
     m_baselineAlignment.setWritingMode(m_renderGrid->style().writingMode());
     BaselineItemsCache& baselineItemsCache = axis == GridAxis::GridColumnAxis ? m_columnBaselineItemsMap : m_rowBaselineItemsMap;
     BaselineItemsCache tmpBaselineItemsCache = baselineItemsCache;
-    for (auto& child : tmpBaselineItemsCache.keys()) {
+    for (auto& gridItem : tmpBaselineItemsCache.keys()) {
         // FIXME (jfernandez): We may have to get rid of the baseline participation
         // flag (hence just using a HashSet) depending on the CSS WG resolution on
         // https://github.com/w3c/csswg-drafts/issues/3046
-        if (canParticipateInBaselineAlignment(child, axis)) {
-            updateBaselineAlignmentContext(child, axis);
-            baselineItemsCache.set(child, true);
+        if (canParticipateInBaselineAlignment(gridItem, axis)) {
+            updateBaselineAlignmentContext(gridItem, axis);
+            baselineItemsCache.set(gridItem, true);
         } else
-            baselineItemsCache.set(child, false);
+            baselineItemsCache.set(gridItem, false);
     }
 }
 
@@ -1843,7 +1843,7 @@ bool GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid()
     if (!parentTracks.size())
         return false;
 
-    GridSpan span = outer->gridSpanForChild(*m_renderGrid, direction);
+    GridSpan span = outer->gridSpanForGridItem(*m_renderGrid, direction);
     Vector<GridTrack>& allTracks = tracks(m_direction);
     int numTracks = allTracks.size();
     RELEASE_ASSERT((parentTracks.size()  - 1) >= (numTracks - 1 + span.startLine()));

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -132,12 +132,12 @@ public:
     LayoutUnit minContentSize() const { return m_minContentSize; };
     LayoutUnit maxContentSize() const { return m_maxContentSize; };
 
-    LayoutUnit baselineOffsetForChild(const RenderBox&, GridAxis) const;
+    LayoutUnit baselineOffsetForGridItem(const RenderBox&, GridAxis) const;
 
     // The estimated grid area should be use pre-layout versus the grid area, which should be used once
     // layout is complete.
-    std::optional<LayoutUnit> gridAreaBreadthForChild(const RenderBox&, GridTrackSizingDirection) const;
-    std::optional<LayoutUnit> estimatedGridAreaBreadthForChild(const RenderBox&, GridTrackSizingDirection) const;
+    std::optional<LayoutUnit> gridAreaBreadthForGridItem(const RenderBox&, GridTrackSizingDirection) const;
+    std::optional<LayoutUnit> estimatedGridAreaBreadthForGridItem(const RenderBox&, GridTrackSizingDirection) const;
 
     void cacheBaselineAlignedItem(const RenderBox&, GridAxis, bool cachingRowSubgridsForRootGrid);
     void copyBaselineItemsCache(const GridTrackSizingAlgorithm&, GridAxis);
@@ -313,9 +313,9 @@ private:
 class GridTrackSizingAlgorithmStrategy {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    virtual LayoutUnit minContentForChild(RenderBox&) const;
-    LayoutUnit maxContentForChild(RenderBox&) const;
-    LayoutUnit minSizeForChild(RenderBox&) const;
+    virtual LayoutUnit minContentForGridItem(RenderBox&) const;
+    LayoutUnit maxContentForGridItem(RenderBox&) const;
+    LayoutUnit minSizeForGridItem(RenderBox&) const;
 
     virtual ~GridTrackSizingAlgorithmStrategy() = default;
 
@@ -331,11 +331,11 @@ protected:
     GridTrackSizingAlgorithmStrategy(GridTrackSizingAlgorithm& algorithm)
         : m_algorithm(algorithm) { }
 
-    virtual LayoutUnit minLogicalSizeForChild(RenderBox&, const Length& childMinSize, std::optional<LayoutUnit> availableSize) const;
+    virtual LayoutUnit minLogicalSizeForGridItem(RenderBox&, const Length& gridItemMinSize, std::optional<LayoutUnit> availableSize) const;
     virtual void layoutGridItemForMinSizeComputation(RenderBox&, bool overrideSizeHasChanged) const = 0;
 
-    LayoutUnit logicalHeightForChild(RenderBox&) const;
-    bool updateOverridingContainingBlockContentSizeForChild(RenderBox&, GridTrackSizingDirection, std::optional<LayoutUnit> = std::nullopt) const;
+    LayoutUnit logicalHeightForGridItem(RenderBox&) const;
+    bool updateOverridingContainingBlockContentSizeForGridItem(RenderBox&, GridTrackSizingDirection, std::optional<LayoutUnit> = std::nullopt) const;
 
     // GridTrackSizingAlgorithm accessors for subclasses.
     LayoutUnit computeTrackBasedSize() const { return m_algorithm.computeTrackBasedSize(); }

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -79,10 +79,10 @@ public:
 
     std::optional<LayoutUnit> explicitIntrinsicInnerLogicalSize(GridTrackSizingDirection) const;
     void updateGridAreaLogicalSize(RenderBox&, std::optional<LayoutUnit> width, std::optional<LayoutUnit> height) const;
-    bool isBaselineAlignmentForChild(const RenderBox&) const;
-    bool isBaselineAlignmentForChild(const RenderBox& child, GridAxis, AllowedBaseLine = AllowedBaseLine::BothLines) const;
+    bool isBaselineAlignmentForGridItem(const RenderBox&) const;
+    bool isBaselineAlignmentForGridItem(const RenderBox& gridItem, GridAxis, AllowedBaseLine = AllowedBaseLine::BothLines) const;
 
-    StyleSelfAlignmentData selfAlignmentForChild(GridAxis, const RenderBox&, const RenderStyle* = nullptr) const;
+    StyleSelfAlignmentData selfAlignmentForGridItem(GridAxis, const RenderBox&, const RenderStyle* = nullptr) const;
 
     StyleContentAlignmentData contentAlignment(GridTrackSizingDirection) const;
 
@@ -93,9 +93,9 @@ public:
     void layoutGrid(bool);
     void layoutMasonry(bool);
 
-    // Computes the span relative to this RenderGrid, even if the RenderBox is a child
+    // Computes the span relative to this RenderGrid, even if the RenderBox is a grid item
     // of a descendant subgrid.
-    GridSpan gridSpanForChild(const RenderBox&, GridTrackSizingDirection) const;
+    GridSpan gridSpanForGridItem(const RenderBox&, GridTrackSizingDirection) const;
 
     bool isSubgrid(GridTrackSizingDirection) const;
     bool isSubgridRows() const
@@ -142,10 +142,10 @@ private:
     void computeLayoutRequirementsForItemsBeforeLayout(GridLayoutState&) const;
     bool canSetColumnAxisStretchRequirementForItem(const RenderBox&) const;
 
-    ItemPosition selfAlignmentNormalBehavior(const RenderBox* child = nullptr) const override
+    ItemPosition selfAlignmentNormalBehavior(const RenderBox* gridItem = nullptr) const override
     {
-        ASSERT(child);
-        return child->isRenderReplaced() ? ItemPosition::Start : ItemPosition::Stretch;
+        ASSERT(gridItem);
+        return gridItem->isRenderReplaced() ? ItemPosition::Start : ItemPosition::Stretch;
     }
 
     ASCIILiteral renderName() const override;
@@ -186,8 +186,8 @@ private:
     }
 
     bool canPerformSimplifiedLayout() const final;
-    void prepareChildForPositionedLayout(RenderBox&);
-    bool hasStaticPositionForChild(const RenderBox&, GridTrackSizingDirection) const;
+    void prepareGridItemForPositionedLayout(RenderBox&);
+    bool hasStaticPositionForGridItem(const RenderBox&, GridTrackSizingDirection) const;
     void layoutPositionedObject(RenderBox&, bool relayoutChildren, bool fixedPositionObjectsOnly) override;
 
     void computeTrackSizesForDefiniteSize(GridTrackSizingDirection, LayoutUnit availableSpace, GridLayoutState&);
@@ -203,35 +203,35 @@ private:
 
     void populateGridPositionsForDirection(GridTrackSizingDirection);
 
-    LayoutUnit gridAreaBreadthForOutOfFlowChild(const RenderBox&, GridTrackSizingDirection);
-    LayoutUnit logicalOffsetForOutOfFlowChild(const RenderBox&, GridTrackSizingDirection, LayoutUnit) const;
-    void gridAreaPositionForOutOfFlowChild(const RenderBox&, GridTrackSizingDirection, LayoutUnit& start, LayoutUnit& end) const;
-    void gridAreaPositionForInFlowChild(const RenderBox&, GridTrackSizingDirection, LayoutUnit& start, LayoutUnit& end) const;
-    void gridAreaPositionForChild(const RenderBox&, GridTrackSizingDirection, LayoutUnit& start, LayoutUnit& end) const;
+    LayoutUnit gridAreaBreadthForOutOfFlowGridItem(const RenderBox&, GridTrackSizingDirection);
+    LayoutUnit logicalOffsetForOutOfFlowGridItem(const RenderBox&, GridTrackSizingDirection, LayoutUnit) const;
+    void gridAreaPositionForOutOfFlowGridItem(const RenderBox&, GridTrackSizingDirection, LayoutUnit& start, LayoutUnit& end) const;
+    void gridAreaPositionForInFlowGridItem(const RenderBox&, GridTrackSizingDirection, LayoutUnit& start, LayoutUnit& end) const;
+    void gridAreaPositionForGridItem(const RenderBox&, GridTrackSizingDirection, LayoutUnit& start, LayoutUnit& end) const;
 
-    GridAxisPosition columnAxisPositionForChild(const RenderBox&) const;
-    GridAxisPosition rowAxisPositionForChild(const RenderBox&) const;
-    LayoutUnit columnAxisOffsetForChild(const RenderBox&) const;
-    LayoutUnit rowAxisOffsetForChild(const RenderBox&) const;
+    GridAxisPosition columnAxisPositionForGridItem(const RenderBox&) const;
+    GridAxisPosition rowAxisPositionForGridItem(const RenderBox&) const;
+    LayoutUnit columnAxisOffsetForGridItem(const RenderBox&) const;
+    LayoutUnit rowAxisOffsetForGridItem(const RenderBox&) const;
     void computeContentPositionAndDistributionOffset(GridTrackSizingDirection, const LayoutUnit& availableFreeSpace, unsigned numberOfGridTracks);
-    void setLogicalPositionForChild(RenderBox&) const;
-    void setLogicalOffsetForChild(RenderBox&, GridTrackSizingDirection) const;
-    LayoutUnit logicalOffsetForChild(const RenderBox&, GridTrackSizingDirection) const;
+    void setLogicalPositionForGridItem(RenderBox&) const;
+    void setLogicalOffsetForGridItem(RenderBox&, GridTrackSizingDirection) const;
+    LayoutUnit logicalOffsetForGridItem(const RenderBox&, GridTrackSizingDirection) const;
 
-    LayoutUnit gridAreaBreadthForChildIncludingAlignmentOffsets(const RenderBox&, GridTrackSizingDirection) const;
+    LayoutUnit gridAreaBreadthForGridItemIncludingAlignmentOffsets(const RenderBox&, GridTrackSizingDirection) const;
 
     void paintChildren(PaintInfo& forSelf, const LayoutPoint& paintOffset, PaintInfo& forChild, bool usePrintRect) override;
     LayoutOptionalOutsets allowedLayoutOverflow() const override;
 
-    LayoutUnit availableAlignmentSpaceForChildBeforeStretching(LayoutUnit gridAreaBreadthForChild, const RenderBox&, GridTrackSizingDirection) const;
-    StyleSelfAlignmentData justifySelfForChild(const RenderBox&, StretchingMode = StretchingMode::Any, const RenderStyle* = nullptr) const;
-    StyleSelfAlignmentData alignSelfForChild(const RenderBox&, StretchingMode = StretchingMode::Any, const RenderStyle* = nullptr) const;
-    void applyStretchAlignmentToChildIfNeeded(RenderBox&, GridLayoutState&);
-    void applySubgridStretchAlignmentToChildIfNeeded(RenderBox&);
-    bool hasAutoSizeInColumnAxis(const RenderBox& child) const;
-    bool hasAutoSizeInRowAxis(const RenderBox& child) const;
-    inline bool allowedToStretchChildAlongColumnAxis(const RenderBox& child) const;
-    inline bool allowedToStretchChildAlongRowAxis(const RenderBox& child) const;
+    LayoutUnit availableAlignmentSpaceForGridItemBeforeStretching(LayoutUnit gridAreaBreadthForGridItem, const RenderBox&, GridTrackSizingDirection) const;
+    StyleSelfAlignmentData justifySelfForGridItem(const RenderBox&, StretchingMode = StretchingMode::Any, const RenderStyle* = nullptr) const;
+    StyleSelfAlignmentData alignSelfForGridItem(const RenderBox&, StretchingMode = StretchingMode::Any, const RenderStyle* = nullptr) const;
+    void applyStretchAlignmentToGridItemIfNeeded(RenderBox&, GridLayoutState&);
+    void applySubgridStretchAlignmentToGridItemIfNeeded(RenderBox&);
+    bool hasAutoSizeInColumnAxis(const RenderBox& gridItem) const;
+    bool hasAutoSizeInRowAxis(const RenderBox& gridItem) const;
+    inline bool allowedToStretchGridItemAlongColumnAxis(const RenderBox& gridItem) const;
+    inline bool allowedToStretchGridItemAlongRowAxis(const RenderBox& gridItem) const;
     bool hasAutoMarginsInColumnAxis(const RenderBox&) const;
     bool hasAutoMarginsInRowAxis(const RenderBox&) const;
     void resetAutoMarginsAndLogicalTopInColumnAxis(RenderBox& child);
@@ -242,12 +242,12 @@ private:
     LayoutUnit baselinePosition(FontBaseline, bool firstLine, LineDirectionMode, LinePositionMode = PositionOnContainingLine) const final;
     std::optional<LayoutUnit> firstLineBaseline() const final;
     std::optional<LayoutUnit> lastLineBaseline() const final;
-    SingleThreadWeakPtr<RenderBox> getBaselineChild(ItemPosition alignment) const;
+    SingleThreadWeakPtr<RenderBox> getBaselineGridItem(ItemPosition alignment) const;
     std::optional<LayoutUnit> inlineBlockBaseline(LineDirectionMode) const final;
     bool isInlineBaselineAlignedChild(const RenderBox&) const;
 
-    LayoutUnit columnAxisBaselineOffsetForChild(const RenderBox&) const;
-    LayoutUnit rowAxisBaselineOffsetForChild(const RenderBox&) const;
+    LayoutUnit columnAxisBaselineOffsetForGridItem(const RenderBox&) const;
+    LayoutUnit rowAxisBaselineOffsetForGridItem(const RenderBox&) const;
 
     unsigned nonCollapsedTracks(GridTrackSizingDirection) const;
 
@@ -256,13 +256,13 @@ private:
     bool shouldResetLogicalHeightBeforeLayout() const override { return true; }
     bool establishesIndependentFormattingContext() const override;
 
-    bool aspectRatioPrefersInline(const RenderBox& child, bool blockFlowIsColumnAxis);
+    bool aspectRatioPrefersInline(const RenderBox& gridItem, bool blockFlowIsColumnAxis);
 
     Vector<RenderBox*> computeAspectRatioDependentAndBaselineItems();
 
-    GridSpan gridSpanForOutOfFlowChild(const RenderBox&, GridTrackSizingDirection) const;
+    GridSpan gridSpanForOutOfFlowGridItem(const RenderBox&, GridTrackSizingDirection) const;
 
-    bool computeGridPositionsForOutOfFlowChild(const RenderBox&, GridTrackSizingDirection, int&, bool&, int&, bool&) const;
+    bool computeGridPositionsForOutOfFlowGridItem(const RenderBox&, GridTrackSizingDirection, int&, bool&, int&, bool&) const;
 
     AutoRepeatType autoRepeatColumnsType() const;
     AutoRepeatType autoRepeatRowsType() const;

--- a/Source/WebCore/rendering/style/GridPositionsResolver.cpp
+++ b/Source/WebCore/rendering/style/GridPositionsResolver.cpp
@@ -253,7 +253,7 @@ NamedLineCollection::NamedLineCollection(const RenderGrid& initialGrid, const St
             }
             direction = directionFromSide(currentSide);
 
-            auto span = currentAncestorSubgridParent->gridSpanForChild(currentAncestorSubgrid, direction);
+            auto span = currentAncestorSubgridParent->gridSpanForGridItem(currentAncestorSubgrid, direction);
             search.translateTo(span, GridLayoutFunctions::isSubgridReversedDirection(*currentAncestorSubgridParent, direction, currentAncestorSubgrid));
 
             auto convertToInitialSpace = [&](unsigned i) {
@@ -397,8 +397,8 @@ unsigned GridPositionsResolver::explicitGridColumnCount(const RenderGrid& gridCo
 {
     if (gridContainer.isSubgridColumns()) {
         const RenderGrid& parent = *downcast<RenderGrid>(gridContainer.parent());
-        GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForChild(parent, gridContainer, GridTrackSizingDirection::ForColumns);
-        return parent.gridSpanForChild(gridContainer, direction).integerSpan();
+        GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForGridItem(parent, gridContainer, GridTrackSizingDirection::ForColumns);
+        return parent.gridSpanForGridItem(gridContainer, direction).integerSpan();
     }
     return std::min<unsigned>(std::max(gridContainer.style().gridColumnTrackSizes().size() + gridContainer.autoRepeatCountForDirection(GridTrackSizingDirection::ForColumns), gridContainer.style().namedGridAreaColumnCount()), GridPosition::max());
 }
@@ -407,8 +407,8 @@ unsigned GridPositionsResolver::explicitGridRowCount(const RenderGrid& gridConta
 {
     if (gridContainer.isSubgridRows()) {
         const RenderGrid& parent = *downcast<RenderGrid>(gridContainer.parent());
-        GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForChild(parent, gridContainer, GridTrackSizingDirection::ForRows);
-        return parent.gridSpanForChild(gridContainer, direction).integerSpan();
+        GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForGridItem(parent, gridContainer, GridTrackSizingDirection::ForRows);
+        return parent.gridSpanForGridItem(gridContainer, direction).integerSpan();
     }
     return std::min<unsigned>(std::max(gridContainer.style().gridRowTrackSizes().size() + gridContainer.autoRepeatCountForDirection(GridTrackSizingDirection::ForRows), gridContainer.style().namedGridAreaRowCount()), GridPosition::max());
 }


### PR DESCRIPTION
#### 3d47cc57612d6c856089aa3dfb6cdb9dd598e538
<pre>
[Grid] Rename child/children references to gridItem/gridItems.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276978">https://bugs.webkit.org/show_bug.cgi?id=276978</a>
<a href="https://rdar.apple.com/problem/132364014">rdar://problem/132364014</a>

Reviewed by Alan Baradlay.

These renderers participate in grid layout and are grid items so
renaming them to such in the code makes it more consistent with the
spec and easier to read. There are some instances that are used as part
of generic render tree logic and not specifially grid layout which I
left alone.

There were also a couple of instances of &quot;childIterator&quot; in the
grid track sizing algorithm that I changed to &quot;subgridIterator,&quot;&quot; since
that&apos;s what they are.

* Source/WebCore/rendering/AncestorSubgridIterator.cpp:
(WebCore::AncestorSubgridIterator::operator++):
* Source/WebCore/rendering/Grid.cpp:
(WebCore::Grid::insert):
(WebCore::GridIterator::GridIterator):
(WebCore::GridIterator::nextGridItem):
(WebCore::GridIterator::isEmptyAreaEnough const):
(WebCore::GridIterator::createForSubgrid):
* Source/WebCore/rendering/Grid.h:
* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::logicalAscentForGridItem const):
(WebCore::GridBaselineAlignment::ascentForGridItem const):
(WebCore::GridBaselineAlignment::descentForGridItem const):
(WebCore::GridBaselineAlignment::isDescentBaselineForGridItem const):
(WebCore::GridBaselineAlignment::isOrthogonalGridItemForBaseline const):
(WebCore::GridBaselineAlignment::isParallelToAlignmentAxisForGridItem const):
(WebCore::GridBaselineAlignment::baselineGroupForGridItem const):
(WebCore::GridBaselineAlignment::updateBaselineAlignmentContext):
(WebCore::GridBaselineAlignment::baselineOffsetForGridItem const):
(WebCore::GridBaselineAlignment::logicalAscentForChild const): Deleted.
(WebCore::GridBaselineAlignment::ascentForChild const): Deleted.
(WebCore::GridBaselineAlignment::descentForChild const): Deleted.
(WebCore::GridBaselineAlignment::isDescentBaselineForChild const): Deleted.
(WebCore::GridBaselineAlignment::isOrthogonalChildForBaseline const): Deleted.
(WebCore::GridBaselineAlignment::isParallelToAlignmentAxisForChild const): Deleted.
(WebCore::GridBaselineAlignment::baselineGroupForChild const): Deleted.
(WebCore::GridBaselineAlignment::baselineOffsetForChild const): Deleted.
* Source/WebCore/rendering/GridBaselineAlignment.h:
* Source/WebCore/rendering/GridLayoutFunctions.cpp:
(WebCore::GridLayoutFunctions::marginStartIsAuto):
(WebCore::GridLayoutFunctions::marginEndIsAuto):
(WebCore::GridLayoutFunctions::gridItemHasMargin):
(WebCore::GridLayoutFunctions::computeMarginLogicalSizeForGridItem):
(WebCore::GridLayoutFunctions::hasRelativeOrIntrinsicSizeForGridItem):
(WebCore::GridLayoutFunctions::extraMarginForSubgrid):
(WebCore::GridLayoutFunctions::extraMarginForSubgridAncestors):
(WebCore::GridLayoutFunctions::marginLogicalSizeForGridItem):
(WebCore::GridLayoutFunctions::isOrthogonalGridItem):
(WebCore::GridLayoutFunctions::isAspectRatioBlockSizeDependentGridItem):
(WebCore::GridLayoutFunctions::flowAwareDirectionForGridItem):
(WebCore::GridLayoutFunctions::overridingContainingBlockContentSizeForGridItem):
(WebCore::GridLayoutFunctions::isSubgridReversedDirection):
(WebCore::GridLayoutFunctions::childHasMargin): Deleted.
(WebCore::GridLayoutFunctions::computeMarginLogicalSizeForChild): Deleted.
(WebCore::GridLayoutFunctions::hasRelativeOrIntrinsicSizeForChild): Deleted.
(WebCore::GridLayoutFunctions::marginLogicalSizeForChild): Deleted.
(WebCore::GridLayoutFunctions::isOrthogonalChild): Deleted.
(WebCore::GridLayoutFunctions::isAspectRatioBlockSizeDependentChild): Deleted.
(WebCore::GridLayoutFunctions::flowAwareDirectionForChild): Deleted.
(WebCore::GridLayoutFunctions::overridingContainingBlockContentSizeForChild): Deleted.
* Source/WebCore/rendering/GridLayoutFunctions.h:
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::collectMasonryItems):
(WebCore::GridMasonryLayout::placeItemsUsingOrderModifiedDocumentOrder):
(WebCore::GridMasonryLayout::gridAreaForDefiniteGridAxisItem const):
(WebCore::GridMasonryLayout::setItemGridAxisContainingBlockToGridArea):
(WebCore::GridMasonryLayout::insertIntoGridAndLayoutItem):
(WebCore::GridMasonryLayout::masonryAxisMarginBoxForItem):
(WebCore::GridMasonryLayout::updateRunningPositions):
(WebCore::GridMasonryLayout::updateItemOffset):
(WebCore::GridMasonryLayout::offsetForGridItem const):
(WebCore::GridMasonryLayout::hasDefiniteGridAxisPosition const):
(WebCore::GridMasonryLayout::offsetForChild const): Deleted.
* Source/WebCore/rendering/GridMasonryLayout.h:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::hasRelativeMarginOrPaddingForGridItem):
(WebCore::hasRelativeOrIntrinsicSizeForGridItem):
(WebCore::shouldClearOverridingContainingBlockContentSizeForGridItem):
(WebCore::setOverridingContainingBlockContentSizeForGridItem):
(WebCore::GridTrackSizingAlgorithm::sizeTrackToFitNonSpanningItem):
(WebCore::GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhase const):
(WebCore::GridTrackSizingAlgorithm::estimatedGridAreaBreadthForGridItem const):
(WebCore::GridTrackSizingAlgorithm::gridAreaBreadthForGridItem const):
(WebCore::GridTrackSizingAlgorithm::isIntrinsicSizedGridArea const):
(WebCore::GridTrackSizingAlgorithmStrategy::logicalHeightForGridItem const):
(WebCore::GridTrackSizingAlgorithmStrategy::minContentForGridItem const):
(WebCore::GridTrackSizingAlgorithmStrategy::maxContentForGridItem const):
(WebCore::GridTrackSizingAlgorithmStrategy::minSizeForGridItem const):
(WebCore::GridTrackSizingAlgorithm::canParticipateInBaselineAlignment const):
(WebCore::GridTrackSizingAlgorithm::participateInBaselineAlignment const):
(WebCore::GridTrackSizingAlgorithm::updateBaselineAlignmentContext):
(WebCore::GridTrackSizingAlgorithm::baselineOffsetForGridItem const):
(WebCore::GridTrackSizingAlgorithm::cacheBaselineAlignedItem):
(WebCore::GridTrackSizingAlgorithmStrategy::updateOverridingContainingBlockContentSizeForGridItem const):
(WebCore::GridTrackSizingAlgorithmStrategy::minLogicalSizeForGridItem const):
(WebCore::IndefiniteSizeStrategy::layoutGridItemForMinSizeComputation const):
(WebCore::IndefiniteSizeStrategy::accumulateFlexFraction const):
(WebCore::DefiniteSizeStrategy::minLogicalSizeForGridItem const):
(WebCore::DefiniteSizeStrategy::layoutGridItemForMinSizeComputation const):
(WebCore::DefiniteSizeStrategy::minContentForGridItem const):
(WebCore::computeSubgridMarginBorderPadding):
(WebCore::extraMarginFromSubgridAncestorGutters):
(WebCore::GridTrackSizingAlgorithm::shouldExcludeGridItemForMasonryTrackSizing const):
(WebCore::GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack):
(WebCore::GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrackMasonry):
(WebCore::GridTrackSizingAlgorithm::computeIndefiniteItemsForMasonry const):
(WebCore::GridTrackSizingAlgorithm::setup):
(WebCore::GridTrackSizingAlgorithm::computeBaselineAlignmentContext):
(WebCore::GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid):
(WebCore::hasRelativeMarginOrPaddingForChild): Deleted.
(WebCore::hasRelativeOrIntrinsicSizeForChild): Deleted.
(WebCore::shouldClearOverridingContainingBlockContentSizeForChild): Deleted.
(WebCore::setOverridingContainingBlockContentSizeForChild): Deleted.
(WebCore::GridTrackSizingAlgorithm::estimatedGridAreaBreadthForChild const): Deleted.
(WebCore::GridTrackSizingAlgorithm::gridAreaBreadthForChild const): Deleted.
(WebCore::GridTrackSizingAlgorithmStrategy::logicalHeightForChild const): Deleted.
(WebCore::GridTrackSizingAlgorithmStrategy::minContentForChild const): Deleted.
(WebCore::GridTrackSizingAlgorithmStrategy::maxContentForChild const): Deleted.
(WebCore::GridTrackSizingAlgorithmStrategy::minSizeForChild const): Deleted.
(WebCore::GridTrackSizingAlgorithm::baselineOffsetForChild const): Deleted.
(WebCore::GridTrackSizingAlgorithmStrategy::updateOverridingContainingBlockContentSizeForChild const): Deleted.
(WebCore::GridTrackSizingAlgorithmStrategy::minLogicalSizeForChild const): Deleted.
(WebCore::DefiniteSizeStrategy::minLogicalSizeForChild const): Deleted.
(WebCore::DefiniteSizeStrategy::minContentForChild const): Deleted.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::selfAlignmentForGridItem const):
(WebCore::RenderGrid::selfAlignmentChangedToStretch const):
(WebCore::RenderGrid::selfAlignmentChangedFromStretch const):
(WebCore::RenderGrid::styleDidChange):
(WebCore::RenderGrid::repeatTracksSizingIfNeeded):
(WebCore::cacheBaselineAlignedGridItems):
(WebCore::RenderGrid::canSetColumnAxisStretchRequirementForItem const):
(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
(WebCore::insertIntoGrid):
(WebCore::RenderGrid::placeItemsOnGrid):
(WebCore::RenderGrid::gridItemsLayoutRects):
(WebCore::RenderGrid::performPreLayoutForGridItems const):
(WebCore::RenderGrid::populateExplicitGridAndOrderIterator):
(WebCore::overrideSizeChanged):
(WebCore::hasRelativeBlockAxisSize):
(WebCore::RenderGrid::updateGridAreaLogicalSize const):
(WebCore::RenderGrid::updateGridAreaForAspectRatioItems):
(WebCore::RenderGrid::layoutGridItems):
(WebCore::RenderGrid::layoutMasonryItems):
(WebCore::RenderGrid::prepareGridItemForPositionedLayout):
(WebCore::RenderGrid::hasStaticPositionForGridItem const):
(WebCore::RenderGrid::layoutPositionedObject):
(WebCore::RenderGrid::gridAreaBreadthForGridItemIncludingAlignmentOffsets const):
(WebCore::computeOverflowAlignmentOffset):
(WebCore::RenderGrid::availableAlignmentSpaceForGridItemBeforeStretching const):
(WebCore::RenderGrid::alignSelfForGridItem const):
(WebCore::RenderGrid::justifySelfForGridItem const):
(WebCore::RenderGrid::aspectRatioPrefersInline):
(WebCore::RenderGrid::allowedToStretchGridItemAlongColumnAxis const):
(WebCore::RenderGrid::allowedToStretchGridItemAlongRowAxis const):
(WebCore::RenderGrid::applyStretchAlignmentToGridItemIfNeeded):
(WebCore::RenderGrid::applySubgridStretchAlignmentToGridItemIfNeeded):
(WebCore::RenderGrid::hasAutoMarginsInColumnAxis const):
(WebCore::RenderGrid::hasAutoMarginsInRowAxis const):
(WebCore::RenderGrid::updateAutoMarginsInRowAxisIfNeeded):
(WebCore::RenderGrid::updateAutoMarginsInColumnAxisIfNeeded):
(WebCore::RenderGrid::isChildEligibleForMarginTrim const):
(WebCore::RenderGrid::isBaselineAlignmentForGridItem const):
(WebCore::RenderGrid::firstLineBaseline const):
(WebCore::RenderGrid::lastLineBaseline const):
(WebCore::RenderGrid::getBaselineGridItem const):
(WebCore::RenderGrid::columnAxisBaselineOffsetForGridItem const):
(WebCore::RenderGrid::rowAxisBaselineOffsetForGridItem const):
(WebCore::RenderGrid::columnAxisPositionForGridItem const):
(WebCore::RenderGrid::rowAxisPositionForGridItem const):
(WebCore::RenderGrid::columnAxisOffsetForGridItem const):
(WebCore::RenderGrid::rowAxisOffsetForGridItem const):
(WebCore::RenderGrid::isSubgridInParentDirection const):
(WebCore::RenderGrid::gridAreaBreadthForOutOfFlowGridItem):
(WebCore::RenderGrid::logicalOffsetForOutOfFlowGridItem const):
(WebCore::RenderGrid::gridAreaPositionForOutOfFlowGridItem const):
(WebCore::RenderGrid::gridAreaPositionForInFlowGridItem const):
(WebCore::RenderGrid::gridAreaPositionForGridItem const):
(WebCore::RenderGrid::setLogicalPositionForGridItem const):
(WebCore::RenderGrid::setLogicalOffsetForGridItem const):
(WebCore::RenderGrid::logicalOffsetForGridItem const):
(WebCore::RenderGrid::numTracks const):
(WebCore::RenderGrid::paintChildren):
(WebCore::RenderGrid::hasAutoSizeInColumnAxis const):
(WebCore::RenderGrid::hasAutoSizeInRowAxis const):
(WebCore::RenderGrid::computeGridPositionsForOutOfFlowGridItem const):
(WebCore::RenderGrid::gridSpanForOutOfFlowGridItem const):
(WebCore::RenderGrid::gridSpanForGridItem const):
(WebCore::RenderGrid::selfAlignmentForChild const): Deleted.
(WebCore::cacheBaselineAlignedChildren): Deleted.
(WebCore::RenderGrid::prepareChildForPositionedLayout): Deleted.
(WebCore::RenderGrid::hasStaticPositionForChild const): Deleted.
(WebCore::RenderGrid::gridAreaBreadthForChildIncludingAlignmentOffsets const): Deleted.
(WebCore::RenderGrid::availableAlignmentSpaceForChildBeforeStretching const): Deleted.
(WebCore::RenderGrid::alignSelfForChild const): Deleted.
(WebCore::RenderGrid::justifySelfForChild const): Deleted.
(WebCore::RenderGrid::allowedToStretchChildAlongColumnAxis const): Deleted.
(WebCore::RenderGrid::allowedToStretchChildAlongRowAxis const): Deleted.
(WebCore::RenderGrid::applyStretchAlignmentToChildIfNeeded): Deleted.
(WebCore::RenderGrid::applySubgridStretchAlignmentToChildIfNeeded): Deleted.
(WebCore::RenderGrid::isBaselineAlignmentForChild const): Deleted.
(WebCore::RenderGrid::getBaselineChild const): Deleted.
(WebCore::RenderGrid::columnAxisBaselineOffsetForChild const): Deleted.
(WebCore::RenderGrid::rowAxisBaselineOffsetForChild const): Deleted.
(WebCore::RenderGrid::columnAxisPositionForChild const): Deleted.
(WebCore::RenderGrid::rowAxisPositionForChild const): Deleted.
(WebCore::RenderGrid::columnAxisOffsetForChild const): Deleted.
(WebCore::RenderGrid::rowAxisOffsetForChild const): Deleted.
(WebCore::RenderGrid::gridAreaBreadthForOutOfFlowChild): Deleted.
(WebCore::RenderGrid::logicalOffsetForOutOfFlowChild const): Deleted.
(WebCore::RenderGrid::gridAreaPositionForOutOfFlowChild const): Deleted.
(WebCore::RenderGrid::gridAreaPositionForInFlowChild const): Deleted.
(WebCore::RenderGrid::gridAreaPositionForChild const): Deleted.
(WebCore::RenderGrid::setLogicalPositionForChild const): Deleted.
(WebCore::RenderGrid::setLogicalOffsetForChild const): Deleted.
(WebCore::RenderGrid::logicalOffsetForChild const): Deleted.
(WebCore::RenderGrid::computeGridPositionsForOutOfFlowChild const): Deleted.
(WebCore::RenderGrid::gridSpanForOutOfFlowChild const): Deleted.
(WebCore::RenderGrid::gridSpanForChild const): Deleted.
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/style/GridPositionsResolver.cpp:
(WebCore::NamedLineCollection::NamedLineCollection):
(WebCore::GridPositionsResolver::explicitGridColumnCount):
(WebCore::GridPositionsResolver::explicitGridRowCount):

Canonical link: <a href="https://commits.webkit.org/281294@main">https://commits.webkit.org/281294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e46d7af4b1c0a0635d1f71c221dd836c6df52a88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63284 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9813 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48199 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6964 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29024 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8641 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8817 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54824 "2 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65017 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55546 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55652 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13160 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2739 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34529 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35612 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35357 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->