### PR TITLE
[visionOS] Add a mechanism to check user authorization for gamepads

### DIFF
--- a/Source/WebCore/Modules/gamepad/GamepadManager.h
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.h
@@ -55,6 +55,10 @@ public:
     void registerDOMWindow(LocalDOMWindow&);
     void unregisterDOMWindow(LocalDOMWindow&);
 
+#if PLATFORM(VISION)
+    void updateQuarantineStatus();
+#endif
+
 private:
     GamepadManager();
 
@@ -64,12 +68,21 @@ private:
     void maybeStartMonitoringGamepads();
     void maybeStopMonitoringGamepads();
 
+#if PLATFORM(VISION)
+    void findUnquarantinedNavigatorsAndWindows(WeakHashSet<NavigatorGamepad>&, WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData>&);
+#endif
+
     bool m_isMonitoringGamepads;
 
     WeakHashSet<NavigatorGamepad> m_navigators;
     WeakHashSet<NavigatorGamepad> m_gamepadBlindNavigators;
     WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_domWindows;
     WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_gamepadBlindDOMWindows;
+
+#if PLATFORM(VISION)
+    WeakHashSet<NavigatorGamepad> m_gamepadQuarantinedNavigators;
+    WeakHashSet<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_gamepadQuarantinedDOMWindows;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -190,6 +190,12 @@ void NavigatorGamepad::gamepadDisconnected(PlatformGamepad& platformGamepad)
     m_gamepads[platformGamepad.index()] = nullptr;
 }
 
