### PR TITLE
Adopt more smart pointers in accessibility table code

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -107,10 +107,10 @@ AccessibilityTable* AccessibilityTableCell::parentTable() const
     // The RenderTableCell's table() object might be anonymous sometimes. We should handle it gracefully
     // by finding the right table.
     if (!tableFromRenderTree->node()) {
-        for (auto* ancestor = parentObject(); ancestor; ancestor = ancestor->parentObject()) {
+        for (RefPtr ancestor = parentObject(); ancestor; ancestor = ancestor->parentObject()) {
             // If this is a non-anonymous table object, but not an accessibility table, we should stop because
             // we don't want to choose another ancestor table as this cell's table.
-            if (auto* ancestorTable = dynamicDowncast<AccessibilityTable>(ancestor)) {
+            if (auto* ancestorTable = dynamicDowncast<AccessibilityTable>(ancestor.get())) {
                 if (ancestorTable->isExposable())
                     return ancestorTable;
                 if (ancestorTable->node())
@@ -262,7 +262,7 @@ bool AccessibilityTableCell::supportsExpandedTextValue() const
 
 AXCoreObject::AccessibilityChildrenVector AccessibilityTableCell::columnHeaders()
 {
-    auto* parent = parentTable();
+    RefPtr parent = parentTable();
     if (!parent)
         return { };
 
@@ -276,12 +276,12 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityTableCell::columnHeaders(
     auto colRange = columnIndexRange();
 
     for (unsigned row = 0; row < rowRange.first; row++) {
-        auto* tableCell = parent->cellForColumnAndRow(colRange.first, row);
+        RefPtr tableCell = parent->cellForColumnAndRow(colRange.first, row);
         if (!tableCell || tableCell == this || headers.contains(tableCell))
             continue;
 
         ASSERT(is<AccessibilityObject>(tableCell));
-        if (tableCell->cellScope() == "colgroup"_s && isTableCellInSameColGroup(tableCell))
+        if (tableCell->cellScope() == "colgroup"_s && isTableCellInSameColGroup(tableCell.get()))
             headers.append(tableCell);
         else if (tableCell->isColumnHeader())
             headers.append(tableCell);
@@ -293,7 +293,7 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityTableCell::columnHeaders(
 AXCoreObject::AccessibilityChildrenVector AccessibilityTableCell::rowHeaders()
 {
     AccessibilityChildrenVector headers;
-    AccessibilityTable* parent = parentTable();
+    RefPtr parent = parentTable();
     if (!parent)
         return headers;
 
@@ -301,11 +301,11 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityTableCell::rowHeaders()
     auto colRange = columnIndexRange();
 
     for (unsigned column = 0; column < colRange.first; column++) {
-        auto* tableCell = parent->cellForColumnAndRow(column, rowRange.first);
+        RefPtr tableCell = parent->cellForColumnAndRow(column, rowRange.first);
         if (!tableCell || tableCell == this || headers.contains(tableCell))
             continue;
 
-        if (tableCell->cellScope() == "rowgroup"_s && isTableCellInSameRowGroup(tableCell))
+        if (tableCell->cellScope() == "rowgroup"_s && isTableCellInSameRowGroup(tableCell.get()))
             headers.append(tableCell);
         else if (tableCell->isRowHeader())
             headers.append(tableCell);
@@ -338,7 +338,7 @@ AccessibilityTableRow* AccessibilityTableCell::parentRow() const
 
 void AccessibilityTableCell::ensureIndexesUpToDate() const
 {
-    if (auto* parentTable = this->parentTable())
+    if (RefPtr parentTable = this->parentTable())
         parentTable->ensureCellIndexesUpToDate();
 }
 
@@ -436,7 +436,7 @@ int AccessibilityTableCell::axRowIndex() const
     if (int value = getIntegralAttribute(aria_rowindexAttr); value >= 1)
         return value;
 
-    if (AccessibilityTableRow* parentRow = this->parentRow())
+    if (RefPtr parentRow = this->parentRow())
         return parentRow->axRowIndex();
 
     return -1;

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
@@ -103,7 +103,7 @@ void AccessibilityTableColumn::addChildren()
     ASSERT(!m_childrenInitialized); 
     m_childrenInitialized = true;
 
-    auto* parentTable = dynamicDowncast<AccessibilityTable>(m_parent.get());
+    RefPtr parentTable = dynamicDowncast<AccessibilityTable>(m_parent.get());
     if (!parentTable || !parentTable->isExposable())
         return;
 

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
@@ -66,7 +66,7 @@ void AccessibilityTableHeaderContainer::addChildren()
     ASSERT(!m_childrenInitialized); 
     
     m_childrenInitialized = true;
-    auto* parentTable = dynamicDowncast<AccessibilityTable>(m_parent.get());
+    RefPtr parentTable = dynamicDowncast<AccessibilityTable>(m_parent.get());
     if (!parentTable || !parentTable->isExposable())
         return;
 

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -105,7 +105,7 @@ AccessibilityTable* AccessibilityTableRow::parentTable() const
 {
     // The parent table might not be the direct ancestor of the row unfortunately. ARIA states that role="grid" should
     // only have "row" elements, but if not, we still should handle it gracefully by finding the right table.
-    for (AccessibilityObject* parent = parentObject(); parent; parent = parent->parentObject()) {
+    for (RefPtr parent = parentObject(); parent; parent = parent->parentObject()) {
         // If this is a non-anonymous table object, but not an accessibility table, we should stop because we don't want to
         // choose another ancestor table as this row's table.
         if (auto* parentTable = dynamicDowncast<AccessibilityTable>(*parent)) {


### PR DESCRIPTION
#### 9a71189f24d2a61b309ce67d5d5cb69295972649
<pre>
Adopt more smart pointers in accessibility table code
<a href="https://bugs.webkit.org/show_bug.cgi?id=277072">https://bugs.webkit.org/show_bug.cgi?id=277072</a>

Reviewed by Chris Dumez.

Use smart pointers in accessibility table code as indicated by
[alpha.webkit.UncountedCallArgsChecker] warnings. The choice of using a
smart pointer is motivated by the fact the following methods are not
trivial:

  - AXCoreObject::isTableCellInSameColGroup()
  - AXCoreObject::isTableCellInSameRowGroup()
  - AXObjectCache::getOrCreate()
  - AccessibilityNodeObject::parentObject()
  - AccessibilityObject::addChild()
  - AccessibilityObject::children()
  - AccessibilityTable::cellForColumnAndRow()
  - AccessibilityTable::columnHeaders()
  - AccessibilityTable::ensureCellIndexesUpToDate()
  - AccessibilityTable::rowCount()
  - AccessibilityTableCell::colSpan()
  - AccessibilityTableCell::isColumnHeader()
  - AccessibilityTableCell::rowSpan()
  - AccessibilityTableRow::axRowIndex()

* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::isDataTable const):
(WebCore::AccessibilityTable::addChildren):
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::parentTable const):
(WebCore::AccessibilityTableCell::columnHeaders):
(WebCore::AccessibilityTableCell::rowHeaders):
(WebCore::AccessibilityTableCell::ensureIndexesUpToDate const):
(WebCore::AccessibilityTableCell::axRowIndex const):
* Source/WebCore/accessibility/AccessibilityTableColumn.cpp:
(WebCore::AccessibilityTableColumn::addChildren):
* Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp:
(WebCore::AccessibilityTableHeaderContainer::addChildren):
* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
(WebCore::AccessibilityTableRow::parentTable const):

Canonical link: <a href="https://commits.webkit.org/281982@main">https://commits.webkit.org/281982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6293a305ac6a7977d223fa160569e32cf6f6d82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12043 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49652 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8356 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30496 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10494 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10956 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56431 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67178 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57034 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57253 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13723 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4490 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36659 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37742 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->