### PR TITLE
The ECDH and X25519 deriveBits returns an empty string when 'length' is 0

### DIFF
--- a/LayoutTests/crypto/subtle/ecdh-derive-bits-length-limits-expected.txt
+++ b/LayoutTests/crypto/subtle/ecdh-derive-bits-length-limits-expected.txt
@@ -3,17 +3,17 @@ Test ECDH deriveBits operation for corner-case length values.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS deriveBits(..., 0) successfully derived 256 bits for a P-256 curve
+PASS deriveBits(..., 0) successfully derived 0 bits for a P-256 curve
 PASS deriveBits(..., 8) successfully derived 8 bits for a P-256 curve
 PASS deriveBits(..., 256) successfully derived 256 bits for a P-256 curve
 PASS Bit derivations for EC P-256 with minimum and maximum lengths succeeded
 PASS deriveBits(P256, 256 + 8) rejected promise  with OperationError: The operation failed for an operation-specific reason.
-PASS deriveBits(..., 0) successfully derived 384 bits for a P-384 curve
+PASS deriveBits(..., 0) successfully derived 0 bits for a P-384 curve
 PASS deriveBits(..., 8) successfully derived 8 bits for a P-384 curve
 PASS deriveBits(..., 384) successfully derived 384 bits for a P-384 curve
 PASS Bit derivations for EC P-384 with minimum and maximum lengths succeeded
 PASS deriveBits(P384, 384 + 8) rejected promise  with OperationError: The operation failed for an operation-specific reason.
-PASS deriveBits(..., 0) successfully derived 528 bits for a P-521 curve
+PASS deriveBits(..., 0) successfully derived 0 bits for a P-521 curve
 PASS deriveBits(..., 8) successfully derived 8 bits for a P-521 curve
 PASS deriveBits(..., 528) successfully derived 528 bits for a P-521 curve
 PASS Bit derivations for EC P-521 with minimum and maximum lengths succeeded

