### PR TITLE
[WPE] Do not connect ot the default EGL display in the UI process

### DIFF
--- a/Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
+++ b/Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
@@ -58,13 +58,6 @@ std::unique_ptr<PlatformDisplayLibWPE> PlatformDisplayLibWPE::create()
     return std::unique_ptr<PlatformDisplayLibWPE>(new PlatformDisplayLibWPE());
 }
 
-PlatformDisplayLibWPE::PlatformDisplayLibWPE()
-{
-#if PLATFORM(GTK)
-    PlatformDisplay::setSharedDisplayForCompositing(*this);
-#endif
-}
-
 PlatformDisplayLibWPE::~PlatformDisplayLibWPE()
 {
     if (m_backend)
@@ -116,6 +109,13 @@ bool PlatformDisplayLibWPE::initialize(int hostFd)
     }
 #endif
     return m_eglDisplay != EGL_NO_DISPLAY;
+}
+
+void PlatformDisplayLibWPE::initializeEGLDisplay()
+{
+    if (!m_backend)
+        m_eglDisplay = eglGetCurrentDisplay();
+    PlatformDisplay::initializeEGLDisplay();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.h
+++ b/Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.h
@@ -44,9 +44,11 @@ public:
     struct wpe_renderer_backend_egl* backend() const { return m_backend; }
 
 private:
-    PlatformDisplayLibWPE();
+    PlatformDisplayLibWPE() = default;
 
     Type type() const override { return PlatformDisplay::Type::WPE; }
+
+    void initializeEGLDisplay() override;
 
     struct wpe_renderer_backend_egl* m_backend { nullptr };
 };


### PR DESCRIPTION
#### 33127761563faf88ac93847845cafa35f49c9008
<pre>
[WPE] Do not connect ot the default EGL display in the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=277070">https://bugs.webkit.org/show_bug.cgi?id=277070</a>

Reviewed by Michael Catanzaro.

When using the old API, a PlatformDisplayLibWPE is created in the UI
process to query the drm render node to pass to the web process. The
display is not initialized with a backend, so the default
PlatformDisplay::initializeEGL is called and the default native display
is used to create the EGL display. The default display doesn&apos;t need to
be the right one, so we should try to use the current EGL display and
only connect to the default if there&apos;s no current display.

* Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.cpp:
(WebCore::PlatformDisplayLibWPE::initializeEGLDisplay):
(WebCore::PlatformDisplayLibWPE::PlatformDisplayLibWPE): Deleted.
* Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.h:

Canonical link: <a href="https://commits.webkit.org/281389@main">https://commits.webkit.org/281389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d52098504ca418aaadffb2eaa4b491b012ea06e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63522 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10130 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48360 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7091 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61637 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29198 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33059 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8850 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9054 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65254 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9015 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55705 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55832 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2932 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8929 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34766 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35849 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36935 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35594 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->