### PR TITLE
[GStreamer][WebRTC] Simplified pipeline for incoming tracks

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2105,7 +2105,8 @@ webkit.org/b/235885 webrtc/datachannel/getStats-no-prflx-remote-candidate.html [
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-statsSelector.html [ Skip ]
 webkit.org/b/187064 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getStats.https.html [ Skip ]
 
-webkit.org/b/269285 webrtc/h265.html [ Failure ]
+# FIXME: Remove Timeout expectation once bug #275685 is fixed.
+webkit.org/b/269285 webrtc/h265.html [ Failure Timeout ]
 
 # Too slow with filtering implemented in WebKit. Should be done directly by GstWebRTC.
 webrtc/datachannel/filter-ice-candidate.html [ Skip ]

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -24,7 +24,6 @@
 #include "GStreamerCommon.h"
 #include "GStreamerQuirks.h"
 #include "GStreamerRegistryScanner.h"
-#include <wtf/text/MakeString.h>
 
 GST_DEBUG_CATEGORY(webkit_webrtc_incoming_track_processor_debug);
 #define GST_CAT_DEFAULT webkit_webrtc_incoming_track_processor_debug
@@ -43,16 +42,24 @@ void GStreamerIncomingTrackProcessor::configure(ThreadSafeWeakPtr<GStreamerMedia
 {
     m_endPoint = WTFMove(endPoint);
     m_pad = WTFMove(pad);
-    m_data.mediaStreamBinName = span(GST_OBJECT_NAME(m_pad.get()));
-    m_bin = gst_bin_new(m_data.mediaStreamBinName.ascii().data());
 
     auto caps = adoptGRef(gst_pad_get_current_caps(m_pad.get()));
     if (!caps)
         caps = adoptGRef(gst_pad_query_caps(m_pad.get(), nullptr));
 
-    GST_DEBUG_OBJECT(m_bin.get(), "Processing track with caps %" GST_PTR_FORMAT, caps.get());
-    m_data.type = doCapsHaveType(caps.get(), "audio") ? RealtimeMediaSource::Type::Audio : RealtimeMediaSource::Type::Video;
+    ASCIILiteral typeName;
+    if (doCapsHaveType(caps.get(), "audio")) {
+        typeName = "audio"_s;
+        m_data.type = RealtimeMediaSource::Type::Audio;
+    } else {
+        typeName = "video"_s;
+        m_data.type = RealtimeMediaSource::Type::Video;
+    }
     m_data.caps = WTFMove(caps);
+
+    m_data.mediaStreamBinName = makeString("incoming-"_s, typeName, "-track-"_s, span(GST_OBJECT_NAME(m_pad.get())));
+    m_bin = gst_bin_new(m_data.mediaStreamBinName.ascii().data());
+    GST_DEBUG_OBJECT(m_bin.get(), "Processing track with caps %" GST_PTR_FORMAT, m_data.caps.get());
 
     g_object_get(m_pad.get(), "transceiver", &m_data.transceiver.outPtr(), nullptr);
 
@@ -73,15 +80,30 @@ void GStreamerIncomingTrackProcessor::configure(ThreadSafeWeakPtr<GStreamerMedia
     if (!m_sdpMsIdAndTrackId.second.isEmpty())
         m_data.trackId = m_sdpMsIdAndTrackId.second;
 
-    m_tee = gst_element_factory_make("tee", "tee");
-    g_object_set(m_tee.get(), "allow-not-linked", TRUE, nullptr);
+    m_sink = gst_element_factory_make("fakesink", "sink");
+    g_object_set(m_sink.get(), "sync", TRUE, "enable-last-sample", FALSE, nullptr);
+    auto queue = gst_element_factory_make("queue", "queue");
 
     auto trackProcessor = incomingTrackProcessor();
-    m_data.isUpstreamDecoding = m_isDecoding;
 
-    gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_tee.get(), trackProcessor.get(), nullptr);
+    gst_bin_add_many(GST_BIN_CAST(m_bin.get()), trackProcessor.get(), queue, m_sink.get(), nullptr);
+    gst_element_link(queue, m_sink.get());
+
     auto sinkPad = adoptGRef(gst_element_get_static_pad(trackProcessor.get(), "sink"));
     gst_element_add_pad(m_bin.get(), gst_ghost_pad_new("sink", sinkPad.get()));
+
+    if (m_data.type != RealtimeMediaSource::Type::Video || !m_isDecoding)
+        return;
+
+    auto sinkSinkPad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
+    gst_pad_add_probe(sinkSinkPad.get(), GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad*, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
+        auto query = GST_PAD_PROBE_INFO_QUERY(info);
+        if (GST_QUERY_TYPE(query) != GST_QUERY_ALLOCATION)
+            return GST_PAD_PROBE_OK;
+
+        gst_query_add_allocation_meta(query, GST_VIDEO_META_API_TYPE, nullptr);
+        return GST_PAD_PROBE_REMOVE;
+    }), nullptr, nullptr);
 }
 
 String GStreamerIncomingTrackProcessor::mediaStreamIdFromPad()
