### PR TITLE
SourceBuffer will always perform a sync call to GPU process when there's a need to evict content.

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-seek-and-evictable-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-seek-and-evictable-expected.txt
@@ -1,0 +1,679 @@
+
+RUN(video.disableRemotePlayback = true)
+EVENT(sourceopen)
+EVENT(updateend)
+EXPECTED (source.duration == '300') OK
+EXPECTED (video.duration == '300') OK
+Appending PTS=0
+EVENT(updateend)
+Appending PTS=1
+EVENT(updateend)
+Appending PTS=2
+EVENT(updateend)
+Appending PTS=3
+EVENT(updateend)
+Appending PTS=4
+EVENT(updateend)
+Appending PTS=5
+EVENT(updateend)
+Appending PTS=6
+EVENT(updateend)
+Appending PTS=7
+EVENT(updateend)
+Appending PTS=8
+EVENT(updateend)
+Appending PTS=9
+EVENT(updateend)
+Appending PTS=10
+EVENT(updateend)
+Appending PTS=11
+EVENT(updateend)
+Appending PTS=12
+EVENT(updateend)
+Appending PTS=13
+EVENT(updateend)
+Appending PTS=14
+EVENT(updateend)
+Appending PTS=15
+EVENT(updateend)
+Appending PTS=16
+EVENT(updateend)
+Appending PTS=17
+EVENT(updateend)
+Appending PTS=18
+EVENT(updateend)
+Appending PTS=19
+EVENT(updateend)
+Appending PTS=20
+EVENT(updateend)
+Appending PTS=21
+EVENT(updateend)
+Appending PTS=22
+EVENT(updateend)
+Appending PTS=23
+EVENT(updateend)
+Appending PTS=24
+EVENT(updateend)
+Appending PTS=25
+EVENT(updateend)
+Appending PTS=26
+EVENT(updateend)
+Appending PTS=27
+EVENT(updateend)
+Appending PTS=28
+EVENT(updateend)
+Appending PTS=29
+EVENT(updateend)
+Appending PTS=30
+EVENT(updateend)
+Appending PTS=31
+EVENT(updateend)
+Appending PTS=32
+EVENT(updateend)
+Appending PTS=33
+EVENT(updateend)
+Appending PTS=34
+EVENT(updateend)
+Appending PTS=35
+EVENT(updateend)
+Appending PTS=36
+EVENT(updateend)
+Appending PTS=37
+EVENT(updateend)
+Appending PTS=38
+EVENT(updateend)
+Appending PTS=39
+EVENT(updateend)
+Appending PTS=40
+EVENT(updateend)
+Appending PTS=41
+EVENT(updateend)
+Appending PTS=42
+EVENT(updateend)
+Appending PTS=43
+EVENT(updateend)
+Appending PTS=44
+EVENT(updateend)
+Appending PTS=45
+EVENT(updateend)
+Appending PTS=46
+EVENT(updateend)
+Appending PTS=47
+EVENT(updateend)
+Appending PTS=48
+EVENT(updateend)
+Appending PTS=49
+EVENT(updateend)
+Appending PTS=50
+EVENT(updateend)
+Appending PTS=51
+EVENT(updateend)
+Appending PTS=52
+EVENT(updateend)
+Appending PTS=53
+EVENT(updateend)
+Appending PTS=54
+EVENT(updateend)
+Appending PTS=55
+EVENT(updateend)
+Appending PTS=56
+EVENT(updateend)
+Appending PTS=57
+EVENT(updateend)
+Appending PTS=58
+EVENT(updateend)
+Appending PTS=59
+EVENT(updateend)
+Appending PTS=60
+EVENT(updateend)
+Appending PTS=61
+EVENT(updateend)
+Appending PTS=62
+EVENT(updateend)
+Appending PTS=63
+EVENT(updateend)
+Appending PTS=64
+EVENT(updateend)
+Appending PTS=65
+EVENT(updateend)
+Appending PTS=66
+EVENT(updateend)
+Appending PTS=67
+EVENT(updateend)
+Appending PTS=68
+EVENT(updateend)
+Appending PTS=69
+EVENT(updateend)
+Appending PTS=70
+EVENT(updateend)
+Appending PTS=71
+EVENT(updateend)
+Appending PTS=72
+EVENT(updateend)
+Appending PTS=73
+EVENT(updateend)
+Appending PTS=74
+EVENT(updateend)
+Appending PTS=75
+EVENT(updateend)
+Appending PTS=76
+EVENT(updateend)
+Appending PTS=77
+EVENT(updateend)
+Appending PTS=78
+EVENT(updateend)
+Appending PTS=79
+EVENT(updateend)
+Appending PTS=80
+EVENT(updateend)
+Appending PTS=81
+EVENT(updateend)
+Appending PTS=82
+EVENT(updateend)
+Appending PTS=83
+EVENT(updateend)
+Appending PTS=84
+EVENT(updateend)
+Appending PTS=85
+EVENT(updateend)
+Appending PTS=86
+EVENT(updateend)
+Appending PTS=87
+EVENT(updateend)
+Appending PTS=88
+EVENT(updateend)
+Appending PTS=89
+EVENT(updateend)
+Appending PTS=90
+EVENT(updateend)
+Appending PTS=91
+EVENT(updateend)
+Appending PTS=92
+EVENT(updateend)
+Appending PTS=93
+EVENT(updateend)
+Appending PTS=94
+EVENT(updateend)
+Appending PTS=95
+EVENT(updateend)
+Appending PTS=96
+EVENT(updateend)
+Appending PTS=97
+EVENT(updateend)
+Appending PTS=98
+EVENT(updateend)
+Appending PTS=99
+EVENT(updateend)
+EXPECTED (exception == 'null') OK
+EXPECTED (internals.evictableSize(sourceBuffer) == '0') OK
+EXPECTED (bufferedRanges() == '[ 0...100 ]') OK
+Appending PTS=101
+EXPECTED (exception == 'QuotaExceededError: The quota has been exceeded.') OK
+EXPECTED (internals.evictableSize(sourceBuffer) == '0') OK
+Appending PTS=200
+EXPECTED (exception == 'QuotaExceededError: The quota has been exceeded.') OK
+EXPECTED (internals.evictableSize(sourceBuffer) == '0') OK
+RUN(video.currentTime = 175)
+EXPECTED (video.currentTime == '175') OK
+Appending PTS=175
+EVENT(updateend)
+Appending PTS=176
+EVENT(updateend)
+Appending PTS=177
+EVENT(updateend)
+Appending PTS=178
+EVENT(updateend)
+Appending PTS=179
+EVENT(updateend)
+Appending PTS=180
+EVENT(updateend)
+Appending PTS=181
+EVENT(updateend)
+Appending PTS=182
+EVENT(updateend)
+Appending PTS=183
+EVENT(updateend)
+Appending PTS=184
+EVENT(updateend)
+Appending PTS=185
+EVENT(updateend)
+Appending PTS=186
+EVENT(updateend)
+Appending PTS=187
+EVENT(updateend)
+Appending PTS=188
+EVENT(updateend)
+Appending PTS=189
+EVENT(updateend)
+Appending PTS=190
+EVENT(updateend)
+Appending PTS=191
+EVENT(updateend)
+Appending PTS=192
+EVENT(updateend)
+Appending PTS=193
+EVENT(updateend)
+Appending PTS=194
+EVENT(updateend)
+Appending PTS=195
+EVENT(updateend)
+Appending PTS=196
+EVENT(updateend)
+Appending PTS=197
+EVENT(updateend)
+Appending PTS=198
+EVENT(updateend)
+Appending PTS=199
+EVENT(updateend)
+Appending PTS=200
+EVENT(updateend)
+EXPECTED (bufferedRanges() == '[ 30...100, 175...201 ]') OK
+EXPECTED (internals.evictableSize(sourceBuffer) == '5040') OK
+EVENT(updateend)
+RUN(video.currentTime = 0)
+EXPECTED (video.currentTime == '0') OK
+Appending PTS=0
+EVENT(updateend)
+Appending PTS=1
+EVENT(updateend)
+Appending PTS=2
+EVENT(updateend)
+Appending PTS=3
+EVENT(updateend)
+Appending PTS=4
+EVENT(updateend)
+Appending PTS=5
+EVENT(updateend)
+Appending PTS=6
+EVENT(updateend)
+Appending PTS=7
+EVENT(updateend)
+Appending PTS=8
+EVENT(updateend)
+Appending PTS=9
+EVENT(updateend)
+Appending PTS=10
+EVENT(updateend)
+Appending PTS=11
+EVENT(updateend)
+Appending PTS=12
+EVENT(updateend)
+Appending PTS=13
+EVENT(updateend)
+Appending PTS=14
+EVENT(updateend)
+Appending PTS=15
+EVENT(updateend)
+Appending PTS=16
+EVENT(updateend)
+Appending PTS=17
+EVENT(updateend)
+Appending PTS=18
+EVENT(updateend)
+Appending PTS=19
+EVENT(updateend)
+Appending PTS=20
+EVENT(updateend)
+Appending PTS=21
+EVENT(updateend)
+Appending PTS=22
+EVENT(updateend)
+Appending PTS=23
+EVENT(updateend)
+Appending PTS=24
+EVENT(updateend)
+Appending PTS=25
+EVENT(updateend)
+Appending PTS=26
+EVENT(updateend)
+Appending PTS=27
+EVENT(updateend)
+Appending PTS=28
+EVENT(updateend)
+Appending PTS=29
+EVENT(updateend)
+Appending PTS=30
+EVENT(updateend)
+Appending PTS=31
+EVENT(updateend)
+Appending PTS=32
+EVENT(updateend)
+Appending PTS=33
+EVENT(updateend)
+Appending PTS=34
+EVENT(updateend)
+Appending PTS=35
+EVENT(updateend)
+Appending PTS=36
+EVENT(updateend)
+Appending PTS=37
+EVENT(updateend)
+Appending PTS=38
+EVENT(updateend)
+Appending PTS=39
+EVENT(updateend)
+Appending PTS=40
+EVENT(updateend)
+Appending PTS=41
+EVENT(updateend)
+Appending PTS=42
+EVENT(updateend)
+Appending PTS=43
+EVENT(updateend)
+Appending PTS=44
+EVENT(updateend)
+Appending PTS=45
+EVENT(updateend)
+Appending PTS=46
+EVENT(updateend)
+Appending PTS=47
+EVENT(updateend)
+Appending PTS=48
+EVENT(updateend)
+Appending PTS=49
+EVENT(updateend)
+EXPECTED (bufferedRanges() == '[ 0...50 ]') OK
+EXPECTED (internals.evictableSize(sourceBuffer) == '0') OK
+Appending PTS=200
+EVENT(updateend)
+Appending PTS=201
+EVENT(updateend)
+Appending PTS=202
+EVENT(updateend)
+Appending PTS=203
+EVENT(updateend)
+Appending PTS=204
+EVENT(updateend)
+Appending PTS=205
+EVENT(updateend)
+Appending PTS=206
+EVENT(updateend)
+Appending PTS=207
+EVENT(updateend)
+Appending PTS=208
+EVENT(updateend)
+Appending PTS=209
+EVENT(updateend)
+Appending PTS=210
+EVENT(updateend)
+Appending PTS=211
+EVENT(updateend)
+Appending PTS=212
+EVENT(updateend)
+Appending PTS=213
+EVENT(updateend)
+Appending PTS=214
+EVENT(updateend)
+Appending PTS=215
+EVENT(updateend)
+Appending PTS=216
+EVENT(updateend)
+Appending PTS=217
+EVENT(updateend)
+Appending PTS=218
+EVENT(updateend)
+Appending PTS=219
+EVENT(updateend)
+Appending PTS=220
+EVENT(updateend)
+Appending PTS=221
+EVENT(updateend)
+Appending PTS=222
+EVENT(updateend)
+Appending PTS=223
+EVENT(updateend)
+Appending PTS=224
+EVENT(updateend)
+Appending PTS=225
+EVENT(updateend)
+Appending PTS=226
+EVENT(updateend)
+Appending PTS=227
+EVENT(updateend)
+Appending PTS=228
+EVENT(updateend)
+Appending PTS=229
+EVENT(updateend)
+Appending PTS=230
+EVENT(updateend)
+Appending PTS=231
+EVENT(updateend)
+Appending PTS=232
+EVENT(updateend)
+Appending PTS=233
+EVENT(updateend)
+Appending PTS=234
+EVENT(updateend)
+Appending PTS=235
+EVENT(updateend)
+Appending PTS=236
+EVENT(updateend)
+Appending PTS=237
+EVENT(updateend)
+Appending PTS=238
+EVENT(updateend)
+Appending PTS=239
+EVENT(updateend)
+Appending PTS=240
+EVENT(updateend)
+Appending PTS=241
+EVENT(updateend)
+Appending PTS=242
+EVENT(updateend)
+Appending PTS=243
+EVENT(updateend)
+Appending PTS=244
+EVENT(updateend)
+Appending PTS=245
+EVENT(updateend)
+Appending PTS=246
+EVENT(updateend)
+Appending PTS=247
+EVENT(updateend)
+Appending PTS=248
+EVENT(updateend)
+Appending PTS=249
+EVENT(updateend)
+EXPECTED (exception == 'null') OK
+EXPECTED (bufferedRanges() == '[ 0...50, 200...250 ]') OK
+EXPECTED (internals.evictableSize(sourceBuffer) == '3600') OK
+RUN(video.currentTime = 60)
+EXPECTED (video.currentTime == '60') OK
+Appending PTS=55
+EVENT(updateend)
+Appending PTS=56
+EVENT(updateend)
+Appending PTS=57
+EVENT(updateend)
+Appending PTS=58
+EVENT(updateend)
+Appending PTS=59
+EVENT(updateend)
+Appending PTS=60
+EVENT(updateend)
+Appending PTS=61
+EVENT(updateend)
+Appending PTS=62
+EVENT(updateend)
+Appending PTS=63
+EVENT(updateend)
+Appending PTS=64
+EVENT(updateend)
+Appending PTS=65
+EVENT(updateend)
+Appending PTS=66
+EVENT(updateend)
+Appending PTS=67
+EVENT(updateend)
+Appending PTS=68
+EVENT(updateend)
+Appending PTS=69
+EVENT(updateend)
+Appending PTS=70
+EVENT(updateend)
+Appending PTS=71
+EVENT(updateend)
+Appending PTS=72
+EVENT(updateend)
+Appending PTS=73
+EVENT(updateend)
+Appending PTS=74
+EVENT(updateend)
+Appending PTS=75
+EVENT(updateend)
+Appending PTS=76
+EVENT(updateend)
+Appending PTS=77
+EVENT(updateend)
+Appending PTS=78
+EVENT(updateend)
+Appending PTS=79
+EVENT(updateend)
+Appending PTS=80
+EVENT(updateend)
+Appending PTS=81
+EVENT(updateend)
+Appending PTS=82
+EVENT(updateend)
+Appending PTS=83
+EVENT(updateend)
+Appending PTS=84
+EVENT(updateend)
+Appending PTS=85
+EVENT(updateend)
+Appending PTS=86
+EVENT(updateend)
+Appending PTS=87
+EVENT(updateend)
+Appending PTS=88
+EVENT(updateend)
+Appending PTS=89
+EVENT(updateend)
+Appending PTS=90
+EVENT(updateend)
+Appending PTS=91
+EVENT(updateend)
+Appending PTS=92
+EVENT(updateend)
+Appending PTS=93
+EVENT(updateend)
+Appending PTS=94
+EVENT(updateend)
+Appending PTS=95
+EVENT(updateend)
+Appending PTS=96
+EVENT(updateend)
+Appending PTS=97
+EVENT(updateend)
+Appending PTS=98
+EVENT(updateend)
+Appending PTS=99
+EVENT(updateend)
+EXPECTED (bufferedRanges() == '[ 45...50, 55...100, 200...250 ]') OK
+EXPECTED (internals.evictableSize(sourceBuffer) == '4104') OK
+RUN(video.currentTime = 0)
+EXPECTED (video.currentTime == '0') OK
+Appending PTS=0
+EVENT(updateend)
+Appending PTS=1
+EVENT(updateend)
+Appending PTS=2
+EVENT(updateend)
+Appending PTS=3
+EVENT(updateend)
+Appending PTS=4
+EVENT(updateend)
+Appending PTS=5
+EVENT(updateend)
+Appending PTS=6
+EVENT(updateend)
+Appending PTS=7
+EVENT(updateend)
+Appending PTS=8
+EVENT(updateend)
+Appending PTS=9
+EVENT(updateend)
+Appending PTS=10
+EVENT(updateend)
+Appending PTS=11
+EVENT(updateend)
+Appending PTS=12
+EVENT(updateend)
+Appending PTS=13
+EVENT(updateend)
+Appending PTS=14
+EVENT(updateend)
+Appending PTS=15
+EVENT(updateend)
+Appending PTS=16
+EVENT(updateend)
+Appending PTS=17
+EVENT(updateend)
+Appending PTS=18
+EVENT(updateend)
+Appending PTS=19
+EVENT(updateend)
+Appending PTS=20
+EVENT(updateend)
+Appending PTS=21
+EVENT(updateend)
+Appending PTS=22
+EVENT(updateend)
+Appending PTS=23
+EVENT(updateend)
+Appending PTS=24
+EVENT(updateend)
+Appending PTS=25
+EVENT(updateend)
+Appending PTS=26
+EVENT(updateend)
+Appending PTS=27
+EVENT(updateend)
+Appending PTS=28
+EVENT(updateend)
+Appending PTS=29
+EVENT(updateend)
+Appending PTS=30
+EVENT(updateend)
+Appending PTS=31
+EVENT(updateend)
+Appending PTS=32
+EVENT(updateend)
+Appending PTS=33
+EVENT(updateend)
+Appending PTS=34
+EVENT(updateend)
+Appending PTS=35
+EVENT(updateend)
+Appending PTS=36
+EVENT(updateend)
+Appending PTS=37
+EVENT(updateend)
+Appending PTS=38
+EVENT(updateend)
+Appending PTS=39
+EVENT(updateend)
+Appending PTS=40
+EVENT(updateend)
+Appending PTS=41
+EVENT(updateend)
+Appending PTS=42
+EVENT(updateend)
+Appending PTS=43
+EVENT(updateend)
+Appending PTS=44
+EVENT(updateend)
+Appending PTS=45
+EVENT(updateend)
+Appending PTS=46
+EVENT(updateend)
+Appending PTS=47
+EVENT(updateend)
+Appending PTS=48
+EVENT(updateend)
+Appending PTS=49
+EVENT(updateend)
+EXPECTED (bufferedRanges() == '[ 0...50, 55...100 ]') OK
+EXPECTED (internals.evictableSize(sourceBuffer) == '3240') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-seek-and-evictable.html
+++ b/LayoutTests/media/media-source/media-managedmse-seek-and-evictable.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>mock-media-source</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initSegment;
+    var exception;
+    var sampleSize = 72;
+
+    function bufferedRanges() {
+        var bufferedRanges = '[ ';
+        var timeRanges = sourceBuffer.buffered;
+        for (var i = 0 ; i < timeRanges.length ; i++) {
+            if (i)
+                bufferedRanges += ', ';
+            bufferedRanges += timeRanges.start(i) + '...' + timeRanges.end(i);
+        }
+        bufferedRanges += ' ]';
+        return bufferedRanges;
+    }
+
+    async function appendPtsRange(firstPts, lastPts) {
+        var resultException = null;
+        for (var pts = firstPts; pts <= lastPts; pts++) {
+            try {
+                consoleWrite('Appending PTS='+pts);
+                sourceBuffer.appendBuffer(makeASample(pts, pts, 1, 1, 1, SAMPLE_FLAG.SYNC, 1));
+                await waitFor(sourceBuffer, 'updateend');
+            } catch (e) {
+                resultException = e;
+                sourceBuffer.abort();
+                break;
+            }
+        }
+        return resultException;
+    }
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    window.addEventListener('load', async() => {
+        findMediaElement();
+        source = new ManagedMediaSource();
+
+        const videoSource = document.createElement('source');
+        videoSource.type = 'video/mock; codecs=mock';
+        videoSource.src = URL.createObjectURL(source);
+        run('video.disableRemotePlayback = true');
+        video.appendChild(videoSource);
+
+        await waitFor(source, 'sourceopen');
+        sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock");
+        initSegment = makeAInit(300, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]);
+        sourceBuffer.appendBuffer(initSegment);
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('source.duration', 300, '==');
+        testExpected('video.duration', 300, '==');
+
+        // This allows bufering up to 100
+        await internals.setMaximumSourceBufferSize(sourceBuffer, 100 * sampleSize);
+
+        exception = await appendPtsRange(0, 99);
+        // No past data, and all contiguous, nothing evictable and nothing evicted.
+        testExpected('exception', null, '==');
+        testExpected('internals.evictableSize(sourceBuffer)', 0, '==');
+        testExpected('bufferedRanges()', '[ 0...100 ]', '==');
+        
+        // Attempting to append one more sample will fail.
+        exception = await appendPtsRange(101, 180);
+        testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '==');
+        testExpected('internals.evictableSize(sourceBuffer)', 0, '==');
+
+        exception = await appendPtsRange(200, 250);
+        testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '==');
+        testExpected('internals.evictableSize(sourceBuffer)', 0, '==');
+
+        run('video.currentTime = 175');
+        testExpected('video.currentTime', 175, '==');
+
+        // Samples before currentTime are evictable.
+        await Promise.all([ waitFor(video, 'seeked', true), appendPtsRange(175, 200) ]);
+        testExpected('bufferedRanges()', '[ 30...100, 175...201 ]', '==');
+        testExpected('internals.evictableSize(sourceBuffer)', (100 - 30) * sampleSize, '==');
+       
+        sourceBuffer.remove(0, 500);
+        await waitFor(sourceBuffer, 'updateend');
+        
+        run('video.currentTime = 0');
+        testExpected('video.currentTime', 0, '==');
+
+        await Promise.all([ waitFor(video, 'seeked', true), appendPtsRange(0, 49) ]);
+        testExpected('bufferedRanges()', '[ 0...50 ]', '==');
+        testExpected('internals.evictableSize(sourceBuffer)', 0, '==');
+
+        exception = await appendPtsRange(200, 249);
+        testExpected('exception', null, '==');
+        testExpected('bufferedRanges()', '[ 0...50, 200...250 ]', '==');
+        testExpected('internals.evictableSize(sourceBuffer)', (250 - 200) * sampleSize, '==');
+
+        run('video.currentTime = 60');
+        testExpected('video.currentTime', 60, '==');
+
+        // Appending new data, will evict past data up to currentTime - 3s.
+        await Promise.all([ waitFor(video, 'seeked', true), appendPtsRange(55, 99) ]);
+        testExpected('bufferedRanges()', '[ 45...50, 55...100, 200...250 ]', '==');
+        testExpected('internals.evictableSize(sourceBuffer)', ((50 - 45) + (video.currentTime - 3 - 55) + (250 - 200)) * sampleSize, '==');
+
+        // Appending new data, will evict future data, no contiguous with the currently playing range.
+        run('video.currentTime = 0');
+        testExpected('video.currentTime', 0, '==');
+        await Promise.all([ waitFor(video, 'seeked', true), appendPtsRange(0, 49) ]);
+        testExpected('bufferedRanges()', '[ 0...50, 55...100 ]', '==');
+        testExpected('internals.evictableSize(sourceBuffer)', (100 - 55) * 72, '==');
+
+        endTest();
+     });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1514,6 +1514,11 @@ bool SourceBuffer::enabledForContext(ScriptExecutionContext& context)
     return true;
 }
 
