### PR TITLE
Unreviewed follow-up fix: Update compare-static-analysis-results for better readability and EWS support

### DIFF
--- a/Tools/Scripts/compare-static-analysis-results
+++ b/Tools/Scripts/compare-static-analysis-results
@@ -165,6 +165,7 @@ def compare_project_results_by_run(args, archive_path, new_path, project):
     new_files_total = set()
     fixed_issues_total = set()
     fixed_files_total = set()
+    unexpected_result_paths_total = set()
     project_results_passes = {}
     project_results_failures = {}
 
@@ -176,6 +177,15 @@ def compare_project_results_by_run(args, archive_path, new_path, project):
         new_issues_total.update(new_issues)
         new_files_total.update(new_files)
 
+        # Get unexpected issues per checker
+        unexpected_result_paths = set()
+        with open(f'{new_path}/issue_to_report.json') as f:
+            issue_to_report = json.load(f)
+        for issue in new_issues:
+            unexpected_result_paths.add(issue_to_report[checker][issue])
+        unexpected_result_paths_total.update(unexpected_result_paths)
+
+        # JSON
         project_results_passes[checker] = list(fixed_files)
         project_results_failures[checker] = list(new_files)
 
@@ -189,7 +199,7 @@ def compare_project_results_by_run(args, archive_path, new_path, project):
             print('    No unexpected results')
 
     if new_issues_total and args.scan_build:
-        create_filtered_results_dir(args, project, new_issues_total, 'StaticAnalyzerRegressions')
+        create_filtered_results_dir(args, project, unexpected_result_paths_total, 'StaticAnalyzerRegressions')
 
     return new_issues_total, new_files_total, fixed_files_total, fixed_issues_total, project_results_passes, project_results_failures
 

--- a/Tools/Scripts/generate-dirty-files
+++ b/Tools/Scripts/generate-dirty-files
@@ -85,7 +85,7 @@ def parse_results_file(args, file_path):
     return None, None, None, None
 
 
-def find_project_results(args, project, file_list, results_data):
+def find_project_results(args, project, file_list, results_data, issue_to_report):
     bug_counts = {}
     files_per_project = {key: set() for key in CHECKER_MAP.values()}
 
@@ -115,6 +115,11 @@ def find_project_results(args, project, file_list, results_data):
             file_dict[file_name][issue_hash] = result_file
         results_data[CHECKER_MAP[bug_type]] = file_dict
 
+        # Add direct mapping from issue hash to report path
+        if not CHECKER_MAP[bug_type] in issue_to_report.keys():
+            issue_to_report[CHECKER_MAP[bug_type]] = {}
+        issue_to_report[CHECKER_MAP[bug_type]][issue_hash] = result_file
+
         output_file_name = os.path.abspath(f'{args.output_dir}/{project}/{CHECKER_MAP[bug_type]}Issues')
         with open(output_file_name, 'a') as f:
             f.write(f'{issue_hash}\n')
@@ -136,6 +141,7 @@ def find_all_results(args):
     file_list = []
     results_data = {}
     result_counts = {}
+    issue_to_report = {}
 
     for project in PROJECTS:
         subprocess.run(['mkdir', os.path.abspath(f'{args.output_dir}/{project}')])
@@ -153,13 +159,18 @@ def find_all_results(args):
 
         print(f'\n------ {project} ------\n')
         print(f'TOTAL ISSUES: {len(project_files)}')
-        find_project_results(args, project, project_files, results_data)
+        find_project_results(args, project, project_files, results_data, issue_to_report)
 
     print("\nWriting results files...")
+    # Checker -> File -> Issue -> Report
     results_data_file = os.path.abspath(f'{args.output_dir}/issues_per_file.json')
     with open(results_data_file, "w") as f:
         results_data_obj = json.dumps(results_data, indent=4)
         f.write(results_data_obj)
+    # Checker -> Issue -> Report
+    issue_to_report_file = os.path.abspath(f'{args.output_dir}/issue_to_report.json')
+    with open(issue_to_report_file, "w") as f:
+        f.write(json.dumps(issue_to_report, indent=4))
     print(f'Done! Find them in {os.path.abspath(args.output_dir)}\n')
 
     results_msg = f'Total ({sum([c for c in result_counts.values()])}) '


### PR DESCRIPTION
#### cb0af56f13e83934cfd340a127948bacc362788d
<pre>
Unreviewed follow-up fix: Update compare-static-analysis-results for better readability and EWS support
<a href="https://bugs.webkit.org/show_bug.cgi?id=276783">https://bugs.webkit.org/show_bug.cgi?id=276783</a>
<a href="https://rdar.apple.com/132017828">rdar://132017828</a>

Fixes logic in the previous change to account for EWS results being tracked
by issue rather than by filename. The previous changes resulted in a bug where results
did not show up in the generated index.

* Tools/Scripts/compare-static-analysis-results:
(compare_project_results_by_run):
* Tools/Scripts/generate-dirty-files:
(parse_results_file):
(find_project_results):
(find_all_results):

Canonical link: <a href="https://commits.webkit.org/281316@main">https://commits.webkit.org/281316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c147e4b8a1d3864d4ca414860e7a21ca74a18cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59521 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/38866 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/12044 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/63436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/10036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/61650 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/46519 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/10196 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/63436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/10036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/61551 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/46519 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/12044 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/63436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/46519 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/12044 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/8968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/46519 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/12044 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/65168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/3449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/10196 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/65168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/3460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/12044 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/65168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8884 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/34680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/36849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->