### PR TITLE
Enable Wasm BBQ JIT on Windows

### DIFF
--- a/JSTests/wasm/v8/shared-memory-gc-stress.js
+++ b/JSTests/wasm/v8/shared-memory-gc-stress.js
@@ -1,4 +1,3 @@
-//@ skip if $hostOS == "windows"
 //@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -561,7 +561,7 @@ macro boxInt32(r, rTag)
 end
 
 // This is the interpreted analogue to createJSToWasmWrapper
-if JSVALUE64 and (ARM64 or ARM64E or X86_64)
+if JSVALUE64 and (ARM64 or ARM64E or X86_64 or X86_64_WIN)
 op(js_to_wasm_wrapper_entry, macro ()
     if not WEBASSEMBLY or C_LOOP or C_LOOP_WIN
         error
@@ -640,7 +640,7 @@ end
             storep wasmInstance, -3 * SlotSize[cfr]
             # These are just for us to spill things
             # MPCSpill
-        elsif X86_64
+        elsif X86_64 or X86_64_WIN
             # These must match the wasmToJS thunk, since the unwinder won't be able to tell the difference between us and them.
             # See calleeSaveRegistersImpl
             storep boundsCheckingSize, -1 * SlotSize[cfr]
@@ -662,7 +662,7 @@ end
         if ARM64 or ARM64E
             loadpairq -2 * SlotSize[cfr], memoryBase, boundsCheckingSize
             loadp -3 * SlotSize[cfr], wasmInstance
-        elsif X86_64
+        elsif X86_64 or X86_64_WIN
             loadp -1 * SlotSize[cfr], boundsCheckingSize
             loadp -2 * SlotSize[cfr], memoryBase
             loadp -3 * SlotSize[cfr], wasmInstance
@@ -795,7 +795,7 @@ opcode(LoadF64)
 opcode(StoreI32)
     advanceSigned()
     lshiftq 3, Scratch
-if X86_64
+if X86_64 or X86_64_WIN
     addp sp, Scratch
 else
     move sp, Scratch2
@@ -909,7 +909,7 @@ opcodesEnd()
     if ARM64 or ARM64E
         pcrtoaddr _js_to_wasm_wrapper_entry_interp_begin, Scratch2
         addp Scratch2, Scratch
-    elsif X86_64
+    elsif X86_64 or X86_64_WIN
         storeq Accumulator, AccumulatorSpill[cfr]
         leap (_js_to_wasm_wrapper_entry_interp_begin), Accumulator
         addp Accumulator, Scratch
@@ -927,7 +927,7 @@ opcodesEnd()
 .memory:
     if ARM64 or ARM64E
         loadpairq JSWebAssemblyInstance::m_cachedMemory[wasmInstance], memoryBase, boundsCheckingSize
-    elsif X86_64
+    elsif X86_64 or X86_64_WIN
         loadp JSWebAssemblyInstance::m_cachedMemory[wasmInstance], memoryBase
         loadp JSWebAssemblyInstance::m_cachedBoundsCheckingSize[wasmInstance], boundsCheckingSize
     end

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -753,10 +753,8 @@ void Options::notifyOptionsChanged()
             Options::useFTLJIT() = false;
         }
 
-        // Windows: Building with WEBASSEMBLY_BBQJIT and disabling at runtime
         // Windows: Building with WEBASSEMBLY_OMGJIT and disabling at runtime
 #if OS(WINDOWS)
-        Options::useBBQJIT() = false;
         Options::useOMGJIT() = false;
 #endif
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -76,7 +76,9 @@ namespace BBQJITImpl {
 
 Location Location::none()
 {
-    return Location();
+    Location loc;
+    loc.m_kind = None;
+    return loc;
 }
 
 Location Location::fromStack(int32_t stackOffset)

--- a/Source/WTF/wtf/Gigacage.cpp
+++ b/Source/WTF/wtf/Gigacage.cpp
@@ -53,7 +53,7 @@ void* tryAllocateZeroedVirtualPages(Kind, size_t requestedSize)
 {
     size_t size = roundUpToMultipleOf(WTF::pageSize(), requestedSize);
     RELEASE_ASSERT(size >= requestedSize);
-    void* result = OSAllocator::reserveAndCommit(size);
+    void* result = OSAllocator::tryReserveAndCommit(size);
 #if ASSERT_ENABLED
     if (result) {
         for (size_t i = 0; i < size / sizeof(uintptr_t); ++i)


### PR DESCRIPTION
#### 11682f9ed717ff578468b07a7cac6ce52826538a
<pre>
Enable Wasm BBQ JIT on Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=277037">https://bugs.webkit.org/show_bug.cgi?id=277037</a>

Reviewed by Yusuke Suzuki.

Inside tryAllocateZeroedVirtualPages we were calling
OSAllocator::reserveAndCommit which crashes if it fails to allocate,
instead of tryReserveAndCommit which returns a null pointer. This caused
a number of memory-related wasm test failures.

* JSTests/wasm/v8/shared-memory-gc-stress.js:
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::Location::none):
* Source/WTF/wtf/Gigacage.cpp:
(Gigacage::tryAllocateZeroedVirtualPages):

Canonical link: <a href="https://commits.webkit.org/281324@main">https://commits.webkit.org/281324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cde0f12cb7e6d453faa724a4446baab5e7aa8358

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10041 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10200 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7042 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61555 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29140 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32997 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8779 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8972 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/52617 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65172 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58770 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3453 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/8955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55768 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2871 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80527 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8891 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34684 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13963 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36853 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35512 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->