### PR TITLE
[GTK] Remove PlatformDisplay::colorProfile()

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -592,15 +592,6 @@ const Vector<PlatformDisplay::DMABufFormat>& PlatformDisplay::dmabufFormats()
 }
 #endif // USE(GBM)
 
-#if USE(LCMS)
-cmsHPROFILE PlatformDisplay::colorProfile() const
-{
-    if (!m_iccProfile)
-        m_iccProfile = LCMSProfilePtr(cmsCreate_sRGBProfile());
-    return m_iccProfile.get();
-}
-#endif
-
 #if USE(ATSPI)
 const String& PlatformDisplay::accessibilityBusAddress() const
 {

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -55,10 +55,6 @@ typedef struct _GstGLContext GstGLContext;
 typedef struct _GstGLDisplay GstGLDisplay;
 #endif // ENABLE(VIDEO) && USE(GSTREAMER_GL)
 
-#if USE(LCMS)
-#include "LCMSUniquePtr.h"
-#endif
-
 #if USE(SKIA)
 #include <skia/gpu/GrDirectContext.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
@@ -148,10 +144,6 @@ public:
     GrDirectContext* skiaGrContext();
 #endif
 
-#if USE(LCMS)
-    virtual cmsHPROFILE colorProfile() const;
-#endif
-
 #if USE(ATSPI)
     const String& accessibilityBusAddress() const;
 #endif
@@ -188,10 +180,6 @@ protected:
 #if ENABLE(WEBGL) && !PLATFORM(WIN)
     std::optional<int> m_anglePlatform;
     void* m_angleNativeDisplay { nullptr };
-#endif
-
-#if USE(LCMS)
-    mutable LCMSProfilePtr m_iccProfile;
 #endif
 
 #if USE(ATSPI)

--- a/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp
+++ b/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp
@@ -144,46 +144,6 @@ void PlatformDisplayX11::initializeEGLDisplay()
 #endif
 }
 
