### PR TITLE
[GStreamer] Implement gstStructureGetString()

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -740,7 +740,10 @@ GRefPtr<GstPad> GStreamerMediaEndpoint::requestPad(const GRefPtr<GstCaps>& allow
             i++;
             continue;
         }
-        auto payloadType = payloadTypeForEncodingName(gst_structure_get_string(structure, "encoding-name"));
+        std::optional<int> payloadType;
+        if (auto encodingName = gstStructureGetString(structure, "encoding-name"_s))
+            payloadType = payloadTypeForEncodingName(encodingName);
+
         if (!payloadType) {
             if (availablePayloadType < 128)
                 payloadType = availablePayloadType++;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -109,7 +109,7 @@ bool GStreamerRtpTransceiverBackend::stopped() const
     return m_isStopped;
 }
 
-static inline WARN_UNUSED_RETURN ExceptionOr<GstCaps*> toRtpCodecCapability(const RTCRtpCodecCapability& codec, int& dynamicPayloadType, const char* msid)
+static inline WARN_UNUSED_RETURN ExceptionOr<GRefPtr<GstCaps>> toRtpCodecCapability(const RTCRtpCodecCapability& codec, int& dynamicPayloadType, StringView msid)
 {
     if (!codec.mimeType.startsWith("video/"_s) && !codec.mimeType.startsWith("audio/"_s))
         return Exception { ExceptionCode::InvalidModificationError, "RTCRtpCodecCapability bad mimeType"_s };
@@ -118,10 +118,10 @@ static inline WARN_UNUSED_RETURN ExceptionOr<GstCaps*> toRtpCodecCapability(cons
     const auto mediaType = components[0];
     const auto codecName = components[1];
 
-    int payloadType = payloadTypeForEncodingName(codecName.ascii().data()).value_or(dynamicPayloadType++);
-    auto* caps = gst_caps_new_simple("application/x-rtp", "media", G_TYPE_STRING, mediaType.ascii().data(), "encoding-name", G_TYPE_STRING, codecName.ascii().data(), "clock-rate", G_TYPE_INT, codec.clockRate, "payload", G_TYPE_INT, payloadType, nullptr);
+    int payloadType = payloadTypeForEncodingName(codecName).value_or(dynamicPayloadType++);
+    auto caps = adoptGRef(gst_caps_new_simple("application/x-rtp", "media", G_TYPE_STRING, mediaType.ascii().data(), "encoding-name", G_TYPE_STRING, codecName.ascii().data(), "clock-rate", G_TYPE_INT, codec.clockRate, "payload", G_TYPE_INT, payloadType, nullptr));
     if (codec.channels)
-        gst_caps_set_simple(caps, "channels", G_TYPE_INT, *codec.channels, nullptr);
+        gst_caps_set_simple(caps.get(), "channels", G_TYPE_INT, *codec.channels, nullptr);
 
     if (!codec.sdpFmtpLine.isEmpty()) {
         // Forward each fmtp attribute as codec-<fmtp-name> in the caps so that the downstream
@@ -131,40 +131,40 @@ static inline WARN_UNUSED_RETURN ExceptionOr<GstCaps*> toRtpCodecCapability(cons
         for (auto& attribute : codec.sdpFmtpLine.split(';')) {
             auto components = attribute.split('=');
             auto field = makeString(codecName.convertToASCIILowercase(), '-', components[0]);
-            gst_caps_set_simple(caps, field.ascii().data(), G_TYPE_STRING, components[1].ascii().data(), nullptr);
+            gst_caps_set_simple(caps.get(), field.ascii().data(), G_TYPE_STRING, components[1].ascii().data(), nullptr);
         }
     }
 
     if (msid)
-        gst_caps_set_simple(caps, "a-msid", G_TYPE_STRING, msid, nullptr);
+        gst_caps_set_simple(caps.get(), "a-msid", G_TYPE_STRING, msid.toStringWithoutCopying().ascii().data(), nullptr);
 
-    GST_DEBUG("Codec capability: %" GST_PTR_FORMAT, caps);
+    GST_DEBUG("Codec capability: %" GST_PTR_FORMAT, caps.get());
     return caps;
 }
 
-static GUniquePtr<char> getMsidFromCurrentCodecPreferences(GstWebRTCRTPTransceiver* transceiver)
+static StringView getMsidFromCurrentCodecPreferences(GstWebRTCRTPTransceiver* transceiver)
 {
     GRefPtr<GstCaps> currentCaps;
-    GUniquePtr<char> msid;
     g_object_get(transceiver, "codec-preferences", &currentCaps.outPtr(), nullptr);
     GST_TRACE_OBJECT(transceiver, "Current codec preferences: %" GST_PTR_FORMAT, currentCaps.get());
     if (gst_caps_get_size(currentCaps.get()) > 0) {
         auto* s = gst_caps_get_structure(currentCaps.get(), 0);
-        msid = GUniquePtr<char>(g_strdup(gst_structure_get_string(s, "a-msid")));
+        if (auto msIdValue = gstStructureGetString(s, "a-msid"_s))
+            return msIdValue;
     }
-    return msid;
+    return nullptr;
 }
 
 ExceptionOr<void> GStreamerRtpTransceiverBackend::setCodecPreferences(const Vector<RTCRtpCodecCapability>& codecs)
 {
     auto gstCodecs = adoptGRef(gst_caps_new_empty());
-    GUniquePtr<char> msid = getMsidFromCurrentCodecPreferences(m_rtcTransceiver.get());
+    auto msid = getMsidFromCurrentCodecPreferences(m_rtcTransceiver.get());
     int dynamicPayloadType = 96;
     for (auto& codec : codecs) {
-        auto result = toRtpCodecCapability(codec, dynamicPayloadType, msid.get());
+        auto result = toRtpCodecCapability(codec, dynamicPayloadType, msid);
         if (result.hasException())
             return result.releaseException();
-        gst_caps_append(gstCodecs.get(), result.releaseReturnValue());
+        gst_caps_append(gstCodecs.get(), result.releaseReturnValue().leakRef());
     }
     g_object_set(m_rtcTransceiver.get(), "codec-preferences", gstCodecs.get(), nullptr);
     return { };

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -281,7 +281,7 @@ private:
     Vector<uint32_t> m_knownIds WTF_GUARDED_BY_LOCK(m_lock);
 };
 
-std::optional<int> payloadTypeForEncodingName(const char* encodingName);
+std::optional<int> payloadTypeForEncodingName(StringView encodingName);
 
 WARN_UNUSED_RETURN GRefPtr<GstCaps> capsFromRtpCapabilities(RefPtr<UniqueSSRCGenerator>, const RTCRtpCapabilities&, Function<void(GstStructure*)> supplementCapsCallback);
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1013,25 +1013,32 @@ static ASCIILiteral webrtcStatsTypeName(int value)
 template<typename T>
 std::optional<T> gstStructureGet(const GstStructure* structure, ASCIILiteral key)
 {
+    return gstStructureGet<T>(structure, StringView { key });
+}
+
+template<typename T>
+std::optional<T> gstStructureGet(const GstStructure* structure, StringView key)
+{
     T value;
+    auto strKey = key.toStringWithoutCopying();
     if constexpr(std::is_same_v<T, int>) {
-        if (gst_structure_get_int(structure, key.characters(), &value))
+        if (gst_structure_get_int(structure, strKey.ascii().data(), &value))
             return value;
     } else if constexpr(std::is_same_v<T, int64_t>) {
-        if (gst_structure_get_int64(structure, key.characters(), &value))
+        if (gst_structure_get_int64(structure, strKey.ascii().data(), &value))
             return value;
     } else if constexpr(std::is_same_v<T, unsigned>) {
-        if (gst_structure_get_uint(structure, key.characters(), &value))
+        if (gst_structure_get_uint(structure, strKey.ascii().data(), &value))
             return value;
     } else if constexpr(std::is_same_v<T, uint64_t>) {
-        if (gst_structure_get_uint64(structure, key.characters(), &value))
+        if (gst_structure_get_uint64(structure, strKey.ascii().data(), &value))
             return value;
     } else if constexpr(std::is_same_v<T, double>) {
-        if (gst_structure_get_double(structure, key.characters(), &value))
+        if (gst_structure_get_double(structure, strKey.ascii().data(), &value))
             return value;
     } else if constexpr(std::is_same_v<T, bool>) {
         gboolean gstValue;
-        if (gst_structure_get_boolean(structure, key.characters(), &gstValue)) {
+        if (gst_structure_get_boolean(structure, strKey.ascii().data(), &gstValue)) {
             value = gstValue;
             return value;
         }
@@ -1046,6 +1053,23 @@ template std::optional<unsigned> gstStructureGet(const GstStructure*, ASCIILiter
 template std::optional<uint64_t> gstStructureGet(const GstStructure*, ASCIILiteral key);
 template std::optional<double> gstStructureGet(const GstStructure*, ASCIILiteral key);
 template std::optional<bool> gstStructureGet(const GstStructure*, ASCIILiteral key);
+
+template std::optional<int> gstStructureGet(const GstStructure*, StringView key);
+template std::optional<int64_t> gstStructureGet(const GstStructure*, StringView key);
+template std::optional<unsigned> gstStructureGet(const GstStructure*, StringView key);
+template std::optional<uint64_t> gstStructureGet(const GstStructure*, StringView key);
+template std::optional<double> gstStructureGet(const GstStructure*, StringView key);
+template std::optional<bool> gstStructureGet(const GstStructure*, StringView key);
+
+StringView gstStructureGetString(const GstStructure* structure, ASCIILiteral key)
+{
+    return gstStructureGetString(structure, StringView { key });
+}
+
+StringView gstStructureGetString(const GstStructure* structure, StringView key)
+{
+    return StringView::fromLatin1(gst_structure_get_string(structure, static_cast<const char*>(key.rawCharacters())));
+}
 
 static RefPtr<JSON::Value> gstStructureToJSON(const GstStructure*);
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -274,6 +274,11 @@ GstElement* makeGStreamerBin(const char* description, bool ghostUnlinkedPads);
 
 template<typename T>
 std::optional<T> gstStructureGet(const GstStructure*, ASCIILiteral key);
+template<typename T>
+std::optional<T> gstStructureGet(const GstStructure*, StringView key);
+
+StringView gstStructureGetString(const GstStructure*, ASCIILiteral key);
+StringView gstStructureGetString(const GstStructure*, StringView key);
 
 String gstStructureToJSONString(const GstStructure*);
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
@@ -56,7 +56,10 @@ String GStreamerMediaDescription::extractCodecName(const GRefPtr<GstCaps>& caps)
         if (!gst_structure_has_field(structure, "original-media-type"))
             return String();
 
-        gst_structure_set_name(structure, gst_structure_get_string(structure, "original-media-type"));
+        auto originalMediaType = WebCore::gstStructureGetString(structure, "original-media-type"_s);
+        RELEASE_ASSERT(originalMediaType);
+        gst_structure_set_name(structure, originalMediaType.toStringWithoutCopying().ascii().data());
+
         // Remove the DRM related fields from the caps.
         for (int j = 0; j < gst_structure_n_fields(structure); ++j) {
             const char* fieldName = gst_structure_nth_field_name(structure, j);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -187,9 +187,8 @@ const Vector<CaptureDevice>& GStreamerCaptureDeviceManager::captureDevices()
 void GStreamerCaptureDeviceManager::addDevice(GRefPtr<GstDevice>&& device)
 {
     GUniquePtr<GstStructure> properties(gst_device_get_properties(device.get()));
-    const char* klass = gst_structure_get_string(properties.get(), "device.class");
-
-    if (klass && !g_strcmp0(klass, "monitor"))
+    auto deviceClassString = gstStructureGetString(properties.get(), "device.class"_s);
+    if (deviceClassString == "monitor"_s)
         return;
 
     CaptureDevice::DeviceType type = deviceType();
@@ -209,8 +208,8 @@ void GStreamerCaptureDeviceManager::addDevice(GRefPtr<GstDevice>&& device)
 
     auto identifier = label;
     bool isMock = false;
-    if (const char* persistentId = gst_structure_get_string(properties.get(), "persistent-id")) {
-        identifier = String::fromLatin1(persistentId);
+    if (auto persistentId = gstStructureGetString(properties.get(), "persistent-id"_s)) {
+        identifier = makeString(persistentId);
         isMock = true;
     }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -279,7 +279,7 @@ void GStreamerVideoCapturer::reconfigure()
 
     struct MimeTypeSelector {
         const char* mimeType = "video/x-raw";
-        const char* format = nullptr;
+        String format;
         int maxWidth = 0;
         int maxHeight = 0;
         double maxFrameRate = 0;
@@ -327,10 +327,9 @@ void GStreamerVideoCapturer::reconfigure()
                 selector->maxHeight = *height;
                 selector->maxFrameRate = *frameRate;
                 selector->mimeType = gst_structure_get_name(structure);
-                selector->format = nullptr;
                 if (gst_structure_has_name(structure, "video/x-raw")) {
                     if (gst_structure_has_field(structure, "format"))
-                        selector->format = gst_structure_get_string(structure, "format");
+                        selector->format = makeString(gstStructureGetString(structure, "format"_s));
                     else
                         return TRUE;
                 }
@@ -342,10 +341,9 @@ void GStreamerVideoCapturer::reconfigure()
                 selector->maxHeight = *height;
                 selector->maxFrameRate = *frameRate;
                 selector->mimeType = gst_structure_get_name(structure);
-                selector->format = nullptr;
                 if (gst_structure_has_name(structure, "video/x-raw")) {
                     if (gst_structure_has_field(structure, "format"))
-                        selector->format = gst_structure_get_string(structure, "format");
+                        selector->format = makeString(gstStructureGetString(structure, "format"_s));
                     else
                         return TRUE;
                 }
@@ -358,8 +356,8 @@ void GStreamerVideoCapturer::reconfigure()
         "height", G_TYPE_INT, selector.maxHeight, nullptr));
 
     // Workaround for https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/1793.
-    if (selector.format)
-        gst_caps_set_simple(caps.get(), "format", G_TYPE_STRING, selector.format, nullptr);
+    if (!selector.format.isEmpty())
+        gst_caps_set_simple(caps.get(), "format", G_TYPE_STRING, selector.format.ascii().data(), nullptr);
 
     GST_INFO_OBJECT(m_pipeline.get(), "Setting video capture device caps to %" GST_PTR_FORMAT, caps.get());
     g_object_set(m_videoSrcMIMETypeFilter.get(), "caps", caps.get(), nullptr);

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -4058,6 +4058,8 @@ def check_language(filename, clean_lines, line_number, file_extension, include_s
     if filename != 'Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp':
         if search(r'gst_structure_get_(int|uint|double|boolean)', line):
             error(line_number, 'readability/check', 4, 'Consider using gstStructureGet<T>() instead')
+        if search(r'gst_structure_get_string', line):
+            error(line_number, 'readability/check', 4, 'Consider using gstStructureGetString() instead')
 
 
 def check_identifier_name_in_declaration(filename, line_number, line, file_state, error):

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -1045,6 +1045,7 @@ class CppStyleTest(CppStyleTestBase):
         self.assert_lint('gst_structure_get_uint(s, "foo", &bar)', error_message)
         self.assert_lint('gst_structure_get_double(s, "foo", &bar)', error_message)
         self.assert_lint('gst_structure_get_boolean(s, "foo", &bar)', error_message)
+        self.assert_lint('const char* foo = gst_structure_get_string(s, "foo")', 'Consider using gstStructureGetString() instead  [readability/check] [4]')
 
     # We cannot test this functionality because of difference of
     # function definitions.  Anyway, we may never enable this.

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
@@ -52,7 +52,7 @@ void GStreamerTest::TearDownTestSuite()
 
 TEST_F(GStreamerTest, gstStructureGetters)
 {
-    GUniquePtr<GstStructure> structure(gst_structure_new("foo", "int-val", G_TYPE_INT, -5, "int64-val", G_TYPE_INT64, -10, "uint-val", G_TYPE_UINT, 5, "uint64-val", G_TYPE_UINT64, 18014398509481982, "double-val", G_TYPE_DOUBLE, 1.0, "bool-val", G_TYPE_BOOLEAN, TRUE, nullptr));
+    GUniquePtr<GstStructure> structure(gst_structure_new("foo", "int-val", G_TYPE_INT, -5, "int64-val", G_TYPE_INT64, -10, "uint-val", G_TYPE_UINT, 5, "uint64-val", G_TYPE_UINT64, 18014398509481982, "double-val", G_TYPE_DOUBLE, 1.0, "bool-val", G_TYPE_BOOLEAN, TRUE, "str-val", G_TYPE_STRING, "hello-world", nullptr));
     ASSERT_EQ(gstStructureGet<int>(structure.get(), "int-val"_s), -5);
     ASSERT_TRUE(!gstStructureGet<int>(structure.get(), "int-val-noexist"_s).has_value());
     ASSERT_EQ(gstStructureGet<int64_t>(structure.get(), "int64-val"_s), -10);
@@ -65,6 +65,8 @@ TEST_F(GStreamerTest, gstStructureGetters)
     ASSERT_TRUE(!gstStructureGet<double>(structure.get(), "double-val-noexist"_s).has_value());
     ASSERT_EQ(gstStructureGet<bool>(structure.get(), "bool-val"_s), true);
     ASSERT_TRUE(!gstStructureGet<bool>(structure.get(), "bool-val-noexist"_s).has_value());
+    ASSERT_EQ(gstStructureGetString(structure.get(), "str-val"_s), "hello-world"_s);
+    ASSERT_TRUE(!gstStructureGetString(structure.get(), "str-val-noexist"_s));
 
     // webkit.org/b/276224
     auto emptyIntOpt = gstStructureGet<int>(structure.get(), "int-val-noexist2"_s);


### PR DESCRIPTION
#### 6ca202068171d6cced2d5a381eba85074fdabbdb
<pre>
[GStreamer] Implement gstStructureGetString()
<a href="https://bugs.webkit.org/show_bug.cgi?id=277000">https://bugs.webkit.org/show_bug.cgi?id=277000</a>

Reviewed by Xabier Rodriguez-Calvar.

Usage of gst_structure_get_string() is no longer recommended. Use this new helper instead.
This patch includes drive-by changes, reducing usage of raw pointers and avoiding memory allocations
when possible (using StringView instead of GUniquePtr&lt;char&gt; in the GStreamerRtpTransceiverBackend).

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::requestPad):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::toRtpCodecCapability):
(WebCore::getMsidFromCurrentCodecPreferences):
(WebCore::GStreamerRtpTransceiverBackend::setCodecPreferences):
(): Deleted.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::RTCStatsReport::Stats::Stats):
(WebCore::RTCStatsReport::RtpStreamStats::RtpStreamStats):
(WebCore::RTCStatsReport::CodecStats::CodecStats):
(WebCore::RTCStatsReport::RemoteInboundRtpStreamStats::RemoteInboundRtpStreamStats):
(WebCore::RTCStatsReport::RemoteOutboundRtpStreamStats::RemoteOutboundRtpStreamStats):
(WebCore::RTCStatsReport::OutboundRtpStreamStats::OutboundRtpStreamStats):
(WebCore::RTCStatsReport::TransportStats::TransportStats):
(WebCore::iceCandidateType):
(WebCore::RTCStatsReport::IceCandidateStats::IceCandidateStats):
(WebCore::RTCStatsReport::IceCandidatePairStats::IceCandidatePairStats):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::toRTCEncodingParameters):
(WebCore::toRTCRtpSendParameters):
(WebCore::payloadTypeForEncodingName):
(WebCore::capsFromRtpCapabilities):
(WebCore::capsFromSDPMedia):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::gstStructureGet):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
(WebCore::MediaPlayerPrivateGStreamer::loadNextLocation):
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(transformCaps):
(transformInPlace):
* Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp:
(WebCore::GStreamerMediaDescription::extractCodecName const):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::GStreamerCaptureDeviceManager::addDevice):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::configure):
(WebCore::GStreamerIncomingTrackProcessor::incomingTrackProcessor):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::reconfigure):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::setPayloadType):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::setPayloadType):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_language):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(CppStyleTest):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/281559@main">https://commits.webkit.org/281559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/918e62fcb17e4aa4ff57dc8e53a63fcf85a15d45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64254 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10866 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11099 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48849 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7567 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29696 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/59860 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9497 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9783 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65986 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4268 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56210 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56378 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13390 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3554 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35496 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37667 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->