### PR TITLE
AX: Add findMatchingRange functionality to search for misspellings.

### DIFF
--- a/LayoutTests/accessibility/search-misspellings-expected.txt
+++ b/LayoutTests/accessibility/search-misspellings-expected.txt
@@ -1,0 +1,27 @@
+Tests navigation by misspelled words.
+
+Find all misspelled word from the beginning of content:
+tezt
+isd
+mispeled
+Therd
+paragrph
+Loock
+thes
+Find all misspelled words backwards from the end of content:
+thes
+Loock
+paragrph
+Therd
+mispeled
+isd
+tezt
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+
+
+

--- a/LayoutTests/accessibility/search-misspellings.html
+++ b/LayoutTests/accessibility/search-misspellings.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<div id="content" contenteditable=true>
+<p id="p1">This paragraph contains some tezt that isd</p>
+<p id="p2">mispeled.</p>
+<p id="p3">Therd paragrph.</p>
+<br>
+<a href="#">Loock at thes pictures...</a>
+</div>
+
+<script>
+let output = "Tests navigation by misspelled words.\n\n";
+
+if (accessibilityController) {
+    content = accessibilityController.accessibleElementById("content");
+
+    output += "Find all misspelled word from the beginning of content:\n";
+    startRange = content.textMarkerRangeForMarkers(content.startTextMarker, content.startTextMarker);
+    result = content.textMarkerRangeForSearchPredicate(startRange, true, "AXMisspelledWordSearchKey");
+    while (result) {
+        output += `${content.stringForTextMarkerRange(result)}\n`;
+        result = content.textMarkerRangeForSearchPredicate(result, true, "AXMisspelledWordSearchKey");
+    }
+
+    output += "Find all misspelled words backwards from the end of content:\n";
+    startRange = content.textMarkerRangeForMarkers(content.endTextMarker, content.endTextMarker);
+    result = content.textMarkerRangeForSearchPredicate(startRange, false, "AXMisspelledWordSearchKey");
+    while (result) {
+        output += `${content.stringForTextMarkerRange(result)}\n`;
+        result = content.textMarkerRangeForSearchPredicate(result, false, "AXMisspelledWordSearchKey");
+    }
+
+    document.getElementById("content").style.visibility = "hidden";
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -514,6 +514,7 @@ imported/w3c/web-platform-tests/quirks/line-height-in-list-item.tentative.html [
 # AXObjectCache::announce not implemented.
 accessibility/announcement-notification.html [ Skip ]
 
+accessibility/search-misspellings.html [ Skip ]
 accessibility/shadow-dom-hit-test.html [ Skip ]
 
 # AccessibilityUIElement::isAttributeSupported needs to be updated to handle AXSelectedRows.

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -826,6 +826,7 @@ accessibility/list [ WontFix ]
 accessibility/announcement-notification.html [ WontFix ]
 accessibility/menuitem-is-selected.html [ WontFix ]
 accessibility/relationships.html [ WontFix ]
+accessibility/search-misspellings.html [ WontFix ]
 accessibility/shadow-dom-hit-test.html [ WontFix ]
 accessibility/mac/text-marker-range-for-line.html [ WontFix ]
 # Datalist is unsupported in WK1

--- a/Source/WebCore/accessibility/AXSearchManager.h
+++ b/Source/WebCore/accessibility/AXSearchManager.h
@@ -76,33 +76,26 @@ enum class AccessibilitySearchKey {
     VisitedLink,
 };
 
-struct TextCheckingResult;
-
 struct AccessibilitySearchCriteria {
+    // FIXME: change the object pointers to object IDs.
     AXCoreObject* anchorObject { nullptr };
-    AXCoreObject* startObject;
-    AccessibilitySearchDirection searchDirection;
+    AXCoreObject* startObject { nullptr };
+    CharacterRange startRange;
+    AccessibilitySearchDirection searchDirection { AccessibilitySearchDirection::Next };
     Vector<AccessibilitySearchKey> searchKeys;
     String searchText;
-    unsigned resultsLimit;
-    bool visibleOnly;
-    bool immediateDescendantsOnly;
-
-    AccessibilitySearchCriteria(AXCoreObject* startObject, AccessibilitySearchDirection searchDirection, String searchText, unsigned resultsLimit, bool visibleOnly, bool immediateDescendantsOnly)
-        : startObject(startObject)
-        , searchDirection(searchDirection)
-        , searchText(searchText)
-        , resultsLimit(resultsLimit)
-        , visibleOnly(visibleOnly)
-        , immediateDescendantsOnly(immediateDescendantsOnly)
-    { }
+    unsigned resultsLimit { 0 };
+    bool visibleOnly { false };
+    bool immediateDescendantsOnly { false };
 };
 
 class AXSearchManager {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AXSearchManager);
 public:
     AXCoreObject::AccessibilityChildrenVector findMatchingObjects(AccessibilitySearchCriteria&&);
+    std::optional<AXTextMarkerRange> findMatchingRange(AccessibilitySearchCriteria&&);
 private:
+    AXCoreObject::AccessibilityChildrenVector findMatchingObjectsInternal(const AccessibilitySearchCriteria&);
     bool matchWithResultsLimit(RefPtr<AXCoreObject>, const AccessibilitySearchCriteria&, AXCoreObject::AccessibilityChildrenVector&);
     bool match(RefPtr<AXCoreObject>, const AccessibilitySearchCriteria&);
     bool matchText(RefPtr<AXCoreObject>, const String&);
@@ -111,6 +104,11 @@ private:
     // Keeps the ranges of misspellings for each object.
     HashMap<AXID, Vector<CharacterRange>> m_spellCheckerResultRanges;
 };
+
+inline AXCoreObject::AccessibilityChildrenVector AXSearchManager::findMatchingObjects(AccessibilitySearchCriteria&& criteria)
+{
+    return findMatchingObjectsInternal(std::forward<AccessibilitySearchCriteria>(criteria));
+}
 
 WTF::TextStream& operator<<(WTF::TextStream&, AccessibilitySearchKey);
 WTF::TextStream& operator<<(WTF::TextStream&, const AccessibilitySearchCriteria&);

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -281,7 +281,7 @@ std::optional<SimpleRange> AXTextMarkerRange::simpleRange() const
 std::optional<CharacterRange> AXTextMarkerRange::characterRange() const
 {
     if (m_start.m_data.objectID != m_end.m_data.objectID
-        || m_start.m_data.treeID != m_end.m_data.treeID)
+        || UNLIKELY(m_start.m_data.treeID != m_end.m_data.treeID))
         return std::nullopt;
 
     if (m_start.m_data.characterOffset > m_end.m_data.characterOffset) {

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -244,6 +244,7 @@ public:
     AXTextMarker start() const { return m_start; }
     AXTextMarker end() const { return m_end; }
     bool isConfinedTo(AXID) const;
+    bool isConfined() const;
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
     // Traverses from m_start to m_end, collecting all text along the way.

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -2116,8 +2116,12 @@ static RenderObject* rendererForView(WAKView* view)
 
 - (NSArray<WebAccessibilityObjectWrapper *> *)accessibilityFindMatchingObjects:(NSDictionary *)parameters
 {
-    auto criteria = accessibilitySearchCriteriaForSearchPredicateParameterizedAttribute(parameters);
-    return makeNSArray(self.axBackingObject->findMatchingObjects(WTFMove(criteria)));
+    RefPtr<AXCoreObject> backingObject = self.axBackingObject;
+    if (!backingObject)
+        return nil;
+
+    auto criteria = accessibilitySearchCriteriaForSearchPredicate(*backingObject, parameters);
+    return makeNSArray(backingObject->findMatchingObjects(WTFMove(criteria)));
 }
 
 - (void)accessibilityModifySelection:(TextGranularity)granularity increase:(BOOL)increase

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
@@ -118,7 +118,7 @@ RetainPtr<NSAttributedString> attributedStringCreate(Node*, StringView, const Si
 
 - (NSDictionary<NSString *, id> *)baseAccessibilityResolvedEditingStyles;
 
-extern WebCore::AccessibilitySearchCriteria accessibilitySearchCriteriaForSearchPredicateParameterizedAttribute(const NSDictionary *);
+extern WebCore::AccessibilitySearchCriteria accessibilitySearchCriteriaForSearchPredicate(WebCore::AXCoreObject&, const NSDictionary *);
 
 extern NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector&);
 extern NSRange makeNSRange(std::optional<WebCore::SimpleRange>);

--- a/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
@@ -1134,12 +1134,19 @@ unsigned AccessibilityUIElement::uiElementCountForSearchPredicate(JSContextRef c
 AccessibilityUIElement AccessibilityUIElement::uiElementForSearchPredicate(JSContextRef context, AccessibilityUIElement *startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSDictionary *parameterizedAttribute = searchPredicateParameterizedAttributeForSearchCriteria(context, startElement, isDirectionNext, 1, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
-    id value = [m_element accessibilityAttributeValue:@"AXUIElementsForSearchPredicate" forParameter:parameterizedAttribute];
-    if ([value isKindOfClass:[NSArray class]])
-        return AccessibilityUIElement([value lastObject]);
+    NSDictionary *parameter = searchPredicateParameterizedAttributeForSearchCriteria(context, startElement, isDirectionNext, 1, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
+    id value = [m_element accessibilityAttributeValue:@"AXUIElementsForSearchPredicate" forParameter:parameter];
+    if (![value isKindOfClass:[NSArray class]] || ![value count])
+        return nullptr;
+
+    id result = [value firstObject];
+    if ([result isKindOfClass:NSDictionary.class]) {
+        RELEASE_ASSERT([result objectForKey:@"AXSearchResultElement"]);
+        return AccessibilityUIElement([result objectForKey:@"AXSearchResultElement"]);
+    }
+    return AccessibilityUIElement(result);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -160,6 +160,7 @@ RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousParagraphStartTe
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::sentenceTextMarkerRangeForTextMarker(AccessibilityTextMarker*) { return nullptr; }
 RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextSentenceEndTextMarkerForTextMarker(AccessibilityTextMarker*) { return nullptr; }
 RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousSentenceStartTextMarkerForTextMarker(AccessibilityTextMarker*) { return nullptr; }
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForSearchPredicate(JSContextRef, AccessibilityTextMarkerRange*, bool, JSValueRef, JSStringRef, bool, bool) { return nullptr; }
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::misspellingTextMarkerRange(AccessibilityTextMarkerRange*, bool) { return nullptr; }
 void AccessibilityUIElement::dismiss() { }
 JSValueRef AccessibilityUIElement::children(JSContextRef) { return { }; }

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -323,6 +323,7 @@ public:
     RefPtr<AccessibilityTextMarker> previousLineStartTextMarkerForTextMarker(AccessibilityTextMarker*);
     RefPtr<AccessibilityTextMarker> nextLineEndTextMarkerForTextMarker(AccessibilityTextMarker*);
     int lineIndexForTextMarker(AccessibilityTextMarker*) const;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForSearchPredicate(JSContextRef, AccessibilityTextMarkerRange* startRange, bool forward, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
     RefPtr<AccessibilityTextMarkerRange> misspellingTextMarkerRange(AccessibilityTextMarkerRange* start, bool forward);
     RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForElement(AccessibilityUIElement*);
     RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -239,6 +239,7 @@ interface AccessibilityUIElement {
     AccessibilityTextMarker previousLineStartTextMarkerForTextMarker(AccessibilityTextMarker textMarker);
     AccessibilityTextMarker nextLineEndTextMarkerForTextMarker(AccessibilityTextMarker textMarker);
     long lineIndexForTextMarker(AccessibilityTextMarker textMarker);
+    AccessibilityTextMarkerRange textMarkerRangeForSearchPredicate(AccessibilityTextMarkerRange startRange, boolean forward, object searchKey, DOMString searchText, boolean visibleOnly, boolean immediateDescendantsOnly);
     AccessibilityTextMarkerRange misspellingTextMarkerRange(AccessibilityTextMarkerRange start, boolean forward);
     AccessibilityTextMarkerRange textMarkerRangeForElement(AccessibilityUIElement element);
     AccessibilityTextMarkerRange textMarkerRangeForMarkers(AccessibilityTextMarker startMarker, AccessibilityTextMarker endMarker);

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.h
@@ -29,6 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import "AccessibilityTextMarkerRange.h"
 #import "AccessibilityUIElement.h"
 #import <JavaScriptCore/JSRetainPtr.h>
 
@@ -50,6 +51,6 @@ namespace WTR {
 
 Class webAccessibilityObjectWrapperClass();
 JSValueRef makeValueRefForValue(JSContextRef, id value);
-extern NSDictionary *searchPredicateParameterizedAttributeForSearchCriteria(JSContextRef, AccessibilityUIElement *startElement, bool isDirectionNext, unsigned resultsLimit, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
+extern NSDictionary *searchPredicateForSearchCriteria(JSContextRef, AccessibilityUIElement* startElement, AccessibilityTextMarkerRange* startRange, bool forward, unsigned resultsLimit, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
 
 };

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
@@ -102,12 +102,15 @@ JSValueRef makeValueRefForValue(JSContextRef context, id value)
     return nullptr;
 }
 
-NSDictionary *searchPredicateParameterizedAttributeForSearchCriteria(JSContextRef context, AccessibilityUIElement *startElement, bool isDirectionNext, unsigned resultsLimit, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
+NSDictionary *searchPredicateForSearchCriteria(JSContextRef context, AccessibilityUIElement *startElement, AccessibilityTextMarkerRange* startRange, bool isDirectionNext, unsigned resultsLimit, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
 {
     NSMutableDictionary *parameterizedAttribute = [NSMutableDictionary dictionary];
 
     if (startElement && startElement->platformUIElement())
         [parameterizedAttribute setObject:startElement->platformUIElement() forKey:@"AXStartElement"];
+
+    if (startRange)
+        [parameterizedAttribute setObject:startRange->platformTextMarkerRange() forKey:@"AXStartRange"];
 
     [parameterizedAttribute setObject:(isDirectionNext) ? @"AXDirectionNext" : @"AXDirectionPrevious" forKey:@"AXDirection"];
 

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -807,8 +807,8 @@ unsigned AccessibilityUIElement::uiElementCountForSearchPredicate(JSContextRef c
 
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementForSearchPredicate(JSContextRef context, AccessibilityUIElement *startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
 {
-    NSDictionary *parameterizedAttribute = searchPredicateParameterizedAttributeForSearchCriteria(context, startElement, isDirectionNext, 5, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
-    id results = [m_element accessibilityFindMatchingObjects:parameterizedAttribute];
+    NSDictionary *parameter = searchPredicateForSearchCriteria(context, startElement, nullptr, isDirectionNext, 5, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
+    id results = [m_element accessibilityFindMatchingObjects:parameter];
     if (![results isKindOfClass:[NSArray class]])
         return nullptr;
 
@@ -1259,6 +1259,12 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::lineTextMarkerRange
     
     id textMarkerRange = [m_element textMarkerRangeForMarkers:textMarkers];
     return AccessibilityTextMarkerRange::create(textMarkerRange);
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForSearchPredicate(JSContextRef context, AccessibilityTextMarkerRange *startRange, bool forward, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
+{
+    // FIXME: add implementation for iOS.
+    return nullptr;
 }
 
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::misspellingTextMarkerRange(AccessibilityTextMarkerRange* start, bool forward)


### PR DESCRIPTION
#### cb7830fdfa6c0519dd901f995ae0996b170c5aca
<pre>
AX: Add findMatchingRange functionality to search for misspellings.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276960">https://bugs.webkit.org/show_bug.cgi?id=276960</a>
&lt;<a href="https://rdar.apple.com/problem/132327628">rdar://problem/132327628</a>&gt;

Reviewed by Tyler Wilcock.

Before this change, there was no API for a client to search for the range of misspelled words across objects. This patch implements this functionality on Mac by extending the search with predicate functionality to return not just a matching object, but also a matching range. This allows clients like VoiceOver to support navigation by misspelled words.

* LayoutTests/accessibility/search-misspellings-expected.txt: Added.
* LayoutTests/accessibility/search-misspellings.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::appendChildrenToArray):
(WebCore::AXSearchManager::findMatchingObjectsInternal):
(WebCore::AXSearchManager::findMatchingRange):
(WebCore::AXSearchManager::findMatchingObjects): Deleted.
* Source/WebCore/accessibility/AXSearchManager.h:
(WebCore::AXSearchManager::findMatchingObjects):
(WebCore::AccessibilitySearchCriteria::AccessibilitySearchCriteria): Deleted.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::characterRange const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityFindMatchingObjects:]):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(accessibilitySearchCriteriaForSearchPredicate):
(accessibilitySearchCriteriaForSearchPredicateParameterizedAttribute): Deleted.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
* Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm:
(AccessibilityUIElement::uiElementForSearchPredicate):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
(WTR::textMarkerRangeForSearchPredicate):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.h:
* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm:
(WTR::searchPredicateForSearchCriteria):
(WTR::searchPredicateParameterizedAttributeForSearchCriteria): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElement::uiElementForSearchPredicate):
(WTR::AccessibilityUIElement::textMarkerRangeForSearchPredicate):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElement::uiElementCountForSearchPredicate):
(WTR::AccessibilityUIElement::uiElementForSearchPredicate):
(WTR::AccessibilityUIElement::textMarkerRangeForSearchPredicate):

Canonical link: <a href="https://commits.webkit.org/281312@main">https://commits.webkit.org/281312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/082626a84caa010c57e5e41f2b7b072f29466001

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63340 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9937 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48251 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6987 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29075 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32920 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8689 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8873 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65072 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3354 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55588 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55693 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13179 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2785 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34585 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35668 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36754 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->