### PR TITLE
[text-underline-position] Overline should flip side even when underline is not painted

### DIFF
--- a/LayoutTests/fast/inline/text-underline-position-right-simple-expected.html
+++ b/LayoutTests/fast/inline/text-underline-position-right-simple-expected.html
@@ -3,7 +3,7 @@
 div {
   writing-mode: vertical-rl;
   text-decoration: overline;
-  text-underline-position: right;
+  text-underline-position: left;
   white-space: pre;
   font-size: 40px;
   font-family: Ahem;

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -318,21 +318,14 @@ float underlineOffsetForTextBoxPainting(const InlineIterator::InlineBox& inlineB
 
 float overlineOffsetForTextBoxPainting(const InlineIterator::InlineBox& inlineBox, const RenderStyle& style)
 {
-    if (!style.textDecorationsInEffect().contains(TextDecorationLine::Underline))
-        return { };
-
     if (style.typographicMode() == TypographicMode::Horizontal || style.textOrientation() == TextOrientation::Sideways)
         return { };
 
     auto underlinePosition = style.textUnderlinePosition();
     auto overBecomesUnder = [&] {
-        auto typographicMode = style.typographicMode();
         // If 'right' causes the underline to be drawn on the "over" side of the text, then an overline also switches sides and is drawn on the "under" side.
         if (underlinePosition.contains(TextUnderlinePosition::Right))
-            return typographicMode == TypographicMode::Vertical || style.blockFlowDirection() == BlockFlowDirection::RightToLeft;
-        // If 'left' causes the underline to be drawn on the "over" side of the text, then an overline also switches sides and is drawn on the "under" side.
-        if (underlinePosition.contains(TextUnderlinePosition::Left))
-            return typographicMode == TypographicMode::Horizontal && style.blockFlowDirection() == BlockFlowDirection::LeftToRight;
+            return style.typographicMode() == TypographicMode::Vertical || style.blockFlowDirection() == BlockFlowDirection::RightToLeft;
         return false;
     };
     return overBecomesUnder() ? inlineBoxContentBoxHeight(inlineBox) : 0.f;


### PR DESCRIPTION
#### 8b5a90bd92d223d641d72d87faa1e5663137af03
<pre>
[text-underline-position] Overline should flip side even when underline is not painted
<a href="https://bugs.webkit.org/show_bug.cgi?id=277056">https://bugs.webkit.org/show_bug.cgi?id=277056</a>
<a href="https://rdar.apple.com/132446719">rdar://132446719</a>

Reviewed by Alan Baradlay.

It doesn&apos;t matter whether if the underline is drawn or not, the overline flips side if the underline would be drawn on the &quot;over&quot; side.

Both of these tests need this change to pass:
css/css-text-decor/text-decoration-underline-position-vertical-ja.html [ ImageOnlyFailure ]
css/css-text-decor/text-decoration-underline-position-vertical.html [ ImageOnlyFailure ]

(These tests still fail for different reasons, which is why they&apos;re not unskipped)

* LayoutTests/fast/inline/text-underline-position-right-simple-expected.html:

Update the test expectation now that the overline is flipped.

* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::overlineOffsetForTextBoxPainting):

Remove the check for the underline being painted.

Remove an no-op check that assumed that sideways writing mode support `text-underline-position: left | right`.
That check is no-op since 281304@main which removed underline-position support for sideways text.

Canonical link: <a href="https://commits.webkit.org/281434@main">https://commits.webkit.org/281434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d860757d20172527792b6a6d6987a7d68b66ffe6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10190 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10344 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48400 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7132 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29238 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8899 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9113 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55063 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65313 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3594 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9066 "layout-tests (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55741 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55872 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2983 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8971 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34825 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35908 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36994 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->