@@ -168,12 +190,6 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
     GRefPtr<GstElement> decodebin = makeGStreamerElement("decodebin3", nullptr);
     m_isDecoding = true;
 
-    m_queue = gst_element_factory_make("queue", nullptr);
-    m_fakeVideoSink = makeGStreamerElement("fakevideosink", nullptr);
-    g_object_set(m_fakeVideoSink.get(), "enable-last-sample", FALSE, nullptr);
-    gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_queue.get(), m_fakeVideoSink.get(), nullptr);
-    gst_element_link(m_queue.get(), m_fakeVideoSink.get());
-
     g_signal_connect(decodebin.get(), "deep-element-added", G_CALLBACK(+[](GstBin*, GstBin*, GstElement* element, gpointer) {
         String elementClass = WTF::span(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
         auto classifiers = elementClass.split('/');
@@ -209,13 +225,9 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
     }), this);
 
     g_signal_connect_swapped(decodebin.get(), "pad-added", G_CALLBACK(+[](GStreamerIncomingTrackProcessor* self, GstPad* pad) {
-        auto sinkPad = adoptGRef(gst_element_get_static_pad(self->m_tee.get(), "sink"));
+        auto queue = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(self->m_bin.get()), "queue"));
+        auto sinkPad = adoptGRef(gst_element_get_static_pad(queue.get(), "sink"));
         gst_pad_link(pad, sinkPad.get());
-
-        gst_element_link(self->m_tee.get(), self->m_queue.get());
-        gst_element_sync_state_with_parent(self->m_tee.get());
-        gst_element_sync_state_with_parent(self->m_queue.get());
-        gst_element_sync_state_with_parent(self->m_fakeVideoSink.get());
         self->trackReady();
     }), this);
     return decodebin;
@@ -250,9 +262,9 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::createParser()
     }
 
     g_signal_connect_swapped(parsebin.get(), "pad-added", G_CALLBACK(+[](GStreamerIncomingTrackProcessor* self, GstPad* pad) {
-        auto sinkPad = adoptGRef(gst_element_get_static_pad(self->m_tee.get(), "sink"));
+        auto queue = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(self->m_bin.get()), "queue"));
+        auto sinkPad = adoptGRef(gst_element_get_static_pad(queue.get(), "sink"));
         gst_pad_link(pad, sinkPad.get());
-        gst_element_sync_state_with_parent(self->m_tee.get());
         self->trackReady();
     }), this);
     return parsebin;
@@ -283,7 +295,7 @@ const GstStructure* GStreamerIncomingTrackProcessor::stats()
 
     m_stats.reset(gst_structure_new_empty("incoming-video-stats"));
     GUniqueOutPtr<GstStructure> stats;
-    g_object_get(m_fakeVideoSink.get(), "stats", &stats.outPtr(), nullptr);
+    g_object_get(m_sink.get(), "stats", &stats.outPtr(), nullptr);
 
     auto droppedVideoFrames = gstStructureGet<uint64_t>(stats.get(), "dropped"_s);
     if (!droppedVideoFrames)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
@@ -61,7 +61,6 @@ private:
     ThreadSafeWeakPtr<GStreamerMediaEndpoint> m_endPoint;
     GRefPtr<GstPad> m_pad;
     GRefPtr<GstElement> m_bin;
-    GRefPtr<GstElement> m_tee;
     WebRTCTrackData m_data;
 
     std::pair<String, String> m_sdpMsIdAndTrackId;
@@ -69,8 +68,7 @@ private:
     bool m_isDecoding { false };
     FloatSize m_videoSize;
     uint64_t m_decodedVideoFrames { 0 };
-    GRefPtr<GstElement> m_queue;
-    GRefPtr<GstElement> m_fakeVideoSink;
+    GRefPtr<GstElement> m_sink;
     GUniquePtr<GstStructure> m_stats;
     bool m_isReady { false };
 };

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCCommon.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCCommon.h
@@ -27,7 +27,6 @@ using WebRTCTrackData = struct _WebRTCTrackData {
     String trackId;
     String mediaStreamBinName;
     GRefPtr<GstWebRTCRTPTransceiver> transceiver;
-    bool isUpstreamDecoding;
     RealtimeMediaSource::Type type;
     GRefPtr<GstCaps> caps;
 };

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
@@ -38,9 +38,6 @@ RealtimeIncomingAudioSourceGStreamer::RealtimeIncomingAudioSourceGStreamer(AtomS
     std::call_once(debugRegisteredFlag, [] {
         GST_DEBUG_CATEGORY_INIT(webkit_webrtc_incoming_audio_debug, "webkitwebrtcincomingaudio", 0, "WebKit WebRTC incoming audio");
     });
-    static Atomic<uint64_t> sourceCounter = 0;
-    gst_element_set_name(bin(), makeString("incoming-audio-source-"_s, sourceCounter.exchangeAdd(1)).ascii().data());
-    GST_DEBUG_OBJECT(bin(), "New incoming audio source created with ID %s", persistentID().ascii().data());
 }
 
 RealtimeIncomingAudioSourceGStreamer::~RealtimeIncomingAudioSourceGStreamer()

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
@@ -40,25 +40,51 @@ RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer(const CaptureDe
     std::call_once(debugRegisteredFlag, [] {
         GST_DEBUG_CATEGORY_INIT(webkit_webrtc_incoming_media_debug, "webkitwebrtcincoming", 0, "WebKit WebRTC incoming media");
     });
-    m_bin = gst_bin_new(nullptr);
 }
 
