### PR TITLE
[tvOS] Add a scrubber bar to media controls

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
@@ -242,11 +242,17 @@ class TimeControl extends LayoutItem
             return this.width;
         })();
 
+        if (this._timeLabelsAttachment == TimeControl.TimeLabelsAttachment.Below)
+            this.elapsedTimeLabel.y = this.scrubber.height;
+
         durationOrRemainingTimeLabel.x = (() => {
             if (this._timeLabelsDisplayOnScrubberSide)
                 return this.scrubber.x + this.scrubber.width + scrubberMargin;
             return this.width - durationOrRemainingTimeLabel.width;
         })();
+
+        if (this._timeLabelsAttachment == TimeControl.TimeLabelsAttachment.Below)
+            durationOrRemainingTimeLabel.y = this.scrubber.height;
 
         this.children = [this._loading ? this.activityIndicator : this.elapsedTimeLabel, this.scrubber, durationOrRemainingTimeLabel];
     }
@@ -260,5 +266,6 @@ class TimeControl extends LayoutItem
 
 TimeControl.TimeLabelsAttachment = {
     Above: 1 << 0,
-    Side:  1 << 1
+    Side:  1 << 1,
+    Below: 1 << 2
 };

--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
@@ -32,8 +32,9 @@
 }
 
 .media-controls.fullscreen.tvos > .controls-bar {
-    --tvos-controls-top-margin: 32px;
     --tvos-controls-horizontal-margin: 24px;
+    --tvos-controls-vertical-margin: 32px;
+    --tvos-controls-bar-height: 56px;
 }
 
 .media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction > .controls-bar.top-left,
@@ -41,7 +42,7 @@
     position: absolute;
     left: var(--tvos-controls-horizontal-margin);
     right: auto;
-    top: var(--tvos-controls-top-margin);
+    top: var(--tvos-controls-vertical-margin);
 }
 
 .media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction > .controls-bar.top-right,
@@ -49,12 +50,19 @@
     position: absolute;
     left: auto;
     right: var(--tvos-controls-horizontal-margin);
-    top: var(--tvos-controls-top-margin);
+    top: var(--tvos-controls-vertical-margin);
 }
 
