### PR TITLE
[GTK] Remove PlatformDisplay::sharedDisplayForCompositing()

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -71,7 +71,7 @@ class PlatformDisplay {
     WTF_MAKE_NONCOPYABLE(PlatformDisplay); WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT static PlatformDisplay& sharedDisplay();
-    WEBCORE_EXPORT static PlatformDisplay& sharedDisplayForCompositing();
+    WEBCORE_EXPORT static void setSharedDisplay(std::unique_ptr<PlatformDisplay>&&);
     virtual ~PlatformDisplay();
 
     enum class Type {
@@ -148,17 +148,11 @@ public:
     const String& accessibilityBusAddress() const;
 #endif
 
-#if PLATFORM(WPE)
-    static void setUseDMABufForRendering(bool useDMABufForRendering) { s_useDMABufForRendering = useDMABufForRendering; }
-#endif
-
 protected:
     PlatformDisplay();
 #if PLATFORM(GTK)
     explicit PlatformDisplay(GdkDisplay*);
 #endif
-
-    static void setSharedDisplayForCompositing(PlatformDisplay&);
 
     virtual void initializeEGLDisplay();
 
@@ -223,10 +217,6 @@ private:
 
 #if USE(SKIA)
     ThreadSafeWeakHashSet<SkiaGLContext> m_skiaGLContexts;
-#endif
-
-#if PLATFORM(WPE)
-    static bool s_useDMABufForRendering;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp
+++ b/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp
@@ -38,10 +38,6 @@ std::unique_ptr<PlatformDisplaySurfaceless> PlatformDisplaySurfaceless::create()
 
 PlatformDisplaySurfaceless::PlatformDisplaySurfaceless()
 {
-#if PLATFORM(GTK)
-    PlatformDisplay::setSharedDisplayForCompositing(*this);
-#endif
-
     const char* extensions = eglQueryString(nullptr, EGL_EXTENSIONS);
     if (GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base"))
         m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr);

--- a/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp
@@ -40,10 +40,6 @@ std::unique_ptr<PlatformDisplayGBM> PlatformDisplayGBM::create(struct gbm_device
 
 PlatformDisplayGBM::PlatformDisplayGBM(struct gbm_device* device)
 {
-#if PLATFORM(GTK)
-    PlatformDisplay::setSharedDisplayForCompositing(*this);
-#endif
-
     const char* extensions = eglQueryString(nullptr, EGL_EXTENSIONS);
     if (GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base"))
         m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_GBM_KHR, device, nullptr);

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -125,7 +125,7 @@ void webKitGLVideoSinkFinalize(GObject* object)
 
 std::optional<GRefPtr<GstContext>> requestGLContext(const char* contextType)
 {
-    auto& sharedDisplay = PlatformDisplay::sharedDisplayForCompositing();
+    auto& sharedDisplay = PlatformDisplay::sharedDisplay();
     auto* gstGLDisplay = sharedDisplay.gstGLDisplay();
     auto* gstGLContext = sharedDisplay.gstGLContext();
 
@@ -227,7 +227,7 @@ void webKitGLVideoSinkSetMediaPlayerPrivate(WebKitGLVideoSink* sink, MediaPlayer
 
 bool webKitGLVideoSinkProbePlatform()
 {
-    if (!PlatformDisplay::sharedDisplayForCompositing().gstGLContext()) {
+    if (!PlatformDisplay::sharedDisplay().gstGLContext()) {
         GST_WARNING("WebKit shared GL context is not available.");
         return false;
     }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -552,7 +552,7 @@ void WebCoreLogObserver::removeWatch(const Logger& logger)
 void deinitializeGStreamer()
 {
 #if USE(GSTREAMER_GL)
-    auto& sharedDisplay = PlatformDisplay::sharedDisplayForCompositing();
+    auto& sharedDisplay = PlatformDisplay::sharedDisplay();
     sharedDisplay.clearGStreamerGLState();
 #endif
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -113,11 +113,11 @@ RefPtr<VideoFrame> VideoFrame::fromNativeImage(NativeImage& image)
 
     GRefPtr<GstBuffer> buffer;
     if (platformImage->isTextureBacked()) {
-        if (!PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent())
+        if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
             return nullptr;
 
         auto data = SkData::MakeUninitialized(size);
-        GrDirectContext* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
+        GrDirectContext* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
         if (!platformImage->readPixels(grContext, imageInfo, static_cast<uint8_t*>(data->writable_data()), strides[0], 0, 0))
             return nullptr;
 

--- a/Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.h
+++ b/Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.h
@@ -36,15 +36,15 @@ namespace WebCore {
 class PlatformDisplayLibWPE final : public PlatformDisplay {
 public:
     static std::unique_ptr<PlatformDisplayLibWPE> create();
+    static std::unique_ptr<PlatformDisplayLibWPE> create(int);
 
     virtual ~PlatformDisplayLibWPE();
-
-    bool initialize(int);
 
     struct wpe_renderer_backend_egl* backend() const { return m_backend; }
 
 private:
     PlatformDisplayLibWPE() = default;
+    explicit PlatformDisplayLibWPE(int);
 
     Type type() const override { return PlatformDisplay::Type::WPE; }
 

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
@@ -148,7 +148,7 @@ AcceleratedBuffer::AcceleratedBuffer(sk_sp<SkSurface>&& surface, Flags flags)
 AcceleratedBuffer::~AcceleratedBuffer()
 {
     ensureOnMainThread([surface = WTFMove(m_surface), fence = WTFMove(m_fence)]() mutable {
-        PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent();
+        PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent();
         fence = nullptr;
         surface = nullptr;
     });
@@ -169,7 +169,7 @@ void AcceleratedBuffer::completePainting()
 {
     m_surface->getCanvas()->restore();
 
-    auto* grContext = WebCore::PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
+    auto* grContext = WebCore::PlatformDisplay::sharedDisplay().skiaGrContext();
     if (WebCore::GLFence::isSupported()) {
         grContext->flushAndSubmit(m_surface.get(), GrSyncCpu::kNo);
         m_fence = WebCore::GLFence::create();

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPlaceholderRenderingContextSource.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPlaceholderRenderingContextSource.cpp
@@ -124,7 +124,7 @@ void NicosiaPlaceholderRenderingContextSource::setPlaceholderBuffer(ImageBuffer&
         unsigned textureID = 0;
         auto image = nativeImage->platformImage();
         if (image->isTextureBacked()) {
-            auto& display = PlatformDisplay::sharedDisplayForCompositing();
+            auto& display = PlatformDisplay::sharedDisplay();
             if (!display.skiaGLContext()->makeContextCurrent())
                 return;
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
@@ -100,10 +100,10 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
 
     if (platformImage->isTextureBacked()) {
         auto data = SkData::MakeUninitialized(imageInfo.computeMinByteSize());
-        if (!PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent())
+        if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
             return false;
 
-        GrDirectContext* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
+        GrDirectContext* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
         if (!platformImage->readPixels(grContext, imageInfo, static_cast<uint8_t*>(data->writable_data()), bytesPerRow, 0, 0))
             return false;
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -99,7 +99,7 @@ bool GraphicsContextSkia::makeGLContextCurrentIfNeeded() const
     if (m_renderingMode == RenderingMode::Unaccelerated || m_renderingPurpose != RenderingPurpose::Canvas)
         return true;
 
-    return PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent();
+    return PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent();
 }
 
 void GraphicsContextSkia::save(GraphicsContextState::Purpose purpose)

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -65,11 +65,11 @@ std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBac
     if (parameters.purpose != RenderingPurpose::Canvas && !ProcessCapabilities::canUseAcceleratedBuffers())
         return nullptr;
 
-    auto* glContext = PlatformDisplay::sharedDisplayForCompositing().skiaGLContext();
+    auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
     if (!glContext || !glContext->makeContextCurrent())
         return nullptr;
 
-    auto* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
     RELEASE_ASSERT(grContext);
     auto imageInfo = SkImageInfo::MakeN32Premul(backendSize.width(), backendSize.height(), parameters.colorSpace.platformColorSpace());
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
@@ -96,7 +96,7 @@ ImageBufferSkiaAcceleratedBackend::~ImageBufferSkiaAcceleratedBackend()
 {
 #if USE(NICOSIA)
     if (m_texture.back || m_texture.front) {
-        GLContext::ScopedGLContextCurrent scopedContext(*PlatformDisplay::sharedDisplayForCompositing().sharingGLContext());
+        GLContext::ScopedGLContextCurrent scopedContext(*PlatformDisplay::sharedDisplay().sharingGLContext());
         m_texture.back = nullptr;
         m_texture.front = nullptr;
     }
@@ -119,7 +119,7 @@ RefPtr<NativeImage> ImageBufferSkiaAcceleratedBackend::createNativeImageReferenc
 
 void ImageBufferSkiaAcceleratedBackend::getPixelBuffer(const IntRect& srcRect, PixelBuffer& destination)
 {
-    if (!PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent())
+    if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
         return;
 
     auto info = m_surface->imageInfo();
@@ -132,7 +132,7 @@ void ImageBufferSkiaAcceleratedBackend::getPixelBuffer(const IntRect& srcRect, P
 
 void ImageBufferSkiaAcceleratedBackend::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
-    if (!PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent())
+    if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
         return;
 
     auto info = m_surface->imageInfo();
@@ -151,7 +151,7 @@ RefPtr<GraphicsLayerContentsDisplayDelegate> ImageBufferSkiaAcceleratedBackend::
 
 void ImageBufferSkiaAcceleratedBackend::swapBuffersIfNeeded()
 {
-    auto& display = PlatformDisplay::sharedDisplayForCompositing();
+    auto& display = PlatformDisplay::sharedDisplay();
     if (!display.skiaGLContext()->makeContextCurrent())
         return;
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp
@@ -66,10 +66,10 @@ private:
 
 static sk_sp<SkData> encodeAcceleratedImage(SkImage* image, const String& mimeType, std::optional<double> quality)
 {
-    if (!PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent())
+    if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
         return nullptr;
 
-    GrDirectContext* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
+    GrDirectContext* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
 
     if (MIMETypeRegistry::isJPEGMIMEType(mimeType)) {
         SkJpegEncoder::Options options;

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -74,10 +74,10 @@ std::optional<Color> NativeImage::singlePixelSolidColor() const
 
     auto platformImage = this->platformImage();
     if (platformImage->isTextureBacked()) {
-        if (!PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent())
+        if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
             return std::nullopt;
 
-        GrDirectContext* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
+        GrDirectContext* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
         const auto& imageInfo = platformImage->imageInfo();
         uint32_t pixel;
         SkPixmap pixmap(imageInfo, &pixel, imageInfo.minRowBytes());

--- a/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
@@ -69,7 +69,7 @@ RefPtr<Nicosia::Buffer> SkiaAcceleratedBufferPool::acquireBuffer(const IntSize& 
 
 RefPtr<Nicosia::Buffer> SkiaAcceleratedBufferPool::createAcceleratedBuffer(const IntSize& size, bool supportsAlpha)
 {
-    auto* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
     RELEASE_ASSERT(grContext);
     auto imageInfo = SkImageInfo::MakeN32Premul(size.width(), size.height(), SkColorSpace::MakeSRGB());
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -129,7 +129,7 @@ RefPtr<PixelBuffer> GraphicsContextGLTextureMapperANGLE::readCompositedResults()
 RefPtr<GraphicsContextGL> createWebProcessGraphicsContextGL(const GraphicsContextGLAttributes& attributes, SerialFunctionDispatcher*)
 {
 #if USE(ANGLE_GBM)
-    auto& eglExtensions = PlatformDisplay::sharedDisplayForCompositing().eglExtensions();
+    auto& eglExtensions = PlatformDisplay::sharedDisplay().eglExtensions();
     if (eglExtensions.KHR_image_base && eglExtensions.EXT_image_dma_buf_import)
         return GraphicsContextGLGBMTextureMapper::create(GraphicsContextGLAttributes { attributes });
 #endif
@@ -186,7 +186,7 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitializeContext()
 {
     m_isForWebGL2 = contextAttributes().isWebGL2;
 
-    auto& sharedDisplay = PlatformDisplay::sharedDisplayForCompositing();
+    auto& sharedDisplay = PlatformDisplay::sharedDisplay();
     m_displayObj = sharedDisplay.angleEGLDisplay();
     if (m_displayObj == EGL_NO_DISPLAY)
         return false;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
@@ -54,7 +54,7 @@ struct TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::EGLImageData {
     ~EGLImageData()
     {
         if (numImages) {
-            auto& platformDisplay = PlatformDisplay::sharedDisplayForCompositing();
+            auto& platformDisplay = PlatformDisplay::sharedDisplay();
             glDeleteTextures(numImages, texture.data());
 
             for (unsigned i = 0; i < numImages; ++i) {
@@ -303,7 +303,7 @@ std::unique_ptr<TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::EGLImageData
 {
     using EGLImageData = TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::EGLImageData;
 
-    auto& platformDisplay = PlatformDisplay::sharedDisplayForCompositing();
+    auto& platformDisplay = PlatformDisplay::sharedDisplay();
 
     EGLImageKHR image[DMABufFormat::c_maxPlanes];
     for (unsigned i = 0; i < object.format.numPlanes; ++i) {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp
@@ -79,7 +79,7 @@ Ref<Nicosia::Buffer> CoordinatedGraphicsLayer::paintTile(const IntRect& tileRect
 
     // Skia/GPU - accelerated rendering.
     if (auto* acceleratedBufferPool = m_coordinator->skiaAcceleratedBufferPool()) {
-        PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent();
+        PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent();
         if (auto buffer = acceleratedBufferPool->acquireBuffer(tileRect.size(), !contentsOpaque())) {
             paintBuffer(*buffer);
             return Ref { *buffer };

--- a/Source/WebKit/GPUProcess/playstation/GPUProcessPlayStation.cpp
+++ b/Source/WebKit/GPUProcess/playstation/GPUProcessPlayStation.cpp
@@ -39,8 +39,7 @@ namespace WebKit {
 void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters&)
 {
 #if USE(WPE_RENDERER)
-    RELEASE_ASSERT(is<WebCore::PlatformDisplayLibWPE>(WebCore::PlatformDisplay::sharedDisplay()));
-    downcast<WebCore::PlatformDisplayLibWPE>(WebCore::PlatformDisplay::sharedDisplay()).initialize(0);
+    WebCore::PlatformDisplay::setSharedDisplay(WebCore::PlatformDisplayLibWPE::create(0));
 #endif
 }
 

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -132,7 +132,7 @@ void ThreadedCompositor::createGLContext()
     // a plain C cast expression in this one instance works in all cases.
     static_assert(sizeof(GLNativeWindowType) <= sizeof(uint64_t), "GLNativeWindowType must not be longer than 64 bits.");
     auto windowType = (GLNativeWindowType) m_nativeSurfaceHandle;
-    m_context = GLContext::create(windowType, PlatformDisplay::sharedDisplayForCompositing());
+    m_context = GLContext::create(windowType, PlatformDisplay::sharedDisplay());
     if (m_context) {
         m_context->makeContextCurrent();
         m_client.didCreateGLContext();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -64,10 +64,6 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringView.h>
 
-#if PLATFORM(GTK)
-#include <WebCore/PlatformDisplay.h>
-#endif
-
 namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
@@ -623,15 +619,11 @@ void WebEditorClient::setInputMethodState(Element* element)
 
 bool WebEditorClient::supportsGlobalSelection()
 {
-#if PLATFORM(GTK) && PLATFORM(X11)
-    if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::X11)
-        return true;
-#endif
-#if PLATFORM(GTK) && PLATFORM(WAYLAND)
-    if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::Wayland)
-        return true;
-#endif
+#if PLATFORM(GTK)
+    return true;
+#else
     return false;
+#endif
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
@@ -50,10 +50,10 @@ std::unique_ptr<AcceleratedSurface> AcceleratedSurface::create(WebPage& webPage,
 {
 #if (PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM)))
 #if USE(GBM)
-    if (PlatformDisplay::sharedDisplayForCompositing().type() == PlatformDisplay::Type::GBM)
+    if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::GBM)
         return AcceleratedSurfaceDMABuf::create(webPage, client);
 #endif
-    if (PlatformDisplay::sharedDisplayForCompositing().type() == PlatformDisplay::Type::Surfaceless)
+    if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::Surfaceless)
         return AcceleratedSurfaceDMABuf::create(webPage, client);
 #endif
 #if USE(WPE_RENDERER)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -90,7 +90,7 @@ CompositingCoordinator::CompositingCoordinator(WebPage& page, CompositingCoordin
 #endif
 {
 #if USE(SKIA)
-    if (ProcessCapabilities::canUseAcceleratedBuffers() && PlatformDisplay::sharedDisplayForCompositing().skiaGLContext())
+    if (ProcessCapabilities::canUseAcceleratedBuffers() && PlatformDisplay::sharedDisplay().skiaGLContext())
         m_skiaAcceleratedBufferPool = makeUnique<SkiaAcceleratedBufferPool>();
     else if (auto numberOfThreads = skiaNumberOfCpuPaintingThreads(); numberOfThreads > 0)
         m_skiaUnacceleratedThreadedRenderingPool = WorkerPool::create("SkiaPaintingThread"_s, numberOfThreads);

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -208,7 +208,7 @@ std::unique_ptr<AcceleratedSurfaceDMABuf::RenderTarget> AcceleratedSurfaceDMABuf
 
     attributes.append(EGL_NONE);
 
-    auto& display = WebCore::PlatformDisplay::sharedDisplayForCompositing();
+    auto& display = WebCore::PlatformDisplay::sharedDisplay();
     auto image = display.createEGLImage(EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attributes);
     gbm_bo_destroy(bo);
 
@@ -235,7 +235,7 @@ AcceleratedSurfaceDMABuf::RenderTargetEGLImage::~RenderTargetEGLImage()
     if (!m_image)
         return;
 
-    WebCore::PlatformDisplay::sharedDisplayForCompositing().destroyEGLImage(m_image);
+    WebCore::PlatformDisplay::sharedDisplay().destroyEGLImage(m_image);
 }
 #endif
 
@@ -282,7 +282,7 @@ std::unique_ptr<AcceleratedSurfaceDMABuf::RenderTarget> AcceleratedSurfaceDMABuf
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, size.width(), size.height(), 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
-    auto& display = WebCore::PlatformDisplay::sharedDisplayForCompositing();
+    auto& display = WebCore::PlatformDisplay::sharedDisplay();
     auto image = display.createEGLImage(eglGetCurrentContext(), EGL_GL_TEXTURE_2D, (EGLClientBuffer)(uint64_t)texture, { });
     if (!image) {
         glDeleteTextures(1, &texture);
@@ -346,7 +346,7 @@ void AcceleratedSurfaceDMABuf::RenderTargetTexture::willRenderFrame() const
 AcceleratedSurfaceDMABuf::SwapChain::SwapChain(uint64_t surfaceID)
     : m_surfaceID(surfaceID)
 {
-    auto& display = WebCore::PlatformDisplay::sharedDisplayForCompositing();
+    auto& display = WebCore::PlatformDisplay::sharedDisplay();
     switch (display.type()) {
     case WebCore::PlatformDisplay::Type::Surfaceless:
         if (display.eglExtensions().MESA_image_dma_buf_export && WebProcess::singleton().dmaBufRendererBufferMode().contains(DMABufRendererBufferMode::Hardware))
@@ -384,7 +384,7 @@ void AcceleratedSurfaceDMABuf::SwapChain::setupBufferFormat(const Vector<DMABufR
     // The preferred formats vector is sorted by usage, but all formats for the same usage has the same priority.
     Locker locker { m_dmabufFormatLock };
     BufferFormat dmabufFormat;
-    const auto& supportedFormats = WebCore::PlatformDisplay::sharedDisplayForCompositing().dmabufFormats();
+    const auto& supportedFormats = WebCore::PlatformDisplay::sharedDisplay().dmabufFormats();
     for (const auto& bufferFormat : preferredFormats) {
         for (const auto& format : supportedFormats) {
             auto index = bufferFormat.formats.findIf([&](const auto& item) {

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
@@ -68,7 +68,7 @@ void AcceleratedSurfaceLibWPE::initialize()
         nullptr
     };
     wpe_renderer_backend_egl_target_set_client(m_backend, &s_client, this);
-    wpe_renderer_backend_egl_target_initialize(m_backend, downcast<PlatformDisplayLibWPE>(PlatformDisplay::sharedDisplayForCompositing()).backend(),
+    wpe_renderer_backend_egl_target_initialize(m_backend, downcast<PlatformDisplayLibWPE>(PlatformDisplay::sharedDisplay()).backend(),
         std::max(1, m_size.width()), std::max(1, m_size.height()));
 }
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -71,10 +71,6 @@ OBJC_CLASS NSMutableDictionary;
 
 #endif
 
-#if PLATFORM(GTK)
-#include <WebCore/PlatformDisplay.h>
-#endif
-
 #if PLATFORM(GTK) || PLATFORM(WPE)
 #include "DMABufRendererBufferMode.h"
 #endif
@@ -774,10 +770,6 @@ private:
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     OptionSet<DMABufRendererBufferMode> m_dmaBufRendererBufferMode;
-#endif
-
-#if PLATFORM(GTK)
-    std::unique_ptr<WebCore::PlatformDisplay> m_displayForCompositing;
 #endif
 
     bool m_hasSuspendedPageProxy { false };

--- a/Source/WebKit/WebProcess/playstation/WebProcessPlayStation.cpp
+++ b/Source/WebKit/WebProcess/playstation/WebProcessPlayStation.cpp
@@ -40,10 +40,8 @@ namespace WebKit {
 void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& parameters)
 {
 #if USE(WPE_RENDERER)
-    if (!parameters.isServiceWorkerProcess) {
-        RELEASE_ASSERT(is<WebCore::PlatformDisplayLibWPE>(WebCore::PlatformDisplay::sharedDisplay()));
-        downcast<WebCore::PlatformDisplayLibWPE>(WebCore::PlatformDisplay::sharedDisplay()).initialize(parameters.hostClientFileDescriptor.release());
-    }
+    if (!parameters.isServiceWorkerProcess)
+        WebCore::Platform::setSharedDisplay(WebCore::PlatformDisplayLibWPE::create(parameters.hostClientFileDescriptor.release()));
 #endif
     applyProcessCreationParameters(parameters.auxiliaryProcessParameters);
 }


### PR DESCRIPTION
#### d16394f878fcc8e37dc905a0ba4787d0232dc17e
<pre>
[GTK] Remove PlatformDisplay::sharedDisplayForCompositing()
<a href="https://bugs.webkit.org/show_bug.cgi?id=277079">https://bugs.webkit.org/show_bug.cgi?id=277079</a>

Reviewed by Miguel Gomez.

This is no longer needed because the GTK port doesn&apos;t support rendering
into platform surfaces and native display isn&apos;t used by the web process
either. In the web/GPU process the shared display is now created and set on
process initialization, and in the UI process it&apos;s created the first
time sharedDisplay() is called as before. In follow up patches I plan to
remove the usage of PlatformDisplay in the UI process.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::createPlatformDisplay):
(WebCore::PlatformDisplay::sharedDisplay):
(WebCore::PlatformDisplay::setSharedDisplay):
(WebCore::PlatformDisplay::~PlatformDisplay):
(WebCore::PlatformDisplay::sharedDisplayForCompositing): Deleted.
(WebCore::PlatformDisplay::setSharedDisplayForCompositing): Deleted.
* Source/WebCore/platform/graphics/PlatformDisplay.h:
(WebCore::PlatformDisplay::setUseDMABufForRendering): Deleted.
* Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp:
(WebCore::PlatformDisplaySurfaceless::PlatformDisplaySurfaceless):
* Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp:
(WebCore::PlatformDisplayGBM::PlatformDisplayGBM):
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(requestGLContext):
(webKitGLVideoSinkProbePlatform):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::deinitializeGStreamer):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrame::fromNativeImage):
* Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.cpp:
(WebCore::PlatformDisplayLibWPE::create):
(WebCore::PlatformDisplayLibWPE::PlatformDisplayLibWPE):
(WebCore::PlatformDisplayLibWPE::~PlatformDisplayLibWPE):
(WebCore::PlatformDisplayLibWPE::initialize): Deleted.
* Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.h:
* Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp:
(Nicosia::AcceleratedBuffer::~AcceleratedBuffer):
(Nicosia::AcceleratedBuffer::completePainting):
* Source/WebCore/platform/graphics/nicosia/NicosiaPlaceholderRenderingContextSource.cpp:
(Nicosia::NicosiaPlaceholderRenderingContextSource::setPlaceholderBuffer):
* Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp:
(WebCore::GraphicsContextGLImageExtractor::extractImage):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::makeGLContextCurrentIfNeeded const):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::create):
(WebCore::ImageBufferSkiaAcceleratedBackend::~ImageBufferSkiaAcceleratedBackend):
(WebCore::ImageBufferSkiaAcceleratedBackend::getPixelBuffer):
(WebCore::ImageBufferSkiaAcceleratedBackend::putPixelBuffer):
(WebCore::ImageBufferSkiaAcceleratedBackend::swapBuffersIfNeeded):
* Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp:
(WebCore::encodeAcceleratedImage):
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::NativeImage::singlePixelSolidColor const):
* Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp:
(WebCore::SkiaAcceleratedBufferPool::createAcceleratedBuffer):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::createWebProcessGraphicsContextGL):
(WebCore::GraphicsContextGLTextureMapperANGLE::platformInitializeContext):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp:
(WebCore::TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::EGLImageData::~EGLImageData):
(WebCore::TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::createEGLImageData):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp:
(WebCore::CoordinatedGraphicsLayer::paintTile):
* Source/WebKit/GPUProcess/playstation/GPUProcessPlayStation.cpp:
(WebKit::GPUProcess::platformInitializeGPUProcess):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::createGLContext):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::supportsGlobalSelection):
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::create):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::CompositingCoordinator):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::create):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::~RenderTargetEGLImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetTexture::create):
(WebKit::AcceleratedSurfaceDMABuf::SwapChain::SwapChain):
(WebKit::AcceleratedSurfaceDMABuf::SwapChain::setupBufferFormat):
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp:
(WebKit::AcceleratedSurfaceLibWPE::initialize):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):
* Source/WebKit/WebProcess/playstation/WebProcessPlayStation.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/281553@main">https://commits.webkit.org/281553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0369652f47b522cc4515e86299ec0ab3effa0578

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63674 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10282 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48467 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7190 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61788 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36485 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29308 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8980 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9205 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55125 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65405 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55806 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3697 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55943 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3070 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9044 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34917 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36000 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->