-void RealtimeIncomingSourceGStreamer::setUpstreamBin(const GRefPtr<GstElement>& bin)
+bool RealtimeIncomingSourceGStreamer::setBin(const GRefPtr<GstElement>& bin)
 {
-    m_upstreamBin = bin;
-    m_tee = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_upstreamBin.get()), "tee"));
-}
+    ASSERT(!m_bin);
+    if (UNLIKELY(m_bin)) {
+        GST_ERROR_OBJECT(m_bin.get(), "Calling setBin twice on the same incoming source instance is not allowed");
+        return false;
+    }
 
-void RealtimeIncomingSourceGStreamer::startProducingData()
-{
-    GST_DEBUG_OBJECT(bin(), "Starting data flow");
-    m_isStarted = true;
-}
+    m_bin = bin;
+    m_sink = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_bin.get()), "sink"));
+    g_object_set(m_sink.get(), "signal-handoffs", TRUE, nullptr);
 
-void RealtimeIncomingSourceGStreamer::stopProducingData()
-{
-    GST_DEBUG_OBJECT(bin(), "Stopping data flow");
-    m_isStarted = false;
+    auto handoffCallback = G_CALLBACK(+[](GstElement*, GstBuffer* buffer, GstPad* pad, gpointer userData) {
+        auto source = reinterpret_cast<RealtimeIncomingSourceGStreamer*>(userData);
+        auto caps = adoptGRef(gst_pad_get_current_caps(pad));
+        auto sample = adoptGRef(gst_sample_new(buffer, caps.get(), nullptr, nullptr));
+        // dispatchSample might trigger RealtimeMediaSource::notifySettingsDidChangeObservers()
+        // which expects to run in the main thread.
+        callOnMainThread([source, sample = WTFMove(sample)]() mutable {
+            source->dispatchSample(WTFMove(sample));
+        });
+    });
+    g_signal_connect(m_sink.get(), "preroll-handoff", handoffCallback, this);
+    g_signal_connect(m_sink.get(), "handoff", handoffCallback, this);
+
+    auto sinkPad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
+    gst_pad_add_probe(sinkPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM | GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM), reinterpret_cast<GstPadProbeCallback>(+[](GstPad* pad, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
+        auto self = reinterpret_cast<RealtimeIncomingSourceGStreamer*>(userData);
+        if (info->type & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM) {
+            GRefPtr event = GST_PAD_PROBE_INFO_EVENT(info);
+            auto sink = adoptGRef(gst_pad_get_parent_element(pad));
+            self->handleDownstreamEvent(sink.get(), WTFMove(event));
+            return GST_PAD_PROBE_OK;
+        }
+
+        auto query = GST_PAD_PROBE_INFO_QUERY(info);
+        self->forEachClient([&](auto* appsrc) {
+            auto srcSrcPad = adoptGRef(gst_element_get_static_pad(appsrc, "src"));
+            gst_pad_peer_query(srcSrcPad.get(), query);
+        });
+        return GST_PAD_PROBE_OK;
+    }), this, nullptr);
+    return true;
 }
 
 const RealtimeMediaSourceCapabilities& RealtimeIncomingSourceGStreamer::capabilities()
@@ -76,121 +102,50 @@ bool RealtimeIncomingSourceGStreamer::hasClient(const GRefPtr<GstElement>& appsr
     return false;
 }
 