+size_t SourceBuffer::evictableSize() const
+{
+    return m_private->evictionData().evictableSize;
+}
+
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -219,6 +219,7 @@ private:
     WEBCORE_EXPORT MediaTime minimumUpcomingPresentationTimeForTrackID(TrackID);
     WEBCORE_EXPORT void setMaximumQueueDepthForTrackID(TrackID, uint64_t);
     WEBCORE_EXPORT Ref<GenericPromise> setMaximumSourceBufferSize(uint64_t);
+    WEBCORE_EXPORT size_t evictableSize() const;
 
     void updateBuffered();
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4702,6 +4702,11 @@ void Internals::setMaximumQueueDepthForTrackID(SourceBuffer& buffer, const AtomS
     buffer.setMaximumQueueDepthForTrackID(parseInteger<TrackID>(trackID).value_or(0), maxQueueDepth);
 }
 
+size_t Internals::evictableSize(SourceBuffer& buffer)
+{
+    return buffer.evictableSize();
+}
+
 #endif
 
 void Internals::enableMockMediaCapabilities()

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -810,6 +810,7 @@ public:
     double minimumUpcomingPresentationTimeForTrackID(SourceBuffer&, const AtomString&);
     void setShouldGenerateTimestamps(SourceBuffer&, bool);
     void setMaximumQueueDepthForTrackID(SourceBuffer&, const AtomString&, size_t);
