### PR TITLE
[WebGPU] Fixup debug assertions caught by fuzzer tests

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1123,8 +1123,8 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                     [argumentEncoder[stage] setTexture:texture atIndex:index];
                 if (texture) {
                     stageResources[metalRenderStage(stage)][resourceUsage - 1].append(texture);
-                    ASSERT(texture.parentRelativeLevel == apiTextureView.baseMipLevel());
-                    ASSERT(texture.parentRelativeSlice == apiTextureView.baseArrayLayer());
+                    ASSERT(apiTextureView.isDestroyed() || texture.parentRelativeLevel == apiTextureView.baseMipLevel());
+                    ASSERT(apiTextureView.isDestroyed() || texture.parentRelativeSlice == apiTextureView.baseArrayLayer());
                     stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(textureEntry ? usageForTexture(*textureEntry) : (storageTextureEntry ? usageForStorageTexture(*storageTextureEntry) : BindGroupEntryUsage::ConstantTexture), entry.binding, apiTextureView));
                 }
             } else if (externalTextureIsPresent) {


### PR DESCRIPTION
#### 6826bea4763fa32116e631c2b2edf4f9d7768e63
<pre>
[WebGPU] Fixup debug assertions caught by fuzzer tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=277032">https://bugs.webkit.org/show_bug.cgi?id=277032</a>
<a href="https://rdar.apple.com/132434047">rdar://132434047</a>

Reviewed by Dan Glastonbury.

Running some of the fuzzer tests in Debug triggers these two
assertions, which were harmless. Correct the assertions.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):

Canonical link: <a href="https://commits.webkit.org/281362@main">https://commits.webkit.org/281362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95315c3e61e0c4ef147edb2f11c855ed13241aeb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63496 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10104 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48344 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7074 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29181 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33040 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9028 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54987 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65228 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55687 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55811 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2911 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34740 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36909 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35568 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->