--- a/LayoutTests/crypto/subtle/ecdh-derive-bits-length-limits.html
+++ b/LayoutTests/crypto/subtle/ecdh-derive-bits-length-limits.html
@@ -85,7 +85,7 @@ crypto.subtle.importKey("jwk", jwkPrivateKeyP256, { name: "ECDH", namedCurve: "P
     return Promise.resolve().then(function(result) {
         // P-256
         return Promise.all([
-            deriveBits(P256, 0, 256),
+            deriveBits(P256, 0, 0),
             deriveBits(P256, 8, 8),
             deriveBits(P256, 256, 256),
         ]).then(function(result) {
@@ -95,7 +95,7 @@ crypto.subtle.importKey("jwk", jwkPrivateKeyP256, { name: "ECDH", namedCurve: "P
     }).then(function(result) {
         // P-384
         return Promise.all([
-            deriveBits(P384, 0, 384),
+            deriveBits(P384, 0, 0),
             deriveBits(P384, 8, 8),
             deriveBits(P384, 384, 384),
         ]).then(function(result) {
@@ -111,7 +111,7 @@ crypto.subtle.importKey("jwk", jwkPrivateKeyP256, { name: "ECDH", namedCurve: "P
 
             // P-521
             return Promise.all([
-                deriveBits(P521, 0, 528),
+                deriveBits(P521, 0, 0),
                 deriveBits(P521, 8, 8),
                 deriveBits(P521, 528, 528),
             ]).then(function(result) {

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any-expected.txt
@@ -11,12 +11,12 @@ PASS PBKDF2 derivation with null as 'length' parameter
 PASS PBKDF2 derivation with undefined as 'length' parameter
 PASS PBKDF2 derivation with omitted as 'length' parameter
 PASS ECDH derivation with 256 as 'length' parameter
-FAIL ECDH derivation with 0 as 'length' parameter assert_array_equals: Derived bits do not match the expected result. lengths differ, expected array object "" length 0, got object "87,31,26,232,151,28,227,35,250,17,131,137,203,95,65,196,59,61,181,161" length 32
+PASS ECDH derivation with 0 as 'length' parameter
 PASS ECDH derivation with null as 'length' parameter
 PASS ECDH derivation with undefined as 'length' parameter
 PASS ECDH derivation with omitted as 'length' parameter
 PASS X25519 derivation with 256 as 'length' parameter
-FAIL X25519 derivation with 0 as 'length' parameter assert_array_equals: Derived bits do not match the expected result. lengths differ, expected array object "" length 0, got object "63,245,136,2,149,247,97,118,8,143,137,228,61,254,190,126,161,149,0,8" length 32
+PASS X25519 derivation with 0 as 'length' parameter
 PASS X25519 derivation with null as 'length' parameter
 PASS X25519 derivation with undefined as 'length' parameter
 PASS X25519 derivation with omitted as 'length' parameter

--- a/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.worker-expected.txt
@@ -11,12 +11,12 @@ PASS PBKDF2 derivation with null as 'length' parameter
 PASS PBKDF2 derivation with undefined as 'length' parameter
 PASS PBKDF2 derivation with omitted as 'length' parameter
 PASS ECDH derivation with 256 as 'length' parameter
-FAIL ECDH derivation with 0 as 'length' parameter assert_array_equals: Derived bits do not match the expected result. lengths differ, expected array object "" length 0, got object "87,31,26,232,151,28,227,35,250,17,131,137,203,95,65,196,59,61,181,161" length 32
+PASS ECDH derivation with 0 as 'length' parameter
 PASS ECDH derivation with null as 'length' parameter
 PASS ECDH derivation with undefined as 'length' parameter
 PASS ECDH derivation with omitted as 'length' parameter
 PASS X25519 derivation with 256 as 'length' parameter
-FAIL X25519 derivation with 0 as 'length' parameter assert_array_equals: Derived bits do not match the expected result. lengths differ, expected array object "" length 0, got object "63,245,136,2,149,247,97,118,8,143,137,228,61,254,190,126,161,149,0,8" length 32
+PASS X25519 derivation with 0 as 'length' parameter
 PASS X25519 derivation with null as 'length' parameter
 PASS X25519 derivation with undefined as 'length' parameter
 PASS X25519 derivation with omitted as 'length' parameter

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
@@ -89,12 +89,20 @@ void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters
         return;
     }
 
+    // Return an empty string doesn't make much sense, but truncating either at all.
+    // https://github.com/w3c/webcrypto/issues/369
+    if (length && !(*length)) {
+        // Avoid executing the key-derivation, since we are going to return an empty string.
+        callback({ });
+        return;
+    }
+
     auto unifiedCallback = [callback = WTFMove(callback), exceptionCallback = WTFMove(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey, std::optional<size_t> length) mutable {
         if (!derivedKey) {
             exceptionCallback(ExceptionCode::OperationError);
             return;
         }
-        if (!length || !(*length)) {
+        if (!length) {
             callback(WTFMove(*derivedKey));
             return;
         }

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
@@ -87,12 +87,20 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
         return;
     }
 
+    // Return an empty string doesn't make much sense, but truncating either at all.
+    // https://github.com/WICG/webcrypto-secure-curves/pull/29
+    if (length && !(*length)) {
+        // Avoid executing the key-derivation, since we are going to return an empty string.
+        callback({ });
+        return;
+    }
+
     auto unifiedCallback = [callback = WTFMove(callback), exceptionCallback = WTFMove(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey, std::optional<size_t> length) mutable {
         if (!derivedKey) {
             exceptionCallback(ExceptionCode::OperationError);
             return;
         }
-        if (!length || !(*length)) {
+        if (!length) {
             callback(WTFMove(*derivedKey));
             return;
         }


### PR DESCRIPTION
#### 0b46039641c2700f55501d4121d825aa86f22b98
<pre>
The ECDH and X25519 deriveBits returns an empty string when &apos;length&apos; is 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=276916">https://bugs.webkit.org/show_bug.cgi?id=276916</a>

Reviewed by Matthew Finkel.

The WebCrypto API spec&apos;s draft states that the ECDH&apos;s deriveBits should
handle a zero length as any regular number, only throwing an exception
in case of &apos;null&apos;. The same is stated in the Secure Curves specification
draft for the X25519 algorithm.

We were not supporting &apos;null&apos; value before, but since r281240 the &apos;length&apos;
parameter is defined as optional, with &apos;null&apos; as default value. Hence
in case of a zero length the derived bits are truncated so that the
operation returns an empty string.

* LayoutTests/crypto/subtle/ecdh-derive-bits-length-limits-expected.txt:
* LayoutTests/crypto/subtle/ecdh-derive-bits-length-limits.html:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.worker-expected.txt:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp:
(WebCore::CryptoAlgorithmECDH::deriveBits):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp:
(WebCore::CryptoAlgorithmX25519::deriveBits):

Canonical link: <a href="https://commits.webkit.org/285383@main">https://commits.webkit.org/285383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c8d375ec46eaf92cad5db4d868055cf97b307e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/71617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/24391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/75729 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/22822 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/73732 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/58831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/22642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56568 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/15048 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/74683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/61693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/37017 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21163 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/19523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/77447 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/18702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/64282 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/64279 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/16002 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/12426 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6067 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/46830 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/1609 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47901 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/49185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/47643 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->