+    size_t evictableSize(SourceBuffer&);
 #endif
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -968,6 +968,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     [Conditional=MEDIA_SOURCE] undefined setShouldGenerateTimestamps(SourceBuffer buffer, boolean flag);
     [Conditional=MEDIA_SOURCE] double minimumUpcomingPresentationTimeForTrackID(SourceBuffer buffer, [AtomString] DOMString trackID);
     [Conditional=MEDIA_SOURCE] undefined setMaximumQueueDepthForTrackID(SourceBuffer buffer, [AtomString] DOMString trackID, unsigned long maxQueueDepth);
+    [Conditional=MEDIA_SOURCE] unsigned long evictableSize(SourceBuffer buffer);
 
     [Conditional=VIDEO] undefined beginMediaSessionInterruption(DOMString interruptionType);
     [Conditional=VIDEO] undefined endMediaSessionInterruption(DOMString flags);


### PR DESCRIPTION
#### 082067e37acd774037dc66d5f3e2dd4cfe66a3f0
<pre>
SourceBuffer will always perform a sync call to GPU process when there&apos;s a need to evict content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=276999">https://bugs.webkit.org/show_bug.cgi?id=276999</a>
<a href="https://rdar.apple.com/132402500">rdar://132402500</a>

Reviewed by Youenn Fablet.

Prior 275380@main, eviction was performed synchronously and the eviction data algorithm would evict 3s of data at a time
until there was sufficient buffer space available for the appendBuffer operation to complete.
In 275380@main, we pre-calculated how much data could be removed in total. However, the calculation incorrectly
looked at the initial 3s of removable data only. Which would make the SourceBuffer always consider that no data was evictable
preventing an asynchronous eviction to occur and instead generating a sync call to SourceBufferPrivate::evictData.

Added tests.

* LayoutTests/media/media-source/media-managedmse-seek-and-evictable-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-seek-and-evictable.html: Added.
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::evictableSize const):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::seekToTime):
(WebCore::SourceBufferPrivate::computeEvictionData):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::evictableSize):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/281326@main">https://commits.webkit.org/281326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a23f2e47b42c95761b88adbff6d1e058f64d3d37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63456 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10060 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10216 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7048 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29151 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8793 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8988 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/54957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65188 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3469 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3480 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55781 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13193 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2879 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34700 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36869 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->