### PR TITLE
[JSC] IPInt: define structs to describe metadata.

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -559,6 +559,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     assembler/ARMv7Registers.h
     assembler/AbortReason.h
     assembler/AbstractMacroAssembler.h
+    assembler/AllowMacroScratchRegisterUsage.h
     assembler/AssemblerBuffer.h
     assembler/AssemblerCommon.h
     assembler/AssemblyComments.h
@@ -1259,6 +1260,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/WasmBranchHints.h
     wasm/WasmCallee.h
     wasm/WasmCalleeGroup.h
+    wasm/WasmCallingConvention.h
     wasm/WasmCallsiteCollection.h
     wasm/WasmCapabilities.h
     wasm/WasmCompilationContext.h
@@ -1287,6 +1289,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/WasmSIMDOpcodes.h
     wasm/WasmSections.h
     wasm/WasmTypeDefinition.h
+    wasm/WasmTypeDefinitionInlines.h
     wasm/WasmStreamingCompiler.h
     wasm/WasmStreamingParser.h
     wasm/WasmTierUpCount.h

--- a/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp
+++ b/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp
@@ -73,6 +73,7 @@
 #include "ValueProfile.h"
 #include "WasmCallingConvention.h"
 #include "WasmFunctionCodeBlockGenerator.h"
+#include "WasmIPIntGenerator.h"
 #include "Watchdog.h"
 #include "WebAssemblyFunction.h"
 #include <stdio.h>

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -88,13 +88,11 @@ public:
 
 private:
 
-    void addBlankSpace(uint32_t size);
-    void addRawValue(uint64_t value);
-    void addLength(uint32_t length);
-    void addLEB128ConstantInt32AndLength(uint32_t value, uint32_t length);
-    void addCondensedLocalIndexAndLength(uint32_t index, uint32_t length);
-    void addLEB128ConstantAndLengthForType(Type, uint64_t value, uint32_t length);
-    void addLEB128V128Constant(v128_t value, uint32_t length);
+    void addBlankSpace(size_t);
+    void addLength(size_t length);
+    void addLEB128ConstantInt32AndLength(uint32_t value, size_t length);
+    void addLEB128ConstantAndLengthForType(Type, uint64_t value, size_t length);
+    void addLEB128V128Constant(v128_t value, size_t length);
     void addReturnData(const Vector<Type, 16>& types);
 
     uint32_t m_functionIndex;

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "WasmCallingConvention.h"
 #include <wtf/Expected.h>
 #include <wtf/text/WTFString.h>
 
@@ -38,6 +39,171 @@ struct ModuleInformation;
 
 Expected<std::unique_ptr<FunctionIPIntMetadataGenerator>, String> parseAndCompileMetadata(std::span<const uint8_t>, const TypeDefinition&, ModuleInformation&, uint32_t functionIndex);
 