-void RealtimeIncomingSourceGStreamer::configureAppSink(GstElement* sink)
+int RealtimeIncomingSourceGStreamer::registerClient(GRefPtr<GstElement>&& appsrc)
 {
-    static GstAppSinkCallbacks callbacks = {
-        nullptr, // eos
-        [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
-            auto source = reinterpret_cast<ThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>*>(userData);
-            auto strongSource = source->get();
-            if (!strongSource)
-                return GST_FLOW_OK;
+    Locker lock { m_clientLock };
+    static Atomic<int> counter = 1;
+    auto clientId = counter.exchangeAdd(1);
 
-            auto sample = adoptGRef(gst_app_sink_pull_preroll(sink));
-            // dispatchSample might trigger RealtimeMediaSource::notifySettingsDidChangeObservers()
-            // which expects to run in the main thread.
-            callOnMainThread([source = ThreadSafeWeakPtr { *strongSource.get() }, sample = WTFMove(sample)]() mutable {
-                auto strongSource = source.get();
-                if (!strongSource)
-                    return;
-
-                strongSource->dispatchSample(WTFMove(sample));
-            });
-            return GST_FLOW_OK;
-        },
-        [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
-            auto source = reinterpret_cast<ThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>*>(userData);
-            auto strongSource = source->get();
-            if (!strongSource)
-                return GST_FLOW_OK;
-
-            auto sample = adoptGRef(gst_app_sink_pull_sample(sink));
-            // dispatchSample might trigger RealtimeMediaSource::notifySettingsDidChangeObservers()
-            // which expects to run in the main thread.
-            callOnMainThread([source = ThreadSafeWeakPtr { *strongSource.get() }, sample = WTFMove(sample)]() mutable {
-                auto strongSource = source.get();
-                if (!strongSource)
-                    return;
-
-                strongSource->dispatchSample(WTFMove(sample));
-            });
-            return GST_FLOW_OK;
-        },
-        [](GstAppSink* sink, gpointer userData) -> gboolean {
-            auto source = reinterpret_cast<ThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>*>(userData);
-            auto strongSource = source->get();
-            if (!strongSource)
-                return false;
-
-            auto event = adoptGRef(GST_EVENT_CAST(gst_app_sink_pull_object(sink)));
-            strongSource->handleDownstreamEvent(GST_ELEMENT_CAST(sink), WTFMove(event));
-            return false;
-        },
-#if GST_CHECK_VERSION(1, 24, 0)
-        [](GstAppSink*, GstQuery* query, gpointer userData) -> gboolean {
-            auto source = reinterpret_cast<ThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>*>(userData);
-            auto strongSource = source->get();
-            if (!strongSource)
-                return false;
-
-            if (strongSource->isIncomingVideoSource() && strongSource->m_isUpstreamDecoding) {
-                gst_query_add_allocation_meta(query, GST_VIDEO_META_API_TYPE, nullptr);
-                return true;
-            }
-            return false;
-        },
-#endif
-        { nullptr }
-    };
-    gst_app_sink_set_callbacks(GST_APP_SINK(sink), &callbacks, new ThreadSafeWeakPtr { *this }, [](void* data) {
-        delete static_cast<ThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>*>(data);
-    });
+    m_clients.add(clientId, WTFMove(appsrc));
+    return clientId;
 }
 
-void RealtimeIncomingSourceGStreamer::configureFakeVideoSink(GstElement* sink)
+void RealtimeIncomingSourceGStreamer::unregisterClient(int clientId)
 {
-    g_object_set(sink, "signal-handoffs", TRUE, nullptr);
+    Locker lock { m_clientLock };
+    GST_DEBUG_OBJECT(m_bin.get(), "Unregistering client %d", clientId);
+    m_clients.remove(clientId);
+}
 
-    auto handoffCallback = G_CALLBACK(+[](GstElement*, GstBuffer* buffer, GstPad* pad, gpointer userData) {
-        auto source = reinterpret_cast<ThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>*>(userData);
-        auto strongSource = source->get();
-        if (!strongSource)
-            return;
+void RealtimeIncomingSourceGStreamer::forEachClient(Function<void(GstElement*)>&& applyFunction)
+{
+    Locker lock { m_clientLock };
+    for (auto& client : m_clients.values())
+        applyFunction(client.get());
+}
 
-        auto caps = adoptGRef(gst_pad_get_current_caps(pad));
-        auto sample = adoptGRef(gst_sample_new(buffer, caps.get(), nullptr, nullptr));
-        // dispatchSample might trigger RealtimeMediaSource::notifySettingsDidChangeObservers()
-        // which expects to run in the main thread.
-        callOnMainThread([source = ThreadSafeWeakPtr { *strongSource.get() }, sample = WTFMove(sample)]() mutable {
-            auto strongSource = source.get();
-            if (!strongSource)
-                return;
+void RealtimeIncomingSourceGStreamer::handleUpstreamEvent(GRefPtr<GstEvent>&& event)
+{
+    // FIXME: This early return shouldn't be necessary anymore after bug #275685 has been fixed.
+    if (!m_bin)
+        return;
 
-            strongSource->dispatchSample(WTFMove(sample));
-        });
-    });
-    g_signal_connect_data(sink, "preroll-handoff", handoffCallback, new ThreadSafeWeakPtr { *this },
-        [](void* data, GClosure*) {
-            delete static_cast<ThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>*>(data);
-        }, static_cast<GConnectFlags>(0));
-    g_signal_connect_data(sink, "handoff", handoffCallback, new ThreadSafeWeakPtr { *this },
-        [](void* data, GClosure*) {
-            delete static_cast<ThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>*>(data);
-        }, static_cast<GConnectFlags>(0));
+    GST_DEBUG_OBJECT(m_bin.get(), "Handling %" GST_PTR_FORMAT, event.get());
+    auto pad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
+    gst_pad_push_event(pad.get(), event.leakRef());
+}
 
