### PR TITLE
Update Web Extension tabs API based on feedback.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionCommand.h
@@ -42,7 +42,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  web content. These commands enhance the functionality of the extension by allowing users to invoke actions quickly.
  */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(WKWebExtension.Command)
+WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(_WKWebExtension.Command)
 @interface _WKWebExtensionCommand : NSObject
 
 + (instancetype)new NS_UNAVAILABLE;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -787,9 +787,6 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
     if (properties == _WKWebExtensionTabChangedPropertiesNone)
         return { };
 
-    if (properties == _WKWebExtensionTabChangedPropertiesAll)
-        return WebKit::WebExtensionTab::allChangedProperties();
-
     OptionSet<WebKit::WebExtensionTab::ChangedProperties> result;
 
     if (properties & _WKWebExtensionTabChangedPropertiesAudible)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
@@ -116,6 +116,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  */
 - (BOOL)isUsingPrivateBrowsingForWebExtensionContext:(_WKWebExtensionContext *)context;
 
+#if TARGET_OS_OSX
 /*!
  @abstract Called when the screen frame containing the window is needed.
  @param context The context associated with the running web extension.
@@ -123,6 +124,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @discussion Defaults to `CGRectNull` if not implemented.
  */
 - (CGRect)screenFrameForWebExtensionContext:(_WKWebExtensionContext *)context;
