### PR TITLE
Avoid surfacing invisible `pointer-events: none;` elements with a single rendered child as targets

### DIFF
--- a/LayoutTests/fast/element-targeting/targeted-element-ignores-pointer-events-none-overlay-expected.txt
+++ b/LayoutTests/fast/element-targeting/targeted-element-ignores-pointer-events-none-overlay-expected.txt
@@ -1,5 +1,6 @@
 PASS firstSelector is "DIV.box"
 PASS secondSelector is "DIV.overlay.dimmed"
+PASS thirdSelector is "DIV.bottombox"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/element-targeting/targeted-element-ignores-pointer-events-none-overlay.html
+++ b/LayoutTests/fast/element-targeting/targeted-element-ignores-pointer-events-none-overlay.html
@@ -32,6 +32,25 @@ body, html {
     pointer-events: auto;
 }
 
+.bottom {
+    position: fixed;
+    pointer-events: none;
+    bottom: 0;
+    width: 100%;
+    height: 150px;
+    text-align: center;
+}
+
+.bottombox {
+    width: 150px;
+    height: 150px;
+    border: 2px black solid;
+    box-sizing: border-box;
+    background: papayawhip;
+    margin: 0 auto;
+    pointer-events: auto;
+}
+
 .dimmed {
     pointer-events: auto;
     background-color: rgba(0, 0, 0, 0.25);
@@ -49,6 +68,9 @@ addEventListener("load", async () => {
     secondSelector = await UIHelper.adjustVisibilityForFrontmostTarget(50, 100);
     shouldBeEqualToString("secondSelector", "DIV.overlay.dimmed");
 
+    thirdSelector = await UIHelper.adjustVisibilityForFrontmostTarget(document.querySelector(".bottombox"));
+    shouldBeEqualToString("thirdSelector", "DIV.bottombox");
+
     finishJSTest();
 });
 </script>
@@ -56,6 +78,9 @@ addEventListener("load", async () => {
 <body>
 <div class="overlay">
     <div class="box"></div>
+</div>
+<div class="bottom">
+    <div class="bottombox"></div>
 </div>
 <main>
     <p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.</p>

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -999,8 +999,17 @@ Vector<TargetedElementInfo> ElementTargetingController::extractTargets(Vector<Re
         auto targetBoundingBox = target->boundingBoxInRootViewCoordinates();
         auto targetAreaRatio = computeViewportAreaRatio(targetBoundingBox);
 
-        bool shouldSkipTargetThatCoversViewport = [&] {
-            if (targetAreaRatio < minimumAreaRatioForElementToCoverViewport)
+        auto hasOneRenderedChild = [](const Element& target) {
+            CheckedPtr renderer = target.renderer();
+            if (!renderer)
+                return false;
+
+            CheckedPtr firstChild = renderer->firstChild();
+            return firstChild && firstChild == renderer->lastChild();
+        };
+
+        bool shouldSkipIrrelevantTarget = [&] {
+            if (targetAreaRatio < minimumAreaRatioForElementToCoverViewport && !hasOneRenderedChild(target))
                 return false;
 
             auto& style = targetRenderer->style();
@@ -1012,7 +1021,7 @@ Vector<TargetedElementInfo> ElementTargetingController::extractTargets(Vector<Re
                 && targetRenderer->usedPointerEvents() == PointerEvents::None;
         }();
 
-        if (shouldSkipTargetThatCoversViewport)
+        if (shouldSkipIrrelevantTarget)
             continue;
 
         bool shouldAddTarget = targetAreaRatio > 0


### PR DESCRIPTION
#### 1aa0ecbc9e1bc8f99ae9a9f6484f32d0dced128f
<pre>
Avoid surfacing invisible `pointer-events: none;` elements with a single rendered child as targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=277011">https://bugs.webkit.org/show_bug.cgi?id=277011</a>
<a href="https://rdar.apple.com/130710791">rdar://130710791</a>

Reviewed by Abrar Rahman Protyasha.

Make a small adjustment to target an only child below a fixed-position `pointer-events: none;` or a
negative `z-index` when selecting targets for remote inspection (as opposed to targeting the outer
container).

* LayoutTests/fast/element-targeting/targeted-element-ignores-pointer-events-none-overlay-expected.txt:
* LayoutTests/fast/element-targeting/targeted-element-ignores-pointer-events-none-overlay.html:
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::extractTargets):

Canonical link: <a href="https://commits.webkit.org/281311@main">https://commits.webkit.org/281311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f4cd0f2ef25376a2a8988149b66ba977ffb5938

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63381 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9977 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48272 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7006 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29097 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8727 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8913 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54901 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65113 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3394 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8915 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55614 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55722 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13175 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2821 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34625 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36794 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->