### PR TITLE
[WPE][cross-toolchain-helper] Add sysprof and userland/vcgencmd tools into the image

### DIFF
--- a/Tools/yocto/meta-openembedded_and_meta-webkit.patch
+++ b/Tools/yocto/meta-openembedded_and_meta-webkit.patch
@@ -25,20 +25,6 @@ index f4911f3..b13abad 100644
  
  [Install]
  WantedBy=multi-user.target
-diff --git a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
-index 9459f4c..e74a20c 100644
---- a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
-+++ b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
-@@ -170,9 +170,6 @@ RDEPENDS:packagegroup-wpewebkit-depends-desktop = "\
-     libxtst \
-     libx11-locale \
-     xorg-minimal-fonts \
--    gdk-pixbuf-loader-ico \
--    gdk-pixbuf-loader-bmp \
--    gdk-pixbuf-loader-ani \
-     gdk-pixbuf-xlib \
-     liberation-fonts \
-     atk \
 diff --git a/sources/poky/meta/recipes-support/icu/icu/ICU-22813_rise_buffer_sizes_pkgdata_PR3058.patch b/sources/poky/meta/recipes-support/icu/icu/ICU-22813_rise_buffer_sizes_pkgdata_PR3058.patch
 new file mode 100644
 index 0000000..21bc060
