### PR TITLE
[WebGPU] PresentationContextIOSurface::present doesn't check for valid device

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277035-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277035-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-277035.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-277035.html
@@ -1,0 +1,5626 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ */
+function pseudoSubmit(device) {
+  for (let i = 0; i < 63; i++) {
+    device.createCommandEncoder();
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  label: '\u4860\u{1ff2d}\u0147\u{1fa91}',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 4,
+    maxColorAttachmentBytesPerSample: 45,
+    maxVertexAttributes: 18,
+    maxVertexBufferArrayStride: 45434,
+    maxStorageTexturesPerShaderStage: 5,
+    maxStorageBuffersPerShaderStage: 28,
+    maxDynamicStorageBuffersPerPipelineLayout: 65239,
+    maxDynamicUniformBuffersPerPipelineLayout: 38362,
+    maxBindingsPerBindGroup: 7670,
+    maxTextureArrayLayers: 793,
+    maxTextureDimension1D: 14728,
+    maxTextureDimension2D: 15163,
+    maxBindGroupsPlusVertexBuffers: 25,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 35992523,
+    maxStorageBufferBindingSize: 170485015,
+    maxUniformBuffersPerShaderStage: 24,
+    maxSampledTexturesPerShaderStage: 20,
+    maxInterStageShaderVariables: 42,
+    maxInterStageShaderComponents: 86,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+try {
+device0.queue.submit([]);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let commandEncoder0 = device0.createCommandEncoder({label: '\u0c87\u4fef\u2422\u638e\u{1ffec}\u0d67\ua0e2\u{1fafe}\u5e6d\u{1fefb}'});
+let texture0 = device0.createTexture({
+  label: '\ufaf3\u00c9\u6cc6\u42f9\u6c2e\u02a8\u4cce\ucb14',
+  size: [1296, 60, 41],
+  mipLevelCount: 11,
+  sampleCount: 1,
+  format: 'astc-12x10-unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView0 = texture0.createView({
+  label: '\ud69e\u{1fc85}\u{1fc6f}\u3b4e\u3a90\u2221\u644b\uc6cb\u0e8a',
+  format: 'astc-12x10-unorm',
+  baseMipLevel: 4,
+  mipLevelCount: 6,
+  baseArrayLayer: 7,
+  arrayLayerCount: 12,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 1,
+  origin: {x: 216, y: 0, z: 2},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(80)), /* required buffer size: 1_036_983 */
+{offset: 973, bytesPerRow: 274, rowsPerImage: 270}, {width: 12, height: 20, depthOrArrayLayers: 15});
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(1628778556, 2139758447);
+let video0 = await videoWithData();
+let texture1 = device0.createTexture({
+  label: '\u34b1\u0152\u{1f93e}',
+  size: {width: 640, height: 64, depthOrArrayLayers: 302},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView1 = texture0.createView({dimension: '2d', baseMipLevel: 9, baseArrayLayer: 35});
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+try {
+  await device0.popErrorScope();
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 2850});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let canvas1 = document.createElement('canvas');
+let querySet1 = device0.createQuerySet({label: '\u{1f845}\u{1f812}\u{1f6bf}\u09e3\ufc82\uaf29\u0ecc', type: 'occlusion', count: 338});
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.STORAGE_BINDING, colorSpace: 'srgb'});
+} catch {}
+let videoFrame0 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let textureView2 = texture0.createView({
+  label: '\u08f3\u{1ff8e}\u8259\u0c3b\u{1f6d1}\u05ca',
+  baseMipLevel: 5,
+  mipLevelCount: 4,
+  baseArrayLayer: 12,
+  arrayLayerCount: 20,
+});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\uea89\u2291\u{1f892}\ue403'});
+let offscreenCanvas1 = new OffscreenCanvas(165, 394);
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  label: '\u{1fc8b}\u912f\u2be0\u5333\ud46a',
+  entries: [{binding: 5545, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u0fca\ue3c1\u4f80\u{1f982}\ud88c\u5814\u03dc\u096a\u6c9d\u0dd0\u{1f9bd}',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let commandEncoder1 = device0.createCommandEncoder({label: '\u{1f62a}\u2f4f\u{1fd73}\u{1fad3}\u0d1d'});
+let commandBuffer0 = commandEncoder1.finish({label: '\u23b2\ua964\ua35e\u0851\u6750\u425c\u{1fc82}'});
+let texture2 = device0.createTexture({
+  label: '\u0966\u054b\u73a1\u{1fa6e}\u0283\ueb06\u{1fc8b}\uf6d1',
+  size: [324, 15, 138],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture3 = gpuCanvasContext0.getCurrentTexture();
+let textureView3 = texture3.createView({
+  label: '\ub495\u0305\u90c5\u{1ff3c}\u{1fbe0}\u{1fb69}\u92ff\u{1fbdb}\u8859',
+  dimension: '2d-array',
+  format: 'bgra8unorm',
+});
+let textureView4 = texture0.createView({
+  label: '\u{1f995}\u885c\u{1f863}\u{1f9aa}\u{1f9a6}\u112b\u{1fb54}\u81b8\udab3\u00d7',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 40,
+});
+let promise0 = device0.queue.onSubmittedWorkDone();
+let shaderModule0 = device0.createShaderModule({
+  label: '\ub946\u09fd\u1be3\u3f4d\u0c64\u{1fcb5}\u0cb2\ud8e8\u{1ff6d}\ubf1b',
+  code: `@group(1) @binding(5545)
+var<storage, read_write> field0: array<u32>;
+@group(2) @binding(5545)
+var<storage, read_write> type0: array<u32>;
+
+@compute @workgroup_size(2, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+  @location(25) f0: vec4<u32>,
+  @location(12) f1: f16,
+  @location(27) f2: vec2<i32>,
+  @location(11) f3: f16,
+  @location(21) f4: vec2<f32>,
+  @location(14) f5: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec3<i32>,
+  @location(1) f1: vec4<u32>,
+  @location(4) f2: vec4<u32>,
+  @location(6) f3: vec4<f32>,
+  @location(3) f4: vec4<i32>,
+  @location(5) f5: vec3<f32>,
+  @location(0) f6: vec2<u32>
+}
+
+@fragment
+fn fragment0(a0: S1, @location(7) a1: vec3<u32>, @location(19) a2: vec2<f32>, @location(9) a3: i32, @location(39) a4: vec4<f16>, @location(20) a5: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(2) f0: vec2<f16>,
+  @location(17) f1: f32
+}
+struct VertexOutput0 {
+  @location(37) f0: vec2<f16>,
+  @location(14) f1: vec4<f16>,
+  @location(19) f2: vec2<f32>,
+  @location(22) f3: vec2<i32>,
+  @location(21) f4: vec2<f32>,
+  @location(28) f5: f32,
+  @location(11) f6: f16,
+  @location(7) f7: vec3<u32>,
+  @location(39) f8: vec4<f16>,
+  @location(9) f9: i32,
+  @location(12) f10: f16,
+  @location(24) f11: i32,
+  @location(20) f12: vec4<f32>,
+  @location(25) f13: vec4<u32>,
+  @location(0) f14: f32,
+  @builtin(position) f15: vec4<f32>,
+  @location(27) f16: vec2<i32>,
+  @location(35) f17: vec3<u32>,
+  @location(15) f18: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec4<f16>, a1: S0, @location(13) a2: vec4<f32>, @builtin(vertex_index) a3: u32, @builtin(instance_index) a4: u32, @location(11) a5: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let textureView5 = texture0.createView({label: '\u3a8b\uc3b4\u{1f7a5}\u3d81', dimension: '2d', baseArrayLayer: 10});
+let renderBundle1 = renderBundleEncoder0.finish({label: '\u2118\u0852\u0aae\u{1f63c}\u{1fcb6}\u8af8\u0db8\u3694\u{1fa92}\u990e'});
+let externalTexture0 = device0.importExternalTexture({label: '\u6643\u2f6c\u{1fcfc}\u00cc\u0cb7\u4aa2', source: videoFrame0});
+video0.width = 214;
+let canvas2 = document.createElement('canvas');
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u779d\u0299\u62ec\u05b5\u4648\u84ed',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let texture4 = device0.createTexture({
+  size: [80, 8, 1],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView6 = texture0.createView({baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 20, arrayLayerCount: 19});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 9, y: 2, z: 4},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(32)), /* required buffer size: 3_083_794 */
+{offset: 446, bytesPerRow: 1628, rowsPerImage: 157}, {width: 193, height: 10, depthOrArrayLayers: 13});
+} catch {}
+let texture5 = device0.createTexture({
+  label: '\u302b\uf5e6\ub948\u0c72\u{1f738}\u7fda',
+  size: {width: 1296, height: 60, depthOrArrayLayers: 41},
+  mipLevelCount: 6,
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView7 = texture1.createView({label: '\u92c1\u0816', baseMipLevel: 1, arrayLayerCount: 1});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 90226773, y: 715438519 },
+  flipY: false,
+}, {
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline0 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule0, entryPoint: 'compute0'}});
+let imageBitmap0 = await createImageBitmap(offscreenCanvas0);
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u08b2\u{1fc2f}',
+  entries: [
+    {
+      binding: 2527,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 5302,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let texture6 = device0.createTexture({
+  label: '\u0313\u3acb\u5c18\u046e\u{1f88b}',
+  size: [952],
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 82, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 960 */
+{offset: 960}, {width: 14, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: video0,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  label: '\u737b\uc0ef\u0401',
+  code: `@group(0) @binding(5545)
+var<storage, read_write> function0: array<u32>;
+@group(1) @binding(5545)
+var<storage, read_write> local0: array<u32>;
+@group(2) @binding(5545)
+var<storage, read_write> local1: array<u32>;
+
+@compute @workgroup_size(7, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(0) f1: vec3<u32>,
+  @location(2) f2: vec4<i32>,
+  @builtin(sample_mask) f3: u32,
+  @location(5) f4: vec4<f32>,
+  @location(4) f5: vec3<u32>,
+  @location(6) f6: vec4<f32>,
+  @location(3) f7: i32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(6) a0: i32, @location(13) a1: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundle2 = renderBundleEncoder0.finish({label: '\u4056\u5b6f'});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(8)), /* required buffer size: 6_395 */
+{offset: 587, bytesPerRow: 44, rowsPerImage: 6}, {width: 0, height: 0, depthOrArrayLayers: 23});
+} catch {}
+let textureView8 = texture5.createView({baseMipLevel: 1, mipLevelCount: 4, baseArrayLayer: 9, arrayLayerCount: 6});
+let renderBundle3 = renderBundleEncoder0.finish({});
+let imageData0 = new ImageData(136, 252);
+let commandEncoder2 = device0.createCommandEncoder({label: '\u{1fcd1}\u8996\u{1fa2b}\uebe8\u0c18\ua194'});
+let textureView9 = texture2.createView({
+  label: '\ub342\u4a40\ua779\u{1fcd1}\u02f8\u049e\u057d\u1d7d\uc09f\ud593\u{1f9e3}',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let renderBundle4 = renderBundleEncoder0.finish();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 162, height: 7, depthOrArrayLayers: 69}
+*/
+{
+  source: video0,
+  origin: { x: 1, y: 1 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 15},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise0;
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u0ec3\u0962\u03a5\u6fdd\u09c8\u3fdd\u{1fbb9}',
+  entries: [
+    {
+      binding: 5287,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 765,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 5830,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let texture7 = device0.createTexture({
+  label: '\u07c4\u{1fa28}\u82d4\u0015\u1f8d\ud148\u071d\u0ad9\u{1fd08}\u6082',
+  size: {width: 1905, height: 4, depthOrArrayLayers: 1},
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let texture8 = gpuCanvasContext0.getCurrentTexture();
+let textureView10 = texture5.createView({
+  label: '\u0150\u5d62\u0bea\u6f00\u47e7\u{1fb33}\u09a8\ua40c\u281c\u{1f710}',
+  dimension: '2d-array',
+  mipLevelCount: 4,
+  baseArrayLayer: 10,
+  arrayLayerCount: 26,
+});
+let pipeline1 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: 0}, {format: 'rgba16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'r8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'replace'},
+    stencilBack: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 1699201482,
+    stencilWriteMask: 1503589498,
+    depthBiasClamp: 684.3477200033667,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 18576,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 584, shaderLocation: 6}],
+      },
+      {
+        arrayStride: 16968,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 1998, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+try {
+window.someLabel = textureView8.label;
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder({label: '\uc558\u0b9e\u4052\u9242\u{1f6ce}\ubdad\u874c\ue826\uee5e\ud4fe\u{1fb7b}'});
+let commandBuffer1 = commandEncoder2.finish({label: '\u{1ffbf}\uf6dc\u4f8f'});
+let texture9 = device0.createTexture({
+  label: '\u9547\u{1fc5b}\ue2b1\uc7c6\u36a3\u{1fc50}',
+  size: [162, 7, 73],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\u0282\uad0b\u7022\u0a61\u00cd\u056f\ub677\ub11f\u02dc',
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+});
+let renderBundle5 = renderBundleEncoder0.finish({});
+try {
+texture5.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 55, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(80)), /* required buffer size: 85 */
+{offset: 85}, {width: 572, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext2 = canvas1.getContext('webgpu');
+let shaderModule2 = device0.createShaderModule({
+  label: '\u9d06\u{1fd5e}',
+  code: `@group(0) @binding(5545)
+var<storage, read_write> function1: array<u32>;
+@group(1) @binding(5545)
+var<storage, read_write> parameter0: array<u32>;
+
+@compute @workgroup_size(6, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec4<f32>,
+  @location(3) f1: vec4<i32>,
+  @location(1) f2: vec4<u32>,
+  @location(5) f3: vec3<f32>,
+  @location(2) f4: vec2<i32>,
+  @location(4) f5: vec3<u32>,
+  @builtin(sample_mask) f6: u32,
+  @location(0) f7: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(2) f0: u32,
+  @location(17) f1: vec3<f16>,
+  @location(15) f2: vec2<i32>,
+  @location(10) f3: i32,
+  @location(6) f4: u32,
+  @location(5) f5: vec2<f32>,
+  @location(8) f6: vec3<f32>,
+  @location(7) f7: i32,
+  @location(14) f8: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec4<f32>, @location(11) a1: vec2<f16>, @location(4) a2: vec2<i32>, @location(1) a3: vec4<u32>, @location(16) a4: vec2<i32>, @location(3) a5: vec3<u32>, @location(0) a6: vec3<i32>, a7: S2, @location(13) a8: i32, @location(12) a9: f32, @builtin(vertex_index) a10: u32, @builtin(instance_index) a11: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let textureView11 = texture1.createView({label: '\u337c\udfc1\u0a29\ucd0f\u3f88\u8045\u0c7f\ude7d', mipLevelCount: 1});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+gc();
+let shaderModule3 = device0.createShaderModule({
+  label: '\u1ace\u1656\ubece\u0038',
+  code: `@group(2) @binding(5545)
+var<storage, read_write> function2: array<u32>;
+@group(1) @binding(5545)
+var<storage, read_write> type1: array<u32>;
+
+@compute @workgroup_size(7, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+  @location(11) f0: vec4<f16>,
+  @location(18) f1: vec4<f32>,
+  @location(38) f2: vec4<i32>,
+  @location(31) f3: vec2<f16>,
+  @location(24) f4: vec3<f32>
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec4<u32>,
+  @location(3) f1: vec4<i32>,
+  @location(6) f2: vec4<f32>,
+  @location(2) f3: vec2<i32>,
+  @location(5) f4: vec4<f32>,
+  @location(1) f5: vec4<u32>,
+  @location(0) f6: u32
+}
+
+@fragment
+fn fragment0(@location(21) a0: vec3<f16>, @location(16) a1: f32, @location(7) a2: vec3<i32>, @location(33) a3: vec4<f16>, @location(0) a4: vec2<f16>, @location(9) a5: vec3<f32>, @location(40) a6: f32, @location(20) a7: vec4<f32>, @location(10) a8: vec4<u32>, @builtin(front_facing) a9: bool, @location(13) a10: vec4<u32>, @location(6) a11: vec4<i32>, a12: S4, @location(15) a13: u32, @location(3) a14: vec3<i32>, @location(2) a15: vec2<u32>, @location(34) a16: vec4<f32>, @builtin(sample_mask) a17: u32, @location(4) a18: vec3<i32>, @location(36) a19: vec2<f32>, @location(28) a20: vec3<u32>, @location(23) a21: u32, @location(30) a22: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S3 {
+  @location(0) f0: vec2<u32>,
+  @location(12) f1: vec4<f32>,
+  @location(9) f2: vec2<i32>,
+  @location(6) f3: vec3<f32>
+}
+struct VertexOutput0 {
+  @location(11) f19: vec4<f16>,
+  @location(28) f20: vec3<u32>,
+  @location(9) f21: vec3<f32>,
+  @location(40) f22: f32,
+  @location(7) f23: vec3<i32>,
+  @location(13) f24: vec4<u32>,
+  @location(41) f25: vec3<i32>,
+  @location(29) f26: vec3<f16>,
+  @location(16) f27: f32,
+  @location(6) f28: vec4<i32>,
+  @location(23) f29: u32,
+  @location(21) f30: vec3<f16>,
+  @location(4) f31: vec3<i32>,
+  @location(38) f32: vec4<i32>,
+  @location(24) f33: vec3<f32>,
+  @location(31) f34: vec2<f16>,
+  @location(33) f35: vec4<f16>,
+  @location(18) f36: vec4<f32>,
+  @location(34) f37: vec4<f32>,
+  @location(0) f38: vec2<f16>,
+  @builtin(position) f39: vec4<f32>,
+  @location(15) f40: u32,
+  @location(37) f41: vec3<f16>,
+  @location(36) f42: vec2<f32>,
+  @location(20) f43: vec4<f32>,
+  @location(30) f44: vec2<u32>,
+  @location(25) f45: vec3<f32>,
+  @location(3) f46: vec3<i32>,
+  @location(10) f47: vec4<u32>,
+  @location(2) f48: vec2<u32>,
+  @location(8) f49: f32,
+  @location(27) f50: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(4) a0: u32, @location(14) a1: vec4<f16>, @location(13) a2: vec4<u32>, @location(5) a3: u32, @location(16) a4: vec2<i32>, @location(7) a5: vec4<f16>, @location(3) a6: vec2<i32>, @location(11) a7: vec4<f32>, @builtin(instance_index) a8: u32, @location(17) a9: vec2<f16>, @location(8) a10: u32, @location(15) a11: vec4<u32>, @builtin(vertex_index) a12: u32, a13: S3, @location(1) a14: vec2<i32>, @location(2) a15: vec4<f16>, @location(10) a16: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout2 = device0.createPipelineLayout({label: '\uf6b5\u5913', bindGroupLayouts: [bindGroupLayout1]});
+let renderBundle6 = renderBundleEncoder0.finish({label: '\u0b83\ub706\ubbf7\u2d34\u09d1\ua373\u1c57\u9bbd\u3056\u02ce\u0c41'});
+let sampler0 = device0.createSampler({
+  label: '\u{1f661}\u2980\u06b8\u{1f676}\u02b9',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 67.46,
+  lodMaxClamp: 88.83,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 1_516 */
+{offset: 554, bytesPerRow: 369}, {width: 56, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder4 = device0.createCommandEncoder();
+let querySet2 = device0.createQuerySet({label: '\u{1fe53}\u790b', type: 'occlusion', count: 2769});
+let textureView12 = texture4.createView({label: '\u{1f92a}\u0293\u{1f931}\u{1fa70}\u83fc', baseMipLevel: 0, mipLevelCount: 2});
+let computePassEncoder1 = commandEncoder3.beginComputePass({});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline2 = device0.createComputePipeline({layout: pipelineLayout2, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+try {
+canvas0.getContext('webgl2');
+} catch {}
+let querySet3 = device0.createQuerySet({label: '\u{1feb8}\u077e\uc813\udd45\u{1f9d5}\u0fe7\uc0bb\ua175\u8e7b', type: 'occlusion', count: 2381});
+let texture10 = device0.createTexture({
+  label: '\u9b43\ua7c8\u2ea4\u0693',
+  size: {width: 952, height: 2, depthOrArrayLayers: 266},
+  mipLevelCount: 6,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8sint', 'r8sint', 'r8sint'],
+});
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 66, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 758, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 543, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 5,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 253_733 */
+{offset: 689, bytesPerRow: 297, rowsPerImage: 284}, {width: 15, height: 0, depthOrArrayLayers: 4});
+} catch {}
+let pipeline3 = device0.createRenderPipeline({
+  label: '\u1e02\ub7f8\u0743\u0cbd',
+  layout: pipelineLayout0,
+  multisample: {},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rg16sint'}, {format: 'r8sint', writeMask: 0}, {format: 'rg32uint', writeMask: GPUColorWrite.ALL}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'zero'},
+    alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'less', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 1176262068,
+    stencilWriteMask: 3937675444,
+    depthBias: 174978864,
+    depthBiasClamp: 371.76370545301825,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 204,
+        attributes: [
+          {format: 'float32x4', offset: 16, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 12, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 48, shaderLocation: 10},
+          {format: 'unorm8x4', offset: 8, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 8, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'ccw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let canvas3 = document.createElement('canvas');
+let pipelineLayout3 = device0.createPipelineLayout({
+  label: '\u6d9b\u049b\u{1f7ca}\uec6c\u5fc7\u283f\u0e17\u54ff\uacfc',
+  bindGroupLayouts: [bindGroupLayout0],
+});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 4039});
+let commandBuffer2 = commandEncoder4.finish({label: '\u{1f9cc}\u0eee\u{1fa48}\u0894\ue040\u0463\ud0aa\u2ea8\u09ec\u91f8\u{1fc9a}'});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\ub420\u495c\u04be\u6b0a\u{1fb45}\u{1fd0c}\u096f\u{1fc66}\u68a7',
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder2.setVertexBuffer(1008, undefined);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer0 = device0.createBuffer({
+  label: '\u{1fa3d}\ubc03\u{1f912}\u0081\u{1fe82}\u{1f902}\u0e7a',
+  size: 284842,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder5 = device0.createCommandEncoder({label: '\u1b3e\u3691\uced7\ue8d9\u4d84\u079e\u7c2f\udb11\ub572\u055f\u082e'});
+let textureView13 = texture2.createView({label: '\ud10f\u05fd', aspect: 'all', mipLevelCount: 4});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 8, y: 2, z: 11},
+  aspect: 'all',
+},
+{width: 228, height: 29, depthOrArrayLayers: 11});
+} catch {}
+let imageData1 = new ImageData(128, 220);
+let bindGroupLayout3 = device0.createBindGroupLayout({label: '\uee1d\u0a68\u00bf\ue99c', entries: []});
+let commandEncoder6 = device0.createCommandEncoder({});
+try {
+commandEncoder5.resolveQuerySet(querySet0, 1988, 770, buffer0, 216064);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: imageData0,
+  origin: { x: 26, y: 42 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet5 = device0.createQuerySet({label: '\u73c1\u0214\u1b2f\uc23d\uba34\u7226\u0ccc\u0033\u3f40', type: 'occlusion', count: 193});
+let textureView14 = texture8.createView({label: '\u7052\uf019\ue987\u5b88\u{1fb39}\u972d\u0ca8', dimension: '2d-array'});
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 41, y: 7, z: 6},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 32, y: 3, z: 12},
+  aspect: 'all',
+},
+{width: 149, height: 12, depthOrArrayLayers: 21});
+} catch {}
+try {
+commandEncoder5.insertDebugMarker('\u7d1a');
+} catch {}
+let bindGroup0 = device0.createBindGroup({layout: bindGroupLayout3, entries: []});
+let querySet6 = device0.createQuerySet({label: '\u1541\ua05d\u0f49\udfa5\u05a6\u1b5e', type: 'occlusion', count: 3535});
+let textureView15 = texture2.createView({
+  label: '\u0ab1\u{1fd82}\ub8a4\u{1fb99}\u2750\u{1ffe1}\u0809\u0500\ua901\u0bb0\u8f10',
+  format: 'rgb10a2unorm',
+});
+let computePassEncoder2 = commandEncoder6.beginComputePass({label: '\ud0df\u0dd8\u2bd4\u0f3c\u{1f760}\udce5\ubacf'});
+try {
+renderBundleEncoder1.setVertexBuffer(2887, undefined, 1631479893, 1367869783);
+} catch {}
+let gpuCanvasContext3 = canvas3.getContext('webgpu');
+offscreenCanvas0.width = 1101;
+let shaderModule4 = device0.createShaderModule({
+  label: '\ue2fb\udead\u7b1b\udc2e\u840b\u6cb4\u2d69\u192c\u{1f7a6}\u1650\u0dae',
+  code: `@group(0) @binding(2527)
+var<storage, read_write> global0: array<u32>;
+@group(0) @binding(5302)
+var<storage, read_write> n0: array<u32>;
+
+@compute @workgroup_size(5, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S6 {
+  @builtin(sample_index) f0: u32,
+  @location(33) f1: u32,
+  @location(11) f2: vec4<u32>,
+  @location(5) f3: vec3<f16>,
+  @location(21) f4: vec4<u32>,
+  @builtin(front_facing) f5: bool,
+  @location(37) f6: vec4<f32>,
+  @location(8) f7: vec4<i32>,
+  @location(15) f8: vec4<f32>,
+  @location(0) f9: vec3<f32>,
+  @location(1) f10: vec4<u32>,
+  @location(28) f11: vec4<i32>,
+  @location(36) f12: vec2<i32>,
+  @location(25) f13: vec2<i32>,
+  @location(35) f14: vec3<f16>,
+  @location(41) f15: f16,
+  @builtin(sample_mask) f16: u32,
+  @location(34) f17: vec2<i32>,
+  @location(19) f18: vec4<f16>,
+  @location(9) f19: vec3<f32>,
+  @location(29) f20: vec2<f16>,
+  @location(14) f21: vec2<f16>,
+  @builtin(position) f22: vec4<f32>,
+  @location(4) f23: vec3<f16>,
+  @location(18) f24: i32,
+  @location(17) f25: vec3<f16>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(2) f1: vec2<i32>,
+  @location(4) f2: vec3<u32>,
+  @location(6) f3: vec4<f32>,
+  @location(3) f4: vec2<i32>,
+  @builtin(sample_mask) f5: u32,
+  @location(5) f6: vec3<f32>,
+  @location(0) f7: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(38) a0: vec3<i32>, a1: S6, @location(20) a2: f32, @location(26) a3: f32, @location(22) a4: u32, @location(39) a5: vec3<f32>, @location(24) a6: f32, @location(40) a7: f32, @location(3) a8: vec3<f32>, @location(6) a9: vec2<u32>, @location(2) a10: u32, @location(31) a11: vec2<f32>, @location(27) a12: vec2<f16>, @location(16) a13: vec2<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S5 {
+  @location(6) f0: u32,
+  @location(13) f1: vec2<f16>,
+  @location(12) f2: vec4<i32>,
+  @builtin(vertex_index) f3: u32
+}
+struct VertexOutput0 {
+  @location(16) f51: vec2<f32>,
+  @location(38) f52: vec3<i32>,
+  @location(35) f53: vec3<f16>,
+  @location(39) f54: vec3<f32>,
+  @location(6) f55: vec2<u32>,
+  @location(19) f56: vec4<f16>,
+  @location(40) f57: f32,
+  @location(1) f58: vec4<u32>,
+  @location(27) f59: vec2<f16>,
+  @location(14) f60: vec2<f16>,
+  @location(41) f61: f16,
+  @location(36) f62: vec2<i32>,
+  @location(5) f63: vec3<f16>,
+  @location(25) f64: vec2<i32>,
+  @location(15) f65: vec4<f32>,
+  @location(26) f66: f32,
+  @location(22) f67: u32,
+  @builtin(position) f68: vec4<f32>,
+  @location(17) f69: vec3<f16>,
+  @location(8) f70: vec4<i32>,
+  @location(11) f71: vec4<u32>,
+  @location(9) f72: vec3<f32>,
+  @location(0) f73: vec3<f32>,
+  @location(33) f74: u32,
+  @location(34) f75: vec2<i32>,
+  @location(28) f76: vec4<i32>,
+  @location(24) f77: f32,
+  @location(21) f78: vec4<u32>,
+  @location(37) f79: vec4<f32>,
+  @location(3) f80: vec3<f32>,
+  @location(29) f81: vec2<f16>,
+  @location(2) f82: u32,
+  @location(4) f83: vec3<f16>,
+  @location(20) f84: f32,
+  @location(31) f85: vec2<f32>,
+  @location(18) f86: i32
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec4<f16>, @location(16) a1: f32, @location(2) a2: vec2<u32>, a3: S5) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2, bindGroupLayout0, bindGroupLayout3, bindGroupLayout3]});
+let buffer1 = device0.createBuffer({
+  label: '\u{1f78b}\u04f7\u03c8\u0d88\u{1f627}\u0ad3\u6af5\u06f4\u8c0a',
+  size: 337160,
+  usage: GPUBufferUsage.INDEX,
+  mappedAtCreation: true,
+});
+let commandEncoder7 = device0.createCommandEncoder({label: '\u0763\u0576\uc123\u3660\u0dca\u0f76'});
+let querySet7 = device0.createQuerySet({
+  label: '\u0361\udec1\u{1fc34}\ub51c\u0727\u4bcf\u527b\u0ca5\u0eca\u04d0',
+  type: 'occlusion',
+  count: 1319,
+});
+let texture11 = device0.createTexture({
+  label: '\u647d\u{1ff0f}\u3b41\u{1ff4b}\u14d0\u956e\u8c2b\u1bea',
+  size: {width: 1296, height: 60, depthOrArrayLayers: 41},
+  mipLevelCount: 11,
+  format: 'astc-6x6-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle7 = renderBundleEncoder1.finish({label: '\u9dff\u067d\u0fea\u{1ffdd}\u341d'});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 22, y: 7 },
+  flipY: true,
+}, {
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(914, 225);
+let buffer2 = device0.createBuffer({size: 263719, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let computePassEncoder3 = commandEncoder7.beginComputePass({});
+try {
+computePassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 105984, new DataView(new ArrayBuffer(22612)), 11853, 1636);
+} catch {}
+let pipeline4 = device0.createComputePipeline({layout: pipelineLayout2, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let bindGroup1 = device0.createBindGroup({
+  label: '\u9e01\u0e0c\u{1f726}\u3fef\u{1f8d5}\u452d\u099d\u959a\ue09a',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let querySet8 = device0.createQuerySet({
+  label: '\u6513\u{1fbce}\u2905\u077d\u0b29\udcb9\ueca8\u0a45\ub279\u43b7\uc633',
+  type: 'occlusion',
+  count: 2110,
+});
+let texture12 = device0.createTexture({
+  label: '\u{1fa36}\u27c7\u921e\u0b10\u0771\u0643\u8ba4\u2f35\u{1f7d4}\u73db',
+  size: {width: 320, height: 32, depthOrArrayLayers: 679},
+  mipLevelCount: 6,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView16 = texture5.createView({
+  label: '\u{1fb88}\u9f87\u{1fcaf}\u{1fa53}\u0859',
+  baseMipLevel: 4,
+  baseArrayLayer: 16,
+  arrayLayerCount: 20,
+});
+try {
+renderBundleEncoder2.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder();
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 92, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 910, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 9072748, y: 96949814 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise1 = device0.createComputePipelineAsync({
+  label: '\u5a97\u06ba\u071c\u71bb\u{1fd50}\ub781\u0ed4\u44a6',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext4 = canvas2.getContext('webgpu');
+try {
+offscreenCanvas2.getContext('webgl');
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({label: '\ucae5\u0438\u59d1\ubd57'});
+let externalTexture3 = device0.importExternalTexture({label: '\u4190\u0dc8\uf107\ue8b6\u{1fbe3}\uacdf\u178e', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet4, 3746, 35, buffer0, 75264);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 18356, new DataView(new ArrayBuffer(60905)), 37050, 460);
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  label: '\u1364\u0030\u0678\u0ca3\u07c6\u0e02\u{1f726}',
+  entries: [
+    {
+      binding: 5665,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let texture13 = device0.createTexture({
+  label: '\u{1f764}\u12da\u042b\u{1fc3c}\u{1ff45}',
+  size: [640, 64, 285],
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm'],
+});
+let textureView17 = texture9.createView({label: '\ub960\ueb4a', format: 'r16uint', baseMipLevel: 2});
+let renderBundle8 = renderBundleEncoder1.finish({label: '\u8630\u051b\u{1f89b}\ud319\u8f91\u02bd\u625f'});
+let externalTexture4 = device0.importExternalTexture({label: '\ub448\u4033\u04d2\u0af8\uca6f', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer1, 'uint32', 185192, 103828);
+} catch {}
+try {
+commandEncoder5.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3448 widthInBlocks: 862 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2952 */
+  offset: 2952,
+  bytesPerRow: 3584,
+  buffer: buffer2,
+}, {width: 862, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let textureView18 = texture0.createView({
+  label: '\ua80e\uea06\u2e07\u0d18\u{1f778}\u0784\u4d5d\u05c8',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u094b\u0d16\u588c\u0ae1\u3579\u0608\u883c\u99ff',
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+});
+let sampler1 = device0.createSampler({
+  label: '\udabd\ue0af',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 20.69,
+  lodMaxClamp: 29.33,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder5.setIndexBuffer(buffer1, 'uint32', 235112, 62404);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer2, 103428, 52708);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline5 = device0.createComputePipeline({
+  label: '\u0ff8\u05cc\u0f53\u06c9\uaf69',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let pipeline6 = await device0.createRenderPipelineAsync({
+  label: '\u4f19\u0367\udf32\u026a\uad8c\u50d0\u{1fbbf}\u02ac',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x3e583233},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rg32uint'}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALL}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1764,
+        attributes: [
+          {format: 'uint32x4', offset: 196, shaderLocation: 2},
+          {format: 'float32x3', offset: 76, shaderLocation: 16},
+          {format: 'sint32x4', offset: 288, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 236, shaderLocation: 13},
+          {format: 'float32x3', offset: 52, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 17052, stepMode: 'instance', attributes: []},
+      {arrayStride: 7516, attributes: [{format: 'uint8x4', offset: 132, shaderLocation: 6}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', unclippedDepth: false},
+});
+gc();
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\uf4dc\u{1fd54}\u440d\u5202\u5ac9\u{1fb55}\u0cfb\ueea3',
+  entries: [{binding: 5278, visibility: GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let commandEncoder10 = device0.createCommandEncoder();
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup0, new Uint32Array(9652), 4748, 0);
+} catch {}
+let imageBitmap1 = await createImageBitmap(offscreenCanvas0);
+let texture14 = device0.createTexture({
+  size: {width: 1905},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture15 = gpuCanvasContext0.getCurrentTexture();
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u{1f8c4}\u7fc3\uea10\ubd4e\u20b8\u0f7f\u{1fd11}\u{1fd8c}',
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let renderBundle9 = renderBundleEncoder3.finish();
+let externalTexture5 = device0.importExternalTexture({label: '\u70f1\u0222\u47e1\u{1fafd}\u5cdf\u63c9\u075c\u0cdd\uc917\u{1f65e}', source: videoFrame0});
+try {
+renderBundleEncoder2.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(2587, undefined);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 141776, new BigUint64Array(63945), 25379, 2180);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 8, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 63, y: 86 },
+  flipY: false,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let externalTexture6 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder7.resolveQuerySet(querySet4, 2384, 1613, buffer0, 181760);
+} catch {}
+let pipeline7 = device0.createRenderPipeline({
+  label: '\u032a\u0794\u{1fe5f}',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0xb7e11937},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg16sint'}, {format: 'r8sint'}, {format: 'rg32uint'}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 7856, shaderLocation: 12},
+          {format: 'uint8x2', offset: 6846, shaderLocation: 6},
+          {format: 'sint32x3', offset: 8280, shaderLocation: 4},
+          {format: 'sint16x2', offset: 34116, shaderLocation: 10},
+          {format: 'float32x2', offset: 5376, shaderLocation: 9},
+          {format: 'sint32x3', offset: 3556, shaderLocation: 15},
+          {format: 'uint32x2', offset: 4096, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 15796, shaderLocation: 8},
+          {format: 'sint8x2', offset: 4562, shaderLocation: 7},
+          {format: 'sint32x4', offset: 8664, shaderLocation: 13},
+          {format: 'float32x4', offset: 17748, shaderLocation: 17},
+          {format: 'float32', offset: 404, shaderLocation: 11},
+          {format: 'uint8x2', offset: 10726, shaderLocation: 1},
+          {format: 'uint32', offset: 14740, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 4872, shaderLocation: 14},
+          {format: 'sint32x2', offset: 1760, shaderLocation: 0},
+          {format: 'sint16x4', offset: 27964, shaderLocation: 16},
+          {format: 'unorm10-10-10-2', offset: 656, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: true},
+});
+offscreenCanvas2.width = 344;
+let canvas4 = document.createElement('canvas');
+try {
+canvas4.getContext('webgl2');
+} catch {}
+let buffer3 = device0.createBuffer({
+  label: '\u2c1f\u8046\u622f\u8b16\u096e\u05a5',
+  size: 212041,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder11 = device0.createCommandEncoder();
+let texture16 = device0.createTexture({
+  label: '\u25c8\ue05f\ua55c\u2c02\u095b\u09dc',
+  size: {width: 952, height: 2, depthOrArrayLayers: 154},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32uint', 'rg32uint'],
+});
+try {
+renderBundleEncoder4.setIndexBuffer(buffer1, 'uint16', 172182, 41176);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 14, y: 9, z: 10},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 92, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 207, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 17}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 50, y: 683443940 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline8 = device0.createComputePipeline({
+  label: '\u6603\u08d7',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+let imageBitmap2 = await createImageBitmap(offscreenCanvas2);
+let commandEncoder12 = device0.createCommandEncoder({label: '\u57a1\u{1f741}\ua97f\uc63b\ud6e6'});
+let textureView19 = texture8.createView({label: '\u3cf7\u091f\u{1f93f}', dimension: '2d-array', baseArrayLayer: 0});
+let computePassEncoder4 = commandEncoder7.beginComputePass({label: '\uf1da\u2924\u{1fcc3}\ufe56\ud750\u{1fd7b}'});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u{1f9a2}\uf67d\uf9d1\u{1fa26}\u0e6d\u2454\u{1f9b6}\uc416',
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+});
+try {
+renderBundleEncoder4.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer2, 157452, 18244);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder8.resolveQuerySet(querySet8, 1186, 885, buffer0, 251648);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(24)), /* required buffer size: 742 */
+{offset: 742, rowsPerImage: 87}, {width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let querySet9 = device0.createQuerySet({label: '\u0e55\u{1f9d3}\u{1fe71}\u0182\u2898\uf1e8', type: 'occlusion', count: 1077});
+let textureView20 = texture1.createView({
+  label: '\u0ce6\u802d\ub431\u0196\u0de8\u4d05\ua353\u0d1d\u0781\u296e\uac1d',
+  dimension: '3d',
+  baseMipLevel: 1,
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\ua4a3\u0347\u0328\u41d9\u{1f813}\u64a4\uc2ee\ub137\u64b1',
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(buffer3, 61048, buffer2, 261872, 1692);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder5.clearBuffer(buffer2, 262880, 308);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 620, new BigUint64Array(58379), 1084, 5116);
+} catch {}
+let textureView21 = texture0.createView({label: '\u592f\u3911', mipLevelCount: 8, baseArrayLayer: 9, arrayLayerCount: 25});
+try {
+renderBundleEncoder2.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer3, 20696, buffer2, 158812, 20168);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder9.resolveQuerySet(querySet0, 243, 53, buffer0, 171776);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas4);
+let commandBuffer3 = commandEncoder12.finish({label: '\u683d\u1410\u{1fa8f}\u5630\u4661\uaa24\u63ae\u6080\u5161'});
+let texture17 = device0.createTexture({
+  size: {width: 160, height: 16, depthOrArrayLayers: 75},
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg32uint', 'rg32uint'],
+});
+let textureView22 = texture5.createView({label: '\u{1f848}\u5f89\u{1f9ee}\u01a5', dimension: '2d', baseMipLevel: 3});
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup0, new Uint32Array(7306), 5305, 0);
+} catch {}
+try {
+commandEncoder5.copyBufferToTexture({
+  /* bytesInLastRow: 2360 widthInBlocks: 1180 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 15988 */
+  offset: 13628,
+  buffer: buffer3,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 58, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1180, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let videoFrame1 = new VideoFrame(canvas2, {timestamp: 0});
+let commandEncoder13 = device0.createCommandEncoder({label: '\uc734\u0b68\u1d81\u1052\u5d0c\u2859\uc44a\u0d4b\u0370\u5431'});
+let commandBuffer4 = commandEncoder9.finish();
+let textureView23 = texture13.createView({
+  label: '\u030e\uee42\u{1fcfc}\u07de\u{1fa3e}',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 140,
+  arrayLayerCount: 84,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup1, new Uint32Array(8980), 4824, 0);
+} catch {}
+try {
+commandEncoder8.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 106, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 800 widthInBlocks: 200 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 22496 */
+  offset: 22496,
+  buffer: buffer2,
+}, {width: 200, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1, commandBuffer3]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 9076, new BigUint64Array(4965), 195, 1020);
+} catch {}
+let pipeline9 = await device0.createComputePipelineAsync({
+  label: '\uefc3\ua1e9\u5f28\ub731\ue583\u{1fa4a}\u{1fe3e}',
+  layout: 'auto',
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+document.body.prepend(video0);
+let querySet10 = device0.createQuerySet({label: '\u0595\u2c66\u9d5f\u{1fb49}\ucdaf\u001b\u{1f6d3}', type: 'occlusion', count: 3932});
+let texture18 = device0.createTexture({
+  label: '\u{1fe50}\ueabf\u0cc6\ue4ab\u{1f72a}\u388f\u1f03\u209c\u67b1\u7ed5\u{1fe28}',
+  size: [952, 2, 183],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView24 = texture3.createView({label: '\u{1fd60}\ud70e\u6b5b\ue5f9\ua4ef\u7d08', dimension: '2d-array'});
+let computePassEncoder5 = commandEncoder8.beginComputePass({label: '\ufacb\ufb7b'});
+let externalTexture7 = device0.importExternalTexture({label: '\u2e1e\ue50e\udc79\u0141\u{1f842}\ud8bf\ub4a4', source: video0, colorSpace: 'srgb'});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup1, new Uint32Array(4848), 3711, 0);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder10.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 3,
+  origin: {x: 6, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 460, y: 7, z: 116},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 12});
+} catch {}
+try {
+commandEncoder3.resolveQuerySet(querySet1, 128, 90, buffer0, 108032);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 36, y: 32 },
+  flipY: true,
+}, {
+  texture: texture4,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline10 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule3, entryPoint: 'compute0'}});
+let commandEncoder14 = device0.createCommandEncoder({label: '\u50f0\ucfa2\u0ceb\ubd66\u0e59\u{1fdcc}\ue841\u019e\u9473'});
+let querySet11 = device0.createQuerySet({label: '\u13e4\u792c\uca7a\u1f7f\u{1f761}\u621a\u068b', type: 'occlusion', count: 2227});
+let texture19 = device0.createTexture({
+  label: '\u8bad\u0e53\uecb9\u0c73\u08c2\u893e\u{1f8cf}\u014d\udc01\uc4ca\u{1ff5e}',
+  size: [162, 7, 1854],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundle10 = renderBundleEncoder5.finish({label: '\u074e\uba15\u7b4b\u018f\u8ab2\u50bf\u0d2d\u0f48\u2a88\u09c7\u0bf0'});
+let externalTexture8 = device0.importExternalTexture({
+  label: '\ud3fd\u4770\u0f8e\u0189\u73fa\u{1fb39}\ucfaf\u0d59',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder2.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 19},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 18, y: 18, z: 10},
+  aspect: 'all',
+},
+{width: 590, height: 2, depthOrArrayLayers: 43});
+} catch {}
+try {
+commandEncoder3.clearBuffer(buffer2, 32776, 186556);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 86516, new Float32Array(36634), 6616, 488);
+} catch {}
+gc();
+let adapter1 = await navigator.gpu.requestAdapter({});
+let textureView25 = texture11.createView({
+  label: '\u983f\u{1f83e}\u3c8a\ud5fc\ube57\u7905\ue59b\ua5dc',
+  aspect: 'all',
+  baseMipLevel: 6,
+  baseArrayLayer: 8,
+  arrayLayerCount: 2,
+});
+let renderBundle11 = renderBundleEncoder1.finish({});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+querySet1.destroy();
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet0, 1160, 1010, buffer0, 143104);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 480 */
+{offset: 452}, {width: 7, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup2 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 5545, resource: externalTexture4}]});
+let texture20 = device0.createTexture({
+  size: [320, 32, 1],
+  mipLevelCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(119), 48, 0);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder10.copyBufferToTexture({
+  /* bytesInLastRow: 392 widthInBlocks: 196 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 22678 */
+  offset: 22678,
+  buffer: buffer3,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 284, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 196, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 3160, new BigUint64Array(21238), 16287, 500);
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder15 = device0.createCommandEncoder({label: '\u63e3\u0622\u{1f647}\u0363\u0047\u{1f7ea}'});
+let textureView26 = texture12.createView({label: '\u{1fa3c}\u44bd', dimension: '2d', baseMipLevel: 1, mipLevelCount: 3, baseArrayLayer: 674});
+let computePassEncoder6 = commandEncoder11.beginComputePass({label: '\u9c7d\u091f\u1af7\ua1a0\u05fa\u{1fa64}\ua57b\u9e91\uc312'});
+try {
+renderBundleEncoder6.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer3, 118628, buffer2, 174532, 156);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 81, height: 3, depthOrArrayLayers: 34}
+*/
+{
+  source: canvas0,
+  origin: { x: 6, y: 75 },
+  flipY: false,
+}, {
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 13, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({});
+let texture21 = device0.createTexture({
+  size: [648, 30, 41],
+  mipLevelCount: 9,
+  format: 'astc-8x6-unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-8x6-unorm-srgb', 'astc-8x6-unorm'],
+});
+let textureView27 = texture17.createView({label: '\u2ff0\u8c1e\u6390\u{1fb90}\u8536'});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u0e59\u98f2\u0e2c\u0c8d\uc5e0\u0341\ud582\u{1f6c6}',
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+});
+let sampler2 = device0.createSampler({
+  label: '\u{1ffc3}\u1b56\u4daf\u{1fef5}\u{1ff7b}\u0310\u{1fa33}',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 56.41,
+  lodMaxClamp: 83.94,
+});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 1616 widthInBlocks: 404 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 36224 */
+  offset: 32816,
+  bytesPerRow: 1792,
+  buffer: buffer3,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 372, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 404, height: 2, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 53944, new Float32Array(52762), 10142, 344);
+} catch {}
+let video1 = await videoWithData();
+let bindGroup3 = device0.createBindGroup({
+  label: '\ud103\u468b\u{1fd51}\u{1fd20}',
+  layout: bindGroupLayout1,
+  entries: [{binding: 2527, resource: sampler2}, {binding: 5302, resource: textureView22}],
+});
+let commandEncoder17 = device0.createCommandEncoder({label: '\u5923\u{1fee4}\uf2fa\u{1ffa2}\ud2a9\u{1febc}'});
+let texture22 = device0.createTexture({
+  label: '\ub2e2\uf2c9\u0bc3\ud17d\u6b3d\u59ed\u0021\u09ca\u48e6\ue430\u0424',
+  size: {width: 640, height: 64, depthOrArrayLayers: 302},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture23 = gpuCanvasContext0.getCurrentTexture();
+let textureView28 = texture11.createView({
+  label: '\uaee7\u{1fbb4}\u3832\u{1fca9}\ufd02\u{1fac2}\u8c01\u{1fa95}\uf269\u{1fbd0}',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 25,
+});
+try {
+computePassEncoder0.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 1656 widthInBlocks: 414 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 49752 */
+  offset: 49752,
+  bytesPerRow: 1792,
+  rowsPerImage: 13,
+  buffer: buffer3,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 319, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 414, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder5.resolveQuerySet(querySet4, 1741, 1192, buffer0, 136448);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 2795869, y: 1032392876 },
+  flipY: true,
+}, {
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let video2 = await videoWithData();
+let querySet12 = device0.createQuerySet({
+  label: '\u0f08\ufda7\uad97\u3b7e\u5976\ud613\u{1fbba}\u{1fa2d}\u04e2\u{1fd4d}',
+  type: 'occlusion',
+  count: 3881,
+});
+let texture24 = device0.createTexture({
+  label: '\u962c\u0986\u0b1b\uf6db\u0332',
+  size: [3810],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView29 = texture14.createView({label: '\u{1f753}\u3aff\u086e\ufd9d\u{1fe41}\u0962\u0d10'});
+let renderBundle12 = renderBundleEncoder2.finish({label: '\u8859\u9085\u089e\ua46b\ua9df\u{1f72c}\u05aa\u4ee0\u{1f9a8}\u039b\u3f8a'});
+let externalTexture9 = device0.importExternalTexture({label: '\u{1fd01}\u6d32\u{1f9c0}\ub952\u4302\u{1f6f2}\uad22', source: videoFrame0, colorSpace: 'srgb'});
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder16.pushDebugGroup('\u07e4');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 15304, new DataView(new ArrayBuffer(22292)), 7817, 5024);
+} catch {}
+let pipeline11 = await device0.createComputePipelineAsync({
+  label: '\uf73c\u6317\ud28a\udd09\u0375\u{1fd8f}\u{1fdd2}\u661e\u73ec\u6001',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder18 = device0.createCommandEncoder();
+let textureView30 = texture4.createView({dimension: '2d', mipLevelCount: 1});
+let externalTexture10 = device0.importExternalTexture({label: '\u0868\u{1fba5}\u2d2f\u{1fd38}\u0e40\u{1fcf1}\u6124', source: video2, colorSpace: 'srgb'});
+try {
+computePassEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer3, 40972, buffer2, 39848, 41560);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer2, 233000, 23920);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync({
+  label: '\u{1fa58}\u0cac',
+  layout: pipelineLayout2,
+  multisample: {count: 4},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'equal', failOp: 'zero', depthFailOp: 'keep'},
+    stencilBack: {compare: 'greater', failOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 1281310471,
+    stencilWriteMask: 1111448909,
+    depthBias: -2011575621,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 758.9532701538141,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 21288,
+        attributes: [
+          {format: 'unorm16x4', offset: 296, shaderLocation: 2},
+          {format: 'uint8x4', offset: 3300, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 172, shaderLocation: 15},
+          {format: 'uint8x4', offset: 444, shaderLocation: 13},
+          {format: 'float16x2', offset: 12848, shaderLocation: 14},
+          {format: 'sint32', offset: 22916, shaderLocation: 9},
+          {format: 'uint32x3', offset: 12344, shaderLocation: 0},
+          {format: 'sint16x4', offset: 6248, shaderLocation: 1},
+          {format: 'uint32x4', offset: 8828, shaderLocation: 5},
+          {format: 'sint32x4', offset: 17432, shaderLocation: 3},
+          {format: 'snorm16x4', offset: 4952, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 6000,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 168, shaderLocation: 8},
+          {format: 'uint8x2', offset: 98, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 3448,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 440, shaderLocation: 16},
+          {format: 'unorm10-10-10-2', offset: 160, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 284, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 472, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 2700,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 160, shaderLocation: 7},
+          {format: 'float32', offset: 36, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\ud7cd\u{1f812}',
+  entries: [
+    {binding: 2153, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 7175,
+      visibility: 0,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\u{1fe77}\u117d\u{1fc35}\u022b\u03e2\udee0\u{1f6e7}\u{1f8ba}\u06de\u{1fa27}\u0b91',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout4, bindGroupLayout2],
+});
+let buffer4 = device0.createBuffer({label: '\u71ad\u61fb\u{1f7da}', size: 116783, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder19 = device0.createCommandEncoder({label: '\u035b\ua970'});
+let texture25 = device0.createTexture({
+  size: [320],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let textureView31 = texture14.createView({label: '\uf615\u{1fb32}', dimension: '1d'});
+let computePassEncoder7 = commandEncoder5.beginComputePass({label: '\u41e4\u042b\u92fa\u0060\ub7ca'});
+let renderBundle13 = renderBundleEncoder3.finish({label: '\u8c10\u0e80\uafdd\u0662\ua672\u4209\u{1f9fe}\ucb65\u012a'});
+try {
+renderBundleEncoder7.setVertexBuffer(5441, undefined, 0);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(buffer3, 96096, buffer2, 174972, 11768);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder6.clearBuffer(buffer2, 148552, 3396);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet2, 260, 1731, buffer0, 107776);
+} catch {}
+try {
+commandEncoder16.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 1_925_921 */
+{offset: 641, bytesPerRow: 420, rowsPerImage: 191}, {width: 60, height: 0, depthOrArrayLayers: 25});
+} catch {}
+let pipeline13 = device0.createComputePipeline({
+  label: '\u7f3d\u0c5f',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let canvas5 = document.createElement('canvas');
+let offscreenCanvas3 = new OffscreenCanvas(630, 350);
+try {
+commandEncoder18.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 8432 */
+  offset: 8432,
+  bytesPerRow: 0,
+  rowsPerImage: 287,
+  buffer: buffer3,
+}, {
+  texture: texture0,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 27});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+renderBundleEncoder8.insertDebugMarker('\u{1f765}');
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({label: '\u0660\u{1fcd2}\u8b0e\u1819'});
+let textureView32 = texture16.createView({
+  label: '\u0806\u8fc5\ub686\u0bc1\u{1fe01}\u05de',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  arrayLayerCount: 1,
+});
+let sampler3 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.02,
+  lodMaxClamp: 90.38,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder0.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup2, new Uint32Array(7038), 592, 0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer2, 73636, 14892);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(querySet0, 2579, 256, buffer0, 276736);
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter();
+let offscreenCanvas4 = new OffscreenCanvas(272, 656);
+let shaderModule5 = device0.createShaderModule({
+  label: '\u3e2b\u{1f7f3}\u06bd\u1f7e\u01c5\u0418\u{1f935}\u2ef0\u44b0\u7a45',
+  code: `@group(0) @binding(5545)
+var<storage, read_write> field1: array<u32>;
+
+@compute @workgroup_size(8, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2<i32>,
+  @location(6) f1: vec4<f32>,
+  @location(5) f2: vec3<f32>,
+  @location(4) f3: vec2<u32>,
+  @location(0) f4: vec2<u32>,
+  @location(2) f5: vec2<i32>,
+  @location(1) f6: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(32) a0: f16, @builtin(front_facing) a1: bool, @location(29) a2: u32, @location(14) a3: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @location(15) f0: i32,
+  @location(8) f1: u32,
+  @location(1) f2: vec3<f16>,
+  @location(12) f3: vec3<f32>,
+  @location(17) f4: vec3<i32>
+}
+struct VertexOutput0 {
+  @location(17) f87: vec4<u32>,
+  @location(9) f88: vec4<f32>,
+  @location(26) f89: vec2<f32>,
+  @location(32) f90: f16,
+  @location(1) f91: f16,
+  @location(29) f92: u32,
+  @location(14) f93: vec3<f32>,
+  @builtin(position) f94: vec4<f32>
+}
+
+@vertex
+fn vertex0(a0: S7, @location(7) a1: vec3<i32>, @location(3) a2: vec4<u32>, @location(14) a3: vec3<i32>, @location(2) a4: vec4<f32>, @location(16) a5: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let textureView33 = texture12.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 2, baseArrayLayer: 150});
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline6);
+} catch {}
+try {
+querySet12.destroy();
+} catch {}
+try {
+commandEncoder3.resolveQuerySet(querySet7, 846, 187, buffer0, 59648);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline14 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16uint'}, {format: 'rg16sint', writeMask: GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: 0}, {format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8unorm'}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7604,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 64, shaderLocation: 2},
+          {format: 'uint32', offset: 1280, shaderLocation: 0},
+          {format: 'uint8x2', offset: 54, shaderLocation: 10},
+          {format: 'uint32', offset: 640, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 880, shaderLocation: 6},
+          {format: 'float32x2', offset: 220, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 40, shaderLocation: 11},
+          {format: 'uint32x3', offset: 668, shaderLocation: 5},
+          {format: 'uint32x4', offset: 1036, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 108, shaderLocation: 14},
+          {format: 'uint32x4', offset: 48, shaderLocation: 4},
+          {format: 'sint8x4', offset: 1104, shaderLocation: 9},
+          {format: 'sint32x4', offset: 356, shaderLocation: 1},
+          {format: 'uint32x3', offset: 120, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 496, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 11340,
+        attributes: [
+          {format: 'unorm16x4', offset: 628, shaderLocation: 12},
+          {format: 'sint32', offset: 684, shaderLocation: 16},
+          {format: 'sint32x4', offset: 4960, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder21 = device0.createCommandEncoder({label: '\u466f\u1c96\u494b\u0905\u{1f7f9}\u0a50\u53c2'});
+let textureView34 = texture18.createView({label: '\u041a\u{1fb58}\u{1fcd6}\u33a4\ua50e\u{1fa8e}\u274f\u3f6b', baseMipLevel: 1, mipLevelCount: 3});
+let computePassEncoder8 = commandEncoder21.beginComputePass({});
+let externalTexture11 = device0.importExternalTexture({label: '\u{1f7fa}\u0842\u0d8e\ud920\u83e5\u25ac\u96b6\u3406\ud0e9', source: videoFrame1});
+try {
+renderBundleEncoder7.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(4834, undefined);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 3467, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(querySet9, 239, 300, buffer0, 145664);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 21108, new DataView(new ArrayBuffer(46124)), 25273, 7116);
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas3.getContext('webgpu');
+let canvas6 = document.createElement('canvas');
+let offscreenCanvas5 = new OffscreenCanvas(583, 272);
+try {
+canvas5.getContext('2d');
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  label: '\u01ad\u8f7e\ud812\u7a6b\uc90b\u1d7b\u9621',
+  layout: bindGroupLayout0,
+  entries: [{binding: 5545, resource: externalTexture3}],
+});
+let commandEncoder22 = device0.createCommandEncoder();
+let textureView35 = texture24.createView({label: '\u0539\u{1f6a0}\u{1f653}\u05f0\ua4d9\u3100\u2c1f\u0085', baseArrayLayer: 0});
+let renderBundle14 = renderBundleEncoder4.finish({});
+try {
+device0.queue.writeBuffer(buffer2, 41660, new Int16Array(60996), 47554, 7820);
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({
+  label: '\ub2bc\u06e1\uf8bc\ue657\u0801\u{1f801}\u7f1b\ub51c',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout3],
+});
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3148 */
+  offset: 3148,
+  bytesPerRow: 256,
+  buffer: buffer3,
+}, {
+  texture: texture2,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 185, y: 4, z: 63},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 174, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 280, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video0);
+gc();
+let canvas7 = document.createElement('canvas');
+let shaderModule6 = device0.createShaderModule({
+  label: '\u050a\u88af\u{1fe39}\u0227\u{1fdeb}\u{1f64c}\u20e0\u{1fe7e}\u2852',
+  code: `@group(0) @binding(765)
+var<storage, read_write> n1: array<u32>;
+@group(2) @binding(5830)
+var<storage, read_write> field2: array<u32>;
+@group(2) @binding(5287)
+var<storage, read_write> type2: array<u32>;
+@group(2) @binding(765)
+var<storage, read_write> function3: array<u32>;
+@group(0) @binding(5287)
+var<storage, read_write> type3: array<u32>;
+
+@compute @workgroup_size(4, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<i32>,
+  @location(2) f1: vec3<i32>,
+  @location(1) f2: vec4<u32>,
+  @location(4) f3: vec2<u32>,
+  @location(5) f4: vec4<f32>,
+  @location(0) f5: u32,
+  @location(6) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(38) a0: vec2<i32>, @location(34) a1: i32, @location(39) a2: vec3<i32>, @location(3) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(40) f95: f32,
+  @location(6) f96: vec2<u32>,
+  @location(18) f97: u32,
+  @location(12) f98: u32,
+  @location(41) f99: vec4<f16>,
+  @builtin(position) f100: vec4<f32>,
+  @location(22) f101: i32,
+  @location(19) f102: f32,
+  @location(13) f103: f32,
+  @location(8) f104: i32,
+  @location(20) f105: f16,
+  @location(11) f106: vec4<u32>,
+  @location(10) f107: vec4<i32>,
+  @location(4) f108: vec4<u32>,
+  @location(35) f109: i32,
+  @location(3) f110: vec4<f32>,
+  @location(31) f111: i32,
+  @location(26) f112: vec2<i32>,
+  @location(38) f113: vec2<i32>,
+  @location(34) f114: i32,
+  @location(1) f115: vec2<u32>,
+  @location(39) f116: vec3<i32>,
+  @location(16) f117: f16,
+  @location(21) f118: u32,
+  @location(32) f119: vec3<u32>,
+  @location(24) f120: vec3<f16>,
+  @location(15) f121: vec4<i32>,
+  @location(25) f122: vec3<f32>,
+  @location(37) f123: vec4<i32>,
+  @location(27) f124: vec3<f32>,
+  @location(14) f125: vec3<u32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(16) a1: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let commandEncoder23 = device0.createCommandEncoder();
+let sampler4 = device0.createSampler({
+  label: '\u0aea\u028a\u027b\u045d\u{1f758}\u081d\u{1f7ad}\u{1fcf4}',
+  addressModeU: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 45.30,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup4, []);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(3, bindGroup1, new Uint32Array(528), 397, 0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup0, new Uint32Array(5910), 1254, 0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer1, 'uint16', 257304, 21762);
+} catch {}
+try {
+commandEncoder6.copyBufferToBuffer(buffer3, 206176, buffer2, 245368, 4540);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 11232, new Float32Array(15161), 11902, 1284);
+} catch {}
+let imageBitmap3 = await createImageBitmap(imageBitmap0);
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup4, new Uint32Array(7016), 2112, 0);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 696 widthInBlocks: 174 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1720 */
+  offset: 1720,
+  bytesPerRow: 1024,
+  buffer: buffer3,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 191, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 174, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline15 = await device0.createRenderPipelineAsync({
+  label: '\u0002\u076e',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rg8unorm'}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'src'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'greater-equal', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 112956267,
+    stencilWriteMask: 2026152666,
+    depthBias: -2141771313,
+    depthBiasClamp: 496.50205213773904,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'unorm16x4', offset: 5956, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 1340, shaderLocation: 11},
+          {format: 'float32x4', offset: 7448, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 14360, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 4236,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 272, shaderLocation: 2}],
+      },
+      {
+        arrayStride: 992,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x4', offset: 40, shaderLocation: 17}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+video1.height = 130;
+let imageData2 = new ImageData(64, 204);
+let buffer5 = device0.createBuffer({size: 609504, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: true});
+let textureView36 = texture1.createView({label: '\uc696\u2e52\u0818\udb40', baseMipLevel: 1});
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(querySet10, 1957, 1144, buffer0, 139008);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 283, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(110), /* required buffer size: 110 */
+{offset: 110, bytesPerRow: 2310}, {width: 1055, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView37 = texture18.createView({label: '\ub71d\u9dd2\u{1fa26}\u{1feb8}\u00b4', baseMipLevel: 2, mipLevelCount: 3, baseArrayLayer: 0});
+try {
+commandEncoder18.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 692, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 7, y: 2, z: 3},
+  aspect: 'all',
+},
+{width: 96, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(8)), /* required buffer size: 312_414 */
+{offset: 482, bytesPerRow: 146, rowsPerImage: 178}, {width: 19, height: 1, depthOrArrayLayers: 13});
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({
+  label: '\u131d\u0f78\uf86f\u4811\u{1f726}\uaa45\u{1f612}\u8055\u7580\u0bd3',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout3, bindGroupLayout5, bindGroupLayout4],
+});
+let renderBundle15 = renderBundleEncoder4.finish();
+try {
+computePassEncoder0.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(5862, undefined, 0, 601713446);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 69},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 213, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 306, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(querySet5, 30, 76, buffer0, 26112);
+} catch {}
+try {
+commandEncoder3.insertDebugMarker('\ua1c6');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 356 */
+{offset: 356, bytesPerRow: 7531, rowsPerImage: 141}, {width: 1816, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: canvas3,
+  origin: { x: 18, y: 19 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 5,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas8 = document.createElement('canvas');
+let bindGroup5 = device0.createBindGroup({
+  label: '\u{1f82b}\u31bc\u30ec\uf098\uabd8\u{1fa1f}\u1839\u0160\u532c',
+  layout: bindGroupLayout5,
+  entries: [{binding: 5278, resource: externalTexture11}],
+});
+let commandEncoder24 = device0.createCommandEncoder({label: '\u3b60\u022a\u0b49\u18bb\u{1fde1}\ub73e'});
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder14.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 5,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 128 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 40232 */
+  offset: 16552,
+  bytesPerRow: 256,
+  rowsPerImage: 46,
+  buffer: buffer2,
+}, {width: 16, height: 1, depthOrArrayLayers: 3});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer2, 120100, 110800);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 124684, new DataView(new ArrayBuffer(61999)), 8475, 756);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 162, height: 7, depthOrArrayLayers: 69}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 85, y: 292982320 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 69, y: 1, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 24, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let pipeline16 = device0.createRenderPipeline({
+  label: '\u{1f739}\u0f05\ua6ba\uf80f',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16uint'}, {format: 'rgba16uint'}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rg32uint'}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'dst'},
+  },
+}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilReadMask: 1210015868,
+    stencilWriteMask: 215221563,
+    depthBias: -1759680477,
+    depthBiasSlopeScale: 977.7018536892883,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7380,
+        attributes: [
+          {format: 'float32', offset: 304, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 1052, shaderLocation: 12},
+          {format: 'sint16x4', offset: 492, shaderLocation: 15},
+          {format: 'float16x4', offset: 2880, shaderLocation: 16},
+          {format: 'sint32x3', offset: 464, shaderLocation: 17},
+          {format: 'uint16x4', offset: 5708, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 35188,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 1144, shaderLocation: 7}],
+      },
+      {arrayStride: 1972, attributes: []},
+      {
+        arrayStride: 5072,
+        attributes: [
+          {format: 'float32', offset: 524, shaderLocation: 2},
+          {format: 'sint8x4', offset: 564, shaderLocation: 14},
+          {format: 'uint32', offset: 160, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', unclippedDepth: true},
+});
+let gpuCanvasContext6 = canvas6.getContext('webgpu');
+let offscreenCanvas6 = new OffscreenCanvas(433, 978);
+let bindGroupLayout7 = pipeline4.getBindGroupLayout(0);
+let buffer6 = device0.createBuffer({label: '\u04c6\u63d3', size: 128698, usage: GPUBufferUsage.MAP_WRITE});
+let querySet13 = device0.createQuerySet({label: '\u136e\u206c', type: 'occlusion', count: 1249});
+let externalTexture12 = device0.importExternalTexture({
+  label: '\u753c\u0e53\u88ce\u0aea\u{1f9bc}\u2283\u{1fb06}\u78a2\u{1f821}\u{1fd3d}',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  label: '\u3e06\u{1fc79}\u4020\u6119\u0fa8',
+  layout: bindGroupLayout0,
+  entries: [{binding: 5545, resource: externalTexture4}],
+});
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\ufeca\u1ac6\u{1fbc0}\u0db7\u{1f94a}\u{1f975}\u037d\ue0f9\u95f4\u0a48\ue8a8',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout3, bindGroupLayout1],
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\u2029\u{1faf2}\u84a2\uefd0\u{1fe60}\u6b13\u{1fecf}\ubc36\u{1ff25}\u081a\u4551',
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let externalTexture13 = device0.importExternalTexture({label: '\u3bf3\u{1f604}\u{1fd6a}\u0092\u844e\u08de', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+commandEncoder3.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 60 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 7388 */
+  offset: 7388,
+  buffer: buffer2,
+}, {width: 30, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder6.clearBuffer(buffer5);
+dissociateBuffer(device0, buffer5);
+} catch {}
+gc();
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  label: '\u03cd\u4100\u1aa6\u{1fbbe}',
+  entries: [
+    {binding: 2351, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 5527, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let texture26 = device0.createTexture({
+  size: {width: 320},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm'],
+});
+let textureView38 = texture20.createView({
+  label: '\u040a\ub9ca\u133f\u30da\u0cc0\ub465\ud618\u06b9\u0ef2\u275e\u{1f7a8}',
+  dimension: '2d-array',
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup0);
+} catch {}
+let buffer7 = device0.createBuffer({label: '\u6065\u0299', size: 25605, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE});
+let commandEncoder25 = device0.createCommandEncoder({label: '\u1428\u11e5\u23b2\u5905\ude5c\u0518\u072e\u{1f71d}\u678b\u036b'});
+try {
+computePassEncoder5.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer1, 'uint32');
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(5954, undefined, 2183438201, 1749976678);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 5684 widthInBlocks: 1421 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 38308 */
+  offset: 38308,
+  bytesPerRow: 5888,
+  buffer: buffer3,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 484, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1421, height: 4, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  code: `@group(2) @binding(5545)
+var<storage, read_write> parameter1: array<u32>;
+@group(0) @binding(5545)
+var<storage, read_write> field3: array<u32>;
+@group(1) @binding(5545)
+var<storage, read_write> type4: array<u32>;
+
+@compute @workgroup_size(7, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: u32,
+  @location(6) f1: vec4<f32>,
+  @location(1) f2: vec4<u32>,
+  @location(3) f3: vec4<i32>,
+  @location(4) f4: vec2<u32>,
+  @location(2) f5: vec3<i32>,
+  @location(5) f6: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(9) a0: vec3<u32>, @location(13) a1: vec4<u32>, @location(5) a2: vec4<u32>, @builtin(instance_index) a3: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  label: '\u{1fbdf}\u975c\u01b0\uf7cf\u0cec\u093f',
+  entries: [
+    {binding: 6435, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 6622,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let commandEncoder26 = device0.createCommandEncoder({label: '\ud0e6\u{1f65b}\u496e\u043e\u{1f943}\uba10\uc36a\u7761\u076d'});
+try {
+computePassEncoder4.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline6);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 156, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(16)), /* required buffer size: 877 */
+{offset: 877}, {width: 972, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 7, y: 19 },
+  flipY: true,
+}, {
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  code: `@group(1) @binding(5545)
+var<storage, read_write> global1: array<u32>;
+@group(0) @binding(5830)
+var<storage, read_write> local2: array<u32>;
+@group(0) @binding(765)
+var<storage, read_write> parameter2: array<u32>;
+
+@compute @workgroup_size(1, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S8 {
+  @builtin(sample_mask) f0: u32,
+  @location(37) f1: vec3<i32>,
+  @builtin(position) f2: vec4<f32>,
+  @location(27) f3: vec2<i32>,
+  @location(36) f4: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: u32,
+  @location(5) f1: vec4<f32>,
+  @location(2) f2: vec2<i32>,
+  @location(3) f3: vec3<i32>,
+  @location(1) f4: vec4<u32>,
+  @location(6) f5: vec4<f32>,
+  @location(4) f6: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(41) a0: vec3<u32>, @location(31) a1: vec2<f32>, @location(4) a2: vec4<u32>, @builtin(sample_index) a3: u32, @location(33) a4: vec2<f16>, @location(0) a5: i32, @builtin(front_facing) a6: bool, @location(14) a7: vec2<i32>, @location(21) a8: vec3<f32>, @location(13) a9: f32, a10: S8, @location(16) a11: f16, @location(20) a12: vec3<f32>, @location(17) a13: i32, @location(12) a14: vec3<f16>, @location(28) a15: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(13) f126: f32,
+  @location(28) f127: u32,
+  @location(21) f128: vec3<f32>,
+  @location(41) f129: vec3<u32>,
+  @location(17) f130: i32,
+  @location(20) f131: vec3<f32>,
+  @location(31) f132: vec2<f32>,
+  @location(14) f133: vec2<i32>,
+  @location(16) f134: f16,
+  @builtin(position) f135: vec4<f32>,
+  @location(0) f136: i32,
+  @location(37) f137: vec3<i32>,
+  @location(33) f138: vec2<f16>,
+  @location(12) f139: vec3<f16>,
+  @location(4) f140: vec4<u32>,
+  @location(36) f141: u32,
+  @location(27) f142: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec4<f16>, @location(2) a1: i32, @location(17) a2: vec2<f32>, @location(14) a3: vec4<u32>, @location(9) a4: u32, @location(3) a5: f16, @location(4) a6: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder27 = device0.createCommandEncoder({label: '\u6680\u35fc\u{1fbe7}\u43fa\u4069\u18a5\u0a84\u0244'});
+let computePassEncoder9 = commandEncoder25.beginComputePass({label: '\u67d6\u0a8f\u{1fb4d}\u8c3b'});
+try {
+commandEncoder17.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1748 */
+  offset: 1748,
+  bytesPerRow: 512,
+  buffer: buffer3,
+}, {
+  texture: texture2,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline17 = device0.createRenderPipeline({
+  label: '\u0bdb\ub180\u{1f93e}\u{1fdd0}\u{1f8c6}\uf4f1\u0d8f\u{1f811}',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0xa55d1615},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16sint'}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rg32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one-minus-dst-alpha'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 9112, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2656,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 712, shaderLocation: 16}],
+      },
+    ],
+  },
+});
+let device1 = await adapter1.requestDevice({
+  label: '\u4233\uf7ee\u1fa7\ufc5e\u0100\u0262\ud938\ue188\u0866\ue26b',
+  defaultQueue: {label: '\u{1fa75}\ucb5a\udf0f\u7e81\u0ba6\u{1fd50}'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 6,
+    maxColorAttachmentBytesPerSample: 46,
+    maxVertexAttributes: 20,
+    maxVertexBufferArrayStride: 50960,
+    maxStorageTexturesPerShaderStage: 34,
+    maxStorageBuffersPerShaderStage: 21,
+    maxDynamicStorageBuffersPerPipelineLayout: 34630,
+    maxDynamicUniformBuffersPerPipelineLayout: 36503,
+    maxBindingsPerBindGroup: 5423,
+    maxTextureArrayLayers: 1786,
+    maxTextureDimension1D: 16115,
+    maxTextureDimension2D: 13523,
+    maxVertexBuffers: 9,
+    maxBindGroupsPlusVertexBuffers: 28,
+    minStorageBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 110534293,
+    maxStorageBufferBindingSize: 148940278,
+    maxUniformBuffersPerShaderStage: 20,
+    maxSampledTexturesPerShaderStage: 24,
+    maxInterStageShaderVariables: 79,
+    maxInterStageShaderComponents: 124,
+  },
+});
+let querySet14 = device1.createQuerySet({label: '\u0f5c\u{1f758}\u0725\u1c1d\ucada', type: 'occlusion', count: 2616});
+let sampler5 = device1.createSampler({
+  label: '\u64e7\u4882\u0681\ua81f\u1c0f\u076e\u403b\u{1fb01}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 93.98,
+});
+try {
+querySet14.destroy();
+} catch {}
+let bindGroup7 = device0.createBindGroup({label: '\u5e0a\ub937\u0399\u9989\u8bfa\ucb8b', layout: bindGroupLayout3, entries: []});
+let commandEncoder28 = device0.createCommandEncoder({label: '\uc6d1\ub8da'});
+let renderBundle16 = renderBundleEncoder1.finish({label: '\u8c1a\u01f4\u0045\u{1f90d}\u{1f9f4}'});
+let arrayBuffer0 = buffer5.getMappedRange(34264);
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 220 widthInBlocks: 110 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 21344 */
+  offset: 21344,
+  buffer: buffer2,
+}, {width: 110, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer5);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet12, 1799, 2007, buffer0, 186880);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 8, y: 1, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer0), /* required buffer size: 958 */
+{offset: 640, bytesPerRow: 278}, {width: 10, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+adapter0.label = '\u0ac1\u023b\ub7c4\u0c1b\u{1f7d8}\ue4d7\u31b5\ud2e4\ubc42';
+} catch {}
+let commandEncoder29 = device1.createCommandEncoder({label: '\uc21f\u{1fa5c}\u2b8d\u46d2\u3652\u00d1\u3ec4\u5493\u{1f7cd}\uf5d3\u3c9e'});
+let externalTexture14 = device1.importExternalTexture({label: '\u3843\uedd5\ue1f3\u992e\u2cdf', source: videoFrame1, colorSpace: 'display-p3'});
+let imageData3 = new ImageData(252, 20);
+let texture27 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder10 = commandEncoder17.beginComputePass({label: '\u2cab\ue4ad\u{1face}\u{1fb98}\u6af4\u{1fba7}'});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u5ef2\u0d86\u8de2\u0c4d\u070b\u97b6',
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+});
+let arrayBuffer1 = buffer5.getMappedRange(11408, 16840);
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 47, y: 0, z: 5},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(querySet2, 1470, 1041, buffer0, 214784);
+} catch {}
+let texture28 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder11 = commandEncoder23.beginComputePass({label: '\u068a\u0dca'});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u0f3c\u02d0\u46c3\u3592\u0164\u{1fbac}',
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder8.setVertexBuffer(3999, undefined, 0, 2811181418);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer5);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 39_846 */
+{offset: 832, bytesPerRow: 310, rowsPerImage: 123}, {width: 66, height: 3, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.destroy();
+} catch {}
+let imageData4 = new ImageData(140, 72);
+let commandEncoder30 = device1.createCommandEncoder({label: '\u{1fb7b}\u6bc4\uedeb\u{1f700}\u0524\ufa4a\ub330\u{1f8e4}\u0f46\u3a82'});
+let querySet15 = device1.createQuerySet({type: 'occlusion', count: 857});
+gc();
+let texture29 = device1.createTexture({
+  label: '\u{1f7a2}\u{1fd65}\u0c50\u6edf\u8005\u{1fe66}\u00a8\u0b71\u3871\u056a\uf609',
+  size: [240, 1, 1947],
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint'],
+});
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let imageData5 = new ImageData(12, 164);
+let buffer8 = device1.createBuffer({
+  label: '\u41ea\ue7e8\u8b05\u0759\u5d75',
+  size: 49036,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder12 = commandEncoder30.beginComputePass({});
+let sampler6 = device1.createSampler({
+  label: '\ud9b5\u0c9e\u{1feaf}\u{1f9c4}\u{1f67a}\uf218\u33c7\uf03d\u{1f8ea}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.46,
+  lodMaxClamp: 80.90,
+  maxAnisotropy: 19,
+});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder29.resolveQuerySet(querySet14, 1114, 67, buffer8, 19968);
+} catch {}
+document.body.prepend(video0);
+video1.width = 205;
+gc();
+try {
+canvas7.getContext('2d');
+} catch {}
+let promise2 = adapter2.requestAdapterInfo();
+let bindGroup8 = device0.createBindGroup({
+  label: '\u061c\ue8c3\u0ecf\ued20\ua38b\u2666\uc4a0\u4108\u13e9\u0367',
+  layout: bindGroupLayout0,
+  entries: [{binding: 5545, resource: externalTexture7}],
+});
+let buffer9 = device0.createBuffer({
+  label: '\u22a7\u04b2\u{1fac2}\u8f6a\u3e01\ua40b\u0f30\u0e4e\u{1fcee}\u0e67\u{1f7ef}',
+  size: 3012,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+let texture30 = device0.createTexture({
+  label: '\u{1f834}\u0f60\u0d59',
+  size: {width: 1905, height: 4, depthOrArrayLayers: 26},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16uint'],
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\u0f4f\uf685\u5ca5\u0390\u{1fb6d}\u13ec',
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 89, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2928 widthInBlocks: 1464 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 25224 */
+  offset: 22296,
+  buffer: buffer2,
+}, {width: 1464, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer2, 90276, 101464);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 10040, new BigUint64Array(5193), 3583, 16);
+} catch {}
+let textureView39 = texture29.createView({baseMipLevel: 1, mipLevelCount: 8});
+document.body.prepend(canvas2);
+let commandEncoder31 = device1.createCommandEncoder();
+let textureView40 = texture29.createView({
+  label: '\u060c\uc692\u885d\u0c28\uc582\u{1f757}\u953a',
+  format: 'rg8uint',
+  baseMipLevel: 1,
+  mipLevelCount: 5,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder15 = device1.createRenderBundleEncoder({
+  label: '\u4ccd\u{1f903}\u{1fbb9}\u{1f749}\u6e18\u030c\u{1fad0}\u0585\u0fbd\ufcc8',
+  colorFormats: ['rgba8uint', 'rg8uint', 'rgba8uint', 'rgba32uint'],
+  depthReadOnly: true,
+});
+let renderBundle17 = renderBundleEncoder15.finish({label: '\uf3fe\u0de4\u19d1\u35fa\u8095\u007a\uce14\ue33d\uf25b\ub58b'});
+let sampler7 = device1.createSampler({
+  label: '\u00f6\u955f\u0837\u{1f8f1}\u097c',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  lodMaxClamp: 91.11,
+});
+let adapter3 = await navigator.gpu.requestAdapter({});
+let sampler8 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.727,
+  lodMaxClamp: 45.13,
+  maxAnisotropy: 13,
+});
+try {
+commandEncoder29.clearBuffer(buffer8);
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+device1.destroy();
+} catch {}
+try {
+  await promise2;
+} catch {}
+document.body.prepend(canvas8);
+let canvas9 = document.createElement('canvas');
+let video3 = await videoWithData();
+try {
+offscreenCanvas6.getContext('webgpu');
+} catch {}
+gc();
+try {
+offscreenCanvas5.getContext('webgl');
+} catch {}
+let videoFrame2 = new VideoFrame(canvas8, {timestamp: 0});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let canvas10 = document.createElement('canvas');
+let offscreenCanvas7 = new OffscreenCanvas(974, 503);
+let video4 = await videoWithData();
+let videoFrame3 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+try {
+adapter0.label = '\u{1ff8d}\u4348\u0128\u0b13';
+} catch {}
+try {
+offscreenCanvas4.getContext('webgl');
+} catch {}
+let video5 = await videoWithData();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+canvas9.width = 241;
+let videoFrame4 = new VideoFrame(offscreenCanvas5, {timestamp: 0});
+gc();
+let canvas11 = document.createElement('canvas');
+let gpuCanvasContext7 = offscreenCanvas7.getContext('webgpu');
+try {
+canvas11.getContext('webgl');
+} catch {}
+let promise3 = adapter1.requestAdapterInfo();
+try {
+  await promise3;
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+window.someLabel = device1.queue.label;
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+gc();
+try {
+canvas9.getContext('2d');
+} catch {}
+let imageBitmap4 = await createImageBitmap(imageBitmap1);
+try {
+canvas8.getContext('webgpu');
+} catch {}
+let buffer10 = device0.createBuffer({
+  label: '\u20b5\ub2d3\ueb01\u0d35\u0159\ua9a0\u0421\u9564\ub46b\uddcc',
+  size: 203647,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let textureView41 = texture17.createView({});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+commandEncoder14.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 495, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1718 widthInBlocks: 859 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 8018 */
+  offset: 6300,
+  buffer: buffer7,
+}, {width: 859, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 4944, new Int16Array(61969), 58767, 312);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 10, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 18, y: 12 },
+  flipY: true,
+}, {
+  texture: texture2,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas10.getContext('bitmaprenderer');
+} catch {}
+let bindGroup9 = device0.createBindGroup({layout: bindGroupLayout5, entries: [{binding: 5278, resource: externalTexture4}]});
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\ue078\u2951\ufe0a\ued35\ucf10',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout3, bindGroupLayout1],
+});
+let buffer11 = device0.createBuffer({
+  label: '\u14d3\u5d4a\u063d\u{1fbef}\u71a9\u9d6f\u0c97\u85e9\u0e25',
+  size: 69441,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u0ee7\u{1ffb4}\ud8fa\ub3da',
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+});
+let renderBundle18 = renderBundleEncoder13.finish({label: '\uc410\u081f\u922b\u0119\u59be\u0a5c\u00a0\u0890'});
+let externalTexture15 = device0.importExternalTexture({label: '\u{1f7fb}\ue62e\u4b22', source: videoFrame3, colorSpace: 'srgb'});
+try {
+renderBundleEncoder12.setPipeline(pipeline7);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+canvas6.width = 1041;
+let img0 = await imageWithData(212, 256, '#57681310', '#150efc0d');
+try {
+window.someLabel = renderBundleEncoder7.label;
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(925, 692);
+let texture31 = device0.createTexture({
+  label: '\u0ab7\u2295\u0d39\u22f5\u00fa\u05df\uaeca\uc70d\u{1fd29}\u0312\uc1df',
+  size: [324],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder13 = commandEncoder22.beginComputePass({label: '\u{1ff60}\u{1fc17}\ua414\u6312'});
+let renderBundle19 = renderBundleEncoder8.finish({label: '\u465e\u40ea\uc4a5\u{1ff38}\u965f\u0157'});
+let externalTexture16 = device0.importExternalTexture({source: video4, colorSpace: 'srgb'});
+try {
+commandEncoder3.clearBuffer(buffer2, 130944, 62220);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder24.pushDebugGroup('\u501e');
+} catch {}
+let pipeline18 = await promise1;
+let pipeline19 = device0.createRenderPipeline({
+  label: '\u3da0\u{1fc01}\ud4fd\u6ca9\u{1fe3f}',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16uint'}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8sint'}, {format: 'rg32uint', writeMask: 0}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'zero'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'equal', passOp: 'increment-wrap'},
+    stencilReadMask: 1060893830,
+    depthBiasSlopeScale: 936.6375495453337,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5728,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 1292, shaderLocation: 16}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let promise4 = adapter2.requestAdapterInfo();
+let video6 = await videoWithData();
+let gpuCanvasContext8 = offscreenCanvas8.getContext('webgpu');
+let imageBitmap5 = await createImageBitmap(offscreenCanvas3);
+canvas4.height = 100;
+gc();
+let videoFrame5 = new VideoFrame(canvas7, {timestamp: 0});
+try {
+  await promise4;
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(canvas2);
+let videoFrame6 = new VideoFrame(imageBitmap4, {timestamp: 0});
+let promise5 = adapter3.requestAdapterInfo();
+try {
+  await promise5;
+} catch {}
+offscreenCanvas5.height = 1329;
+let canvas12 = document.createElement('canvas');
+let videoFrame7 = new VideoFrame(videoFrame1, {timestamp: 0});
+video5.height = 129;
+let offscreenCanvas9 = new OffscreenCanvas(345, 971);
+let img1 = await imageWithData(288, 22, '#6f3dc19d', '#481cf0c7');
+let gpuCanvasContext9 = offscreenCanvas9.getContext('webgpu');
+let canvas13 = document.createElement('canvas');
+let imageBitmap6 = await createImageBitmap(offscreenCanvas1);
+let commandEncoder32 = device0.createCommandEncoder({label: '\u{1f6a3}\u01fb\u37c6\u4fe9\u009e'});
+let querySet16 = device0.createQuerySet({label: '\ue88c\uf3a8', type: 'occlusion', count: 18});
+let textureView42 = texture2.createView({label: '\u{1ffec}\u{1f777}\u726f\u0f52\u5c69\u8eff\u0dae', mipLevelCount: 6});
+let externalTexture17 = device0.importExternalTexture({source: video3, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup7, new Uint32Array(5299), 242, 0);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(93, undefined, 0, 4159095344);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 6904 widthInBlocks: 3452 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 14182 */
+  offset: 14182,
+  buffer: buffer3,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3452, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder6.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 15, y: 1, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 5, y: 3, z: 22},
+  aspect: 'all',
+},
+{width: 132, height: 12, depthOrArrayLayers: 61});
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(querySet6, 2007, 750, buffer0, 190720);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 58_060 */
+{offset: 262, bytesPerRow: 2638, rowsPerImage: 90}, {width: 300, height: 22, depthOrArrayLayers: 1});
+} catch {}
+gc();
+gc();
+let videoFrame8 = new VideoFrame(canvas8, {timestamp: 0});
+let imageData6 = new ImageData(76, 52);
+try {
+canvas13.getContext('bitmaprenderer');
+} catch {}
+try {
+adapter0.label = '\ub593\u02ad\u0475\u0968\u0ef0\ucc89\u{1fb77}\u02b5\u8769\u0989';
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let canvas14 = document.createElement('canvas');
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+adapter0.label = '\ub8ce\u{1fc6e}\u{1fb35}\u2f0d\ud99a';
+} catch {}
+let gpuCanvasContext10 = canvas14.getContext('webgpu');
+gc();
+let gpuCanvasContext11 = canvas12.getContext('webgpu');
+try {
+device1.label = '\u99b4\u0c34\u42a2\u0e65\u067a\u9d46\uf2ec\ua7f4\u0197\u0ac9\u079c';
+} catch {}
+let imageData7 = new ImageData(256, 140);
+gc();
+try {
+adapter1.label = '\u0436\u2ada\u0aca\ufb77\u0ae6';
+} catch {}
+let img2 = await imageWithData(95, 101, '#373ffd17', '#623ce846');
+let videoFrame9 = new VideoFrame(img2, {timestamp: 0});
+let canvas15 = document.createElement('canvas');
+try {
+canvas15.getContext('2d');
+} catch {}
+let img3 = await imageWithData(249, 227, '#0cb42831', '#d5c0a373');
+let bindGroup10 = device0.createBindGroup({layout: bindGroupLayout3, entries: []});
+let buffer12 = device0.createBuffer({size: 51421, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder33 = device0.createCommandEncoder({label: '\u{1f7dc}\u85ef\u01d6\u085f\u08dc\ud15f\u9846'});
+let textureView43 = texture23.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let sampler9 = device0.createSampler({
+  label: '\ud22b\u0e41\u0a3c\u{1feb8}\uea91\u{1fb2d}\u{1f9d7}\u5127',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 6.304,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder10.insertDebugMarker('\u{1f9ab}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 2520, new DataView(new ArrayBuffer(27463)), 19749, 296);
+} catch {}
+let pipeline20 = device0.createComputePipeline({layout: pipelineLayout7, compute: {module: shaderModule2, entryPoint: 'compute0'}});
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+gc();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let device2 = await adapter3.requestDevice({
+  requiredLimits: {
+    maxBindGroups: 8,
+    maxColorAttachmentBytesPerSample: 37,
+    maxVertexAttributes: 24,
+    maxVertexBufferArrayStride: 60715,
+    maxStorageTexturesPerShaderStage: 6,
+    maxStorageBuffersPerShaderStage: 17,
+    maxDynamicStorageBuffersPerPipelineLayout: 3819,
+    maxDynamicUniformBuffersPerPipelineLayout: 13570,
+    maxBindingsPerBindGroup: 8492,
+    maxTextureArrayLayers: 689,
+    maxTextureDimension1D: 11172,
+    maxTextureDimension2D: 12698,
+    maxBindGroupsPlusVertexBuffers: 27,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 203955250,
+    maxStorageBufferBindingSize: 138348779,
+    maxUniformBuffersPerShaderStage: 19,
+    maxSampledTexturesPerShaderStage: 17,
+    maxInterStageShaderVariables: 94,
+    maxInterStageShaderComponents: 68,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+let offscreenCanvas10 = new OffscreenCanvas(721, 906);
+gc();
+let offscreenCanvas11 = new OffscreenCanvas(456, 279);
+let offscreenCanvas12 = new OffscreenCanvas(205, 145);
+try {
+device2.label = '\u0c9a\u5a58\ufad7\ud2a2\u{1fa63}';
+} catch {}
+let commandEncoder34 = device2.createCommandEncoder({label: '\u1307\u{1fa64}\uf509'});
+let texture32 = device2.createTexture({
+  size: [126, 1, 481],
+  mipLevelCount: 5,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView44 = texture32.createView({
+  label: '\u61de\u8222\uc3d5\u085f\u{1f806}',
+  aspect: 'depth-only',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 72,
+  arrayLayerCount: 31,
+});
+let commandEncoder35 = device2.createCommandEncoder();
+let textureView45 = texture32.createView({
+  label: '\u087f\u0db1\ua6ee\u62c5\u182a\u004c',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 444,
+  arrayLayerCount: 1,
+});
+let gpuCanvasContext12 = offscreenCanvas11.getContext('webgpu');
+let videoFrame10 = new VideoFrame(canvas3, {timestamp: 0});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u0977\u{1f89d}\ua961\u07b9\u09a3\u0639\u0e74\u5440\u0e97\u0b1c',
+  entries: [{binding: 5419, visibility: 0, externalTexture: {}}],
+});
+let textureView46 = texture6.createView({format: 'rg16sint'});
+let computePassEncoder14 = commandEncoder26.beginComputePass();
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\u0f78\u1627\u40c6\u0a71\u58b0\u22c4\u{1fa59}\u{1ff88}\uea6d\u7cf5',
+  colorFormats: ['r16uint', 'rgba16uint', 'rg16sint', 'r8sint', 'rg32uint', 'rg8unorm', 'rgb10a2unorm'],
+  sampleCount: 4,
+});
+try {
+renderBundleEncoder10.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2260 */
+  offset: 2260,
+  buffer: buffer3,
+}, {
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer2, 66776, 88016);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder32.insertDebugMarker('\ud0b6');
+} catch {}
+let promise6 = device0.createComputePipelineAsync({
+  label: '\u4e00\u08ec\u166c\u0ccf\u5b4c\u6924\u6b29\u{1f8da}\u0f27',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext13 = offscreenCanvas12.getContext('webgpu');
+try {
+offscreenCanvas10.getContext('bitmaprenderer');
+} catch {}
+gc();
+let video7 = await videoWithData();
+let bindGroupLayout11 = device2.createBindGroupLayout({
+  label: '\u{1fb40}\u0e3f\u03a1\u0107\u{1f85e}',
+  entries: [{binding: 2190, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let commandEncoder36 = device2.createCommandEncoder({label: '\u9994\uc388'});
+let querySet17 = device2.createQuerySet({
+  label: '\u97a6\u0c1b\u0830\u17f4\u{1fbfb}\u3895\u82bc\ud9be\ue15b\u4033',
+  type: 'occlusion',
+  count: 2458,
+});
+let textureView47 = texture32.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 2, baseArrayLayer: 306, arrayLayerCount: 1});
+let computePassEncoder15 = commandEncoder36.beginComputePass({label: '\u0c46\u{1f668}\u6924\u0cf6\u376d\u0cce\ue617\u8a55\u{1f90e}\u02a0\u0d4f'});
+try {
+computePassEncoder15.end();
+} catch {}
+let pipelineLayout10 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout11, bindGroupLayout11, bindGroupLayout11]});
+let commandEncoder37 = device2.createCommandEncoder({label: '\u0daa\ucb56\u068f\u2831\u0042\uaeb1'});
+let textureView48 = texture32.createView({
+  label: '\uc03e\u03df\ud7ab\u00ae\u{1fa65}\u{1f643}',
+  aspect: 'depth-only',
+  format: 'depth24plus',
+  baseMipLevel: 4,
+  baseArrayLayer: 145,
+  arrayLayerCount: 325,
+});
+let externalTexture18 = device2.importExternalTexture({label: '\u{1feb7}\u2e62\u8db0', source: videoFrame6, colorSpace: 'srgb'});
+let promise7 = navigator.gpu.requestAdapter({});
+let shaderModule9 = device2.createShaderModule({
+  label: '\u5be1\u{1fff7}\u037e\u089d\u7547',
+  code: `@group(0) @binding(2190)
+var<storage, read_write> function4: array<u32>;
+@group(2) @binding(2190)
+var<storage, read_write> function5: array<u32>;
+@group(1) @binding(2190)
+var<storage, read_write> type5: array<u32>;
+
+@compute @workgroup_size(7, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+  @builtin(sample_index) f0: u32,
+  @location(25) f1: vec2<i32>,
+  @builtin(front_facing) f2: bool,
+  @location(63) f3: vec4<f32>,
+  @location(84) f4: vec2<f16>
+}
+struct FragmentOutput0 {
+  @location(6) f0: vec2<i32>,
+  @builtin(sample_mask) f1: u32,
+  @location(0) f2: f32,
+  @location(1) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(76) a0: vec4<i32>, @location(16) a1: vec4<i32>, @location(49) a2: vec4<f16>, @location(50) a3: f32, @location(48) a4: vec3<f16>, a5: S10, @location(93) a6: vec3<i32>, @location(43) a7: vec3<f32>, @builtin(position) a8: vec4<f32>, @builtin(sample_mask) a9: u32, @location(52) a10: vec4<i32>, @location(40) a11: vec4<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @location(11) f0: vec2<f16>,
+  @location(16) f1: vec2<f32>,
+  @location(12) f2: f16,
+  @location(19) f3: vec3<i32>,
+  @location(7) f4: vec4<i32>,
+  @location(15) f5: vec4<i32>,
+  @location(3) f6: vec4<f32>,
+  @builtin(instance_index) f7: u32,
+  @location(13) f8: vec2<f16>,
+  @location(21) f9: vec4<u32>,
+  @location(20) f10: vec3<i32>,
+  @location(6) f11: i32,
+  @location(10) f12: i32,
+  @location(4) f13: vec4<u32>,
+  @location(17) f14: vec4<f16>,
+  @location(8) f15: vec2<i32>,
+  @location(14) f16: vec2<i32>
+}
+struct VertexOutput0 {
+  @location(84) f143: vec2<f16>,
+  @location(16) f144: vec4<i32>,
+  @location(25) f145: vec2<i32>,
+  @builtin(position) f146: vec4<f32>,
+  @location(49) f147: vec4<f16>,
+  @location(52) f148: vec4<i32>,
+  @location(50) f149: f32,
+  @location(76) f150: vec4<i32>,
+  @location(48) f151: vec3<f16>,
+  @location(93) f152: vec3<i32>,
+  @location(40) f153: vec4<u32>,
+  @location(63) f154: vec4<f32>,
+  @location(43) f155: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(23) a0: vec4<f16>, @location(18) a1: vec4<f16>, @builtin(vertex_index) a2: u32, a3: S9, @location(2) a4: f32, @location(9) a5: vec3<u32>, @location(5) a6: vec3<f16>, @location(22) a7: vec4<u32>, @location(0) a8: vec3<f32>, @location(1) a9: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder38 = device2.createCommandEncoder({label: '\u4a55\u{1fd5e}\u{1ff1c}\u9444\u042b\u3be9'});
+let textureView49 = texture32.createView({
+  label: '\u7990\u0f20\u3417\ucf3b\u{1f9df}\u07cb\ud4e7',
+  aspect: 'depth-only',
+  format: 'depth24plus',
+  baseMipLevel: 4,
+  baseArrayLayer: 69,
+  arrayLayerCount: 298,
+});
+let pipeline21 = device2.createRenderPipeline({
+  label: '\u{1fb7e}\ue3d8\u752a\u{1f9ae}',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 4140,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32', offset: 60, shaderLocation: 3}],
+      },
+      {
+        arrayStride: 136,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 32, shaderLocation: 4},
+          {format: 'sint32', offset: 16, shaderLocation: 14},
+          {format: 'uint16x2', offset: 12, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 7144,
+        attributes: [
+          {format: 'snorm8x4', offset: 3444, shaderLocation: 17},
+          {format: 'uint16x4', offset: 24, shaderLocation: 22},
+          {format: 'uint32', offset: 3228, shaderLocation: 21},
+          {format: 'float32', offset: 572, shaderLocation: 16},
+          {format: 'float32x2', offset: 468, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 8, shaderLocation: 23},
+          {format: 'sint32x4', offset: 1680, shaderLocation: 19},
+          {format: 'sint32', offset: 204, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 18936,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 2792, shaderLocation: 10},
+          {format: 'sint16x2', offset: 4344, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 3256, shaderLocation: 2},
+          {format: 'sint32', offset: 320, shaderLocation: 8},
+          {format: 'sint32x4', offset: 9120, shaderLocation: 6},
+          {format: 'float16x4', offset: 360, shaderLocation: 13},
+          {format: 'float32x3', offset: 940, shaderLocation: 0},
+          {format: 'float16x2', offset: 8984, shaderLocation: 1},
+          {format: 'sint32x3', offset: 2628, shaderLocation: 20},
+          {format: 'snorm16x2', offset: 3348, shaderLocation: 18},
+          {format: 'float16x4', offset: 4216, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 6900, attributes: []},
+      {arrayStride: 928, attributes: []},
+      {
+        arrayStride: 3916,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 524, shaderLocation: 5}],
+      },
+    ],
+  },
+});
+let imageData8 = new ImageData(128, 128);
+let commandEncoder39 = device1.createCommandEncoder({});
+let texture33 = device1.createTexture({
+  label: '\u072a\u3796\ub5e0',
+  size: [1260, 6, 1454],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8uint', 'rg8uint', 'rg8uint'],
+});
+let computePassEncoder16 = commandEncoder31.beginComputePass({label: '\u9f3e\u0ee3'});
+let renderBundleEncoder18 = device1.createRenderBundleEncoder({label: '\u03c1\u0906\u{1fe1b}', colorFormats: ['rgba8uint', 'rg8uint', 'rgba8uint', 'rgba32uint']});
+let externalTexture19 = device1.importExternalTexture({
+  label: '\u130c\ucd6e\ub393\u0812\u9f8a\uafa6\u5ae5\u{1fc2d}\u{1fbaa}\ubd52\u0e01',
+  source: videoFrame5,
+  colorSpace: 'display-p3',
+});
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let offscreenCanvas13 = new OffscreenCanvas(40, 34);
+let img4 = await imageWithData(270, 55, '#928c7a19', '#a723d5c8');
+let gpuCanvasContext14 = offscreenCanvas13.getContext('webgpu');
+let img5 = await imageWithData(266, 3, '#9a820e6c', '#beb152ec');
+let imageBitmap7 = await createImageBitmap(imageData2);
+let bindGroupLayout12 = device2.createBindGroupLayout({
+  label: '\u6470\u3751\u4242\uef4f\u{1fe4e}\u{1f80f}\u5d33\uc047\u5310\u07c5\u9ee3',
+  entries: [
+    {
+      binding: 3689,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 2460,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 8040,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let buffer13 = device2.createBuffer({
+  label: '\ub740\u0e25\u83ad\u1ba4\u01ed\u8536\u92d9',
+  size: 279705,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+});
+let texture34 = device2.createTexture({
+  label: '\uea82\ub48e\u{1fd4c}\u{1f789}\u4010\u2c16\u79d1\uae57',
+  size: [126, 1, 4],
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView50 = texture32.createView({
+  label: '\u85fa\ue2d6\u0996\u{1fb6d}\u0410\u{1f6f6}\u{1fade}\uaad3\udc12\u{1face}',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 364,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 55_009 */
+{offset: 365, bytesPerRow: 227, rowsPerImage: 240}, {width: 41, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let pipeline22 = await device2.createComputePipelineAsync({
+  label: '\u46a8\ue6e1\u0b10\u1eb2\u{1fc04}\u{1f83d}\u{1fbc1}\u181a\u0019',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let pipeline23 = device2.createRenderPipeline({
+  label: '\u6789\u0374\uefc1\u{1f6ba}\u{1fec9}\u0a97\u0cd1\u{1ff68}\u0c1e',
+  layout: pipelineLayout10,
+  multisample: {mask: 0x64f30645},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 756,
+        attributes: [
+          {format: 'float32x3', offset: 256, shaderLocation: 11},
+          {format: 'float32x2', offset: 68, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 2600,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 228, shaderLocation: 16},
+          {format: 'snorm8x4', offset: 408, shaderLocation: 12},
+          {format: 'float16x2', offset: 76, shaderLocation: 17},
+          {format: 'uint8x2', offset: 566, shaderLocation: 9},
+          {format: 'sint32x2', offset: 412, shaderLocation: 15},
+          {format: 'sint32x4', offset: 128, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 540, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 636, shaderLocation: 3},
+          {format: 'uint32', offset: 24, shaderLocation: 4},
+          {format: 'unorm8x2', offset: 514, shaderLocation: 1},
+          {format: 'sint32', offset: 1180, shaderLocation: 14},
+          {format: 'sint32x2', offset: 12, shaderLocation: 20},
+          {format: 'uint32x4', offset: 56, shaderLocation: 22},
+          {format: 'sint32x3', offset: 1140, shaderLocation: 8},
+          {format: 'float32x4', offset: 108, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 684, shaderLocation: 23},
+          {format: 'unorm8x2', offset: 366, shaderLocation: 5},
+          {format: 'float32x4', offset: 64, shaderLocation: 2},
+          {format: 'sint16x4', offset: 492, shaderLocation: 19},
+          {format: 'sint32x4', offset: 588, shaderLocation: 10},
+          {format: 'sint32x4', offset: 0, shaderLocation: 7},
+          {format: 'uint8x2', offset: 354, shaderLocation: 21},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+gc();
+let querySet18 = device2.createQuerySet({label: '\ua39c\u4bd0\u{1fdd9}\ua0ac\u3602\u9df5\uc389\u{1f9a9}', type: 'occlusion', count: 198});
+let computePassEncoder17 = commandEncoder36.beginComputePass({label: '\u{1fc68}\uc93b\u083b\u{1f8d1}\ud032\u1bf3'});
+let renderBundleEncoder19 = device2.createRenderBundleEncoder({
+  label: '\u0b67\uc6d2\u08b0\u568d\u089d\u324b\u235d\u{1fd94}\u{1f692}\uaa0a',
+  colorFormats: ['r16float', 'rg16sint'],
+  depthReadOnly: true,
+});
+let renderBundle20 = renderBundleEncoder19.finish({label: '\u{1ff5b}\u{1f68d}\u{1fd5d}'});
+let externalTexture20 = device2.importExternalTexture({
+  label: '\u341a\u306b\u{1fad7}\u3d84\ua815\u{1fd34}\u0d2d',
+  source: videoFrame3,
+  colorSpace: 'display-p3',
+});
+try {
+device2.queue.writeBuffer(buffer13, 41792, new Float32Array(16249), 14374, 716);
+} catch {}
+let pipeline24 = device2.createComputePipeline({
+  label: '\ucf1c\u{1fa50}\u46f5\ub44b\u03cf',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let pipeline25 = device2.createRenderPipeline({
+  label: '\ue641\u{1fc72}\u{1f9a1}\ua236\u1cf2\u09ed\u0533',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16float', writeMask: GPUColorWrite.BLUE}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilReadMask: 3702655734,
+    stencilWriteMask: 2701951432,
+    depthBiasSlopeScale: 400.34210795972643,
+    depthBiasClamp: 618.3923327985416,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2852,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm8x2', offset: 128, shaderLocation: 3},
+          {format: 'float16x4', offset: 1036, shaderLocation: 17},
+          {format: 'uint32x4', offset: 696, shaderLocation: 4},
+          {format: 'sint32x3', offset: 296, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 172, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 4956,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32x4', offset: 36, shaderLocation: 7},
+          {format: 'sint8x2', offset: 278, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 1010, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 1276, shaderLocation: 0},
+          {format: 'unorm8x4', offset: 88, shaderLocation: 2},
+          {format: 'float32x4', offset: 252, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 4296,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 724, shaderLocation: 19}],
+      },
+      {
+        arrayStride: 3032,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 464, shaderLocation: 13},
+          {format: 'uint16x2', offset: 444, shaderLocation: 22},
+          {format: 'snorm8x2', offset: 62, shaderLocation: 18},
+          {format: 'unorm10-10-10-2', offset: 216, shaderLocation: 11},
+          {format: 'sint8x4', offset: 32, shaderLocation: 20},
+          {format: 'uint16x2', offset: 1128, shaderLocation: 9},
+          {format: 'uint32x2', offset: 776, shaderLocation: 21},
+          {format: 'snorm8x4', offset: 580, shaderLocation: 1},
+          {format: 'sint32x2', offset: 72, shaderLocation: 10},
+          {format: 'sint32', offset: 2308, shaderLocation: 14},
+          {format: 'sint32x2', offset: 1028, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 312, shaderLocation: 23},
+        ],
+      },
+    ],
+  },
+});
+let imageData9 = new ImageData(200, 4);
+let bindGroup11 = device2.createBindGroup({layout: bindGroupLayout11, entries: [{binding: 2190, resource: externalTexture18}]});
+let commandEncoder40 = device2.createCommandEncoder();
+let computePassEncoder18 = commandEncoder38.beginComputePass({});
+let renderBundleEncoder20 = device2.createRenderBundleEncoder({
+  label: '\uf34b\u093a\u2269\u5039\u281c\ue3ea\u0039',
+  colorFormats: ['r16float', 'rg16sint'],
+  stencilReadOnly: true,
+});
+let renderBundle21 = renderBundleEncoder20.finish({label: '\ud4d5\u{1feb0}\u214f\uf9e0\u0109\u78e1'});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup11, new Uint32Array(3759), 2125, 0);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer13, 111308, new Int16Array(61242), 40747, 1992);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 91 */
+{offset: 91}, {width: 9, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let imageData10 = new ImageData(160, 28);
+let commandEncoder41 = device2.createCommandEncoder({label: '\u9f31\u{1fcb6}\uf316\ue6a9\u5170\u0ba6\u{1fb60}\u{1fe83}\u{1fef4}\u0bc3'});
+let textureView51 = texture32.createView({label: '\u7a17\ufbe7', dimension: '2d', aspect: 'depth-only', baseMipLevel: 4, baseArrayLayer: 36});
+let externalTexture21 = device2.importExternalTexture({label: '\u{1feef}\ua187\u0031\u{1faf8}\u31e5', source: video4, colorSpace: 'display-p3'});
+try {
+commandEncoder40.clearBuffer(buffer13, 39020, 35452);
+dissociateBuffer(device2, buffer13);
+} catch {}
+let pipeline26 = device2.createRenderPipeline({
+  label: '\u{1fdfa}\u9e3a\u{1fe02}\ub897',
+  layout: pipelineLayout10,
+  multisample: {count: 4, mask: 0x6c22fa6f},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'zero'},
+    stencilBack: {compare: 'greater', failOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilWriteMask: 2658160395,
+    depthBiasSlopeScale: 432.9544787652186,
+    depthBiasClamp: 386.5909222144228,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 16392,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 1126, shaderLocation: 6},
+          {format: 'float32', offset: 8, shaderLocation: 12},
+          {format: 'float16x2', offset: 2756, shaderLocation: 17},
+          {format: 'snorm16x4', offset: 2728, shaderLocation: 3},
+          {format: 'uint16x2', offset: 0, shaderLocation: 21},
+          {format: 'snorm16x2', offset: 3652, shaderLocation: 11},
+          {format: 'float32', offset: 1924, shaderLocation: 23},
+          {format: 'uint8x4', offset: 232, shaderLocation: 4},
+          {format: 'uint32x4', offset: 2252, shaderLocation: 22},
+          {format: 'unorm10-10-10-2', offset: 4428, shaderLocation: 18},
+          {format: 'float16x2', offset: 148, shaderLocation: 2},
+          {format: 'float32x4', offset: 96, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 896, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 594, shaderLocation: 5},
+          {format: 'sint32x4', offset: 2992, shaderLocation: 15},
+          {format: 'sint16x4', offset: 2156, shaderLocation: 19},
+          {format: 'uint8x2', offset: 4752, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 2744, shaderLocation: 13},
+          {format: 'sint32x2', offset: 1228, shaderLocation: 7},
+          {format: 'sint8x4', offset: 10472, shaderLocation: 14},
+          {format: 'sint32x4', offset: 3492, shaderLocation: 10},
+          {format: 'sint32x2', offset: 348, shaderLocation: 20},
+          {format: 'sint32x2', offset: 116, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 340, shaderLocation: 0}],
+      },
+    ],
+  },
+});
+try {
+computePassEncoder18.setPipeline(pipeline22);
+} catch {}
+try {
+texture32.destroy();
+} catch {}
+let pipeline27 = await device2.createComputePipelineAsync({
+  label: '\u3ddd\u{1f757}\uabea',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let pipeline28 = device2.createRenderPipeline({
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+}, {
+  format: 'rg16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 41356,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm8x4', offset: 2700, shaderLocation: 3},
+          {format: 'uint32x2', offset: 2912, shaderLocation: 21},
+          {format: 'snorm8x2', offset: 104, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 5852, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 8540, shaderLocation: 17},
+          {format: 'sint32x3', offset: 19476, shaderLocation: 20},
+          {format: 'snorm8x2', offset: 1692, shaderLocation: 0},
+          {format: 'sint16x4', offset: 3148, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 27040, shaderLocation: 23},
+          {format: 'float32x3', offset: 8996, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 5860, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 4728, shaderLocation: 18},
+          {format: 'sint16x4', offset: 4424, shaderLocation: 6},
+          {format: 'sint16x2', offset: 14560, shaderLocation: 7},
+          {format: 'float16x2', offset: 4532, shaderLocation: 13},
+          {format: 'uint32x4', offset: 33032, shaderLocation: 4},
+          {format: 'float32x3', offset: 2320, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 16016,
+        attributes: [
+          {format: 'uint32', offset: 1392, shaderLocation: 9},
+          {format: 'sint32', offset: 13964, shaderLocation: 10},
+          {format: 'sint32x2', offset: 332, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 1084, attributes: [{format: 'sint8x2', offset: 106, shaderLocation: 8}]},
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float16x2', offset: 9704, shaderLocation: 5},
+          {format: 'sint16x4', offset: 912, shaderLocation: 19},
+        ],
+      },
+      {arrayStride: 6820, stepMode: 'instance', attributes: []},
+      {arrayStride: 112, stepMode: 'instance', attributes: []},
+      {arrayStride: 7888, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 1448, shaderLocation: 22}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: false},
+});
+document.body.prepend(canvas3);
+let renderBundle22 = renderBundleEncoder20.finish({label: '\ub365\udda5\uc3bc\ubd65\u1d33\u0e72'});
+try {
+device2.queue.writeBuffer(buffer13, 60376, new BigUint64Array(57989), 1547, 612);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 82_315 */
+{offset: 327, bytesPerRow: 452, rowsPerImage: 181}, {width: 44, height: 1, depthOrArrayLayers: 2});
+} catch {}
+document.body.prepend(video5);
+let img6 = await imageWithData(28, 237, '#72cc3d1b', '#f49ff1d4');
+let textureView52 = texture32.createView({
+  label: '\u{1ffab}\ubd3a',
+  aspect: 'depth-only',
+  baseMipLevel: 4,
+  baseArrayLayer: 338,
+  arrayLayerCount: 3,
+});
+let computePassEncoder19 = commandEncoder37.beginComputePass();
+try {
+device2.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 148 */
+{offset: 148, bytesPerRow: 536}, {width: 76, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise8 = device2.queue.onSubmittedWorkDone();
+let bindGroupLayout13 = device2.createBindGroupLayout({label: '\u2d68\u{1fb89}\ub9df\ud1d9\u1262\uac74\u0521\u5966\u0a88\u6d7b', entries: []});
+let commandEncoder42 = device2.createCommandEncoder({});
+let querySet19 = device2.createQuerySet({label: '\u{1f844}\u0858\u99e4\u289a\u{1fb38}', type: 'occlusion', count: 2605});
+let commandBuffer5 = commandEncoder40.finish();
+let computePassEncoder20 = commandEncoder41.beginComputePass({label: '\u4862\ub5de\u0c86\u78c6\u0baa\ucea7\u5c57\u087a\u091b\uf388'});
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 476 widthInBlocks: 119 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2540 */
+  offset: 2540,
+  buffer: buffer13,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 119, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let img7 = await imageWithData(251, 248, '#c3357df2', '#5d0ee3c8');
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let img8 = await imageWithData(154, 94, '#3b4a691a', '#e29484d1');
+try {
+adapter2.label = '\u532d\u{1fd2c}\u7b9b\u{1ff18}';
+} catch {}
+try {
+  await promise8;
+} catch {}
+let bindGroup12 = device2.createBindGroup({layout: bindGroupLayout13, entries: []});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup12);
+} catch {}
+let commandEncoder43 = device2.createCommandEncoder({});
+let computePassEncoder21 = commandEncoder43.beginComputePass({label: '\u0bc7\u3079\u0f53\u5684\ubd62\u{1f845}\u04f1\u0388\u{1fc52}'});
+let renderBundleEncoder21 = device2.createRenderBundleEncoder({
+  label: '\uad70\u5ad9\ub770\u{1fd23}\u{1fa41}\ub4c6\u4189\u{1fa95}\u0370\u{1f98a}',
+  colorFormats: ['rg32uint', 'rg16uint', 'r32uint', 'r16sint', 'rg32sint', 'rg32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup12, new Uint32Array(9424), 8173, 0);
+} catch {}
+let pipeline29 = device2.createComputePipeline({
+  label: '\u{1fb5a}\u9eeb\u9db4\ubc8a\u{1fefe}\ue5a4\udded\u3a25\u{1f7b2}\u1fa1\u1436',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule9, entryPoint: 'compute0'},
+});
+let bindGroupLayout14 = device2.createBindGroupLayout({
+  label: '\u056d\u01cd\u0a06',
+  entries: [
+    {
+      binding: 4304,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 5786,
+      visibility: 0,
+      buffer: { type: 'storage', minBindingSize: 112906804, hasDynamicOffset: false },
+    },
+  ],
+});
+let texture35 = device2.createTexture({
+  label: '\u4d35\u{1fedc}\u{1f6e5}\u90dd\u9b90\ufeb8\u0e9d\u963b\ua9b8\u08ea\u7ff1',
+  size: [504, 1, 1917],
+  mipLevelCount: 11,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let renderBundle23 = renderBundleEncoder21.finish({});
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 200 widthInBlocks: 50 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13784 */
+  offset: 13784,
+  buffer: buffer13,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 50, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer13);
+} catch {}
+let pipeline30 = device2.createComputePipeline({
+  label: '\u0fb2\u04b5\u0d7b\u0ac9\u06ac\u{1faf5}\u{1f790}\u9024\u0174\u{1ff29}\u0e5e',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let pipeline31 = device2.createRenderPipeline({
+  label: '\u6829\u9480\u0027\u14aa\u02d7',
+  layout: pipelineLayout10,
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 963010486,
+    depthBias: 0,
+    depthBiasSlopeScale: 465.64750483085083,
+    depthBiasClamp: 58.277541759286265,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 20840,
+        attributes: [
+          {format: 'sint32x4', offset: 11692, shaderLocation: 7},
+          {format: 'float16x2', offset: 2204, shaderLocation: 16},
+          {format: 'snorm8x4', offset: 20836, shaderLocation: 3},
+          {format: 'uint32', offset: 1080, shaderLocation: 21},
+          {format: 'sint32', offset: 4840, shaderLocation: 10},
+          {format: 'float32x2', offset: 10936, shaderLocation: 2},
+          {format: 'float32', offset: 2804, shaderLocation: 11},
+          {format: 'uint32x2', offset: 4404, shaderLocation: 4},
+          {format: 'float32x4', offset: 7712, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 9596, shaderLocation: 13},
+          {format: 'uint32', offset: 13256, shaderLocation: 22},
+          {format: 'float32', offset: 376, shaderLocation: 23},
+          {format: 'sint32x2', offset: 1356, shaderLocation: 20},
+          {format: 'sint32', offset: 1396, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 11000,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 6024, shaderLocation: 8},
+          {format: 'uint8x4', offset: 2260, shaderLocation: 9},
+          {format: 'sint8x2', offset: 192, shaderLocation: 19},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 8450, shaderLocation: 18},
+          {format: 'sint32x3', offset: 2044, shaderLocation: 6},
+          {format: 'unorm10-10-10-2', offset: 8076, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 12068, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 396, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 5320,
+        attributes: [
+          {format: 'sint16x4', offset: 2428, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 500, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+});
+document.body.prepend(video4);
+gc();
+let video8 = await videoWithData();
+let bindGroup13 = device2.createBindGroup({
+  label: '\u{1f6b0}\u7bea',
+  layout: bindGroupLayout11,
+  entries: [{binding: 2190, resource: externalTexture18}],
+});
+let texture36 = device2.createTexture({
+  label: '\ufa98\u604a\u{1ff89}\u{1fc3e}',
+  size: [96],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let textureView53 = texture36.createView({baseArrayLayer: 0});
+let renderBundle24 = renderBundleEncoder21.finish();
+try {
+device2.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer1), /* required buffer size: 691 */
+{offset: 691, rowsPerImage: 87}, {width: 126, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise9 = device2.createRenderPipelineAsync({
+  label: '\u1365\u0c97\u05d5\u026a\u6805',
+  layout: pipelineLayout10,
+  multisample: {mask: 0x8b059df5},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'rg16sint'}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint8x4', offset: 2616, shaderLocation: 8},
+          {format: 'float32x3', offset: 12596, shaderLocation: 5},
+          {format: 'uint8x4', offset: 5740, shaderLocation: 9},
+          {format: 'float32', offset: 5728, shaderLocation: 18},
+          {format: 'snorm16x2', offset: 8528, shaderLocation: 13},
+          {format: 'sint32x4', offset: 2816, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 356,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 20, shaderLocation: 15},
+          {format: 'float32x3', offset: 72, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 30, shaderLocation: 17},
+          {format: 'unorm8x2', offset: 112, shaderLocation: 23},
+          {format: 'sint16x4', offset: 12, shaderLocation: 19},
+          {format: 'sint16x4', offset: 32, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 15040,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 142, shaderLocation: 16},
+          {format: 'sint32x3', offset: 4932, shaderLocation: 14},
+          {format: 'float16x4', offset: 3220, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 668, shaderLocation: 3},
+          {format: 'uint32x3', offset: 3352, shaderLocation: 4},
+          {format: 'uint32x4', offset: 724, shaderLocation: 22},
+          {format: 'float32x2', offset: 356, shaderLocation: 2},
+          {format: 'float32x4', offset: 6756, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 4384,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 584, shaderLocation: 10}],
+      },
+      {
+        arrayStride: 14076,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 144, shaderLocation: 11}],
+      },
+      {arrayStride: 1196, stepMode: 'vertex', attributes: []},
+      {arrayStride: 8464, attributes: []},
+      {
+        arrayStride: 6216,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint16x4', offset: 2992, shaderLocation: 20},
+          {format: 'uint8x4', offset: 508, shaderLocation: 21},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'ccw', cullMode: 'front'},
+});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+offscreenCanvas9.width = 454;
+let offscreenCanvas14 = new OffscreenCanvas(529, 250);
+let shaderModule10 = device2.createShaderModule({
+  label: '\u8c1c\u00d1\u2473\u0e9a\u0bb8\u0b1d\u{1f9e8}\u61c2\ub973\u07b9\u7990',
+  code: `@group(1) @binding(2190)
+var<storage, read_write> n2: array<u32>;
+@group(0) @binding(2190)
+var<storage, read_write> function6: array<u32>;
+@group(2) @binding(2190)
+var<storage, read_write> function7: array<u32>;
+
+@compute @workgroup_size(8, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S12 {
+  @location(56) f0: vec3<f32>,
+  @location(14) f1: vec4<i32>,
+  @location(19) f2: vec3<u32>,
+  @location(25) f3: vec4<i32>,
+  @location(53) f4: vec4<u32>,
+  @location(81) f5: vec2<u32>,
+  @builtin(sample_index) f6: u32,
+  @location(52) f7: vec4<u32>,
+  @location(44) f8: vec3<u32>,
+  @location(39) f9: vec4<u32>,
+  @location(68) f10: u32,
+  @location(13) f11: vec3<f16>,
+  @location(88) f12: f32,
+  @builtin(front_facing) f13: bool,
+  @location(74) f14: i32,
+  @location(15) f15: vec2<u32>,
+  @builtin(sample_mask) f16: u32,
+  @location(22) f17: f16,
+  @location(7) f18: vec2<f32>,
+  @location(17) f19: vec2<f32>,
+  @location(86) f20: f16,
+  @location(2) f21: u32,
+  @location(32) f22: vec4<u32>,
+  @location(11) f23: f32,
+  @location(82) f24: vec2<u32>,
+  @location(36) f25: vec2<u32>,
+  @location(64) f26: f16,
+  @location(60) f27: f32,
+  @location(3) f28: u32,
+  @location(61) f29: vec4<u32>,
+  @location(90) f30: f32,
+  @builtin(position) f31: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: f32,
+  @location(2) f1: f32,
+  @location(1) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(66) a0: vec4<u32>, @location(16) a1: f32, a2: S12) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @location(2) f0: i32,
+  @location(9) f1: vec2<i32>,
+  @location(17) f2: vec4<f32>,
+  @location(0) f3: vec3<f32>,
+  @location(6) f4: vec2<f16>,
+  @location(22) f5: vec3<f16>,
+  @location(16) f6: vec4<f16>,
+  @location(14) f7: vec2<f16>,
+  @location(12) f8: vec4<f16>,
+  @location(11) f9: vec4<u32>
+}
+struct VertexOutput0 {
+  @location(7) f156: vec2<f32>,
+  @location(16) f157: f32,
+  @location(22) f158: f16,
+  @builtin(position) f159: vec4<f32>,
+  @location(53) f160: vec4<u32>,
+  @location(44) f161: vec3<u32>,
+  @location(17) f162: vec2<f32>,
+  @location(64) f163: f16,
+  @location(36) f164: vec2<u32>,
+  @location(90) f165: f32,
+  @location(3) f166: u32,
+  @location(81) f167: vec2<u32>,
+  @location(56) f168: vec3<f32>,
+  @location(39) f169: vec4<u32>,
+  @location(88) f170: f32,
+  @location(14) f171: vec4<i32>,
+  @location(19) f172: vec3<u32>,
+  @location(86) f173: f16,
+  @location(52) f174: vec4<u32>,
+  @location(2) f175: u32,
+  @location(11) f176: f32,
+  @location(15) f177: vec2<u32>,
+  @location(60) f178: f32,
+  @location(74) f179: i32,
+  @location(32) f180: vec4<u32>,
+  @location(13) f181: vec3<f16>,
+  @location(61) f182: vec4<u32>,
+  @location(82) f183: vec2<u32>,
+  @location(25) f184: vec4<i32>,
+  @location(66) f185: vec4<u32>,
+  @location(68) f186: u32
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec3<f32>, @location(23) a1: vec2<f16>, a2: S11, @location(21) a3: vec2<i32>, @location(10) a4: vec3<f16>, @location(7) a5: vec2<f32>, @location(19) a6: vec3<f32>, @builtin(instance_index) a7: u32, @location(20) a8: vec2<i32>, @location(15) a9: vec4<i32>, @location(8) a10: vec3<f16>, @location(4) a11: vec4<i32>, @location(1) a12: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup14 = device2.createBindGroup({
+  label: '\uf3c8\u2f14\u0de8\u06d4\u31f7\u{1f77a}\u92f1\u0a10\uc52d\uf215',
+  layout: bindGroupLayout13,
+  entries: [],
+});
+let commandEncoder44 = device2.createCommandEncoder({label: '\u3803\u{1fc3d}\u0937'});
+let textureView54 = texture35.createView({label: '\u0e36\u00db', baseMipLevel: 10, arrayLayerCount: 1});
+let computePassEncoder22 = commandEncoder35.beginComputePass({label: '\u6367\u{1fdbd}\ued83\u0b90\u7305\u{1ffc2}\u057c'});
+let renderBundleEncoder22 = device2.createRenderBundleEncoder({
+  label: '\u4505\uf378\udb71\u00d2\u0143',
+  colorFormats: ['rg32uint', 'rg16uint', 'r32uint', 'r16sint', 'rg32sint', 'rg32sint'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup13, new Uint32Array(8435), 6428, 0);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(5, bindGroup14, new Uint32Array(4119), 3987, 0);
+} catch {}
+try {
+buffer13.destroy();
+} catch {}
+try {
+device1.queue.label = '\u9b6d\u0517\u405d\u8a80\ub731';
+} catch {}
+gc();
+let bindGroup15 = device2.createBindGroup({
+  label: '\u0940\ud646\u0006\u0ac5\u661c\u7f0f\ue983\u061d\uc6ef',
+  layout: bindGroupLayout11,
+  entries: [{binding: 2190, resource: externalTexture20}],
+});
+let commandEncoder45 = device2.createCommandEncoder({});
+let texture37 = device2.createTexture({
+  label: '\u{1fc59}\uee96\u0919\u2f54\u02bf\ucaad\u0b34\ubed9\u846b\ub5e3\u8738',
+  size: {width: 504},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+try {
+computePassEncoder18.setPipeline(pipeline22);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 692 widthInBlocks: 173 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3260 */
+  offset: 3260,
+  bytesPerRow: 768,
+  buffer: buffer13,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 173, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(0)), /* required buffer size: 692 */
+{offset: 692, rowsPerImage: 286}, {width: 147, height: 1, depthOrArrayLayers: 0});
+} catch {}
+video8.width = 128;
+let commandEncoder46 = device2.createCommandEncoder();
+let commandBuffer6 = commandEncoder42.finish({label: '\ub0ec\u5708\u8fe5\ufc92'});
+let texture38 = device2.createTexture({
+  label: '\u{1fdcb}\u5cbc\u08f2\u{1f7a6}\u91e7\u{1fb2d}',
+  size: [252],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32sint', 'rg32sint'],
+});
+let textureView55 = texture32.createView({
+  label: '\udcee\u{1fab9}\ud933\u04de\u0903\u008a\u{1f79d}\u{1f65a}\u610a\ude5e\u{1f897}',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 4,
+  baseArrayLayer: 319,
+});
+let renderBundleEncoder23 = device2.createRenderBundleEncoder({
+  colorFormats: ['rg32uint', 'rg16uint', 'r32uint', 'r16sint', 'rg32sint', 'rg32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(1598, undefined, 0, 2498043206);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let bindGroupLayout15 = device2.createBindGroupLayout({
+  label: '\u{1fc74}\u{1f76e}\u0712\u{1f751}\u{1fc06}\u6664\u787b\u1e26\uf395\u674b',
+  entries: [{binding: 4823, visibility: 0, sampler: { type: 'comparison' }}],
+});
+let bindGroup16 = device2.createBindGroup({
+  label: '\u8255\u0bf0\uff0f\u05d5\u058f\u507c\u{1fb1b}\u{1fe47}\u0ea5\u{1f82e}\u0868',
+  layout: bindGroupLayout13,
+  entries: [],
+});
+let querySet20 = device2.createQuerySet({type: 'occlusion', count: 1126});
+let textureView56 = texture37.createView({label: '\u9340\u2cdd\u00a9\ue2c3'});
+let externalTexture22 = device2.importExternalTexture({label: '\ue23c\ua54f\u42d3\u4c6a', source: video5});
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup15, new Uint32Array(8814), 349, 0);
+} catch {}
+let pipeline32 = await device2.createComputePipelineAsync({layout: pipelineLayout10, compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}}});
+let img9 = await imageWithData(187, 22, '#f8c07a94', '#11fb575f');
+let imageBitmap8 = await createImageBitmap(canvas10);
+let gpuCanvasContext15 = offscreenCanvas14.getContext('webgpu');
+document.body.prepend(img7);
+let img10 = await imageWithData(72, 17, '#6614d901', '#0f7260de');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let promise10 = adapter0.requestAdapterInfo();
+try {
+window.someLabel = texture19.label;
+} catch {}
+canvas6.height = 655;
+try {
+externalTexture1.label = '\u9b37\u{1ff1e}\u{1fe16}\u707b\u342b\ucc6b\u{1fb17}\uadb0\u{1f7c9}\u{1f780}\u{1f85c}';
+} catch {}
+try {
+  await promise10;
+} catch {}
+let canvas16 = document.createElement('canvas');
+let commandEncoder47 = device2.createCommandEncoder({label: '\u01db\ue039\u5e94\ud19e\u0233'});
+let textureView57 = texture36.createView({
+  label: '\u0624\u5739\ue660\u017d\u{1fae8}\ud9a9\ua0ee\u{1f9c5}\u4739\u8718',
+  dimension: '1d',
+  arrayLayerCount: 1,
+});
+let offscreenCanvas15 = new OffscreenCanvas(659, 941);
+let textureView58 = texture36.createView({label: '\u019f\u3f8a\uf64a\u7b39'});
+try {
+commandEncoder46.clearBuffer(buffer13, 21008, 168052);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline33 = await promise9;
+let offscreenCanvas16 = new OffscreenCanvas(822, 138);
+try {
+adapter3.label = '\ucb2d\u31f1\u{1febc}';
+} catch {}
+let textureView59 = texture36.createView({label: '\ua201\u5fb6\ud7f2\uf47e\u014f'});
+let renderBundleEncoder24 = device2.createRenderBundleEncoder({
+  label: '\u215a\ue63f\u4c91',
+  colorFormats: ['r16float', 'rg16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder23.setBindGroup(5, bindGroup14, []);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(7, bindGroup15, new Uint32Array(8667), 6211, 0);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+video7.width = 46;
+let commandEncoder48 = device2.createCommandEncoder({label: '\uf081\u{1fb48}\u9cc2\u953c\u2be9\ua4cd\udc0b\ue727'});
+let renderBundle25 = renderBundleEncoder23.finish({label: '\ue215\u{1fade}\u0bbb\uc9fa\u7a4f\u7736\ubb3e\u566d\u7fc8\u6e6a'});
+let externalTexture23 = device2.importExternalTexture({label: '\u0cdb\u0a6b\u0945\u{1f6af}\u{1feee}', source: videoFrame7, colorSpace: 'srgb'});
+try {
+computePassEncoder19.setBindGroup(7, bindGroup16, new Uint32Array(1206), 210, 0);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder49 = device2.createCommandEncoder();
+let textureView60 = texture35.createView({
+  label: '\u0ee4\u00b9\u4b23\u9334\ub3e0\u04bc\u3021\u0b71\ubeab\u97ac\uef32',
+  baseMipLevel: 2,
+  mipLevelCount: 6,
+});
+let externalTexture24 = device2.importExternalTexture({source: video4, colorSpace: 'srgb'});
+try {
+renderBundleEncoder22.setBindGroup(4, bindGroup16, new Uint32Array(1990), 1774, 0);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+commandEncoder48.insertDebugMarker('\u6fcf');
+} catch {}
+try {
+gpuCanvasContext15.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline34 = await device2.createComputePipelineAsync({layout: pipelineLayout10, compute: {module: shaderModule10, entryPoint: 'compute0'}});
+let canvas17 = document.createElement('canvas');
+gc();
+let querySet21 = device2.createQuerySet({
+  label: '\u{1f98f}\u0017\u{1f8e7}\u{1fa68}\u00a6\u{1fdb5}\u{1fc5f}\u8ad2\u{1fdca}\u082f',
+  type: 'occlusion',
+  count: 2874,
+});
+let sampler10 = device2.createSampler({
+  label: '\uf76e\ubf01\u9026\u8ba8\u0844\u46e7',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 54.63,
+  maxAnisotropy: 12,
+});
+try {
+commandEncoder46.clearBuffer(buffer13, 229436, 16788);
+dissociateBuffer(device2, buffer13);
+} catch {}
+canvas16.width = 3084;
+let offscreenCanvas17 = new OffscreenCanvas(896, 143);
+try {
+adapter0.label = '\u0fbb\u476b\u6246\u1208\u21a7\u{1f8f8}\u228a\u{1fe8f}\u07fe\u{1f6d1}';
+} catch {}
+let videoFrame11 = new VideoFrame(imageBitmap7, {timestamp: 0});
+let commandEncoder50 = device2.createCommandEncoder({label: '\u{1fd0e}\u0e97\ud8f7\uc228\uc4f5\ub206'});
+let textureView61 = texture35.createView({label: '\u2d9f\u5411\udf1c\u{1f60d}\u0336\u1dca', baseArrayLayer: 0});
+try {
+commandEncoder48.clearBuffer(buffer13, 206032, 53272);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+canvas1.height = 246;
+try {
+canvas17.getContext('2d');
+} catch {}
+try {
+offscreenCanvas17.getContext('bitmaprenderer');
+} catch {}
+let imageBitmap9 = await createImageBitmap(imageBitmap2);
+offscreenCanvas9.width = 634;
+let bindGroupLayout16 = device2.createBindGroupLayout({
+  label: '\u0358\u7110\u0435\u07a7\u0df3\ud9c1\ub8be',
+  entries: [
+    {binding: 4625, visibility: 0, externalTexture: {}},
+    {binding: 3086, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let bindGroup17 = device2.createBindGroup({label: '\u09a0\u{1f9aa}\u079a\u03ea\u{1f86e}\u076a', layout: bindGroupLayout13, entries: []});
+let texture39 = device2.createTexture({
+  label: '\uc40c\uc300\u4755\udb55\u0155\u4e96\u037e',
+  size: [504, 1, 1],
+  mipLevelCount: 6,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+let sampler11 = device2.createSampler({
+  label: '\ue244\u{1f8ab}\u{1ffb0}\ua0a6',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 64.50,
+  lodMaxClamp: 86.24,
+});
+try {
+computePassEncoder22.setBindGroup(5, bindGroup16, new Uint32Array(3580), 2328, 0);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let commandEncoder51 = device2.createCommandEncoder({label: '\u7cb0\u0c13\u77a9\u6029'});
+let commandBuffer7 = commandEncoder45.finish({});
+let renderBundle26 = renderBundleEncoder20.finish();
+let promise11 = device2.queue.onSubmittedWorkDone();
+let commandEncoder52 = device2.createCommandEncoder({label: '\u2ec7\u06ac\u1c8e'});
+let textureView62 = texture37.createView({label: '\u{1fe0f}\u591a\u{1f685}\u{1fc65}\u0231\u0c9a'});
+let video9 = await videoWithData();
+try {
+offscreenCanvas15.getContext('webgl2');
+} catch {}
+document.body.prepend(img4);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+gc();
+let shaderModule11 = device2.createShaderModule({
+  code: `@group(2) @binding(2190)
+var<storage, read_write> local3: array<u32>;
+@group(0) @binding(2190)
+var<storage, read_write> field4: array<u32>;
+@group(1) @binding(2190)
+var<storage, read_write> local4: array<u32>;
+
+@compute @workgroup_size(3, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2<i32>,
+  @location(5) f1: vec4<i32>,
+  @location(4) f2: vec3<i32>,
+  @location(0) f3: vec3<u32>,
+  @location(1) f4: vec3<u32>,
+  @location(2) f5: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S13 {
+  @location(12) f0: vec4<f16>,
+  @location(22) f1: vec4<i32>,
+  @location(21) f2: i32,
+  @location(3) f3: vec3<i32>,
+  @location(13) f4: vec3<i32>,
+  @builtin(vertex_index) f5: u32,
+  @location(17) f6: vec2<f32>,
+  @location(19) f7: vec3<i32>,
+  @location(6) f8: vec3<f32>,
+  @location(10) f9: vec3<f32>,
+  @location(9) f10: f32,
+  @location(5) f11: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec2<u32>, @location(1) a1: vec3<i32>, @location(23) a2: f32, @location(4) a3: u32, @location(15) a4: vec4<f16>, @location(11) a5: vec4<u32>, @location(14) a6: vec3<i32>, @location(16) a7: vec3<u32>, a8: S13, @location(2) a9: vec3<i32>, @builtin(instance_index) a10: u32, @location(20) a11: vec2<f32>, @location(18) a12: vec3<i32>, @location(0) a13: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder53 = device2.createCommandEncoder({label: '\u0415\ub6d6\u1422\u038a\u{1fec2}'});
+let texture40 = device2.createTexture({
+  size: {width: 192, height: 24, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint'],
+});
+let textureView63 = texture37.createView({
+  label: '\u0f88\u026a\u8d19\u061f\u{1ff7f}\uf586\u{1faaf}\u0301\u0f08',
+  format: 'r32uint',
+  mipLevelCount: 1,
+});
+let sampler12 = device2.createSampler({
+  label: '\u8c36\u6fae\u05bc\u{1ff53}\u01f7\u{1fc7a}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.57,
+  lodMaxClamp: 16.70,
+  maxAnisotropy: 3,
+});
+try {
+commandEncoder49.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 171324 */
+  offset: 1084,
+  bytesPerRow: 256,
+  rowsPerImage: 133,
+  buffer: buffer13,
+}, {width: 1, height: 0, depthOrArrayLayers: 6});
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer13, 1884, 256056);
+dissociateBuffer(device2, buffer13);
+} catch {}
+let pipeline35 = device2.createComputePipeline({
+  label: '\uab00\u{1ff9b}\u{1f880}\u23f1\uc433\u{1fde3}\u0400\u0b45',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule11, entryPoint: 'compute0'},
+});
+let pipeline36 = await device2.createRenderPipelineAsync({
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'decrement-clamp'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 442508420,
+    stencilWriteMask: 3801116839,
+    depthBias: -1885621641,
+    depthBiasSlopeScale: 271.4811071908712,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 3832,
+        attributes: [
+          {format: 'sint32x4', offset: 2752, shaderLocation: 10},
+          {format: 'float32x3', offset: 428, shaderLocation: 23},
+          {format: 'sint16x2', offset: 1356, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 3764,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 96, shaderLocation: 2},
+          {format: 'sint32', offset: 644, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 312, shaderLocation: 0},
+          {format: 'float16x2', offset: 604, shaderLocation: 13},
+          {format: 'float16x2', offset: 924, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 5880,
+        attributes: [
+          {format: 'sint32x4', offset: 3200, shaderLocation: 6},
+          {format: 'sint16x4', offset: 1340, shaderLocation: 19},
+          {format: 'sint32x4', offset: 788, shaderLocation: 20},
+          {format: 'snorm8x2', offset: 424, shaderLocation: 3},
+          {format: 'sint8x4', offset: 420, shaderLocation: 15},
+          {format: 'float32', offset: 48, shaderLocation: 18},
+          {format: 'uint32x3', offset: 1400, shaderLocation: 9},
+          {format: 'uint32x4', offset: 268, shaderLocation: 4},
+          {format: 'sint32x4', offset: 192, shaderLocation: 14},
+          {format: 'float32x2', offset: 320, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 596, shaderLocation: 17},
+          {format: 'uint16x2', offset: 1792, shaderLocation: 21},
+          {format: 'float32x2', offset: 408, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 918, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 4788,
+        attributes: [
+          {format: 'uint8x2', offset: 216, shaderLocation: 22},
+          {format: 'unorm16x4', offset: 1244, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+let bindGroupLayout17 = device2.createBindGroupLayout({
+  label: '\u5475\uf7c8\u58d8\ub999\u{1f6d1}\ub00c\u{1ff97}\u9381\ue2de',
+  entries: [{binding: 1686, visibility: GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let computePassEncoder23 = commandEncoder44.beginComputePass({label: '\u177c\u39d7\u0475'});
+let externalTexture25 = device2.importExternalTexture({label: '\u{1fae3}\u8fe8\u04d6\u{1f9ca}\udcf8\u{1f6f6}\u0733', source: video7});
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 11044 */
+  offset: 9732,
+  bytesPerRow: 256,
+  buffer: buffer13,
+}, {
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 6, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+device2.destroy();
+} catch {}
+try {
+offscreenCanvas16.getContext('2d');
+} catch {}
+let gpuCanvasContext16 = canvas16.getContext('webgpu');
+try {
+  await promise11;
+} catch {}
+let img11 = await imageWithData(59, 234, '#09e0ce97', '#9e4810a8');
+let imageBitmap10 = await createImageBitmap(canvas4);
+let img12 = await imageWithData(281, 286, '#58f635cf', '#b9c82a71');
+let video10 = await videoWithData();
+let img13 = await imageWithData(266, 195, '#fcb88ddb', '#f6faa3e1');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+video0.width = 98;
+let video11 = await videoWithData();
+let imageBitmap11 = await createImageBitmap(canvas11);
+let videoFrame12 = new VideoFrame(offscreenCanvas7, {timestamp: 0});
+video8.width = 285;
+let offscreenCanvas18 = new OffscreenCanvas(340, 379);
+let gpuCanvasContext17 = offscreenCanvas18.getContext('webgpu');
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let imageData11 = new ImageData(196, 252);
+let videoFrame13 = new VideoFrame(img4, {timestamp: 0});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend(canvas0);
+document.body.prepend(video10);
+let offscreenCanvas19 = new OffscreenCanvas(959, 955);
+try {
+renderBundleEncoder10.label = '\u03bd\u4940';
+} catch {}
+gc();
+let device3 = await adapter2.requestDevice({
+  label: '\u49f2\u{1f6f2}\u03e5\u0c03\u032b\u2a42\u0c2a\u8da4\ue2b9\u663a',
+  defaultQueue: {label: '\ue805\u3091\uebcb\u0f55\u4fb2\uea18'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 6,
+    maxColorAttachmentBytesPerSample: 42,
+    maxVertexAttributes: 22,
+    maxVertexBufferArrayStride: 35503,
+    maxStorageTexturesPerShaderStage: 32,
+    maxStorageBuffersPerShaderStage: 13,
+    maxDynamicStorageBuffersPerPipelineLayout: 42644,
+    maxDynamicUniformBuffersPerPipelineLayout: 60338,
+    maxBindingsPerBindGroup: 9709,
+    maxTextureArrayLayers: 807,
+    maxTextureDimension1D: 13384,
+    maxTextureDimension2D: 13337,
+    maxVertexBuffers: 11,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minStorageBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 167514248,
+    maxStorageBufferBindingSize: 186160228,
+    maxUniformBuffersPerShaderStage: 14,
+    maxSampledTexturesPerShaderStage: 16,
+    maxInterStageShaderVariables: 39,
+    maxInterStageShaderComponents: 103,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+video6.width = 282;
+let commandEncoder54 = device3.createCommandEncoder({label: '\u5985\u0c69\u{1f7a4}\u6222\u{1fe6c}'});
+let texture41 = device3.createTexture({
+  label: '\u6d45\u{1fa0b}\u2a3b\u0b97\u7dba',
+  size: [288, 32, 502],
+  mipLevelCount: 3,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float'],
+});
+try {
+gpuCanvasContext11.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 2,
+  origin: {x: 9, y: 5, z: 1},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 1_544_134 */
+{offset: 796, bytesPerRow: 192, rowsPerImage: 57}, {width: 21, height: 2, depthOrArrayLayers: 142});
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>


### PR DESCRIPTION
#### 6e8106f73d639ea1f0dde7fb2529956d1279e8eb
<pre>
[WebGPU] PresentationContextIOSurface::present doesn&apos;t check for valid device
<a href="https://bugs.webkit.org/show_bug.cgi?id=277035">https://bugs.webkit.org/show_bug.cgi?id=277035</a>
&lt;radar://130758850&gt;

Reviewed by Dan Glastonbury.

Check for valid device prior and index to indexing into the Vector.

* LayoutTests/fast/webgpu/nocrash/fuzz-277035-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-277035.html: Added.
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:

Canonical link: <a href="https://commits.webkit.org/281331@main">https://commits.webkit.org/281331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60653081f4b022b3a84eca323b0eb5f6cf9277c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63432 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10030 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48309 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7034 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29141 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32991 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8775 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8964 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65164 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55645 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55760 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13198 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2863 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34676 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35759 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->