-    auto pad = adoptGRef(gst_element_get_static_pad(sink, "sink"));
-    gst_pad_add_probe(pad.get(), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad* pad, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
-        auto source = reinterpret_cast<ThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>*>(userData);
-        auto strongSource = source->get();
-        if (!strongSource)
-            return GST_PAD_PROBE_OK;
-        GRefPtr event = GST_PAD_PROBE_INFO_EVENT(info);
-        auto sink = adoptGRef(gst_pad_get_parent_element(pad));
-        strongSource->handleDownstreamEvent(sink.get(), WTFMove(event));
-        return GST_PAD_PROBE_OK;
-    }), new ThreadSafeWeakPtr { *this }, [](void* data) {
-        delete static_cast<ThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>*>(data);
-    });
+bool RealtimeIncomingSourceGStreamer::handleUpstreamQuery(GstQuery* query)
+{
+    // FIXME: This early return shouldn't be necessary anymore after bug #275685 has been fixed.
+    if (!m_bin)
+        return false;
+
+    GST_DEBUG_OBJECT(m_bin.get(), "Handling %" GST_PTR_FORMAT, query);
+    auto pad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
+    return gst_pad_peer_query(pad.get(), query);
 }
 
 void RealtimeIncomingSourceGStreamer::handleDownstreamEvent(GstElement* sink, GRefPtr<GstEvent>&& event)
