### PR TITLE
[Site Isolation] Make setPageScaleFactor async

### DIFF
--- a/LayoutTests/accessibility/tree-update-with-dirty-layout.html
+++ b/LayoutTests/accessibility/tree-update-with-dirty-layout.html
@@ -24,7 +24,8 @@ if (window.accessibilityController) {
     var scale = 0.1;
     // Repeatedly dirty layout by changing the page scalor factor.
     setInterval(async function () {
-        internals.setPageScaleFactor(scale, 0, 0);
+        if (window.testRunner)
+            await testRunner.setPageScaleFactor(scale, 0, 0);
 
         scale += 0.01;
         if (scale >= 4)
@@ -33,12 +34,14 @@ if (window.accessibilityController) {
 
     var traversalOutput;
     setTimeout(async function() {
-        internals.setPageScaleFactor(2, 0, 0);
+        if (window.testRunner)
+            await testRunner.setPageScaleFactor(2, 0, 0);
 
         const newParagraph = document.createElement("p");
         newParagraph.innerText = "Paragraph four";
         document.getElementById("main").appendChild(newParagraph);
-        internals.setPageScaleFactor(2.5, 0, 0);
+        if (window.testRunner)
+            await testRunner.setPageScaleFactor(2.5, 0, 0);
 
         await waitFor(() => {
             // Depending on the scale factor at the time we traverse, there may be scrollbars present. They aren't important

--- a/LayoutTests/compositing/canvas/hidpi-canvas-backing-store-invalidation-2.html
+++ b/LayoutTests/compositing/canvas/hidpi-canvas-backing-store-invalidation-2.html
@@ -28,12 +28,10 @@ function doTest() {
     document.getElementById('layers-before').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_DEVICE_SCALE);
   }
 
-  requestAnimationFrame(function() {
-    if (window.internals) {
-      window.internals.setPageScaleFactor(0.5, 0, 0);
-    }
+  requestAnimationFrame(async function() {
 
     if (window.testRunner) {
+      await window.testRunner.setPageScaleFactor(0.5, 0, 0);
       document.getElementById('layers-after').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_DEVICE_SCALE);
       testRunner.notifyDone();
     }

--- a/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-down.html
+++ b/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-down.html
@@ -13,15 +13,21 @@
 }
 </style>
 <script>
-  if (window.internals) {
-    window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
-    window.internals.setPageScaleFactor(0.5, 0, 0);
-  }
   if (window.testRunner)
-    testRunner.dumpAsText(true);
+      window.testRunner.waitUntilDone();
+  async function runTest() {
+    if (window.internals) {
+        window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
+    }
+    if (window.testRunner) {
+        await window.testRunner.setPageScaleFactor(0.5, 0, 0);
+        testRunner.dumpAsText(true);
+        testRunner.notifyDone();
+    }
+  }
 </script>
 </head>
-<body style="width:2000px;height:2000px;">
+<body style="width:2000px;height:2000px;" onload="runTest()">
 <div class="fixed-no-z-index">TEST</div><br>
 <div class="fixed-with-z-index">TEST</div>
 </body>

--- a/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-scroll.html
+++ b/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-scroll.html
@@ -14,18 +14,23 @@
 }
 </style>
 <script>
-  if (window.internals) {
-    window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
-    window.internals.setPageScaleFactor(2, 0, 0);
-  }
-  function test() {
-    window.scrollTo(100,100);
+  if (window.testRunner)
+      window.testRunner.waitUntilDone();
+  async function test() {
+    if (window.internals) {
+        window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
+    }
     if (window.testRunner)
+        await window.testRunner.setPageScaleFactor(2, 0, 0);
+    window.scrollTo(100,100);
+    if (window.testRunner) {
       testRunner.dumpAsText();
+      testRunner.notifyDone();
+    }
   }
 </script>
 </head>
-<body onload="test();" style="width:2000px;height:2000px;">
+<body onload="test()" style="width:2000px;height:2000px;">
 <div class="fixed-no-z-index">This test should not hit an assertion in RenderGeometryMap in debug builds</div><br>
 <div class="fixed-with-z-index">This test should not hit an assertion in RenderGeometryMap in debug builds</div>
 </body>

--- a/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport-expected.html
+++ b/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport-expected.html
@@ -8,11 +8,13 @@
   }
 </style>
 <script>
-  if (window.internals)
-    window.internals.setPageScaleFactor(0.5, 0, 0);
+  async function runTest() {
+    if (window.testRunner)
+      await testRunner.setPageScaleFactor(0.5, 0, 0);
+  }
 </script>
 </head>
-<body>
+<body onload="runTest();">
   On success, the blue reference box should be invisible (covered by the fixed box).
 </body>
 </html>

--- a/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html
+++ b/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html
@@ -27,11 +27,13 @@
   if (window.internals) {
     window.internals.settings.setVisualViewportEnabled(false);
     window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
-    window.internals.setPageScaleFactor(0.5, 0, 0);
+  }
+  async function runTest() {
+    await window.testRunner.setPageScaleFactor(0.5, 0, 0);
   }
 </script>
 </head>
-<body>
+<body onload="runTest();">
   On success, the blue reference box should be invisible (covered by the fixed box).
   <div class="reference"></div>
   <div class="fixed"></div>

--- a/LayoutTests/compositing/geometry/fixed-position-composited-page-scale.html
+++ b/LayoutTests/compositing/geometry/fixed-position-composited-page-scale.html
@@ -13,15 +13,22 @@
 }
 </style>
 <script>
+if (window.testRunner)
+    window.testRunner.waitUntilDone();
+
+async function runTest() {
   if (window.internals) {
     window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
-    window.internals.setPageScaleFactor(2, 0, 0);
+    await window.testRunner.setPageScaleFactor(2, 0, 0);
   }
-  if (window.testRunner)
+  if (window.testRunner) {
     testRunner.dumpAsText(true);
+    testRunner.notifyDone();
+  }
+}
 </script>
 </head>
-<body style="width:2000px;height:2000px;">
+<body onload="runTest()" style="width:2000px;height:2000px;">
 <div class="fixed-no-z-index">TEST</div><br>
 <div class="fixed-with-z-index">TEST</div>
 </body>

--- a/LayoutTests/compositing/geometry/fixed-position-iframe-composited-page-scale-down.html
+++ b/LayoutTests/compositing/geometry/fixed-position-iframe-composited-page-scale-down.html
@@ -13,17 +13,21 @@
 }
 </style>
 <script>
-  if (window.internals) {
-    window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
-    window.internals.setPageScaleFactor(0.5, 0, 0);
-  }
-  function test() {
-    if (window.testRunner)
+  if (window.testRunner)
+      window.testRunner.waitUntilDone();
+  async function test() {
+    if (window.internals) {
+        window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
+    }
+    if (window.testRunner) {
+      await window.testRunner.setPageScaleFactor(0.5, 0, 0);
       testRunner.dumpAsText(true);
 
-    var d = document.getElementById('frame').contentDocument.open();
-    d.write("<div style='position:fixed; z-index: 1; left; 10px;'>TEST</div>");
-    d.close();
+      var d = document.getElementById('frame').contentDocument.open();
+      d.write("<div style='position:fixed; z-index: 1; left; 10px;'>TEST</div>");
+      d.close();
+      window.testRunner.notifyDone();
+    }
   }
 </script>
 </head>

--- a/LayoutTests/compositing/geometry/fixed-position-iframe-composited-page-scale.html
+++ b/LayoutTests/compositing/geometry/fixed-position-iframe-composited-page-scale.html
@@ -13,17 +13,20 @@
 }
 </style>
 <script>
-  if (window.internals) {
-    window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
-    window.internals.setPageScaleFactor(2, 0, 0);
-  }
-  function test() {
-    if (window.testRunner)
-      testRunner.dumpAsText(true);
-
-    var d = document.getElementById('frame').contentDocument.open();
-    d.write("<div style='position:fixed; z-index: 1; left; 10px;'>TEST</div>");
-    d.close();
+  if (window.testRunner)
+      window.testRunner.waitUntilDone();
+  async function test() {
+    if (window.internals) {
+        window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
+    }
+    if (window.testRunner) {
+        await window.testRunner.setPageScaleFactor(2, 0, 0);
+        testRunner.dumpAsText(true);
+        var d = document.getElementById('frame').contentDocument.open();
+        d.write("<div style='position:fixed; z-index: 1; left; 10px;'>TEST</div>");
+        d.close();
+        window.testRunner.notifyDone();
+    }
   }
 </script>
 </head>

--- a/LayoutTests/compositing/geometry/fixed-position-transform-composited-page-scale-down.html
+++ b/LayoutTests/compositing/geometry/fixed-position-transform-composited-page-scale-down.html
@@ -15,15 +15,20 @@
 }
 </style>
 <script>
-  if (window.internals) {
+if (window.testRunner)
+    testRunner.waitUntilDone();
+async function runTest() {
+  if (window.internals)
     window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
-    window.internals.setPageScaleFactor(0.5, 0, 0);
-  }
-  if (window.testRunner)
+  if (window.testRunner) {
+    await window.testRunner.setPageScaleFactor(0.5, 0, 0);
     testRunner.dumpAsText(true);
+    testRunner.notifyDone();
+  }
+}
 </script>
 </head>
-<body style="width:2000px;height:2000px;">
+<body onload="runTest()" style="width:2000px;height:2000px;">
 <div class="fixed-no-z-index">TEST</div><br>
 <div class="fixed-with-z-index">TEST</div>
 </body>

--- a/LayoutTests/compositing/geometry/fixed-position-transform-composited-page-scale.html
+++ b/LayoutTests/compositing/geometry/fixed-position-transform-composited-page-scale.html
@@ -14,16 +14,23 @@
   -webkit-transform: translateX(10px) rotate(20deg);
 }
 </style>
+
 <script>
-  if (window.internals) {
-    window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
-    window.internals.setPageScaleFactor(2, 0, 0);
-  }
   if (window.testRunner)
-    testRunner.dumpAsText(true);
+      window.testRunner.waitUntilDone();
+  async function runTest() {
+    if (window.internals) {
+        window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
+    }
+      if (window.testRunner) {
+        await window.testRunner.setPageScaleFactor(2, 0, 0);
+        testRunner.dumpAsText(true);
+        testRunner.notifyDone();
+      }
+  }
 </script>
 </head>
-<body style="width:2000px;height:2000px;">
+<body style="width:2000px;height:2000px;" onload="runTest()">
 <div class="fixed-no-z-index">TEST</div><br>
 <div class="fixed-with-z-index">TEST</div>
 </body>

--- a/LayoutTests/compositing/layer-creation/fixed-position-out-of-view-scaled-iframe-scroll.html
+++ b/LayoutTests/compositing/layer-creation/fixed-position-out-of-view-scaled-iframe-scroll.html
@@ -10,19 +10,22 @@
     window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
 
     addEventListener("load", function() {
-      window.internals.setPageScaleFactor(0.5, 0, 0);
-      setTimeout(function() {
-        var layerTreeScaledDown = internals.layerTreeAsText(document.getElementById("iframe").contentDocument);
-
-        window.internals.setPageScaleFactor(1.5, 0, 0);
-        setTimeout(function() {
-          var layerTreeScaledUp = internals.layerTreeAsText(document.getElementById("iframe").contentDocument);
-          // Because logical size of the frame is unchanged, the layer tree in the frame should not be affected by the page scale.
-          document.getElementById("result").innerText =
-              layerTreeScaledUp == layerTreeScaledDown ? "PASS" : "FAIL";
-          testRunner.notifyDone();
-        }, 0);
-      }, 0);
+      if (window.testRunner)
+        window.testRunner.setPageScaleFactor(0.5, 0, 0).then(() => {
+          setTimeout(async function() {
+            var layerTreeScaledDown = internals.layerTreeAsText(document.getElementById("iframe").contentDocument);
+            if (window.testRunner)
+              window.testRunner.setPageScaleFactor(1.5, 0, 0).then(() => {
+                setTimeout(function() {
+                  var layerTreeScaledUp = internals.layerTreeAsText(document.getElementById("iframe").contentDocument);
+                  // Because logical size of the frame is unchanged, the layer tree in the frame should not be affected by the page scale.
+                  document.getElementById("result").innerText =
+                  layerTreeScaledUp == layerTreeScaledDown ? "PASS" : "FAIL";
+                  testRunner.notifyDone();
+                }, 0);
+              });
+          }, 0);
+        });
     }, false);
   }
 </script>

--- a/LayoutTests/compositing/layer-creation/fixed-position-out-of-view-scaled-iframe.html
+++ b/LayoutTests/compositing/layer-creation/fixed-position-out-of-view-scaled-iframe.html
@@ -10,19 +10,22 @@
     window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
 
     addEventListener("load", function() {
-      window.internals.setPageScaleFactor(0.5, 0, 0);
-      setTimeout(function() {
-        var layerTreeScaledDown = internals.layerTreeAsText(document.getElementById("iframe").contentDocument);
-
-        window.internals.setPageScaleFactor(1.5, 0, 0);
-        setTimeout(function() {
-          var layerTreeScaledUp = internals.layerTreeAsText(document.getElementById("iframe").contentDocument);
-          // Because logical size of the frame is unchanged, the layer tree in the frame should not be affected by the page scale.
-          document.getElementById("result").innerText =
-              layerTreeScaledUp == layerTreeScaledDown ? "PASS" : "FAIL";
-          testRunner.notifyDone();
-        }, 0);
-      }, 0);
+      if (window.testRunner)
+        window.testRunner.setPageScaleFactor(0.5, 0, 0).then(() => {
+          setTimeout(async function() {
+            var layerTreeScaledDown = internals.layerTreeAsText(document.getElementById("iframe").contentDocument);
+            if (window.testRunner)
+              window.testRunner.setPageScaleFactor(1.5, 0, 0).then(() => {
+                setTimeout(function() {
+                  var layerTreeScaledUp = internals.layerTreeAsText(document.getElementById("iframe").contentDocument);
+                  // Because logical size of the frame is unchanged, the layer tree in the frame should not be affected by the page scale.
+                  document.getElementById("result").innerText =
+                  layerTreeScaledUp == layerTreeScaledDown ? "PASS" : "FAIL";
+                  testRunner.notifyDone();
+                }, 0);
+              });
+          }, 0);
+        });
     }, false);
   }
 </script>

--- a/LayoutTests/compositing/layer-creation/fixed-position-out-of-view-scaled-scroll.html
+++ b/LayoutTests/compositing/layer-creation/fixed-position-out-of-view-scaled-scroll.html
@@ -14,19 +14,19 @@
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
   }
-  if (window.internals) {
+  if (window.internals && window.testRunner) {
     window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
 
-    addEventListener("load", function() {
+    addEventListener("load", async function() {
       window.scrollTo(100,100);
 
       document.getElementById("layerTree").innerText = internals.layerTreeAsText(document);
 
-      window.internals.setPageScaleFactor(0.5, 0, 0);
-      setTimeout(function() {
+      await window.testRunner.setPageScaleFactor(0.5, 0, 0);
+      setTimeout(async function() {
         document.getElementById("layerTreeScaledDown").innerText = internals.layerTreeAsText(document);
 
-        window.internals.setPageScaleFactor(1.5, 0, 0);
+        await window.testRunner.setPageScaleFactor(1.5, 0, 0);
         setTimeout(function() {
           document.getElementById("layerTreeScaledUp").innerText = internals.layerTreeAsText(document);
           testRunner.notifyDone();

--- a/LayoutTests/compositing/layer-creation/fixed-position-out-of-view-scaled.html
+++ b/LayoutTests/compositing/layer-creation/fixed-position-out-of-view-scaled.html
@@ -14,17 +14,17 @@
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
   }
-  if (window.internals) {
+  if (window.internals && window.testRunner) {
     window.internals.settings.setAcceleratedCompositingForFixedPositionEnabled(true);
 
-    addEventListener("load", function() {
+    addEventListener("load", async function() {
       document.getElementById("layerTree").innerText = internals.layerTreeAsText(document);
 
-      window.internals.setPageScaleFactor(0.5, 0, 0);
-      setTimeout(function() {
+      await window.testRunner.setPageScaleFactor(0.5, 0, 0);
+      setTimeout(async function() {
         document.getElementById("layerTreeScaledDown").innerText = internals.layerTreeAsText(document);
 
-        window.internals.setPageScaleFactor(1.5, 0, 0);
+        await window.testRunner.setPageScaleFactor(1.5, 0, 0);
         setTimeout(function() {
           document.getElementById("layerTreeScaledUp").innerText = internals.layerTreeAsText(document);
           testRunner.notifyDone();

--- a/LayoutTests/compositing/overflow/overflow-scaled-descendant-overlapping.html
+++ b/LayoutTests/compositing/overflow/overflow-scaled-descendant-overlapping.html
@@ -4,11 +4,14 @@
     containers and other render layers when page scaling is used. See
     https://bugs.webkit.org/show_bug.cgi?id=76850 -->
     <script>
-        window.onload = function() {
-            if (window.testRunner)
-                testRunner.dumpAsText(true);
-            if (window.internals)
-                window.internals.setPageScaleFactor(0.5, 0, 0);
+        if (window.testRunner)
+            window.testRunner.waitUntilDone();
+        window.onload = async function() {
+            if (!window.testRunner)
+                return;
+            testRunner.dumpAsText(true);
+            await window.testRunner.setPageScaleFactor(0.5, 0, 0);
+            window.testRunner.notifyDone();
         }
     </script>
 

--- a/LayoutTests/compositing/repaint/page-scale-repaint.html
+++ b/LayoutTests/compositing/repaint/page-scale-repaint.html
@@ -2,11 +2,14 @@
 <html>
 <body style="height:10000px;background-image:url('resources/grid.png')" onload="runTest();">
 <script>
-function runTest() {
-    if (window.testRunner)
+if (window.testRunner)
+    window.testRunner.waitUntilDone();
+async function runTest() {
+    if (window.testRunner) {
         testRunner.displayAndTrackRepaints();
-    if (window.internals)
-        window.internals.setPageScaleFactor(0.5, 0, 0);
+        await window.testRunner.setPageScaleFactor(0.5, 0, 0);
+        testRunner.notifyDone();
+    }
 }
 </script>
 <div style="-webkit-transform:translateZ(0);"></div>

--- a/LayoutTests/compositing/scaling/tiled-layer-recursion.html
+++ b/LayoutTests/compositing/scaling/tiled-layer-recursion.html
@@ -11,13 +11,17 @@
     }
   </style>
   <script>
-    if (window.testRunner)
-      testRunner.dumpAsText(true);
+    if (window.testRunner) {
+        testRunner.dumpAsText(true);
+        testRunner.waitUntilDone();
+    }
 
-    function scalePage()
+    async function scalePage()
     {
-      if (window.internals)
-        window.internals.setPageScaleFactor(1.50025, 0, 0);
+      if (window.testRunner) {
+        await window.testRunner.setPageScaleFactor(1.50025, 0, 0);
+        window.testRunner.notifyDone();
+      }
     }
   
     window.addEventListener('load', scalePage, false);

--- a/LayoutTests/css3/filters/backdrop-filter-page-scale-expected.html
+++ b/LayoutTests/css3/filters/backdrop-filter-page-scale-expected.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="utf-8">
     <script>
-        window.onload = function() {
-            if (window.internals)
-                window.internals.setPageScaleFactor(2, 0, 0);
+        window.onload = async function() {
+            if (window.testRunner)
+                await window.testRunner.setPageScaleFactor(2, 0, 0);
         }
     </script>
 <style>

--- a/LayoutTests/css3/filters/backdrop-filter-page-scale.html
+++ b/LayoutTests/css3/filters/backdrop-filter-page-scale.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="utf-8">
     <script>
-        window.onload = function() {
-            if (window.internals)
-                window.internals.setPageScaleFactor(2, 0, 0);
+        window.onload = async function() {
+            if (window.testRunner)
+                await window.testRunner.setPageScaleFactor(2, 0, 0);
         }
     </script>
 <style>

--- a/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-scaled-expected.html
+++ b/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-scaled-expected.html
@@ -2,10 +2,14 @@
 <html>
 <head>
 </head>
-<body>
+<body onload="test();">
 <script>
-if (window.internals)
-    window.internals.setPageScaleFactor(100, 0, 0);
+if (window.testRunner)
+    window.testRunner.waitUntilDone();
+async function test() {
+    await window.testRunner.setPageScaleFactor(100, 0, 0);
+    window.testRunner.notifyDone();
+}
 </script>
 <div style="position: absolute; left: 0px; top: 0px; width: 1px; height: 1px; background: white;">
 </div>

--- a/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-scaled.html
+++ b/LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-scaled.html
@@ -2,10 +2,14 @@
 <html>
 <head>
 </head>
-<body>
+<body onload="test();">
 <script>
-if (window.internals)
-    window.internals.setPageScaleFactor(100, 0, 0);
+if (window.testRunner)
+    window.testRunner.waitUntilDone();
+async function test() {
+    await window.testRunner.setPageScaleFactor(100, 0, 0);
+    window.testRunner.notifyDone();
+}
 </script>
 <div style="position: absolute; left: 0px; top: 0px; width: 1px; height: 1px; overflow: hidden;">
 <div style="font-family: Ahem; font-size: 12px; overflow: hidden; position: absolute; left: 0px; top: -12px; text-decoration: underline;">&nbsp;</div>

--- a/LayoutTests/fast/dom/Element/scale-page-bounding-client-rect-in-frame.html
+++ b/LayoutTests/fast/dom/Element/scale-page-bounding-client-rect-in-frame.html
@@ -2,7 +2,9 @@
 <html>
 <head>
 <script>
-function testRects()
+if (window.testRunner)
+    window.testRunner.waitUntilDone();
+async function testRects()
 {
     if (!window.testRunner || !window.internals)
         return;
@@ -10,7 +12,7 @@ function testRects()
     
     var div = document.getElementById("frame").contentDocument.getElementById("div");
     var rect = div.getBoundingClientRect();
-    window.internals.setPageScaleFactor(2, 0, 0);
+    await window.testRunner.setPageScaleFactor(2, 0, 0);
     var scaledRect = div.getBoundingClientRect();
 
     var result = document.getElementById("result");
@@ -21,6 +23,7 @@ function testRects()
         result.innerHTML = "Pass";
     else
         result.innerHTML = "Fail";
+    testRunner.notifyDone();
     
 }
 </script>

--- a/LayoutTests/fast/dom/Element/scale-page-bounding-client-rect.html
+++ b/LayoutTests/fast/dom/Element/scale-page-bounding-client-rect.html
@@ -1,15 +1,16 @@
 <html>
 <head>
 <script>
-function testRects()
+async function testRects()
 {
     if (!window.testRunner || !window.internals)
         return;
     testRunner.dumpAsText();
+    testRunner.waitUntilDone();
     
     var div = document.getElementById("div");
     var rect = div.getBoundingClientRect();
-    window.internals.setPageScaleFactor(2, 0, 0);
+    await window.testRunner.setPageScaleFactor(2, 0, 0);
     var scaledRect = div.getBoundingClientRect();
 
     var result = document.getElementById("result");
@@ -20,6 +21,7 @@ function testRects()
         result.innerHTML = "Pass";
     else
         result.innerHTML = "Fail";
+    testRunner.notifyDone();
     
 }
 </script>

--- a/LayoutTests/fast/dom/Element/scale-page-client-rects-in-frame.html
+++ b/LayoutTests/fast/dom/Element/scale-page-client-rects-in-frame.html
@@ -2,15 +2,16 @@
 <html>
 <head>
 <script>
-function testRects()
+async function testRects()
 {
     if (!window.testRunner || !window.internals)
         return;
     testRunner.dumpAsText();
+    testRunner.waitUntilDone();
     
     var div = document.getElementById("frame").contentDocument.getElementById("div");
     var rect = div.getClientRects()[0];
-    window.internals.setPageScaleFactor(2, 0, 0);
+    await window.testRunner.setPageScaleFactor(2, 0, 0);
     var scaledRect = div.getClientRects()[0];
 
     var result = document.getElementById("result");
@@ -21,6 +22,7 @@ function testRects()
         result.innerHTML = "Pass";
     else
         result.innerHTML = "Fail";
+    testRunner.notifyDone();
     
 }
 </script>

--- a/LayoutTests/fast/dom/Element/scale-page-client-rects.html
+++ b/LayoutTests/fast/dom/Element/scale-page-client-rects.html
@@ -1,7 +1,9 @@
 <html>
 <head>
 <script>
-function testRects()
+if (window.testRunner)
+    window.testRunner.waitUntilDone();
+async function testRects()
 {
     if (!window.testRunner || !window.internals)
         return;
@@ -9,7 +11,7 @@ function testRects()
     
     var div = document.getElementById("div");
     var rectList = div.getClientRects();
-    window.internals.setPageScaleFactor(2, 0, 0);
+    await window.testRunner.setPageScaleFactor(2, 0, 0);
     var scaledRectList = div.getClientRects();
 
     var result = document.getElementById("result");
@@ -23,6 +25,7 @@ function testRects()
         result.innerHTML = "Pass";
     else
         result.innerHTML = "Fail";
+    testRunner.notifyDone();
     
 }
 </script>

--- a/LayoutTests/fast/dom/Range/scale-page-bounding-client-rect.html
+++ b/LayoutTests/fast/dom/Range/scale-page-bounding-client-rect.html
@@ -1,7 +1,9 @@
 <html>
 <head>
 <script>
-function testRects()
+if (window.testRunner)
+    window.testRunner.waitUntilDone();
+async function testRects()
 {
     if (!window.testRunner || !window.internals)
         return;
@@ -11,7 +13,7 @@ function testRects()
     range.selectNode(document.getElementById('div'));
     var rect = range.getBoundingClientRect();
    
-    window.internals.setPageScaleFactor(2, 0, 0);
+    await window.testRunner.setPageScaleFactor(2, 0, 0);
     var scaledRange = document.createRange();
     scaledRange.selectNode(document.getElementById('div'));
     var scaledRect = scaledRange.getBoundingClientRect();
@@ -24,6 +26,7 @@ function testRects()
         result.innerHTML = "Pass";
     else
         result.innerHTML = "Fail";
+    testRunner.notifyDone();
     
 }
 </script>

--- a/LayoutTests/fast/dom/Range/scale-page-client-rects.html
+++ b/LayoutTests/fast/dom/Range/scale-page-client-rects.html
@@ -1,7 +1,9 @@
 <html>
 <head>
 <script>
-function testRects()
+if (window.testRunner)
+    window.testRunner.waitUntilDone();
+async function testRects()
 {
     if (!window.testRunner ||  !window.internals)
         return;
@@ -12,7 +14,7 @@ function testRects()
     var rectList = range.getClientRects();
     var rect = rectList[0];
    
-    window.internals.setPageScaleFactor(2, 0, 0);
+    await window.testRunner.setPageScaleFactor(2, 0, 0);
     var scaledRange = document.createRange();
     scaledRange.selectNode(document.getElementById('div'));
     var scaledRectList = scaledRange.getClientRects();
@@ -26,6 +28,7 @@ function testRects()
         result.innerHTML = "Pass";
     else
         result.innerHTML = "Fail";
+    testRunner.notifyDone();
     
 }
 </script>

--- a/LayoutTests/fast/dom/elementFromPoint-scaled-scrolled-layout-viewport-expected.txt
+++ b/LayoutTests/fast/dom/elementFromPoint-scaled-scrolled-layout-viewport-expected.txt
@@ -3,9 +3,6 @@ This test applies page scale and scrolls the page, and checks that elementFromPo
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS successfullyParsed is true
-
-TEST COMPLETE
 PASS document.elementFromPoint(225, 125) is b1
 PASS document.elementFromPoint(525, 425) is b2
 PASS document.elementFromPoint(225, 125) is b1

--- a/LayoutTests/fast/dom/elementFromPoint-scaled-scrolled-layout-viewport.html
+++ b/LayoutTests/fast/dom/elementFromPoint-scaled-scrolled-layout-viewport.html
@@ -26,11 +26,14 @@
 <button id="b1"></button>
 <button id="b2"></button>
 <script>
-function runTest() {
+window.jsTestIsAsync = true;
+
+async function runTest() {
     description("This test applies page scale and scrolls the page, and checks that elementFromPoint returns the correct element.");
     if (window.internals) {
         window.internals.settings.setClientCoordinatesRelativeToLayoutViewport(true);
-        window.internals.setPageScaleFactor(2, 0, 0);
+        if (window.testRunner)
+            await window.testRunner.setPageScaleFactor(2, 0, 0);
     }
     window.scrollTo(100, 100);
 

--- a/LayoutTests/fast/dom/elementFromPoint-scaled-scrolled.html
+++ b/LayoutTests/fast/dom/elementFromPoint-scaled-scrolled.html
@@ -3,20 +3,24 @@
 <head>
 <script src="../../../../resources/js-test-pre.js"></script>
 </head>
-<body onload="runTest();" style="width:2000px;height:2000px;margin:0px;padding:100px">
+<body onload="runTest()" style="width:2000px;height:2000px;margin:0px;padding:100px">
 <button style="width:50px;height:50px;">B1</button><button style="width:50px;height:50px;">B2</button><button style="width:50px;height:50px;">B3</button>
 <div>This test is successful if elementFromPoint returns the correct element.</div>
 <div id="result"></div>
 <script>
-function runTest() {
-    if (window.internals)
-        window.internals.setPageScaleFactor(2, 0, 0);
+if (window.testRunner)
+    window.testRunner.waitUntilDone();
+async function runTest() {
+    if (window.testRunner)
+        await window.testRunner.setPageScaleFactor(2, 0, 0);
     window.scrollTo(100,100);
 
     if (window.testRunner)
         testRunner.dumpAsText();
 
     document.getElementById("result").innerText = document.elementFromPoint(125, 25).innerText;
+    if (window.testRunner)
+        window.testRunner.notifyDone();
 }
 </script>
 </script>

--- a/LayoutTests/fast/dom/iframe-inner-size-scaling.html
+++ b/LayoutTests/fast/dom/iframe-inner-size-scaling.html
@@ -5,13 +5,13 @@
         description("This tests that innerWidth/innerHeight on an frame window returns the size of the frame itself in CSS pixels, regardless of page scale.");
         window.jsTestIsAsync = true;
 
-        function runTest() {
+        async function runTest() {
             frame = document.getElementById('iframe');
             originalWidth = frame.contentWindow.innerWidth;
             originalHeight = frame.contentWindow.innerHeight;
 
-            if (window.internals)
-                window.internals.setPageScaleFactor(2, 0, 0);
+            if (window.testRunner)
+                await window.testRunner.setPageScaleFactor(2, 0, 0);
 
             shouldBeNonZero("frame.contentWindow.innerWidth");
             shouldBeNonZero("frame.contentWindow.innerHeight");

--- a/LayoutTests/fast/dom/window-inner-size-scaling-expected.txt
+++ b/LayoutTests/fast/dom/window-inner-size-scaling-expected.txt
@@ -3,9 +3,9 @@ This test ensures window.innerWidth/innerHeight return the size of the visual vi
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS window.innerWidth is Math.floor(originalWidth / scale)
-PASS window.innerHeight is Math.floor(originalHeight / scale)
 PASS successfullyParsed is true
 
 TEST COMPLETE
+PASS window.innerWidth is Math.floor(originalWidth / scale)
+PASS window.innerHeight is Math.floor(originalHeight / scale)
 

--- a/LayoutTests/fast/dom/window-inner-size-scaling.html
+++ b/LayoutTests/fast/dom/window-inner-size-scaling.html
@@ -1,17 +1,22 @@
 <html>
     <script src="../../resources/js-test-pre.js"></script>
     <script>
-        description("This test ensures window.innerWidth/innerHeight return the size of the visual viewport in CSS pixels.");
-
-        var originalWidth = window.innerWidth;
-        var originalHeight = window.innerHeight;
-        var scale = 2;
-
-        if (window.internals)
-            window.internals.setPageScaleFactor(scale, 0, 0);
+    description("This test ensures window.innerWidth/innerHeight return the size of the visual viewport in CSS pixels.");
+    var originalWidth = window.innerWidth;
+    var originalHeight = window.innerHeight;
+    var scale = 2;
+    if (window.testRunner)
+        window.testRunner.waitUntilDone();
+    async function runTest() {
+        if (window.testRunner)
+            await window.testRunner.setPageScaleFactor(scale, 0, 0);
 
         shouldBe("window.innerWidth", "Math.floor(originalWidth / scale)");
         shouldBe("window.innerHeight", "Math.floor(originalHeight / scale)");
+        if (window.testRunner)
+            window.testRunner.notifyDone();
+    }
     </script>
     <script src="../../resources/js-test-post.js"></script>
+    <body onload="runTest()"></body>
 </html>

--- a/LayoutTests/fast/dom/window-scroll-scaling-expected.txt
+++ b/LayoutTests/fast/dom/window-scroll-scaling-expected.txt
@@ -3,9 +3,9 @@ This test ensures that document content width (height) as reported by scrollWidt
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS body.scrollWidth is originalScrollWidth
-PASS body.scrollHeight is originalScrollHeight
 PASS successfullyParsed is true
 
 TEST COMPLETE
+PASS body.scrollWidth is originalScrollWidth
+PASS body.scrollHeight is originalScrollHeight
 

--- a/LayoutTests/fast/dom/window-scroll-scaling.html
+++ b/LayoutTests/fast/dom/window-scroll-scaling.html
@@ -1,11 +1,12 @@
 <html>
-<body>
+<body onload="runTest();">
     <script src="../../resources/js-test-pre.js"></script>
     <script>
+        if (window.testRunner)
+            window.testRunner.waitUntilDone();
         description("This test ensures that document content width (height) as reported by scrollWidth (scrollHeight) is invariant to changes in page scale factor.");
 
         var body = document.body;
-
         // According to CSSOM (http://dev.w3.org/csswg/cssom-view/#dom-element-scrollwidth)
         // the scrollWidth of the body element (in Quirks mode) is defined as
         //    max(document content width, value of innerWidth).
@@ -20,16 +21,18 @@
         var originalScrollHeight = body.scrollHeight;
 
         var scale = 1.1;
-        if (window.internals)
-            window.internals.setPageScaleFactor(scale, 0, 0);
-
-        // As we have increased the scale factor, the innerWidth will be less
-        // as fewer CSS pixels will be rendered in the same viewport, so
-        // body.scrollWidth (scrollHeight) will still be measuring the document
-        // content width (height).
-
-        shouldBe("body.scrollWidth", "originalScrollWidth");
-        shouldBe("body.scrollHeight", "originalScrollHeight");
+        function runTest (){
+        if (window.testRunner)
+            testRunner.setPageScaleFactor(scale, 0, 0).then(() =>  {
+                // As we have increased the scale factor, the innerWidth will be less
+                // as fewer CSS pixels will be rendered in the same viewport, so
+                // body.scrollWidth (scrollHeight) will still be measuring the document
+                // content width (height).
+                shouldBe("body.scrollWidth", "originalScrollWidth");
+                shouldBe("body.scrollHeight", "originalScrollHeight");
+                testRunner.notifyDone();
+            });
+        }
     </script>
     <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/fast/events/autoscroll-when-zoomed.html
+++ b/LayoutTests/fast/events/autoscroll-when-zoomed.html
@@ -59,14 +59,14 @@
             window.setTimeout(doOneScroll, 2);
         }
 
-        function doTest()
+        async function doTest()
         {
             if (!window.testRunner || !window.eventSender) {
                 debug('This test requires testRunner and eventSender');
                 return;
             }
             
-            window.internals.setPageScaleFactor(pageScale, 0, 0);
+            await window.testRunner.setPageScaleFactor(pageScale, 0, 0);
 
             var containerRect = document.getElementById('container').getBoundingClientRect();
             var lineHeight = containerRect.height / 3;

--- a/LayoutTests/fast/events/drag-select-when-zoomed-with-header.html
+++ b/LayoutTests/fast/events/drag-select-when-zoomed-with-header.html
@@ -50,14 +50,14 @@
             window.setTimeout(doOneMouseMove, 2);
         }
 
-        function doTest()
+        async function doTest()
         {
             if (!window.testRunner || !window.eventSender) {
                 debug('This test requires testRunner and eventSender');
                 return;
             }
             
-            window.internals.setPageScaleFactor(pageScale, 0, 0);
+            await window.testRunner.setPageScaleFactor(pageScale, 0, 0);
             
             var containerRect = document.getElementById('container').getBoundingClientRect();
             var lineHeight = containerRect.height / 3;

--- a/LayoutTests/fast/events/drag-select-when-zoomed.html
+++ b/LayoutTests/fast/events/drag-select-when-zoomed.html
@@ -46,14 +46,14 @@
             window.setTimeout(doOneMouseMove, 2);
         }
 
-        function doTest()
+        async function doTest()
         {
             if (!window.testRunner || !window.eventSender) {
                 debug('This test requires testRunner and eventSender');
                 return;
             }
             
-            window.internals.setPageScaleFactor(pageScale, 0, 0);
+            await window.testRunner.setPageScaleFactor(pageScale, 0, 0);
             
             var containerRect = document.getElementById('container').getBoundingClientRect();
             var lineHeight = containerRect.height / 3;

--- a/LayoutTests/fast/events/page-scaled-mouse-click-iframe.html
+++ b/LayoutTests/fast/events/page-scaled-mouse-click-iframe.html
@@ -54,12 +54,12 @@ function testEvents(button, description, expectedString) {
     debug("");
 }
 
-function iframeLoaded() {
+async function iframeLoaded() {
   // Add the div to the iframe.
   div.addEventListener("click", appendEventLog, false);
   iframe.contentWindow.document.body.insertBefore(div, iframe.contentWindow.document.body.firstChild);
 
-  if (window.eventSender && window.internals) {
+  if (window.eventSender && window.internals && window.testRunner) {
     eventSender.mouseMoveTo(10, 10);
     // We are clicking in the same position on screen. As we scale or transform the page,
     // we expect the pageX and pageY event coordinates to change because different
@@ -67,15 +67,15 @@ function iframeLoaded() {
 
     testEvents(0, "Unscaled", "click(10, 10)");
 
-    window.internals.setPageScaleFactor(0.5, 0, 0);
+    await window.testRunner.setPageScaleFactor(0.5, 0, 0);
     testEvents(0, "setPageScale(0.5)", "click(20, 20)");
 
-    window.internals.setPageScaleFactor(1.0, 0, 0);
+    await window.testRunner.setPageScaleFactor(1.0, 0, 0);
     html.style["-webkit-transform"] = "scale(0.5, 2.0)";
     html.style["-webkit-transform-origin"] = "0 0";
     testEvents(0, "CSS scale(0.5, 2.0)", "click(20, 5)");
 
-    window.internals.setPageScaleFactor(0.5, 0, 0);
+    await window.testRunner.setPageScaleFactor(0.5, 0, 0);
     testEvents(0, "setPageScale(0.5), CSS scale(0.5, 2.0)", "click(40, 10)");
   }
 

--- a/LayoutTests/fast/events/page-scaled-mouse-click.html
+++ b/LayoutTests/fast/events/page-scaled-mouse-click.html
@@ -3,8 +3,9 @@
 <head>
 <script src="../../resources/js-test-pre.js"></script>
 </head>
-<body style="margin:0px">
+<body style="margin:0px" onload="runTest()">
 <script>
+window.jsTestIsAsync = true;
 description("This tests that page scaling does not affect mouse event pageX and pageY coordinates.");
 
 var html = document.documentElement;
@@ -49,16 +50,18 @@ function testEvents(button, description, expectedString) {
     debug("");
     clearEventLog();
 }
-
-if (window.eventSender && window.internals) {
+async function runTest() {
+if (window.eventSender && window.internals && window.testRunner) {
     eventSender.mouseMoveTo(10, 10);
     // We are clicking in the same position on screen. As we scale or transform the page,
     // we expect the pageX and pageY event coordinates to change because different
     // parts of the document are under the mouse.
     testEvents(0, "Unscaled", "click(10, 10)");
 
-    window.internals.setPageScaleFactor(0.5, 0, 0);
+    await window.testRunner.setPageScaleFactor(0.5, 0, 0);
     testEvents(0, "setPageScale(0.5)", "click(20, 20)");
+    finishJSTest();
+}
 }
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/events/scale-and-scroll-body.html
+++ b/LayoutTests/fast/events/scale-and-scroll-body.html
@@ -8,14 +8,16 @@
     </style>
     <script>
       window.enablePixelTesting = true;
+      if (window.testRunner)
+          window.testRunner.waitUntilDone();
 
-      function scrollViaJavascript() {
+      async function scrollViaJavascript() {
           var scaleFactor = 2.0;
-          if (window.internals) {
-             window.internals.setPageScaleFactor(scaleFactor, 0, 0);
+          if (window.testRunner) {
+             await window.testRunner.setPageScaleFactor(scaleFactor, 0, 0);
           }
 
-          // The page scale, as set by window.internals.setPageScaleFactor should not be apparent
+          // The page scale, as set by window.testRunner.setPageScaleFactor should not be apparent
           // to javascript. So, we expect scrolling to (100,100) to be page coordinates, rather
           // than device pixels.
           document.scrollingElement.scrollLeft = 100;
@@ -27,19 +29,20 @@
           shouldBe("window.scrollY", "100");
       }
 
-      function scrollViaSetScaleFactor() {
-          if (window.internals) {
-              // Test that the scroll offset changes even if scaleFactor remains
-              // the same.
-              window.internals.setPageScaleFactor(1, 30, 30);
-              shouldBe("window.document.scrollingElement.scrollTop", "30");
-              shouldBe("window.document.scrollingElement.scrollLeft", "30");
-          }
+      async function scrollViaSetScaleFactor() {
+        // Test that the scroll offset changes even if scaleFactor remains
+        // the same.
+        if (window.testRunner)
+            await window.testRunner.setPageScaleFactor(1, 30, 30);
+        shouldBe("window.document.scrollingElement.scrollTop", "30");
+        shouldBe("window.document.scrollingElement.scrollLeft", "30");
       }
 
-      function test() {
-          scrollViaSetScaleFactor();
-          scrollViaJavascript();
+      async function test() {
+          await scrollViaSetScaleFactor();
+          await scrollViaJavascript();
+          if (window.testRunner)
+              window.testRunner.notifyDone();
       }
     </script>
     <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/events/scale-and-scroll-iframe-body.html
+++ b/LayoutTests/fast/events/scale-and-scroll-iframe-body.html
@@ -8,6 +8,8 @@
     </style>
     <script>
         window.enablePixelTesting = true;
+        if (window.testRunner)
+            window.testRunner.waitUntilDone();
 
         function scroll() {
             window.scrollTo(0, 100);
@@ -19,18 +21,20 @@
             shouldBe("frame.contentDocument.body.scrollLeft", "100");
             shouldBe("frame.contentWindow.scrollX", "100");
             shouldBe("frame.contentWindow.scrollY", "100");
+            if (window.testRunner)
+                window.testRunner.notifyDone();
         }
 
-        function scaleWithEventSender() {
+        async function scaleWithEventSender() {
             var scaleFactor = 0.5;
             var scaleOffset = 0;
-            if (window.internals) {
-                 window.internals.setPageScaleFactor(scaleFactor, scaleOffset, scaleOffset);
+            if (window.testRunner) {
+                 await window.testRunner.setPageScaleFactor(scaleFactor, scaleOffset, scaleOffset);
             }
         }
 
-        function test() {
-            scaleWithEventSender();
+        async function test() {
+            await scaleWithEventSender();
             scroll();
         }
     </script>

--- a/LayoutTests/fast/events/scale-and-scroll-iframe-window.html
+++ b/LayoutTests/fast/events/scale-and-scroll-iframe-window.html
@@ -8,6 +8,8 @@
     </style>
     <script>
         window.enablePixelTesting = true;
+        if (window.testRunner)
+            window.testRunner.waitUntilDone();
 
         function scroll() {
             window.scrollTo(0, 100);
@@ -18,18 +20,20 @@
             shouldBe("frame.contentDocument.body.scrollLeft", "100");
             shouldBe("frame.contentWindow.scrollX", "100");
             shouldBe("frame.contentWindow.scrollY", "100");
+            if (window.testRunner)
+                window.testRunner.notifyDone();
         }
 
-        function scaleWithEventSender() {
+        async function scaleWithEventSender() {
             var scaleFactor = 0.5;
             var scaleOffset = 0;
-            if (window.internals) {
-                 window.internals.setPageScaleFactor(scaleFactor, scaleOffset, scaleOffset);
+            if (window.testRunner) {
+                await window.testRunner.setPageScaleFactor(scaleFactor, scaleOffset, scaleOffset);
             }
         }
 
-        function test() {
-            scaleWithEventSender();
+        async function test() {
+            await scaleWithEventSender();
             scroll();
         }
     </script>

--- a/LayoutTests/fast/events/scale-and-scroll-window.html
+++ b/LayoutTests/fast/events/scale-and-scroll-window.html
@@ -8,9 +8,10 @@
     </style>
     <script>
       window.enablePixelTesting = true;
-
+      if (window.testRunner)
+          window.testRunner.waitUntilDone();
       function scroll() {
-          // The page scale, as set by window.internals.setPageScaleFactor should not be apparent
+          // The page scale, as set by window.testRunner.setPageScaleFactor should not be apparent
           // to javascript. So, we expect scrolling to (100,100) to be page coordinates, rather
           // than device pixels.
           window.scrollTo(100,100);
@@ -19,18 +20,20 @@
           shouldBe("window.document.scrollingElement.scrollLeft", "100");
           shouldBe("window.scrollX", "100");
           shouldBe("window.scrollY", "100");
+          if (window.testRunner)
+              window.testRunner.notifyDone();
       }
 
-      function scaleWithEventSender() {
+      async function scaleWithEventSender() {
           var scaleFactor = 2.0;
           var scaleOffset = 0;
-          if (window.internals) {
-             window.internals.setPageScaleFactor(scaleFactor, scaleOffset, scaleOffset);
+          if (window.testRunner) {
+             await window.testRunner.setPageScaleFactor(scaleFactor, scaleOffset, scaleOffset);
           }
       }
 
-      function test() {
-          scaleWithEventSender();
+      async function test() {
+          await scaleWithEventSender();
           scroll();
       }
     </script>

--- a/LayoutTests/fast/events/scroll-in-scaled-page-with-overflow-hidden.html
+++ b/LayoutTests/fast/events/scroll-in-scaled-page-with-overflow-hidden.html
@@ -25,8 +25,8 @@
         // Force a layout.
         document.body.offsetLeft;
 
-        if (window.internals)
-            window.internals.setPageScaleFactor(2, 0, 0);
+        if (window.testRunner)
+            await window.testRunner.setPageScaleFactor(2, 0, 0);
 
         // Note that with CSSOMViewScrollingAPI enabled, the HTML body is potentially scrollable.
         // Hence document.scrollingElement is null and we can't use document.body.scrollTop to

--- a/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-scaled.html
+++ b/LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-scaled.html
@@ -103,12 +103,12 @@ function firstGestureScroll()
 if (window.testRunner)
     testRunner.waitUntilDone();
 
-function runTest()
+async function runTest()
 {
     var scaleFactor = 2.0;
     var scaleOffset = 0;
-    if (window.internals) {
-       window.internals.setPageScaleFactor(scaleFactor, scaleOffset, scaleOffset);
+    if (window.testRunner) {
+       await window.testRunner.setPageScaleFactor(scaleFactor, scaleOffset, scaleOffset);
     }
 
     movingdiv = document.getElementById('movingbox');
@@ -125,6 +125,8 @@ function runTest()
     } else {
         debug("This test requires DumpRenderTree.  Touch scroll the red rect to log.");
     }
+    if (window.testRunner)
+        window.testRunner.notifyDone();
 }
 </script>
 </body>

--- a/LayoutTests/fast/events/touch/page-scaled-touch-gesture-click.html
+++ b/LayoutTests/fast/events/touch/page-scaled-touch-gesture-click.html
@@ -63,9 +63,9 @@ function endTest()
     testRunner.notifyDone();
 }
 
-function runTest() {
-    if (window.internals) {
-        window.internals.setPageScaleFactor(0.5, 0, 0);
+async function runTest() {
+    if (window.testRunner) {
+        await window.testRunner.setPageScaleFactor(0.5, 0, 0);
     }
 
     var div = document.getElementById('touchtarget');

--- a/LayoutTests/fast/events/touch/touch-scaled-scrolled.html
+++ b/LayoutTests/fast/events/touch/touch-scaled-scrolled.html
@@ -13,9 +13,9 @@ function touched(e) {
         window.testRunner.notifyDone()
 }
 
-function runTest() {
-    if (window.internals)
-        window.internals.setPageScaleFactor(2, 0, 0);
+async function runTest() {
+    if (window.testRunner)
+        await window.testRunner.setPageScaleFactor(2, 0, 0);
     window.scrollTo(100,100);
 
     if (window.testRunner) {

--- a/LayoutTests/fast/frames/frame-set-rotation-hit.html
+++ b/LayoutTests/fast/frames/frame-set-rotation-hit.html
@@ -3,17 +3,21 @@
     <title>FrameSet Rotation Hit Test</title>
 
     <script>
-        function init() {
-            if (!window.eventSender || !window.internals)
+        if (window.testRunner)
+            window.testRunner.waitUntilDone();
+        async function init() {
+            if (!window.eventSender || !window.testRunner)
                 return;
             // Scale the page and resize the frames to verify hit testing on the frameset
             var leftPanelWidth = window.innerWidth / 8;
             var panelHeight = window.innerHeight / 2;
-            window.internals.setPageScaleFactor(0.5, 0, 0);
+            await window.testRunner.setPageScaleFactor(0.5, 0, 0);
             eventSender.mouseMoveTo(panelHeight / 2, leftPanelWidth);
             eventSender.mouseDown();
             eventSender.mouseMoveTo(panelHeight / 2, 2 * leftPanelWidth);
             eventSender.mouseUp();
+            if (window.testRunner)
+                window.testRunner.notifyDone();
         }
         window.onload = init;
     </script>

--- a/LayoutTests/fast/frames/frame-set-scaling-hit.html
+++ b/LayoutTests/fast/frames/frame-set-scaling-hit.html
@@ -3,17 +3,21 @@
     <title>Frame Scale Hit Test</title>
 
     <script>
-        function init() {
-            if (!window.eventSender || !window.internals)
+        if (window.testRunner)
+            window.testRunner.waitUntilDone();
+        async function init() {
+            if (!window.eventSender || !window.testRunner)
                 return;
             // Scale the page and resize the frames to verify hit testing on the frameset
             var leftPanelWidth = window.innerWidth / 8;
             var panelHeight = window.innerHeight / 2;
-            window.internals.setPageScaleFactor(0.5, 0, 0);
+            await window.testRunner.setPageScaleFactor(0.5, 0, 0);
             eventSender.mouseMoveTo(leftPanelWidth, panelHeight / 2);
             eventSender.mouseDown();
             eventSender.mouseMoveTo(2 * leftPanelWidth, panelHeight / 2);
             eventSender.mouseUp();
+            if (window.testRunner)
+                window.testRunner.notifyDone();
         }
         window.onload = init;
     </script>

--- a/LayoutTests/fast/frames/iframe-double-scale-contents.html
+++ b/LayoutTests/fast/frames/iframe-double-scale-contents.html
@@ -18,19 +18,24 @@
       // iframe has not yet been computed. If we've already laid out
       // the iframe, then CSSStyleSelector::styleForDocument does not appear
       // to get called for the iframe.
-      scalePage(0.5);
+      scalePage(0.5).then(() => {
+          let frame = document.createElement("iframe");
+          frame.src = "resources/iframe-content-scaling-bug-iframe.html";
+          frame.style = "position: absolute; left: 0px; top: 0px; border: none; width: 300px; height: 300px;";
+          document.getElementById("body").appendChild(frame);
+      });
 
-      function scalePage(scaleFactor) {
+      async function scalePage(scaleFactor) {
           var scaleOffset = 0;
-          if (window.internals) {
-            window.internals.setPageScaleFactor(scaleFactor, scaleOffset, scaleOffset);
+          if (window.testRunner) {
+            await window.testRunner.setPageScaleFactor(scaleFactor, scaleOffset, scaleOffset);
           }
       }
 
-      function test() {
+      async function test() {
           // Curiously, the document style for the iframe does not
           // appear to be recalculated after this
-          scalePage(1.0);
+          await scalePage(1.0);
           document.body.offsetWidth;
           if (window.testRunner)
             testRunner.notifyDone();
@@ -38,8 +43,7 @@
     </script>
     <script src="../../resources/js-test-pre.js"></script>
 </head>
-<body onload="test();">
-  <iframe id="frame" src="resources/iframe-content-scaling-bug-iframe.html" style="position: absolute; left: 0px; top: 0px; border: none; width: 300px; height: 300px;"></iframe>
+<body id="body" onload="test();">
   <div id="rightbox" style="position: absolute; left: 300px; top: 0px; width: 300px; height: 300px; background-color: green;"></div>
   <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/fast/repaint/background-scaling.html
+++ b/LayoutTests/fast/repaint/background-scaling.html
@@ -2,10 +2,14 @@
 <head> 
 <script src="resources/repaint.js" type="text/javascript" charset="utf-8"></script> 
 <script type="text/javascript"> 
-    function repaintTest()
+    if (window.testRunner)
+        window.testRunner.waitUntilDone();
+    async function repaintTest()
     {
-        if (window.internals)
-            window.internals.setPageScaleFactor(0.25, 0, 0);
+        if (window.testRunner) {
+            await window.testRunner.setPageScaleFactor(0.25, 0, 0);
+            window.testRunner.notifyDone();
+        }
     }
 </script> 
 </head> 

--- a/LayoutTests/fast/repaint/scale-page-shrink.html
+++ b/LayoutTests/fast/repaint/scale-page-shrink.html
@@ -2,10 +2,14 @@
 <head>
 <script src="resources/repaint.js" type="text/javascript" charset="utf-8"></script>
 <script type="text/javascript">
-    function repaintTest()
+    if (window.testRunner)
+        window.testRunner.waitUntilDone();
+    async function repaintTest()
     {
-        if (window.internals)
-            window.internals.setPageScaleFactor(0.25, 0, 0);
+        if (window.testRunner) {
+            window.testRunner.setPageScaleFactor(0.25, 0, 0);
+            window.testRunner.notifyDone();
+        }
     }
 </script>
 </head>

--- a/LayoutTests/fast/scrolling/mac/async-scroll-overflow-rtl-zoomed.html
+++ b/LayoutTests/fast/scrolling/mac/async-scroll-overflow-rtl-zoomed.html
@@ -100,10 +100,10 @@
             finishJSTest();
         }
 
-        window.addEventListener('load', () => {
+        window.addEventListener('load', async () => {
             
-            if (window.internals)
-                internals.setPageScaleFactor(1.5, 0, 0);
+            if (window.testRunner)
+                await testRunner.setPageScaleFactor(1.5, 0, 0);
             
             scroller = document.querySelector('.scroller');
             scroller.addEventListener('scroll', () => {

--- a/LayoutTests/fast/scrolling/mac/overflow-zoomed-document.html
+++ b/LayoutTests/fast/scrolling/mac/overflow-zoomed-document.html
@@ -62,7 +62,7 @@
 
         const pageScale = 2;
 
-        window.addEventListener('load', () => {
+        window.addEventListener('load', async () => {
             scroller = document.querySelector('.scroller');
             scroller.addEventListener('scroll', () => {
                 ++overflowScrollEventCount;
@@ -72,8 +72,8 @@
                 ++windowScrollEventCount;
             }, false);
 
-            if (window.internals)
-                internals.setPageScaleFactor(pageScale, 0, 0);
+            if (window.testRunner)
+                await testRunner.setPageScaleFactor(pageScale, 0, 0);
 
             setTimeout(scrollTest, 0);
         }, false);

--- a/LayoutTests/fast/scrolling/scroll-to-anchor-zoomed-header.html
+++ b/LayoutTests/fast/scrolling/scroll-to-anchor-zoomed-header.html
@@ -24,11 +24,12 @@
 
     if (window.internals) {
         internals.setHeaderHeight(headerHeight);
-        internals.setPageScaleFactor(pageScale, 0, 0);
     }
 
-    function runTest()
+    async function runTest()
     {
+        if (window.testRunner)
+            await testRunner.setPageScaleFactor(pageScale, 0, 0);
         setTimeout(function() {
             window.location='#anchor';
             setTimeout(finishTest, 0);

--- a/LayoutTests/fast/text/descent-clip-in-scaled-page-expected.html
+++ b/LayoutTests/fast/text/descent-clip-in-scaled-page-expected.html
@@ -15,21 +15,25 @@
 <script>
     if (window.testRunner && window.testRunner.setTextSubpixelPositioning)
         window.testRunner.setTextSubpixelPositioning(true);
-    if (window.internals)
-        window.internals.setPageScaleFactor(1.7, 0, 0);
+        window.testRunner.waitUntilDone();
+        window.testRunner.setPageScaleFactor(1.7, 0, 0).then(() => {
+            [13, 14, 15, 16, 17, 18].forEach((item) => {
+            let div = document.createElement("div");
+            div.innerHTML += "&nbsp;pppp&nbsp;";
+            div.style = "font-size: " + item + "px";
+            document.getElementById("body").appendChild(div);
+            });
+            if (window.testRunner)
+                window.testRunner.notifyDone();
+        });
+     }
 </script>
 </head>
-<body>
+<body id="body">
     Tests if the bottom of the text is truncated when the page is scaled by a fractional factor.
     If success, the text in the "overflow: hidden" div (the test case) should be displayed
     the same as in a normal div (the ref html).
     'p' is the character in ahem font with only the descent part.
     <br><br>
-    <div style="font-size: 13px">&nbsp;pppp&nbsp;</div>
-    <div style="font-size: 14px">&nbsp;pppp&nbsp;</div>
-    <div style="font-size: 15px">&nbsp;pppp&nbsp;</div>
-    <div style="font-size: 16px">&nbsp;pppp&nbsp;</div>
-    <div style="font-size: 17px">&nbsp;pppp&nbsp;</div>
-    <div style="font-size: 18px">&nbsp;pppp&nbsp;</div>
 </body>
 </html>

--- a/LayoutTests/fast/text/descent-clip-in-scaled-page.html
+++ b/LayoutTests/fast/text/descent-clip-in-scaled-page.html
@@ -21,23 +21,27 @@
     }
 </style>
 <script>
-    if (window.testRunner && window.testRunner.setTextSubpixelPositioning)
+    if (window.testRunner && window.testRunner.setTextSubpixelPositioning){
         window.testRunner.setTextSubpixelPositioning(true);
-    if (window.internals)
-        window.internals.setPageScaleFactor(1.7, 0, 0);
+        window.testRunner.waitUntilDone();
+        window.testRunner.setPageScaleFactor(1.7, 0, 0).then(() => {
+            [13, 14, 15, 16, 17, 18].forEach((item) => {
+            let div = document.createElement("div");
+            div.innerHTML += "&nbsp;pppp&nbsp;";
+            div.style = "font-size: " + item + "px";
+            document.getElementById("body").appendChild(div);
+            });
+            if (window.testRunner)
+                window.testRunner.notifyDone();
+        });
+    }
 </script>
 </head>
-<body>
+<body id="body">
     Tests if the bottom of the text is truncated when the page is scaled by a fractional factor.
     If success, the text in the "overflow: hidden" div (the test case) should be displayed
     the same as in a normal div (the ref html).
     'p' is the character in ahem font with only the descent part.
     <br><br>
-    <div style="font-size: 13px">&nbsp;pppp&nbsp;</div>
-    <div style="font-size: 14px">&nbsp;pppp&nbsp;</div>
-    <div style="font-size: 15px">&nbsp;pppp&nbsp;</div>
-    <div style="font-size: 16px">&nbsp;pppp&nbsp;</div>
-    <div style="font-size: 17px">&nbsp;pppp&nbsp;</div>
-    <div style="font-size: 18px">&nbsp;pppp&nbsp;</div>
 </body>
 </html>

--- a/LayoutTests/fast/transforms/selection-bounds-in-transformed-view.html
+++ b/LayoutTests/fast/transforms/selection-bounds-in-transformed-view.html
@@ -4,14 +4,16 @@
     <div style="height: 100px;">target</div>
     <div style="height: 1000px;"></div>
     <script>
-        if (window.testRunner && window.internals) {
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
             testRunner.dumpAsText();
-            window.internals.setPageScaleFactor(2, 0, 0);
+            window.testRunner.setPageScaleFactor(2, 0, 0).then(() => {
+                document.execCommand("FindString", false, "target");
+                var scrollTop = document.scrollingElement.scrollTop;
+                var expectedScrollTop = 864;
+                document.getElementById("result").innerText = scrollTop === expectedScrollTop ? "PASS" : "FAIL: document.scrollingElement.scrollTop was " + scrollTop + ", should be " + expectedScrollTop;
+                testRunner.notifyDone();
+            });
         }
-
-        document.execCommand("FindString", false, "target");
-        var scrollTop = document.scrollingElement.scrollTop;
-        var expectedScrollTop = 864;
-        document.getElementById("result").innerText = scrollTop === expectedScrollTop ? "PASS" : "FAIL: document.scrollingElement.scrollTop was " + scrollTop + ", should be " + expectedScrollTop;
     </script>
 </body>

--- a/LayoutTests/imported/blink/fast/backgrounds/root-background-with-page-scaled-out-expected.html
+++ b/LayoutTests/imported/blink/fast/backgrounds/root-background-with-page-scaled-out-expected.html
@@ -2,8 +2,13 @@
 <html style="background:green;">
 <head>
 <script>
-if (window.internals)
-    internals.setPageScaleFactor(0.5);
+if (window.testRunner) {
+    window.testRunner.waitUntilDone();
+
+    window.testRunner.setPageScaleFactor(0.5, 0, 0).then(() => {
+        testRunner.notifyDone();
+    });
+}
 </script>
 </head>
 <body>

--- a/LayoutTests/imported/blink/fast/backgrounds/root-background-with-page-scaled-out.html
+++ b/LayoutTests/imported/blink/fast/backgrounds/root-background-with-page-scaled-out.html
@@ -2,9 +2,14 @@
 <html style="position:absolute; left:100px; top:100px; width:100px; height:100px; background:green;">
 <head>
 <script>
+if (window.testRunner) {
+    window.testRunner.waitUntilDone();
 // This test ensures we paint the entirety of the root background even when zooming page out
-if (window.internals)
-    internals.setPageScaleFactor(0.5);
+
+    window.testRunner.setPageScaleFactor(0.5, 0, 0).then(() => {
+        window.testRunner.notifyDone();
+    });
+}
 </script>
 </head>
 <body>

--- a/LayoutTests/scrollingcoordinator/non-fast-scrollable-region-scaled-iframe.html
+++ b/LayoutTests/scrollingcoordinator/non-fast-scrollable-region-scaled-iframe.html
@@ -3,8 +3,17 @@
 <html>
 <head>
 <script src="resources/non-fast-scrollable-region-testing.js"></script>
+<script>
+if (window.testRunner)
+    window.testRunner.waitUntilDone();
+async function runTest() {
+    await runNonFastScrollableRegionTest(2);
+    if (window.testRunner)
+        window.testRunner.notifyDone();
+}
+</script>
 </head>
-<body onload="runNonFastScrollableRegionTest(2);">
+<body onload="runTest();">
 <iframe src="data:text/html;charset=utf-8,<html><body style='width:1000px;height:1000px;'></body></html>" style="position:absolute;left:50px;top:50px;width;150px;height:200px;padding:10px;"></iframe>
 </body>
 </html>

--- a/LayoutTests/scrollingcoordinator/resources/non-fast-scrollable-region-testing.js
+++ b/LayoutTests/scrollingcoordinator/resources/non-fast-scrollable-region-testing.js
@@ -1,7 +1,8 @@
-function runNonFastScrollableRegionTest(scale) {
+async function runNonFastScrollableRegionTest(scale) {
     var invScale;
     if (scale != undefined) {
-        window.internals.setPageScaleFactor(scale, 0, 0);
+        if (window.testRunner)
+            await window.testRunner.setPageScaleFactor(scale, 0, 0);
         // FIXME: This is a hack for applyPageScaleFactorInCompositor() == false.
         invScale = 1 / scale;
     } else {

--- a/LayoutTests/svg/as-background-image/tiled-background-image-expected.html
+++ b/LayoutTests/svg/as-background-image/tiled-background-image-expected.html
@@ -14,9 +14,9 @@
   }
 </style>
 <script>
-  function setScale() {
-    if (window.internals)
-      window.internals.setPageScaleFactor(2, 0, 0);
+  async function setScale() {
+    if (window.testRunner)
+      await window.testRunner.setPageScaleFactor(2, 0, 0);
   }
 </script>
 </head>

--- a/LayoutTests/svg/as-background-image/tiled-background-image.html
+++ b/LayoutTests/svg/as-background-image/tiled-background-image.html
@@ -35,9 +35,13 @@
   }
 </style>
 <script>
-  function setScale() {
-    if (window.internals)
-      window.internals.setPageScaleFactor(2, 0, 0);
+  if (window.testRunner)
+      window.testRunner.waitUntilDone();
+  async function setScale() {
+    if (window.testRunner) {
+      await window.testRunner.setPageScaleFactor(2, 0, 0);
+      window.testRunner.notifyDone();
+    }
   }
 </script>
 </head>

--- a/LayoutTests/svg/as-image/image-respects-pageScaleFactor-change.html
+++ b/LayoutTests/svg/as-image/image-respects-pageScaleFactor-change.html
@@ -6,20 +6,18 @@
         testRunner.waitUntilDone();
     }
     
-    function load() {
-        if (!window.internals)
+    async function load() {
+        if (!window.testRunner)
             return;
 
-        window.internals.setPageScaleFactor(2, 0, 0);
+        await window.testRunner.setPageScaleFactor(2, 0, 0);
         
         setTimeout(increasePageScale, 0);
     }
     
-    function increasePageScale() {
-        window.internals.setPageScaleFactor(4, 0, 0);
-        
-        if (window.testRunner)
-            testRunner.notifyDone();
+    async function increasePageScale() {
+        await window.testRunner.setPageScaleFactor(4, 0, 0);
+        testRunner.notifyDone();
     }
 
     window.onload = load;

--- a/LayoutTests/svg/as-image/image-respects-pageScaleFactor.html
+++ b/LayoutTests/svg/as-image/image-respects-pageScaleFactor.html
@@ -1,11 +1,14 @@
 <html>
 <head>
     <script>
-    function init() {
-        if (!window.internals)
+    if (window.testRunner)
+        window.testRunner.waitUntilDone();
+    async function init() {
+        if (!window.testRunner)
             return;
 
-        window.internals.setPageScaleFactor(2, 0, 0);
+        await window.testRunner.setPageScaleFactor(2, 0, 0);
+        window.testRunner.notifyDone();
     }
     window.onload = init;
     </script>

--- a/LayoutTests/tiled-drawing/fixed-layout-size-fixed-attachment-cover.html
+++ b/LayoutTests/tiled-drawing/fixed-layout-size-fixed-attachment-cover.html
@@ -12,12 +12,15 @@
   }
 </style>
 <script>
-  function runTest() {
-    if (window.internals) {
+  if (window.testRunner)
+      window.testRunner.waitUntilDone();
+  async function runTest() {
+    if (window.internals && window.testRunner) {
       window.internals.setFixedLayoutSize(800, 600);
-      window.internals.setPageScaleFactor(0.5, 0, 0);
+      await window.testRunner.setPageScaleFactor(0.5, 0, 0);
       window.internals.setUseFixedLayout(true);
       window.internals.settings.setVisualViewportEnabled(false);
+      window.testRunner.notifyDone();
     }
   }
   window.addEventListener('load', runTest, false);

--- a/LayoutTests/tiled-drawing/fixed-layout-size-fixed-attachment-local.html
+++ b/LayoutTests/tiled-drawing/fixed-layout-size-fixed-attachment-local.html
@@ -15,12 +15,15 @@
     }
   </style>
   <script>
-  function runTest() {
-    if (window.internals) {
+  if (window.testRunner)
+      window.testRunner.waitUntilDone();
+  async function runTest() {
+    if (window.internals && window.testRunner) {
       window.internals.setFixedLayoutSize(800, 600);
-      window.internals.setPageScaleFactor(0.5, 0, 0);
+      await window.testRunner.setPageScaleFactor(0.5, 0, 0);
       window.internals.setUseFixedLayout(true);
       window.internals.settings.setVisualViewportEnabled(false);
+      window.testRunner.notifyDone();
     }
   }
   window.addEventListener('load', runTest, false);

--- a/LayoutTests/tiled-drawing/header-and-footer-hit-testing-with-page-scale.html
+++ b/LayoutTests/tiled-drawing/header-and-footer-hit-testing-with-page-scale.html
@@ -9,16 +9,19 @@
 </style>
 <script>
     var numberOfClicks = 0;
+    if (window.testRunner)
+        window.testRunner.waitUntilDone();
 
-    function runTest() {
+    async function runTest() {
         if (!window.eventSender)
             return;
-        if (window.internals) {
+        if (window.internals)
             window.internals.setHeaderHeight(100);
-            window.internals.setPageScaleFactor(2, 0, 0);
-        }
-        if (window.testRunner)
+
+        if (window.testRunner) {
+            await window.testRunner.setPageScaleFactor(2, 0, 0);
             testRunner.dumpAsText();
+        }
 
         // The page should scale, but the header should not.
         eventSender.mouseMoveTo(25, 125);
@@ -30,6 +33,8 @@
             result.innerHTML = "Pass!";
         else
             result.innerHTML = "Fail.";
+        if (window.testRunner)
+            window.testRunner.notifyDone();
     }
     
     function clicked() {

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3724,16 +3724,6 @@ ExceptionOr<float> Internals::pageScaleFactor() const
     return document->page()->pageScaleFactor();
 }
 
-ExceptionOr<void> Internals::setPageScaleFactor(float scaleFactor, int x, int y)
-{
-    Document* document = contextDocument();
-    if (!document || !document->page())
-        return Exception { ExceptionCode::InvalidAccessError };
-
-    document->page()->setPageScaleFactor(scaleFactor, IntPoint(x, y));
-    return { };
-}
-
 ExceptionOr<void> Internals::setPageZoomFactor(float zoomFactor)
 {
     Document* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -602,8 +602,6 @@ public:
     ExceptionOr<String> pageSizeAndMarginsInPixels(int pageNumber, int width, int height, int marginTop, int marginRight, int marginBottom, int marginLeft) const;
 
     ExceptionOr<float> pageScaleFactor() const;
-
-    ExceptionOr<void> setPageScaleFactor(float scaleFactor, int x, int y);
     ExceptionOr<void> setPageZoomFactor(float);
     ExceptionOr<void> setTextZoomFactor(float);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -817,7 +817,6 @@ enum RenderingMode {
     DOMString pageProperty(DOMString propertyName, long pageNumber);
     DOMString pageSizeAndMarginsInPixels(long pageIndex, long width, long height, long marginTop, long marginRight, long marginBottom, long marginLeft);
 
-    undefined setPageScaleFactor(unrestricted float scaleFactor, long x, long y);
     float pageScaleFactor();
 
     undefined setPageZoomFactor(unrestricted float zoomFactor);

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3287,3 +3287,14 @@ void WKPageSetTopContentInsetForTesting(WKPageRef pageRef, float contentInset, v
         callback(context);
     });
 }
+
+void WKPageSetPageScaleFactorForTesting(WKPageRef pageRef, float scaleFactor, WKPoint point, void* context, WKPageSetPageScaleFactorForTestingFunction completionHandler)
+{
+    auto* pageForTesting = toImpl(pageRef)->pageForTesting();
+    if (!pageForTesting)
+        return completionHandler(context);
+
+    pageForTesting->setPageScaleFactor(scaleFactor, toIntPoint(point), [context, completionHandler] {
+        completionHandler(context);
+    });
+}

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -218,7 +218,8 @@ WK_EXPORT void WKPageSetPermissionLevelForTesting(WKPageRef page, WKStringRef or
 
 typedef void (*WKPageSetTopContentInsetForTestingFunction)(void* functionContext);
 WK_EXPORT void WKPageSetTopContentInsetForTesting(WKPageRef page, float contentInset, void* context, WKPageSetTopContentInsetForTestingFunction callback);
-
+typedef void (*WKPageSetPageScaleFactorForTestingFunction)(void* functionContext);
+WK_EXPORT void WKPageSetPageScaleFactorForTesting(WKPageRef page, float scaleFactor, WKPoint point, void* context, WKPageSetPageScaleFactorForTestingFunction completionHandler);
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -31,9 +31,12 @@
 #include "NetworkProcessMessages.h"
 #include "NetworkProcessProxy.h"
 #include "WebFrameProxy.h"
+#include "WebPageMessages.h"
 #include "WebPageProxy.h"
 #include "WebPageTestingMessages.h"
 #include "WebProcessProxy.h"
+#include <WebCore/IntPoint.h>
+#include <wtf/CallbackAggregator.h>
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
 #include "DisplayCaptureSessionManager.h"
@@ -202,6 +205,14 @@ void WebPageProxyTesting::setTopContentInset(float contentInset, CompletionHandl
 Ref<WebPageProxy> WebPageProxyTesting::protectedPage() const
 {
     return m_page.get();
+}
+
+void WebPageProxyTesting::setPageScaleFactor(float scaleFactor, IntPoint point, CompletionHandler<void()>&& completionHandler)
+{
+    Ref callback = CallbackAggregator::create(WTFMove(completionHandler));
+    protectedPage()->forEachWebContentProcess([&](auto& process, auto pageID) {
+        process.sendWithAsyncReply(Messages::WebPageTesting::SetPageScaleFactor(scaleFactor, point), [callback] { }, pageID);
+    });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -30,6 +30,10 @@
 #include <WebCore/PageIdentifier.h>
 #include <wtf/WeakPtr.h>
 
+namespace WebCore {
+class IntPoint;
+}
+
 namespace WebKit {
 
 class WebPageProxy;
@@ -73,6 +77,7 @@ public:
 
     void setTopContentInset(float, CompletionHandler<void()>&&);
 
+    void setPageScaleFactor(float scaleFactor, WebCore::IntPoint, CompletionHandler<void()>&&);
 private:
     bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>) final;
     bool sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&&, AsyncReplyHandler, OptionSet<IPC::SendOption>) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -34,6 +34,7 @@
 #include "WebProcess.h"
 #include <WebCore/Editor.h>
 #include <WebCore/FocusController.h>
+#include <WebCore/IntPoint.h>
 #include <WebCore/NotificationController.h>
 #include <WebCore/Page.h>
 
@@ -110,6 +111,15 @@ void WebPageTesting::clearWheelEventTestMonitor()
 void WebPageTesting::setTopContentInset(float contentInset, CompletionHandler<void()>&& completionHandler)
 {
     protectedPage()->setTopContentInset(contentInset);
+    completionHandler();
+}
+
+void WebPageTesting::setPageScaleFactor(double scale, IntPoint origin, CompletionHandler<void()>&& completionHandler)
+{
+    RefPtr page = m_page->corePage();
+    if (!page)
+        return completionHandler();
+    page->setPageScaleFactor(scale, origin);
     completionHandler();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -33,6 +33,10 @@ class Connection;
 class Decoder;
 }
 
+namespace WebCore {
+class IntPoint;
+}
+
 namespace WebKit {
 
 class WebPage;
@@ -58,6 +62,8 @@ private:
 #endif
 
     void setTopContentInset(float, CompletionHandler<void()>&&);
+
+    void setPageScaleFactor(double scale, WebCore::IntPoint origin, CompletionHandler<void()>&&);
 
     void clearWheelEventTestMonitor();
     Ref<WebPage> protectedPage() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
@@ -33,4 +33,5 @@ messages -> WebPageTesting NotRefCounted {
     ClearWheelEventTestMonitor()
 
     SetTopContentInset(float contentInset) -> ()
+    SetPageScaleFactor(double scale, WebCore::IntPoint origin) -> ()
 }

--- a/Tools/DumpRenderTree/TestRunner.cpp
+++ b/Tools/DumpRenderTree/TestRunner.cpp
@@ -495,7 +495,7 @@ static JSValueRef flushConsoleLogsCallback(JSContextRef context, JSObjectRef fun
 {
     if (argumentCount == 1)
         JSObjectCallAsFunction(context, JSValueToObject(context, arguments[0], 0), thisObject, 0, 0, 0);
-    return JSValueMakeUndefined(context);
+    return TestRunner::alwaysResolvePromise(context);
 }
 
 static JSValueRef generateTestReportCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
@@ -1792,7 +1792,7 @@ static JSValueRef setTopContentInsetCallback(JSContextRef context, JSObjectRef f
     TestRunner* controller = static_cast<TestRunner*>(JSObjectGetPrivate(thisObject));
     double contentInset = JSValueToNumber(context, arguments[0], exception);
     controller->setTopContentInset(contentInset);
-    return JSValueMakeUndefined(context);
+    return TestRunner::alwaysResolvePromise(context);
 }
 
 static JSValueRef failNextNewCodeBlock(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
@@ -1842,6 +1842,21 @@ static JSValueRef runUIScriptCallback(JSContextRef context, JSObjectRef, JSObjec
     controller->runUIScript(context, script.get(), callback);
 
     return JSValueMakeUndefined(context);
+}
+
+static JSValueRef setPageScaleFactorCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    if (argumentCount == 3) {
+        TestRunner* controller = static_cast<TestRunner*>(JSObjectGetPrivate(thisObject));
+        double scaleFactor = JSValueToNumber(context, arguments[0], exception);
+        ASSERT(!*exception);
+        int x = JSValueToInt64(context, arguments[1], exception);
+        ASSERT(!*exception);
+        int y = JSValueToInt64(context, arguments[2], exception);
+        ASSERT(!*exception);
+        controller->setPageScaleFactor(scaleFactor, x, y);
+    }
+    return TestRunner::alwaysResolvePromise(context);
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -2100,6 +2115,7 @@ const JSStaticFunction* TestRunner::staticFunctions()
         { "stopLoading", stopLoadingCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "forceImmediateCompletion", forceImmediateCompletionCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "setTopContentInset", setTopContentInsetCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+        { "setPageScaleFactor", setPageScaleFactorCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
 #if PLATFORM(IOS_FAMILY)
         { "setPagePaused", setPagePausedCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
 #endif

--- a/Tools/DumpRenderTree/TestRunner.h
+++ b/Tools/DumpRenderTree/TestRunner.h
@@ -398,6 +398,9 @@ public:
 
     void setTopContentInset(double);
 
+    void setPageScaleFactor(double scaleFactor, long x, long y);
+    static JSValueRef alwaysResolvePromise(JSContextRef);
+
 private:
     TestRunner(const std::string& testURL, const std::string& expectedPixelHash);
 

--- a/Tools/DumpRenderTree/mac/TestRunnerMac.mm
+++ b/Tools/DumpRenderTree/mac/TestRunnerMac.mm
@@ -41,6 +41,7 @@
 #import "WorkQueue.h"
 #import "WorkQueueItem.h"
 #import <Foundation/Foundation.h>
+#import <JavaScriptCore/APICast.h>
 #import <JavaScriptCore/JSStringRefCF.h>
 #import <WebCore/GeolocationPositionData.h>
 #import <WebKit/DOMDocument.h>
@@ -472,6 +473,20 @@ void TestRunner::setAutomaticLinkDetectionEnabled(bool enabled)
 #if !PLATFORM(IOS_FAMILY)
     [[mainFrame webView] setAutomaticLinkDetectionEnabled:enabled];
 #endif
+}
+
+JSValueRef TestRunner::alwaysResolvePromise(JSContextRef context)
+{
+    JSContext *jsContext = [JSContext contextWithJSGlobalContextRef:toGlobalRef(toJS(context))];
+    auto callback = ^(JSValue *resolve, JSValue *) {
+        [resolve callWithArguments:nil];
+    };
+    return [[JSValue valueWithNewPromiseInContext:jsContext fromExecutor:callback] JSValueRef];
+}
+
+void TestRunner::setPageScaleFactor(double scaleFactor, long x, long y)
+{
+    [[mainFrame webView] _scaleWebView:scaleFactor atOrigin:NSMakePoint(x, y)];
 }
 
 void TestRunner::setTabKeyCyclesThroughElements(bool cycles)

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -463,4 +463,5 @@ interface TestRunner {
     Promise<undefined> flushConsoleLogs();
 
     Promise<undefined> setTopContentInset(double contentInset);
+    Promise<undefined> setPageScaleFactor(unrestricted double scaleFactor, long x, long y);
 };

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -2139,6 +2139,15 @@ void TestRunner::flushConsoleLogs(JSContextRef context, JSValueRef callback)
     postMessageWithAsyncReply(context, "FlushConsoleLogs", callback);
 }
 
+void TestRunner::setPageScaleFactor(JSContextRef context, double scaleFactor, long x, long y, JSValueRef callback)
+{
+    postMessageWithAsyncReply(context, "SetPageScaleFactor", createWKDictionary({
+        { "scaleFactor", toWK(scaleFactor) },
+        { "x", toWK(static_cast<double>(x)) },
+        { "y", toWK(static_cast<double>(y)) },
+        }), callback);
+}
+
 void TestRunner::generateTestReport(JSContextRef context, JSStringRef message, JSStringRef group)
 {
     auto frame = WKBundleFrameForJavaScriptContext(context);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -565,6 +565,8 @@ public:
 
     void setTopContentInset(JSContextRef, double, JSValueRef);
 
+    void setPageScaleFactor(JSContextRef, double scaleFactor, long x, long y, JSValueRef callback);
+
 private:
     TestRunner();
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1991,6 +1991,14 @@ void TestController::didReceiveAsyncMessageFromInjectedBundle(WKStringRef messag
     if (WKStringIsEqualToUTF8CString(messageName, "FlushConsoleLogs"))
         return completionHandler(nullptr);
 
+    if (WKStringIsEqualToUTF8CString(messageName, "SetPageScaleFactor")) {
+        auto messageBodyDictionary = dictionaryValue(messageBody);
+        auto scaleFactor = doubleValue(messageBodyDictionary, "scaleFactor");
+        auto x = doubleValue(messageBodyDictionary, "x");
+        auto y = doubleValue(messageBodyDictionary, "y");
+        return setPageScaleFactor(static_cast<float>(scaleFactor), static_cast<int>(x), static_cast<int>(y), WTFMove(completionHandler));
+    }
+
     if (WKStringIsEqualToUTF8CString(messageName, "GetAllStorageAccessEntries"))
         return getAllStorageAccessEntries(WTFMove(completionHandler));
 
@@ -3491,6 +3499,11 @@ void TestController::clearAppPrivacyReportTestingData()
 }
 
 #endif // !PLATFORM(COCOA)
+
+void TestController::setPageScaleFactor(float scaleFactor, int x, int y, CompletionHandler<void(WKTypeRef)>&& completionHandler)
+{
+    WKPageSetPageScaleFactorForTesting(mainWebView()->page(), scaleFactor, WKPointMake(x, y), completionHandler.leak(), adoptAndCallCompletionHandler);
+}
 
 void TestController::getAllStorageAccessEntries(CompletionHandler<void(WKTypeRef)>&& completionHandler)
 {

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -289,6 +289,8 @@ public:
     bool didLoadAppInitiatedRequest();
     bool didLoadNonAppInitiatedRequest();
 
+    void setPageScaleFactor(float scaleFactor, int x, int y, CompletionHandler<void(WKTypeRef)>&&);
+
     void reloadFromOrigin();
 
     void updateBundleIdentifierInNetworkProcess(const std::string& bundleIdentifier);


### PR DESCRIPTION
#### 3b2b06f92fc7a57e191fa92e8e7e826be40319de
<pre>
[Site Isolation] Make setPageScaleFactor async
<a href="https://bugs.webkit.org/show_bug.cgi?id=277046">https://bugs.webkit.org/show_bug.cgi?id=277046</a>
<a href="https://rdar.apple.com/132440505">rdar://132440505</a>

Reviewed by Alex Christensen and Charlie Wolfe.

Also move it to TestRunner as that seems a better suited place for it. All Layout tests that use this API have been refactored.
I have used whatever strategy possible to not have diffs in the -expected files as much as possible.
That is why some tests are using waitUntilDone and some tests are using jsTestIsAsync.

* LayoutTests/accessibility/tree-update-with-dirty-layout.html:
* LayoutTests/compositing/canvas/hidpi-canvas-backing-store-invalidation-2.html:
* LayoutTests/compositing/geometry/fixed-position-composited-page-scale-down.html:
* LayoutTests/compositing/geometry/fixed-position-composited-page-scale-scroll.html:
* LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport-expected.html:
* LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html:
* LayoutTests/compositing/geometry/fixed-position-composited-page-scale.html:
* LayoutTests/compositing/geometry/fixed-position-iframe-composited-page-scale-down.html:
* LayoutTests/compositing/geometry/fixed-position-iframe-composited-page-scale.html:
* LayoutTests/compositing/geometry/fixed-position-transform-composited-page-scale-down.html:
* LayoutTests/compositing/geometry/fixed-position-transform-composited-page-scale.html:
* LayoutTests/compositing/layer-creation/fixed-position-out-of-view-scaled-iframe-scroll.html:
* LayoutTests/compositing/layer-creation/fixed-position-out-of-view-scaled-iframe.html:
* LayoutTests/compositing/layer-creation/fixed-position-out-of-view-scaled-scroll.html:
* LayoutTests/compositing/layer-creation/fixed-position-out-of-view-scaled.html:
* LayoutTests/compositing/overflow/overflow-scaled-descendant-overlapping.html:
* LayoutTests/compositing/repaint/page-scale-repaint.html:
* LayoutTests/compositing/scaling/tiled-layer-recursion.html:
* LayoutTests/css3/filters/backdrop-filter-page-scale-expected.html:
* LayoutTests/css3/filters/backdrop-filter-page-scale.html:
* LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-scaled-expected.html:
* LayoutTests/fast/css3-text/css3-text-decoration/text-decoration-scaled.html:
* LayoutTests/fast/dom/Element/scale-page-bounding-client-rect-in-frame.html:
* LayoutTests/fast/dom/Element/scale-page-bounding-client-rect.html:
* LayoutTests/fast/dom/Element/scale-page-client-rects-in-frame.html:
* LayoutTests/fast/dom/Element/scale-page-client-rects.html:
* LayoutTests/fast/dom/Range/scale-page-bounding-client-rect.html:
* LayoutTests/fast/dom/Range/scale-page-client-rects.html:
* LayoutTests/fast/dom/elementFromPoint-scaled-scrolled-layout-viewport-expected.txt:
* LayoutTests/fast/dom/elementFromPoint-scaled-scrolled-layout-viewport.html:
* LayoutTests/fast/dom/elementFromPoint-scaled-scrolled.html:
* LayoutTests/fast/dom/iframe-inner-size-scaling.html:
* LayoutTests/fast/dom/window-inner-size-scaling-expected.txt:
* LayoutTests/fast/dom/window-inner-size-scaling.html:
* LayoutTests/fast/dom/window-scroll-scaling-expected.txt:
* LayoutTests/fast/dom/window-scroll-scaling.html:
* LayoutTests/fast/events/autoscroll-when-zoomed.html:
* LayoutTests/fast/events/drag-select-when-zoomed-with-header.html:
* LayoutTests/fast/events/drag-select-when-zoomed.html:
* LayoutTests/fast/events/page-scaled-mouse-click-iframe.html:
* LayoutTests/fast/events/page-scaled-mouse-click.html:
* LayoutTests/fast/events/scale-and-scroll-body.html:
* LayoutTests/fast/events/scale-and-scroll-iframe-body.html:
* LayoutTests/fast/events/scale-and-scroll-iframe-window.html:
* LayoutTests/fast/events/scale-and-scroll-window.html:
* LayoutTests/fast/events/scroll-in-scaled-page-with-overflow-hidden.html:
* LayoutTests/fast/events/touch/gesture/touch-gesture-scroll-div-scaled.html:
* LayoutTests/fast/events/touch/page-scaled-touch-gesture-click.html:
* LayoutTests/fast/events/touch/touch-scaled-scrolled.html:
* LayoutTests/fast/frames/frame-set-rotation-hit.html:
* LayoutTests/fast/frames/frame-set-scaling-hit.html:
* LayoutTests/fast/frames/iframe-double-scale-contents.html:
* LayoutTests/fast/repaint/background-scaling.html:
* LayoutTests/fast/repaint/scale-page-shrink.html:
* LayoutTests/fast/scrolling/mac/async-scroll-overflow-rtl-zoomed.html:
* LayoutTests/fast/scrolling/mac/overflow-zoomed-document.html:
* LayoutTests/fast/scrolling/scroll-to-anchor-zoomed-header.html:
* LayoutTests/fast/text/descent-clip-in-scaled-page-expected.html:
* LayoutTests/fast/text/descent-clip-in-scaled-page.html:
* LayoutTests/fast/transforms/selection-bounds-in-transformed-view.html:
* LayoutTests/imported/blink/fast/backgrounds/root-background-with-page-scaled-out-expected.html:
* LayoutTests/imported/blink/fast/backgrounds/root-background-with-page-scaled-out.html:
* LayoutTests/scrollingcoordinator/resources/non-fast-scrollable-region-testing.js:
(async runNonFastScrollableRegionTest):
(runNonFastScrollableRegionTest): Deleted.
* LayoutTests/svg/as-background-image/tiled-background-image-expected.html:
* LayoutTests/svg/as-background-image/tiled-background-image.html:
* LayoutTests/svg/as-image/image-respects-pageScaleFactor-change.html:
* LayoutTests/svg/as-image/image-respects-pageScaleFactor.html:
* LayoutTests/tiled-drawing/fixed-layout-size-fixed-attachment-cover.html:
* LayoutTests/tiled-drawing/fixed-layout-size-fixed-attachment-local.html:
* LayoutTests/tiled-drawing/header-and-footer-hit-testing-with-page-scale.html:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setPageScaleFactor): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageScaleFactor):
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setPageScaleFactor):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setPageScaleFactor):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::requestCookieConsent):
* Tools/DumpRenderTree/TestRunner.cpp:
(setPageScaleFactorCallback):
(TestRunner::staticFunctions):
* Tools/DumpRenderTree/TestRunner.h:
* Tools/DumpRenderTree/mac/TestRunnerMac.mm:
(TestRunner::setPageScaleFactor):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setPageScaleFactor):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveAsyncMessageFromInjectedBundle):
(WTR::TestController::setPageScaleFactor):
* Tools/WebKitTestRunner/TestController.h:

Canonical link: <a href="https://commits.webkit.org/282170@main">https://commits.webkit.org/282170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dc6d74e77fe18113019d5c1548ada6d95edf662

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41717 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/14957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/12911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64482 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/49403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13247 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/66346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/12911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65431 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/49403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/14957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/49403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/14957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/11842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/49403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/14957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/6305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/11358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/68072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/6333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/14957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9380 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/37517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/38602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/39699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->