### PR TITLE
Add missing null-check of cues in TextTrack::didMoveToNewDocument

### DIFF
--- a/LayoutTests/media/remove-from-document-with-text-track-expected.txt
+++ b/LayoutTests/media/remove-from-document-with-text-track-expected.txt
@@ -1,0 +1,10 @@
+Test that removing a media element with an empty text track from the DOM and reinserting it does not crash.
+
+RUN(track = video.addTextTrack('subtitles', 'English', 'en'))
+RUN(video.src = findMediaFile('video', 'content/test'))
+EVENT(playing)
+EXPECTED (track.cues.length == '0') OK
+RUN(document.body.removeChild(video))
+RUN(document.body.appendChild(video))
+END OF TEST
+

--- a/LayoutTests/media/remove-from-document-with-text-track.html
+++ b/LayoutTests/media/remove-from-document-with-text-track.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="media-file.js"></script>
+        <script src="video-test.js"></script>
+        <script>
+
+            window.addEventListener('load', async event => {
+
+                video = document.querySelector('video');
+                run(`track = video.addTextTrack('subtitles', 'English', 'en')`);
+                run(`video.src = findMediaFile('video', 'content/test')`);
+
+                await waitFor(video, 'playing');
+                testExpected('track.cues.length', 0);
+                await sleepFor(100);
+                
+                run(`document.body.removeChild(video)`);
+                await sleepFor(100);
+                run(`document.body.appendChild(video)`);
+                
+                endTest();
+            });
+    </script>
+</head>
+<body>
+    <p>Test that removing a media element with an empty text track from the DOM and reinserting it does not crash.</p>
+    <video controls autoplay></video>
+</body>
+</html>

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -151,7 +151,8 @@ void TextTrack::didMoveToNewDocument(Document& newDocument)
 {
     TrackBase::didMoveToNewDocument(newDocument);
     ActiveDOMObject::didMoveToNewDocument(newDocument);
-    protectedCues()->didMoveToNewDocument(newDocument);
+    if (RefPtr cues = protectedCues())
+        cues->didMoveToNewDocument(newDocument);
 }
 
 TextTrackList* TextTrack::textTrackList() const


### PR DESCRIPTION
#### 138f982ba57377628c7c0cb28972f1bbfc8013a1
<pre>
Add missing null-check of cues in TextTrack::didMoveToNewDocument
<a href="https://bugs.webkit.org/show_bug.cgi?id=277021">https://bugs.webkit.org/show_bug.cgi?id=277021</a>
<a href="https://rdar.apple.com/132386816">rdar://132386816</a>

Reviewed by Wenson Hsieh and Ryosuke Niwa.

Don&apos;t call TextTrackCueList::didMoveToNewDocument if there are is no cue list.

* LayoutTests/media/remove-from-document-with-text-track-expected.txt: Added.
* LayoutTests/media/remove-from-document-with-text-track.html: Added.
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::didMoveToNewDocument):

Canonical link: <a href="https://commits.webkit.org/281320@main">https://commits.webkit.org/281320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9bbe366cf7c2cfa50a874eafbfbee49a71dc816

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63412 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10172 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48289 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7024 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29119 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8750 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8944 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65144 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3425 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55632 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55741 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13185 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2852 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34656 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->