### PR TITLE
Use CheckedPtr for DOM tree pointers

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -56,6 +56,7 @@ template<typename IDLType> class DOMPromiseProxyWithResolveCallback;
 
 class HTMLModelElement final : public HTMLElement, private CachedRawResourceClient, public ModelPlayerClient, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(HTMLModelElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLModelElement);
 public:
     using HTMLElement::weakPtrFactory;
     using HTMLElement::WeakValueType;

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -35,6 +35,7 @@ class MutableStyleProperties;
 
 class Attr final : public Node {
     WTF_MAKE_ISO_ALLOCATED(Attr);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Attr);
 public:
     static Ref<Attr> create(Element&, const QualifiedName&);
     static Ref<Attr> create(Document&, const QualifiedName&, const AtomString& value);

--- a/Source/WebCore/dom/CDATASection.h
+++ b/Source/WebCore/dom/CDATASection.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class CDATASection final : public Text {
     WTF_MAKE_ISO_ALLOCATED(CDATASection);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CDATASection);
 public:
     static Ref<CDATASection> create(Document&, String&&);
 

--- a/Source/WebCore/dom/CharacterData.h
+++ b/Source/WebCore/dom/CharacterData.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class CharacterData : public Node {
     WTF_MAKE_ISO_ALLOCATED(CharacterData);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CharacterData);
 public:
     const String& data() const { return m_data; }
     static constexpr ptrdiff_t dataMemoryOffset() { return OBJECT_OFFSETOF(CharacterData, m_data); }

--- a/Source/WebCore/dom/Comment.h
+++ b/Source/WebCore/dom/Comment.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class Comment final : public CharacterData {
     WTF_MAKE_ISO_ALLOCATED(Comment);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Comment);
 public:
     static Ref<Comment> create(Document&, String&&);
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -95,7 +95,7 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         RELEASE_ASSERT(!connectedSubframeCount() && !hasRareData() && !wrapper());
         bool hadElementChild = false;
-        while (RefPtr child = m_firstChild) {
+        while (RefPtr child = m_firstChild.get()) {
             hadElementChild |= is<Element>(*child);
             removeBetween(nullptr, child->protectedNextSibling().get(), *child);
         }
@@ -137,7 +137,7 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
 
         RefAllowingPartiallyDestroyed<Document> { document() }->nodeChildrenWillBeRemoved(*this);
 
-        while (RefPtr child = m_firstChild) {
+        while (RefPtr child = m_firstChild.get()) {
             if (is<Element>(*child))
                 hadElementChild = true;
 
@@ -577,7 +577,7 @@ void ContainerNode::insertBeforeCommon(Node& nextChild, Node& newChild)
     ASSERT(!newChild.isShadowRoot());
 
     RefPtr previousSibling = nextChild.previousSibling();
-    ASSERT(m_lastChild != previousSibling);
+    ASSERT(m_lastChild != previousSibling.get());
     nextChild.setPreviousSibling(&newChild);
     if (previousSibling) {
         ASSERT(m_firstChild != &nextChild);

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -34,16 +34,17 @@ class RenderElement;
 
 class ContainerNode : public Node {
     WTF_MAKE_ISO_ALLOCATED(ContainerNode);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ContainerNode);
 public:
     virtual ~ContainerNode();
 
-    Node* firstChild() const { return m_firstChild; }
-    RefPtr<Node> protectedFirstChild() const { return m_firstChild; }
+    Node* firstChild() const { return m_firstChild.get(); }
+    RefPtr<Node> protectedFirstChild() const { return m_firstChild.get(); }
     static constexpr ptrdiff_t firstChildMemoryOffset() { return OBJECT_OFFSETOF(ContainerNode, m_firstChild); }
-    Node* lastChild() const { return m_lastChild; }
-    RefPtr<Node> protectedLastChild() const { return m_lastChild; }
+    Node* lastChild() const { return m_lastChild.get(); }
+    RefPtr<Node> protectedLastChild() const { return m_lastChild.get(); }
     static constexpr ptrdiff_t lastChildMemoryOffset() { return OBJECT_OFFSETOF(ContainerNode, m_lastChild); }
-    bool hasChildNodes() const { return m_firstChild; }
+    bool hasChildNodes() const { return m_firstChild.get(); }
     bool hasOneChild() const { return m_firstChild && m_firstChild == m_lastChild; }
 
     bool directChildNeedsStyleRecalc() const { return hasStyleFlag(NodeStyleFlag::DirectChildNeedsStyleResolution); }
@@ -173,8 +174,8 @@ private:
 
     bool isContainerNode() const = delete;
 
-    Node* m_firstChild { nullptr };
-    Node* m_lastChild { nullptr };
+    CheckedPtr<Node> m_firstChild;
+    CheckedPtr<Node> m_lastChild;
 };
 
 inline ContainerNode::ContainerNode(Document& document, NodeType type, OptionSet<TypeFlag> typeFlags)

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -147,6 +147,8 @@ RemovedSubtreeObservability notifyChildNodeRemoved(ContainerNode& oldParentOfRem
 
 void removeDetachedChildrenInContainer(ContainerNode& container)
 {
+    container.setLastChild(nullptr);
+
     RefPtr<Node> next;
     for (RefPtr node = container.firstChild(); node; node = WTFMove(next)) {
         ASSERT(!node->deletionHasBegun());
@@ -163,8 +165,6 @@ void removeDetachedChildrenInContainer(ContainerNode& container)
             notifyChildNodeRemoved(container, *node);
         ASSERT_WITH_SECURITY_IMPLICATION(!node->isInTreeScope());
     }
-
-    container.setLastChild(nullptr);
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -420,6 +420,7 @@ class Document
     , public Logger::Observer
     , public ReportingClient {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(Document, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Document);
 public:
     using EventTarget::weakPtrFactory;
     using EventTarget::WeakValueType;

--- a/Source/WebCore/dom/DocumentFragment.h
+++ b/Source/WebCore/dom/DocumentFragment.h
@@ -30,6 +30,7 @@ namespace WebCore {
 
 class DocumentFragment : public ContainerNode {
     WTF_MAKE_ISO_ALLOCATED(DocumentFragment);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DocumentFragment);
 public:
     WEBCORE_EXPORT static Ref<DocumentFragment> create(Document&);
     static Ref<DocumentFragment> createForInnerOuterHTML(Document&);

--- a/Source/WebCore/dom/DocumentType.h
+++ b/Source/WebCore/dom/DocumentType.h
@@ -31,6 +31,7 @@ class NamedNodeMap;
 
 class DocumentType final : public Node {
     WTF_MAKE_ISO_ALLOCATED(DocumentType);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DocumentType);
 public:
     static Ref<DocumentType> create(Document& document, const String& name, const String& publicId, const String& systemId)
     {

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -157,6 +157,7 @@ struct ResolvedStyle;
 
 class Element : public ContainerNode {
     WTF_MAKE_ISO_ALLOCATED(Element);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Element);
 public:
     static Ref<Element> create(const QualifiedName&, Document&);
     virtual ~Element();

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -108,7 +108,7 @@ WTF_MAKE_COMPACT_ISO_ALLOCATED_IMPL(Node);
 
 using namespace HTMLNames;
 
-struct SameSizeAsNode : EventTarget {
+struct SameSizeAsNode : EventTarget, CanMakeCheckedPtr<SameSizeAsNode> {
 #if ASSERT_ENABLED
     uint32_t m_isAllocatedMemory;
     bool inRemovedLastRefFunction;

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -33,6 +33,7 @@ class CSSStyleSheet;
 
 class ProcessingInstruction final : public CharacterData, private CachedStyleSheetClient {
     WTF_MAKE_ISO_ALLOCATED(ProcessingInstruction);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ProcessingInstruction);
 public:
     using CharacterData::weakPtrFactory;
     using CharacterData::WeakValueType;

--- a/Source/WebCore/dom/PseudoElement.h
+++ b/Source/WebCore/dom/PseudoElement.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class PseudoElement final : public Element {
     WTF_MAKE_ISO_ALLOCATED(PseudoElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PseudoElement);
 public:
     static Ref<PseudoElement> create(Element& host, PseudoId);
     virtual ~PseudoElement();

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -52,6 +52,7 @@ class Scope;
 
 class ShadowRoot final : public DocumentFragment, public TreeScope {
     WTF_MAKE_ISO_ALLOCATED(ShadowRoot);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ShadowRoot);
 public:
 
     enum class DelegatesFocus : bool { No, Yes };

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -42,6 +42,7 @@ class StylePropertyMap;
 
 class StyledElement : public Element {
     WTF_MAKE_ISO_ALLOCATED(StyledElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StyledElement);
 public:
     virtual ~StyledElement();
 

--- a/Source/WebCore/dom/TemplateContentDocumentFragment.h
+++ b/Source/WebCore/dom/TemplateContentDocumentFragment.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class TemplateContentDocumentFragment final : public DocumentFragment {
     WTF_MAKE_ISO_ALLOCATED(TemplateContentDocumentFragment);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TemplateContentDocumentFragment);
 public:
     static Ref<TemplateContentDocumentFragment> create(Document& document, const Element& host)
     {

--- a/Source/WebCore/dom/Text.h
+++ b/Source/WebCore/dom/Text.h
@@ -31,6 +31,7 @@ class RenderText;
 
 class Text : public CharacterData {
     WTF_MAKE_ISO_ALLOCATED(Text);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Text);
 public:
     static const unsigned defaultLengthLimit = 1 << 16;
 

--- a/Source/WebCore/dom/XMLDocument.h
+++ b/Source/WebCore/dom/XMLDocument.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class XMLDocument : public Document {
     WTF_MAKE_ISO_ALLOCATED(XMLDocument);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(XMLDocument);
 public:
     static Ref<XMLDocument> create(LocalFrame* frame, const Settings& settings, const URL& url)
     {

--- a/Source/WebCore/html/FTPDirectoryDocument.h
+++ b/Source/WebCore/html/FTPDirectoryDocument.h
@@ -30,6 +30,7 @@ namespace WebCore {
 
 class FTPDirectoryDocument final : public HTMLDocument {
     WTF_MAKE_ISO_ALLOCATED(FTPDirectoryDocument);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FTPDirectoryDocument);
 public:
     static Ref<FTPDirectoryDocument> create(LocalFrame* frame, const Settings& settings, const URL& url)
     {

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -46,6 +46,7 @@ enum class Relation : uint8_t {
 
 class HTMLAnchorElement : public HTMLElement, public URLDecomposition {
     WTF_MAKE_ISO_ALLOCATED(HTMLAnchorElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLAnchorElement);
 public:
     static Ref<HTMLAnchorElement> create(Document&);
     static Ref<HTMLAnchorElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLAreaElement.cpp
+++ b/Source/WebCore/html/HTMLAreaElement.cpp
@@ -47,6 +47,8 @@ inline HTMLAreaElement::HTMLAreaElement(const QualifiedName& tagName, Document& 
     ASSERT(hasTagName(areaTag));
 }
 
+HTMLAreaElement::~HTMLAreaElement() = default;
+
 Ref<HTMLAreaElement> HTMLAreaElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new HTMLAreaElement(tagName, document));

--- a/Source/WebCore/html/HTMLAreaElement.h
+++ b/Source/WebCore/html/HTMLAreaElement.h
@@ -34,8 +34,10 @@ class Path;
 
 class HTMLAreaElement final : public HTMLAnchorElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLAreaElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLAreaElement);
 public:
     static Ref<HTMLAreaElement> create(const QualifiedName&, Document&);
+    ~HTMLAreaElement();
 
     bool isDefault() const { return m_shape == Shape::Default; }
 

--- a/Source/WebCore/html/HTMLArticleElement.h
+++ b/Source/WebCore/html/HTMLArticleElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class HTMLArticleElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLArticleElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLArticleElement);
 public:
     static Ref<HTMLArticleElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -44,6 +44,7 @@ class FragmentedSharedBuffer;
 
 class HTMLAttachmentElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLAttachmentElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLAttachmentElement);
 public:
     static Ref<HTMLAttachmentElement> create(const QualifiedName&, Document&);
     WEBCORE_EXPORT static String getAttachmentIdentifier(HTMLElement&);

--- a/Source/WebCore/html/HTMLAudioElement.h
+++ b/Source/WebCore/html/HTMLAudioElement.h
@@ -36,6 +36,7 @@ class Document;
 
 class HTMLAudioElement final : public HTMLMediaElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLAudioElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLAudioElement);
 public:
     static Ref<HTMLAudioElement> create(const QualifiedName&, Document&, bool);
     static Ref<HTMLAudioElement> createForLegacyFactoryFunction(Document&, const AtomString& src);

--- a/Source/WebCore/html/HTMLBDIElement.h
+++ b/Source/WebCore/html/HTMLBDIElement.h
@@ -26,6 +26,7 @@ namespace WebCore {
 
 class HTMLBDIElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLBDIElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLBDIElement);
 public:
     static Ref<HTMLBDIElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLBRElement.h
+++ b/Source/WebCore/html/HTMLBRElement.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class HTMLBRElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLBRElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLBRElement);
 public:
     static Ref<HTMLBRElement> create(Document&);
     static Ref<HTMLBRElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLBaseElement.h
+++ b/Source/WebCore/html/HTMLBaseElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLBaseElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLBaseElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLBaseElement);
 public:
     static Ref<HTMLBaseElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLBodyElement.h
+++ b/Source/WebCore/html/HTMLBodyElement.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class HTMLBodyElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLBodyElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLBodyElement);
 public:
     WEBCORE_EXPORT static Ref<HTMLBodyElement> create(Document&);
     static Ref<HTMLBodyElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -31,6 +31,7 @@ class RenderButton;
 
 class HTMLButtonElement final : public HTMLFormControlElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLButtonElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLButtonElement);
 public:
     static Ref<HTMLButtonElement> create(const QualifiedName&, Document&, HTMLFormElement*);
     static Ref<HTMLButtonElement> create(Document&);

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -63,6 +63,7 @@ struct UncachedString;
 
 class HTMLCanvasElement final : public HTMLElement, public CanvasBase, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(HTMLCanvasElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLCanvasElement);
 public:
     static Ref<HTMLCanvasElement> create(Document&);
     static Ref<HTMLCanvasElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLDListElement.h
+++ b/Source/WebCore/html/HTMLDListElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLDListElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLDListElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDListElement);
 public:
     static Ref<HTMLDListElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLDataElement.h
+++ b/Source/WebCore/html/HTMLDataElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class HTMLDataElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLDataElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDataElement);
 public:
     static Ref<HTMLDataElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLDataListElement.h
+++ b/Source/WebCore/html/HTMLDataListElement.h
@@ -42,6 +42,7 @@ class HTMLCollection;
 
 class HTMLDataListElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLDataListElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDataListElement);
 public:
     static Ref<HTMLDataListElement> create(const QualifiedName&, Document&);
     ~HTMLDataListElement();

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -95,6 +95,8 @@ HTMLDetailsElement::HTMLDetailsElement(const QualifiedName& tagName, Document& d
     ASSERT(hasTagName(detailsTag));
 }
 
+HTMLDetailsElement::~HTMLDetailsElement() = default;
+
 RenderPtr<RenderElement> HTMLDetailsElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
     return createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, *this, WTFMove(style));

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -39,8 +39,10 @@ struct DetailsToggleEventData {
 
 class HTMLDetailsElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLDetailsElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDetailsElement);
 public:
     static Ref<HTMLDetailsElement> create(const QualifiedName& tagName, Document&);
+    ~HTMLDetailsElement();
 
     void toggleOpen();
 

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class HTMLDialogElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLDialogElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDialogElement);
 public:
     template<typename... Args> static Ref<HTMLDialogElement> create(Args&&... args) { return adoptRef(*new HTMLDialogElement(std::forward<Args>(args)...)); }
 

--- a/Source/WebCore/html/HTMLDirectoryElement.h
+++ b/Source/WebCore/html/HTMLDirectoryElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLDirectoryElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLDirectoryElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDirectoryElement);
 public:
     static Ref<HTMLDirectoryElement> create(const QualifiedName& tagName, Document&);
 

--- a/Source/WebCore/html/HTMLDivElement.h
+++ b/Source/WebCore/html/HTMLDivElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLDivElement : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLDivElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDivElement);
 public:
     WEBCORE_EXPORT static Ref<HTMLDivElement> create(Document&);
     static Ref<HTMLDivElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLDocument.h
+++ b/Source/WebCore/html/HTMLDocument.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class HTMLDocument : public Document {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(HTMLDocument, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDocument);
 public:
     static Ref<HTMLDocument> create(LocalFrame*, const Settings&, const URL&, ScriptExecutionContextIdentifier = { });
     static Ref<HTMLDocument> createSynthesizedDocument(LocalFrame&, const URL&);

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -61,6 +61,7 @@ enum class SelectionRenderingBehavior : bool;
 
 class HTMLElement : public StyledElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLElement);
 public:
     static Ref<HTMLElement> create(const QualifiedName& tagName, Document&);
 

--- a/Source/WebCore/html/HTMLEmbedElement.h
+++ b/Source/WebCore/html/HTMLEmbedElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLEmbedElement final : public HTMLPlugInImageElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLEmbedElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLEmbedElement);
 public:
     static Ref<HTMLEmbedElement> create(Document&);
     static Ref<HTMLEmbedElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLFieldSetElement.h
+++ b/Source/WebCore/html/HTMLFieldSetElement.h
@@ -30,6 +30,7 @@ namespace WebCore {
 
 class HTMLFieldSetElement final : public HTMLFormControlElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLFieldSetElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFieldSetElement);
 public:
     static Ref<HTMLFieldSetElement> create(const QualifiedName&, Document&, HTMLFormElement*);
 

--- a/Source/WebCore/html/HTMLFontElement.h
+++ b/Source/WebCore/html/HTMLFontElement.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class HTMLFontElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLFontElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFontElement);
 public:
     static Ref<HTMLFontElement> create(const QualifiedName&, Document&);
     

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class HTMLFormControlElement : public HTMLElement, public ValidatedFormListedElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLFormControlElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFormControlElement);
 public:
     virtual ~HTMLFormControlElement();
 

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -43,6 +43,7 @@ class ValidatedFormListedElement;
 
 class HTMLFormElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLFormElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFormElement);
 public:
     static Ref<HTMLFormElement> create(Document&);
     static Ref<HTMLFormElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLFrameElement.h