+#endif // TARGET_OS_OSX
 
 /*!
  @abstract Called when the frame of the window is needed.

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -330,10 +330,7 @@ void WebExtensionContext::tabsReload(WebPageProxyIdentifier webPageProxyIdentifi
         return;
     }
 
-    if (reloadFromOrigin == ReloadFromOrigin::Yes)
-        tab->reloadFromOrigin(WTFMove(completionHandler));
-    else
-        tab->reload(WTFMove(completionHandler));
+    tab->reload(reloadFromOrigin, WTFMove(completionHandler));
 }
 
 void WebExtensionContext::tabsGoBack(WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
@@ -54,7 +54,9 @@ WebExtensionWindow::WebExtensionWindow(const WebExtensionContext& context, _WKWe
     , m_respondsToIsUsingPrivateBrowsing([delegate respondsToSelector:@selector(isUsingPrivateBrowsingForWebExtensionContext:)])
     , m_respondsToFrame([delegate respondsToSelector:@selector(frameForWebExtensionContext:)])
     , m_respondsToSetFrame([delegate respondsToSelector:@selector(setFrame:forWebExtensionContext:completionHandler:)])
+#if PLATFORM(MAC)
     , m_respondsToScreenFrame([delegate respondsToSelector:@selector(screenFrameForWebExtensionContext:)])
+#endif
     , m_respondsToFocus([delegate respondsToSelector:@selector(focusForWebExtensionContext:completionHandler:)])
     , m_respondsToClose([delegate respondsToSelector:@selector(closeForWebExtensionContext:completionHandler:)])
 {
@@ -413,6 +415,7 @@ void WebExtensionWindow::setFrame(CGRect frame, CompletionHandler<void(Expected<
     }).get()];
 }
 
+#if PLATFORM(MAC)
 CGRect WebExtensionWindow::screenFrame() const
 {
     if (!isValid() || !m_respondsToScreenFrame)
@@ -420,6 +423,7 @@ CGRect WebExtensionWindow::screenFrame() const
 
     return CGRectStandardize([m_delegate screenFrameForWebExtensionContext:m_extensionContext->wrapper()]);
 }
+#endif
 
 void WebExtensionWindow::close(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -214,9 +214,10 @@ public:
     using TabIdentifierWebViewPair = std::pair<WebExtensionTabIdentifier, RetainPtr<WKWebView>>;
 #endif
 
+    using ReloadFromOrigin = WebExtensionTab::ReloadFromOrigin;
+
     enum class EqualityOnly : bool { No, Yes };
     enum class WindowIsClosing : bool { No, Yes };
-    enum class ReloadFromOrigin : bool { No, Yes };
     enum class UserTriggered : bool { No, Yes };
     enum class SuppressEvents : bool { No, Yes };
     enum class UpdateWindowOrder : bool { No, Yes };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -98,6 +98,7 @@ public:
     using ImageFormat = WebExtensionTabImageFormat;
 
     enum class AssumeWindowMatches : bool { No, Yes };
+    enum class ReloadFromOrigin : bool { No, Yes };
 
     using WebProcessProxySet = HashSet<Ref<WebProcessProxy>>;
 
@@ -138,25 +139,28 @@ public:
     void didOpen() { ASSERT(!m_isOpen); m_isOpen = true; }
     void didClose() { ASSERT(m_isOpen); m_isOpen = false; }
 
-    bool isActive() const;
-    bool isSelected() const;
     bool isPrivate() const;
 
-    void pin(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
-    void unpin(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
-
     bool isPinned() const;
+    void setPinned(bool, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
-    void toggleReaderMode(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void pin(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler) { setPinned(true, WTFMove(completionHandler)); }
+    void unpin(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler) { setPinned(false, WTFMove(completionHandler)); }
 
     bool isReaderModeAvailable() const;
-    bool isShowingReaderMode() const;
 
-    void mute(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
-    void unmute(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    bool isReaderModeShowing() const;
+    void setReaderModeShowing(bool, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+
+    void toggleReaderMode(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler) { setReaderModeShowing(!isReaderModeShowing(), WTFMove(completionHandler)); }
 
     bool isAudible() const;
+
     bool isMuted() const;
+    void setMuted(bool, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+
+    void mute(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler) { setMuted(true, WTFMove(completionHandler)); }
+    void unmute(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler) { setMuted(false, WTFMove(completionHandler)); }
 
     CGSize size() const;
 
@@ -173,15 +177,19 @@ public:
 
     void loadURL(URL, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
-    void reload(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
-    void reloadFromOrigin(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void reload(ReloadFromOrigin, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
     void goBack(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
     void goForward(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
+    bool isActive() const;
     void activate(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
-    void select(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
-    void deselect(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+
+    bool isSelected() const;
+    void setSelected(bool, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+
+    void select(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler) { setSelected(true, WTFMove(completionHandler)); }
+    void deselect(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler) { setSelected(false, WTFMove(completionHandler)); }
 
     void duplicate(const WebExtensionTabParameters&, CompletionHandler<void(Expected<RefPtr<WebExtensionTab>, WebExtensionError>&&)>&&);
 
@@ -211,34 +219,30 @@ private:
     bool m_respondsToParentTab : 1 { false };
     bool m_respondsToSetParentTab : 1 { false };
     bool m_respondsToMainWebView : 1 { false };
-    bool m_respondsToTabTitle : 1 { false };
-    bool m_respondsToIsSelected : 1 { false };
+    bool m_respondsToTitle : 1 { false };
     bool m_respondsToIsPinned : 1 { false };
-    bool m_respondsToPin : 1 { false };
-    bool m_respondsToUnpin : 1 { false };
+    bool m_respondsToSetPinned : 1 { false };
     bool m_respondsToIsReaderModeAvailable : 1 { false };
-    bool m_respondsToIsShowingReaderMode : 1 { false };
-    bool m_respondsToToggleReaderMode : 1 { false };
+    bool m_respondsToIsReaderModeShowing : 1 { false };
+    bool m_respondsToSetReaderModeShowing : 1 { false };
     bool m_respondsToIsAudible : 1 { false };
     bool m_respondsToIsMuted : 1 { false };
-    bool m_respondsToMute : 1 { false };
-    bool m_respondsToUnmute : 1 { false };
+    bool m_respondsToSetMuted : 1 { false };
     bool m_respondsToSize : 1 { false };
     bool m_respondsToZoomFactor : 1 { false };
     bool m_respondsToSetZoomFactor : 1 { false };
     bool m_respondsToURL : 1 { false };
     bool m_respondsToPendingURL : 1 { false };
     bool m_respondsToIsLoadingComplete : 1 { false };
-    bool m_respondsToDetectWebpageLocale : 1 { false };
-    bool m_respondsToCaptureVisibleWebpage : 1 { false };
+    bool m_respondsToWebpageLocale : 1 { false };
+    bool m_respondsToTakeSnapshot : 1 { false };
     bool m_respondsToLoadURL : 1 { false };
     bool m_respondsToReload : 1 { false };
-    bool m_respondsToReloadFromOrigin : 1 { false };
     bool m_respondsToGoBack : 1 { false };
     bool m_respondsToGoForward : 1 { false };
     bool m_respondsToActivate : 1 { false };
-    bool m_respondsToSelect : 1 { false };
-    bool m_respondsToDeselect : 1 { false };
+    bool m_respondsToIsSelected : 1 { false };
+    bool m_respondsToSetSelected : 1 { false };
     bool m_respondsToDuplicate : 1 { false };
     bool m_respondsToClose : 1 { false };
     bool m_respondsToShouldGrantTabPermissionsOnUserGesture : 1 { false };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -129,7 +129,9 @@ public:
     CGRect frame() const;
     void setFrame(CGRect, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
+#if PLATFORM(MAC)
     CGRect screenFrame() const;
+#endif
 
     void close(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -830,7 +830,7 @@ TEST(WKWebExtensionAPITabs, ToggleReaderMode)
 
     __block size_t toggleReaderModeCounter = 0;
 
-    manager.get().defaultTab.toggleReaderMode = ^{
+    manager.get().defaultTab.setReaderModeShowing = ^(BOOL showing) {
         ++toggleReaderModeCounter;
     };
 
@@ -865,7 +865,7 @@ TEST(WKWebExtensionAPITabs, DetectLanguage)
 
     __block bool detectWebpageLocaleCalled = false;
 
-    manager.get().defaultTab.detectWebpageLocale = ^{
+    manager.get().defaultTab.webpageLocale = ^{
         detectWebpageLocaleCalled = true;
         return [NSLocale localeWithLocaleIdentifier:@"en-US"];
     };
@@ -915,12 +915,11 @@ TEST(WKWebExtensionAPITabs, Reload)
     __block bool reloadCalled = false;
     __block bool reloadFromOriginCalled = false;
 
-    manager.get().defaultTab.reload = ^{
-        reloadCalled = true;
-    };
-
-    manager.get().defaultTab.reloadFromOrigin = ^{
-        reloadFromOriginCalled = true;
+    manager.get().defaultTab.reload = ^(BOOL fromOrigin) {
+        if (fromOrigin)
+            reloadFromOriginCalled = true;
+        else
+            reloadCalled = true;
     };
 
     [manager loadAndRun];

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -86,11 +86,10 @@
 @property (nonatomic, getter=isSelected) bool selected;
 @property (nonatomic, getter=isShowingReaderMode) bool showingReaderMode;
 
-@property (nonatomic, copy) void (^toggleReaderMode)(void);
-@property (nonatomic, copy) NSLocale *(^detectWebpageLocale)(void);
+@property (nonatomic, copy) void (^setReaderModeShowing)(BOOL);
+@property (nonatomic, copy) NSLocale *(^webpageLocale)(void);
 
-@property (nonatomic, copy) void (^reload)(void);
-@property (nonatomic, copy) void (^reloadFromOrigin)(void);
+@property (nonatomic, copy) void (^reload)(BOOL);
 @property (nonatomic, copy) void (^goBack)(void);
 @property (nonatomic, copy) void (^goForward)(void);
 @property (nonatomic, copy) void (^duplicate)(_WKWebExtensionTabCreationOptions *, void (^completionHandler)(TestWebExtensionTab *, NSError *));


### PR DESCRIPTION
#### 442841bf92b4e7def4d5edbf6006afe26c5dd9ff
<pre>
Update Web Extension tabs API based on feedback.
<a href="https://webkit.org/b/277019">https://webkit.org/b/277019</a>
<a href="https://rdar.apple.com/problem/132419218">rdar://problem/132419218</a>

Reviewed by Brian Weinstein.

Revise several `_WKWebExtensionTab` protocol methods to have a single setter instead of two.
This simplifies the client’s code and reduces the likelihood of forgetting to implement both
true and false states for features like pin, mute, reader mode, and select.

To ensure future-proofing, I changed the `captureVisibleWebpage` method to `takeSnapshot` and
pass along the `WKSnapshotConfiguration`. This allows Web Extensions to have different options
in the future without requiring additional changes.

Additionally, I reduced the reload methods to one with a parameter for fromOrigin, and I
removed the “detect” keyword from `detectWebpageLocale`.

Finally, `_WKWebExtensionTabChangedPropertiesAll` has been removed since it is not future proof
and dangerous if more properties are added later.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(toImpl):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsReload):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::WebExtensionTab):
(WebKit::WebExtensionTab::parameters const):
(WebKit::WebExtensionTab::changedParameters const):
(WebKit::WebExtensionTab::title const):
(WebKit::WebExtensionTab::setPinned):
(WebKit::WebExtensionTab::setReaderModeShowing):
(WebKit::WebExtensionTab::isReaderModeShowing const):
(WebKit::WebExtensionTab::setMuted):
(WebKit::WebExtensionTab::detectWebpageLocale):
(WebKit::WebExtensionTab::captureVisibleWebpage):
(WebKit::WebExtensionTab::reload):
(WebKit::WebExtensionTab::setSelected):
(WebKit::WebExtensionTab::pin): Deleted.
(WebKit::WebExtensionTab::unpin): Deleted.
(WebKit::WebExtensionTab::toggleReaderMode): Deleted.
(WebKit::WebExtensionTab::isShowingReaderMode const): Deleted.
(WebKit::WebExtensionTab::mute): Deleted.
(WebKit::WebExtensionTab::unmute): Deleted.
(WebKit::WebExtensionTab::reloadFromOrigin): Deleted.
(WebKit::WebExtensionTab::select): Deleted.
(WebKit::WebExtensionTab::deselect): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::WebExtensionWindow::WebExtensionWindow):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
(WebKit::WebExtensionTab::pin):
(WebKit::WebExtensionTab::unpin):
(WebKit::WebExtensionTab::toggleReaderMode):
(WebKit::WebExtensionTab::mute):
(WebKit::WebExtensionTab::unmute):
(WebKit::WebExtensionTab::select):
(WebKit::WebExtensionTab::deselect):
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, ToggleReaderMode)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, DetectLanguage)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, Reload)):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionTab isReaderModeShowingForWebExtensionContext:]):
(-[TestWebExtensionTab setReaderModeShowing:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab webpageLocaleForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab reloadForWebExtensionContext:fromOrigin:completionHandler:]):
(-[TestWebExtensionTab setPinned:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab setMuted:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab setSelected:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab isShowingReaderModeForWebExtensionContext:]): Deleted.
(-[TestWebExtensionTab toggleReaderModeForWebExtensionContext:completionHandler:]): Deleted.
(-[TestWebExtensionTab detectWebpageLocaleForWebExtensionContext:completionHandler:]): Deleted.
(-[TestWebExtensionTab reloadForWebExtensionContext:completionHandler:]): Deleted.
(-[TestWebExtensionTab reloadFromOriginForWebExtensionContext:completionHandler:]): Deleted.
(-[TestWebExtensionTab pinForWebExtensionContext:completionHandler:]): Deleted.
(-[TestWebExtensionTab unpinForWebExtensionContext:completionHandler:]): Deleted.
(-[TestWebExtensionTab muteForWebExtensionContext:completionHandler:]): Deleted.
(-[TestWebExtensionTab unmuteForWebExtensionContext:completionHandler:]): Deleted.
(-[TestWebExtensionTab selectForWebExtensionContext:completionHandler:]): Deleted.
(-[TestWebExtensionTab deselectForWebExtensionContext:completionHandler:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/281355@main">https://commits.webkit.org/281355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ade7957d584e2c1c01a917f0d31d4188b01a20a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63555 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/10163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10317 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/10163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61669 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/36382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/51627 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33085 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8875 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/9086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/9153 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/65286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3567 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/65286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51616 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/65286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2957 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8905 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/34798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/36967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->