@@ -204,11 +159,10 @@ void RealtimeIncomingSourceGStreamer::handleDownstreamEvent(GstElement* sink, GR
     case GST_EVENT_LATENCY: {
         GstClockTime minLatency, maxLatency;
         if (gst_base_sink_query_latency(GST_BASE_SINK(sink), nullptr, nullptr, &minLatency, &maxLatency)) {
-            if (int clientId = GPOINTER_TO_INT(g_object_get_qdata(G_OBJECT(sink), m_clientQuark))) {
+            forEachClient([&](auto* appsrc) {
                 GST_DEBUG_OBJECT(sink, "Setting client latency to min %" GST_TIME_FORMAT " max %" GST_TIME_FORMAT, GST_TIME_ARGS(minLatency), GST_TIME_ARGS(maxLatency));
-                auto appsrc = m_clients.get(clientId);
                 g_object_set(appsrc, "min-latency", minLatency, "max-latency", maxLatency, nullptr);
-            }
+            });
         }
         return;
     }
@@ -216,141 +170,12 @@ void RealtimeIncomingSourceGStreamer::handleDownstreamEvent(GstElement* sink, GR
         break;
     }
 
-    if (int clientId = GPOINTER_TO_INT(g_object_get_qdata(G_OBJECT(sink), m_clientQuark))) {
-        GST_DEBUG_OBJECT(sink, "Forwarding event %" GST_PTR_FORMAT " to client", event.get());
-        auto appsrc = m_clients.get(clientId);
+    forEachClient([&](auto* appsrc) {
         auto pad = adoptGRef(gst_element_get_static_pad(appsrc, "src"));
-        gst_pad_push_event(pad.get(), event.leakRef());
-    }
-}
-
-std::optional<int> RealtimeIncomingSourceGStreamer::registerClient(GRefPtr<GstElement>&& appsrc)
-{
-    if (!m_tee)
-        return std::nullopt;
-
-    Locker lock { m_clientLock };
-    static Atomic<int> counter = 1;
-    auto clientId = counter.exchangeAdd(1);
-
-    auto* queue = gst_element_factory_make("queue", makeString("queue-"_s, clientId).ascii().data());
-
-    ASCIILiteral sinkName = "appsink"_s;
-#if !GST_CHECK_VERSION(1, 24, 0)
-    if (isIncomingVideoSource() && m_isUpstreamDecoding)
-        sinkName = "fakevideosink"_s;
-#endif
-    auto* sink = makeGStreamerElement(sinkName.characters(), makeString("sink-"_s, clientId).ascii().data());
-    g_object_set(sink, "enable-last-sample", FALSE, nullptr);
-
-    if (!m_clientQuark)
-        m_clientQuark = g_quark_from_static_string("client-id");
-    g_object_set_qdata(G_OBJECT(sink), m_clientQuark, GINT_TO_POINTER(clientId));
-    GST_DEBUG_OBJECT(m_bin.get(), "Client %" GST_PTR_FORMAT " with id %d associated to new sink %" GST_PTR_FORMAT, appsrc.get(), clientId, sink);
-    m_clients.add(clientId, WTFMove(appsrc));
-
-    if (GST_IS_APP_SINK(sink))
-        configureAppSink(sink);
-    else
-        configureFakeVideoSink(sink);
-
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(sink, "sink"));
-    gst_pad_add_probe(sinkPad.get(), GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad* pad, GstPadProbeInfo* info, RealtimeIncomingSourceGStreamer* self) -> GstPadProbeReturn {
-        auto query = GST_QUERY_CAST(info->data);
-        if (self->isIncomingVideoSource() && self->m_isUpstreamDecoding && GST_QUERY_TYPE(query) == GST_QUERY_ALLOCATION) {
-            // Let fakevideosink handle the allocation query.
-            return GST_PAD_PROBE_OK;
-        }
-
-        auto sink = adoptGRef(gst_pad_get_parent_element(pad));
-        int clientId = GPOINTER_TO_INT(g_object_get_qdata(G_OBJECT(sink.get()), self->m_clientQuark));
-        if (!clientId)
-            return GST_PAD_PROBE_OK;
-
-        auto appsrc = self->m_clients.get(clientId);
-        auto srcSrcPad = adoptGRef(gst_element_get_static_pad(appsrc, "src"));
-        if (gst_pad_peer_query(srcSrcPad.get(), query))
-            return GST_PAD_PROBE_HANDLED;
-
-        return GST_PAD_PROBE_OK;
-    }), this, nullptr);
-
-    auto padName = makeString("src_"_s, clientId);
-    auto teeSrcPad = adoptGRef(gst_element_request_pad_simple(m_tee.get(), padName.ascii().data()));
-
-    GUniquePtr<char> name(gst_pad_get_name(teeSrcPad.get()));
-    auto ghostSrcPad = gst_ghost_pad_new(name.get(), teeSrcPad.get());
-    gst_element_add_pad(m_upstreamBin.get(), ghostSrcPad);
-
-    gst_bin_add_many(GST_BIN_CAST(m_bin.get()), queue, sink, nullptr);
-    gst_element_link(queue, sink);
-
-    auto queueSinkPad = adoptGRef(gst_element_get_static_pad(queue, "sink"));
-    auto ghostSinkPadName = makeString("sink-"_s, clientId);
-    auto ghostSinkPad = gst_ghost_pad_new(ghostSinkPadName.ascii().data(), queueSinkPad.get());
-    gst_element_add_pad(m_bin.get(), ghostSinkPad);
-
-    gst_pad_link(ghostSrcPad, ghostSinkPad);
-    gst_element_sync_state_with_parent(queue);
-    gst_element_sync_state_with_parent(sink);
-    gst_element_sync_state_with_parent(m_bin.get());
-
-    GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(m_bin.get()), GST_DEBUG_GRAPH_SHOW_ALL, GST_OBJECT_NAME(m_bin.get()));
-    return clientId;
-}
-
-void RealtimeIncomingSourceGStreamer::unregisterClient(int clientId)
-{
-    Locker lock { m_clientLock };
-    unregisterClientLocked(clientId);
-}
-
-void RealtimeIncomingSourceGStreamer::unregisterClientLocked(int clientId)
-{
-    GST_DEBUG_OBJECT(m_bin.get(), "Unregistering client %d", clientId);
-    auto name = makeString("sink-"_s, clientId);
-    auto sink = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_bin.get()), name.ascii().data()));
-    auto queue = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_bin.get()), makeString("queue-"_s, clientId).ascii().data()));
-
-    auto ghostSinkPad = adoptGRef(gst_element_get_static_pad(m_bin.get(), name.ascii().data()));
-    auto padName = makeString("src_"_s, clientId);
-    auto teeSrcPad = adoptGRef(gst_element_get_static_pad(m_tee.get(), padName.ascii().data()));
-
-    gst_element_set_locked_state(m_upstreamBin.get(), TRUE);
-    gst_element_set_locked_state(m_bin.get(), TRUE);
-    gst_element_set_state(queue.get(), GST_STATE_NULL);
-    gst_element_set_state(sink.get(), GST_STATE_NULL);
-    gst_pad_unlink(teeSrcPad.get(), ghostSinkPad.get());
-    gst_element_unlink(queue.get(), sink.get());
-
-    auto ghostSrcPad = adoptGRef(gst_element_get_static_pad(m_upstreamBin.get(), padName.ascii().data()));
-    gst_ghost_pad_set_target(GST_GHOST_PAD_CAST(ghostSrcPad.get()), nullptr);
-    gst_element_remove_pad(m_upstreamBin.get(), ghostSrcPad.get());
-    gst_element_release_request_pad(m_tee.get(), teeSrcPad.get());
-
-    gst_ghost_pad_set_target(GST_GHOST_PAD_CAST(ghostSinkPad.get()), nullptr);
-    gst_element_remove_pad(m_bin.get(), ghostSinkPad.get());
-
-    gst_bin_remove_many(GST_BIN_CAST(m_bin.get()), queue.get(), sink.get(), nullptr);
-    gst_element_set_locked_state(m_bin.get(), FALSE);
-    gst_element_set_locked_state(m_upstreamBin.get(), FALSE);
-    m_clients.remove(clientId);
-}
-
-void RealtimeIncomingSourceGStreamer::handleUpstreamEvent(GRefPtr<GstEvent>&& event, int clientId)
-{
-    GST_DEBUG_OBJECT(m_bin.get(), "Handling %" GST_PTR_FORMAT, event.get());
-    auto sink = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_bin.get()), makeString("sink-"_s, clientId).ascii().data()));
-    auto pad = adoptGRef(gst_element_get_static_pad(sink.get(), "sink"));
-    gst_pad_push_event(pad.get(), event.leakRef());
-}
-
-bool RealtimeIncomingSourceGStreamer::handleUpstreamQuery(GstQuery* query, int clientId)
-{
-    GST_DEBUG_OBJECT(m_bin.get(), "Handling %" GST_PTR_FORMAT, query);
-    auto sink = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_bin.get()), makeString("sink-"_s, clientId).ascii().data()));
-    auto pad = adoptGRef(gst_element_get_static_pad(sink.get(), "sink"));
-    return gst_pad_peer_query(pad.get(), query);
+        GRefPtr eventCopy(event);
+        GST_DEBUG_OBJECT(sink, "Forwarding event %" GST_PTR_FORMAT " to client", eventCopy.get());
+        gst_pad_push_event(pad.get(), eventCopy.leakRef());
+    });
 }
 
 void RealtimeIncomingSourceGStreamer::tearDown()

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
@@ -32,47 +32,34 @@ public:
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>::deref(); }
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RealtimeIncomingSourceGStreamer>::controlBlock(); }
 
