### PR TITLE
Add limits to the number of ImageBuffers that the GPU process can create

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7874,6 +7874,8 @@ imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-
 
 # -- End: Anchor Positioning -- #
 
+fast/canvas/image-buffer-resource-limits.html [ Slow ]
+
 # Standardized CSS zoom tests.
 imported/w3c/web-platform-tests/css/css-viewport/width.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/border-spacing.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/canvas/image-buffer-resource-limits-expected.txt
+++ b/LayoutTests/fast/canvas/image-buffer-resource-limits-expected.txt
@@ -1,0 +1,36 @@
+Check that GPU process ImageBuffer resource limits are enforced
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS () => checkLimits(limits) is true
+Increasing canvas count to 500
+PASS () => renderingModeCounts.accelerated is 500
+PASS () => renderingModeCounts.unaccelerated is 0
+PASS () => renderingModeCounts.noBackend is 0
+Increasing canvas count to 5000
+PASS () => renderingModeCounts.accelerated is 5000
+PASS () => renderingModeCounts.unaccelerated is 0
+PASS () => renderingModeCounts.noBackend is 0
+Increasing canvas count to 5500
+PASS () => renderingModeCounts.accelerated is 5000
+PASS () => renderingModeCounts.unaccelerated is 500
+PASS () => renderingModeCounts.noBackend is 0
+PASS () => nonCanvasImageBufferRenderingMode == "Accelerated" is true
+Increasing canvas count to 50000
+PASS () => renderingModeCounts.accelerated is 5000
+PASS () => renderingModeCounts.unaccelerated is 45000
+PASS () => renderingModeCounts.noBackend is 0
+Increasing canvas count to 50500
+PASS () => renderingModeCounts.accelerated is 5000
+PASS () => renderingModeCounts.unaccelerated is 45000
+PASS () => renderingModeCounts.noBackend is 500
+Decreasing canvas count to 500
+Increasing canvas count to 600
+PASS () => renderingModeCounts.accelerated is 600
+PASS () => renderingModeCounts.unaccelerated is 0
+PASS () => renderingModeCounts.noBackend is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/image-buffer-resource-limits.html
+++ b/LayoutTests/fast/canvas/image-buffer-resource-limits.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<script src=../../resources/js-test-pre.js></script>
+<script>
+var jsTestIsAsync = true;
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+description("Check that GPU process ImageBuffer resource limits are enforced");
+
+// Waits until getImageBufferResourceLimits() returns values that match the
+// specified query. We do this because there is asynchrony involved in
+// these values (from IPC messages and the use of atomics), so cannot guarantee
+// that we will get the values we expect at the exact time of the call.
+async function imageBufferResourceLimitsMatch(query) {
+    for (;;) {
+        let limits = await internals.getImageBufferResourceLimits();
+        let queryMatched = true;
+        for (let key in query) {
+            let queryValue = query[key];
+            if (typeof queryValue == "number") {
+                if (limits[key] != queryValue)
+                    queryMatched = false;
+            } else {
+                if (!query[key](limits[key]))
+                    queryMatched = false;
+            }
+        }
+        if (queryMatched)
+            return true;
+    }
+}
+
+function checkLimits(limits) {
+    return limits.acceleratedImageBufferForCanvasLimit >= 1000 &&
+           (limits.globalAcceleratedImageBufferLimit - limits.acceleratedImageBufferForCanvasLimit) >= 1000 &&
+           (limits.imageBufferForCanvasLimit - limits.globalAcceleratedImageBufferLimit) >= 1000 &&
+           (limits.globalImageBufferForCanvasLimit - limits.imageBufferForCanvasLimit) >= 1000;
+}
+
+function growCanvasesTo(canvases, count) {
+    debug(`Increasing canvas count to ${count}`);
+    while (canvases.length < count) {
+        let e = document.createElement("canvas");
+        e.width = 10;
+        e.height = 10;
+        canvases.push(e);
+    }
+}
+
+function shrinkCanvasesTo(canvases, count) {
+    debug(`Decreasing canvas count to ${count}`);
+    canvases.length = count;
+}
+
+function getEffectiveRenderingModeCounts(canvases) {
+    let accelerated = 0;
+    let unaccelerated = 0;
+    let noBackend = 0;
+    for (let c of canvases) {
+        let m = c.getContext("2d").getEffectiveRenderingModeForTesting();
+        if (m == "Accelerated")
+            ++accelerated;
+        else if (m == "Unaccelerated")
+            ++unaccelerated;
+        else if (m === null)
+            ++noBackend;
+    }
+    return { accelerated, unaccelerated, noBackend };
+}
+
+async function run() {
+    if (!window.internals) {
+        debug("Test requires internals");
+        return;
+    }
+
+    // First, wait until any canvases from previous tests have been deleted.
+    gc();
+    try {
+        await imageBufferResourceLimitsMatch({ imageBufferForCanvasCount: 0 });
+    } catch {
+        debug("Platform does not enforce ImageBuffer resource limits");
+        return;
+    }
+
+    // Check that the hard code limits are reasonable enough for this test to
+    // rely on.
+    let limits = await internals.getImageBufferResourceLimits();
+    shouldBeTrue(() => checkLimits(limits));
+
+    let canvases = [];
+    let renderingModeCounts;
+
+    // Create 500 canvases. This is below acceleratedImageBufferForCanvasLimit,
+    // so should they should all get accelerated ImageBuffer backing stores.
+    growCanvasesTo(canvases, 500);
+    renderingModeCounts = getEffectiveRenderingModeCounts(canvases);
+
+    shouldEvaluateTo(() => renderingModeCounts.accelerated, 500);
+    shouldEvaluateTo(() => renderingModeCounts.unaccelerated, 0);
+    shouldEvaluateTo(() => renderingModeCounts.noBackend, 0);
+
+    // Wait until the values returned by getImageBufferResourceLimits match our
+    // expectations.
+    await imageBufferResourceLimitsMatch({
+        acceleratedImageBufferForCanvasCount: 500,
+        globalAcceleratedImageBufferCount: x => x >= 500,
+        imageBufferForCanvasCount: 500,
+        globalImageBufferForCanvasCount: 500,
+    });
+
+    // Create enough canvases to reach the per Web Process
+    // acceleratedImageBufferForCanvasLimit.
+    growCanvasesTo(canvases, limits.acceleratedImageBufferForCanvasLimit);
+    renderingModeCounts = getEffectiveRenderingModeCounts(canvases);
+
+    shouldEvaluateTo(() => renderingModeCounts.accelerated, limits.acceleratedImageBufferForCanvasLimit);
+    shouldEvaluateTo(() => renderingModeCounts.unaccelerated, 0);
+    shouldEvaluateTo(() => renderingModeCounts.noBackend, 0);
+
+    await imageBufferResourceLimitsMatch({
+        acceleratedImageBufferForCanvasCount: limits.acceleratedImageBufferForCanvasLimit,
+        globalAcceleratedImageBufferCount: x => x >= limits.acceleratedImageBufferForCanvasLimit,
+        imageBufferForCanvasCount: limits.acceleratedImageBufferForCanvasLimit,
+        globalImageBufferForCanvasCount: limits.acceleratedImageBufferForCanvasLimit,
+    });
+
+    // Create a few more canvases over the per Web Process
+    // acceleratedImageBufferForCanvasLimit. These should all be unaccelerated.
+    growCanvasesTo(canvases, limits.acceleratedImageBufferForCanvasLimit + 500);
+    renderingModeCounts = getEffectiveRenderingModeCounts(canvases);
+
+    shouldEvaluateTo(() => renderingModeCounts.accelerated, limits.acceleratedImageBufferForCanvasLimit);
+    shouldEvaluateTo(() => renderingModeCounts.unaccelerated, 500);
+    shouldEvaluateTo(() => renderingModeCounts.noBackend, 0);
+
+    await imageBufferResourceLimitsMatch({
+        acceleratedImageBufferForCanvasCount: limits.acceleratedImageBufferForCanvasLimit,
+        globalAcceleratedImageBufferCount: x => x >= limits.acceleratedImageBufferForCanvasLimit,
+        imageBufferForCanvasCount: limits.acceleratedImageBufferForCanvasLimit + 500,
+        globalImageBufferForCanvasCount: limits.acceleratedImageBufferForCanvasLimit + 500,
+    });
+
+    // Create an ImageBuffer with a non-canvas purpose and requested to be
+    // accelerated. Since we haven't reached globalAcceleratedImageBufferLimit,
+    // this should be accelerated.
+    let nonCanvasImageBufferRenderingMode = internals.getEffectiveRenderingModeOfNewlyCreatedAcceleratedImageBuffer();
+    shouldBeTrue(() => nonCanvasImageBufferRenderingMode == "Accelerated");
+
+    // Create enough canvases to reach the per Web Process
+    // imageBufferForCanvasLimit.
+    growCanvasesTo(canvases, limits.imageBufferForCanvasLimit);
+    renderingModeCounts = getEffectiveRenderingModeCounts(canvases);
+
+    shouldEvaluateTo(() => renderingModeCounts.accelerated, limits.acceleratedImageBufferForCanvasLimit);
+    shouldEvaluateTo(() => renderingModeCounts.unaccelerated, limits.imageBufferForCanvasLimit - limits.acceleratedImageBufferForCanvasLimit);
+    shouldEvaluateTo(() => renderingModeCounts.noBackend, 0);
+
+    await imageBufferResourceLimitsMatch({
+        acceleratedImageBufferForCanvasCount: limits.acceleratedImageBufferForCanvasLimit,
+        globalAcceleratedImageBufferCount: x => x >= limits.acceleratedImageBufferForCanvasLimit,
+        imageBufferForCanvasCount: limits.imageBufferForCanvasLimit,
+        globalImageBufferForCanvasCount: limits.imageBufferForCanvasLimit,
+    });
+
+    // Create a few more canvases over the per Web Process
+    // imageBufferForCanvasLimit. These should all fail to create a backend.
+    growCanvasesTo(canvases, limits.imageBufferForCanvasLimit + 500);
+    renderingModeCounts = getEffectiveRenderingModeCounts(canvases);
+
+    shouldEvaluateTo(() => renderingModeCounts.accelerated, limits.acceleratedImageBufferForCanvasLimit);
+    shouldEvaluateTo(() => renderingModeCounts.unaccelerated, limits.imageBufferForCanvasLimit - limits.acceleratedImageBufferForCanvasLimit);
+    shouldEvaluateTo(() => renderingModeCounts.noBackend, 500);
+
+    // Release all the canvases except for the initial 500 accelerated ones.
+    shrinkCanvasesTo(canvases, 500);
+    gc();
+
+    await imageBufferResourceLimitsMatch({
+        acceleratedImageBufferForCanvasCount: 500,
+        globalAcceleratedImageBufferCount: x => x >= 500,
+        imageBufferForCanvasCount: 500,
+        globalImageBufferForCanvasCount: 500,
+    });
+
+    // Create another 100 canvases, which all should be accelerated.
+    growCanvasesTo(canvases, 600);
+    renderingModeCounts = getEffectiveRenderingModeCounts(canvases);
+
+    shouldEvaluateTo(() => renderingModeCounts.accelerated, 600);
+    shouldEvaluateTo(() => renderingModeCounts.unaccelerated, 0);
+    shouldEvaluateTo(() => renderingModeCounts.noBackend, 0);
+}
+
+onload = async function() {
+    await run();
+    finishJSTest();
+};
+</script>
+<script src=../../resources/js-test-post.js></script>

