### PR TITLE
[JSC] Add ChangePrototype transition

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -7461,7 +7461,7 @@ AccessGenerationResult InlineCacheCompiler::compileOneAccessCaseHandler(Polymorp
     if (statelessType) {
         auto stub = createPreCompiledICJITStubRoutine(WTFMove(code), vm);
         connectWatchpointSets(stub->watchpoints(), stub->watchpointSet(), WTFMove(m_conditions), WTFMove(additionalWatchpointSets));
-        dataLogLnIf(InlineCacheCompilerInternal::verbose, "Installing ", m_stubInfo.accessType, " / ", stub->cases().first()->m_type);
+        dataLogLnIf(InlineCacheCompilerInternal::verbose, "Installing ", m_stubInfo.accessType, " / ", accessCase.m_type);
         vm.m_sharedJITStubs->setStatelessStub(statelessType.value(), Ref { stub });
         return finishPreCompiledCodeGeneration(WTFMove(stub));
     }

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -52,13 +52,13 @@ inline void StructureTransitionTable::setSingleTransition(VM& vm, JSCell* owner,
     vm.writeBarrier(owner, structure);
 }
 
-bool StructureTransitionTable::contains(UniquedStringImpl* rep, unsigned attributes, TransitionKind transitionKind) const
+bool StructureTransitionTable::contains(PointerKey rep, unsigned attributes, TransitionKind transitionKind) const
 {
     if (isUsingSingleSlot()) {
         Structure* transition = trySingleTransition();
-        return transition && transition->m_transitionPropertyName == rep && transition->transitionPropertyAttributes() == attributes && transition->transitionKind() == transitionKind;
+        return transition && transition->m_transitionPropertyName == rep.pointer() && transition->transitionPropertyAttributes() == attributes && transition->transitionKind() == transitionKind;
     }
-    return map()->get(StructureTransitionTable::Hash::Key(rep, attributes, transitionKind));
+    return map()->get(StructureTransitionTable::Hash::createKey(rep, attributes, transitionKind));
 }
 
 void StructureTransitionTable::add(VM& vm, JSCell* owner, Structure* structure)
@@ -79,7 +79,7 @@ void StructureTransitionTable::add(VM& vm, JSCell* owner, Structure* structure)
     }
 
     // Add the structure to the map.
-    map()->set(StructureTransitionTable::Hash::Key(structure->m_transitionPropertyName.get(), structure->transitionPropertyAttributes(), structure->transitionKind()), structure);
+    map()->set(StructureTransitionTable::Hash::createFromStructure(structure), structure);
 }
 
 void Structure::dumpStatistics()
