### PR TITLE
Add default UA stylesheet for CJK text decorations

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1472,3 +1472,22 @@ embed, object, img {
 ins, del {
     text-decoration-skip: none;
 }
+
+/* https://drafts.csswg.org/css-text-decor-4/#default-stylesheet */
+/* set language-appropriate default emphasis mark position */
+:root:lang(zh), [lang|=zh] {
+    text-emphasis-position: under right;
+}
+[lang|=ja], [lang|=ko] {
+    text-emphasis-position: over right;
+}
+
+/* set language-appropriate default underline position */
+:root:lang(ja), [lang|=ja],
+:root:lang(mn), [lang|=mn],
+:root:lang(ko), [lang|=ko] {
+    text-underline-position: right;
+}
+:root:lang(zh), [lang|=zh] {
+    text-underline-position: left;
+}

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -55,6 +55,7 @@ CSSParserContext::CSSParserContext(CSSParserMode mode, const URL& baseURL)
 {
     // FIXME: We should turn all of the features on from their WebCore Settings defaults.
     if (isUASheetBehavior(mode)) {
+        cssTextUnderlinePositionLeftRightEnabled = true;
         lightDarkEnabled = true;
         popoverAttributeEnabled = true;
         propertySettings.cssInputSecurityEnabled = true;


### PR DESCRIPTION
#### 9a35d5bc4646de662769596fbaff30f3f9020574
<pre>
Add default UA stylesheet for CJK text decorations
<a href="https://bugs.webkit.org/show_bug.cgi?id=277052">https://bugs.webkit.org/show_bug.cgi?id=277052</a>
<a href="https://rdar.apple.com/132444497">rdar://132444497</a>

Reviewed by Alan Baradlay.

This is one of the changes required to make css/css-text-decor/text-decoration-underline-position-vertical-ja.html pass.

Spec: <a href="https://drafts.csswg.org/css-text-decor-4/#default-stylesheet">https://drafts.csswg.org/css-text-decor-4/#default-stylesheet</a>

* Source/WebCore/css/html.css:
(:root:lang(zh), [lang|=zh]):
([lang|=ja], [lang|=ko]):
(:root:lang(ja), [lang|=ja],):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):

Canonical link: <a href="https://commits.webkit.org/281445@main">https://commits.webkit.org/281445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3477c8bb60d441c0739e1cf03dbf50563210f2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10086 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10238 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48328 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-content/quotes-031.html imported/w3c/web-platform-tests/css/css-content/quotes-032.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7061 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29163 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33029 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-content/quotes-031.html imported/w3c/web-platform-tests/css/css-content/quotes-032.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8814 "Found 3 new test failures: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html imported/w3c/web-platform-tests/css/css-content/quotes-031.html imported/w3c/web-platform-tests/css/css-content/quotes-032.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9010 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54977 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9092 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-content/quotes-031.html imported/w3c/web-platform-tests/css/css-content/quotes-032.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65210 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3491 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8980 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-content/quotes-031.html imported/w3c/web-platform-tests/css/css-content/quotes-032.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55672 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-content/quotes-031.html imported/w3c/web-platform-tests/css/css-content/quotes-032.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3502 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51554 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55797 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2896 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8977 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34722 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35805 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->