--- a/LayoutTests/platform/glib/fast/canvas/image-buffer-resource-limits-expected.txt
+++ b/LayoutTests/platform/glib/fast/canvas/image-buffer-resource-limits-expected.txt
@@ -1,0 +1,10 @@
+Check that GPU process ImageBuffer resource limits are enforced
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Platform does not enforce ImageBuffer resource limits
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2819,6 +2819,9 @@ http/tests/media/hls/hls-webvtt-style.html [ Pass Timeout ]
 [ Ventura Debug ] imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-mode-disabled.html [ Skip ]
 [ Ventura Debug ] imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-mode.html [ Skip ]
 
+# Test relies on GPUP.
+fast/canvas/image-buffer-resource-limits.html [ Skip ]
+
 webkit.org/b/273577 [ Ventura ] http/tests/media/hls/track-webvtt-multitracks.html [ Skip ]
 
 # rdar://65188503

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4173,6 +4173,9 @@ css3/filters/backdrop-filter-page-scale.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/trusted-types/trusted-types-navigation.html [ Failure Pass ]
 js/dom/encode-URI-test.html [ Pass Failure ]
 
+# WinCairo doesn't create accelerated ImageBuffer backends.
+fast/canvas/image-buffer-resource-limits.html [ Skip ]
+
 # eventSender.leapForward should be reimplemented without Sleep.
 editing/selection/mouse/click-left-of-rtl-wrapping-text.html [ Skip ] # Timeout
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1990,6 +1990,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ImageBufferBackendParameters.h
     platform/graphics/ImageBufferPixelFormat.h
     platform/graphics/ImageBufferPlatformBackend.h
