### PR TITLE
Update thai-joiner.html test for progressed Thai text layout

### DIFF
--- a/LayoutTests/fast/text/thai-joiner-expected.txt
+++ b/LayoutTests/fast/text/thai-joiner-expected.txt
@@ -1,4 +1,4 @@
-PASS 50 is >= document.getElementById('target').offsetWidth
+PASS 54 is >= document.getElementById('target').offsetWidth
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/text/thai-joiner.html
+++ b/LayoutTests/fast/text/thai-joiner.html
@@ -14,7 +14,7 @@
 <script>
 window.jsTestIsAsync = true;
 [...document.fonts.entries()][0].load().then(function() {
-    shouldBeGreaterThanOrEqual("50", "document.getElementById('target').offsetWidth");
+    shouldBeGreaterThanOrEqual("54", "document.getElementById('target').offsetWidth");
     finishJSTest();
 });
 </script>


### PR DESCRIPTION
#### 84a45f3008a2b40b4d3f43d246af34a418a2d614
<pre>
Update thai-joiner.html test for progressed Thai text layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=277090">https://bugs.webkit.org/show_bug.cgi?id=277090</a>
&lt;<a href="https://rdar.apple.com/131862456">rdar://131862456</a>&gt;

Reviewed by Vitor Roriz.

An underlying bug in the operating system has been fixed in iOS 18 and macOS Sequoia
that allows a Thai language layout test to render properly.

This patch updates the test and expectation to reflect the full glyph being rendered
(which makes the containing &lt;div&gt; slightly larger). This also causes WebKit to match
the behavior of Blink and Gecko on this case.

* LayoutTests/fast/text/thai-joiner-expected.txt:
* LayoutTests/fast/text/thai-joiner.html:

Canonical link: <a href="https://commits.webkit.org/281409@main">https://commits.webkit.org/281409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66266ae0dfbc2b4d79b2debe0149d4199cb647f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63586 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10194 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48402 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7133 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29240 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8900 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9117 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65317 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9068 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55748 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55880 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13259 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2984 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34829 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35912 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36998 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->