-#if USE(LCMS)
-cmsHPROFILE PlatformDisplayX11::colorProfile() const
-{
-    if (m_iccProfile)
-        return m_iccProfile.get();
-
-    Atom iccAtom = XInternAtom(m_display, "_ICC_PROFILE", False);
-    Atom type;
-    int format;
-    unsigned long itemCount, bytesAfter;
-    unsigned char* data = nullptr;
-    auto result = XGetWindowProperty(m_display, RootWindowOfScreen(DefaultScreenOfDisplay(m_display)), iccAtom, 0L, ~0L, False, XA_CARDINAL, &type, &format, &itemCount, &bytesAfter, &data);
-    if (result == Success && type == XA_CARDINAL && itemCount > 0) {
-        unsigned long dataSize;
-        switch (format) {
-        case 8:
-            dataSize = itemCount;
-            break;
-        case 16:
-            dataSize = sizeof(short) * itemCount;
-            break;
-        case 32:
-            dataSize = sizeof(long) * itemCount;
-            break;
-        default:
-            dataSize = 0;
-            break;
-        }
-
-        if (dataSize)
-            m_iccProfile = LCMSProfilePtr(cmsOpenProfileFromMem(data, dataSize));
-    }
-
-    if (data)
-        XFree(data);
-
-    return m_iccProfile ? m_iccProfile.get() : PlatformDisplay::colorProfile();
-}
-#endif
-
 #if USE(ATSPI)
 String PlatformDisplayX11::platformAccessibilityBusAddress() const
 {

--- a/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h
+++ b/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h
@@ -60,10 +60,6 @@ private:
 #endif
     void initializeEGLDisplay() override;
 
-#if USE(LCMS)
-    cmsHPROFILE colorProfile() const override;
-#endif
-
 #if USE(ATSPI)
     String platformAccessibilityBusAddress() const override;
 #endif

--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
@@ -40,7 +40,9 @@
 #include "config.h"
 #include "JPEGImageDecoder.h"
 
-#include "PlatformDisplay.h"
+#if USE(LCMS)
+#include "LCMSUniquePtr.h"
+#endif
 
 extern "C" {
 #include <setjmp.h>
@@ -723,14 +725,11 @@ void JPEGImageDecoder::setICCProfile(RefPtr<SharedBuffer>&& buffer)
 
     auto span = buffer->span();
     auto iccProfile = LCMSProfilePtr(cmsOpenProfileFromMem(span.data(), span.size()));
-    if (!iccProfile)
+    if (!iccProfile || cmsGetColorSpace(iccProfile.get()) != cmsSigRgbData)
         return;
 
-    auto* displayProfile = PlatformDisplay::sharedDisplay().colorProfile();
-    if (cmsGetColorSpace(iccProfile.get()) != cmsSigRgbData || cmsGetColorSpace(displayProfile) != cmsSigRgbData)
-        return;
-
-    m_iccTransform = LCMSTransformPtr(cmsCreateTransform(iccProfile.get(), TYPE_BGRA_8, displayProfile, TYPE_BGRA_8, INTENT_RELATIVE_COLORIMETRIC, 0));
+    auto srgbProfile = LCMSProfilePtr(cmsCreate_sRGBProfile());
+    m_iccTransform = LCMSTransformPtr(cmsCreateTransform(iccProfile.get(), TYPE_BGRA_8, srgbProfile.get(), TYPE_BGRA_8, INTENT_RELATIVE_COLORIMETRIC, 0));
 }
 #endif
 

--- a/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
@@ -32,7 +32,7 @@
 #include "PixelBufferConversion.h"
 
 #if USE(LCMS)
-#include "PlatformDisplay.h"
+#include "LCMSUniquePtr.h"
 #endif
 
 #if PLATFORM(COCOA)
@@ -410,18 +410,14 @@ void JPEGXLImageDecoder::prepareColorTransform()
     if (m_iccTransform)
         return;
 
-    cmsHPROFILE displayProfile = PlatformDisplay::sharedDisplay().colorProfile();
-    if (!displayProfile)
-        return;
-
     auto profile = tryDecodeICCColorProfile();
-    if (!profile)
+    if (!profile || cmsGetColorSpace(profile.get()) != cmsSigRgbData)
         return; // TODO(bugs.webkit.org/show_bug.cgi?id=234222): We should try to use encoded color profile if ICC profile is not available.
 
     // TODO(bugs.webkit.org/show_bug.cgi?id=234221): We should handle CMYK color but it may require two extra channels (Alpha and K)
     // and libjxl has yet to support it.
-    if (cmsGetColorSpace(profile.get()) == cmsSigRgbData && cmsGetColorSpace(displayProfile) == cmsSigRgbData)
-        m_iccTransform = LCMSTransformPtr(cmsCreateTransform(profile.get(), TYPE_BGRA_8, displayProfile, TYPE_BGRA_8, INTENT_RELATIVE_COLORIMETRIC, 0));
+    auto srgbProfile = LCMSProfilePtr(cmsCreate_sRGBProfile());
+    m_iccTransform = LCMSTransformPtr(cmsCreateTransform(profile.get(), TYPE_BGRA_8, srgbProfile.get(), TYPE_BGRA_8, INTENT_RELATIVE_COLORIMETRIC, 0));
 }
 
 LCMSProfilePtr JPEGXLImageDecoder::tryDecodeICCColorProfile()


### PR DESCRIPTION
#### bcc92ec7dd55a4c12f6c79f547ba5417467100e6
<pre>
[GTK] Remove PlatformDisplay::colorProfile()
<a href="https://bugs.webkit.org/show_bug.cgi?id=276991">https://bugs.webkit.org/show_bug.cgi?id=276991</a>

Reviewed by Michael Catanzaro.

This is used by some image decoders to convert from embedded ICC profile
to destination target. However, the target is not really the display,
but the SkImage that is always created with SRGB color space. Also,
PlatformDisplay::colorProfile() is always creating an SRGB profile
except for X11 platform that the profile id the one from the display.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::colorProfile const): Deleted.
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp:
(WebCore::PlatformDisplayX11::colorProfile const): Deleted.
* Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h:
* Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp:
(WebCore::JPEGImageDecoder::setICCProfile):
* Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp:
(WebCore::JPEGXLImageDecoder::prepareColorTransform):
* Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp:
(WebCore::PNGImageDecoder::headerAvailable):

Canonical link: <a href="https://commits.webkit.org/281293@main">https://commits.webkit.org/281293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8d0d1835173f4f8779954f4e8149a37aa279919

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63326 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/9922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10086 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48241 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/9922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29065 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8678 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8859 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65059 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8871 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55579 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55684 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2774 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8869 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34571 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36740 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->