@@ -127,3 +113,106 @@ index 8352bf2..c81cfe9 100644
             "
  
  SRC_URI:append:class-target = "\
+diff --git a/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof/0001-meson-Check-for-libunwind-instead-of-libunwind-gener.patch b/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof/0001-meson-Check-for-libunwind-instead-of-libunwind-gener.patch
+index dc702a0e37..1082fe4ffc 100644
+--- a/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof/0001-meson-Check-for-libunwind-instead-of-libunwind-gener.patch
++++ b/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof/0001-meson-Check-for-libunwind-instead-of-libunwind-gener.patch
+@@ -13,15 +13,15 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
+  1 file changed, 1 insertion(+), 1 deletion(-)
+ 
+ diff --git a/meson.build b/meson.build
+-index 2835782..0fdb39a 100644
++index 3d3d8b5..4a1963d 100644
+ --- a/meson.build
+ +++ b/meson.build
+-@@ -81,7 +81,7 @@ config_h.set10('HAVE_POLKIT_AGENT', polkit_agent_dep.found())
+- config_h.set10('HAVE_POLKIT', polkit_dep.found())
+- 
++@@ -96,7 +96,7 @@ config_h.set10('HAVE_POLKIT', polkit_dep.found())
+  if get_option('libunwind')
+--  libunwind_dep = dependency('libunwind-generic')
+-+  libunwind_dep = dependency('libunwind')
++   # Force libunwind usage if it's specified to avoid back compiles
++   # and backtrace() showing up in builds
++-  libunwind_dep = dependency('libunwind-generic', required: true)
+++  libunwind_dep = dependency('libunwind', required: true)
+    config_h.set('ENABLE_LIBUNWIND', libunwind_dep.found())
+    config_h.set('HAVE_UNW_SET_CACHE_SIZE', libunwind_dep.found() and cc.has_header_symbol('libunwind.h', 'unw_set_cache_size', dependencies: [libunwind_dep]))
+  endif
+diff --git a/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof/0002-meson-Do-not-invoke-the-commands-to-update-the-icon-.patch b/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof/0002-meson-Do-not-invoke-the-commands-to-update-the-icon-.patch
+new file mode 100644
+index 0000000000..998c20c657
+--- /dev/null
++++ b/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof/0002-meson-Do-not-invoke-the-commands-to-update-the-icon-.patch
+@@ -0,0 +1,32 @@
++From 9ad120283f4b61b97da67f18a95bb3b4f1e8a3b9 Mon Sep 17 00:00:00 2001
++From: Carlos Alberto Lopez Perez <clopez@igalia.com>
++Date: Wed, 24 Jul 2024 15:51:05 +0100
++Subject: [PATCH] meson: Do not invoke the commands to update the icon caches
++ when cross-building
++
++This does not have any useful efect when cross-building and it requires
++the cross-builder environment to have gtk4-native built in order to invoke
++gtk-update-icon-cache program.
++
++Upstream-Status: Pending
++Signed-off-by: Carlos Alberto Lopez Perez <clopez@igalia.com>
++---
++ meson.build | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/meson.build b/meson.build
++index 3d3d8b5..da622f1 100644
++--- a/meson.build
+++++ b/meson.build
++@@ -250,7 +250,7 @@ configure_file(
++   configuration: config_h
++ )
++ 
++-if get_option('gtk') and gnome.found()
+++if get_option('gtk') and gnome.found() and not meson.is_cross_build()
++   gnome.post_install(
++       gtk_update_icon_cache: true,
++     update_desktop_database: true
++-- 
++2.39.2
++
+diff --git a/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof_3.44.0.bb b/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof_3.48.0.bb
+similarity index 71%
+rename from meta-gnome/recipes-gnome/sysprof/sysprof_3.44.0.bb
+rename to meta-gnome/recipes-gnome/sysprof/sysprof_3.48.0.bb
+index 3523bad3e2..bf4ee7a73e 100644
+--- a/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof_3.44.0.bb
++++ b/sources/meta-openembedded/meta-gnome/recipes-gnome/sysprof/sysprof_3.48.0.bb
+@@ -14,19 +14,24 @@ DEPENDS += " \
+     json-glib \
+ "
+ 
+-SRC_URI += "file://0001-meson-Check-for-libunwind-instead-of-libunwind-gener.patch"
+-SRC_URI[archive.sha256sum] = "ab5d9f5b71973b3088d58a1bfdf1dc23c39a02f5fce4e5e9c73e034b178b005b"
++SRC_URI += "file://0001-meson-Check-for-libunwind-instead-of-libunwind-gener.patch \
++            file://0002-meson-Do-not-invoke-the-commands-to-update-the-icon-.patch "
++SRC_URI[archive.sha256sum] = "07d9081a66cf2fb52753f48ff2b85ada75c60ff1bc1af1bd14d8aeb627972168"
+ 
+-PACKAGECONFIG ?= "${@bb.utils.contains('DISTRO_FEATURES', 'polkit', 'sysprofd libsysprof', '', d)} \
++PACKAGECONFIG ?= "${@bb.utils.contains('DISTRO_FEATURES', 'polkit', 'sysprofd', '', d)} \
+                   ${@bb.utils.contains_any('DISTRO_FEATURES', '${GTK3DISTROFEATURES}', 'gtk', '', d)} \
+-                  libunwind"
++                  agent \
++                  libsysprof \
++                  libunwind \
++                  "
+ # nongnu libunwind needs porting to RV32
+ PACKAGECONFIG:remove:riscv32 = "libunwind"
+ 
+-PACKAGECONFIG[gtk] = "-Denable_gtk=true,-Denable_gtk=false,gtk+3 libdazzle"
+-PACKAGECONFIG[sysprofd] = "-Dwith_sysprofd=bundled,-Dwith_sysprofd=none,polkit"
+-PACKAGECONFIG[libsysprof] = "-Dlibsysprof=true,-Dlibsysprof=false,polkit"
++PACKAGECONFIG[gtk] = "-Dgtk=true,-Dgtk=false,gtk4 libadwaita"
++PACKAGECONFIG[sysprofd] = "-Dsysprofd=bundled,-Dsysprofd=none,polkit"
++PACKAGECONFIG[libsysprof] = "-Dlibsysprof=true,-Dlibsysprof=false,json-glib"
+ PACKAGECONFIG[libunwind] = "-Dlibunwind=true,-Dlibunwind=false,libunwind"
++PACKAGECONFIG[agent] = "-Dagent=true,-Dagent=false,"
+ 
+ EXTRA_OEMESON += "-Dsystemdunitdir=${systemd_unitdir}/system"
+ 

--- a/Tools/yocto/riscv/bblayers.conf
+++ b/Tools/yocto/riscv/bblayers.conf
@@ -9,6 +9,7 @@ BBLAYERS ?= " \
   %(BSPDIR)s/sources/poky/meta \
   %(BSPDIR)s/sources/poky/meta-poky \
   %(BSPDIR)s/sources/poky/meta-yocto-bsp \
+  %(BSPDIR)s/sources/meta-openembedded/meta-gnome \
   %(BSPDIR)s/sources/meta-openembedded/meta-multimedia \
   %(BSPDIR)s/sources/meta-openembedded/meta-networking \
   %(BSPDIR)s/sources/meta-openembedded/meta-oe \

--- a/Tools/yocto/riscv/manifest.xml
+++ b/Tools/yocto/riscv/manifest.xml
@@ -11,6 +11,6 @@
   <project remote="yocto"  revision="f7def85be9f99dcb4ba488bead201f670304379b" name="poky" path="sources/poky"/>
   <project remote="github" revision="4a7bb77f7ebe0ac8be5bab5103d8bd993e17e18d" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
   <project remote="github" revision="d330dfe4011a873d379cdf6228fa1f243cf5a6db" name="riscv/meta-riscv" path="sources/meta-riscv"/>
-  <project remote="github" revision="5062466a2f1436f438627e9934273b3b1825e732" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
+  <project remote="github" revision="d5d6eb779e1c86832dd8f645c3a8471d0d15ff3d" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
 
 </manifest>

--- a/Tools/yocto/rpi/bblayers.conf
+++ b/Tools/yocto/rpi/bblayers.conf
@@ -9,6 +9,7 @@ BBLAYERS ?= " \
   %(BSPDIR)s/sources/poky/meta \
   %(BSPDIR)s/sources/poky/meta-poky \
   %(BSPDIR)s/sources/poky/meta-yocto-bsp \
+  %(BSPDIR)s/sources/meta-openembedded/meta-gnome \
   %(BSPDIR)s/sources/meta-openembedded/meta-multimedia \
   %(BSPDIR)s/sources/meta-openembedded/meta-networking \
   %(BSPDIR)s/sources/meta-openembedded/meta-oe \

--- a/Tools/yocto/rpi/manifest.xml
+++ b/Tools/yocto/rpi/manifest.xml
@@ -11,7 +11,7 @@
   <project remote="yocto"  revision="f7def85be9f99dcb4ba488bead201f670304379b" name="poky" path="sources/poky"/>
   <project remote="github" revision="4a7bb77f7ebe0ac8be5bab5103d8bd993e17e18d" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
   <project remote="yocto"  revision="1918a27419dcd5e79954c0dc0edddcde91057a7e" name="meta-raspberrypi" path="sources/meta-raspberrypi"/>
-  <project remote="github" revision="5062466a2f1436f438627e9934273b3b1825e732" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
+  <project remote="github" revision="d5d6eb779e1c86832dd8f645c3a8471d0d15ff3d" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
   <project remote="github" revision="e7dceb1c92caf7f21ef1d7b49c85328c30cffd90" name="kraj/meta-clang.git" path="sources/meta-clang"/>
   <project remote="github" revision="40ef1d0799124a36b22df11a7562868c0edb23b1" name="OSSystems/meta-browser.git" path="sources/meta-browser"/>
 


### PR DESCRIPTION
#### 26796239d990f7b51f4dc9418a764feb900d469b
<pre>
[WPE][cross-toolchain-helper] Add sysprof and userland/vcgencmd tools into the image
<a href="https://bugs.webkit.org/show_bug.cgi?id=277075">https://bugs.webkit.org/show_bug.cgi?id=277075</a>

Reviewed by Nikolas Zimmermann.

Add a few debugging utilities into the image by default that will be helpful to debug
issues, like

 - sysprof (the last stable version as of today, which is 3.48.0)
 - rpi userland tools: include a bunch of cli tools, like vcgencmd that allow to tune
   features like voltages and internal settings of the SoC.
   This seems to work also with the open source stack.
 - weston: enable RDP plugin to make easier see the remote scren

* Tools/yocto/meta-openembedded_and_meta-webkit.patch: update sysprof recipe.
* Tools/yocto/riscv/bblayers.conf: we now need meta-gnome for sysprof.
* Tools/yocto/riscv/manifest.xml: update to last version of meta-webkit that is the
  commit adding sysprof, userland and enabling rdp for weston.
  See: <a href="https://github.com/Igalia/meta-webkit/commit/d5d6eb779">https://github.com/Igalia/meta-webkit/commit/d5d6eb779</a>
* Tools/yocto/rpi/bblayers.conf: we now need meta-gnome for sysprof.
* Tools/yocto/rpi/manifest.xml: Same than the other manifest.xml file.

Canonical link: <a href="https://commits.webkit.org/281346@main">https://commits.webkit.org/281346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1be84ced841e1cb9c019c3fc1e17619e6ea9be4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10136 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61742 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48365 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7097 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29203 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8854 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9060 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55012 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65260 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3541 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9021 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55708 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55836 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2938 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8902 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34772 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35855 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36941 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35600 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->