+++ b/Source/WebCore/html/HTMLFrameElement.h
@@ -31,6 +31,7 @@ class RenderFrame;
 
 class HTMLFrameElement final : public HTMLFrameElementBase {
     WTF_MAKE_ISO_ALLOCATED(HTMLFrameElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFrameElement);
 public:
     static Ref<HTMLFrameElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLFrameElementBase.h
+++ b/Source/WebCore/html/HTMLFrameElementBase.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class HTMLFrameElementBase : public HTMLFrameOwnerElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLFrameElementBase);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFrameElementBase);
 public:
     void setLocation(JSC::JSGlobalObject&, const String&);
 

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -34,6 +34,7 @@ class RenderWidget;
 
 class HTMLFrameOwnerElement : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLFrameOwnerElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFrameOwnerElement);
 public:
     virtual ~HTMLFrameOwnerElement();
 

--- a/Source/WebCore/html/HTMLFrameSetElement.h
+++ b/Source/WebCore/html/HTMLFrameSetElement.h
@@ -32,6 +32,7 @@ class WindowProxy;
 
 class HTMLFrameSetElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLFrameSetElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFrameSetElement);
 public:
     static Ref<HTMLFrameSetElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLHRElement.h
+++ b/Source/WebCore/html/HTMLHRElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLHRElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLHRElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLHRElement);
 public:
     static Ref<HTMLHRElement> create(Document&);
     static Ref<HTMLHRElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLHeadElement.h
+++ b/Source/WebCore/html/HTMLHeadElement.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class HTMLHeadElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLHeadElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLHeadElement);
 public:
     static Ref<HTMLHeadElement> create(Document&);
     static Ref<HTMLHeadElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLHeadingElement.h
+++ b/Source/WebCore/html/HTMLHeadingElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLHeadingElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLHeadingElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLHeadingElement);
 public:
     static Ref<HTMLHeadingElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLHtmlElement.h
+++ b/Source/WebCore/html/HTMLHtmlElement.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class HTMLHtmlElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLHtmlElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLHtmlElement);
 public:
     WEBCORE_EXPORT static Ref<HTMLHtmlElement> create(Document&);
     static Ref<HTMLHtmlElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -57,6 +57,8 @@ inline HTMLIFrameElement::HTMLIFrameElement(const QualifiedName& tagName, Docume
     ASSERT(hasTagName(iframeTag));
 }
 
+HTMLIFrameElement::~HTMLIFrameElement() = default;
+
 Ref<HTMLIFrameElement> HTMLIFrameElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new HTMLIFrameElement(tagName, document));

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -35,8 +35,10 @@ class TrustedHTML;
 
 class HTMLIFrameElement final : public HTMLFrameElementBase {
     WTF_MAKE_ISO_ALLOCATED(HTMLIFrameElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLIFrameElement);
 public:
     static Ref<HTMLIFrameElement> create(const QualifiedName&, Document&);
+    ~HTMLIFrameElement();
 
     DOMTokenList& sandbox();
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -56,6 +56,7 @@ class HTMLImageElement
     , public FormAssociatedElement
     , public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(HTMLImageElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLImageElement);
 public:
     static Ref<HTMLImageElement> create(Document&);
     static Ref<HTMLImageElement> create(const QualifiedName&, Document&, HTMLFormElement* = nullptr);

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -60,6 +60,7 @@ enum class WasSetByJavaScript : bool { No, Yes };
 
 class HTMLInputElement final : public HTMLTextFormControlElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLInputElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLInputElement);
 public:
     static Ref<HTMLInputElement> create(const QualifiedName&, Document&, HTMLFormElement*, bool createdByParser);
     virtual ~HTMLInputElement();

--- a/Source/WebCore/html/HTMLLIElement.h
+++ b/Source/WebCore/html/HTMLLIElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLLIElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLLIElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLLIElement);
 public:
     static Ref<HTMLLIElement> create(Document&);
     static Ref<HTMLLIElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLLabelElement.h
+++ b/Source/WebCore/html/HTMLLabelElement.h
@@ -30,6 +30,7 @@ namespace WebCore {
 
 class HTMLLabelElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLLabelElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLLabelElement);
 public:
     static Ref<HTMLLabelElement> create(const QualifiedName&, Document&);
     static Ref<HTMLLabelElement> create(Document&);

--- a/Source/WebCore/html/HTMLLegendElement.h
+++ b/Source/WebCore/html/HTMLLegendElement.h
@@ -30,6 +30,7 @@ namespace WebCore {
 
 class HTMLLegendElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLLegendElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLLegendElement);
 public:
     static Ref<HTMLLegendElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -46,6 +46,7 @@ using LinkEventSender = EventSender<HTMLLinkElement, WeakPtrImplWithEventTargetD
 
 class HTMLLinkElement final : public HTMLElement, public CachedStyleSheetClient, public LinkLoaderClient {
     WTF_MAKE_ISO_ALLOCATED(HTMLLinkElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLLinkElement);
 public:
     using HTMLElement::weakPtrFactory;
     using HTMLElement::WeakValueType;

--- a/Source/WebCore/html/HTMLMapElement.h
+++ b/Source/WebCore/html/HTMLMapElement.h
@@ -31,6 +31,7 @@ class HTMLImageElement;
     
 class HTMLMapElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLMapElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMapElement);
 public:
     static Ref<HTMLMapElement> create(Document&);
     static Ref<HTMLMapElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLMarqueeElement.h
+++ b/Source/WebCore/html/HTMLMarqueeElement.h
@@ -31,6 +31,7 @@ class RenderMarquee;
 
 class HTMLMarqueeElement final : public HTMLElement, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(HTMLMarqueeElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMarqueeElement);
 public:
     static Ref<HTMLMarqueeElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -168,6 +168,7 @@ class HTMLMediaElement
     , public CanMakeWeakPtr<HTMLMediaElement, WeakPtrFactoryInitialization::Eager>
 {
     WTF_MAKE_ISO_ALLOCATED(HTMLMediaElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMediaElement);
 public:
     using CanMakeWeakPtr<HTMLMediaElement, WeakPtrFactoryInitialization::Eager>::weakPtrFactory;
     using CanMakeWeakPtr<HTMLMediaElement, WeakPtrFactoryInitialization::Eager>::WeakValueType;

--- a/Source/WebCore/html/HTMLMenuElement.h
+++ b/Source/WebCore/html/HTMLMenuElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLMenuElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLMenuElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMenuElement);
 public:
     static Ref<HTMLMenuElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLMetaElement.h