-} } // namespace JSC::Wasm
+} // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY[:w
+namespace IPInt {
+
+#pragma pack(1)
+
+// mINT: mini-interpreter / minimalist interpreter (whichever floats your boat)
+
+// Metadata structure for control flow instructions
+
+struct InstructionLengthMetadata {
+    uint8_t length; // 1B for length of current instruction
+};
+
+struct BlockMetadata {
+    uint32_t newPC; // 2B for new PC
+    uint32_t newMC; // 2B for new MC
+};
+
+struct IfMetadata {
+    uint32_t elsePC; // 4B PC for new else PC
+    uint32_t elseMC; // 4B MC of new else MC
+    InstructionLengthMetadata instructionLength;
+};
+
+struct throwMetadata {
+    uint32_t exceptionIndex; // 4B for exception index
+};
+
+struct rethrowMetadata {
+    uint32_t tryDepth; // 4B for try depth
+};
+
+struct catchMetadata {
+    uint32_t stackSizeInV128; // 4B for stack size
+};
+
+struct branchTargetMetadata {
+    BlockMetadata block; // 2B for stack values to pop
+    uint16_t toPop; // 2B for stack values to keep
+    uint16_t toKeep;
+};
+
+struct branchMetadata {
+    branchTargetMetadata target;
+    InstructionLengthMetadata instructionLength;
+};
+
+struct switchMetadata {
+    uint32_t size; // 4B for number of jump targets
+    branchTargetMetadata target[0];
+};
+
+// Global get/set metadata structure
+
+struct globalMetadata {
+    uint32_t index; // 4B for index of global
+    InstructionLengthMetadata instructionLength;
+    uint8_t bindingMode; // 1B for bindingMode
+    uint8_t isRef; // 1B for ref flag
+};
+
+// Constant metadat structures
+
+struct const32Metadata {
+    InstructionLengthMetadata instructionLength;
+    uint32_t value;
+};
+
+struct const64Metadata {
+    InstructionLengthMetadata instructionLength;
+    uint64_t value;
+};
+
+struct const128Metadata {
+    InstructionLengthMetadata instructionLength;
+    v128_t value;
+};
+
+struct tableInitMetadata {
+    uint32_t elementIndex; // 4B for index of element
+    uint32_t tableIndex; // 4B for index of table
+    uint32_t dst; // 4B for destination (set by interpreter)
+    uint32_t src; // 4B for source (set by interpreter)
+    uint32_t length; // 4B for length (set by interpreter)
+    InstructionLengthMetadata instructionLength;
+};
+
+struct tableFillMetadata {
+    uint32_t tableIndex; // 4B for index of table
+    EncodedJSValue fill; // 8B for fill value
+    uint32_t offset; // 4B for offset (set by interpreter)
+    uint32_t length; // 4B for length (set by interpreter)
+    InstructionLengthMetadata instructionLength;
+};
+
+struct tableGrowMetadata {
+    uint32_t tableIndex; // 4B for index of table
+    EncodedJSValue fill; // 8B for fill value
+    uint32_t length; // 4B for length (set by interpreter)
+    InstructionLengthMetadata instructionLength;
+};
+
+struct tableCopyMetadata {
+    uint32_t dstTableIndex; // 4B for index of destination table
+    uint32_t srcTableIndex; // 4B for index of source table
+    uint32_t dstOffset; // 4B for destination offset (set by interpreter)
+    uint32_t srcOffset; // 4B for source offset (set by interpreter)
+    uint32_t length; // 4B for length (set by interpreter)
+    InstructionLengthMetadata instructionLength;
+};
+
+// Metadata structure for calls:
+
+struct calleeMetadata {
+    JSWebAssemblyInstance* instance; // Ptr for callee instance (set by operation)
+    void* entrypoint; // Ptr for callee entrypoint (set by operation)
+    EncodedJSValue boxedCallee; // 8B for callee (set by operation)
+};
+
+enum class CallArgumentBytecode : uint8_t { // (mINT)
+    ArgumentGPR = 0x0, // 0x00 - 0x07: push into a0, a1, ...
+    ArgumentFPR = 0x8, // 0x08 - 0x0b: push into fa0, fa1, ...
+    ArgumentStackAligned = 0xc, // 0x0c: pop stack value, push onto stack[0]
+    ArgumentStackUnaligned = 0xd, // 0x0d: pop stack value, add another 16B for params, push onto stack[8]
+    StackAlign = 0xe, // 0x0e: add another 16B for params
+    End = 0xf // 0x0f: stop
+};
+
+struct callMetadata {
+    uint8_t length; // 1B for instruction length
+    uint32_t functionIndex; // 4B for decoded index
+    calleeMetadata callee;
+    CallArgumentBytecode argumentBytecode[0];
+};
+
+struct callIndirectMetadata {
+    uint8_t length; // 1B for length
+    uint32_t tableIndex; // 4B for table index
+    uint32_t typeIndex; // 4B for type index
+    uint32_t functionRef; // 4B for function ref (set by interpreter)
+    CallFrame* callFrame; // Ptr for call frame (set by interpreter)
+    calleeMetadata callee;
+    CallArgumentBytecode argumentBytecode[0];
+};
+
+// Metadata structure for returns:
+
+enum class CallResultBytecode : uint8_t { // (mINT)
+    ResultGPR = 0x0, // 0x00 - 0x07: r0 - r7
+    ResultFPR = 0x8, // 0x08 - 0x0b: fr0 - fr3
+    ResultStack = 0xc, // 0x0c: stack
+    End = 0xd // 0x0d: end
+};
+
+struct callReturnMetadata {
+    uint16_t stackSlots; // 2B for number of arguments on stack (to clean up current call frame)
+    uint16_t argumentCount; // 2B for number of arguments (to take off arguments)
+    CallResultBytecode resultBytecode[0];
+};
+
+#pragma pack()
+
+} // namespace JSC::IPInt
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -40,6 +40,7 @@
 #include "WasmCallee.h"
 #include "WasmCallingConvention.h"
 #include "WasmFunctionCodeBlockGenerator.h"
