### PR TITLE
[WIP] Optimization for CodeBlock::finishCreation()

### DIFF
--- a/Source/JavaScriptCore/bytecode/MetadataTable.h
+++ b/Source/JavaScriptCore/bytecode/MetadataTable.h
@@ -135,6 +135,8 @@ public:
         return !unlinkedMetadataPtr;
     }
 
+    void clear(UnlinkedMetadataTable::CacheMap&);
+
 private:
     MetadataTable(UnlinkedMetadataTable&);
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -345,4 +345,11 @@ void UnlinkedCodeBlock::allocateSharedProfiles(unsigned numBinaryArithProfiles, 
     m_unaryArithProfiles = FixedVector<UnaryArithProfile>(numUnaryArithProfiles);
 }
 
+RefPtr<MetadataTable> UnlinkedCodeBlock::metadataLink()
+{
+    if (!m_cachedIDs)
+        return m_metadata->link();
+    return m_metadata->link(*m_cachedIDs);
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -499,6 +499,19 @@ private:
     FixedVector<BinaryArithProfile> m_binaryArithProfiles;
     FixedVector<UnaryArithProfile> m_unaryArithProfiles;
 
+public:
+    template<typename Bytecode>
+    void cache(const Bytecode& bytecode)
+    {
+        ASSERT(bytecode.opcodeID == op_resolve_scope || bytecode.opcodeID == op_get_from_scope);
+
+        if (!m_cachedIDs)
+            m_cachedIDs = makeUnique<UnlinkedMetadataTable::CacheMap>();
+        m_cachedIDs->add(bytecode.opcodeID, UnlinkedMetadataTable::MetadataIDs()).iterator->value.add(bytecode.m_metadataID);
+    }
+    RefPtr<MetadataTable> metadataLink();
+    std::unique_ptr<UnlinkedMetadataTable::CacheMap> m_cachedIDs;
+
 #if ASSERT_ENABLED
     Lock m_cachedIdentifierUidsLock;
     HashSet<UniquedStringImpl*> m_cachedIdentifierUids;

--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp
@@ -146,7 +146,7 @@ void UnlinkedMetadataTable::finalize()
     });
 #endif
 
-    unsigned valueProfileSize = m_numValueProfiles * sizeof(ValueProfile);
+    unsigned valueProfileSize = this->valueProfileSize();
     if (m_is32Bit) {
         // offset already accounts for s_offset16TableSize
         uint8_t* newBuffer = reinterpret_cast_ptr<uint8_t*>(MetadataTableMalloc::malloc(valueProfileSize + sizeof(LinkingData) + s_offset32TableSize + offset));

--- a/Source/JavaScriptCore/runtime/GetPutInfo.h
+++ b/Source/JavaScriptCore/runtime/GetPutInfo.h
@@ -197,6 +197,7 @@ ALWAYS_INLINE bool needsVarInjectionChecks(ResolveType type)
 }
 
 struct ResolveOp {
+    ResolveOp() = default;
     ResolveOp(ResolveType type, size_t depth, Structure* structure, JSLexicalEnvironment* lexicalEnvironment, WatchpointSet* watchpointSet, uintptr_t operand, UniquedStringImpl* importedName = nullptr)
         : type(type)
         , depth(depth)

--- a/Source/JavaScriptCore/runtime/JSScope.h
+++ b/Source/JavaScriptCore/runtime/JSScope.h
@@ -57,7 +57,8 @@ public:
 
     static JSObject* resolve(JSGlobalObject*, JSScope*, const Identifier&);
     static JSValue resolveScopeForHoistingFuncDeclInEval(JSGlobalObject*, JSScope*, const Identifier&);
-    static ResolveOp abstractResolve(JSGlobalObject*, size_t depthOffset, JSScope*, const Identifier&, GetOrPut, ResolveType, InitializationMode);
+    static ResolveOp abstractResolveFast(JSGlobalObject*, size_t cachedDepth, size_t scopeDepth, JSScope*, const Identifier&, GetOrPut, ResolveType, InitializationMode);
+    static ResolveOp abstractResolve(JSGlobalObject*, size_t scopeDepth, JSScope*, const Identifier&, GetOrPut, ResolveType, InitializationMode);
 
     static bool hasConstantScope(ResolveType);
     static JSScope* constantScopeForCodeBlock(ResolveType, CodeBlock*);


### PR DESCRIPTION
#### d72b08da2ef7c3184e740987f11c57af28ee8789
<pre>
[WIP] Optimization for CodeBlock::finishCreation()

1. We found that CodeBlock finishCreation is costly in SP3, this is bc we may have massive scope resolutions.
2. We&apos;ve confirmed that there are some unlinkedcodeblocks which can be used for linking different code blocks with closure vars.
3. Since the scope depth of closure vars is consistent after the first resolution, we propose to cache the resolved scope depth for those closure vars in the unlinkedmetadatatable.
4. Then, in the later linking with the same unlinkedcodeblock, we can directly use the cached scope depth to skip the costly look up in the scope resolution.
5. The draft patch is almost done. Currently just handling some corner cases for managing the the liveness of the cached data, metadatatable, and unlinkedmetadatatable.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::CodeBlock):
(JSC::CodeBlock::finishCreation):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp:
(JSC::UnlinkedCodeBlock::metadataLink):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
(JSC::UnlinkedCodeBlock::cache):
* Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp:
(JSC::UnlinkedMetadataTable::finalize):
* Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h:
(JSC::UnlinkedMetadataTable::isLinked):
(JSC::UnlinkedMetadataTable::valueProfileSize const):
(JSC::UnlinkedMetadataTable::totalSize const):
(JSC::UnlinkedMetadataTable::buffer const):
(JSC::UnlinkedMetadataTable::offsetTable16 const):
(JSC::UnlinkedMetadataTable::offsetTable32 const):
* Source/JavaScriptCore/bytecode/UnlinkedMetadataTableInlines.h:
(JSC::UnlinkedMetadataTable::link):
(JSC::UnlinkedMetadataTable::asMetadataTable):
* Source/JavaScriptCore/runtime/GetPutInfo.h:
* Source/JavaScriptCore/runtime/JSScope.cpp:
(JSC::JSScope::abstractResolveFast):
(JSC::JSScope::abstractResolve):
* Source/JavaScriptCore/runtime/JSScope.h:
* Source/JavaScriptCore/runtime/ProgramExecutable.cpp:
(JSC::ProgramExecutable::initializeGlobalProperties):
* Source/JavaScriptCore/runtime/ScriptExecutable.cpp:
(JSC::ScriptExecutable::newCodeBlockFor):
(JSC::ScriptExecutable::prepareForExecutionImpl):
* Source/JavaScriptCore/runtime/VM.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d72b08da2ef7c3184e740987f11c57af28ee8789

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12508 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63874 "Hash d72b08da for PR 31188 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10486 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10682 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/63874 "Hash d72b08da for PR 31188 does not build (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7311 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51915 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/63874 "Hash d72b08da for PR 31188 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9156 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9405 "Hash d72b08da for PR 31188 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/53050 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55273 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9441 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65606 "Hash d72b08da for PR 31188 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59201 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9296 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/65606 "Hash d72b08da for PR 31188 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3904 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51909 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/65606 "Hash d72b08da for PR 31188 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3222 "Passed tests") | | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80959 "Hash d72b08da for PR 31188 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35117 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/80959 "Hash d72b08da for PR 31188 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36199 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->