+++ b/Source/WebCore/html/HTMLMetaElement.h
@@ -30,6 +30,7 @@ namespace WebCore {
 
 class HTMLMetaElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLMetaElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMetaElement);
 public:
     static Ref<HTMLMetaElement> create(Document&);
     static Ref<HTMLMetaElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLMeterElement.h
+++ b/Source/WebCore/html/HTMLMeterElement.h
@@ -29,6 +29,7 @@ class RenderMeter;
 
 class HTMLMeterElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLMeterElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMeterElement);
 public:
     static Ref<HTMLMeterElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLModElement.h
+++ b/Source/WebCore/html/HTMLModElement.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class HTMLModElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLModElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLModElement);
 public:
     static Ref<HTMLModElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLOListElement.h
+++ b/Source/WebCore/html/HTMLOListElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLOListElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLOListElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLOListElement);
 public:
     static Ref<HTMLOListElement> create(Document&);
     static Ref<HTMLOListElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -31,6 +31,7 @@ class HTMLFormElement;
 
 class HTMLObjectElement final : public HTMLPlugInImageElement, public FormListedElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLObjectElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLObjectElement);
 public:
     static Ref<HTMLObjectElement> create(const QualifiedName&, Document&, HTMLFormElement*);
 

--- a/Source/WebCore/html/HTMLOptGroupElement.h
+++ b/Source/WebCore/html/HTMLOptGroupElement.h
@@ -31,6 +31,7 @@ class HTMLSelectElement;
 
 class HTMLOptGroupElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLOptGroupElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLOptGroupElement);
 public:
     static Ref<HTMLOptGroupElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -34,6 +34,7 @@ enum class AllowStyleInvalidation : bool { No, Yes };
 
 class HTMLOptionElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLOptionElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLOptionElement);
 public:
     static Ref<HTMLOptionElement> create(Document&);
     static Ref<HTMLOptionElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLOutputElement.cpp
+++ b/Source/WebCore/html/HTMLOutputElement.cpp
@@ -49,6 +49,8 @@ inline HTMLOutputElement::HTMLOutputElement(const QualifiedName& tagName, Docume
 {
 }
 
+HTMLOutputElement::~HTMLOutputElement() = default;
+
 Ref<HTMLOutputElement> HTMLOutputElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
 {
     return adoptRef(*new HTMLOutputElement(tagName, document, form));

--- a/Source/WebCore/html/HTMLOutputElement.h
+++ b/Source/WebCore/html/HTMLOutputElement.h
@@ -39,9 +39,11 @@ class DOMTokenList;
 
 class HTMLOutputElement final : public HTMLFormControlElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLOutputElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLOutputElement);
 public:
     static Ref<HTMLOutputElement> create(const QualifiedName&, Document&, HTMLFormElement*);
     static Ref<HTMLOutputElement> create(Document&);
+    ~HTMLOutputElement();
 
     String value() const;
     void setValue(String&&);

--- a/Source/WebCore/html/HTMLParagraphElement.h
+++ b/Source/WebCore/html/HTMLParagraphElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLParagraphElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLParagraphElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLParagraphElement);
 public:
     static Ref<HTMLParagraphElement> create(Document&);
     static Ref<HTMLParagraphElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLParamElement.h
+++ b/Source/WebCore/html/HTMLParamElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLParamElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLParamElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLParamElement);
 public:
     static Ref<HTMLParamElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLPictureElement.h
+++ b/Source/WebCore/html/HTMLPictureElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class HTMLPictureElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLPictureElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLPictureElement);
 public:
     static Ref<HTMLPictureElement> create(const QualifiedName&, Document&);
     virtual ~HTMLPictureElement();

--- a/Source/WebCore/html/HTMLPlugInElement.h
+++ b/Source/WebCore/html/HTMLPlugInElement.h
@@ -41,6 +41,7 @@ class RenderWidget;
 
 class HTMLPlugInElement : public HTMLFrameOwnerElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLPlugInElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLPlugInElement);
 public:
     virtual ~HTMLPlugInElement();
 

--- a/Source/WebCore/html/HTMLPlugInImageElement.h
+++ b/Source/WebCore/html/HTMLPlugInImageElement.h
@@ -32,6 +32,7 @@ enum class CreatePlugins : bool { No, Yes };
 // FIXME: This is the only class that derives from HTMLPlugInElement, so we could merge the two classes.
 class HTMLPlugInImageElement : public HTMLPlugInElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLPlugInImageElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLPlugInImageElement);
 public:
     virtual ~HTMLPlugInImageElement();
 

--- a/Source/WebCore/html/HTMLPreElement.h
+++ b/Source/WebCore/html/HTMLPreElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLPreElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLPreElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLPreElement);
 public:
     static Ref<HTMLPreElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLProgressElement.h
+++ b/Source/WebCore/html/HTMLProgressElement.h
@@ -29,6 +29,7 @@ class RenderProgress;
 
 class HTMLProgressElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLProgressElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLProgressElement);
 public:
     static const double IndeterminatePosition;
     static const double InvalidPosition;

--- a/Source/WebCore/html/HTMLQuoteElement.h
+++ b/Source/WebCore/html/HTMLQuoteElement.h
@@ -30,6 +30,7 @@ namespace WebCore {
 
 class HTMLQuoteElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLQuoteElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLQuoteElement);
 public:
     static Ref<HTMLQuoteElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -35,6 +35,7 @@ enum class RequestPriority : uint8_t;
 
 class HTMLScriptElement final : public HTMLElement, public ScriptElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLScriptElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLScriptElement);
 public:
     static Ref<HTMLScriptElement> create(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted = false);
 

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -36,6 +36,7 @@ class HTMLOptionsCollection;
 
 class HTMLSelectElement : public HTMLFormControlElement, private TypeAheadDataSource {
     WTF_MAKE_ISO_ALLOCATED(HTMLSelectElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLSelectElement);
 public:
     static Ref<HTMLSelectElement> create(const QualifiedName&, Document&, HTMLFormElement*);
     static Ref<HTMLSelectElement> create(Document&);

--- a/Source/WebCore/html/HTMLSlotElement.h
+++ b/Source/WebCore/html/HTMLSlotElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class HTMLSlotElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLSlotElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLSlotElement);
 public:
     using ElementOrText = std::variant<RefPtr<Element>, RefPtr<Text>>;
 

--- a/Source/WebCore/html/HTMLSourceElement.h
+++ b/Source/WebCore/html/HTMLSourceElement.h
@@ -40,6 +40,7 @@ class HTMLSourceElement final
 #endif
     , public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(HTMLSourceElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLSourceElement);
 public:
     static Ref<HTMLSourceElement> create(Document&);
     static Ref<HTMLSourceElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLSpanElement.h
+++ b/Source/WebCore/html/HTMLSpanElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class HTMLSpanElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLSpanElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLSpanElement);
 public:
     static Ref<HTMLSpanElement> create(Document&);
     static Ref<HTMLSpanElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLStyleElement.h
+++ b/Source/WebCore/html/HTMLStyleElement.h
@@ -37,6 +37,7 @@ using StyleEventSender = EventSender<HTMLStyleElement, WeakPtrImplWithEventTarge
 
 class HTMLStyleElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLStyleElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLStyleElement);
 public:
     static Ref<HTMLStyleElement> create(Document&);
     static Ref<HTMLStyleElement> create(const QualifiedName&, Document&, bool createdByParser);

--- a/Source/WebCore/html/HTMLSummaryElement.h
+++ b/Source/WebCore/html/HTMLSummaryElement.h
@@ -28,6 +28,7 @@ class HTMLDetailsElement;
 
 class HTMLSummaryElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLSummaryElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLSummaryElement);
 public:
     static Ref<HTMLSummaryElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLTableCaptionElement.h
+++ b/Source/WebCore/html/HTMLTableCaptionElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class HTMLTableCaptionElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLTableCaptionElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTableCaptionElement);
 public:
     static Ref<HTMLTableCaptionElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLTableCellElement.h
+++ b/Source/WebCore/html/HTMLTableCellElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class HTMLTableCellElement final : public HTMLTablePartElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLTableCellElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTableCellElement);
 public:
     static Ref<HTMLTableCellElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLTableColElement.h
+++ b/Source/WebCore/html/HTMLTableColElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class HTMLTableColElement final : public HTMLTablePartElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLTableColElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTableColElement);
 public:
     static Ref<HTMLTableColElement> create(const QualifiedName& tagName, Document&);
 

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -57,6 +57,8 @@ HTMLTableElement::HTMLTableElement(const QualifiedName& tagName, Document& docum
     ASSERT(hasTagName(tableTag));
 }
 
+HTMLTableElement::~HTMLTableElement() = default;
+
 Ref<HTMLTableElement> HTMLTableElement::create(Document& document)
 {
     return adoptRef(*new HTMLTableElement(tableTag, document));

--- a/Source/WebCore/html/HTMLTableElement.h
+++ b/Source/WebCore/html/HTMLTableElement.h
@@ -36,9 +36,11 @@ class HTMLTableSectionElement;
 
 class HTMLTableElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLTableElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTableElement);
 public:
     static Ref<HTMLTableElement> create(Document&);
     static Ref<HTMLTableElement> create(const QualifiedName&, Document&);
+    ~HTMLTableElement();
 
     WEBCORE_EXPORT RefPtr<HTMLTableCaptionElement> caption() const;
     WEBCORE_EXPORT ExceptionOr<void> setCaption(RefPtr<HTMLTableCaptionElement>&&);

--- a/Source/WebCore/html/HTMLTablePartElement.h
+++ b/Source/WebCore/html/HTMLTablePartElement.h
@@ -33,6 +33,7 @@ class HTMLTableElement;
 
 class HTMLTablePartElement : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLTablePartElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTablePartElement);
 public:
     RefPtr<const HTMLTableElement> findParentTable() const;
     bool isHTMLTablePartElement() const override { return true; }

--- a/Source/WebCore/html/HTMLTableRowElement.h
+++ b/Source/WebCore/html/HTMLTableRowElement.h
@@ -32,6 +32,7 @@ namespace WebCore {
 
 class HTMLTableRowElement final : public HTMLTablePartElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLTableRowElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTableRowElement);
 public:
     static Ref<HTMLTableRowElement> create(Document&);
     static Ref<HTMLTableRowElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLTableSectionElement.h
+++ b/Source/WebCore/html/HTMLTableSectionElement.h
@@ -32,6 +32,7 @@ namespace WebCore {
 
 class HTMLTableSectionElement final : public HTMLTablePartElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLTableSectionElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTableSectionElement);
 public:
     static Ref<HTMLTableSectionElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLTemplateElement.h
+++ b/Source/WebCore/html/HTMLTemplateElement.h
@@ -39,6 +39,7 @@ class TemplateContentDocumentFragment;
 
 class HTMLTemplateElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLTemplateElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTemplateElement);
 public:
     static Ref<HTMLTemplateElement> create(const QualifiedName&, Document&);
     virtual ~HTMLTemplateElement();

--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -34,6 +34,7 @@ enum class SelectionRestorationMode : uint8_t;
 
 class HTMLTextAreaElement final : public HTMLTextFormControlElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLTextAreaElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTextAreaElement);
 public:
     WEBCORE_EXPORT static Ref<HTMLTextAreaElement> create(Document&);
     static Ref<HTMLTextAreaElement> create(const QualifiedName&, Document&, HTMLFormElement*);

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -44,6 +44,7 @@ enum TextControlSetValueSelection { SetSelectionToEnd, Clamp, DoNotSet };
 
 class HTMLTextFormControlElement : public HTMLFormControlElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLTextFormControlElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTextFormControlElement);
 public:
     // Common flag for HTMLInputElement::tooLong() / tooShort() and HTMLTextAreaElement::tooLong() / tooShort().
     enum NeedsToCheckDirtyFlag {CheckDirtyFlag, IgnoreDirtyFlag};