+#include "WasmIPIntGenerator.h"
 #include "WasmLLIntBuiltin.h"
 #include "WasmLLIntGenerator.h"
 #include "WasmModuleInformation.h"
@@ -57,16 +58,17 @@ namespace JSC { namespace IPInt {
         return encodeResult(first, second); \
     } while (false)
 
-#define WASM_THROW(exceptionType) do { \
+#define WASM_THROW(callFrame, exceptionType) do { \
         callFrame->setArgumentCountIncludingThis(static_cast<int>(exceptionType)); \
         WASM_RETURN_TWO(LLInt::wasmExceptionInstructions(), 0); \
     } while (false)
 
-#define WASM_CALL_RETURN(targetInstance, callTarget, callTargetTag) do { \
-        WASM_RETURN_TWO((retagCodePtr<callTargetTag, JSEntrySlowPathPtrTag>(callTarget)), targetInstance); \
+#define WASM_CALL_RETURN(callee, callTarget, callTargetTag) do { \
+        callee.entrypoint = retagCodePtr<callTargetTag, JSEntrySlowPathPtrTag>(callTarget); \
+        WASM_RETURN_TWO(&callee, callee.instance); \
     } while (false)
 
-#define IPINT_CALLEE() \
+#define IPINT_CALLEE(callFrame) \
     static_cast<Wasm::IPIntCallee*>(callFrame->callee().asNativeCallee())
 
 #if ENABLE(WEBASSEMBLY_BBQJIT)
