### PR TITLE
Use smart pointers to access LocalFrameLoaderClient

### DIFF
--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1218,8 +1218,8 @@ PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier
         CookieJar::create(adoptRef(*new EmptyStorageSessionProvider)),
         makeUniqueRef<EmptyProgressTrackerClient>(),
         PageConfiguration::LocalMainFrameCreationParameters {
-            CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&)> { [] (auto&) {
-                return makeUniqueRef<EmptyFrameLoaderClient>();
+            CompletionHandler<Ref<LocalFrameLoaderClient>(LocalFrame&)> { [] (auto&) {
+                return adoptRef(*new EmptyFrameLoaderClient());
             } },
             SandboxFlags::all(),
         },

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -361,7 +361,7 @@ private:
     bool m_inProgress { false };
 };
 
-FrameLoader::FrameLoader(LocalFrame& frame, UniqueRef<LocalFrameLoaderClient>&& client)
+FrameLoader::FrameLoader(LocalFrame& frame, Ref<LocalFrameLoaderClient>&& client)
     : m_frame(frame)
     , m_client(WTFMove(client))
     , m_policyChecker(makeUnique<PolicyChecker>(frame))
@@ -3326,7 +3326,7 @@ void FrameLoader::updateRequestAndAddExtraFields(Frame& targetFrame, ResourceReq
     if (isMainResource)
         request.setHTTPHeaderField(HTTPHeaderName::Accept, CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type::MainResource));
 
-    if (document && localFrame->settings().privateTokenUsageByThirdPartyEnabled() && !localFrame->loader().client().isRemoteWorkerFrameLoaderClient())
+    if (document && localFrame->settings().privateTokenUsageByThirdPartyEnabled() && !localFrame->checkedLoader()->client().isRemoteWorkerFrameLoaderClient())
         request.setIsPrivateTokenUsageByThirdPartyAllowed(PermissionsPolicy::isFeatureEnabled(PermissionsPolicy::Feature::PrivateToken, *document, PermissionsPolicy::ShouldReportViolation::No));
 
     // Only set fallback array if it's still empty (later attempts may be incorrect, see bug 117818).

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -108,7 +108,7 @@ class FrameLoader final : public CanMakeCheckedPtr<FrameLoader> {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameLoader);
     friend class PolicyChecker;
 public:
-    FrameLoader(LocalFrame&, UniqueRef<LocalFrameLoaderClient>&&);
+    FrameLoader(LocalFrame&, Ref<LocalFrameLoaderClient>&&);
     ~FrameLoader();
 
     WEBCORE_EXPORT void init();
@@ -457,7 +457,7 @@ private:
     bool dispatchNavigateEvent(const URL& newURL, FrameLoadType, const AtomString&, NavigationHistoryBehavior, bool isSameDocument, FormState* = nullptr, SerializedScriptValue* classicHistoryAPIState = nullptr);
 
     WeakRef<LocalFrame> m_frame;
-    UniqueRef<LocalFrameLoaderClient> m_client;
+    Ref<LocalFrameLoaderClient> m_client;
 
     const std::unique_ptr<PolicyChecker> m_policyChecker;
     mutable ResourceLoadNotifier m_notifier;

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -103,7 +103,7 @@ enum class WasPrivateRelayed : bool;
 
 struct StringWithDirection;
 
