### PR TITLE
Lock the AVCaptureDevice configuration only once inside a begin/commit session configuration

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -130,9 +130,9 @@ private:
     ASCIILiteral logClassName() const override { return "AVVideoCaptureSource"_s; }
 #endif
 
-    void beginConfiguration();
+    bool beginConfiguration();
     void commitConfiguration();
-    void beginConfigurationForConstraintsIfNeeded();
+    bool beginConfigurationForConstraintsIfNeeded();
     bool lockForConfiguration();
 
     void updateVerifyCapturingTimer();


### PR DESCRIPTION
#### c02fd7d6a027e4012301a893b4b23e9501b39889
<pre>
Lock the AVCaptureDevice configuration only once inside a begin/commit session configuration
<a href="https://rdar.apple.com/132489376">rdar://132489376</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=277088">https://bugs.webkit.org/show_bug.cgi?id=277088</a>

Reviewed by NOBODY (OOPS!).

Updating zoom and enabling torch in the same applyConstraints call does not always work, the torch is only enabled for a small amount of time.

Before the patch, we would do several lock/unlock inside a beginConfiguration/commitConfiguration block.
By enforcing beginConfiguration/lock and then unlock/commitConfiguration, we no longer observe this issue.

We update beginConfigurationForConstraintsIfNeeded to return true if it is ok to proceed with changes or return early.

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::beginConfigurationForConstraintsIfNeeded):
(WebCore::AVVideoCaptureSource::beginConfiguration):
(WebCore::AVVideoCaptureSource::commitConfiguration):
(WebCore::AVVideoCaptureSource::setFrameRateAndZoomWithPreset):
(WebCore::AVVideoCaptureSource::setSessionSizeFrameRateAndZoom):
(WebCore::AVVideoCaptureSource::updateWhiteBalanceMode):
(WebCore::AVVideoCaptureSource::updateTorch):
(WebCore::AVVideoCaptureSource::setupCaptureSession):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c02fd7d6a027e4012301a893b4b23e9501b39889

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10187 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48398 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7129 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8896 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9110 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65310 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55742 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55873 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2979 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34822 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35905 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36991 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35650 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->