### PR TITLE
[Static Analyzer CI] Full static analyzer results are huge and unnecessary on EWS

### DIFF
--- a/Tools/Scripts/compare-static-analysis-results
+++ b/Tools/Scripts/compare-static-analysis-results
@@ -59,6 +59,13 @@ def parser():
         default=False,
         help='Compare new results to expectations (instead of a previous run)'
     )
+    parser.add_argument(
+        '--delete-results',
+        dest='delete_results',
+        action='store_true',
+        default=False,
+        help='Delete static analyzer results'
+    )
     return parser.parse_args()
 
 
@@ -147,6 +154,9 @@ def compare_project_results_to_expectations(args, new_path, project):
     if unexpected_issues_total and args.scan_build:
         create_filtered_results_dir(args, project, unexpected_result_paths_total, STATIC_ANALYZER_UNEXPECTED)
 
+    if not unexpected_buggy_files and not unexpected_clean_files and not unexpected_issues_total:
+        print('No unexpected results!')
+
     return unexpected_buggy_files, unexpected_clean_files, unexpected_issues_total, project_results_passes, project_results_failures
 
 
@@ -169,19 +179,19 @@ def compare_project_results_by_run(args, archive_path, new_path, project):
         project_results_passes[checker] = list(fixed_files)
         project_results_failures[checker] = list(new_files)
 
-        print(f'{checker}:')
+        print(f'\n{checker}:')
         if fixed_issues or fixed_files or new_issues or new_files:
             print(f'    Issues fixed: {len(fixed_issues)}')
             print(f'    Files fixed: {len(fixed_files)}')
             print(f'    Unexpected issues: {len(new_issues)}')
-            print(f'    Unexpected failing files: {len(new_files)}\n')
+            print(f'    Unexpected failing files: {len(new_files)}')
         else:
             print('    No unexpected results')
 
     if new_issues_total and args.scan_build:
         create_filtered_results_dir(args, project, new_issues_total, 'StaticAnalyzerRegressions')
 
-    return new_issues_total, new_files_total, fixed_files_total, project_results_passes, project_results_failures
+    return new_issues_total, new_files_total, fixed_files_total, fixed_issues_total, project_results_passes, project_results_failures
 
 
 def main():
@@ -189,6 +199,7 @@ def main():
     new_issues_total = set()
     new_files_total = set()
     fixed_files_total = set()
+    fixed_issues_total = set()
     unexpected_passes_total = set()
     unexpected_failures_total = set()
     unexpected_issues_total = set()
@@ -204,10 +215,11 @@ def main():
             unexpected_issues_total.update(unexpected_issues)
         else:
             archive_path = os.path.abspath(f'{args.archived_dir}/{project}')
-            new_issues, new_files, fixed_files, project_results_passes, project_results_failures = compare_project_results_by_run(args, archive_path, new_path, project)
+            new_issues, new_files, fixed_files, fixed_issues, project_results_passes, project_results_failures = compare_project_results_by_run(args, archive_path, new_path, project)
             new_issues_total.update(new_issues)
             new_files_total.update(new_files)
             fixed_files_total.update(fixed_files)
+            fixed_issues_total.update(fixed_issues)
         # JSON
         unexpected_results_data['passes'][project] = project_results_passes
         unexpected_results_data['failures'][project] = project_results_failures
@@ -222,12 +234,19 @@ def main():
         'new issues': new_issues_total,
         'new files': new_files_total,
         'fixed files': fixed_files_total,
+        'fixed issues': fixed_issues_total,
         'unexpected failing files': unexpected_failures_total,
         'unexpected passing files': unexpected_passes_total,
         'unexpected issues': unexpected_issues_total
     }.items():
         if type_total:
             print(f'Total {type}: {len(type_total)}')
+
+    # We don't need the full results for EWS runs. Delete full results if option enabled.
+    if args.delete_results:
+        path_to_delete = os.path.abspath(f'{args.build_output}/StaticAnalyzer')
+        print(f'\nDeleting results from {path_to_delete}...')
+        subprocess.run(['rm', '-r', path_to_delete])
 
     return 0
 


### PR DESCRIPTION
#### 91425aded2bbb30be1560b0ee60668625d42bcff
<pre>
[Static Analyzer CI] Full static analyzer results are huge and unnecessary on EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=277015">https://bugs.webkit.org/show_bug.cgi?id=277015</a>
<a href="https://rdar.apple.com/132414285">rdar://132414285</a>

Reviewed by Ryan Haddad.

Add an option to compare-static-analysis-results that automatically deletes
the full results (and keeps the unexpected results) so they are not archived.

* Tools/Scripts/compare-static-analysis-results:
(parser):
(compare_project_results_to_expectations):
(compare_project_results_by_run):
(main):

Canonical link: <a href="https://commits.webkit.org/281303@main">https://commits.webkit.org/281303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d8cb8df2e347b1c293ed4ea07cc24137131befa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59473 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/38817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/11995 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/63388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/9984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/61602 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/46471 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/10148 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/63388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/9984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/61503 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/46471 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/11995 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/63388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/46471 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/11995 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/8920 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/46471 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/11995 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/65120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/3401 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/10148 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/65120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/3412 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/11995 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/65120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8877 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/34632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/36801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->