### PR TITLE
[Cocoa] Adopt CoreText API for adaptive image glyph rendering

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
@@ -31,7 +31,7 @@
 #import "GraphicsContextCG.h"
 #import "IOSurface.h"
 #import "IntRect.h"
-#import <pal/spi/cf/CoreTextSPI.h>
+#import <CoreText/CoreText.h>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/FeatureFlagsSPI.h>
 #import <pal/spi/mac/NSGraphicsSPI.h>
@@ -39,7 +39,7 @@
 #import <wtf/StdLibExtras.h>
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
-#include "MultiRepresentationHEICMetrics.h"
+#import "MultiRepresentationHEICMetrics.h"
 #endif
 
 #if USE(APPKIT)
@@ -49,6 +49,7 @@
 #if PLATFORM(IOS_FAMILY)
 #import "Color.h"
 #import "WKGraphics.h"
+#import <UIKit/UIKit.h>
 #import <pal/ios/UIKitSoftLink.h>
 #import <pal/spi/ios/UIKitSPI.h>
 #endif
@@ -83,9 +84,7 @@ ImageDrawResult GraphicsContext::drawMultiRepresentationHEIC(Image& image, const
     // FIXME (rdar://123044459): This needs to account for vertical writing modes.
     CGContextSetTextPosition(cgContext, 0, font.metricsForMultiRepresentationHEIC().descent);
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    CTFontDrawImageFromEmojiImageProviderAtPoint(font.getCTFont(), multiRepresentationHEIC.get(), CGContextGetTextPosition(cgContext), cgContext);
-ALLOW_DEPRECATED_DECLARATIONS_END
+    CTFontDrawImageFromAdaptiveImageProviderAtPoint(font.getCTFont(), multiRepresentationHEIC.get(), CGContextGetTextPosition(cgContext), cgContext);
 
     auto orientation = options.orientation();
     if (orientation == ImageOrientation::Orientation::FromImage)

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -917,16 +917,12 @@ bool Font::hasAnyComplexColorFormatGlyphs(const GlyphBufferGlyph* glyphs, unsign
 
 MultiRepresentationHEICMetrics Font::metricsForMultiRepresentationHEIC() const
 {
-    CGFloat ascent;
-    CGFloat descent;
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    CGFloat width = CTFontGetTypographicBoundsForEmojiImageProvider(getCTFont(), nullptr, &ascent, &descent);
-ALLOW_DEPRECATED_DECLARATIONS_END
+    CGRect bounds = CTFontGetTypographicBoundsForAdaptiveImageProvider(getCTFont(), nullptr);
 
     MultiRepresentationHEICMetrics metrics;
-    metrics.ascent = ascent;
-    metrics.descent = descent;
-    metrics.width = width;
+    metrics.ascent = CGRectGetMaxY(bounds);
+    metrics.descent = -CGRectGetMinY(bounds);
+    metrics.width = CGRectGetMaxX(bounds);
     return metrics;
 }
 


### PR DESCRIPTION
#### 90ef48a447543cae769b03f3e52f3fb8d301c9ef
<pre>
[Cocoa] Adopt CoreText API for adaptive image glyph rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=277085">https://bugs.webkit.org/show_bug.cgi?id=277085</a>
<a href="https://rdar.apple.com/132500882">rdar://132500882</a>

Reviewed by Richard Robinson.

Drop SPI usage in favor of API.

* Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm:
(WebCore::GraphicsContext::drawMultiRepresentationHEIC):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::metricsForMultiRepresentationHEIC const):

Canonical link: <a href="https://commits.webkit.org/281369@main">https://commits.webkit.org/281369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/752be0a1a16b2d419aa08019b917d82b5341055b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63566 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10174 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48389 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7119 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29227 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33099 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8884 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9097 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55049 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65297 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55732 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55862 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2970 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8911 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34809 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35892 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36978 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->