-    GstElement* bin() { return m_bin.get(); }
-
-    virtual void setUpstreamBin(const GRefPtr<GstElement>&);
+    GstElement* bin() const { return m_bin.get(); }
+    virtual bool setBin(const GRefPtr<GstElement>&);
 
     bool hasClient(const GRefPtr<GstElement>&);
-    std::optional<int> registerClient(GRefPtr<GstElement>&&);
+    int registerClient(GRefPtr<GstElement>&&);
     void unregisterClient(int);
 
-    void handleUpstreamEvent(GRefPtr<GstEvent>&&, int clientId);
-    bool handleUpstreamQuery(GstQuery*, int clientId);
+    void handleUpstreamEvent(GRefPtr<GstEvent>&&);
+    bool handleUpstreamQuery(GstQuery*);
+    void handleDownstreamEvent(GstElement* sink, GRefPtr<GstEvent>&&);
 
     void tearDown();
-
-    void setIsUpstreamDecoding(bool isUpstreamDecoding) { m_isUpstreamDecoding = isUpstreamDecoding; };
 
 protected:
     RealtimeIncomingSourceGStreamer(const CaptureDevice&);
 
-    GRefPtr<GstElement> m_upstreamBin;
-    GRefPtr<GstElement> m_tee;
-
 private:
     // RealtimeMediaSource API
-    void startProducingData() final;
-    void stopProducingData() final;
     const RealtimeMediaSourceCapabilities& capabilities() final;
 
-    void configureAppSink(GstElement*);
-    void configureFakeVideoSink(GstElement*);
-    void handleDownstreamEvent(GstElement*, GRefPtr<GstEvent>&&);
+    virtual void dispatchSample(GRefPtr<GstSample>&&) = 0;
 
-    virtual void dispatchSample(GRefPtr<GstSample>&&) { }
-
-    void unregisterClientLocked(int);
+    void forEachClient(Function<void(GstElement*)>&&);
 
     GRefPtr<GstElement> m_bin;
-    GQuark m_clientQuark { 0 };
+    GRefPtr<GstElement> m_sink;
     Lock m_clientLock;
     HashMap<int, GRefPtr<GstElement>> m_clients WTF_GUARDED_BY_LOCK(m_clientLock);
-    bool m_isStarted { true };
-    bool m_isUpstreamDecoding { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
@@ -40,17 +40,15 @@ RealtimeIncomingVideoSourceGStreamer::RealtimeIncomingVideoSourceGStreamer(AtomS
     std::call_once(debugRegisteredFlag, [] {
         GST_DEBUG_CATEGORY_INIT(webkit_webrtc_incoming_video_debug, "webkitwebrtcincomingvideo", 0, "WebKit WebRTC incoming video");
     });
-    static Atomic<uint64_t> sourceCounter = 0;
-    gst_element_set_name(bin(), makeString("incoming-video-source-"_s, sourceCounter.exchangeAdd(1)).ascii().data());
-    GST_DEBUG_OBJECT(bin(), "New incoming video source created with ID %s", persistentID().ascii().data());
 }
 
-void RealtimeIncomingVideoSourceGStreamer::setUpstreamBin(const GRefPtr<GstElement>& bin)
+bool RealtimeIncomingVideoSourceGStreamer::setBin(const GRefPtr<GstElement>& bin)
 {
-    RealtimeIncomingSourceGStreamer::setUpstreamBin(bin);
+    if (!RealtimeIncomingSourceGStreamer::setBin(bin))
+        return false;
 
-    auto tee = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_upstreamBin.get()), "tee"));
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(tee.get(), "sink"));
+    auto sink = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(this->bin()), "sink"));
+    auto sinkPad = adoptGRef(gst_element_get_static_pad(sink.get(), "sink"));
     gst_pad_add_probe(sinkPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER), [](GstPad*, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
         auto videoFrameTimeMetadata = std::make_optional<VideoFrameTimeMetadata>({ });
         videoFrameTimeMetadata->receiveTime = MonotonicTime::now().secondsSinceEpoch();
@@ -66,6 +64,7 @@ void RealtimeIncomingVideoSourceGStreamer::setUpstreamBin(const GRefPtr<GstEleme
         GST_PAD_PROBE_INFO_DATA(info) = buffer;
         return GST_PAD_PROBE_OK;
     }, nullptr, nullptr);
