### PR TITLE
[JSC] Add UnwrapGlobalProxy

### DIFF
--- a/JSTests/microbenchmarks/global-this-access-get.js
+++ b/JSTests/microbenchmarks/global-this-access-get.js
@@ -1,0 +1,10 @@
+globalThis.value = 42;
+
+function test()
+{
+    return globalThis.value;
+}
+noInline(test);
+
+for (var i = 0; i < 1e8; ++i)
+    test();

--- a/JSTests/microbenchmarks/global-this-access-put.js
+++ b/JSTests/microbenchmarks/global-this-access-put.js
@@ -1,0 +1,10 @@
+globalThis.value = 42;
+
+function test(v)
+{
+    globalThis.value = v;
+}
+noInline(test);
+
+for (var i = 0; i < 1e8; ++i)
+    test(i);

--- a/Source/JavaScriptCore/bytecode/GetByStatus.h
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.h
@@ -139,6 +139,13 @@ public:
     void dump(PrintStream&) const;
 
     CacheableIdentifier singleIdentifier() const;
+
+    bool viaGlobalProxy() const
+    {
+        if (m_variants.isEmpty())
+            return false;
+        return m_variants.first().viaGlobalProxy();
+    }
     
 private:
     void merge(const GetByStatus&);

--- a/Source/JavaScriptCore/bytecode/GetByVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByVariant.cpp
@@ -32,9 +32,10 @@
 
 namespace JSC {
 
-GetByVariant::GetByVariant(CacheableIdentifier identifier, const StructureSet& structureSet, PropertyOffset offset, const ObjectPropertyConditionSet& conditionSet, std::unique_ptr<CallLinkStatus> callLinkStatus, JSFunction* intrinsicFunction, CodePtr<CustomAccessorPtrTag> customAccessorGetter, std::unique_ptr<DOMAttributeAnnotation> domAttribute)
+GetByVariant::GetByVariant(CacheableIdentifier identifier, const StructureSet& structureSet, bool viaGlobalProxy, PropertyOffset offset, const ObjectPropertyConditionSet& conditionSet, std::unique_ptr<CallLinkStatus> callLinkStatus, JSFunction* intrinsicFunction, CodePtr<CustomAccessorPtrTag> customAccessorGetter, std::unique_ptr<DOMAttributeAnnotation> domAttribute)
     : m_structureSet(structureSet)
     , m_conditionSet(conditionSet)
+    , m_viaGlobalProxy(viaGlobalProxy)
     , m_offset(offset)
     , m_callLinkStatus(WTFMove(callLinkStatus))
     , m_intrinsicFunction(intrinsicFunction)
@@ -63,6 +64,7 @@ GetByVariant& GetByVariant::operator=(const GetByVariant& other)
     m_identifier = other.m_identifier;
     m_structureSet = other.m_structureSet;
     m_conditionSet = other.m_conditionSet;
+    m_viaGlobalProxy = other.m_viaGlobalProxy;
     m_offset = other.m_offset;
     m_intrinsicFunction = other.m_intrinsicFunction;
     m_customAccessorGetter = other.m_customAccessorGetter;
@@ -104,6 +106,9 @@ bool GetByVariant::attemptToMerge(const GetByVariant& other)
         return false;
 
     if (m_identifier && (m_identifier != other.m_identifier))
+        return false;
+
+    if (m_viaGlobalProxy != other.m_viaGlobalProxy)
         return false;
 
     if (m_offset != other.m_offset)
@@ -192,6 +197,7 @@ void GetByVariant::dumpInContext(PrintStream& out, DumpContext* context) const
         return;
     }
     out.print(inContext(structureSet(), context), ", ", inContext(m_conditionSet, context));
+    out.print(", viaGlobalProxy = ", viaGlobalProxy());
     out.print(", offset = ", offset());
     if (m_callLinkStatus)
         out.print(", call = ", *m_callLinkStatus);

