### PR TITLE
[CSS] Tokenizer should distinguish newline from whitespace

### DIFF
--- a/LayoutTests/fast/css/test-at-supports-newline-expected.txt
+++ b/LayoutTests/fast/css/test-at-supports-newline-expected.txt
@@ -1,0 +1,2 @@
+Text should be green to PASS, with PASS written below.
+PASS

--- a/LayoutTests/fast/css/test-at-supports-newline.html
+++ b/LayoutTests/fast/css/test-at-supports-newline.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<style id="s">
+    @supports(text-transform: capitalize
+full-width) {
+        div {
+            color: green;
+        }
+    }
+</style>
+<div>Text should be green to PASS, with PASS written below.</div>
+<div id="test_result"></div>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    const styleRule = document.getElementById('s').sheet.cssRules[0];
+
+    var testDiv = document.getElementById('test_result');
+    if (styleRule.conditionText == "(text-transform: capitalize full-width)")
+        testDiv.innerHTML = "PASS";
+    else
+        testDiv.innerHTML = "FAIL";
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Rule that looks like a custom property declaration is ignored
 PASS Rule that looks like an invalid custom property declaration is ignored
-FAIL Nested rule that looks like a custom property declaration assert_equals: expected "hover { }\n    .b { }" but got "hover { }     .b { }"
+PASS Nested rule that looks like a custom property declaration
 PASS Nested rule that looks like an invalid custom property declaration
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -906,6 +906,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/parser/CSSPropertyParserConsumer+UnevaluatedCalc.h
     css/parser/CSSSelectorParser.h
     css/parser/CSSSelectorParserContext.h
+    css/parser/CSSTokenizer.h
+    css/parser/CSSTokenizerInputStream.h
     css/parser/MutableCSSSelector.h
 
     css/query/ContainerQuery.h

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -69,7 +69,7 @@ public:
     unsigned refCount() const { return m_refCount / refCountIncrement; }
     bool hasAtLeastOneRef() const { return m_refCount; }
 
-    String cssText() const;
+    WEBCORE_EXPORT String cssText() const;
 
     bool isAnchorValue() const { return m_classType == AnchorClass; }
     bool isAspectRatioValue() const { return m_classType == AspectRatioClass; }

--- a/Source/WebCore/css/calc/CSSCalcExpressionNodeParser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcExpressionNodeParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,7 @@
 #include "CSSCalcValue.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParserHelpers.h"
+#include "CSSTokenizer.h"
 #include "Logging.h"
 #include <wtf/text/TextStream.h>
 
@@ -202,7 +203,7 @@ bool CSSCalcExpressionNodeParser::parseCalcFunction(CSSParserTokenRange& tokens,
         nodes.append(node.releaseNonNull());
         requireComma = true;
     }
-    
+
     if (argumentCount < minArgumentCount)
         return false;
 
