### PR TITLE
Unreviewed, remove incorrect ASSERTs from JSWebAssemblyInstance

### DIFF
--- a/JSTests/wasm/stress/cross-realm-webassembly-instances.js
+++ b/JSTests/wasm/stress/cross-realm-webassembly-instances.js
@@ -1,0 +1,93 @@
+// Copied from LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/proto-from-ctor-realm.html for jsc-only testing.
+
+const constructorRealm = createGlobalObject();
+const newTargetRealm = createGlobalObject();
+const otherRealm = createGlobalObject();
+
+
+const randomModuleBinary = new Uint8Array([ 0,97,115,109,1,0,0,0,1,136,128,128,128,0,2,96,0,0,96,0,1,124,3,131,128,128,128,0,2,0,1,7,138,128,128,128,0,1,6,114,117,110,102,54,52,0,1,10,165,128,128,128,0,2,130,128,128,128,0,0,11,152,128,128,128,0,0,3,124,68,0,0,0,0,0,0,0,0,65,0,14,0,1,16,0,11,12,0,0,11 ]);
+const interfaces = [
+  ["Module", randomModuleBinary],
+  ["Instance", new WebAssembly.Module(randomModuleBinary)],
+  ["Memory", {initial: 0}],
+  ["Table", {element: "anyfunc", initial: 0}],
+  ["Global", {value: "i32"}],
+
+  // See step 2 of https://tc39.es/ecma262/#sec-nativeerror
+  ["CompileError"],
+  ["LinkError"],
+  ["RuntimeError"],
+];
+
+const primitives = [
+  undefined,
+  null,
+  false,
+  true,
+  0,
+  -1,
+  "",
+  "str",
+  Symbol(),
+];
+
+const getNewTargets = function* (realm) {
+  for (const primitive of primitives) {
+    const newTarget = new realm.Function();
+    newTarget.prototype = primitive;
+    yield [newTarget, "cross-realm NewTarget with `" + typeof(primitive) + "` prototype"];
+  }
+
+  // GetFunctionRealm (https://tc39.es/ecma262/#sec-getfunctionrealm) coverage:
+  const bindOther = otherRealm.Function.prototype.bind;
+  const ProxyOther = otherRealm.Proxy;
+
+  const bound = new realm.Function();
+  bound.prototype = undefined;
+  yield [bindOther.call(bound), "bound cross-realm NewTarget with `undefined` prototype"];
+
+  const boundBound = new realm.Function();
+  boundBound.prototype = null;
+  yield [bindOther.call(bindOther.call(boundBound)), "bound bound cross-realm NewTarget with `null` prototype"];
+
+  const boundProxy = new realm.Function();
+  boundProxy.prototype = false;
+  yield [bindOther.call(new ProxyOther(boundProxy, {})), "bound Proxy of cross-realm NewTarget with `false` prototype"];
+
+  const proxy = new realm.Function();
+  proxy.prototype = true;
+  yield [new ProxyOther(proxy, {}), "Proxy of cross-realm NewTarget with `true` prototype"];
+
+  const proxyProxy = new realm.Function();
+  proxyProxy.prototype = -0;
+  yield [new ProxyOther(new ProxyOther(proxyProxy, {}), {}), "Proxy of Proxy of cross-realm NewTarget with `-0` prototype"];
+
+  const proxyBound = new realm.Function();
+  proxyBound.prototype = NaN;
+  yield [new ProxyOther(bindOther.call(proxyBound), {}), "Proxy of bound cross-realm NewTarget with `NaN` prototype"];
+};
+
+let currentTestName;
+function test(func, name) {
+  currentTestName = name;
+  func();
+}
+
+function assert_equal(a, b) {
+  if (a === b)
+    return;
+  throw new Error(currentTestName + " failed");
+}
+
+for (const [interfaceName, constructorArg] of interfaces) {
+  for (const [newTarget, testDescription] of getNewTargets(newTargetRealm)) {
+    test(() => {
+      const Constructor = constructorRealm.WebAssembly[interfaceName];
+      const object = Reflect.construct(Constructor, [constructorArg], newTarget);
+
+      const NewTargetConstructor = newTargetRealm.WebAssembly[interfaceName];
+      assert_equal(object instanceof NewTargetConstructor, true);
+      assert_equal(Object.getPrototypeOf(object), NewTargetConstructor.prototype);
+    }, `WebAssembly.${interfaceName}: ${testDescription}`);
+  }
+}

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -155,7 +155,6 @@ DEFINE_VISIT_CHILDREN(JSWebAssemblyInstance);
 
 void JSWebAssemblyInstance::initializeImports(JSGlobalObject* globalObject, JSObject* importObject, CreationMode creationMode)
 {
-    ASSERT(globalObject == this->globalObject());
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -170,7 +169,6 @@ void JSWebAssemblyInstance::initializeImports(JSGlobalObject* globalObject, JSOb
 
 void JSWebAssemblyInstance::finalizeCreation(VM& vm, JSGlobalObject* globalObject, Ref<CalleeGroup>&& wasmCalleeGroup, CreationMode creationMode)
 {
-    ASSERT(globalObject == this->globalObject());
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (!wasmCalleeGroup->runnable()) {


### PR DESCRIPTION
#### baa1f6e6d54822d857308d2afa5f20d978dd0df0
<pre>
Unreviewed, remove incorrect ASSERTs from JSWebAssemblyInstance
<a href="https://bugs.webkit.org/show_bug.cgi?id=277073">https://bugs.webkit.org/show_bug.cgi?id=277073</a>

The ASSERT(globalObject == this-&gt;globalObject()) isn&apos;t true when there&apos;s a newTarget

* JSTests/wasm/stress/cross-realm-webassembly-instances.js: Added.
(const.getNewTargets):
(test):
(assert_equal):
(constructorArg.of.interfaces.testDescription.of.getNewTargets):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::initializeImports):
(JSC::JSWebAssemblyInstance::finalizeCreation):

Canonical link: <a href="https://commits.webkit.org/281347@main">https://commits.webkit.org/281347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e49cbde5ff58514885669c0f3b63197809811ac2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63525 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10133 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48363 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7095 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29201 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33063 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8851 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9057 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/52704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65257 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58855 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3538 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55706 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3549 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55834 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13201 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2936 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80612 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34769 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13983 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35852 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->