+    platform/graphics/ImageBufferResourceLimits.h
     platform/graphics/ImageDecoder.h
     platform/graphics/ImageDecoderIdentifier.h
     platform/graphics/ImageFrame.h

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -3035,7 +3035,8 @@ std::optional<CanvasRenderingContext2DBase::RenderingMode> CanvasRenderingContex
 {
     if (auto* buffer = canvasBase().buffer()) {
         buffer->ensureBackendCreated();
-        return buffer->renderingMode();
+        if (buffer->hasBackend())
+            return buffer->renderingMode();
     }
     return std::nullopt;
 }

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -43,6 +43,7 @@
 #include "HostWindow.h"
 #include "Icon.h"
 #include "ImageBuffer.h"
+#include "ImageBufferResourceLimits.h"
 #include "InputMode.h"
 #include "MediaControlsContextMenuItem.h"
 #include "MediaProducer.h"
@@ -691,6 +692,8 @@ public:
 #endif
 
     virtual void hasActiveNowPlayingSessionChanged(bool) { }
+
+    virtual void getImageBufferResourceLimitsForTesting(CompletionHandler<void(std::optional<ImageBufferResourceLimits>)>&& callback) const { callback(std::nullopt); }
 
     WEBCORE_EXPORT virtual ~ChromeClient();
 

