### PR TITLE
startApplyingConstraints is called twice when applying constraints with size changes

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
@@ -413,11 +413,6 @@ void RealtimeVideoCaptureSource::dispatchVideoFrameToObservers(VideoFrame& video
     videoFrameAvailable(videoFrame, metadata);
 }
 
-void RealtimeVideoCaptureSource::clientUpdatedSizeFrameRateAndZoom(std::optional<int> width, std::optional<int> height, std::optional<double> frameRate, std::optional<double> zoom)
-{
-    setSizeFrameRateAndZoom({ width, height, frameRate, zoom });
-}
-
 std::optional<RealtimeVideoCaptureSource::CaptureSizeFrameRateAndZoom> RealtimeVideoCaptureSource::bestSupportedSizeFrameRateAndZoomConsideringObservers(const VideoPresetConstraints& constraints)
 {
     auto& settings = this->settings();
@@ -450,12 +445,10 @@ void RealtimeVideoCaptureSource::setSizeFrameRateAndZoom(const VideoPresetConstr
     m_currentPreset = match->encodingPreset;
     auto newSize = match->encodingPreset->size();
 
-    startApplyingConstraints();
     setFrameRateAndZoomWithPreset(match->requestedFrameRate, match->requestedZoom, WTFMove(match->encodingPreset));
     setSize(newSize);
     setFrameRate(match->requestedFrameRate);
     setZoom(match->requestedZoom);
-    endApplyingConstraints();
 }
 
 auto RealtimeVideoCaptureSource::takePhotoInternal(PhotoSettings&&) -> Ref<TakePhotoNativePromise>

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
@@ -43,8 +43,6 @@ class WEBCORE_EXPORT RealtimeVideoCaptureSource : public RealtimeMediaSource, pu
 public:
     virtual ~RealtimeVideoCaptureSource();
 
-    void clientUpdatedSizeFrameRateAndZoom(std::optional<int> width, std::optional<int> height, std::optional<double> frameRate, std::optional<double> zoom);
-
     bool supportsSizeFrameRateAndZoom(const VideoPresetConstraints&) override;
     virtual void generatePresets() = 0;
 

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -750,11 +750,13 @@ void MockRealtimeVideoSource::setIsInterrupted(bool isInterrupted)
 
 void MockRealtimeVideoSource::startApplyingConstraints()
 {
+    ASSERT(!m_beingConfigured);
     m_beingConfigured = true;
 }
 
 void MockRealtimeVideoSource::endApplyingConstraints()
 {
+    ASSERT(m_beingConfigured);
     m_beingConfigured = false;
 }
 


### PR DESCRIPTION
#### 11158678aa4ef3d613394dfc01f9cccec6687104
<pre>
startApplyingConstraints is called twice when applying constraints with size changes
<a href="https://rdar.apple.com/132339561">rdar://132339561</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=277068">https://bugs.webkit.org/show_bug.cgi?id=277068</a>

Reviewed by Eric Carlson.

startApplyingConstraints was called first in RealtimeMediaSource::applyConstraints and then in RealtimeVideoCaptureSource::setSizeFrameRateAndZoom.
Although it was paired with two calls to endApplyingConstraints, the implementation of AVVideoCaptureSource::startApplyingConstraints/endApplyingConstraints
is not handling nested calls like this.
This was triggering unbalanced AVVideoCaptureSource session beginConfiguration/commitConfiguration calls, which caused zoom/torch values to not always be applied properly.
This also fixes the exception that is sometimes raised when calling AVVideoCaptureSource::stopSession().

To fix this, we update RealtimeVideoCaptureSource::setSizeFrameRateAndZoom to not call directly startApplyingConstraints/endApplyingConstraints.
This is ok since it is only called from RealtimeMediaSource::applyConstraints which already does these calls.
This change is covered in MockRealtimeVideoSource::startApplyingConstraints/endApplyingConstraints by adding debug ASSERTS which are exercised by current layout tests.

The other call site of setFrameRateAndZoomWithPreset is for handling preset changes for photo.
Here we need to keep the calls to startApplyingConstraints/endApplyingConstraints, like done today.

* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp:
(WebCore::RealtimeVideoCaptureSource::setSizeFrameRateAndZoom):
(WebCore::RealtimeVideoCaptureSource::clientUpdatedSizeFrameRateAndZoom): Deleted.
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h:
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::startApplyingConstraints):
(WebCore::MockRealtimeVideoSource::endApplyingConstraints):

Canonical link: <a href="https://commits.webkit.org/281349@main">https://commits.webkit.org/281349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16142284b8cc87bb63f9b9addc2371533cdf07ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63518 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10126 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61732 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48357 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7089 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29195 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8843 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9050 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65250 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55700 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3542 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55827 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13207 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2927 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34762 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35845 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36931 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->