+    return true;
 }
 
 const RealtimeMediaSourceSettings& RealtimeIncomingVideoSourceGStreamer::settings()
@@ -121,6 +120,11 @@ void RealtimeIncomingVideoSourceGStreamer::dispatchSample(GRefPtr<GstSample>&& s
     ASSERT(isMainThread());
     auto* buffer = gst_sample_get_buffer(sample.get());
     auto* caps = gst_sample_get_caps(sample.get());
+    if (!caps) {
+        GST_WARNING_OBJECT(bin(), "Received sample without caps, bailing out.");
+        return;
+    }
+
     ensureSizeAndFramerate(GRefPtr<GstCaps>(caps));
 
     videoFrameAvailable(VideoFrameGStreamer::create(WTFMove(sample), intrinsicSize(), fromGstClockTime(GST_BUFFER_PTS(buffer))), { });

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.h
@@ -36,7 +36,7 @@ public:
 
     const GstStructure* stats();
 
-    void setUpstreamBin(const GRefPtr<GstElement>&) final;
+    bool setBin(const GRefPtr<GstElement>&) final;
 
 protected:
     RealtimeIncomingVideoSourceGStreamer(AtomString&&);


### PR DESCRIPTION
#### 7abc5055a3246204779b7426dfdd5800bb9a9d6d
<pre>
[GStreamer][WebRTC] Simplified pipeline for incoming tracks
<a href="https://bugs.webkit.org/show_bug.cgi?id=276989">https://bugs.webkit.org/show_bug.cgi?id=276989</a>

Reviewed by Xabier Rodriguez-Calvar.

The incoming track processor now feeds a single sink, no tee or dynamic pipeline manipulations
involved anymore. This brings back a timeout in webrtc/h265.html, but it will be fixed once we have
track events dispatching fixed (bug #275685).

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::setConfiguration):
(WebCore::GStreamerMediaEndpoint::connectIncomingTrack):
(WebCore::GStreamerMediaEndpoint::connectPad):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::configure):
(WebCore::GStreamerIncomingTrackProcessor::incomingTrackProcessor):
(WebCore::GStreamerIncomingTrackProcessor::createParser):
(WebCore::GStreamerIncomingTrackProcessor::stats):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCCommon.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp:
(WebCore::RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer):
(WebCore::RealtimeIncomingSourceGStreamer::setBin):
(WebCore::RealtimeIncomingSourceGStreamer::registerClient):
(WebCore::RealtimeIncomingSourceGStreamer::unregisterClient):
(WebCore::RealtimeIncomingSourceGStreamer::unregisterClientLocked):
(WebCore::RealtimeIncomingSourceGStreamer::forEachClient):
(WebCore::RealtimeIncomingSourceGStreamer::handleUpstreamEvent):
(WebCore::RealtimeIncomingSourceGStreamer::handleUpstreamQuery):
(WebCore::RealtimeIncomingSourceGStreamer::handleDownstreamEvent):
(WebCore::RealtimeIncomingSourceGStreamer::setUpstreamBin): Deleted.
(WebCore::RealtimeIncomingSourceGStreamer::startProducingData): Deleted.
(WebCore::RealtimeIncomingSourceGStreamer::stopProducingData): Deleted.
(WebCore::RealtimeIncomingSourceGStreamer::configureAppSink): Deleted.
(WebCore::RealtimeIncomingSourceGStreamer::configureFakeVideoSink): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h:
(WebCore::RealtimeIncomingSourceGStreamer::bin const):
(WebCore::RealtimeIncomingSourceGStreamer::bin): Deleted.
(WebCore::RealtimeIncomingSourceGStreamer::setIsUpstreamDecoding): Deleted.
(WebCore::RealtimeIncomingSourceGStreamer::dispatchSample): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp:
(WebCore::RealtimeIncomingVideoSourceGStreamer::setBin):
(WebCore::RealtimeIncomingVideoSourceGStreamer::dispatchSample):
(WebCore::RealtimeIncomingVideoSourceGStreamer::setUpstreamBin): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/281394@main">https://commits.webkit.org/281394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cc619a61c5190361241065364aa9945cb236e61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10291 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48472 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7195 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29315 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8995 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9214 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55133 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65414 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3695 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55812 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3706 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55950 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13248 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3072 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34926 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37095 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35754 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->