-.media-controls.fullscreen.tvos > .controls-bar.center {
+.media-controls.fullscreen.tvos > .controls-bar.bottom {
     position: absolute;
-    top: 50%;
+    bottom: var(--tvos-controls-vertical-margin);
+    left: var(--tvos-controls-horizontal-margin);
+    right: var(--tvos-controls-horizontal-margin);
+    height: var(--tvos-controls-bar-height);
+}
+
+.media-controls.fullscreen.tvos > .controls-bar.bottom > .buttons-container {
+    position: absolute;
     left: 50%;
-    transform: translate(-50%, -50%);
+    transform: translate(-50%);
 }

--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js
@@ -26,9 +26,10 @@
 class TVOSMediaControls extends MediaControls
 {
     static topButtonsScaleFactor = 1;
-    static backForwardButtonScaleFactor = 2;
-    static playPauseButtonScaleFactor = 3;
-    static centerControlsBarButtonMargin = 48;
+    static backForwardButtonScaleFactor = 1;
+    static playPauseButtonScaleFactor = 2;
+    static bottomControlsBarButtonMargin = 48;
+    static bottomControlsBarMargin = 24;
 
     constructor(options = {})
     {
@@ -39,6 +40,10 @@ class TVOSMediaControls extends MediaControls
         this.element.classList.add("fullscreen");
         this.element.classList.add("tvos");
 
+        this.timeControl.scrubber.allowsRelativeScrubbing = true;
+        this.timeControl.scrubber.knobStyle = Slider.KnobStyle.None;
+        this.timeControl.timeLabelsAttachment = TimeControl.TimeLabelsAttachment.Below;
+
         this.skipBackButton = new SkipBackButton(this);
         this.skipForwardButton = new SkipForwardButton(this);
         
@@ -48,8 +53,8 @@ class TVOSMediaControls extends MediaControls
         this.topRightControlsBar = new ControlsBar("top-right");
         this._topRightControlsBarContainer = this.topRightControlsBar.addChild(new ButtonsContainer);
 
-        this.centerControlsBar = new ControlsBar("center");
-        this._centerControlsBarContainer = this.centerControlsBar.addChild(new ButtonsContainer);
+        this.bottomControlsBar.addChild(this.timeControl);
+        this._bottomControlsBarContainer = this.bottomControlsBar.addChild(new ButtonsContainer);
 
         this.showsStartButton = false;
 
@@ -83,19 +88,25 @@ class TVOSMediaControls extends MediaControls
         this._topRightControlsBarContainer.children = this._topRightContainerButtons();
         this._topRightControlsBarContainer.layout();
 
-        this._centerControlsBarContainer.children = this._centerContainerButtons();
-        this._centerControlsBarContainer.buttonMargin = TVOSMediaControls.centerControlsBarButtonMargin;
-        this._centerControlsBarContainer.layout();
+        this._bottomControlsBarContainer.children = this._bottomContainerButtons();
+        this._bottomControlsBarContainer.buttonMargin = TVOSMediaControls.bottomControlsBarButtonMargin;
+        this._bottomControlsBarContainer.layout();
 
-        this.topLeftControlsBar.with = this._topLeftControlsBarContainer.width;
+        this.topLeftControlsBar.hasBackgroundTint = false;
+        this.topRightControlsBar.hasBackgroundTint = false;
+        this.bottomControlsBar.hasBackgroundTint = false;
+
+        this.topLeftControlsBar.width = this._topLeftControlsBarContainer.width;
         this.topRightControlsBar.width = this._topRightControlsBarContainer.width;
-        this.centerControlsBar.width = this._centerControlsBarContainer.width;
-        
+        this.bottomControlsBar.width = this.width - 2 * TVOSMediaControls.bottomControlsBarMargin;
+
+        this.timeControl.width = this.bottomControlsBar.width;
+
         this.topLeftControlsBar.visible = this._topLeftControlsBarContainer.children.some(button => button.visible);
         this.topRightControlsBar.visible = this._topRightControlsBarContainer.children.some(button => button.visible);
-        this.centerControlsBar.visible = this._centerControlsBarContainer.children.some(button => button.visible);
+        this.bottomControlsBar.visible = true;
 
-        this.children = [this.topLeftControlsBar, this.topRightControlsBar, this.centerControlsBar];
+        this.children = [this.topLeftControlsBar, this.topRightControlsBar, this.bottomControlsBar];
     }
 
     // Private
@@ -114,7 +125,7 @@ class TVOSMediaControls extends MediaControls
         return [this.fullscreenButton];
     }
 
-    _centerContainerButtons()
+    _bottomContainerButtons()
     {
         return [this.skipBackButton, this.playPauseButton, this.skipForwardButton];
     }


### PR DESCRIPTION
#### 700d10c33417fbc5cf21cc0c0ea93a2d5652be2d
<pre>
[tvOS] Add a scrubber bar to media controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=277025">https://bugs.webkit.org/show_bug.cgi?id=277025</a>
<a href="https://rdar.apple.com/132426889">rdar://132426889</a>

Reviewed by Eric Carlson.

Moved the play/pause and seek back/forward buttons to the bottom and added an interactive scrubber
bar above these controls. Added an option to TimeControl to render the elapsed/remaining time
labels below the scrubber.

* Source/WebCore/Modules/modern-media-controls/controls/time-control.js:
(TimeControl.prototype._performIdealLayout):
* Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css:
(.media-controls.fullscreen.tvos &gt; .controls-bar):
(.media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction &gt; .controls-bar.top-left,):
(.media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction &gt; .controls-bar.top-right,):
(.media-controls.fullscreen.tvos &gt; .controls-bar.bottom):
(.media-controls.fullscreen.tvos &gt; .controls-bar.bottom &gt; .buttons-container):
(.media-controls.fullscreen.tvos &gt; .controls-bar.center): Deleted.
* Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js:
(TVOSMediaControls.prototype.layout):
(TVOSMediaControls.prototype._centerContainerButtons): Deleted.

Canonical link: <a href="https://commits.webkit.org/281327@main">https://commits.webkit.org/281327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7f5791a07dae5895f88cf1749260798e8036fbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63422 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10018 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48298 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7030 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29128 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8766 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8954 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65154 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3435 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8944 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55640 "Found 1 new test failure: fast/css/text-overflow-input.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55751 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13194 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2857 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34666 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35749 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->