### PR TITLE
Scroll-to-text-fragment is leaked to the loaded page the fetch event for service workers.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/service-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/service-worker.js
@@ -1,0 +1,3 @@
+self.addEventListener('fetch', function(event) {
+    event.respondWith(new Response(new Blob(["<script>window.opener.postMessage('" + event.request.url + "', '*')</script>"])));
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-service-worker.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-service-worker.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Setup worker
+PASS Test navigation with service worker.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-service-worker.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-service-worker.https.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<title>Service workers text fragment directive visibility</title>
+<meta charset=utf-8>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/common/utils.js"></script>
+<script src="stash.js"></script>
+<body>
+<script>
+
+async function registerServiceWorker()
+{
+    const registration = await navigator.serviceWorker.register("resources/service-worker.js", { scope : "resources/" });
+    let activeWorker = registration.active;
+    if (activeWorker)
+        return registration;
+    activeWorker = registration.installing;
+    return new Promise(resolve => {
+        activeWorker.addEventListener('statechange', () => {
+            if (activeWorker.state === "activated")
+                resolve(registration);
+        });
+    });
+}
+
+promise_test(async (test) => {
+    registration = await registerServiceWorker();
+}, "Setup worker");
+
+promise_test(t => new Promise((resolve, reject) => {
+  test_driver.bless('Open a URL with a text fragment directive', () => {
+    window.addEventListener('message', (event) => {
+
+        assert_equals(event.data.indexOf(':~:'), -1, 'Expected fragment directive to be stripped from the URL.');
+        resolve()
+
+    }, false);
+    window.open(`resources/check-with-service-worker.html?#before_directive:~:text=should_not_be_visible_to_js`);
+  });
+}), `Test navigation with service worker.`);
+
+</script>
+</body>

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-service-worker.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-service-worker.https-expected.txt
@@ -1,0 +1,6 @@
+
+Harness Error (TIMEOUT), message = null
+
+FAIL Setup worker promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'navigator.serviceWorker.register')"
+TIMEOUT Test navigation with service worker. Test timed out
+


### PR DESCRIPTION
#### f64906be25704e04ab1782637a6815ab483563ad
<pre>
Scroll-to-text-fragment is leaked to the loaded page the fetch event for service workers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277010">https://bugs.webkit.org/show_bug.cgi?id=277010</a>
<a href="https://rdar.apple.com/130951144">rdar://130951144</a>

Reviewed by Alex Christensen.

Add a test to show that the fix in <a href="https://commits.webkit.org/281273@main">https://commits.webkit.org/281273@main</a> also fixes the
issue of the fragment being leaked via the fetch event.

* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/resources/service-worker.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-service-worker.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-service-worker.https.html: Added.

Canonical link: <a href="https://commits.webkit.org/281397@main">https://commits.webkit.org/281397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b079fa2f22a3d937d60f5ba75cd53ad89c2acd08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63653 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10261 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48445 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7172 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29297 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33171 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8965 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9184 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65384 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3665 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55787 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55923 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13249 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3044 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34896 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35979 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37065 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35724 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->