@@ -93,8 +95,6 @@ static inline bool shouldJIT(Wasm::IPIntCallee* callee, RequiredWasmJIT required
 
 static inline bool jitCompileAndSetHeuristics(Wasm::IPIntCallee* callee, JSWebAssemblyInstance* instance)
 {
-    ASSERT(!instance->module().moduleInformation().usesSIMD(callee->functionIndex()));
-
     Wasm::IPIntTierUpCounter& tierUpCounter = callee->tierUpCounter();
     if (!tierUpCounter.checkIfOptimizationThresholdReached()) {
         dataLogLnIf(Options::verboseOSR(), "    JIT threshold should be lifted.");
@@ -144,7 +144,7 @@ static inline bool jitCompileAndSetHeuristics(Wasm::IPIntCallee* callee, JSWebAs
 
 WASM_IPINT_EXTERN_CPP_DECL(prologue_osr, CallFrame* callFrame)
 {
-    Wasm::IPIntCallee* callee = IPINT_CALLEE();
+    Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
 
     if (!shouldJIT(callee)) {
         callee->tierUpCounter().deferIndefinitely();
@@ -163,7 +163,7 @@ WASM_IPINT_EXTERN_CPP_DECL(prologue_osr, CallFrame* callFrame)
 
 WASM_IPINT_EXTERN_CPP_DECL(loop_osr, CallFrame* callFrame, uint32_t pc, uint64_t* pl)
 {
-    Wasm::IPIntCallee* callee = IPINT_CALLEE();
+    Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
     Wasm::IPIntTierUpCounter& tierUpCounter = callee->tierUpCounter();
 
     if (!Options::useWasmOSR() || !Options::useWasmIPIntLoopOSR() || !shouldJIT(callee, RequiredWasmJIT::OMG)) {
@@ -284,7 +284,7 @@ WASM_IPINT_EXTERN_CPP_DECL(loop_osr, CallFrame* callFrame, uint32_t pc, uint64_t
 
 WASM_IPINT_EXTERN_CPP_DECL(epilogue_osr, CallFrame* callFrame)
 {
-    Wasm::IPIntCallee* callee = IPINT_CALLEE();
+    Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
 
     if (!shouldJIT(callee)) {
         callee->tierUpCounter().deferIndefinitely();
@@ -307,7 +307,7 @@ WASM_IPINT_EXTERN_CPP_DECL(retrieve_and_clear_exception, CallFrame* callFrame, v
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     RELEASE_ASSERT(!!throwScope.exception());
 
-    Wasm::IPIntCallee* callee = IPINT_CALLEE();
+    Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
     if (callee->m_numRethrowSlotsToAlloc) {
         RELEASE_ASSERT(vm.targetTryDepthForThrow <= callee->m_numRethrowSlotsToAlloc);
         pl[callee->m_localSizeToAlloc + vm.targetTryDepthForThrow - 1] = bitwise_cast<uint64_t>(throwScope.exception()->value());
@@ -338,7 +338,7 @@ WASM_IPINT_EXTERN_CPP_DECL(retrieve_and_clear_exception, CallFrame* callFrame, v
     WASM_RETURN_TWO(nullptr, nullptr);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(throw_exception, CallFrame* callFrame, v128_t* stack, unsigned exceptionIndex)
+WASM_IPINT_EXTERN_CPP_DECL(throw_exception, CallFrame* callFrame, uint64_t* arguments, unsigned exceptionIndex)
 {
     VM& vm = instance->vm();
     SlowPathFrameTracer tracer(vm, callFrame);
@@ -349,19 +349,13 @@ WASM_IPINT_EXTERN_CPP_DECL(throw_exception, CallFrame* callFrame, v128_t* stack,
     JSGlobalObject* globalObject = instance->globalObject();
     const Wasm::Tag& tag = instance->tag(exceptionIndex);
 
-    size_t size = tag.parameterCount();
-    FixedVector<uint64_t> values(size);
-    for (unsigned i = 0; i < size; ++i)
-        values[i] = stack[size - i - 1].u64x2[1];
+    FixedVector<uint64_t> values(tag.parameterBufferSize());
+    for (unsigned i = 0; i < tag.parameterBufferSize(); ++i)
+        values[i] = arguments[i];
 
     ASSERT(tag.type().returnsVoid());
-    if (tag.type().numVectors()) {
-        // Note: the spec is still in flux on what to do here, so we conservatively just disallow throwing any vectors.
-        throwException(globalObject, throwScope, createTypeError(globalObject, errorMessageForExceptionType(Wasm::ExceptionType::TypeErrorInvalidV128Use)));
-    } else {
-        JSWebAssemblyException* exception = JSWebAssemblyException::create(vm, globalObject->webAssemblyExceptionStructure(), tag, WTFMove(values));
-        throwException(globalObject, throwScope, exception);
-    }
+    JSWebAssemblyException* exception = JSWebAssemblyException::create(vm, globalObject->webAssemblyExceptionStructure(), tag, WTFMove(values));
+    throwException(globalObject, throwScope, exception);
 
     genericUnwind(vm, callFrame);
     ASSERT(!!vm.callFrameForCatch);
@@ -377,7 +371,7 @@ WASM_IPINT_EXTERN_CPP_DECL(rethrow_exception, CallFrame* callFrame, uint64_t* pl
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    Wasm::IPIntCallee* callee = IPINT_CALLEE();
+    Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
     RELEASE_ASSERT(tryDepth <= callee->m_numRethrowSlotsToAlloc);
     JSWebAssemblyException* exception = reinterpret_cast<JSWebAssemblyException**>(pl)[callee->m_localSizeToAlloc + tryDepth - 1];
     RELEASE_ASSERT(exception);
@@ -419,50 +413,39 @@ WASM_IPINT_EXTERN_CPP_DECL(table_set, unsigned tableIndex, unsigned index, Encod
 #endif
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(table_init, uint32_t* metadata, uint32_t dest, uint64_t srcAndLength)
+WASM_IPINT_EXTERN_CPP_DECL(table_init, tableInitMetadata* metadata)
 {
 #if CPU(ARM64) || CPU(X86_64)
-    uint32_t dstOffset = dest;
-    uint32_t srcOffset = srcAndLength >> 32;
-    uint32_t length = srcAndLength & 0xffffffff;
-    if (!Wasm::tableInit(instance, metadata[0], metadata[1], dstOffset, srcOffset, length))
+    if (!Wasm::tableInit(instance, metadata->elementIndex, metadata->tableIndex, metadata->dst, metadata->src, metadata->length))
         WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<uintptr_t>(1)), bitwise_cast<void*>(static_cast<uintptr_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
     WASM_RETURN_TWO(0, 0);
 #else
     UNUSED_PARAM(instance);
     UNUSED_PARAM(metadata);
-    UNUSED_PARAM(dest);
-    UNUSED_PARAM(srcAndLength);
     RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
 #endif
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(table_fill, uint32_t tableIndex, EncodedJSValue fill, int64_t offsetAndSize)
+WASM_IPINT_EXTERN_CPP_DECL(table_fill, tableFillMetadata* metadata)
 {
 #if CPU(ARM64) || CPU(X86_64)
-    uint32_t offset = offsetAndSize >> 32;
-    uint32_t size = offsetAndSize & 0xffffffff;
-    if (!Wasm::tableFill(instance, tableIndex, offset, fill, size))
+    if (!Wasm::tableFill(instance, metadata->tableIndex, metadata->offset, metadata->fill, metadata->length))
         WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<uintptr_t>(1)), bitwise_cast<void*>(static_cast<uintptr_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
     WASM_RETURN_TWO(0, 0);
 #else
     UNUSED_PARAM(instance);
-    UNUSED_PARAM(tableIndex);
-    UNUSED_PARAM(fill);
-    UNUSED_PARAM(offsetAndSize);
+    UNUSED_PARAM(metadata);
     RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
 #endif
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(table_grow, int32_t tableIndex, EncodedJSValue fill, uint32_t size)
+WASM_IPINT_EXTERN_CPP_DECL(table_grow, tableGrowMetadata* metadata)
 {
 #if CPU(ARM64) || CPU(X86_64)
-    WASM_RETURN_TWO(bitwise_cast<void*>(Wasm::tableGrow(instance, tableIndex, fill, size)), 0);
+    WASM_RETURN_TWO(bitwise_cast<void*>(Wasm::tableGrow(instance, metadata->tableIndex, metadata->fill, metadata->length)), 0);
 #else
     UNUSED_PARAM(instance);
-    UNUSED_PARAM(tableIndex);
-    UNUSED_PARAM(fill);
-    UNUSED_PARAM(size);
+    UNUSED_PARAM(metadata);
     RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
 #endif
 }
@@ -540,17 +523,15 @@ WASM_IPINT_EXTERN_CPP_DECL(elem_drop, int32_t dataIndex)
     WASM_RETURN_TWO(0, 0);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(table_copy, int32_t* metadata, int32_t dst, int64_t srcAndCount)
+WASM_IPINT_EXTERN_CPP_DECL(table_copy, tableCopyMetadata* metadata)
 {
 #if CPU(ARM64) || CPU(X86_64)
-    if (!Wasm::tableCopy(instance, metadata[0], metadata[1], dst, srcAndCount >> 32, srcAndCount & 0xffffffff))
+    if (!Wasm::tableCopy(instance, metadata->dstTableIndex, metadata->srcTableIndex, metadata->dstOffset, metadata->srcOffset, metadata->length))
         WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<uintptr_t>(1)), bitwise_cast<void*>(static_cast<uintptr_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
     WASM_RETURN_TWO(0, 0);
 #else
     UNUSED_PARAM(instance);
     UNUSED_PARAM(metadata);
-    UNUSED_PARAM(dst);
-    UNUSED_PARAM(srcAndCount);
     RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
 #endif
 }
@@ -567,47 +548,62 @@ WASM_IPINT_EXTERN_CPP_DECL(table_size, int32_t tableIndex)
 #endif
 }
 
-static inline UGPRPair doWasmCall(JSWebAssemblyInstance* instance, unsigned functionIndex)
+static inline UGPRPair doWasmCall(JSWebAssemblyInstance* instance, callMetadata* call)
 {
     uint32_t importFunctionCount = instance->module().moduleInformation().importFunctionCount();
 
     CodePtr<WasmEntryPtrTag> codePtr;
+    EncodedJSValue boxedCallee = CalleeBits::encodeNullCallee();
 
+    auto functionIndex = call->functionIndex;
     if (functionIndex < importFunctionCount) {
         JSWebAssemblyInstance::ImportFunctionInfo* functionInfo = instance->importFunctionInfo(functionIndex);
         codePtr = functionInfo->importFunctionStub;
     } else {
         // Target is a wasm function within the same instance
         codePtr = *instance->calleeGroup()->entrypointLoadLocationFromFunctionIndexSpace(functionIndex);
+        boxedCallee = CalleeBits::encodeNativeCallee(
+            instance->calleeGroup()->wasmCalleeFromFunctionIndexSpace(functionIndex));
     }
 
-    WASM_CALL_RETURN(instance, codePtr.taggedPtr(), WasmEntryPtrTag);
+    call->callee.boxedCallee = boxedCallee;
+    call->callee.instance = instance;
+
+    WASM_CALL_RETURN(call->callee, codePtr.taggedPtr(), WasmEntryPtrTag);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(call, unsigned functionIndex)
+WASM_IPINT_EXTERN_CPP_DECL(call, callMetadata* call)
 {
-    return doWasmCall(instance, functionIndex);
+    return doWasmCall(instance, call);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(call_indirect, CallFrame* callFrame, unsigned functionIndex, unsigned* metadataEntry)
+WASM_IPINT_EXTERN_CPP_DECL(call_indirect, callIndirectMetadata* call)
 {
-    unsigned tableIndex = metadataEntry[0];
-    unsigned typeIndex = metadataEntry[1];
+    Wasm::IPIntCallee* caller = IPINT_CALLEE(call->callFrame);
+    unsigned functionIndex = call->functionRef;
+    unsigned tableIndex = call->tableIndex;
+    unsigned typeIndex = call->typeIndex;
     Wasm::FuncRefTable* table = instance->table(tableIndex)->asFuncrefTable();
 
     if (functionIndex >= table->length())
-        WASM_THROW(Wasm::ExceptionType::OutOfBoundsCallIndirect);
+        WASM_THROW(call->callFrame, Wasm::ExceptionType::OutOfBoundsCallIndirect);
 
     const Wasm::FuncRefTable::Function& function = table->function(functionIndex);
 
     if (function.m_function.typeIndex == Wasm::TypeDefinition::invalidIndex)
-        WASM_THROW(Wasm::ExceptionType::NullTableEntry);
+        WASM_THROW(call->callFrame, Wasm::ExceptionType::NullTableEntry);
 
-    const auto& callSignature = static_cast<Wasm::IPIntCallee*>(callFrame->callee().asNativeCallee())->signature(typeIndex);
+    const auto& callSignature = caller->signature(typeIndex);
     if (callSignature.index() != function.m_function.typeIndex)
-        WASM_THROW(Wasm::ExceptionType::BadSignature);
+        WASM_THROW(call->callFrame, Wasm::ExceptionType::BadSignature);
 
-    WASM_CALL_RETURN(function.m_instance, function.m_function.entrypointLoadLocation->taggedPtr(), WasmEntryPtrTag);
+    if (function.m_function.boxedWasmCalleeLoadLocation)
+        call->callee.boxedCallee = CalleeBits::encodeBoxedNativeCallee(reinterpret_cast<void*>(*function.m_function.boxedWasmCalleeLoadLocation));
+    else
+        call->callee.boxedCallee = CalleeBits::encodeNullCallee();
+    call->callee.instance = function.m_instance;
+
+    WASM_CALL_RETURN(call->callee, function.m_function.entrypointLoadLocation->taggedPtr(), WasmEntryPtrTag);
 }
 
 WASM_IPINT_EXTERN_CPP_DECL(set_global_ref, uint32_t globalIndex, JSValue value)

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -29,6 +29,7 @@
 
 #include "CommonSlowPaths.h"
 #include "WasmExceptionType.h"
+#include "WasmIPIntGenerator.h"
 #include "WasmTypeDefinition.h"
 #include <wtf/StdLibExtras.h>
 
@@ -57,15 +58,15 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(epilogue_osr, CallFrame* callFrame);
 #endif
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_and_clear_exception, CallFrame*, v128_t* stack, uint64_t* pl);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw_exception, CallFrame*, v128_t* stack, unsigned exceptionIndex);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw_exception, CallFrame*, uint64_t* arguments, unsigned exceptionIndex);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(rethrow_exception, CallFrame*, uint64_t* pl, unsigned tryDepth);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(ref_func, unsigned index);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_get, unsigned, unsigned);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_set, unsigned tableIndex, unsigned index, EncodedJSValue value);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_init, uint32_t* metadata, uint32_t dest, uint64_t srcAndLength);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_fill, uint32_t tableIndex, EncodedJSValue fill, int64_t offsetAndSize);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_grow, int32_t tableIndex, EncodedJSValue fill, uint32_t size);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_init, tableInitMetadata* metadata);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_fill, tableFillMetadata* metadata);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_grow, tableGrowMetadata* metadata);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL_1P(current_memory);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_grow, int32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_init, int32_t, int32_t, int64_t);
@@ -73,11 +74,11 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(data_drop, int32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_copy, int32_t, int32_t, int32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_fill, int32_t, int32_t, int32_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(elem_drop, int32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_copy, int32_t*, int32_t, int64_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_copy, tableCopyMetadata* metadata);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_size, int32_t);
 
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call_indirect, CallFrame* callFrame, unsigned functionIndex, unsigned* metadataEntry);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call, unsigned);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call_indirect, callIndirectMetadata* call);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call, callMetadata* call);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(set_global_ref, uint32_t globalIndex, JSValue value);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(get_global_64, unsigned);


### PR DESCRIPTION
#### 612b0032072c266fc0d502b56a11a57357bb071f
<pre>
[JSC] IPInt: define structs to describe metadata.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276997">https://bugs.webkit.org/show_bug.cgi?id=276997</a>

Reviewed by Justin Michaud.

Defines structs and uses their offsets via OffsetExtractor in
the asm files implementing IPInt (instead of hardcoded offsets).

This also updates calling and throw implementations to
match current upstream behavior (so we can run JS2 with IPInt).

* Source/JavaScriptCore/CMakeLists.txt
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addBlankSpace):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLength):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantInt32AndLength):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128V128Constant):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addReturnData):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addRawValue): Deleted.
(JSC::Wasm::FunctionIPIntMetadataGenerator::addCondensedLocalIndexAndLength): Deleted.
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addTableInit):
(JSC::Wasm::IPIntGenerator::addTableGrow):
(JSC::Wasm::IPIntGenerator::addTableFill):
(JSC::Wasm::IPIntGenerator::addTableCopy):
(JSC::Wasm::IPIntGenerator::getGlobal):
(JSC::Wasm::IPIntGenerator::setGlobal):
(JSC::Wasm::IPIntGenerator::addSelect):
(JSC::Wasm::IPIntGenerator::condenseControlFlowInstructions):
(JSC::Wasm::IPIntGenerator::addBlock):
(JSC::Wasm::IPIntGenerator::addLoop):
(JSC::Wasm::IPIntGenerator::addIf):
(JSC::Wasm::IPIntGenerator::addElseToUnreachable):
(JSC::Wasm::IPIntGenerator::addCatchToUnreachable):
(JSC::Wasm::IPIntGenerator::addCatchAllToUnreachable):
(JSC::Wasm::IPIntGenerator::addDelegateToUnreachable):
(JSC::Wasm::IPIntGenerator::addThrow):
(JSC::Wasm::IPIntGenerator::addRethrow):
(JSC::Wasm::IPIntGenerator::addBranch):
(JSC::Wasm::IPIntGenerator::addSwitch):
(JSC::Wasm::IPIntGenerator::addEndToUnreachable):
(JSC::Wasm::IPIntGenerator::addCallCommonData):
(JSC::Wasm::IPIntGenerator::addCall):
(JSC::Wasm::IPIntGenerator::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::jitCompileAndSetHeuristics):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
(JSC::IPInt::doWasmCall):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:

Canonical link: <a href="https://commits.webkit.org/282811@main">https://commits.webkit.org/282811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/594747f063c94db057a562f680efb225c5f81240

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68333 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14919 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51754 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10290 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32373 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13024 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13793 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/57423 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59008 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70032 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/63556 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59077 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55736 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59247 "Found 2 new API test failures: /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14204 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6829 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/511 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/85317 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39488 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/15048 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40567 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41750 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->