--- a/Source/WebCore/html/HTMLTimeElement.h
+++ b/Source/WebCore/html/HTMLTimeElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class HTMLTimeElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLTimeElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTimeElement);
 public:
     static Ref<HTMLTimeElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLTitleElement.h
+++ b/Source/WebCore/html/HTMLTitleElement.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class HTMLTitleElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLTitleElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTitleElement);
 public:
     static Ref<HTMLTitleElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -39,6 +39,7 @@ class LoadableTextTrack;
 
 class HTMLTrackElement final : public HTMLElement, public ActiveDOMObject, public TextTrackClient {
     WTF_MAKE_ISO_ALLOCATED(HTMLTrackElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTrackElement);
 public:
     static Ref<HTMLTrackElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/HTMLUListElement.h
+++ b/Source/WebCore/html/HTMLUListElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class HTMLUListElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLUListElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLUListElement);
 public:
     static Ref<HTMLUListElement> create(Document&);
     static Ref<HTMLUListElement> create(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLUnknownElement.h
+++ b/Source/WebCore/html/HTMLUnknownElement.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class HTMLUnknownElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLUnknownElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLUnknownElement);
 public:
     static Ref<HTMLUnknownElement> create(const QualifiedName& tagName, Document& document)
     {

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -75,6 +75,8 @@ inline HTMLVideoElement::HTMLVideoElement(const QualifiedName& tagName, Document
     m_defaultPosterURL = AtomString { document.settings().defaultVideoPosterURL() };
 }
 
+HTMLVideoElement::~HTMLVideoElement() = default;
+
 Ref<HTMLVideoElement> HTMLVideoElement::create(const QualifiedName& tagName, Document& document, bool createdByParser)
 {
     Ref videoElement = adoptRef(*new HTMLVideoElement(tagName, document, createdByParser));

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -46,9 +46,11 @@ enum class RenderingMode : bool;
 
 class HTMLVideoElement final : public HTMLMediaElement, public Supplementable<HTMLVideoElement> {
     WTF_MAKE_ISO_ALLOCATED(HTMLVideoElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLVideoElement);
 public:
     WEBCORE_EXPORT static Ref<HTMLVideoElement> create(Document&);
     static Ref<HTMLVideoElement> create(const QualifiedName&, Document&, bool createdByParser);
+    ~HTMLVideoElement();
 
     WEBCORE_EXPORT unsigned videoWidth() const;
     WEBCORE_EXPORT unsigned videoHeight() const;

--- a/Source/WebCore/html/HTMLWBRElement.h
+++ b/Source/WebCore/html/HTMLWBRElement.h
@@ -33,6 +33,7 @@ class RenderLineBreak;
 
 class HTMLWBRElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLWBRElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLWBRElement);
 public:
     static Ref<HTMLWBRElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -98,6 +98,7 @@ private:
 
 class ImageDocumentElement final : public HTMLImageElement {
     WTF_MAKE_ISO_ALLOCATED_INLINE(ImageDocumentElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ImageDocumentElement);
 public:
     static Ref<ImageDocumentElement> create(ImageDocument&);
 

--- a/Source/WebCore/html/ImageDocument.h
+++ b/Source/WebCore/html/ImageDocument.h
@@ -33,6 +33,7 @@ class HTMLImageElement;
 
 class ImageDocument final : public HTMLDocument {
     WTF_MAKE_ISO_ALLOCATED(ImageDocument);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ImageDocument);
 public:
     static Ref<ImageDocument> create(LocalFrame& frame, const URL& url)
     {

--- a/Source/WebCore/html/MediaDocument.h
+++ b/Source/WebCore/html/MediaDocument.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class MediaDocument final : public HTMLDocument {
     WTF_MAKE_ISO_ALLOCATED(MediaDocument);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaDocument);
 public:
     static Ref<MediaDocument> create(LocalFrame* frame, const Settings& settings, const URL& url)
     {

--- a/Source/WebCore/html/ModelDocument.h
+++ b/Source/WebCore/html/ModelDocument.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class ModelDocument final : public HTMLDocument {
     WTF_MAKE_ISO_ALLOCATED(ModelDocument);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ModelDocument);
 public:
     static Ref<ModelDocument> create(LocalFrame* frame, const Settings& settings, const URL& url)
     {

--- a/Source/WebCore/html/PDFDocument.cpp
+++ b/Source/WebCore/html/PDFDocument.cpp
@@ -136,6 +136,8 @@ PDFDocument::PDFDocument(LocalFrame& frame, const URL& url)
 {
 }
 
+PDFDocument::~PDFDocument() = default;
+
 Ref<DocumentParser> PDFDocument::createParser()
 {
     return PDFDocumentParser::create(*this);

--- a/Source/WebCore/html/PDFDocument.h
+++ b/Source/WebCore/html/PDFDocument.h
@@ -36,6 +36,7 @@ class PDFDocumentEventListener;
 
 class PDFDocument final : public HTMLDocument {
     WTF_MAKE_ISO_ALLOCATED(PDFDocument);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PDFDocument);
 public:
     static Ref<PDFDocument> create(LocalFrame& frame, const URL& url)
     {
@@ -43,6 +44,8 @@ public:
         document->addToContextsMap();
         return document;
     }
+
+    ~PDFDocument();
 
     void updateDuringParsing();
     void finishedParsing();

--- a/Source/WebCore/html/TextDocument.h
+++ b/Source/WebCore/html/TextDocument.h
@@ -30,6 +30,7 @@ namespace WebCore {
 
 class TextDocument final : public HTMLDocument {
     WTF_MAKE_ISO_ALLOCATED(TextDocument);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextDocument);
 public:
     static Ref<TextDocument> create(LocalFrame* frame, const Settings& settings, const URL& url, ScriptExecutionContextIdentifier identifier)
     {

--- a/Source/WebCore/html/shadow/AutoFillButtonElement.h
+++ b/Source/WebCore/html/shadow/AutoFillButtonElement.h
@@ -33,6 +33,7 @@ class TextFieldInputType;
 
 class AutoFillButtonElement final : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(AutoFillButtonElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AutoFillButtonElement);
 public:
     class AutoFillButtonOwner {
     public:

--- a/Source/WebCore/html/shadow/DataListButtonElement.h
+++ b/Source/WebCore/html/shadow/DataListButtonElement.h
@@ -35,6 +35,7 @@ class TextFieldInputType;
 
 class DataListButtonElement final : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(DataListButtonElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DataListButtonElement);
 public:
     class DataListButtonOwner {
     public:

--- a/Source/WebCore/html/shadow/DateTimeEditElement.h
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.h
@@ -59,6 +59,7 @@ public:
 
 class DateTimeEditElement final : public HTMLDivElement, public DateTimeFieldElementFieldOwner {
     WTF_MAKE_ISO_ALLOCATED(DateTimeEditElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateTimeEditElement);
 public:
     struct LayoutParameters {
         String dateTimeFormat;

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.h
@@ -68,6 +68,7 @@ public:
 
 class DateTimeFieldElement : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(DateTimeFieldElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateTimeFieldElement);
 public:
     enum EventBehavior : bool { DispatchNoEvent, DispatchInputAndChangeEvents };
 

--- a/Source/WebCore/html/shadow/DateTimeFieldElements.h
+++ b/Source/WebCore/html/shadow/DateTimeFieldElements.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class DateTimeDayFieldElement final : public DateTimeNumericFieldElement {
     WTF_MAKE_ISO_ALLOCATED(DateTimeDayFieldElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateTimeDayFieldElement);
 
 public:
     static Ref<DateTimeDayFieldElement> create(Document&, DateTimeFieldElementFieldOwner&);
@@ -49,6 +50,7 @@ private:
 
 class DateTimeHourFieldElement final : public DateTimeNumericFieldElement {
     WTF_MAKE_ISO_ALLOCATED(DateTimeHourFieldElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateTimeHourFieldElement);
 
 public:
     static Ref<DateTimeHourFieldElement> create(Document&, DateTimeFieldElementFieldOwner&, int minimum, int maximum);
@@ -63,6 +65,7 @@ private:
 
 class DateTimeMeridiemFieldElement final : public DateTimeSymbolicFieldElement {
     WTF_MAKE_ISO_ALLOCATED(DateTimeMeridiemFieldElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateTimeMeridiemFieldElement);
 
 public:
     static Ref<DateTimeMeridiemFieldElement> create(Document&, DateTimeFieldElementFieldOwner&, const Vector<String>&);
@@ -81,6 +84,7 @@ private:
 
 class DateTimeMillisecondFieldElement final : public DateTimeNumericFieldElement {
     WTF_MAKE_ISO_ALLOCATED(DateTimeMillisecondFieldElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateTimeMillisecondFieldElement);
 
 public:
     static Ref<DateTimeMillisecondFieldElement> create(Document&, DateTimeFieldElementFieldOwner&);
@@ -95,6 +99,7 @@ private:
 
 class DateTimeMinuteFieldElement final : public DateTimeNumericFieldElement {
     WTF_MAKE_ISO_ALLOCATED(DateTimeMinuteFieldElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateTimeMinuteFieldElement);
 
 public:
     static Ref<DateTimeMinuteFieldElement> create(Document&, DateTimeFieldElementFieldOwner&);
@@ -109,6 +114,7 @@ private:
 
 class DateTimeMonthFieldElement final : public DateTimeNumericFieldElement {
     WTF_MAKE_ISO_ALLOCATED(DateTimeMonthFieldElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateTimeMonthFieldElement);
 
 public:
     static Ref<DateTimeMonthFieldElement> create(Document&, DateTimeFieldElementFieldOwner&);
@@ -123,6 +129,7 @@ private:
 
 class DateTimeSecondFieldElement final : public DateTimeNumericFieldElement {
     WTF_MAKE_ISO_ALLOCATED(DateTimeSecondFieldElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateTimeSecondFieldElement);
 
 public:
     static Ref<DateTimeSecondFieldElement> create(Document&, DateTimeFieldElementFieldOwner&);
@@ -137,6 +144,7 @@ private:
 
 class DateTimeSymbolicMonthFieldElement final : public DateTimeSymbolicFieldElement {
     WTF_MAKE_ISO_ALLOCATED(DateTimeSymbolicMonthFieldElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateTimeSymbolicMonthFieldElement);
 
 public:
     static Ref<DateTimeSymbolicMonthFieldElement> create(Document&, DateTimeFieldElementFieldOwner&, const Vector<String>&);
@@ -151,6 +159,7 @@ private:
 
 class DateTimeYearFieldElement final : public DateTimeNumericFieldElement {
     WTF_MAKE_ISO_ALLOCATED(DateTimeYearFieldElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DateTimeYearFieldElement);
 
 public:
     static Ref<DateTimeYearFieldElement> create(Document&, DateTimeFieldElementFieldOwner&);

--- a/Source/WebCore/html/shadow/DetailsMarkerControl.h
+++ b/Source/WebCore/html/shadow/DetailsMarkerControl.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class DetailsMarkerControl final : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(DetailsMarkerControl);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DetailsMarkerControl);
 public:
     static Ref<DetailsMarkerControl> create(Document&);
 

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
@@ -50,6 +50,7 @@ class MediaControlTextTrackContainerElement final
 #endif
 {
     WTF_MAKE_ISO_ALLOCATED(MediaControlTextTrackContainerElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaControlTextTrackContainerElement);
 public:
     static Ref<MediaControlTextTrackContainerElement> create(Document&, HTMLMediaElement&);
 

--- a/Source/WebCore/html/shadow/ProgressShadowElement.cpp
+++ b/Source/WebCore/html/shadow/ProgressShadowElement.cpp
@@ -41,6 +41,9 @@
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ProgressShadowElement);
+WTF_MAKE_ISO_ALLOCATED_IMPL(ProgressInnerElement);
+WTF_MAKE_ISO_ALLOCATED_IMPL(ProgressBarElement);
+WTF_MAKE_ISO_ALLOCATED_IMPL(ProgressValueElement);
 
 using namespace HTMLNames;
 

--- a/Source/WebCore/html/shadow/ProgressShadowElement.h
+++ b/Source/WebCore/html/shadow/ProgressShadowElement.h
@@ -40,6 +40,7 @@ class HTMLProgressElement;
 
 class ProgressShadowElement : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(ProgressShadowElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ProgressShadowElement);
 public:
     HTMLProgressElement* progressElement() const;
 
@@ -54,6 +55,8 @@ private:
 // fields to the class.
 
 class ProgressInnerElement final : public ProgressShadowElement {
+    WTF_MAKE_ISO_ALLOCATED(ProgressInnerElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ProgressInnerElement);
 public:
     static Ref<ProgressInnerElement> create(Document&);
 
@@ -66,6 +69,8 @@ private:
 static_assert(sizeof(ProgressInnerElement) == sizeof(ProgressShadowElement));
 
 class ProgressBarElement final : public ProgressShadowElement {
+    WTF_MAKE_ISO_ALLOCATED(ProgressBarElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ProgressBarElement);
 public:
     static Ref<ProgressBarElement> create(Document&);
 
@@ -75,6 +80,8 @@ private:
 static_assert(sizeof(ProgressBarElement) == sizeof(ProgressShadowElement));
 
 class ProgressValueElement final : public ProgressShadowElement {
+    WTF_MAKE_ISO_ALLOCATED(ProgressValueElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ProgressValueElement);
 public:
     static Ref<ProgressValueElement> create(Document&);
     void setInlineSizePercentage(double);

--- a/Source/WebCore/html/shadow/SliderThumbElement.h
+++ b/Source/WebCore/html/shadow/SliderThumbElement.h
@@ -42,6 +42,7 @@ class TouchEvent;
 
 class SliderThumbElement final : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(SliderThumbElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SliderThumbElement);
 public:
     static Ref<SliderThumbElement> create(Document&);
 
@@ -107,6 +108,7 @@ private:
 
 class SliderContainerElement final : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(SliderContainerElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SliderContainerElement);
 public:
     static Ref<SliderContainerElement> create(Document&);
 

--- a/Source/WebCore/html/shadow/SpinButtonElement.h
+++ b/Source/WebCore/html/shadow/SpinButtonElement.h
@@ -54,6 +54,7 @@ public:
 
 class SpinButtonElement final : public HTMLDivElement, public PopupOpeningObserver {
     WTF_MAKE_ISO_ALLOCATED(SpinButtonElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SpinButtonElement);
 public:
     enum UpDownState {
         Indeterminate, // Hovered, but the event is not handled.

--- a/Source/WebCore/html/shadow/TextControlInnerElements.h
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.h
@@ -35,6 +35,7 @@ class RenderTextControlInnerBlock;
 
 class TextControlInnerContainer final : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(TextControlInnerContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextControlInnerContainer);
 public:
     static Ref<TextControlInnerContainer> create(Document&);
 
@@ -46,6 +47,7 @@ private:
 
 class TextControlInnerElement final : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(TextControlInnerElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextControlInnerElement);
 public:
     static Ref<TextControlInnerElement> create(Document&);
 
@@ -58,6 +60,7 @@ private:
 
 class TextControlInnerTextElement final : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(TextControlInnerTextElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextControlInnerTextElement);
 public:
     static Ref<TextControlInnerTextElement> create(Document&, bool isEditable);
 
@@ -83,6 +86,7 @@ private:
 
 class TextControlPlaceholderElement final : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(TextControlPlaceholderElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextControlPlaceholderElement);
 public:
     static Ref<TextControlPlaceholderElement> create(Document&);
 
@@ -94,6 +98,7 @@ private:
 
 class SearchFieldResultsButtonElement final : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(SearchFieldResultsButtonElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SearchFieldResultsButtonElement);
 public:
     static Ref<SearchFieldResultsButtonElement> create(Document&);
 
@@ -115,6 +120,7 @@ private:
 
 class SearchFieldCancelButtonElement final : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(SearchFieldCancelButtonElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SearchFieldCancelButtonElement);
 public:
     static Ref<SearchFieldCancelButtonElement> create(Document&);
 

--- a/Source/WebCore/html/shadow/TextPlaceholderElement.h
+++ b/Source/WebCore/html/shadow/TextPlaceholderElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class TextPlaceholderElement final : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(TextPlaceholderElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextPlaceholderElement);
 public:
     static Ref<TextPlaceholderElement> create(Document&, const LayoutSize&);
 

--- a/Source/WebCore/html/shadow/YouTubeEmbedShadowElement.h
+++ b/Source/WebCore/html/shadow/YouTubeEmbedShadowElement.h
@@ -32,6 +32,7 @@ namespace WebCore {
 
 class YouTubeEmbedShadowElement final : public HTMLDivElement {
     WTF_MAKE_ISO_ALLOCATED(YouTubeEmbedShadowElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(YouTubeEmbedShadowElement);
 public:
     static Ref<YouTubeEmbedShadowElement> create(Document&);
 

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -47,6 +47,7 @@ class TextTrackCue;
 
 class TextTrackCueBox : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(TextTrackCueBox);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextTrackCueBox);
 public:
     static Ref<TextTrackCueBox> create(Document&, TextTrackCue&);
 

--- a/Source/WebCore/html/track/TextTrackCueGeneric.cpp
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.cpp
@@ -48,6 +48,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(TextTrackCueGeneric);
 
 class TextTrackCueGenericBoxElement final : public VTTCueBox {
     WTF_MAKE_ISO_ALLOCATED_INLINE(TextTrackCueGenericBoxElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextTrackCueGenericBoxElement);
 public:
     static Ref<TextTrackCueGenericBoxElement> create(Document&, TextTrackCueGeneric&);
     

--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -91,6 +91,7 @@ enum class VTTAlignSetting : uint8_t {
 
 class VTTCueBox : public TextTrackCueBox {
     WTF_MAKE_ISO_ALLOCATED(VTTCueBox);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VTTCueBox);
 public:
     static Ref<VTTCueBox> create(Document&, VTTCue&);
 

--- a/Source/WebCore/html/track/WebVTTElement.h
+++ b/Source/WebCore/html/track/WebVTTElement.h
@@ -46,6 +46,7 @@ enum WebVTTNodeType {
 
 class WebVTTElement final : public Element {
     WTF_MAKE_ISO_ALLOCATED(WebVTTElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebVTTElement);
 public:
     static Ref<Element> create(const WebVTTNodeType, AtomString language, Document&);
     Ref<HTMLElement> createEquivalentHTMLElement(Document&);

--- a/Source/WebCore/loader/SinkDocument.h
+++ b/Source/WebCore/loader/SinkDocument.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class SinkDocument final : public HTMLDocument {
     WTF_MAKE_ISO_ALLOCATED(SinkDocument);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SinkDocument);
 public:
     static Ref<SinkDocument> create(LocalFrame& frame, const URL& url)
     {

--- a/Source/WebCore/mathml/MathMLAnnotationElement.h
+++ b/Source/WebCore/mathml/MathMLAnnotationElement.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class MathMLAnnotationElement final : public MathMLPresentationElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLAnnotationElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLAnnotationElement);
 public:
     static Ref<MathMLAnnotationElement> create(const QualifiedName& tagName, Document&);
 private:

--- a/Source/WebCore/mathml/MathMLElement.h
+++ b/Source/WebCore/mathml/MathMLElement.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class MathMLElement : public StyledElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLElement);
 public:
     static Ref<MathMLElement> create(const QualifiedName& tagName, Document&);
 

--- a/Source/WebCore/mathml/MathMLFractionElement.h
+++ b/Source/WebCore/mathml/MathMLFractionElement.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class MathMLFractionElement final : public MathMLRowElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLFractionElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLFractionElement);
 public:
     static Ref<MathMLFractionElement> create(const QualifiedName& tagName, Document&);
     const Length& lineThickness();

--- a/Source/WebCore/mathml/MathMLMathElement.h
+++ b/Source/WebCore/mathml/MathMLMathElement.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class MathMLMathElement final : public MathMLRowElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLMathElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLMathElement);
 public:
     static Ref<MathMLMathElement> create(const QualifiedName& tagName, Document&);
 

--- a/Source/WebCore/mathml/MathMLMencloseElement.h
+++ b/Source/WebCore/mathml/MathMLMencloseElement.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class MathMLMencloseElement final: public MathMLRowElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLMencloseElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLMencloseElement);
 public:
     static Ref<MathMLMencloseElement> create(const QualifiedName& tagName, Document&);
 

--- a/Source/WebCore/mathml/MathMLOperatorElement.h
+++ b/Source/WebCore/mathml/MathMLOperatorElement.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class MathMLOperatorElement final : public MathMLTokenElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLOperatorElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLOperatorElement);
 public:
     static Ref<MathMLOperatorElement> create(const QualifiedName& tagName, Document&);
     struct OperatorChar {

--- a/Source/WebCore/mathml/MathMLPaddedElement.h
+++ b/Source/WebCore/mathml/MathMLPaddedElement.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class MathMLPaddedElement final : public MathMLRowElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLPaddedElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLPaddedElement);
 public:
     static Ref<MathMLPaddedElement> create(const QualifiedName& tagName, Document&);
     // FIXME: Pseudo-units are not supported yet (https://bugs.webkit.org/show_bug.cgi?id=85730).

--- a/Source/WebCore/mathml/MathMLPresentationElement.h
+++ b/Source/WebCore/mathml/MathMLPresentationElement.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class MathMLPresentationElement : public MathMLElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLPresentationElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLPresentationElement);
 public:
     static Ref<MathMLPresentationElement> create(const QualifiedName& tagName, Document&);
 

--- a/Source/WebCore/mathml/MathMLRootElement.h
+++ b/Source/WebCore/mathml/MathMLRootElement.h
@@ -35,6 +35,7 @@ enum class RootType;
 
 class MathMLRootElement final : public MathMLRowElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLRootElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLRootElement);
 public:
     static Ref<MathMLRootElement> create(const QualifiedName& tagName, Document&);
     RootType rootType() const { return m_rootType; }

--- a/Source/WebCore/mathml/MathMLRowElement.h
+++ b/Source/WebCore/mathml/MathMLRowElement.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class MathMLRowElement : public MathMLPresentationElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLRowElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLRowElement);
 public:
     static Ref<MathMLRowElement> create(const QualifiedName& tagName, Document&);
 

--- a/Source/WebCore/mathml/MathMLScriptsElement.h
+++ b/Source/WebCore/mathml/MathMLScriptsElement.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class MathMLScriptsElement : public MathMLRowElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLScriptsElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLScriptsElement);
 public:
     static Ref<MathMLScriptsElement> create(const QualifiedName& tagName, Document&);
 

--- a/Source/WebCore/mathml/MathMLSelectElement.h
+++ b/Source/WebCore/mathml/MathMLSelectElement.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class MathMLSelectElement final : public MathMLRowElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLSelectElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLSelectElement);
 public:
     static Ref<MathMLSelectElement> create(const QualifiedName& tagName, Document&);
     static bool isMathMLEncoding(const AtomString& value);

--- a/Source/WebCore/mathml/MathMLSpaceElement.h
+++ b/Source/WebCore/mathml/MathMLSpaceElement.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class MathMLSpaceElement final : public MathMLPresentationElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLSpaceElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLSpaceElement);
 public:
     static Ref<MathMLSpaceElement> create(const QualifiedName& tagName, Document&);
     const Length& width();

--- a/Source/WebCore/mathml/MathMLTokenElement.h
+++ b/Source/WebCore/mathml/MathMLTokenElement.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class MathMLTokenElement : public MathMLPresentationElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLTokenElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLTokenElement);
 public:
     static Ref<MathMLTokenElement> create(const QualifiedName& tagName, Document&);
 

--- a/Source/WebCore/mathml/MathMLUnderOverElement.h
+++ b/Source/WebCore/mathml/MathMLUnderOverElement.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class MathMLUnderOverElement final : public MathMLScriptsElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLUnderOverElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLUnderOverElement);
 public:
     static Ref<MathMLUnderOverElement> create(const QualifiedName& tagName, Document&);
     const BooleanValue& accent();

--- a/Source/WebCore/mathml/MathMLUnknownElement.h
+++ b/Source/WebCore/mathml/MathMLUnknownElement.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class MathMLUnknownElement final : public MathMLElement {
     WTF_MAKE_ISO_ALLOCATED(MathMLUnknownElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLUnknownElement);
 public:
     static Ref<MathMLUnknownElement> create(const QualifiedName& tagName, Document& document)
     {

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -62,6 +62,8 @@ inline SVGAElement::SVGAElement(const QualifiedName& tagName, Document& document
     });
 }
 
+SVGAElement::~SVGAElement() = default;
+
 Ref<SVGAElement> SVGAElement::create(const QualifiedName& tagName, Document& document)
 {
     return adoptRef(*new SVGAElement(tagName, document));

--- a/Source/WebCore/svg/SVGAElement.h
+++ b/Source/WebCore/svg/SVGAElement.h
@@ -32,8 +32,10 @@ class DOMTokenList;
 
 class SVGAElement final : public SVGGraphicsElement, public SVGURIReference {
     WTF_MAKE_ISO_ALLOCATED(SVGAElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAElement);
 public:
     static Ref<SVGAElement> create(const QualifiedName&, Document&);
+    ~SVGAElement();
 
     AtomString target() const final { return AtomString { m_target->currentValue() }; }
     Ref<SVGAnimatedString>& targetAnimated() { return m_target; }

--- a/Source/WebCore/svg/SVGAltGlyphDefElement.h
+++ b/Source/WebCore/svg/SVGAltGlyphDefElement.h
@@ -26,6 +26,7 @@ namespace WebCore {
 
 class SVGAltGlyphDefElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGAltGlyphDefElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAltGlyphDefElement);
 public:
     static Ref<SVGAltGlyphDefElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGAltGlyphElement.h
+++ b/Source/WebCore/svg/SVGAltGlyphElement.h
@@ -30,6 +30,7 @@ class SVGGlyphElement;
 
 class SVGAltGlyphElement final : public SVGTextPositioningElement, public SVGURIReference {
     WTF_MAKE_ISO_ALLOCATED(SVGAltGlyphElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAltGlyphElement);
 public:
     static Ref<SVGAltGlyphElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGAltGlyphItemElement.h
+++ b/Source/WebCore/svg/SVGAltGlyphItemElement.h
@@ -26,6 +26,7 @@ namespace WebCore {
 
 class SVGAltGlyphItemElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGAltGlyphItemElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAltGlyphItemElement);
 public:
     static Ref<SVGAltGlyphItemElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGAnimateElement.h
+++ b/Source/WebCore/svg/SVGAnimateElement.h
@@ -33,6 +33,7 @@ class SVGLegacyAnimatedProperty;
 
 class SVGAnimateElement final : public SVGAnimateElementBase {
     WTF_MAKE_ISO_ALLOCATED(SVGAnimateElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAnimateElement);
 public:
     static Ref<SVGAnimateElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGAnimateElementBase.h
+++ b/Source/WebCore/svg/SVGAnimateElementBase.h
@@ -32,6 +32,7 @@ class SVGAttributeAnimator;
 
 class SVGAnimateElementBase : public SVGAnimationElement {
     WTF_MAKE_ISO_ALLOCATED(SVGAnimateElementBase);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAnimateElementBase);
 public:
     bool isDiscreteAnimator() const;
 

--- a/Source/WebCore/svg/SVGAnimateMotionElement.h
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.h
@@ -29,6 +29,7 @@ class AffineTransform;
             
 class SVGAnimateMotionElement final : public SVGAnimationElement {
     WTF_MAKE_ISO_ALLOCATED(SVGAnimateMotionElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAnimateMotionElement);
 public:
     static Ref<SVGAnimateMotionElement> create(const QualifiedName&, Document&);
     void updateAnimationPath();

--- a/Source/WebCore/svg/SVGAnimateTransformElement.h
+++ b/Source/WebCore/svg/SVGAnimateTransformElement.h
@@ -31,6 +31,7 @@ class AffineTransform;
 
 class SVGAnimateTransformElement final : public SVGAnimateElementBase {
     WTF_MAKE_ISO_ALLOCATED(SVGAnimateTransformElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAnimateTransformElement);
 public:
     static Ref<SVGAnimateTransformElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGAnimationElement.h
+++ b/Source/WebCore/svg/SVGAnimationElement.h
@@ -39,6 +39,7 @@ enum AnimatedPropertyValueType { RegularPropertyValue, CurrentColorValue, Inheri
 
 class SVGAnimationElement : public SVGSMILElement, public SVGTests {
     WTF_MAKE_ISO_ALLOCATED(SVGAnimationElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAnimationElement);
 public:
     ExceptionOr<float> getStartTime() const;
     float getCurrentTime() const;

--- a/Source/WebCore/svg/SVGCircleElement.h
+++ b/Source/WebCore/svg/SVGCircleElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class SVGCircleElement final : public SVGGeometryElement {
     WTF_MAKE_ISO_ALLOCATED(SVGCircleElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGCircleElement);
 public:
     static Ref<SVGCircleElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGClipPathElement.h
+++ b/Source/WebCore/svg/SVGClipPathElement.h
@@ -32,6 +32,7 @@ enum class RepaintRectCalculation : bool;
 
 class SVGClipPathElement final : public SVGGraphicsElement {
     WTF_MAKE_ISO_ALLOCATED(SVGClipPathElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGClipPathElement);
 public:
     static Ref<SVGClipPathElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
@@ -69,6 +69,7 @@ struct SVGPropertyTraits<ComponentTransferType> {
 
 class SVGComponentTransferFunctionElement : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGComponentTransferFunctionElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGComponentTransferFunctionElement);
 public:
     virtual ComponentTransferChannel channel() const = 0;
     ComponentTransferFunction transferFunction() const;

--- a/Source/WebCore/svg/SVGCursorElement.h
+++ b/Source/WebCore/svg/SVGCursorElement.h
@@ -31,6 +31,7 @@ class StyleCursorImage;
 
 class SVGCursorElement final : public SVGElement, public SVGTests, public SVGURIReference {
     WTF_MAKE_ISO_ALLOCATED(SVGCursorElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGCursorElement);
 public:
     static Ref<SVGCursorElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGDefsElement.h
+++ b/Source/WebCore/svg/SVGDefsElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGDefsElement final : public SVGGraphicsElement {
     WTF_MAKE_ISO_ALLOCATED(SVGDefsElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGDefsElement);
 public:
     static Ref<SVGDefsElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGDescElement.h
+++ b/Source/WebCore/svg/SVGDescElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGDescElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGDescElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGDescElement);
 public:
     static Ref<SVGDescElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGDocument.h
+++ b/Source/WebCore/svg/SVGDocument.h
@@ -29,6 +29,7 @@ class SVGSVGElement;
 
 class SVGDocument final : public XMLDocument {
     WTF_MAKE_ISO_ALLOCATED(SVGDocument);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGDocument);
 public:
     static Ref<SVGDocument> create(LocalFrame*, const Settings&, const URL&);
 

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -50,6 +50,7 @@ class Timer;
 
 class SVGElement : public StyledElement, public SVGPropertyOwner {
     WTF_MAKE_ISO_ALLOCATED(SVGElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGElement);
 public:
     bool isInnerSVGSVGElement() const;
     bool isOutermostSVGSVGElement() const;

--- a/Source/WebCore/svg/SVGEllipseElement.h
+++ b/Source/WebCore/svg/SVGEllipseElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class SVGEllipseElement final : public SVGGeometryElement {
     WTF_MAKE_ISO_ALLOCATED(SVGEllipseElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGEllipseElement);
 public:
     static Ref<SVGEllipseElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEBlendElement.h
+++ b/Source/WebCore/svg/SVGFEBlendElement.h
@@ -49,6 +49,7 @@ struct SVGPropertyTraits<BlendMode> {
 
 class SVGFEBlendElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFEBlendElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEBlendElement);
 public:
     static Ref<SVGFEBlendElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.h
@@ -65,6 +65,7 @@ struct SVGPropertyTraits<ColorMatrixType> {
 
 class SVGFEColorMatrixElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFEColorMatrixElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEColorMatrixElement);
 public:
     static Ref<SVGFEColorMatrixElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.h
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.h
@@ -30,6 +30,7 @@ class SVGComponentTransferFunctionElement;
 
 class SVGFEComponentTransferElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFEComponentTransferElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEComponentTransferElement);
 public:
     static Ref<SVGFEComponentTransferElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFECompositeElement.h
+++ b/Source/WebCore/svg/SVGFECompositeElement.h
@@ -77,6 +77,7 @@ struct SVGPropertyTraits<CompositeOperationType> {
 
 class SVGFECompositeElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFECompositeElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFECompositeElement);
 public:
     static Ref<SVGFECompositeElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
@@ -62,6 +62,7 @@ struct SVGPropertyTraits<EdgeModeType> {
 
 class SVGFEConvolveMatrixElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFEConvolveMatrixElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEConvolveMatrixElement);
 public:
     static Ref<SVGFEConvolveMatrixElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.h
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.h
@@ -32,6 +32,7 @@ class SVGColor;
 
 class SVGFEDiffuseLightingElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFEDiffuseLightingElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEDiffuseLightingElement);
 public:
     static Ref<SVGFEDiffuseLightingElement> create(const QualifiedName&, Document&);
     void lightElementAttributeChanged(const SVGFELightElement*, const QualifiedName&);

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.h
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.h
@@ -64,6 +64,7 @@ struct SVGPropertyTraits<ChannelSelectorType> {
 
 class SVGFEDisplacementMapElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFEDisplacementMapElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEDisplacementMapElement);
 public:
     static Ref<SVGFEDisplacementMapElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEDistantLightElement.cpp
+++ b/Source/WebCore/svg/SVGFEDistantLightElement.cpp
@@ -23,8 +23,11 @@
 
 #include "DistantLightSource.h"
 #include "SVGNames.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(SVGFEDistantLightElement);
 
 inline SVGFEDistantLightElement::SVGFEDistantLightElement(const QualifiedName& tagName, Document& document)
     : SVGFELightElement(tagName, document)

--- a/Source/WebCore/svg/SVGFEDistantLightElement.h
+++ b/Source/WebCore/svg/SVGFEDistantLightElement.h
@@ -25,6 +25,8 @@
 namespace WebCore {
 
 class SVGFEDistantLightElement final : public SVGFELightElement {
+    WTF_MAKE_ISO_ALLOCATED(SVGFEDistantLightElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEDistantLightElement);
 public:
     static Ref<SVGFEDistantLightElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEDropShadowElement.h
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGFEDropShadowElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFEDropShadowElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEDropShadowElement);
 public:
     static Ref<SVGFEDropShadowElement> create(const QualifiedName&, Document&);
     

--- a/Source/WebCore/svg/SVGFEFloodElement.h
+++ b/Source/WebCore/svg/SVGFEFloodElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGFEFloodElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFEFloodElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEFloodElement);
 public:
     static Ref<SVGFEFloodElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEFuncAElement.cpp
+++ b/Source/WebCore/svg/SVGFEFuncAElement.cpp
@@ -23,8 +23,11 @@
 
 #include "ImageBuffer.h"
 #include "SVGNames.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(SVGFEFuncAElement);
 
 inline SVGFEFuncAElement::SVGFEFuncAElement(const QualifiedName& tagName, Document& document)
     : SVGComponentTransferFunctionElement(tagName, document)

--- a/Source/WebCore/svg/SVGFEFuncAElement.h
+++ b/Source/WebCore/svg/SVGFEFuncAElement.h
@@ -25,6 +25,8 @@
 namespace WebCore {
 
 class SVGFEFuncAElement final : public SVGComponentTransferFunctionElement {
+    WTF_MAKE_ISO_ALLOCATED(SVGFEFuncAElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEFuncAElement);
 public:
     static Ref<SVGFEFuncAElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEFuncBElement.cpp
+++ b/Source/WebCore/svg/SVGFEFuncBElement.cpp
@@ -23,8 +23,11 @@
 
 #include "ImageBuffer.h"
 #include "SVGNames.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(SVGFEFuncBElement);
 
 inline SVGFEFuncBElement::SVGFEFuncBElement(const QualifiedName& tagName, Document& document)
     : SVGComponentTransferFunctionElement(tagName, document)

--- a/Source/WebCore/svg/SVGFEFuncBElement.h
+++ b/Source/WebCore/svg/SVGFEFuncBElement.h
@@ -25,6 +25,8 @@
 namespace WebCore {
 
 class SVGFEFuncBElement final : public SVGComponentTransferFunctionElement {
+    WTF_MAKE_ISO_ALLOCATED(SVGFEFuncBElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEFuncBElement);
 public:
     static Ref<SVGFEFuncBElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEFuncGElement.cpp
+++ b/Source/WebCore/svg/SVGFEFuncGElement.cpp
@@ -23,8 +23,11 @@
 
 #include "ImageBuffer.h"
 #include "SVGNames.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(SVGFEFuncGElement);
 
 inline SVGFEFuncGElement::SVGFEFuncGElement(const QualifiedName& tagName, Document& document)
     : SVGComponentTransferFunctionElement(tagName, document)

--- a/Source/WebCore/svg/SVGFEFuncGElement.h
+++ b/Source/WebCore/svg/SVGFEFuncGElement.h
@@ -25,6 +25,8 @@
 namespace WebCore {
 
 class SVGFEFuncGElement final : public SVGComponentTransferFunctionElement {
+    WTF_MAKE_ISO_ALLOCATED(SVGFEFuncGElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEFuncGElement);
 public:
     static Ref<SVGFEFuncGElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEFuncRElement.cpp
+++ b/Source/WebCore/svg/SVGFEFuncRElement.cpp
@@ -23,8 +23,11 @@
 
 #include "ImageBuffer.h"
 #include "SVGNames.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(SVGFEFuncRElement);
 
 inline SVGFEFuncRElement::SVGFEFuncRElement(const QualifiedName& tagName, Document& document)
     : SVGComponentTransferFunctionElement(tagName, document)

--- a/Source/WebCore/svg/SVGFEFuncRElement.h
+++ b/Source/WebCore/svg/SVGFEFuncRElement.h
@@ -25,6 +25,8 @@
 namespace WebCore {
 
 class SVGFEFuncRElement final : public SVGComponentTransferFunctionElement {
+    WTF_MAKE_ISO_ALLOCATED(SVGFEFuncRElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEFuncRElement);
 public:
     static Ref<SVGFEFuncRElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.h
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class SVGFEGaussianBlurElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFEGaussianBlurElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEGaussianBlurElement);
 public:
     static Ref<SVGFEGaussianBlurElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -30,6 +30,7 @@ namespace WebCore {
 
 class SVGFEImageElement final : public SVGFilterPrimitiveStandardAttributes, public SVGURIReference, public CachedImageClient {
     WTF_MAKE_ISO_ALLOCATED(SVGFEImageElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEImageElement);
 public:
     static Ref<SVGFEImageElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFELightElement.h
+++ b/Source/WebCore/svg/SVGFELightElement.h
@@ -31,6 +31,7 @@ class SVGFilter;
 
 class SVGFELightElement : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGFELightElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFELightElement);
 public:
     virtual Ref<LightSource> lightSource() const = 0;
     static SVGFELightElement* findLightElement(const SVGElement*);

--- a/Source/WebCore/svg/SVGFEMergeElement.h
+++ b/Source/WebCore/svg/SVGFEMergeElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGFEMergeElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFEMergeElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEMergeElement);
 public:
     static Ref<SVGFEMergeElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEMergeNodeElement.h
+++ b/Source/WebCore/svg/SVGFEMergeNodeElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGFEMergeNodeElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGFEMergeNodeElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEMergeNodeElement);
 public:
     static Ref<SVGFEMergeNodeElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEMorphologyElement.h
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.h
@@ -57,6 +57,7 @@ struct SVGPropertyTraits<MorphologyOperatorType> {
 
 class SVGFEMorphologyElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFEMorphologyElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEMorphologyElement);
 public:
     static Ref<SVGFEMorphologyElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEOffsetElement.h
+++ b/Source/WebCore/svg/SVGFEOffsetElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGFEOffsetElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFEOffsetElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEOffsetElement);
 public:
     static Ref<SVGFEOffsetElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFEPointLightElement.cpp
+++ b/Source/WebCore/svg/SVGFEPointLightElement.cpp
@@ -23,8 +23,11 @@
 
 #include "PointLightSource.h"
 #include "SVGNames.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(SVGFEPointLightElement);
 
 inline SVGFEPointLightElement::SVGFEPointLightElement(const QualifiedName& tagName, Document& document)
     : SVGFELightElement(tagName, document)

--- a/Source/WebCore/svg/SVGFEPointLightElement.h
+++ b/Source/WebCore/svg/SVGFEPointLightElement.h
@@ -25,6 +25,8 @@
 namespace WebCore {
 
 class SVGFEPointLightElement final : public SVGFELightElement {
+    WTF_MAKE_ISO_ALLOCATED(SVGFEPointLightElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEPointLightElement);
 public:
     static Ref<SVGFEPointLightElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.h
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.h
@@ -30,6 +30,7 @@ namespace WebCore {
 
 class SVGFESpecularLightingElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFESpecularLightingElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFESpecularLightingElement);
 public:
     static Ref<SVGFESpecularLightingElement> create(const QualifiedName&, Document&);
     void lightElementAttributeChanged(const SVGFELightElement*, const QualifiedName&);

--- a/Source/WebCore/svg/SVGFESpotLightElement.cpp
+++ b/Source/WebCore/svg/SVGFESpotLightElement.cpp
@@ -23,8 +23,11 @@
 
 #include "SVGNames.h"
 #include "SpotLightSource.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(SVGFESpotLightElement);
 
 inline SVGFESpotLightElement::SVGFESpotLightElement(const QualifiedName& tagName, Document& document)
     : SVGFELightElement(tagName, document)

--- a/Source/WebCore/svg/SVGFESpotLightElement.h
+++ b/Source/WebCore/svg/SVGFESpotLightElement.h
@@ -25,6 +25,8 @@
 namespace WebCore {
 
 class SVGFESpotLightElement final : public SVGFELightElement {
+    WTF_MAKE_ISO_ALLOCATED(SVGFESpotLightElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFESpotLightElement);
 public:
     static Ref<SVGFESpotLightElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFETileElement.h
+++ b/Source/WebCore/svg/SVGFETileElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGFETileElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFETileElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFETileElement);
 public:
     static Ref<SVGFETileElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFETurbulenceElement.h
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.h
@@ -92,6 +92,7 @@ struct SVGPropertyTraits<TurbulenceType> {
 
 class SVGFETurbulenceElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFETurbulenceElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFETurbulenceElement);
 public:
     static Ref<SVGFETurbulenceElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFilterElement.h
+++ b/Source/WebCore/svg/SVGFilterElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class SVGFilterElement final : public SVGElement, public SVGURIReference {
     WTF_MAKE_ISO_ALLOCATED(SVGFilterElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFilterElement);
 public:
     static Ref<SVGFilterElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
@@ -35,6 +35,7 @@ class SVGFilter;
 
 class SVGFilterPrimitiveStandardAttributes : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGFilterPrimitiveStandardAttributes);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFilterPrimitiveStandardAttributes);
 public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFilterPrimitiveStandardAttributes, SVGElement>;
 

--- a/Source/WebCore/svg/SVGFontElement.h
+++ b/Source/WebCore/svg/SVGFontElement.h
@@ -41,6 +41,7 @@ struct SVGKerningPair {
 
 class SVGFontElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGFontElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFontElement);
 public:
     static Ref<SVGFontElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFontFaceElement.h
+++ b/Source/WebCore/svg/SVGFontFaceElement.h
@@ -30,6 +30,7 @@ class StyleRuleFontFace;
 
 class SVGFontFaceElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGFontFaceElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFontFaceElement);
 public:
     static Ref<SVGFontFaceElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFontFaceFormatElement.h
+++ b/Source/WebCore/svg/SVGFontFaceFormatElement.h
@@ -25,6 +25,7 @@ namespace WebCore {
 
 class SVGFontFaceFormatElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGFontFaceFormatElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFontFaceFormatElement);
 public:
     static Ref<SVGFontFaceFormatElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFontFaceNameElement.h
+++ b/Source/WebCore/svg/SVGFontFaceNameElement.h
@@ -27,6 +27,7 @@ class CSSFontFaceSrcLocalValue;
 
 class SVGFontFaceNameElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGFontFaceNameElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFontFaceNameElement);
 public:
     static Ref<SVGFontFaceNameElement> create(const QualifiedName&, Document&);
     

--- a/Source/WebCore/svg/SVGFontFaceSrcElement.h
+++ b/Source/WebCore/svg/SVGFontFaceSrcElement.h
@@ -27,6 +27,7 @@ class CSSValueList;
 
 class SVGFontFaceSrcElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGFontFaceSrcElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFontFaceSrcElement);
 public:
     static Ref<SVGFontFaceSrcElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGFontFaceUriElement.h
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.h
@@ -29,6 +29,7 @@ class CSSFontFaceSrcResourceValue;
 
 class SVGFontFaceUriElement final : public SVGElement, public CachedFontClient {
     WTF_MAKE_ISO_ALLOCATED(SVGFontFaceUriElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFontFaceUriElement);
 public:
     static Ref<SVGFontFaceUriElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGForeignObjectElement.h
+++ b/Source/WebCore/svg/SVGForeignObjectElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGForeignObjectElement final : public SVGGraphicsElement {
     WTF_MAKE_ISO_ALLOCATED(SVGForeignObjectElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGForeignObjectElement);
 public:
     static Ref<SVGForeignObjectElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGGElement.h
+++ b/Source/WebCore/svg/SVGGElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGGElement final : public SVGGraphicsElement {
     WTF_MAKE_ISO_ALLOCATED(SVGGElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGGElement);
 public:
     static Ref<SVGGElement> create(const QualifiedName&, Document&);
     static Ref<SVGGElement> create(Document&);

--- a/Source/WebCore/svg/SVGGeometryElement.h
+++ b/Source/WebCore/svg/SVGGeometryElement.h
@@ -33,6 +33,7 @@ class SVGPoint;
 
 class SVGGeometryElement : public SVGGraphicsElement {
     WTF_MAKE_ISO_ALLOCATED(SVGGeometryElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGGeometryElement);
 public:
     virtual float getTotalLength() const;
     virtual ExceptionOr<Ref<SVGPoint>> getPointAtLength(float distance) const;

--- a/Source/WebCore/svg/SVGGlyphElement.h
+++ b/Source/WebCore/svg/SVGGlyphElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGGlyphElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGGlyphElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGGlyphElement);
 public:
     static Ref<SVGGlyphElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGGlyphRefElement.h
+++ b/Source/WebCore/svg/SVGGlyphRefElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGGlyphRefElement final : public SVGElement, public SVGURIReference {
     WTF_MAKE_ISO_ALLOCATED(SVGGlyphRefElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGGlyphRefElement);
 public:
     static Ref<SVGGlyphRefElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGGradientElement.h
+++ b/Source/WebCore/svg/SVGGradientElement.h
@@ -71,6 +71,7 @@ struct SVGPropertyTraits<SVGSpreadMethodType> {
 
 class SVGGradientElement : public SVGElement, public SVGURIReference {
     WTF_MAKE_ISO_ALLOCATED(SVGGradientElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGGradientElement);
 public:
     enum {
         SVG_SPREADMETHOD_UNKNOWN = SVGSpreadMethodUnknown,

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -34,6 +34,7 @@ class SVGMatrix;
 
 class SVGGraphicsElement : public SVGElement, public SVGTransformable, public SVGTests {
     WTF_MAKE_ISO_ALLOCATED(SVGGraphicsElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGGraphicsElement);
 public:
     virtual ~SVGGraphicsElement();
 

--- a/Source/WebCore/svg/SVGHKernElement.h
+++ b/Source/WebCore/svg/SVGHKernElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGHKernElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGHKernElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGHKernElement);
 public:
     static Ref<SVGHKernElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class SVGImageElement final : public SVGGraphicsElement, public SVGURIReference {
     WTF_MAKE_ISO_ALLOCATED(SVGImageElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGImageElement);
 public:
     static Ref<SVGImageElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGLineElement.h
+++ b/Source/WebCore/svg/SVGLineElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class SVGLineElement final : public SVGGeometryElement {
     WTF_MAKE_ISO_ALLOCATED(SVGLineElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGLineElement);
 public:
     static Ref<SVGLineElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGLinearGradientElement.h
+++ b/Source/WebCore/svg/SVGLinearGradientElement.h
@@ -30,6 +30,7 @@ struct LinearGradientAttributes;
 
 class SVGLinearGradientElement final : public SVGGradientElement {
     WTF_MAKE_ISO_ALLOCATED(SVGLinearGradientElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGLinearGradientElement);
 public:
     static Ref<SVGLinearGradientElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGMPathElement.h
+++ b/Source/WebCore/svg/SVGMPathElement.h
@@ -30,6 +30,7 @@ class SVGPathElement;
 
 class SVGMPathElement final : public SVGElement, public SVGURIReference {
     WTF_MAKE_ISO_ALLOCATED(SVGMPathElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGMPathElement);
 public:
     static Ref<SVGMPathElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGMarkerElement.h
+++ b/Source/WebCore/svg/SVGMarkerElement.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class SVGMarkerElement final : public SVGElement, public SVGFitToViewBox {
     WTF_MAKE_ISO_ALLOCATED(SVGMarkerElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGMarkerElement);
 public:
     // Forward declare enumerations in the W3C naming scheme, for IDL generation.
     enum {

--- a/Source/WebCore/svg/SVGMaskElement.h
+++ b/Source/WebCore/svg/SVGMaskElement.h
@@ -31,6 +31,7 @@ enum class RepaintRectCalculation : bool;
 
 class SVGMaskElement final : public SVGElement, public SVGTests {
     WTF_MAKE_ISO_ALLOCATED(SVGMaskElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGMaskElement);
 public:
     static Ref<SVGMaskElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGMetadataElement.h
+++ b/Source/WebCore/svg/SVGMetadataElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGMetadataElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGMetadataElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGMetadataElement);
 public:
     static Ref<SVGMetadataElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGMissingGlyphElement.h
+++ b/Source/WebCore/svg/SVGMissingGlyphElement.h
@@ -26,6 +26,7 @@ namespace WebCore {
 
 class SVGMissingGlyphElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGMissingGlyphElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGMissingGlyphElement);
 public:
     static Ref<SVGMissingGlyphElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -34,6 +34,7 @@ class SVGPoint;
 
 class SVGPathElement final : public SVGGeometryElement {
     WTF_MAKE_ISO_ALLOCATED(SVGPathElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGPathElement);
 public:
     static Ref<SVGPathElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -34,6 +34,7 @@ struct PatternAttributes;
  
 class SVGPatternElement final : public SVGElement, public SVGFitToViewBox, public SVGTests, public SVGURIReference {
     WTF_MAKE_ISO_ALLOCATED(SVGPatternElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGPatternElement);
 public:
     static Ref<SVGPatternElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGPolyElement.h
+++ b/Source/WebCore/svg/SVGPolyElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class SVGPolyElement : public SVGGeometryElement {
     WTF_MAKE_ISO_ALLOCATED(SVGPolyElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGPolyElement);
 public:
     const SVGPointList& points() const { return m_points->currentValue(); }
 

--- a/Source/WebCore/svg/SVGPolygonElement.h
+++ b/Source/WebCore/svg/SVGPolygonElement.h
@@ -26,6 +26,7 @@ namespace WebCore {
 
 class SVGPolygonElement final : public SVGPolyElement {
     WTF_MAKE_ISO_ALLOCATED(SVGPolygonElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGPolygonElement);
 public:
     static Ref<SVGPolygonElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGPolylineElement.h
+++ b/Source/WebCore/svg/SVGPolylineElement.h
@@ -26,6 +26,7 @@ namespace WebCore {
 
 class SVGPolylineElement final : public SVGPolyElement {
     WTF_MAKE_ISO_ALLOCATED(SVGPolylineElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGPolylineElement);
 public:
     static Ref<SVGPolylineElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGRadialGradientElement.h
+++ b/Source/WebCore/svg/SVGRadialGradientElement.h
@@ -30,6 +30,7 @@ struct RadialGradientAttributes;
 
 class SVGRadialGradientElement final : public SVGGradientElement {
     WTF_MAKE_ISO_ALLOCATED(SVGRadialGradientElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGRadialGradientElement);
 public:
     static Ref<SVGRadialGradientElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGRectElement.h
+++ b/Source/WebCore/svg/SVGRectElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class SVGRectElement final : public SVGGeometryElement {
     WTF_MAKE_ISO_ALLOCATED(SVGRectElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGRectElement);
 public:
     static Ref<SVGRectElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -41,6 +41,7 @@ class SVGViewSpec;
 
 class SVGSVGElement final : public SVGGraphicsElement, public SVGFitToViewBox, public SVGZoomAndPan {
     WTF_MAKE_ISO_ALLOCATED(SVGSVGElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGSVGElement);
 public: // DOM
     float currentScale() const;
     void setCurrentScale(float);

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -30,6 +30,7 @@ namespace WebCore {
 
 class SVGScriptElement final : public SVGElement, public SVGURIReference, public ScriptElement {
     WTF_MAKE_ISO_ALLOCATED(SVGScriptElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGScriptElement);
 public:
     static Ref<SVGScriptElement> create(const QualifiedName&, Document&, bool wasInsertedByParser);
 

--- a/Source/WebCore/svg/SVGSetElement.h
+++ b/Source/WebCore/svg/SVGSetElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 // SVGAnimateElement implements superset of the functionality.
 class SVGSetElement final : public SVGAnimateElementBase {
     WTF_MAKE_ISO_ALLOCATED(SVGSetElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGSetElement);
 public:
     static Ref<SVGSetElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGStopElement.h
+++ b/Source/WebCore/svg/SVGStopElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGStopElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGStopElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGStopElement);
 public:
     static Ref<SVGStopElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGStyleElement.h
+++ b/Source/WebCore/svg/SVGStyleElement.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class SVGStyleElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGStyleElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGStyleElement);
 public:
     static Ref<SVGStyleElement> create(const QualifiedName&, Document&, bool createdByParser);
     virtual ~SVGStyleElement();

--- a/Source/WebCore/svg/SVGSwitchElement.h
+++ b/Source/WebCore/svg/SVGSwitchElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGSwitchElement final : public SVGGraphicsElement {
     WTF_MAKE_ISO_ALLOCATED(SVGSwitchElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGSwitchElement);
 public:
     static Ref<SVGSwitchElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGSymbolElement.h
+++ b/Source/WebCore/svg/SVGSymbolElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class SVGSymbolElement final : public SVGGraphicsElement, public SVGFitToViewBox {
     WTF_MAKE_ISO_ALLOCATED(SVGSymbolElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGSymbolElement);
 public:
     static Ref<SVGSymbolElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGTRefElement.h
+++ b/Source/WebCore/svg/SVGTRefElement.h
@@ -30,6 +30,7 @@ class SVGTRefTargetEventListener;
 
 class SVGTRefElement final : public SVGTextPositioningElement, public SVGURIReference {
     WTF_MAKE_ISO_ALLOCATED(SVGTRefElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGTRefElement);
 public:
     static Ref<SVGTRefElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGTSpanElement.h
+++ b/Source/WebCore/svg/SVGTSpanElement.h
@@ -26,6 +26,7 @@ namespace WebCore {
 
 class SVGTSpanElement final : public SVGTextPositioningElement {
     WTF_MAKE_ISO_ALLOCATED(SVGTSpanElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGTSpanElement);
 public:
     static Ref<SVGTSpanElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGTextContentElement.h
+++ b/Source/WebCore/svg/SVGTextContentElement.h
@@ -63,6 +63,7 @@ template<> struct SVGPropertyTraits<SVGLengthAdjustType> {
 
 class SVGTextContentElement : public SVGGraphicsElement {
     WTF_MAKE_ISO_ALLOCATED(SVGTextContentElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGTextContentElement);
 public:
     enum {
         LENGTHADJUST_UNKNOWN = SVGLengthAdjustUnknown,

--- a/Source/WebCore/svg/SVGTextElement.h
+++ b/Source/WebCore/svg/SVGTextElement.h
@@ -26,6 +26,7 @@ namespace WebCore {
 
 class SVGTextElement final : public SVGTextPositioningElement {
     WTF_MAKE_ISO_ALLOCATED(SVGTextElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGTextElement);
 public:
     static Ref<SVGTextElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGTextPathElement.h
+++ b/Source/WebCore/svg/SVGTextPathElement.h
@@ -99,6 +99,7 @@ struct SVGPropertyTraits<SVGTextPathSpacingType> {
 
 class SVGTextPathElement final : public SVGTextContentElement, public SVGURIReference {
     WTF_MAKE_ISO_ALLOCATED(SVGTextPathElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGTextPathElement);
 public:
     // Forward declare enumerations in the W3C naming scheme, for IDL generation.
     enum {

--- a/Source/WebCore/svg/SVGTextPositioningElement.h
+++ b/Source/WebCore/svg/SVGTextPositioningElement.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class SVGTextPositioningElement : public SVGTextContentElement {
     WTF_MAKE_ISO_ALLOCATED(SVGTextPositioningElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGTextPositioningElement);
 public:
     static SVGTextPositioningElement* elementFromRenderer(RenderBoxModelObject&);
 

--- a/Source/WebCore/svg/SVGTitleElement.h
+++ b/Source/WebCore/svg/SVGTitleElement.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class SVGTitleElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGTitleElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGTitleElement);
 public:
     static Ref<SVGTitleElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGUnknownElement.h
+++ b/Source/WebCore/svg/SVGUnknownElement.h
@@ -37,6 +37,7 @@ namespace WebCore {
 // false to make sure we don't attempt to render such elements.
 class SVGUnknownElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGUnknownElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGUnknownElement);
 public:
     static Ref<SVGUnknownElement> create(const QualifiedName& tagName, Document& document)
     {

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -32,6 +32,7 @@ class CachedSVGDocument;
 
 class SVGUseElement final : public SVGGraphicsElement, public SVGURIReference, private CachedSVGDocumentClient {
     WTF_MAKE_ISO_ALLOCATED(SVGUseElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGUseElement);
 public:
     static Ref<SVGUseElement> create(const QualifiedName&, Document&);
     virtual ~SVGUseElement();

--- a/Source/WebCore/svg/SVGVKernElement.h
+++ b/Source/WebCore/svg/SVGVKernElement.h
@@ -26,6 +26,7 @@ namespace WebCore {
 
 class SVGVKernElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGVKernElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGVKernElement);
 public:
     static Ref<SVGVKernElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGViewElement.h
+++ b/Source/WebCore/svg/SVGViewElement.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class SVGViewElement final : public SVGElement, public SVGFitToViewBox, public SVGZoomAndPan {
     WTF_MAKE_ISO_ALLOCATED(SVGViewElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGViewElement);
 public:
     static Ref<SVGViewElement> create(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -43,6 +43,7 @@ using SMILEventSender = EventSender<SVGSMILElement, WeakPtrImplWithEventTargetDa
 // This class implements SMIL interval timing model as needed for SVG animation.
 class SVGSMILElement : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGSMILElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGSMILElement);
 public:
     SVGSMILElement(const QualifiedName&, Document&, UniqueRef<SVGPropertyRegistry>&&);
     virtual ~SVGSMILElement();


### PR DESCRIPTION
#### c7c0f944e9e9b8a1bd3e3b5753fba4713a986df9
<pre>
Use CheckedPtr for DOM tree pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=277060">https://bugs.webkit.org/show_bug.cgi?id=277060</a>

Reviewed by Ryosuke Niwa.

Use CheckedPtr for DOM tree pointers, for extra safety.

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeAllChildrenWithScriptAssertion):
(WebCore::ContainerNode::insertBeforeCommon):
* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::firstChild const):
(WebCore::ContainerNode::protectedFirstChild const):
(WebCore::ContainerNode::lastChild const):
(WebCore::ContainerNode::protectedLastChild const):
(WebCore::ContainerNode::hasChildNodes const):
(): Deleted.
* Source/WebCore/dom/Node.cpp:
* Source/WebCore/dom/Node.h:
(WebCore::Node::nextSibling const):
(WebCore::Node::protectedNextSibling const):
(WebCore::Node::parentNode const):

Canonical link: <a href="https://commits.webkit.org/281399@main">https://commits.webkit.org/281399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e579849145a3281ed5002018f2e71b4d43e070b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63589 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10197 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48406 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7135 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29244 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8906 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9120 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65320 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55749 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55881 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2988 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8935 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34832 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35915 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37001 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35660 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->