@@ -313,7 +314,7 @@ bool CSSCalcExpressionNodeParser::parseValue(CSSParserTokenRange& tokens, CSSVal
     auto makeCSSCalcPrimitiveValueNode = [&](double value, CSSUnitType type) -> bool {
         if (calcUnitCategory(type) == CalculationCategory::Other)
             return false;
-        
+
         result = CSSCalcPrimitiveValueNode::create(CSSPrimitiveValue::create(value, type));
         return true;
     };
@@ -386,7 +387,7 @@ bool CSSCalcExpressionNodeParser::parseCalcProduct(CSSParserTokenRange& tokens, 
         if (operatorCharacter != static_cast<char>(CalcOperator::Multiply) && operatorCharacter != static_cast<char>(CalcOperator::Divide))
             break;
         tokens.consumeIncludingWhitespace();
-        
+
         RefPtr<CSSCalcExpressionNode> nextValue;
         if (!parseCalcValue(tokens, functionID, depth, nextValue) || !nextValue)
             return false;
@@ -425,11 +426,11 @@ bool CSSCalcExpressionNodeParser::parseCalcSum(CSSParserTokenRange& tokens, CSSV
         if (operatorCharacter != static_cast<char>(CalcOperator::Add) && operatorCharacter != static_cast<char>(CalcOperator::Subtract))
             break;
 
-        if ((&tokens.peek() - 1)->type() != WhitespaceToken)
+        if (!CSSTokenizer::isWhitespace((&tokens.peek() - 1)->type()))
             return false; // calc(1px+ 2px) is invalid
 
         tokens.consume();
-        if (tokens.peek().type() != WhitespaceToken)
+        if (!CSSTokenizer::isWhitespace(tokens.peek().type()))
             return false; // calc(1px +2px) is invalid
 
         tokens.consumeIncludingWhitespace();

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -376,7 +376,8 @@ bool CSSParserImpl::consumeRuleList(CSSParserTokenRange range, RuleList ruleList
     while (!range.atEnd()) {
         RefPtr<StyleRuleBase> rule;
         switch (range.peek().type()) {
-        case WhitespaceToken:
+        case NonNewlineWhitespaceToken:
+        case NewlineToken:
             range.consumeWhitespace();
             continue;
         case AtKeywordToken:
@@ -840,7 +841,8 @@ RefPtr<StyleRuleFontFeatureValuesBlock> CSSParserImpl::consumeFontFeatureValuesR
     Vector<FontFeatureValuesTag> tags;
     while (!range.atEnd()) {
         switch (range.peek().type()) {
-        case WhitespaceToken:
+        case NonNewlineWhitespaceToken:
+        case NewlineToken:
         case SemicolonToken:
             range.consume();
             break;
@@ -1430,7 +1432,8 @@ void CSSParserImpl::consumeBlockContent(CSSParserTokenRange range, StyleRuleType
             consumeUntilSemicolon();
         };
         switch (range.peek().type()) {
-        case WhitespaceToken:
+        case NonNewlineWhitespaceToken:
+        case NewlineToken:
         case SemicolonToken:
             range.consume();
             break;

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -31,9 +31,7 @@
 #include "CSSParserToken.h"
 
 #include "CSSMarkup.h"
-#include "CSSPrimitiveValue.h"
 #include "CSSPropertyParser.h"
-#include <limits.h>
 #include <wtf/HexNumber.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -358,10 +356,10 @@ CSSParserToken::CSSParserToken(CSSParserTokenType type, BlockType blockType)
 {
 }
 
-CSSParserToken::CSSParserToken(unsigned whitespaceCount)
-    : m_type(WhitespaceToken)
+CSSParserToken::CSSParserToken(unsigned nonNewlineWhitespaceCount)
+    : m_type(NonNewlineWhitespaceToken)
     , m_blockType(NotBlock)
-    , m_whitespaceCount(whitespaceCount)
+    , m_whitespaceCount(nonNewlineWhitespaceCount)
 {
 }
 
@@ -532,6 +530,8 @@ bool CSSParserToken::hasStringBacking() const
     case LeftBraceToken:
     case LeftBracketToken:
     case LeftParenthesisToken:
+    case NewlineToken:
+    case NonNewlineWhitespaceToken:
     case PrefixMatchToken:
     case RightBraceToken:
     case RightBracketToken:
@@ -539,7 +539,6 @@ bool CSSParserToken::hasStringBacking() const
     case SemicolonToken:
     case SubstringMatchToken:
     case SuffixMatchToken:
-    case WhitespaceToken:
         return false;
     }
     ASSERT_NOT_REACHED();
@@ -596,7 +595,7 @@ bool CSSParserToken::operator==(const CSSParserToken& other) const
     case NumberToken:
     case PercentageToken:
         return originalText() == other.originalText();
-    case WhitespaceToken:
+    case NonNewlineWhitespaceToken:
         return m_whitespaceCount == other.m_whitespaceCount;
     default:
         return true;
@@ -751,12 +750,15 @@ void CSSParserToken::serialize(StringBuilder& builder, const CSSParserToken* nex
     case BadUrlToken:
         builder.append("url(()"_s);
         break;
-    case WhitespaceToken: {
+    case NonNewlineWhitespaceToken: {
         auto count = mode == SerializationMode::CustomProperty ? m_whitespaceCount : 1;
         for (auto i = 0u; i < count; ++i)
             builder.append(' ');
         break;
     }
+    case NewlineToken:
+        builder.append(mode == SerializationMode::CustomProperty ? '\n' : ' ');
+        break;
     case ColonToken:
         builder.append(':');
         break;

--- a/Source/WebCore/css/parser/CSSParserToken.h
+++ b/Source/WebCore/css/parser/CSSParserToken.h
@@ -1,5 +1,5 @@
 // Copyright 2014 The Chromium Authors. All rights reserved.
-// Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+// Copyright (C) 2016-2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -51,7 +51,8 @@ enum CSSParserTokenType {
     SuffixMatchToken,
     SubstringMatchToken,
     ColumnToken,
-    WhitespaceToken,
+    NonNewlineWhitespaceToken,
+    NewlineToken,
     CDOToken,
     CDCToken,
     ColonToken,
@@ -101,7 +102,7 @@ public:
     CSSParserToken(CSSParserTokenType, BlockType = NotBlock);
     CSSParserToken(CSSParserTokenType, StringView, BlockType = NotBlock);
 
-    explicit CSSParserToken(unsigned whitespaceCount); // WhitespaceToken
+    explicit CSSParserToken(unsigned nonNewlineWhitespaceCount); // NonNewlineWhitespaceToken
     CSSParserToken(CSSParserTokenType, UChar); // for DelimiterToken
     CSSParserToken(double, NumericValueType, NumericSign, StringView originalText); // for NumberToken
 

--- a/Source/WebCore/css/parser/CSSParserTokenRange.cpp
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.cpp
@@ -1,5 +1,5 @@
 // Copyright 2014 The Chromium Authors. All rights reserved.
-// Copyright (C) 2016 Apple Inc. All rights reserved.
+// Copyright (C) 2016-2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -85,7 +85,7 @@ CSSParserTokenRange CSSParserTokenRange::consumeBlockCheckingForEditability(Styl
         if (styleSheet && !styleSheet->usesStyleBasedEditability() && token.type() == IdentToken && equalLettersIgnoringASCIICase(token.value(), "-webkit-user-modify"_s))
             styleSheet->parserSetUsesStyleBasedEditability();
     } while (nestingLevel && m_first < m_last);
-    
+
     if (nestingLevel)
         return makeSubRange(start, m_first); // Ended at EOF
     return makeSubRange(start, m_first - 1);
@@ -108,7 +108,7 @@ void CSSParserTokenRange::consumeComponentValue()
 void CSSParserTokenRange::trimTrailingWhitespace()
 {
     for (; m_last > m_first; --m_last) {
-        if ((m_last - 1)->type() != WhitespaceToken)
+        if (!CSSTokenizer::isWhitespace((m_last - 1)->type()))
             return;
     }
 }

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "CSSParserToken.h"
+#include "CSSTokenizer.h"
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -87,7 +88,7 @@ public:
 
     void consumeWhitespace()
     {
-        while (peek().type() == WhitespaceToken)
+        while (CSSTokenizer::isWhitespace(peek().type()))
             ++m_first;
     }
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -923,7 +923,7 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumePseudo(CSSParserTo
 CSSSelector::Relation CSSSelectorParser::consumeCombinator(CSSParserTokenRange& range)
 {
     auto fallbackResult = CSSSelector::Relation::Subselector;
-    while (range.peek().type() == WhitespaceToken) {
+    while (CSSTokenizer::isWhitespace(range.peek().type())) {
         range.consume();
         fallbackResult = CSSSelector::Relation::DescendantSpace;
     }

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -1,5 +1,5 @@
 // Copyright 2015 The Chromium Authors. All rights reserved.
-// Copyright (C) 2016 Apple Inc. All rights reserved.
+// Copyright (C) 2016-2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -33,6 +33,7 @@
 #include "CSSParserImpl.h"
 #include "CSSPropertyParserHelpers.h"
 #include "CSSSelectorParser.h"
+#include "CSSTokenizer.h"
 #include "FontCustomPlatformData.h"
 #include "StyleRule.h"
 
@@ -100,7 +101,7 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeCondition(CSSParserT
             return Invalid;
 
         range.consume();
-        if (range.peek().type() != WhitespaceToken)
+        if (!CSSTokenizer::isWhitespace(range.peek().type()))
             return Invalid;
         range.consumeWhitespace();
     }
@@ -114,7 +115,7 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeNegation(CSSParserTo
 
     if (range.peek().type() == IdentToken)
         range.consume();
-    if (range.peek().type() != WhitespaceToken)
+    if (!CSSTokenizer::isWhitespace(range.peek().type()))
         return Invalid;
     range.consumeWhitespace();
     auto result = consumeConditionInParenthesis(range, tokenType);

--- a/Source/WebCore/css/parser/CSSTokenizer.h
+++ b/Source/WebCore/css/parser/CSSTokenizer.h
@@ -1,5 +1,5 @@
 // Copyright 2014 The Chromium Authors. All rights reserved.
-// Copyright (C) 2016-2020 Apple Inc. All rights reserved.
+// Copyright (C) 2016-2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -49,11 +49,14 @@ public:
     static std::unique_ptr<CSSTokenizer> tryCreate(const String&);
     static std::unique_ptr<CSSTokenizer> tryCreate(const String&, CSSParserObserverWrapper&); // For the inspector
 
-    explicit CSSTokenizer(const String&);
+    WEBCORE_EXPORT explicit CSSTokenizer(const String&);
     CSSTokenizer(const String&, CSSParserObserverWrapper&); // For the inspector
 
-    CSSParserTokenRange tokenRange() const;
+    WEBCORE_EXPORT CSSParserTokenRange tokenRange() const;
     unsigned tokenCount();
+
+    static bool isWhitespace(CSSParserTokenType);
+    static bool isNewline(UChar);
 
     Vector<String>&& escapedStringsForAdoption() { return WTFMove(m_stringPool); }
 
@@ -91,7 +94,8 @@ private:
     CSSParserToken blockStart(CSSParserTokenType blockType, CSSParserTokenType, StringView);
     CSSParserToken blockEnd(CSSParserTokenType, CSSParserTokenType startType);
 
-    CSSParserToken whiteSpace(UChar);
+    CSSParserToken newline(UChar);
+    CSSParserToken whitespace(UChar);
     CSSParserToken leftParenthesis(UChar);
     CSSParserToken rightParenthesis(UChar);
     CSSParserToken leftBracket(UChar);

--- a/Source/WebCore/css/parser/CSSTokenizerInputStream.h
+++ b/Source/WebCore/css/parser/CSSTokenizerInputStream.h
@@ -85,6 +85,7 @@ public:
     }
 
     void advanceUntilNonWhitespace();
+    void advanceUntilNewlineOrNonWhitespace();
 
     unsigned length() const { return m_stringLength; }
     unsigned offset() const { return std::min(m_offset, m_stringLength); }

--- a/Source/WebCore/css/parser/SizesCalcParser.cpp
+++ b/Source/WebCore/css/parser/SizesCalcParser.cpp
@@ -1,5 +1,5 @@
 // Copyright 2014-2017 The Chromium Authors. All rights reserved.
-// Copyright (C) 2016 Apple Inc. All rights reserved.
+// Copyright (C) 2016-2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -151,7 +151,8 @@ bool SizesCalcParser::calcToReversePolishNotation(CSSParserTokenRange range)
             // Pop the left parenthesis from the stack, but not onto the output queue.
             stack.removeLast();
             break;
-        case WhitespaceToken:
+        case NonNewlineWhitespaceToken:
+        case NewlineToken:
         case EOFToken:
             break;
         case CDOToken:

--- a/Source/WebCore/html/track/WebVTTTokenizer.cpp
+++ b/Source/WebCore/html/track/WebVTTTokenizer.cpp
@@ -34,6 +34,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "CSSTokenizerInputStream.h"
 #include "HTMLEntityParser.h"
 #include "MarkupTokenizerInlines.h"
 #include <wtf/text/StringBuilder.h>

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,7 +81,7 @@ public:
 
     Color() = default;
 
-    Color(SRGBA<uint8_t>, OptionSet<Flags> = { });
+    WEBCORE_EXPORT Color(SRGBA<uint8_t>, OptionSet<Flags> = { });
     Color(std::optional<SRGBA<uint8_t>>, OptionSet<Flags> = { });
     WEBCORE_EXPORT Color(std::optional<ColorDataForIPC>&&);
 

--- a/Source/WebCore/platform/text/SegmentedString.h
+++ b/Source/WebCore/platform/text/SegmentedString.h
@@ -25,10 +25,6 @@
 
 namespace WebCore {
 
-// FIXME: This should not start with "k".
-// FIXME: This is a shared tokenizer concept, not a SegmentedString concept, but this is the only common header for now.
-constexpr LChar kEndOfFileMarker = 0;
-
 class SegmentedString {
 public:
     SegmentedString() = default;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -190,6 +190,7 @@ if (ENABLE_WEBCORE)
 
         Tests/WebCore/AffineTransform.cpp
         Tests/WebCore/CSSParser.cpp
+        Tests/WebCore/CSSTokenizerTests.cpp
         Tests/WebCore/CalculationValue.cpp
         Tests/WebCore/ColorTests.cpp
         Tests/WebCore/ComplexTextController.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		313C3A0221E567C300DBA86E /* SystemPreviewBlobNaming.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 313C3A0121E5677A00DBA86E /* SystemPreviewBlobNaming.html */; };
 		31727A5329F7518C00A7FB0F /* system-preview.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A4A29F7338C00A7FB0F /* system-preview.html */; };
 		31727A5429F7519400A7FB0F /* UnitBox.usdz in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A5229F733D300A7FB0F /* UnitBox.usdz */; };
+		318210CE2C59AEFF00C334B4 /* CSSTokenizerTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 318210CD2C59AEFF00C334B4 /* CSSTokenizerTests.cpp */; };
 		31903C912765077400363472 /* color-scheme.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31903C902764FE1400363472 /* color-scheme.html */; };
 		31B76E4523299BDC007FED2C /* system-preview-trigger.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31B76E4423299BA3007FED2C /* system-preview-trigger.html */; };
 		31E9BDA1247F4C62002E51A2 /* WebGLPrepareDisplayOnWebThread.mm in Sources */ = {isa = PBXBuildFile; fileRef = 31E9BDA0247F4C62002E51A2 /* WebGLPrepareDisplayOnWebThread.mm */; };
@@ -2328,6 +2329,7 @@
 		313C3A0121E5677A00DBA86E /* SystemPreviewBlobNaming.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SystemPreviewBlobNaming.html; sourceTree = "<group>"; };
 		31727A4A29F7338C00A7FB0F /* system-preview.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "system-preview.html"; sourceTree = "<group>"; };
 		31727A5229F733D300A7FB0F /* UnitBox.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = UnitBox.usdz; sourceTree = "<group>"; };
+		318210CD2C59AEFF00C334B4 /* CSSTokenizerTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSTokenizerTests.cpp; sourceTree = "<group>"; };
 		31903C902764FE1400363472 /* color-scheme.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "color-scheme.html"; sourceTree = "<group>"; };
 		31B76E4223298E2B007FED2C /* SystemPreview.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SystemPreview.mm; sourceTree = "<group>"; };
 		31B76E4423299BA3007FED2C /* system-preview-trigger.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "system-preview-trigger.html"; sourceTree = "<group>"; };
@@ -4492,6 +4494,7 @@
 				7CB184C41AA3F2100066EDFD /* ContentExtensions.cpp */,
 				44CF31FB24993F66009CB6CB /* ContextMenuAction.cpp */,
 				CD5451E919E41F9D0016936F /* CSSParser.cpp */,
+				318210CD2C59AEFF00C334B4 /* CSSTokenizerTests.cpp */,
 				5758597E23A2527A00C74572 /* CtapPinTest.cpp */,
 				572B403321769A88000AD43E /* CtapRequestTest.cpp */,
 				572B404321781B42000AD43E /* CtapResponseTest.cpp */,
@@ -6601,6 +6604,7 @@
 				7CCE7EAC1A411A3400447C4C /* Counters.cpp in Sources */,
 				7AEAD47F1E20116C00416EFE /* CrossPartitionFileSchemeAccess.mm in Sources */,
 				7CCE7EDB1A411A9200447C4C /* CSSParser.cpp in Sources */,
+				318210CE2C59AEFF00C334B4 /* CSSTokenizerTests.cpp in Sources */,
 				5758597F23A2527A00C74572 /* CtapPinTest.cpp in Sources */,
 				572B403421769A88000AD43E /* CtapRequestTest.cpp in Sources */,
 				572B404421781B43000AD43E /* CtapResponseTest.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Igalia, S.L. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,14 +26,142 @@
 
 #include "config.h"
 
+#include <WebCore/CSSCustomPropertyValue.h>
 #include <WebCore/CSSGridIntegerRepeatValue.h>
 #include <WebCore/CSSParser.h>
 #include <WebCore/CSSValueList.h>
+#include <WebCore/Color.h>
 #include <WebCore/MutableStyleProperties.h>
+#include <wtf/text/WTFString.h>
 
 namespace TestWebKitAPI {
 
 using namespace WebCore;
+
+TEST(CSSParser, ParseColorInput)
+{
+    CSSParser parser(strictCSSParserContext());
+    auto properties = MutableStyleProperties::create();
+
+    ASSERT_TRUE(parser.parseDeclaration(properties, "color: #ff0000;"_s));
+    auto value = properties->getPropertyCSSValue(CSSPropertyColor).get();
+
+    ASSERT_TRUE(is<CSSValue>(value));
+    Color valueColor(Color::red);
+
+    EXPECT_TRUE(value->isColor());
+    EXPECT_EQ(valueColor, value->color());
+}
+
+TEST(CSSParser, ParseColorWithNewlineAndWhitespacesInput)
+{
+    CSSParser parser(strictCSSParserContext());
+    auto properties = MutableStyleProperties::create();
+
+    ASSERT_TRUE(parser.parseDeclaration(properties, "color:  \n    #ff0000;"_s));
+    auto value = properties->getPropertyCSSValue(CSSPropertyColor).get();
+
+    ASSERT_TRUE(is<CSSValue>(value));
+    Color valueColor(Color::red);
+
+    EXPECT_TRUE(value->isColor());
+    EXPECT_EQ(valueColor, value->color());
+}
+
+TEST(CSSParser, ParseCustomPropertyWithNewlineInput)
+{
+    CSSParser parser(strictCSSParserContext());
+    auto properties = MutableStyleProperties::create();
+
+    ASSERT_TRUE(parser.parseDeclaration(properties, "--mycustomprop: ValueHere\nWithAnotherValue;"_s));
+    auto customPropValue = downcast<CSSCustomPropertyValue>(properties->propertyAt(0).value());
+
+    ASSERT_TRUE(is<CSSCustomPropertyValue>(customPropValue));
+    auto customText = customPropValue->cssText();
+    customText.convertTo16Bit();
+
+    EXPECT_EQ("ValueHere\nWithAnotherValue"_s, customText);
+}
+
+TEST(CSSParser, ParseCustomPropertyWithNewlineAndWhitespacesInput)
+{
+    CSSParser parser(strictCSSParserContext());
+    auto properties = MutableStyleProperties::create();
+
+    ASSERT_TRUE(parser.parseDeclaration(properties, "--mycustomprop: ValueHere\nWithAnotherValue         ShouldPreserveAllWhitespace;"_s));
+    auto customPropValue = downcast<CSSCustomPropertyValue>(properties->propertyAt(0).value());
+
+    ASSERT_TRUE(is<CSSCustomPropertyValue>(customPropValue));
+    auto customText = customPropValue->cssText();
+    customText.convertTo16Bit();
+
+    EXPECT_EQ("ValueHere\nWithAnotherValue         ShouldPreserveAllWhitespace"_s, customText);
+}
+
+TEST(CSSParser, ParseCustomPropertyWithNewlineBetweenIdentInput)
+{
+    CSSParser parser(strictCSSParserContext());
+    auto properties = MutableStyleProperties::create();
+
+    ASSERT_TRUE(parser.parseDeclaration(properties, "--mycustomprop: foo\nbar"_s));
+    auto customPropValue = downcast<CSSCustomPropertyValue>(properties->propertyAt(0).value());
+
+    ASSERT_TRUE(is<CSSCustomPropertyValue>(customPropValue));
+    auto customText = customPropValue->cssText();
+    customText.convertTo16Bit();
+
+    EXPECT_EQ("foo\nbar"_s, customText);
+}
+
+TEST(CSSParser, ParseColorPropertyWithNewlineBetweenIdentInput)
+{
+    CSSParser parser(strictCSSParserContext());
+    auto properties = MutableStyleProperties::create();
+
+    ASSERT_TRUE(parser.parseDeclaration(properties, "color: #ff0000;"_s));
+    auto value = properties->propertyAt(0).value();
+
+    ASSERT_TRUE(is<CSSValue>(value));
+
+    Color valueColor(Color::red);
+
+    EXPECT_TRUE(value->isColor());
+    EXPECT_EQ(valueColor, value->color());
+}
+
+TEST(CSSParser, ParseTextTransformPropertyWithNewlineBetweenTwoIdentInput)
+{
+    auto check = [&] (auto& properties) {
+        ASSERT_EQ((size_t)1, properties->size());
+
+        auto value = properties->propertyAt(0).value();
+        ASSERT_TRUE(is<CSSValueList>(value));
+        auto& valueList = *downcast<CSSValueList>(value);
+
+        ASSERT_EQ((size_t)2, valueList.size());
+        EXPECT_EQ(CSSValueCapitalize, valueList[0].valueID());
+        EXPECT_EQ(CSSValueFullWidth, valueList[1].valueID());
+    };
+
+    CSSParser parser(strictCSSParserContext());
+    auto properties = MutableStyleProperties::create();
+    ASSERT_TRUE(parser.parseDeclaration(properties, "text-transform: capitalize\nfull-width;"_s));
+    check(properties);
+
+    auto value = properties->propertyAt(0).value();
+    auto serialized = value->cssText();
+    EXPECT_EQ(serialized, "capitalize full-width"_s);
+
+    CSSParser parser2(strictCSSParserContext());
+    auto properties2 = MutableStyleProperties::create();
+
+    StringBuilder builder;
+    builder.append("text-transform: "_s, serialized, ";"_s);
+    auto decl = builder.toString();
+
+    ASSERT_TRUE(parser.parseDeclaration(properties2, decl));
+    check(properties2);
+}
 
 static unsigned computeNumberOfTracks(const CSSValueContainingVector& valueList)
 {
@@ -50,29 +179,31 @@ static unsigned computeNumberOfTracks(const CSSValueContainingVector& valueList)
     return numberOfTracks;
 }
 
-TEST(CSSPropertyParserTest, GridTrackLimits)
+TEST(CSSPropertyParser, GridTrackLimits)
 {
     struct {
         const CSSPropertyID propertyID;
         ASCIILiteral input;
         const size_t output;
-    } testCases[] = {
-        {CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(999999, 20px);"_s, 999999},
-        {CSSPropertyGridTemplateRows, "grid-template-rows: repeat(999999, 20px);"_s, 999999},
-        {CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(1000000, 10%);"_s, 1000000},
-        {CSSPropertyGridTemplateRows, "grid-template-rows: repeat(1000000, 10%);"_s, 1000000},
-        {CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(1000000, [first] -webkit-min-content [last]);"_s, 1000000},
-        {CSSPropertyGridTemplateRows, "grid-template-rows: repeat(1000000, [first] -webkit-min-content [last]);"_s, 1000000},
-        {CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(1000001, auto);"_s, 1000000},
-        {CSSPropertyGridTemplateRows, "grid-template-rows: repeat(1000001, auto);"_s, 1000000},
-        {CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(400000, 2em minmax(10px, -webkit-max-content) 0.5fr);"_s, 999999},
-        {CSSPropertyGridTemplateRows, "grid-template-rows: repeat(400000, 2em minmax(10px, -webkit-max-content) 0.5fr);"_s, 999999},
-        {CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(600000, [first] 3vh 10% 2fr [nav] 10px auto 1fr 6em [last]);"_s, 999999},
-        {CSSPropertyGridTemplateRows, "grid-template-rows: repeat(600000, [first] 3vh 10% 2fr [nav] 10px auto 1fr 6em [last]);"_s, 999999},
-        {CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(100000000000000000000, 10% 1fr);"_s, 1000000},
-        {CSSPropertyGridTemplateRows, "grid-template-rows: repeat(100000000000000000000, 10% 1fr);"_s, 1000000},
-        {CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(100000000000000000000, 10% 5em 1fr auto auto 15px -webkit-min-content);"_s, 999999},
-        {CSSPropertyGridTemplateRows, "grid-template-rows: repeat(100000000000000000000, 10% 5em 1fr auto auto 15px -webkit-min-content);"_s, 999999},
+    }
+
+    testCases[] = {
+        { CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(999999, 20px);"_s, 999999 },
+        { CSSPropertyGridTemplateRows, "grid-template-rows: repeat(999999, 20px);"_s, 999999 },
+        { CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(1000000, 10%);"_s, 1000000 },
+        { CSSPropertyGridTemplateRows, "grid-template-rows: repeat(1000000, 10%);"_s, 1000000 },
+        { CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(1000000, [first] -webkit-min-content [last]);"_s, 1000000 },
+        { CSSPropertyGridTemplateRows, "grid-template-rows: repeat(1000000, [first] -webkit-min-content [last]);"_s, 1000000 },
+        { CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(1000001, auto);"_s, 1000000 },
+        { CSSPropertyGridTemplateRows, "grid-template-rows: repeat(1000001, auto);"_s, 1000000 },
+        { CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(400000, 2em minmax(10px, -webkit-max-content) 0.5fr);"_s, 999999 },
+        { CSSPropertyGridTemplateRows, "grid-template-rows: repeat(400000, 2em minmax(10px, -webkit-max-content) 0.5fr);"_s, 999999 },
+        { CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(600000, [first] 3vh 10% 2fr [nav] 10px auto 1fr 6em [last]);"_s, 999999 },
+        { CSSPropertyGridTemplateRows, "grid-template-rows: repeat(600000, [first] 3vh 10% 2fr [nav] 10px auto 1fr 6em [last]);"_s, 999999 },
+        { CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(100000000000000000000, 10% 1fr);"_s, 1000000 },
+        { CSSPropertyGridTemplateRows, "grid-template-rows: repeat(100000000000000000000, 10% 1fr);"_s, 1000000 },
+        { CSSPropertyGridTemplateColumns, "grid-template-columns: repeat(100000000000000000000, 10% 5em 1fr auto auto 15px -webkit-min-content);"_s, 999999 },
+        { CSSPropertyGridTemplateRows, "grid-template-rows: repeat(100000000000000000000, 10% 5em 1fr auto auto 15px -webkit-min-content);"_s, 999999 },
     };
 
     CSSParser parser(strictCSSParserContext());

--- a/Tools/TestWebKitAPI/Tests/WebCore/CSSTokenizerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CSSTokenizerTests.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/CSSParserToken.h>
+#include <WebCore/CSSParserTokenRange.h>
+#include <WebCore/CSSTokenizer.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringView.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+TEST(CSSTokenizerTest, TokenizeWhitespaceLikeInput)
+{
+    CSSTokenizer tokenizer("foo           \n\n\n bar"_s);
+    auto tokenRange = tokenizer.tokenRange();
+    auto tokenRangeSpan = tokenRange.span();
+
+    ASSERT_EQ(tokenRangeSpan.size(), 7ul);
+    EXPECT_EQ(CSSParserTokenType::IdentToken, tokenRangeSpan[0].type());
+    EXPECT_EQ(CSSParserTokenType::NonNewlineWhitespaceToken, tokenRangeSpan[1].type());
+    EXPECT_EQ(CSSParserTokenType::NewlineToken, tokenRangeSpan[2].type());
+    EXPECT_EQ(CSSParserTokenType::NewlineToken, tokenRangeSpan[3].type());
+    EXPECT_EQ(CSSParserTokenType::NewlineToken, tokenRangeSpan[4].type());
+    EXPECT_EQ(CSSParserTokenType::NonNewlineWhitespaceToken, tokenRangeSpan[5].type());
+    EXPECT_EQ(CSSParserTokenType::IdentToken, tokenRangeSpan[6].type());
+}
+
+TEST(CSSTokenizerTest, TokenizeIdentAndCommaInput)
+{
+    CSSTokenizer tokenizer("this, "_s);
+    auto tokenRange = tokenizer.tokenRange();
+    auto tokenRangeSpan = tokenRange.span();
+
+    ASSERT_EQ((size_t)3, tokenRangeSpan.size());
+    EXPECT_EQ(CSSParserTokenType::IdentToken, tokenRangeSpan[0].type());
+    EXPECT_EQ(CSSParserTokenType::CommaToken, tokenRangeSpan[1].type());
+    EXPECT_EQ(CSSParserTokenType::NonNewlineWhitespaceToken, tokenRangeSpan[2].type());
+}
+
+TEST(CSSTokenizerTest, TokenizeMultipleWhitespaceInput)
+{
+    CSSTokenizer tokenizer("          "_s);
+    auto tokenRange = tokenizer.tokenRange();
+    auto tokenRangeSpan = tokenRange.span();
+
+    ASSERT_EQ((size_t)1, tokenRangeSpan.size());
+    EXPECT_EQ(CSSParserTokenType::NonNewlineWhitespaceToken, tokenRangeSpan[0].type());
+}
+
+TEST(CSSTokenizerTest, TokenizeNewlineTokenOnlyInput)
+{
+    CSSTokenizer tokenizer("\n"_s);
+    auto tokenRange = tokenizer.tokenRange();
+    auto tokenRangeSpan = tokenRange.span();
+
+    ASSERT_EQ((size_t)1, tokenRangeSpan.size());
+    EXPECT_EQ(CSSParserTokenType::NewlineToken, tokenRangeSpan[0].type());
+}
+
+TEST(CSSTokenizerTest, TokenizeNewlineAndWhitespaceInput)
+{
+    CSSTokenizer tokenizer("\n "_s);
+    auto tokenRange = tokenizer.tokenRange();
+    auto tokenRangeSpan = tokenRange.span();
+
+    ASSERT_EQ((size_t)2, tokenRangeSpan.size());
+    EXPECT_EQ(CSSParserTokenType::NewlineToken, tokenRangeSpan[0].type());
+    EXPECT_EQ(CSSParserTokenType::NonNewlineWhitespaceToken, tokenRangeSpan[1].type());
+}
+
+TEST(CSSTokenizerTest, TokenizeNewlineWhitespaceAndIdentInput)
+{
+    CSSTokenizer tokenizer("\n identifiervalue"_s);
+    auto tokenRange = tokenizer.tokenRange();
+    auto tokenRangeSpan = tokenRange.span();
+
+    ASSERT_EQ((size_t)3, tokenRangeSpan.size());
+    EXPECT_EQ(CSSParserTokenType::NewlineToken, tokenRangeSpan[0].type());
+    EXPECT_EQ(CSSParserTokenType::NonNewlineWhitespaceToken, tokenRangeSpan[1].type());
+    EXPECT_EQ(CSSParserTokenType::IdentToken, tokenRangeSpan[2].type());
+}
+
+TEST(CSSTokenizerTest, TokenizeURLWithProperInput)
+{
+    CSSTokenizer tokenizer("url(foo)"_s);
+    auto tokenRange = tokenizer.tokenRange();
+    auto tokenRangeSpan = tokenRange.span();
+
+    ASSERT_EQ((size_t)1, tokenRangeSpan.size());
+    EXPECT_EQ(CSSParserTokenType::UrlToken, tokenRangeSpan[0].type());
+}
+
+TEST(CSSTokenizerTest, TokenizeURLWithNewlineWhitespaceInput)
+{
+    CSSTokenizer tokenizer("url(\n   \n foo)"_s);
+    auto tokenRange = tokenizer.tokenRange();
+    auto tokenRangeSpan = tokenRange.span();
+
+    ASSERT_EQ((size_t)1, tokenRangeSpan.size());
+    EXPECT_EQ(CSSParserTokenType::UrlToken, tokenRangeSpan[0].type());
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### de28c5277420b12db5bfcc0483ec65950b7bc53d
<pre>
[CSS] Tokenizer should distinguish newline from whitespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=276431">https://bugs.webkit.org/show_bug.cgi?id=276431</a>
<a href="https://rdar.apple.com/131474098">rdar://131474098</a>

Reviewed by Darin Adler.

Preserve newlines in Custom CSS Properties. Write unit tests to test the CSSTokenizer and the CSSParser.

    * LayoutTests/fast/css/test-at-supports-newline-expected.txt: Added.
    * LayoutTests/fast/css/test-at-supports-newline.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/css-syntax/custom-property-rule-ambiguity-expected.txt:
    * Source/WebCore/Headers.cmake:
    * Source/WebCore/WebCore.xcodeproj/project.pbxproj:
    * Source/WebCore/css/CSSValue.h:
    * Source/WebCore/css/calc/CSSCalcExpressionNodeParser.cpp:
    (WebCore::CSSCalcExpressionNodeParser::parseCalcFunction):
    (WebCore::CSSCalcExpressionNodeParser::parseValue):
    (WebCore::CSSCalcExpressionNodeParser::parseCalcProduct):
    (WebCore::CSSCalcExpressionNodeParser::parseCalcSum):
    * Source/WebCore/css/parser/CSSParserImpl.cpp:
    (WebCore::CSSParserImpl::consumeRuleList):
    (WebCore::CSSParserImpl::consumeFontFeatureValuesRuleBlock):
    (WebCore::CSSParserImpl::consumeBlockContent):
    * Source/WebCore/css/parser/CSSParserToken.cpp:
    (WebCore::CSSParserToken::CSSParserToken):
    (WebCore::CSSParserToken::hasStringBacking const):
    (WebCore::CSSParserToken::operator== const):
    (WebCore::CSSParserToken::serialize const):
    * Source/WebCore/css/parser/CSSParserToken.h:
    * Source/WebCore/css/parser/CSSParserTokenRange.cpp:
    (WebCore::CSSParserTokenRange::consumeBlockCheckingForEditability):
    (WebCore::CSSParserTokenRange::trimTrailingWhitespace):
    * Source/WebCore/css/parser/CSSParserTokenRange.h:
    (WebCore::CSSParserTokenRange::consumeWhitespace):
    * Source/WebCore/css/parser/CSSSelectorParser.cpp:
    (WebCore::CSSSelectorParser::consumeCombinator):
    * Source/WebCore/css/parser/CSSSupportsParser.cpp:
    (WebCore::CSSSupportsParser::consumeCondition):
    (WebCore::CSSSupportsParser::consumeNegation):
    * Source/WebCore/css/parser/CSSTokenizer.cpp:
    (WebCore::CSSTokenizer::preprocessString):
    (WebCore::CSSTokenizer::isWhitespace):
    (WebCore::CSSTokenizer::isNewline):
    (WebCore::CSSTokenizer::newline):
    (WebCore::twoCharsAreValidEscape):
    (WebCore::CSSTokenizer::whitespace):
    (WebCore::CSSTokenizer::leftParenthesis):
    (WebCore::CSSTokenizer::rightParenthesis):
    (WebCore::CSSTokenizer::leftBracket):
    (WebCore::CSSTokenizer::rightBracket):
    (WebCore::CSSTokenizer::leftBrace):
    (WebCore::CSSTokenizer::rightBrace):
    (WebCore::CSSTokenizer::comma):
    (WebCore::CSSTokenizer::colon):
    (WebCore::CSSTokenizer::semiColon):
    (WebCore::CSSTokenizer::endOfFile):
    (WebCore::CSSTokenizer::consumeStringTokenUntil):
    (WebCore::CSSTokenizer::consumeEscape):
    (WebCore::isNewLine): Deleted.
    (WebCore::CSSTokenizer::whiteSpace): Deleted.
    * Source/WebCore/css/parser/CSSTokenizer.h:
    * Source/WebCore/css/parser/CSSTokenizerInputStream.cpp:
    (WebCore::CSSTokenizerInputStream::advanceUntilNonWhitespace):
    (WebCore::CSSTokenizerInputStream::advanceUntilNewlineOrNonWhitespace):
    * Source/WebCore/css/parser/CSSTokenizerInputStream.h:
    * Source/WebCore/css/parser/SizesCalcParser.cpp:
    (WebCore::SizesCalcParser::calcToReversePolishNotation):
    * Source/WebCore/html/track/WebVTTTokenizer.cpp:
    * Source/WebCore/platform/graphics/Color.h:
    (WebCore::Color::Color):
    * Source/WebCore/platform/text/SegmentedString.h:
    * Tools/TestWebKitAPI/CMakeLists.txt:
    * Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
    * Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp:
    (TestWebKitAPI::TEST(CSSParser, ParseColorInput)):
    (TestWebKitAPI::TEST(CSSParser, ParseColorWithNewlineAndWhitespacesInput)):
    (TestWebKitAPI::TEST(CSSParser, ParseCustomPropertyWithNewlineInput)):
    (TestWebKitAPI::TEST(CSSParser, ParseCustomPropertyWithNewlineAndWhitespacesInput)):
    (TestWebKitAPI::TEST(CSSParser, ParseCustomPropertyWithNewlineBetweenIdentInput)):
    (TestWebKitAPI::TEST(CSSParser, ParseColorPropertyWithNewlineBetweenIdentInput)):
    (TestWebKitAPI::TEST(CSSParser, ParseTextTransformPropertyWithNewlineBetweenTwoIdentInput)):
    (TestWebKitAPI::TEST(CSSPropertyParser, GridTrackLimits)):
    (TestWebKitAPI::TEST(CSSPropertyParserTest, GridTrackLimits)): Deleted.
    * Tools/TestWebKitAPI/Tests/WebCore/CSSTokenizerTests.cpp: Added.
    (TestWebKitAPI::TEST(CSSTokenizerTest, TokenizeWhitespaceLikeInput)):
    (TestWebKitAPI::TEST(CSSTokenizerTest, TokenizeIdentAndCommaInput)):
    (TestWebKitAPI::TEST(CSSTokenizerTest, TokenizeMultipleWhitespaceInput)):
    (TestWebKitAPI::TEST(CSSTokenizerTest, TokenizeNewlineTokenOnlyInput)):
    (TestWebKitAPI::TEST(CSSTokenizerTest, TokenizeNewlineAndWhitespaceInput)):
    (TestWebKitAPI::TEST(CSSTokenizerTest, TokenizeNewlineWhitespaceAndIdentInput)):
    (TestWebKitAPI::TEST(CSSTokenizerTest, TokenizeURLWithProperInput)):
    (TestWebKitAPI::TEST(CSSTokenizerTest, TokenizeURLWithNewlineWhitespaceInput)):

Canonical link: <a href="https://commits.webkit.org/282084@main">https://commits.webkit.org/282084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d45e52849841d2c3d50c446e4943da578dbfd590

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65963 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12528 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49914 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8642 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30747 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10906 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11459 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67691 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57292 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57539 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13783 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4851 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37137 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->