--- a/Source/WebCore/platform/graphics/ImageBufferResourceLimits.h
+++ b/Source/WebCore/platform/graphics/ImageBufferResourceLimits.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+struct ImageBufferResourceLimits {
+    size_t acceleratedImageBufferForCanvasCount;
+    size_t acceleratedImageBufferForCanvasLimit;
+    size_t globalAcceleratedImageBufferCount;
+    size_t globalAcceleratedImageBufferLimit;
+    size_t globalImageBufferForCanvasCount;
+    size_t globalImageBufferForCanvasLimit;
+    size_t imageBufferForCanvasCount;
+    size_t imageBufferForCanvasLimit;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -37,10 +37,12 @@
 #include "ExceptionOr.h"
 #include "HEVCUtilities.h"
 #include "IDLTypes.h"
+#include "ImageBufferResourceLimits.h"
 #include "NowPlayingInfo.h"
 #include "OrientationNotifier.h"
 #include "PageConsoleClient.h"
 #include "RealtimeMediaSource.h"
+#include "RenderingMode.h"
 #include "SleepDisabler.h"
 #include "TextIndicator.h"
 #include "VP9Utilities.h"
@@ -1482,6 +1484,13 @@ public:
     const String& defaultSpatialTrackingLabel() const;
 
     bool isEffectivelyMuted(const HTMLMediaElement&);
+
+    using RenderingMode = WebCore::RenderingMode;
+    std::optional<RenderingMode> getEffectiveRenderingModeOfNewlyCreatedAcceleratedImageBuffer();
+
+    using ImageBufferResourceLimits = WebCore::ImageBufferResourceLimits;
+    using ImageBufferResourceLimitsPromise = DOMPromiseDeferred<IDLDictionary<ImageBufferResourceLimits>>;
+    void getImageBufferResourceLimits(ImageBufferResourceLimitsPromise&&);
 
 private:
     explicit Internals(Document&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -449,6 +449,25 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
+    JSGenerateToJSObject,
+] dictionary ImageBufferResourceLimits {
+    unsigned long long acceleratedImageBufferForCanvasCount;
+    unsigned long long acceleratedImageBufferForCanvasLimit;
+    unsigned long long globalAcceleratedImageBufferCount;
+    unsigned long long globalAcceleratedImageBufferLimit;
+    unsigned long long globalImageBufferForCanvasCount;
+    unsigned long long globalImageBufferForCanvasLimit;
+    unsigned long long imageBufferForCanvasCount;
+    unsigned long long imageBufferForCanvasLimit;
+};
+
+enum RenderingMode {
+    "Unaccelerated",
+    "Accelerated"
+};
+
+[
+    ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     LegacyNoInterfaceObject,
 ] interface Internals {
     DOMString address(Node node);
@@ -1376,4 +1395,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     readonly attribute DOMString defaultSpatialTrackingLabel;
 
     boolean isEffectivelyMuted(HTMLMediaElement element);
+
+    RenderingMode? getEffectiveRenderingModeOfNewlyCreatedAcceleratedImageBuffer();
+    Promise<ImageBufferResourceLimits> getImageBufferResourceLimits();
 };

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp
@@ -37,6 +37,21 @@ using namespace WebCore;
 
 constexpr Seconds defaultRemoteSharedResourceCacheTimeout = 15_s;
 
+// Per GPU process limit of accelerated image buffers. These consume limited global OS resources.
+constexpr size_t globalAcceleratedImageBufferLimit = 10000;
+
+// Per GPU process limit of image buffers for canvas. These consume limited process-wide resources.
+constexpr size_t globalImageBufferForCanvasLimit = 200000;
+
+// Per Web Content process limit of accelerated image buffers for canvas. Prevents GPU resource exhaustion affecting other Web Content processes.
+constexpr size_t acceleratedImageBufferForCanvasLimit = 5000;
+
+// Per Web Content process limit of image buffers for canvas. Prevents IPC-related resource exhaustion affecting other Web Content processes.
+constexpr size_t imageBufferForCanvasLimit = 50000;
+
+static std::atomic<size_t> globalAcceleratedImageBufferCount = 0;
+static std::atomic<size_t> globalImageBufferForCanvasCount = 0;
+
 Ref<RemoteSharedResourceCache> RemoteSharedResourceCache::create(GPUConnectionToWebProcess& gpuConnectionToWebProcess)
 {
     return adoptRef(*new RemoteSharedResourceCache(gpuConnectionToWebProcess));
@@ -72,6 +87,54 @@ void RemoteSharedResourceCache::lowMemoryHandler()
 #if HAVE(IOSURFACE)
     m_ioSurfacePool->discardAllSurfaces();
 #endif
+}
+
+void RemoteSharedResourceCache::didCreateImageBuffer(RenderingPurpose purpose, RenderingMode renderingMode)
+{
+    if (purpose == RenderingPurpose::Canvas) {
+        if (renderingMode == RenderingMode::Accelerated)
+            ++m_acceleratedImageBufferForCanvasCount;
+        ++globalImageBufferForCanvasCount;
+        ++m_imageBufferForCanvasCount;
+    }
+    if (renderingMode == RenderingMode::Accelerated)
+        ++globalAcceleratedImageBufferCount;
+}
+
+void RemoteSharedResourceCache::didReleaseImageBuffer(RenderingPurpose purpose, RenderingMode renderingMode)
+{
+    if (purpose == RenderingPurpose::Canvas) {
+        if (renderingMode == RenderingMode::Accelerated)
+            --m_acceleratedImageBufferForCanvasCount;
+        --globalImageBufferForCanvasCount;
+        --m_imageBufferForCanvasCount;
+    }
+    if (renderingMode == RenderingMode::Accelerated)
+        --globalAcceleratedImageBufferCount;
+}
+
+bool RemoteSharedResourceCache::reachedAcceleratedImageBufferLimit(RenderingPurpose purpose) const
+{
+    return (purpose == RenderingPurpose::Canvas && m_acceleratedImageBufferForCanvasCount >= acceleratedImageBufferForCanvasLimit) || globalAcceleratedImageBufferCount >= globalAcceleratedImageBufferLimit;
+}
+
+bool RemoteSharedResourceCache::reachedImageBufferForCanvasLimit() const
+{
+    return m_imageBufferForCanvasCount >= imageBufferForCanvasLimit || globalImageBufferForCanvasCount >= globalImageBufferForCanvasLimit;
+}
+
+ImageBufferResourceLimits RemoteSharedResourceCache::getResourceLimitsForTesting() const
+{
+    return {
+        .acceleratedImageBufferForCanvasCount = m_acceleratedImageBufferForCanvasCount,
+        .acceleratedImageBufferForCanvasLimit = acceleratedImageBufferForCanvasLimit,
+        .globalAcceleratedImageBufferCount = globalAcceleratedImageBufferCount,
+        .globalAcceleratedImageBufferLimit = globalAcceleratedImageBufferLimit,
+        .globalImageBufferForCanvasCount = globalImageBufferForCanvasCount,
+        .globalImageBufferForCanvasLimit = globalImageBufferForCanvasLimit,
+        .imageBufferForCanvasCount = m_imageBufferForCanvasCount,
+        .imageBufferForCanvasLimit = imageBufferForCanvasLimit,
+    };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
@@ -31,6 +31,7 @@
 #include "RemoteSerializedImageBufferIdentifier.h"
 #include "ThreadSafeObjectHeap.h"
 #include <WebCore/ImageBuffer.h>
+#include <WebCore/ImageBufferResourceLimits.h>
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <wtf/FastMalloc.h>
@@ -44,7 +45,7 @@
 namespace WebKit {
 
 class GPUConnectionToWebProcess;
-// Class holding GPU process resources per Web Process.
+// Class holding GPU process resources per Web Content process.
 // Thread-safe.
 class RemoteSharedResourceCache final : public ThreadSafeRefCounted<RemoteSharedResourceCache>, IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
@@ -63,6 +64,12 @@ public:
     WebCore::IOSurfacePool& ioSurfacePool() const { return m_ioSurfacePool; }
 #endif
 
+    void didCreateImageBuffer(WebCore::RenderingPurpose, WebCore::RenderingMode);
+    void didReleaseImageBuffer(WebCore::RenderingPurpose, WebCore::RenderingMode);
+    bool reachedAcceleratedImageBufferLimit(WebCore::RenderingPurpose) const;
+    bool reachedImageBufferForCanvasLimit() const;
+    WebCore::ImageBufferResourceLimits getResourceLimitsForTesting() const;
+
     void lowMemoryHandler();
 
 private:
@@ -76,8 +83,9 @@ private:
 #if HAVE(IOSURFACE)
     Ref<WebCore::IOSurfacePool> m_ioSurfacePool;
 #endif
+    std::atomic<size_t> m_acceleratedImageBufferForCanvasCount;
+    std::atomic<size_t> m_imageBufferForCanvasCount;
 };
-
 
 } // namespace WebKit
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -269,10 +269,20 @@ static RefPtr<ImageBuffer> allocateImageBufferInternal(const FloatSize& logicalS
     return imageBuffer;
 }
 
+static void adjustImageBufferRenderingMode(const RemoteSharedResourceCache& sharedResourceCache, RenderingPurpose purpose, RenderingMode& renderingMode)
+{
+    if (renderingMode == RenderingMode::Accelerated && sharedResourceCache.reachedAcceleratedImageBufferLimit(purpose))
+        renderingMode = RenderingMode::Unaccelerated;
+}
+
 RefPtr<ImageBuffer> RemoteRenderingBackend::allocateImageBuffer(const FloatSize& logicalSize, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, ImageBufferPixelFormat pixelFormat, ImageBufferCreationContext creationContext, RenderingResourceIdentifier imageBufferIdentifier)
 {
     assertIsCurrent(workQueue());
+    if (purpose == RenderingPurpose::Canvas && m_sharedResourceCache->reachedImageBufferForCanvasLimit())
+        return nullptr;
     adjustImageBufferCreationContext(m_sharedResourceCache, creationContext);
+    adjustImageBufferRenderingMode(m_sharedResourceCache, purpose, renderingMode);
+
     RefPtr<ImageBuffer> imageBuffer;
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
@@ -609,6 +619,11 @@ bool RemoteRenderingBackend::shouldUseLockdownFontParser() const
     return m_gpuConnectionToWebProcess->isLockdownSafeFontParserEnabled() && m_gpuConnectionToWebProcess->isLockdownModeEnabled() && PAL::canLoad_CoreText_CTFontManagerCreateMemorySafeFontDescriptorFromData();
 }
 #endif
+
+void RemoteRenderingBackend::getImageBufferResourceLimitsForTesting(CompletionHandler<void(WebCore::ImageBufferResourceLimits)>&& callback)
+{
+    callback(m_sharedResourceCache->getResourceLimitsForTesting());
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -184,6 +184,8 @@ private:
     bool shouldUseLockdownFontParser() const;
 #endif
 
+    void getImageBufferResourceLimitsForTesting(CompletionHandler<void(WebCore::ImageBufferResourceLimits)>&&);
+
     Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     Ref<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -25,6 +25,7 @@
 messages -> RemoteRenderingBackend NotRefCounted Stream {
     CreateImageBuffer(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose, float resolutionScale, WebCore::DestinationColorSpace colorSpace, enum:uint8_t WebCore::ImageBufferPixelFormat pixelFormat, WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
     ReleaseImageBuffer(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
+    GetImageBufferResourceLimitsForTesting() -> (struct WebCore::ImageBufferResourceLimits limits) Async
     DestroyGetPixelBufferSharedMemory()
     CacheNativeImage(WebCore::ShareableBitmapHandle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     CacheFont(struct WebCore::FontInternalAttributes data, struct WebCore::FontPlatformDataAttributes platformData, std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifier) NotStreamEncodable

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8336,3 +8336,15 @@ struct WebCore::OwnerPermissionsPolicyData {
 class WebCore::PermissionsPolicy {
     WebCore::PermissionsPolicy::InheritedPolicy inheritedPolicy()
 };
+
+header: <WebCore/ImageBufferResourceLimits.h>
+struct WebCore::ImageBufferResourceLimits {
+    size_t acceleratedImageBufferForCanvasCount;
+    size_t acceleratedImageBufferForCanvasLimit;
+    size_t globalAcceleratedImageBufferCount;
+    size_t globalAcceleratedImageBufferLimit;
+    size_t globalImageBufferForCanvasCount;
+    size_t globalImageBufferForCanvasLimit;
+    size_t imageBufferForCanvasCount;
+    size_t imageBufferForCanvasLimit;
+};

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -43,6 +43,7 @@
 #include "StreamClientConnection.h"
 #include "ThreadSafeObjectHeap.h"
 #include "WorkQueueMessageReceiver.h"
+#include <WebCore/ImageBufferResourceLimits.h>
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <WebCore/SharedMemory.h>
 #include <WebCore/Timer.h>
@@ -125,6 +126,7 @@ public:
     void markSurfacesVolatile(Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>>&&, CompletionHandler<void(bool madeAllVolatile)>&&, bool forcePurge);
     RefPtr<RemoteImageBufferSetProxy> createRemoteImageBufferSet();
     void releaseRemoteImageBufferSet(RemoteImageBufferSetProxy&);
+    void getImageBufferResourceLimitsForTesting(CompletionHandler<void(WebCore::ImageBufferResourceLimits)>&&);
 
 #if USE(GRAPHICS_LAYER_WC)
     Function<bool()> flushImageBuffers();
@@ -179,6 +181,8 @@ private:
     template<typename T> auto send(T&& message) { return send(std::forward<T>(message), renderingBackendIdentifier()); }
     template<typename T, typename U, typename V, typename W> auto sendSync(T&& message, ObjectIdentifierGeneric<U, V, W>);
     template<typename T> auto sendSync(T&& message) { return sendSync(std::forward<T>(message), renderingBackendIdentifier()); }
+    template<typename T, typename C, typename U, typename V, typename W> auto sendWithAsyncReply(T&& message, C&& callback, ObjectIdentifierGeneric<U, V, W>);
+    template<typename T, typename C> auto sendWithAsyncReply(T&& message, C&& callback) { return sendWithAsyncReply(std::forward<T>(message), std::forward<C>(callback), renderingBackendIdentifier()); }
 
     // Connection::Client
     void didClose(IPC::Connection&) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1918,4 +1918,11 @@ void WebChromeClient::hasActiveNowPlayingSessionChanged(bool hasActiveNowPlaying
     protectedPage()->hasActiveNowPlayingSessionChanged(hasActiveNowPlayingSession);
 }
 
+#if ENABLE(GPU_PROCESS)
+void WebChromeClient::getImageBufferResourceLimitsForTesting(CompletionHandler<void(std::optional<ImageBufferResourceLimits>)>&& callback) const
+{
+    protectedPage()->ensureRemoteRenderingBackendProxy().getImageBufferResourceLimitsForTesting(WTFMove(callback));
+}
+#endif
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -537,6 +537,10 @@ private:
 
     void hasActiveNowPlayingSessionChanged(bool) final;
 
+#if ENABLE(GPU_PROCESS)
+    void getImageBufferResourceLimitsForTesting(CompletionHandler<void(std::optional<WebCore::ImageBufferResourceLimits>)>&&) const final;
+#endif
+
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };
 


### PR DESCRIPTION
#### 80225aaf7451c18e20832dec77948e514d39d368
<pre>
Add limits to the number of ImageBuffers that the GPU process can create
<a href="https://bugs.webkit.org/show_bug.cgi?id=273326">https://bugs.webkit.org/show_bug.cgi?id=273326</a>
<a href="https://rdar.apple.com/95930955">rdar://95930955</a>

Reviewed by Matt Woodrow.

On Cocoa ports, ImageBuffers created in the GPU process consume both
global and process-wide resources. Accelerated ImageBuffers consume
IOSurface handles (which the kernel has a limited number of, and which
also have a per process limit) and Metal objects (which are also limited
per process). Unaccelerated ImageBuffers consume Mach port handles for
their ShareableBitmap handles (which are per process).

Prevent leaks (both undiagnosed and from poorly behaving Web content
creating 2D canvases) from exhausting these resources by placing limits
on the number of ImageBuffers the GPU process can create.

These limits are:

* 200,000 ImageBuffers for the GPU process (a number a bit lower than
  the 256K Mach port limit)
* 50,000 canvas ImageBuffers for each Web Content process (to prevent
  one Web Content process from using the entire global limit)
* 10,000 accelerated ImageBuffers for the GPU process (a number a bit
  lower than the 16K per-process IOSurface limit)
* 5,000 accelerated canvas ImageBuffers for each Web Content process (to
  prevent one Web Content process from using the entire global limit)

* LayoutTests/fast/canvas/image-buffer-resource-limits-expected.txt: Added.
* LayoutTests/fast/canvas/image-buffer-resource-limits.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::getEffectiveRenderingModeForTesting):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::getImageBufferResourceLimitsForTesting const):
* Source/WebCore/platform/graphics/ImageBufferResourceLimits.h: Added.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::getEffectiveRenderingModeOfNewlyCreatedAcceleratedImageBuffer):
(WebCore::Internals::getImageBufferResourceLimits):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp:
(WebKit::RemoteSharedResourceCache::didCreateImageBuffer):
(WebKit::RemoteSharedResourceCache::didReleaseImageBuffer):
(WebKit::RemoteSharedResourceCache::reachedAcceleratedImageBufferLimit const):
(WebKit::RemoteSharedResourceCache::reachedImageBufferForCanvasLimit const):
(WebKit::RemoteSharedResourceCache::getResourceLimitsForTesting const):
* Source/WebKit/GPUProcess/RemoteSharedResourceCache.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::RemoteImageBuffer):
(WebKit::RemoteImageBuffer::~RemoteImageBuffer):
(WebKit::RemoteImageBuffer::stopListeningForIPC):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::adjustImageBufferRenderingMode):
(WebKit::RemoteRenderingBackend::allocateImageBuffer):
(WebKit::RemoteRenderingBackend::getImageBufferResourceLimitsForTesting):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::sendWithAsyncReply):
(WebKit::RemoteRenderingBackendProxy::getImageBufferResourceLimitsForTesting):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
(WebKit::RemoteRenderingBackendProxy::sendWithAsyncReply):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::getImageBufferResourceLimitsForTesting const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:

Canonical link: <a href="https://commits.webkit.org/281395@main">https://commits.webkit.org/281395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1af0dde7ac64f5e9ecf3ed5ecfc2e4a23851d548

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10264 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10443 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48448 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7177 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29288 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8969 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9187 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65387 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55790 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55926 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3049 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8933 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34899 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35982 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->