@@ -432,7 +432,7 @@ PropertyTable* Structure::materializePropertyTable(VM& vm, bool setPropertyTable
 
     for (size_t i = structures.size(); i--;) {
         structure = structures[i];
-        if (!structure->m_transitionPropertyName || structure->transitionKind() == TransitionKind::SetBrand)
+        if (!structure->m_transitionPropertyName)
             continue;
         switch (structure->transitionKind()) {
         case TransitionKind::PropertyAddition: {
@@ -456,6 +456,9 @@ PropertyTable* Structure::materializePropertyTable(VM& vm, bool setPropertyTable
             PropertyOffset offset = table->updateAttributeIfExists(structure->m_transitionPropertyName.get(), structure->transitionPropertyAttributes());
             ASSERT_UNUSED(offset, offset == structure->transitionOffset());
             break;
+        }
+        case TransitionKind::SetBrand: {
+            continue;
         }
         default:
             ASSERT_NOT_REACHED();
@@ -672,15 +675,35 @@ Structure* Structure::changePrototypeTransition(VM& vm, Structure* structure, JS
     ASSERT(isValidPrototype(prototype));
 
     DeferGC deferGC(vm);
+    JSObject* key = prototype.isNull() ? nullptr : asObject(prototype);
+
+    bool shouldChain = !structure->hasPolyProto() && structure->typeInfo().type() != GlobalObjectType && !structure->hasBeenDictionary();
+    if (shouldChain) {
+        ASSERT(structure->isObject());
+        if (Structure* existingTransition = structure->m_transitionTable.get(key, 0, TransitionKind::ChangePrototype)) {
+            ASSERT(!existingTransition->hasPolyProto());
+            existingTransition->checkOffsetConsistency();
+            return existingTransition;
+        }
+    }
+
+    // Changing [[Prototype]] means that we refresh this object completely.
+    // This is very likely that this object will behaves differently from the previous one.
+    // Let's pin the table and break the edge to the previous Structure.
     Structure* transition = Structure::create(vm, structure, &deferred);
-
-    transition->m_prototype.set(vm, transition, prototype);
-
     PropertyTable* table = structure->copyPropertyTableForPinning(vm);
     transition->pin(Locker { transition->m_lock }, vm, table);
+    transition->m_prototype.set(vm, transition, prototype);
+    transition->setTransitionKind(TransitionKind::ChangePrototype);
     transition->setMaxOffset(vm, structure->maxOffset());
-    
+    checkOffset(transition->transitionOffset(), transition->inlineCapacity());
+    if (shouldChain) {
+        GCSafeConcurrentJSLocker locker(structure->m_lock, vm);
+        structure->m_transitionTable.add(vm, structure, transition);
+    }
+
     transition->checkOffsetConsistency();
+    structure->checkOffsetConsistency();
     return transition;
 }
 
@@ -1677,6 +1700,9 @@ void dumpTransitionKind(PrintStream& out, TransitionKind kind)
         break;
     case TransitionKind::BecomePrototype:
         kindName = "BecomePrototype";
+        break;
+    case TransitionKind::ChangePrototype:
+        kindName = "ChangePrototype";
         break;
     case TransitionKind::SetBrand:
         kindName = "SetBrand";

--- a/Source/JavaScriptCore/runtime/StructureTransitionTable.h
+++ b/Source/JavaScriptCore/runtime/StructureTransitionTable.h
@@ -59,9 +59,10 @@ enum class TransitionKind : uint8_t {
     Seal = 13,
     Freeze = 14,
     BecomePrototype = 15,
+    ChangePrototype = 16,
 
     // Support for transitions related with private brand
-    SetBrand = 16
+    SetBrand = 17,
 };
 
 static constexpr auto FirstNonPropertyTransitionKind = TransitionKind::AllocateUndecided;
@@ -151,10 +152,32 @@ inline bool setsReadOnlyOnNonAccessorProperties(TransitionKind transition)
 class StructureTransitionTable {
     static constexpr intptr_t UsingSingleSlotFlag = 1;
 
-    
+    class PointerKey {
+    public:
+        PointerKey(UniquedStringImpl* uid) : m_pointer(bitwise_cast<uintptr_t>(uid)) { }
+        PointerKey(JSObject* object) : m_pointer(bitwise_cast<uintptr_t>(object)) { }
+        constexpr PointerKey(std::nullptr_t) { }
+
+        uintptr_t raw() const { return m_pointer; }
+        void* pointer() const { return bitwise_cast<void*>(m_pointer); }
+
+        static PointerKey fromRaw(uintptr_t key)
+        {
+            return PointerKey(key);
+        }
+
+        friend bool operator==(const PointerKey&, const PointerKey&) = default;
+
+    private:
+        constexpr PointerKey(uintptr_t key) : m_pointer(key) { }
+
+        uintptr_t m_pointer { 0 };
+    };
+    static_assert(sizeof(PointerKey) == sizeof(void*));
+
 #if CPU(ADDRESS64)
     struct Hash {
-        // Logically, Key is a tuple of (1) UniquedStringImpl*, (2) unsigned attributes, and (3) transitionKind.
+        // Logically, Key is a tuple of (1) PointerKey (at least it needs to be 8-byte aligned), (2) unsigned attributes, and (3) transitionKind.
         struct Key {
             friend struct Hash;
             static_assert(WTF_OS_CONSTANT_EFFECTIVE_ADDRESS_WIDTH <= 48);
@@ -164,14 +187,15 @@ class StructureTransitionTable {
             static constexpr uintptr_t hashTableDeletedValue = 0x2;
             static_assert(sizeof(TransitionPropertyAttributes) * 8 <= 8);
             static_assert(sizeof(TransitionKind) * 8 <= 8);
-            static_assert(hashTableDeletedValue < alignof(UniquedStringImpl));
+            static_assert(hashTableDeletedValue < 8);
 
             // Highest 8 bits are for TransitionKind; next 8 belong to TransitionPropertyAttributes.
-            // Remaining bits are for UniquedStringImpl*.
-            Key(UniquedStringImpl* impl, unsigned attributes, TransitionKind transitionKind)
-                : m_encodedData(bitwise_cast<uintptr_t>(impl) | (static_cast<uintptr_t>(attributes) << attributesShift) | (static_cast<uintptr_t>(transitionKind) << transitionKindShift))
+            // Remaining bits are for PointerKey.
+            Key(PointerKey impl, unsigned attributes, TransitionKind transitionKind)
+                : m_encodedData(impl.raw() | (static_cast<uintptr_t>(attributes) << attributesShift) | (static_cast<uintptr_t>(transitionKind) << transitionKindShift))
             {
                 ASSERT(impl == this->impl());
+                ASSERT(roundUpToMultipleOf<8>(impl.raw()) == impl.raw());
                 ASSERT(attributes <= UINT8_MAX);
                 ASSERT(attributes == this->attributes());
                 ASSERT(transitionKind != TransitionKind::Unknown);
@@ -186,7 +210,7 @@ class StructureTransitionTable {
 
             bool isHashTableDeletedValue() const { return m_encodedData == hashTableDeletedValue; }
 
-            UniquedStringImpl* impl() const { return bitwise_cast<UniquedStringImpl*>(m_encodedData & stringMask); }
+            PointerKey impl() const { return PointerKey::fromRaw(m_encodedData & stringMask); }
             TransitionPropertyAttributes attributes() const { return (m_encodedData >> attributesShift) & UINT8_MAX; }
             TransitionKind transitionKind() const { return static_cast<TransitionKind>(m_encodedData >> transitionKindShift); }
 
@@ -207,21 +231,33 @@ class StructureTransitionTable {
             return a == b;
         }
 
+        static Key createFromStructure(Structure*);
+        static Key createKey(PointerKey impl, unsigned attributes, TransitionKind transitionKind)
+        {
+            return Key { impl, attributes, transitionKind };
+        }
+
         static constexpr bool safeToCompareToEmptyOrDeleted = true;
     };
 #else
     struct Hash {
-        using Key = std::tuple<UniquedStringImpl*, unsigned, TransitionKind>;
+        using Key = std::tuple<void*, unsigned, TransitionKind>;
         using KeyTraits = HashTraits<Key>;
         
         static unsigned hash(const Key& p)
         {
-            return PtrHash<UniquedStringImpl*>::hash(std::get<0>(p)) + std::get<1>(p) + static_cast<unsigned>(std::get<2>(p));
+            return PtrHash<void*>::hash(std::get<0>(p)) + std::get<1>(p) + static_cast<unsigned>(std::get<2>(p));
         }
 
         static bool equal(const Key& a, const Key& b)
         {
             return a == b;
+        }
+
+        static Key createFromStructure(Structure*);
+        static Key createKey(PointerKey impl, unsigned attributes, TransitionKind transitionKind)
+        {
+            return Key { impl.pointer(), attributes, transitionKind };
         }
 
         static constexpr bool safeToCompareToEmptyOrDeleted = true;
@@ -242,8 +278,8 @@ public:
     }
 
     void add(VM&, JSCell* owner, Structure*);
-    bool contains(UniquedStringImpl*, unsigned attributes, TransitionKind) const;
-    Structure* get(UniquedStringImpl*, unsigned attributes, TransitionKind) const;
+    bool contains(PointerKey, unsigned attributes, TransitionKind) const;
+    Structure* get(PointerKey, unsigned attributes, TransitionKind) const;
 
     Structure* trySingleTransition() const;
 


### PR DESCRIPTION
#### 4d1e380621d4df47c82344c0ca20d2162169d6a1
<pre>
[JSC] Add ChangePrototype transition
<a href="https://bugs.webkit.org/show_bug.cgi?id=277061">https://bugs.webkit.org/show_bug.cgi?id=277061</a>
<a href="https://rdar.apple.com/132453886">rdar://132453886</a>

Reviewed by Keith Miller.

This patch adds transition tracking for changing [[Prototype]]. Some code is frequently changing [[Prototype]] to create a class,
and this patch teaches the code to use the same Structure by tracing the transition chain to leverage this characteristics in IC and other optimizations.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::StructureTransitionTable::contains const):
(JSC::StructureTransitionTable::add):
(JSC::Structure::materializePropertyTable):
(JSC::Structure::changePrototypeTransition):
(JSC::dumpTransitionKind):
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::StructureTransitionTable::Hash::createFromStructure):
(JSC::StructureTransitionTable::get const):
* Source/JavaScriptCore/runtime/StructureTransitionTable.h:
(JSC::StructureTransitionTable::PointerKey::PointerKey):
(JSC::StructureTransitionTable::PointerKey::raw const):
(JSC::StructureTransitionTable::PointerKey::pointer const):
(JSC::StructureTransitionTable::PointerKey::fromRaw):
(JSC::StructureTransitionTable::Hash::Key::Key):
(JSC::StructureTransitionTable::Hash::Key::impl const):
(JSC::StructureTransitionTable::Hash::createKey):
(JSC::StructureTransitionTable::Hash::hash):

Canonical link: <a href="https://commits.webkit.org/281414@main">https://commits.webkit.org/281414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a924f60042c06f8a24f15ec57eaa545da7136ba9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59838 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63755 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10362 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48530 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7250 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29374 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9053 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9285 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/52932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55187 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65485 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59083 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3766 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55870 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56011 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3129 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80841 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8956 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34997 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14031 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36080 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37166 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->