-class WEBCORE_EXPORT LocalFrameLoaderClient : public FrameLoaderClient {
+class WEBCORE_EXPORT LocalFrameLoaderClient : public FrameLoaderClient, public RefCounted<LocalFrameLoaderClient> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     // An inline function cannot be the first non-abstract virtual function declared

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -120,7 +120,7 @@ using NodeQualifier = Function<Node* (const HitTestResult&, Node* terminationNod
 
 class LocalFrame final : public Frame {
 public:
-    using ClientCreator = CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&)>;
+    using ClientCreator = CompletionHandler<Ref<LocalFrameLoaderClient>(LocalFrame&)>;
     WEBCORE_EXPORT static Ref<LocalFrame> createMainFrame(Page&, ClientCreator&&, FrameIdentifier, SandboxFlags, Frame* opener);
     WEBCORE_EXPORT static Ref<LocalFrame> createSubframe(Page&, ClientCreator&&, FrameIdentifier, SandboxFlags, HTMLFrameOwnerElement&);
     WEBCORE_EXPORT static Ref<LocalFrame> createProvisionalSubframe(Page&, ClientCreator&&, FrameIdentifier, SandboxFlags, Frame& parent);

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -104,7 +104,7 @@ class PageConfiguration {
 public:
 
     struct LocalMainFrameCreationParameters {
-        CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&)> clientCreator;
+        CompletionHandler<Ref<LocalFrameLoaderClient>(LocalFrame&)> clientCreator;
         SandboxFlags effectiveSandboxFlags;
     };
     using MainFrameCreationParameters = std::variant<LocalMainFrameCreationParameters, CompletionHandler<UniqueRef<RemoteFrameClient>(RemoteFrame&)>>;

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -177,11 +177,11 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
         if (effectiveUserAgent.isNull())
             effectiveUserAgent = m_userAgent;
 
-        auto loaderClientForMainFrame = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, effectiveUserAgent);
+        auto loaderClientForMainFrame = adoptRef(*new RemoteWorkerFrameLoaderClient(m_webPageProxyID, m_pageID, effectiveUserAgent));
         if (contextData.serviceWorkerPageIdentifier)
             loaderClientForMainFrame->setServiceWorkerPageIdentifier(*contextData.serviceWorkerPageIdentifier);
         pageConfiguration.mainFrameCreationParameters = PageConfiguration::LocalMainFrameCreationParameters {
-            CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [client = WTFMove(loaderClientForMainFrame)] (auto&) mutable {
+            CompletionHandler<Ref<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [client = WTFMove(loaderClientForMainFrame)] (auto&) mutable {
                 return WTFMove(client);
             } }, SandboxFlags { }
         };

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -112,7 +112,7 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
 #endif
     pageConfiguration.storageProvider = makeUniqueRef<WebStorageProvider>(WebProcess::singleton().mediaKeysStorageDirectory(), WebProcess::singleton().mediaKeysStorageSalt());
 
-    pageConfiguration.mainFrameCreationParameters = WebCore::PageConfiguration::LocalMainFrameCreationParameters { CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [client = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, m_userAgent)] (auto&) mutable {
+    pageConfiguration.mainFrameCreationParameters = WebCore::PageConfiguration::LocalMainFrameCreationParameters { CompletionHandler<Ref<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [client = adoptRef(*new RemoteWorkerFrameLoaderClient(m_webPageProxyID, m_pageID, m_userAgent))] (auto&) mutable {
         return WTFMove(client);
     } }, WebCore::SandboxFlags { } };
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -140,7 +140,7 @@ Ref<WebFrame> WebFrame::createSubframe(WebPage& page, WebFrame& parent, const At
     auto frame = create(page, frameID);
     ASSERT(page.corePage());
     auto coreFrame = LocalFrame::createSubframe(*page.corePage(), [frame] (auto& localFrame) {
-        return makeUniqueRef<WebLocalFrameLoaderClient>(localFrame, frame.get(), frame->makeInvalidator());
+        return adoptRef(*new WebLocalFrameLoaderClient(localFrame, frame.get(), frame->makeInvalidator()));
     }, frameID, effectiveSandboxFlags, ownerElement);
     frame->m_coreFrame = coreFrame.get();
 
@@ -403,7 +403,7 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
 
     RefPtr parent = remoteFrame->tree().parent();
     auto clientCreator = [this, protectedThis = Ref { *this }] (auto& localFrame) mutable {
-        return makeUniqueRef<WebLocalFrameLoaderClient>(localFrame, WTFMove(protectedThis), makeInvalidator());
+        return adoptRef(*new WebLocalFrameLoaderClient(localFrame, WTFMove(protectedThis), makeInvalidator()));
     };
     auto localFrame = parent ? LocalFrame::createProvisionalSubframe(*corePage, WTFMove(clientCreator), m_frameID, parameters.effectiveSandboxFlags, *parent) : LocalFrame::createMainFrame(*corePage, WTFMove(clientCreator), m_frameID, parameters.effectiveSandboxFlags, remoteFrame->opener());
     m_provisionalFrame = localFrame.ptr();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -519,7 +519,7 @@ static PageConfiguration::MainFrameCreationParameters mainFrameCreationParameter
     case Frame::FrameType::Local:
         return PageConfiguration::LocalMainFrameCreationParameters {
             { [mainFrame = WTFMove(mainFrame), invalidator = WTFMove(invalidator)] (auto& localFrame) mutable {
-                return makeUniqueRef<WebLocalFrameLoaderClient>(localFrame, WTFMove(mainFrame), WTFMove(invalidator));
+                return adoptRef(*new WebLocalFrameLoaderClient(localFrame, WTFMove(mainFrame), WTFMove(invalidator)));
             } },
             initialSandboxFlags
         };

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -315,7 +315,7 @@ WebView *getWebView(WebFrame *webFrame)
         effectiveSandboxFlags.add(parentLocalFrame->effectiveSandboxFlags());
 
     auto coreFrame = WebCore::LocalFrame::createSubframe(page, [frame] (auto&) {
-        return makeUniqueRef<WebFrameLoaderClient>(frame.get());
+        return adoptRef(*new WebFrameLoaderClient(frame.get()));
     }, WebCore::FrameIdentifier::generate(), effectiveSandboxFlags, ownerElement);
     frame->_private->coreFrame = coreFrame.ptr();
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1513,8 +1513,8 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
         WebCore::CookieJar::create(storageProvider.copyRef()),
         makeUniqueRef<WebProgressTrackerClient>(self),
         WebCore::PageConfiguration::LocalMainFrameCreationParameters {
-            CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [] (auto&) {
-                return makeUniqueRef<WebFrameLoaderClient>();
+            CompletionHandler<Ref<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [] (auto&) {
+                return adoptRef(*new WebFrameLoaderClient());
             } },
             WebCore::SandboxFlags { } // Set by updateSandboxFlags after instantiation.
         },
@@ -1779,8 +1779,8 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
         WebCore::CookieJar::create(storageProvider.copyRef()),
         makeUniqueRef<WebProgressTrackerClient>(self),
         WebCore::PageConfiguration::LocalMainFrameCreationParameters {
-            CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [] (auto&) {
-                return makeUniqueRef<WebFrameLoaderClient>();
+            CompletionHandler<Ref<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [] (auto&) {
+                return adoptRef(*new WebFrameLoaderClient());
             } },
             WebCore::SandboxFlags { } // Set by updateSandboxFlags after instantiation.
         },


### PR DESCRIPTION
#### 95c09cf83d555b4f3723dd3f964746a9262731a3
<pre>
Use smart pointers in webaudio
<a href="https://bugs.webkit.org/show_bug.cgi?id=285592">https://bugs.webkit.org/show_bug.cgi?id=285592</a>

Reviewed by NOBODY (OOPS!).

WIP.

* Source/WTF/wtf/NativePromise.h:
* Source/WebCore/Modules/webaudio/AudioWorkletThread.cpp:
(WebCore::AudioWorkletThread::workerLoaderProxy):
* Source/WebCore/Modules/webaudio/AudioWorkletThread.h:
(WebCore::AudioWorkletThread::messagingProxy):
</pre>