--- a/Source/JavaScriptCore/bytecode/GetByVariant.h
+++ b/Source/JavaScriptCore/bytecode/GetByVariant.h
@@ -47,7 +47,7 @@ class GetByVariant {
 public:
     GetByVariant(
         CacheableIdentifier,
-        const StructureSet& = StructureSet(), PropertyOffset = invalidOffset,
+        const StructureSet& = StructureSet(), bool viaGlobalProxy = false, PropertyOffset = invalidOffset,
         const ObjectPropertyConditionSet& = ObjectPropertyConditionSet(),
         std::unique_ptr<CallLinkStatus> = nullptr,
         JSFunction* = nullptr,
@@ -89,6 +89,8 @@ public:
 
     bool overlaps(const GetByVariant& other)
     {
+        if (m_viaGlobalProxy != other.m_viaGlobalProxy)
+            return true;
         if (!!m_identifier != !!other.m_identifier)
             return true;
         if (m_identifier) {
@@ -97,7 +99,9 @@ public:
         }
         return structureSet().overlaps(other.structureSet());
     }
-    
+
+    bool viaGlobalProxy() const { return m_viaGlobalProxy; }
+
 private:
     friend class GetByStatus;
 
@@ -105,6 +109,7 @@ private:
     
     StructureSet m_structureSet;
     ObjectPropertyConditionSet m_conditionSet;
+    bool m_viaGlobalProxy { false };
     PropertyOffset m_offset;
     std::unique_ptr<CallLinkStatus> m_callLinkStatus;
     JSFunction* m_intrinsicFunction;

--- a/Source/JavaScriptCore/bytecode/PutByStatus.h
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.h
@@ -140,7 +140,14 @@ public:
     const PutByVariant& at(size_t index) const { return m_variants[index]; }
     const PutByVariant& operator[](size_t index) const { return at(index); }
     CacheableIdentifier singleIdentifier() const;
-    
+
+    bool viaGlobalProxy() const
+    {
+        if (m_variants.isEmpty())
+            return false;
+        return m_variants.first().viaGlobalProxy();
+    }
+
     DECLARE_VISIT_AGGREGATE;
     template<typename Visitor> void markIfCheap(Visitor&);
     bool finalize(VM&);

--- a/Source/JavaScriptCore/bytecode/PutByVariant.h
+++ b/Source/JavaScriptCore/bytecode/PutByVariant.h
@@ -57,13 +57,13 @@ public:
     PutByVariant(const PutByVariant&);
     PutByVariant& operator=(const PutByVariant&);
 
-    static PutByVariant replace(CacheableIdentifier, const StructureSet&, PropertyOffset);
+    static PutByVariant replace(CacheableIdentifier, const StructureSet&, PropertyOffset, bool viaGlobalProxy);
     
     static PutByVariant transition(CacheableIdentifier, const StructureSet& oldStructure, Structure* newStructure, const ObjectPropertyConditionSet&, PropertyOffset);
     
-    static PutByVariant setter(CacheableIdentifier, const StructureSet&, PropertyOffset, const ObjectPropertyConditionSet&, std::unique_ptr<CallLinkStatus>);
+    static PutByVariant setter(CacheableIdentifier, const StructureSet&, PropertyOffset, bool viaGlobalProxy, const ObjectPropertyConditionSet&, std::unique_ptr<CallLinkStatus>);
 
-    static PutByVariant customSetter(CacheableIdentifier, const StructureSet&, const ObjectPropertyConditionSet&, CodePtr<CustomAccessorPtrTag>, std::unique_ptr<DOMAttributeAnnotation>&&);
+    static PutByVariant customSetter(CacheableIdentifier, const StructureSet&, bool viaGlobalProxy, const ObjectPropertyConditionSet&, CodePtr<CustomAccessorPtrTag>, std::unique_ptr<DOMAttributeAnnotation>&&);
 
     static PutByVariant proxy(CacheableIdentifier, const StructureSet&, std::unique_ptr<CallLinkStatus>);
     
@@ -147,6 +147,8 @@ public:
 
     bool overlaps(const PutByVariant& other)
     {
+        if (m_viaGlobalProxy != other.m_viaGlobalProxy)
+            return true;
         if (!!m_identifier != !!other.m_identifier)
             return true;
         if (m_identifier) {
@@ -156,6 +158,8 @@ public:
         return structureSet().overlaps(other.structureSet());
     }
 
+    bool viaGlobalProxy() const { return m_viaGlobalProxy; }
+
     CodePtr<CustomAccessorPtrTag> customAccessorSetter() const { return m_customAccessorSetter; }
     DOMAttributeAnnotation* domAttribute() const { return m_domAttribute.get(); }
 
@@ -163,6 +167,7 @@ private:
     bool attemptToMergeTransitionWithReplace(const PutByVariant& replace);
     
     Kind m_kind;
+    bool m_viaGlobalProxy { false };
     PropertyOffset m_offset { invalidOffset };
     StructureSet m_oldStructure;
     Structure* m_newStructure { nullptr };

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -40,6 +40,7 @@
 #include "JSDataView.h"
 #include "JSFunction.h"
 #include "JSGenericTypedArrayViewInlines.h"
+#include "JSGlobalProxy.h"
 #include "JSMap.h"
 #include "JSMapIterator.h"
 #include "JSPromise.h"
@@ -224,6 +225,11 @@ void dumpSpeculation(PrintStream& outStream, SpeculatedType value)
 
             if (value & SpecProxyObject)
                 strOut.print("ProxyObject");
+            else
+                isTop = false;
+
+            if (value & SpecGlobalProxy)
+                strOut.print("GlobalProxy");
             else
                 isTop = false;
 
@@ -516,6 +522,9 @@ SpeculatedType speculationFromClassInfoInheritance(const ClassInfo* classInfo)
     if (classInfo == ProxyObject::info())
         return SpecProxyObject;
 
+    if (classInfo->isSubClassOf(JSGlobalProxy::info()))
+        return SpecGlobalProxy;
+
     if (classInfo->isSubClassOf(JSDataView::info()))
         return SpecDataViewObject;
 
@@ -683,6 +692,8 @@ std::optional<SpeculatedType> speculationFromJSType(JSType type)
         return SpecDateObject;
     case ProxyObjectType:
         return SpecProxyObject;
+    case GlobalProxyType:
+        return SpecGlobalProxy;
     case JSPromiseType:
         return SpecPromiseObject;
     case JSMapType:
@@ -934,6 +945,8 @@ SpeculatedType speculationFromString(const char* speculation)
         return SpecWeakSetObject;
     if (!strncmp(speculation, "SpecProxyObject", strlen("SpecProxyObject")))
         return SpecProxyObject;
+    if (!strncmp(speculation, "SpecGlobalProxy", strlen("SpecGlobalProxy")))
+        return SpecGlobalProxy;
     if (!strncmp(speculation, "SpecDerivedArray", strlen("SpecDerivedArray")))
         return SpecDerivedArray;
     if (!strncmp(speculation, "SpecDataViewObject", strlen("SpecDataViewObject")))

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.h
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.h
@@ -65,26 +65,27 @@ static constexpr SpeculatedType SpecSetObject                         = 1ull << 
 static constexpr SpeculatedType SpecWeakMapObject                     = 1ull << 23; // It's definitely a WeakMap object or one of its subclasses.
 static constexpr SpeculatedType SpecWeakSetObject                     = 1ull << 24; // It's definitely a WeakSet object or one of its subclasses.
 static constexpr SpeculatedType SpecProxyObject                       = 1ull << 25; // It's definitely a Proxy object or one of its subclasses.
-static constexpr SpeculatedType SpecDerivedArray                      = 1ull << 26; // It's definitely a DerivedArray object.
-static constexpr SpeculatedType SpecObjectOther                       = 1ull << 27; // It's definitely an object but not JSFinalObject, JSArray, or JSFunction.
-static constexpr SpeculatedType SpecStringIdent                       = 1ull << 28; // It's definitely a JSString, and it's an identifier.
-static constexpr SpeculatedType SpecStringVar                         = 1ull << 29; // It's definitely a JSString, and it's not an identifier.
+static constexpr SpeculatedType SpecGlobalProxy                       = 1ull << 26; // It's definitely a Proxy object or one of its subclasses.
+static constexpr SpeculatedType SpecDerivedArray                      = 1ull << 27; // It's definitely a DerivedArray object.
+static constexpr SpeculatedType SpecObjectOther                       = 1ull << 28; // It's definitely an object but not JSFinalObject, JSArray, or JSFunction.
+static constexpr SpeculatedType SpecStringIdent                       = 1ull << 29; // It's definitely a JSString, and it's an identifier.
+static constexpr SpeculatedType SpecStringVar                         = 1ull << 30; // It's definitely a JSString, and it's not an identifier.
 static constexpr SpeculatedType SpecString                            = SpecStringIdent | SpecStringVar; // It's definitely a JSString.
-static constexpr SpeculatedType SpecSymbol                            = 1ull << 30; // It's definitely a Symbol.
-static constexpr SpeculatedType SpecCellOther                         = 1ull << 31; // It's definitely a JSCell but not a subclass of JSObject and definitely not a JSString, BigInt, or Symbol.
-static constexpr SpeculatedType SpecBoolInt32                         = 1ull << 32; // It's definitely an Int32 with value 0 or 1.
-static constexpr SpeculatedType SpecNonBoolInt32                      = 1ull << 33; // It's definitely an Int32 with value other than 0 or 1.
+static constexpr SpeculatedType SpecSymbol                            = 1ull << 31; // It's definitely a Symbol.
+static constexpr SpeculatedType SpecCellOther                         = 1ull << 32; // It's definitely a JSCell but not a subclass of JSObject and definitely not a JSString, BigInt, or Symbol.
+static constexpr SpeculatedType SpecBoolInt32                         = 1ull << 33; // It's definitely an Int32 with value 0 or 1.
+static constexpr SpeculatedType SpecNonBoolInt32                      = 1ull << 34; // It's definitely an Int32 with value other than 0 or 1.
 static constexpr SpeculatedType SpecInt32Only                         = SpecBoolInt32 | SpecNonBoolInt32; // It's definitely an Int32.
 
-static constexpr SpeculatedType SpecInt32AsInt52                      = 1ull << 34; // It's an Int52 and it can fit in an int32.
-static constexpr SpeculatedType SpecNonInt32AsInt52                   = 1ull << 35; // It's an Int52 and it can't fit in an int32.
+static constexpr SpeculatedType SpecInt32AsInt52                      = 1ull << 35; // It's an Int52 and it can fit in an int32.
+static constexpr SpeculatedType SpecNonInt32AsInt52                   = 1ull << 36; // It's an Int52 and it can't fit in an int32.
 static constexpr SpeculatedType SpecInt52Any                          = SpecInt32AsInt52 | SpecNonInt32AsInt52; // It's any kind of Int52.
 
-static constexpr SpeculatedType SpecAnyIntAsDouble                    = 1ull << 36; // It's definitely an Int52 and it's inside a double.
-static constexpr SpeculatedType SpecNonIntAsDouble                    = 1ull << 37; // It's definitely not an Int52 but it's a real number and it's a double.
+static constexpr SpeculatedType SpecAnyIntAsDouble                    = 1ull << 37; // It's definitely an Int52 and it's inside a double.
+static constexpr SpeculatedType SpecNonIntAsDouble                    = 1ull << 38; // It's definitely not an Int52 but it's a real number and it's a double.
 static constexpr SpeculatedType SpecDoubleReal                        = SpecNonIntAsDouble | SpecAnyIntAsDouble; // It's definitely a non-NaN double.
-static constexpr SpeculatedType SpecDoublePureNaN                     = 1ull << 38; // It's definitely a NaN that is safe to tag (i.e. pure).
-static constexpr SpeculatedType SpecDoubleImpureNaN                   = 1ull << 39; // It's definitely a NaN that is unsafe to tag (i.e. impure).
+static constexpr SpeculatedType SpecDoublePureNaN                     = 1ull << 39; // It's definitely a NaN that is safe to tag (i.e. pure).
+static constexpr SpeculatedType SpecDoubleImpureNaN                   = 1ull << 40; // It's definitely a NaN that is unsafe to tag (i.e. impure).
 static constexpr SpeculatedType SpecDoubleNaN                         = SpecDoublePureNaN | SpecDoubleImpureNaN; // It's definitely some kind of NaN.
 static constexpr SpeculatedType SpecBytecodeDouble                    = SpecDoubleReal | SpecDoublePureNaN; // It's either a non-NaN or a NaN double, but it's definitely not impure NaN.
 static constexpr SpeculatedType SpecFullDouble                        = SpecDoubleReal | SpecDoubleNaN; // It's either a non-NaN or a NaN double.
@@ -94,21 +95,21 @@ static constexpr SpeculatedType SpecBytecodeNumber                    = SpecInt3
 static constexpr SpeculatedType SpecIntAnyFormat                      = SpecInt52Any | SpecInt32Only | SpecAnyIntAsDouble;
 
 static constexpr SpeculatedType SpecFullNumber                        = SpecIntAnyFormat | SpecFullDouble; // It's either an Int32, Int52, or a Double, and the Double can be impure NaN.
-static constexpr SpeculatedType SpecBoolean                           = 1ull << 40; // It's definitely a Boolean.
-static constexpr SpeculatedType SpecOther                             = 1ull << 41; // It's definitely either Null or Undefined.
+static constexpr SpeculatedType SpecBoolean                           = 1ull << 41; // It's definitely a Boolean.
+static constexpr SpeculatedType SpecOther                             = 1ull << 42; // It's definitely either Null or Undefined.
 static constexpr SpeculatedType SpecMisc                              = SpecBoolean | SpecOther; // It's definitely either a boolean, Null, or Undefined.
-static constexpr SpeculatedType SpecEmpty                             = 1ull << 42; // It's definitely an empty value marker.
-static constexpr SpeculatedType SpecHeapBigInt                        = 1ull << 43; // It's definitely a BigInt that is allocated on the heap
-static constexpr SpeculatedType SpecBigInt32                          = 1ull << 44; // It's definitely a small BigInt that is inline the JSValue
+static constexpr SpeculatedType SpecEmpty                             = 1ull << 43; // It's definitely an empty value marker.
+static constexpr SpeculatedType SpecHeapBigInt                        = 1ull << 44; // It's definitely a BigInt that is allocated on the heap
+static constexpr SpeculatedType SpecBigInt32                          = 1ull << 45; // It's definitely a small BigInt that is inline the JSValue
 #if USE(BIGINT32)
 static constexpr SpeculatedType SpecBigInt                            = SpecBigInt32 | SpecHeapBigInt;
 #else
 // We should not include SpecBigInt32. We are using SpecBigInt in various places like prediction. If this includes SpecBigInt32, fixup phase is confused if !USE(BIGINT32) since it is not using AnyBigIntUse.
 static constexpr SpeculatedType SpecBigInt                            = SpecHeapBigInt;
 #endif
-static constexpr SpeculatedType SpecDataViewObject                    = 1ull << 45; // It's definitely a JSDataView.
+static constexpr SpeculatedType SpecDataViewObject                    = 1ull << 46; // It's definitely a JSDataView.
 static constexpr SpeculatedType SpecPrimitive                         = SpecString | SpecSymbol | SpecBytecodeNumber | SpecMisc | SpecBigInt; // It's any non-Object JSValue.
-static constexpr SpeculatedType SpecObject                            = SpecFinalObject | SpecArray | SpecFunction | SpecTypedArrayView | SpecDirectArguments | SpecScopedArguments | SpecStringObject | SpecRegExpObject | SpecDateObject | SpecPromiseObject | SpecMapObject | SpecSetObject | SpecWeakMapObject | SpecWeakSetObject | SpecProxyObject | SpecDerivedArray | SpecObjectOther | SpecDataViewObject; // Bitmask used for testing for any kind of object prediction.
+static constexpr SpeculatedType SpecObject                            = SpecFinalObject | SpecArray | SpecFunction | SpecTypedArrayView | SpecDirectArguments | SpecScopedArguments | SpecStringObject | SpecRegExpObject | SpecDateObject | SpecPromiseObject | SpecMapObject | SpecSetObject | SpecWeakMapObject | SpecWeakSetObject | SpecProxyObject | SpecGlobalProxy | SpecDerivedArray | SpecObjectOther | SpecDataViewObject; // Bitmask used for testing for any kind of object prediction.
 static constexpr SpeculatedType SpecCell                              = SpecObject | SpecString | SpecSymbol | SpecCellOther | SpecHeapBigInt; // It's definitely a JSCell.
 static constexpr SpeculatedType SpecHeapTop                           = SpecCell | SpecBigInt32 | SpecBytecodeNumber | SpecMisc; // It can be any of the above, except for SpecInt52Only and SpecDoubleImpureNaN.
 static constexpr SpeculatedType SpecBytecodeTop                       = SpecHeapTop | SpecEmpty; // It can be any of the above, except for SpecInt52Only and SpecDoubleImpureNaN. Corresponds to what could be found in a bytecode local.
@@ -237,6 +238,11 @@ inline bool isFunctionSpeculation(SpeculatedType value)
 inline bool isProxyObjectSpeculation(SpeculatedType value)
 {
     return value == SpecProxyObject;
+}
+
+inline bool isGlobalProxySpeculation(SpeculatedType value)
+{
+    return value == SpecGlobalProxy;
 }
 
 inline bool isDerivedArraySpeculation(SpeculatedType value)

--- a/Source/JavaScriptCore/dfg/DFGAbstractHeap.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractHeap.h
@@ -72,6 +72,7 @@ namespace JSC { namespace DFG {
     macro(RegExpState) \
     macro(MathDotRandomState) \
     macro(JSDateFields) \
+    macro(JSGlobalProxy_target) \
     macro(JSMapFields) \
     macro(JSSetFields) \
     macro(JSMapIteratorFields) \

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3753,8 +3753,13 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case UnwrapGlobalProxy: {
+        setTypeForNode(node, SpecObjectOther);
+        break;
+    }
+
     case GetGlobalThis: {
-        setTypeForNode(node, SpecObject);
+        setTypeForNode(node, SpecGlobalProxy);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -224,7 +224,12 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case CompareEqPtr:
         def(PureValue(node, node->cellOperand()->cell()));
         return;
-        
+
+    case UnwrapGlobalProxy:
+        read(JSGlobalProxy_target);
+        def(HeapLocation(GlobalProxyTargetLoc, JSGlobalProxy_target, node->child1()), LazyNode(node));
+        return;
+
     case ArithIMul:
     case ArithPow:
     case GetScope:

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -546,7 +546,7 @@ private:
                     
                     if (variant.kind() == PutByVariant::Transition
                         && variant.oldStructure().onlyStructure() == variant.newStructure()) {
-                        variant = PutByVariant::replace(variant.identifier(), variant.oldStructure(), variant.offset());
+                        variant = PutByVariant::replace(variant.identifier(), variant.oldStructure(), variant.offset(), variant.viaGlobalProxy());
                         changed = true;
                     }
                 }

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -123,6 +123,7 @@ bool doesGC(Graph& graph, Node* node)
     case SkipScope:
     case GetGlobalObject:
     case GetGlobalThis:
+    case UnwrapGlobalProxy:
     case GetClosureVar:
     case PutClosureVar:
     case GetInternalField:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1972,6 +1972,11 @@ private:
             fixEdge<KnownCellUse>(node->child1());
             break;
         }
+
+        case UnwrapGlobalProxy: {
+            fixEdge<GlobalProxyUse>(node->child1());
+            break;
+        }
             
         case AllocatePropertyStorage:
         case ReallocatePropertyStorage: {
@@ -3410,6 +3415,17 @@ private:
                         Edge(node->child1().node(), ProxyObjectUse));
                     m_graph.convertToConstant(node, jsBoolean(true));
                     observeUseKindOnNode<ProxyObjectUse>(node);
+                    return;
+                }
+                break;
+
+            case SpecGlobalProxy:
+                if (node->child1()->shouldSpeculateGlobalProxy()) {
+                    m_insertionSet.insertNode(
+                        m_indexInBlock, SpecNone, Check, node->origin,
+                        Edge(node->child1().node(), GlobalProxyUse));
+                    m_graph.convertToConstant(node, jsBoolean(true));
+                    observeUseKindOnNode<GlobalProxyUse>(node);
                     return;
                 }
                 break;

--- a/Source/JavaScriptCore/dfg/DFGHeapLocation.cpp
+++ b/Source/JavaScriptCore/dfg/DFGHeapLocation.cpp
@@ -93,6 +93,10 @@ void printInternal(PrintStream& out, LocationKind kind)
     case StackPayloadLoc:
         out.print("StackPayloadLoc");
         return;
+
+    case GlobalProxyTargetLoc:
+        out.print("GlobalProxyTargetLoc");
+        return;
         
     case ArrayLengthLoc:
         out.print("ArrayLengthLoc");

--- a/Source/JavaScriptCore/dfg/DFGHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGHeapLocation.h
@@ -73,6 +73,7 @@ enum LocationKind {
     PrototypeLoc,
     StackLoc,
     StackPayloadLoc,
+    GlobalProxyTargetLoc,
     DateFieldLoc,
     MapBucketLoc,
     MapBucketHeadLoc,

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -3029,6 +3029,11 @@ public:
         return isProxyObjectSpeculation(prediction());
     }
 
+    bool shouldSpeculateGlobalProxy()
+    {
+        return isGlobalProxySpeculation(prediction());
+    }
+
     bool shouldSpeculateDerivedArray()
     {
         return isDerivedArraySpeculation(prediction());

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -283,6 +283,7 @@ namespace JSC { namespace DFG {
     macro(ResolveScopeForHoistingFuncDeclInEval, NodeResultJS | NodeMustGenerate) \
     macro(GetGlobalObject, NodeResultJS) \
     macro(GetGlobalThis, NodeResultJS) \
+    macro(UnwrapGlobalProxy, NodeResultJS) \
     macro(GetClosureVar, NodeResultJS) \
     macro(PutClosureVar, NodeMustGenerate) \
     macro(GetGlobalVar, NodeResultJS) \

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -2536,13 +2536,15 @@ private:
                         // nodes. Those nodes were guarded by the appropriate type checks. This means that
                         // at this point, we can simply trust that the incoming value has the right type
                         // for whatever structure we are using.
-                        data->variants.append(PutByVariant::replace(nullptr, currentSet, currentOffset));
+                        // Now, this data is used directly for the base, so viaGlobalProxy or not does not matter.
+                        data->variants.append(PutByVariant::replace(nullptr, currentSet, currentOffset, /* viaGlobalProxy */ false));
                         currentOffset = offset;
                         currentSet.clear();
                     }
                     currentSet.add(structure.get());
                 }
-                data->variants.append(PutByVariant::replace(nullptr, currentSet, currentOffset));
+                // Now, this data is used directly for the base, so viaGlobalProxy or not does not matter.
+                data->variants.append(PutByVariant::replace(nullptr, currentSet, currentOffset, /* viaGlobalProxy */ false));
             }
 
             return m_graph.addNode(

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1262,13 +1262,14 @@ private:
             break;
 
         case SkipScope:
-        case GetGlobalObject: {
+        case GetGlobalObject:
+        case UnwrapGlobalProxy: {
             setPrediction(SpecObjectOther);
             break;
         }
 
         case GetGlobalThis:
-            setPrediction(SpecObject);
+            setPrediction(SpecGlobalProxy);
             break;
 
         case ResolveScope: {

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -67,6 +67,7 @@ public:
         case RegExpObjectUse:
         case PromiseObjectUse:
         case ProxyObjectUse:
+        case GlobalProxyUse:
         case DerivedArrayUse:
         case DateObjectUse:
         case MapObjectUse:
@@ -240,6 +241,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case SkipScope:
     case GetGlobalObject:
     case GetGlobalThis:
+    case UnwrapGlobalProxy:
     case GetClosureVar:
     case GetGlobalVar:
     case GetGlobalLexicalVariable:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1537,6 +1537,7 @@ public:
     void compileSkipScope(Node*);
     void compileGetGlobalObject(Node*);
     void compileGetGlobalThis(Node*);
+    void compileUnwrapGlobalProxy(Node*);
 
     void compileGetArrayLength(Node*);
 #if USE(LARGE_TYPED_ARRAYS)
@@ -1904,6 +1905,8 @@ public:
     void speculatePromiseObject(Edge, GPRReg cell);
     void speculateProxyObject(Edge, GPRReg cell);
     void speculateProxyObject(Edge);
+    void speculateGlobalProxy(Edge, GPRReg cell);
+    void speculateGlobalProxy(Edge);
     void speculateDerivedArray(Edge, GPRReg cell);
     void speculateDerivedArray(Edge);
     void speculateDateObject(Edge);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3294,6 +3294,10 @@ void SpeculativeJIT::compile(Node* node)
     case GetGlobalThis:
         compileGetGlobalThis(node);
         break;
+
+    case UnwrapGlobalProxy:
+        compileUnwrapGlobalProxy(node);
+        break;
         
     case GetClosureVar: {
         compileGetClosureVar(node);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4636,6 +4636,10 @@ void SpeculativeJIT::compile(Node* node)
     case GetGlobalThis:
         compileGetGlobalThis(node);
         break;
+
+    case UnwrapGlobalProxy:
+        compileUnwrapGlobalProxy(node);
+        break;
         
     case GetClosureVar: {
         compileGetClosureVar(node);

--- a/Source/JavaScriptCore/dfg/DFGUseKind.cpp
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.cpp
@@ -101,6 +101,9 @@ void printInternal(PrintStream& out, UseKind useKind)
     case ProxyObjectUse:
         out.print("ProxyObject");
         return;
+    case GlobalProxyUse:
+        out.print("GlobalProxy");
+        return;
     case DerivedArrayUse:
         out.print("DerivedArray");
         return;

--- a/Source/JavaScriptCore/dfg/DFGUseKind.h
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.h
@@ -58,6 +58,7 @@ enum UseKind : uint8_t {
     PromiseObjectUse,
     RegExpObjectUse,
     ProxyObjectUse,
+    GlobalProxyUse,
     DerivedArrayUse,
     ObjectOrOtherUse,
     StringIdentUse,
@@ -145,6 +146,8 @@ inline SpeculatedType typeFilterFor(UseKind useKind)
         return SpecRegExpObject;
     case ProxyObjectUse:
         return SpecProxyObject;
+    case GlobalProxyUse:
+        return SpecGlobalProxy;
     case DerivedArrayUse:
         return SpecDerivedArray;
     case ObjectOrOtherUse:
@@ -261,6 +264,7 @@ inline bool isCell(UseKind kind)
     case RegExpObjectUse:
     case PromiseObjectUse:
     case ProxyObjectUse:
+    case GlobalProxyUse:
     case DerivedArrayUse:
     case StringIdentUse:
     case StringUse:

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
@@ -33,6 +33,7 @@
 #include "HasOwnPropertyCache.h"
 #include "IndexingType.h"
 #include "JSGlobalObject.h"
+#include "JSGlobalProxy.h"
 #include "JSMap.h"
 #include "JSSet.h"
 #include "JSWeakMap.h"
@@ -118,6 +119,7 @@ namespace JSC { namespace FTL {
     macro(JSGlobalObject_regExpGlobalData_cachedResult_result_start, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfResult() + OBJECT_OFFSETOF(MatchResult, start)) \
     macro(JSGlobalObject_regExpGlobalData_cachedResult_result_end, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfResult() + OBJECT_OFFSETOF(MatchResult, end)) \
     macro(JSGlobalObject_regExpGlobalData_cachedResult_reified, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfReified()) \
+    macro(JSGlobalProxy_target, JSGlobalProxy::targetOffset()) \
     macro(JSObject_butterfly, JSObject::butterflyOffset()) \
     macro(JSPropertyNameEnumerator_cachedInlineCapacity, JSPropertyNameEnumerator::cachedInlineCapacityOffset()) \
     macro(JSPropertyNameEnumerator_cachedPropertyNamesVector, JSPropertyNameEnumerator::cachedPropertyNamesVectorOffset()) \

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -140,6 +140,7 @@ inline CapabilityLevel canCompile(Node* node)
     case SkipScope:
     case GetGlobalObject:
     case GetGlobalThis:
+    case UnwrapGlobalProxy:
     case CreateActivation:
     case PushWithScope:
     case NewFunction:
@@ -564,6 +565,7 @@ CapabilityLevel canCompile(Graph& graph)
                 case PromiseObjectUse:
                 case RegExpObjectUse:
                 case ProxyObjectUse:
+                case GlobalProxyUse:
                 case DerivedArrayUse:
                 case NotCellUse:
                 case NotCellNorBigIntUse:

--- a/Source/JavaScriptCore/runtime/JSType.h
+++ b/Source/JavaScriptCore/runtime/JSType.h
@@ -66,7 +66,7 @@ namespace JSC {
     macro(BooleanObjectType, SpecObjectOther) \
     macro(NumberObjectType, SpecObjectOther) \
     macro(ErrorInstanceType, SpecObjectOther) \
-    macro(GlobalProxyType, SpecObjectOther) \
+    macro(GlobalProxyType, SpecGlobalProxy) \
     macro(DirectArgumentsType, SpecDirectArguments) \
     macro(ScopedArgumentsType, SpecScopedArguments) \
     macro(ClonedArgumentsType, SpecObjectOther) \


### PR DESCRIPTION
#### babcb2b118a830294337bdfb5008cc70ae0a6632
<pre>
[JSC] Add UnwrapGlobalProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=277066">https://bugs.webkit.org/show_bug.cgi?id=277066</a>
<a href="https://rdar.apple.com/132459011">rdar://132459011</a>

Reviewed by Yijia Huang.

This patch adds GlobalProxy property access handling in DFG / FTL. Previously, we gave up completely and offloading it to IC in DFG / FTL.
But this patch collects viaGlobalProxy information in GetByStatus and PutByStatus and use this bit to emit `UnwrapGlobalProxy` DFG node with various
access optimization like GetByOffset etc. so that we can (1) model side effect of accesses better, (2) generate more efficient code inline, and (3) do
not need to use IC for obviously optimization simple cases in DFG / FTL. Attached microbenchmarks showed 24% improvement for Get and 19% improvement for Put.

                                   ToT                     Patched

global-this-access-get      183.9786+-0.3290     ^    148.3344+-1.2277        ^ definitely 1.2403x faster
global-this-access-put      215.5170+-0.9235     ^    181.2201+-0.5363        ^ definitely 1.1893x faster

* JSTests/microbenchmarks/global-this-access-get.js: Added.
(test):
* JSTests/microbenchmarks/global-this-access-put.js: Added.
(test):
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeFromLLInt):
(JSC::GetByStatus::computeForStubInfoWithoutExitSiteFeedback):
(JSC::GetByStatus::computeFor):
* Source/JavaScriptCore/bytecode/GetByStatus.h:
* Source/JavaScriptCore/bytecode/GetByVariant.cpp:
(JSC::GetByVariant::GetByVariant):
(JSC::GetByVariant::operator=):
(JSC::GetByVariant::attemptToMerge):
(JSC::GetByVariant::dumpInContext const):
* Source/JavaScriptCore/bytecode/GetByVariant.h:
(JSC::GetByVariant::overlaps):
(JSC::GetByVariant::viaGlobalProxy const):
* Source/JavaScriptCore/bytecode/PutByStatus.cpp:
(JSC::PutByStatus::computeFromLLInt):
(JSC::PutByStatus::computeForStubInfo):
(JSC::PutByStatus::computeFor):
* Source/JavaScriptCore/bytecode/PutByStatus.h:
* Source/JavaScriptCore/bytecode/PutByVariant.cpp:
(JSC::PutByVariant::operator=):
(JSC::PutByVariant::replace):
(JSC::PutByVariant::setter):
(JSC::PutByVariant::customSetter):
(JSC::PutByVariant::attemptToMerge):
(JSC::PutByVariant::attemptToMergeTransitionWithReplace):
(JSC::PutByVariant::dumpInContext const):
* Source/JavaScriptCore/bytecode/PutByVariant.h:
(JSC::PutByVariant::overlaps):
(JSC::PutByVariant::viaGlobalProxy const):
* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
(JSC::dumpSpeculation):
(JSC::speculationFromClassInfoInheritance):
(JSC::speculationFromJSType):
(JSC::speculationFromString):
* Source/JavaScriptCore/bytecode/SpeculatedType.h:
(JSC::isGlobalProxySpeculation):
* Source/JavaScriptCore/dfg/DFGAbstractHeap.h:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicGetter):
(JSC::DFG::ByteCodeParser::handleDOMJITGetter):
(JSC::DFG::ByteCodeParser::load):
(JSC::DFG::ByteCodeParser::handleGetById):
(JSC::DFG::ByteCodeParser::handleGetPrivateNameById):
(JSC::DFG::ByteCodeParser::handlePutById):
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
(JSC::DFG::FixupPhase::fixupIsCellWithType):
* Source/JavaScriptCore/dfg/DFGHeapLocation.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/dfg/DFGHeapLocation.h:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::shouldSpeculateGlobalProxy):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::SafeToExecuteEdge::operator()):
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGUseKind.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/dfg/DFGUseKind.h:
(JSC::DFG::typeFilterFor):
(JSC::DFG::isCell):
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h:
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileUnwrapGlobalProxy):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/JSType.h:

Canonical link: <a href="https://commits.webkit.org/281406@main">https://commits.webkit.org/281406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c185625fb7ced7d02687dd8cedd51f39fb78d700

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63639 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10247 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48440 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7163 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29279 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33160 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8950 "Found 2 new test failures: fullscreen/element-clear-during-fullscreen-crash.html imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9170 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/52817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55098 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65370 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58968 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9104 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55781 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55916 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3032 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80726 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8947 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34882 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14010 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35965 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37051 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->