+RefPtr<Page> NavigatorGamepad::protectedPage() const
+{
+    RefPtr frame = m_navigator.frame();
+    return frame ? frame->protectedPage() : nullptr;
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
@@ -45,6 +45,7 @@ namespace WebCore {
 
 class Gamepad;
 class Navigator;
+class Page;
 class PlatformGamepad;
 template<typename> class ExceptionOr;
 
@@ -67,6 +68,8 @@ public:
 
     WEBCORE_EXPORT static void setGamepadsRecentlyAccessedThreshold(Seconds);
     static Seconds gamepadsRecentlyAccessedThreshold();
+
+    RefPtr<Page> protectedPage() const;
 
 private:
     static ASCIILiteral supplementName();

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -67,6 +67,10 @@
 #include "ApplicationManifest.h"
 #endif
 
+#if PLATFORM(VISION) && ENABLE(GAMEPAD)
+#include "ShouldRequireExplicitConsentForGamepadAccess.h"
+#endif
+
 namespace JSC {
 class Debugger;
 }
@@ -1149,6 +1153,10 @@ public:
 
 #if ENABLE(GAMEPAD)
     void gamepadsRecentlyAccessed();
+#if PLATFORM(VISION)
+    WEBCORE_EXPORT void allowGamepadAccess();
+    bool gamepadAccessGranted() const { return m_gamepadAccessGranted; }
+#endif
 #endif
 
 #if ENABLE(WRITING_TOOLS)
@@ -1242,6 +1250,10 @@ private:
 
 #if ENABLE(WEBXR)
     RefPtr<WebXRSession> activeImmersiveXRSession() const;
+#endif
+
+#if PLATFORM(VISION) && ENABLE(GAMEPAD)
+    void initializeGamepadAccessForPageLoad();
 #endif
 
     std::optional<PageIdentifier> m_identifier;
@@ -1585,6 +1597,10 @@ private:
 
 #if ENABLE(GAMEPAD)
     MonotonicTime m_lastAccessNotificationTime;
+#if PLATFORM(VISION)
+    bool m_gamepadAccessGranted { true };
+    ShouldRequireExplicitConsentForGamepadAccess m_gamepadAccessRequiresExplicitConsent { ShouldRequireExplicitConsentForGamepadAccess::No };
+#endif
 #endif
 
 #if ENABLE(WRITING_TOOLS)

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -47,6 +47,10 @@
 #include "DeviceOrientationUpdateProvider.h"
 #endif
 
+#if PLATFORM(VISION) && ENABLE(GAMEPAD)
+#include "ShouldRequireExplicitConsentForGamepadAccess.h"
+#endif
+
 namespace WebCore {
 
 class AlternativeTextClient;
@@ -210,6 +214,10 @@ public:
 
     ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension { WebCore::ContentSecurityPolicyModeForExtension::None };
     UniqueRef<CryptoClient> cryptoClient;
+
+#if PLATFORM(VISION) && ENABLE(GAMEPAD)
+    ShouldRequireExplicitConsentForGamepadAccess gamepadAccessRequiresExplicitConsent { ShouldRequireExplicitConsentForGamepadAccess::No };
+#endif
 };
 
 }

--- a/Source/WebCore/platform/gamepad/ShouldRequireExplicitConsentForGamepadAccess.h
+++ b/Source/WebCore/platform/gamepad/ShouldRequireExplicitConsentForGamepadAccess.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(VISION) && ENABLE(GAMEPAD)
+
+namespace WebCore {
+
+enum class ShouldRequireExplicitConsentForGamepadAccess : bool { No, Yes };
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8287,6 +8287,10 @@ enum class WebCore::ShouldContinuePolicyCheck : bool
 
 #if ENABLE(GAMEPAD)
 enum class WebCore::EventMakesGamepadsVisible : bool
+
+#if PLATFORM(VISION)
+enum class WebCore::ShouldRequireExplicitConsentForGamepadAccess : bool;
+#endif
 #endif
 
 enum class WebCore::WillInternallyHandleFailure : bool

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -80,6 +80,10 @@
 #include "HardwareKeyboardState.h"
 #endif
 
+#if PLATFORM(VISION) && ENABLE(GAMEPAD)
+#include <WebCore/ShouldRequireExplicitConsentForGamepadAccess.h>
+#endif
+
 namespace IPC {
 class Decoder;
 class Encoder;
@@ -330,6 +334,10 @@ struct WebPageCreationParameters {
 
 #if (PLATFORM(GTK) || PLATFORM(WPE)) && USE(GBM)
     Vector<DMABufRendererBufferFormat> preferredBufferFormats;
+#endif
+
+#if PLATFORM(VISION) && ENABLE(GAMEPAD)
+    WebCore::ShouldRequireExplicitConsentForGamepadAccess gamepadAccessRequiresExplicitConsent { WebCore::ShouldRequireExplicitConsentForGamepadAccess::No };
 #endif
 };
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -259,6 +259,10 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 #if (PLATFORM(GTK) || PLATFORM(WPE)) && USE(GBM)
     Vector<WebKit::DMABufRendererBufferFormat> preferredBufferFormats;
 #endif
+
+#if PLATFORM(VISION) && ENABLE(GAMEPAD)
+    WebCore::ShouldRequireExplicitConsentForGamepadAccess gamepadAccessRequiresExplicitConsent;
+#endif
 }
 
 [Nested] struct WebKit::RemotePageParameters {

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -47,6 +47,10 @@ OBJC_PROTOCOL(_UIClickInteractionDriving);
 #include <WebCore/UserInterfaceDirectionPolicy.h>
 #endif
 
+#if PLATFORM(VISION) && ENABLE(GAMEPAD)
+#include <WebCore/ShouldRequireExplicitConsentForGamepadAccess.h>
+#endif
+
 namespace WebKit {
 class BrowsingContextGroup;
 class VisitedLinkStore;
@@ -416,6 +420,11 @@ public:
     void setContentSecurityPolicyModeForExtension(WebCore::ContentSecurityPolicyModeForExtension mode) { m_data.contentSecurityPolicyModeForExtension = mode; }
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension() const { return m_data.contentSecurityPolicyModeForExtension; }
 
+#if PLATFORM(VISION) && ENABLE(GAMEPAD)
+    WebCore::ShouldRequireExplicitConsentForGamepadAccess gamepadAccessRequiresExplicitConsent() const { return m_data.gamepadAccessRequiresExplicitConsent; }
+    void setGamepadAccessRequiresExplicitConsent(WebCore::ShouldRequireExplicitConsentForGamepadAccess value) { m_data.gamepadAccessRequiresExplicitConsent = value; }
+#endif
+
 private:
     struct Data {
         template<typename T, Ref<T>(*initializer)()> class LazyInitializedRef {
@@ -577,6 +586,9 @@ private:
         bool allowsInlinePredictions { false };
         bool scrollToTextFragmentIndicatorEnabled { true };
         bool scrollToTextFragmentMarkingEnabled { true };
+#if PLATFORM(VISION) && ENABLE(GAMEPAD)
+        WebCore::ShouldRequireExplicitConsentForGamepadAccess gamepadAccessRequiresExplicitConsent { WebCore::ShouldRequireExplicitConsentForGamepadAccess::No };
+#endif
 
 #if ENABLE(WRITING_TOOLS)
         WebCore::WritingTools::Behavior writingToolsBehavior { WebCore::WritingTools::Behavior::Default };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -216,6 +216,11 @@ struct UIEdgeInsets;
 - (void)_webViewRecentlyAccessedGamepadsForTesting:(WKWebView *)webView WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 - (void)_webViewStoppedAccessingGamepadsForTesting:(WKWebView *)webView WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 
+#if defined(TARGET_OS_VISION) && TARGET_OS_VISION
+- (void)_webView:(WKWebView *)webView setRecentlyAccessedGamepads:(BOOL)recentlyAccessedGamepads WK_API_AVAILABLE(visionos(2.0));
+- (void)_webView:(WKWebView *)webView gamepadsConnectedStateDidChange:(BOOL)gamepadsConnected WK_API_AVAILABLE(visionos(2.0));
+#endif
+
 #if TARGET_OS_IPHONE
 
 - (BOOL)_webView:(WKWebView *)webView shouldIncludeAppLinkActionsForElement:(_WKActivatedElementInfo *)element WK_API_AVAILABLE(ios(9.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2298,11 +2298,38 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 #import <WebKitAdditions/WKWebViewAdditionsAfter.mm>
 #endif
 
-#if ENABLE(GAMEPAD) && !__has_include(<WebKitAdditions/WKWebViewAdditionsAfter+Gamepad.mm>)
+#if ENABLE(GAMEPAD)
+#if !__has_include(<WebKitAdditions/WKWebViewAdditionsAfter+Gamepad.mm>)
 - (void)_setGamepadsRecentlyAccessed:(BOOL)gamepadsRecentlyAccessed
 {
 }
 #endif
+
+#if PLATFORM(VISION)
+- (BOOL)_gamepadsConnected
+{
+    return _page->gamepadsConnected();
+}
+
+- (void)_gamepadsConnectedStateChanged
+{
+    id<WKUIDelegatePrivate> uiDelegate = (id<WKUIDelegatePrivate>)self.UIDelegate;
+    if ([uiDelegate respondsToSelector:@selector(_webView:gamepadsConnectedStateDidChange:)])
+        [uiDelegate _webView:self gamepadsConnectedStateDidChange:_page->gamepadsConnected()];
+}
+
+- (void)_setAllowGamepadsAccess
+{
+    _page->allowGamepadAccess();
+}
+
+#if !__has_include(<WebKitAdditions/WKWebViewAdditionsAfter+Gamepad.mm>)
+- (void)_setAllowGamepadsInput:(BOOL)allowGamepadsInput
+{
+}
+#endif
+#endif // PLATFORM(VISION)
+#endif // ENABLE(GAMEPAD)
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -66,6 +66,10 @@
 #import "_WKWebExtensionControllerInternal.h"
 #endif
 
+#if PLATFORM(VISION) && ENABLE(GAMEPAD)
+#import <WebCore/ShouldRequireExplicitConsentForGamepadAccess.h>
+#endif
+
 #if PLATFORM(IOS_FAMILY)
 
 _WKDragLiftDelay toDragLiftDelay(NSUInteger value)
@@ -249,6 +253,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [coder encodeBool:self._scrollToTextFragmentIndicatorEnabled forKey:@"scrollToTextFragmentIndicatorEnabled"];
     [coder encodeBool:self._scrollToTextFragmentMarkingEnabled forKey:@"scrollToTextFragmentMarkingEnabled"];
     [coder encodeBool:self._multiRepresentationHEICInsertionEnabled forKey:@"multiRepresentationHEICInsertionEnabled"];
+#if PLATFORM(VISION)
+    [coder encodeBool:self._gamepadAccessRequiresExplicitConsent forKey:@"gamepadAccessRequiresExplicitConsent"];
+#endif
 }
 
 - (instancetype)initWithCoder:(NSCoder *)coder
@@ -296,6 +303,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     self._scrollToTextFragmentIndicatorEnabled = [coder decodeBoolForKey:@"scrollToTextFragmentIndicatorEnabled"];
     self._scrollToTextFragmentMarkingEnabled = [coder decodeBoolForKey:@"scrollToTextFragmentMarkingEnabled"];
     self._multiRepresentationHEICInsertionEnabled = [coder decodeBoolForKey:@"multiRepresentationHEICInsertionEnabled"];
+#if PLATFORM(VISION)
+    self._gamepadAccessRequiresExplicitConsent = [coder decodeBoolForKey:@"gamepadAccessRequiresExplicitConsent"];
+#endif
 
     return self;
 }
@@ -1475,6 +1485,24 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
     return NO;
 #endif
 }
+
+#if PLATFORM(VISION)
+- (BOOL)_gamepadAccessRequiresExplicitConsent
+{
+#if ENABLE(GAMEPAD)
+    return _pageConfiguration->gamepadAccessRequiresExplicitConsent() == WebCore::ShouldRequireExplicitConsentForGamepadAccess::Yes;
+#else
+    return NO;
+#endif
+}
+
+- (void)_setGamepadAccessRequiresExplicitConsent:(BOOL)gamepadAccessRequiresExplicitConsent
+{
+#if ENABLE(GAMEPAD)
+    _pageConfiguration->setGamepadAccessRequiresExplicitConsent(gamepadAccessRequiresExplicitConsent ? WebCore::ShouldRequireExplicitConsentForGamepadAccess::Yes : WebCore::ShouldRequireExplicitConsentForGamepadAccess::No);
+#endif
+}
+#endif // PLATFORM(VISION)
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -175,6 +175,10 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 
 @property (nonatomic, setter=_setScrollToTextFragmentMarkingEnabled:) BOOL _scrollToTextFragmentMarkingEnabled WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 
+#if defined(TARGET_OS_VISION) && TARGET_OS_VISION
+@property (nonatomic, setter=_setGamepadAccessRequiresExplicitConsent:) BOOL _gamepadAccessRequiresExplicitConsent WK_API_AVAILABLE(visionos(2.0));
+#endif
+
 @end
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -439,6 +439,13 @@ struct PerWebProcessState {
 
 #if ENABLE(GAMEPAD)
 - (void)_setGamepadsRecentlyAccessed:(BOOL)gamepadsRecentlyAccessed;
+
+#if PLATFORM(VISION)
+@property (nonatomic, readonly) BOOL _gamepadsConnected;
+- (void)_gamepadsConnectedStateChanged;
+- (void)_setAllowGamepadsInput:(BOOL)allowGamepadsInput;
+- (void)_setAllowGamepadsAccess;
+#endif
 #endif
 
 - (WKPageRef)_pageForTesting;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -129,6 +129,9 @@ public:
 
 #if ENABLE(GAMEPAD)
     void setGamepadsRecentlyAccessed(GamepadsRecentlyAccessed) final;
+#if PLATFORM(VISION)
+    void gamepadsConnectedStateChanged() final;
+#endif
 #endif
 
     void hasActiveNowPlayingSessionChanged(bool) final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -316,6 +316,13 @@ void PageClientImplCocoa::setGamepadsRecentlyAccessed(GamepadsRecentlyAccessed g
 {
     [m_webView _setGamepadsRecentlyAccessed:(gamepadsRecentlyAccessed == GamepadsRecentlyAccessed::No) ? NO : YES];
 }
+
+#if PLATFORM(VISION)
+void PageClientImplCocoa::gamepadsConnectedStateChanged()
+{
+    [m_webView _gamepadsConnectedStateChanged];
+}
+#endif
 #endif
 
 void PageClientImplCocoa::hasActiveNowPlayingSessionChanged(bool hasActiveNowPlayingSession)

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -67,8 +67,27 @@ void UIGamepadProvider::gamepadSyncTimerFired()
         return;
 
     webPageProxy->gamepadActivity(snapshotGamepads(), m_shouldMakeGamepadsVisibleOnSync ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No);
+
+#if PLATFORM(VISION)
+    webPageProxy->setGamepadsConnected(isAnyGamepadConnected());
+#endif
+
     m_shouldMakeGamepadsVisibleOnSync = false;
 }
+
+#if PLATFORM(VISION)
+bool UIGamepadProvider::isAnyGamepadConnected() const
+{
+    bool anyGamepadConnected = false;
+    for (auto it = m_gamepads.begin(); it != m_gamepads.end(); ++it) {
+        if (*it) {
+            anyGamepadConnected = true;
+            break;
+        }
+    }
+    return anyGamepadConnected;
+}
+#endif
 
 void UIGamepadProvider::scheduleGamepadStateSync()
 {
@@ -156,12 +175,20 @@ void UIGamepadProvider::viewBecameActive(WebPageProxy& page)
     if (!m_isMonitoringGamepads)
         startMonitoringGamepads();
 
+#if PLATFORM(VISION)
+    page.setGamepadsConnected(isAnyGamepadConnected());
+#endif
+
     if (platformWebPageProxyForGamepadInput())
         platformStartMonitoringInput();
 }
 
 void UIGamepadProvider::viewBecameInactive(WebPageProxy& page)
 {
+#if PLATFORM(VISION)
+    page.setGamepadsConnected(false);
+#endif
+
     RefPtr pageForGamepadInput = platformWebPageProxyForGamepadInput();
     if (pageForGamepadInput == &page)
         platformStopMonitoringInput();

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
@@ -80,6 +80,10 @@ private:
     void scheduleGamepadStateSync();
     void gamepadSyncTimerFired();
 
+#if PLATFORM(VISION)
+    bool isAnyGamepadConnected() const;
+#endif
+
     WeakHashSet<WebProcessPool> m_processPoolsUsingGamepads;
 
     Vector<std::unique_ptr<UIGamepad>> m_gamepads;

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -787,7 +787,11 @@ public:
         Yes
     };
     virtual void setGamepadsRecentlyAccessed(GamepadsRecentlyAccessed) { }
+
+#if PLATFORM(VISION)
+    virtual void gamepadsConnectedStateChanged() { }
 #endif
+#endif // ENABLE(GAMEPAD)
 
     virtual void hasActiveNowPlayingSessionChanged(bool) { }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1922,6 +1922,11 @@ public:
 
     void gamepadActivity(const Vector<std::optional<GamepadData>>&, WebCore::EventMakesGamepadsVisible);
     void gamepadsRecentlyAccessed();
+#if PLATFORM(VISION)
+    bool gamepadsConnected() const { return m_gamepadsConnected; }
+    void setGamepadsConnected(bool);
+    void allowGamepadAccess();
+#endif
 #endif
 
     void isLoadingChanged();
@@ -3076,6 +3081,7 @@ private:
 
 #if ENABLE(GAMEPAD)
     void recentGamepadAccessStateChanged(PAL::HysteresisState);
+    void resetRecentGamepadAccessState();
 #endif
 
     void setAllowsLayoutViewportHeightExpansion(bool);
@@ -3619,6 +3625,9 @@ private:
 
 #if ENABLE(GAMEPAD)
     PAL::HysteresisActivity m_recentGamepadAccessHysteresis;
+#if PLATFORM(VISION)
+    bool m_gamepadsConnected { false };
+#endif
 #endif
 
     std::unique_ptr<WebPageProxyTesting> m_pageForTesting;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -789,6 +789,10 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     pageConfiguration.canShowWhileLocked = parameters.canShowWhileLocked;
 #endif
 
+#if PLATFORM(VISION) && ENABLE(GAMEPAD)
+    pageConfiguration.gamepadAccessRequiresExplicitConsent = parameters.gamepadAccessRequiresExplicitConsent;
+#endif
+
     m_page = Page::create(WTFMove(pageConfiguration));
 
     updateAfterDrawingAreaCreation(parameters);
@@ -8218,7 +8222,14 @@ void WebPage::gamepadsRecentlyAccessed()
     send(Messages::WebPageProxy::GamepadsRecentlyAccessed());
 }
 
+#if PLATFORM(VISION)
+void WebPage::allowGamepadAccess()
+{
+    corePage()->allowGamepadAccess();
+}
 #endif
+
+#endif // ENABLE(GAMEPAD)
 
 #if ENABLE(POINTER_LOCK)
 void WebPage::didAcquirePointerLock()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1423,6 +1423,9 @@ public:
 #if ENABLE(GAMEPAD)
     void gamepadActivity(const Vector<std::optional<GamepadData>>&, WebCore::EventMakesGamepadsVisible);
     void gamepadsRecentlyAccessed();
+#if PLATFORM(VISION)
+    void allowGamepadAccess();
+#endif
 #endif
 
 #if ENABLE(POINTER_LOCK)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -625,6 +625,9 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
 #if ENABLE(GAMEPAD)
     GamepadActivity(Vector<std::optional<WebKit::GamepadData>> gamepadDatas, enum:bool WebCore::EventMakesGamepadsVisible eventVisibility)
+#if PLATFORM(VISION)
+    AllowGamepadAccess()
+#endif
 #endif
 
     RegisterURLSchemeHandler(WebKit::WebURLSchemeHandlerIdentifier handlerIdentifier, String scheme)


### PR DESCRIPTION
#### 015450fc9083884904de9d26c87319b6b123f27f
<pre>
[visionOS] Add a mechanism to check user authorization for gamepads
<a href="https://bugs.webkit.org/show_bug.cgi?id=276842">https://bugs.webkit.org/show_bug.cgi?id=276842</a>
<a href="https://rdar.apple.com/132103378">rdar://132103378</a>

Reviewed by Brady Eidson.

Add a new gamepadAccessRequiresExplicitConsent member in page configuration
to control whether gamepad access is blocked from webpage until
-[WKWebView _setAllowGamepadsAccess:YES] is called. By default,
gamepadAccessRequiresExplicitConsent is false.

Update the logic in GamepadManager that determines when to reveal gamepads
to navigators/windows that are just registered to also consult the
page&apos;s m_gamepadAccessGranted boolean. If Page::gamepadAccessGranted() returns
false when the navigator/window is first registered with the manager, they
are first placed in a separate quarantined set, and they don&apos;t automatically
get gamepads revealed to them on new gamepad connection or gamepad activity.
They are removed from quarantine only after their pages have been explicitly
granted gamepad access.

Also, add WKUIDelegatePrivate methods to communicate gamepad
access/connection state changes.

* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::GamepadManager::findUnquarantinedNavigatorsAndWindows):
Gather all navigators/windows that are not waiting for explicit
user consent for gamepad access.
(WebCore::GamepadManager::platformGamepadConnected):
Do not notify quarantined navigators/windows of new gamepad connections.
(WebCore::GamepadManager::platformGamepadDisconnected):
Ditto for gamepad disconnections.
(WebCore::GamepadManager::registerNavigator):
Add to the quarantined set if access has not been granted.
(WebCore::GamepadManager::unregisterNavigator):
(WebCore::GamepadManager::registerDOMWindow):
Ditto for window.
(WebCore::GamepadManager::unregisterDOMWindow):
(WebCore::GamepadManager::updateQuarantineStatus):
This is called when a page&apos;s gamepad access state has changed.
It goes through the quarantined sets to see which ones are from
pages that have been granted access. Promote them to the blind
sets and remove them from the quarantined sets.
* Source/WebCore/Modules/gamepad/GamepadManager.h:
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::protectedPage const):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/Page.cpp:
(WebCore::m_activeNowPlayingSessionUpdateTimer):
(WebCore::Page::didCommitLoad):
Reset gamepad access on new page load.
(WebCore::Page::allowGamepadAccess):
If gamepad access state has changed, tell GamepadManager to update its
quarantined sets of navigators/windows.
(WebCore::Page::initializeGamepadAccessForPageLoad):
* Source/WebCore/page/Page.h:
(WebCore::Page::gamepadAccessGranted const):
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/platform/gamepad/ShouldRequireExplicitConsentForGamepadAccess.h: Added.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::gamepadAccessRequiresExplicitConsent const):
(API::PageConfiguration::setGamepadAccessRequiresExplicitConsent):
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _gamepadsConnected]):
(-[WKWebView _gamepadsConnectedStateChanged]):
(-[WKWebView _setGamepadsRecentlyAccessed:]):
(-[WKWebView _setAllowGamepadsAccess]):
(-[WKWebView _setAllowGamepadsInput:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration encodeWithCoder:]):
(-[WKWebViewConfiguration initWithCoder:]):
(-[WKWebViewConfiguration _gamepadAccessRequiresExplicitConsent]):
(-[WKWebViewConfiguration _setGamepadAccessRequiresExplicitConsent:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::gamepadsConnectedStateChanged):
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp:
(WebKit::UIGamepadProvider::gamepadSyncTimerFired):
Update the new active page&apos;s gamepads connection state.
(WebKit::UIGamepadProvider::isAnyGamepadConnected const):
Check if there&apos;s any non-null gamepad in m_gamepads.
(WebKit::UIGamepadProvider::viewBecameActive):
Update the new active page&apos;s gamepads connection state.
(WebKit::UIGamepadProvider::viewBecameInactive):
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h:
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::gamepadsConnectedStateChanged):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
Make sure we update the recent gamepad access state to false on page navigation.
(WebKit::WebPageProxy::resetStateAfterProcessExited):
Ditto.
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::resetRecentGamepadAccessState):
Besides cancelling m_recentGamepadAccessHysteresis, we need to make sure
the clients know the recent gamepad access state has been reset to false.
(WebKit::WebPageProxy::setGamepadsConnected):
Notify page client if the gamepad connection state changes.
(WebKit::WebPageProxy::allowGamepadAccess):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::allowGamepadAccess):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/281432@main">https://commits.webkit.org/281432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1136662c1e3bc1f96eecb3113772d63c5b8869be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63805 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10590 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48547 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/7274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51853 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29391 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9092 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9335 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55219 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65535 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9234 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55894 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51834 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13273 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3167 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35049 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->