### PR TITLE
[WASM] Prefixed opcodes should be printed in full in code origins and disassembly

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp
@@ -38,6 +38,22 @@
 namespace JSC {
 namespace Wasm {
 
+ASCIILiteral makeString(PrefixedOpcode prefixedOpcode)
+{
+    switch (prefixedOpcode.prefixOrOpcode) {
+    case OpType::Ext1:
+        return makeString(prefixedOpcode.prefixed.ext1Opcode);
+    case OpType::ExtSIMD:
+        return makeString(prefixedOpcode.prefixed.simdOpcode);
+    case OpType::ExtGC:
+        return makeString(prefixedOpcode.prefixed.gcOpcode);
+    case OpType::ExtAtomic:
+        return makeString(prefixedOpcode.prefixed.atomicOpcode);
+    default:
+        return makeString(prefixedOpcode.prefixOrOpcode);
+    }
+}
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BBQDisassembler);
 
 BBQDisassembler::BBQDisassembler() = default;
@@ -70,7 +86,7 @@ void BBQDisassembler::dumpHeader(PrintStream& out, LinkBuffer& linkBuffer)
     out.print("   Code at [", RawPointer(linkBuffer.debugAddress()), ", ", RawPointer(static_cast<char*>(linkBuffer.debugAddress()) + linkBuffer.size()), "):\n");
 }
 
-Vector<BBQDisassembler::DumpedOp> BBQDisassembler::dumpVectorForInstructions(LinkBuffer& linkBuffer, const char* prefix, Vector<std::tuple<MacroAssembler::Label, OpType, size_t>>& labels, MacroAssembler::Label endLabel)
+Vector<BBQDisassembler::DumpedOp> BBQDisassembler::dumpVectorForInstructions(LinkBuffer& linkBuffer, const char* prefix, Vector<std::tuple<MacroAssembler::Label, PrefixedOpcode, size_t>>& labels, MacroAssembler::Label endLabel)
 {
     StringPrintStream out;
     Vector<DumpedOp> result;
@@ -96,7 +112,7 @@ Vector<BBQDisassembler::DumpedOp> BBQDisassembler::dumpVectorForInstructions(Lin
     return result;
 }
 
-void BBQDisassembler::dumpForInstructions(PrintStream& out, LinkBuffer& linkBuffer, const char* prefix, Vector<std::tuple<MacroAssembler::Label, OpType, size_t>>& labels, MacroAssembler::Label endLabel)
+void BBQDisassembler::dumpForInstructions(PrintStream& out, LinkBuffer& linkBuffer, const char* prefix, Vector<std::tuple<MacroAssembler::Label, PrefixedOpcode, size_t>>& labels, MacroAssembler::Label endLabel)
 {
     Vector<DumpedOp> dumpedOps = dumpVectorForInstructions(linkBuffer, prefix, labels, endLabel);
 

--- a/Source/JavaScriptCore/wasm/WasmBBQDisassembler.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQDisassembler.h
@@ -43,6 +43,53 @@ namespace Wasm {
 
 class BBQCallee;
 
+struct PrefixedOpcode {
+    OpType prefixOrOpcode;
+    union {
+        Ext1OpType ext1Opcode;
+        ExtAtomicOpType atomicOpcode;
+        ExtSIMDOpType simdOpcode;
+        ExtGCOpType gcOpcode;
+    } prefixed;
+
+    inline explicit PrefixedOpcode(OpType opcode)
+    {
+        switch (opcode) {
+        default:
+            prefixOrOpcode = opcode;
+            break;
+        case OpType::ExtGC:
+        case OpType::Ext1:
+        case OpType::ExtAtomic:
+        case OpType::ExtSIMD:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    }
+
+    inline explicit PrefixedOpcode(OpType prefix, uint32_t opcode)
+    {
+        prefixOrOpcode = prefix;
+        switch (prefix) {
+        case OpType::Ext1:
+            prefixed.ext1Opcode = static_cast<Ext1OpType>(opcode);
+            break;
+        case OpType::ExtSIMD:
+            prefixed.simdOpcode = static_cast<ExtSIMDOpType>(opcode);
+            break;
+        case OpType::ExtGC:
+            prefixed.gcOpcode = static_cast<ExtGCOpType>(opcode);
+            break;
+        case OpType::ExtAtomic:
+            prefixed.atomicOpcode = static_cast<ExtAtomicOpType>(opcode);
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Expected a valid WASM opcode prefix.");
+        }
+    }
+};
+
+ASCIILiteral makeString(PrefixedOpcode);
+
 class BBQDisassembler {
     WTF_MAKE_TZONE_ALLOCATED(BBQDisassembler);
 public:
@@ -50,7 +97,7 @@ public:
     ~BBQDisassembler();
 
     void setStartOfCode(MacroAssembler::Label label) { m_startOfCode = label; }
-    void setOpcode(MacroAssembler::Label label, OpType opcode, size_t offset)
+    void setOpcode(MacroAssembler::Label label, PrefixedOpcode opcode, size_t offset)
     {
         m_labels.append(std::tuple { label, opcode, offset });
     }
@@ -66,13 +113,13 @@ private:
     struct DumpedOp {
         CString disassembly;
     };
-    Vector<DumpedOp> dumpVectorForInstructions(LinkBuffer&, const char* prefix, Vector<std::tuple<MacroAssembler::Label, OpType, size_t>>& labels, MacroAssembler::Label endLabel);
+    Vector<DumpedOp> dumpVectorForInstructions(LinkBuffer&, const char* prefix, Vector<std::tuple<MacroAssembler::Label, PrefixedOpcode, size_t>>& labels, MacroAssembler::Label endLabel);
 
-    void dumpForInstructions(PrintStream&, LinkBuffer&, const char* prefix, Vector<std::tuple<MacroAssembler::Label, OpType, size_t>>& labels, MacroAssembler::Label endLabel);
+    void dumpForInstructions(PrintStream&, LinkBuffer&, const char* prefix, Vector<std::tuple<MacroAssembler::Label, PrefixedOpcode, size_t>>& labels, MacroAssembler::Label endLabel);
     void dumpDisassembly(PrintStream&, LinkBuffer&, MacroAssembler::Label from, MacroAssembler::Label to);
 
     MacroAssembler::Label m_startOfCode;
-    Vector<std::tuple<MacroAssembler::Label, OpType, size_t>> m_labels;
+    Vector<std::tuple<MacroAssembler::Label, PrefixedOpcode, size_t>> m_labels;
     MacroAssembler::Label m_endOfOpcode;
     MacroAssembler::Label m_endOfCode;
     void* m_codeStart { nullptr };

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1792,6 +1792,8 @@ public:
 
     ALWAYS_INLINE void willParseOpcode();
 
+    ALWAYS_INLINE void willParseExtendedOpcode();
+
     ALWAYS_INLINE void didParseOpcode();
 
     // SIMD

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -713,6 +713,7 @@ public:
 
     void dump(const ControlStack&, const Stack*) { }
     ALWAYS_INLINE void willParseOpcode() { }
+    ALWAYS_INLINE void willParseExtendedOpcode() { }
     ALWAYS_INLINE void didParseOpcode() {
         if (m_parser->currentOpcode() == Nop)
             m_shouldError = true;

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -496,6 +496,7 @@ public:
     }
     void didPopValueFromStack(ExpressionType, String) { }
     void willParseOpcode() { }
+    void willParseExtendedOpcode() { }
     void didParseOpcode()
     {
         if (!m_parser->unreachableBlocks())

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -385,6 +385,7 @@ public:
     PartialResult WARN_UNUSED_RETURN addCrash();
 
     ALWAYS_INLINE void willParseOpcode() { }
+    ALWAYS_INLINE void willParseExtendedOpcode() { }
     ALWAYS_INLINE void didParseOpcode() { }
     void didFinishParsingLocals();
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -819,6 +819,7 @@ public:
     void dump(const ControlStack&, const Stack* expressionStack);
     void setParser(FunctionParser<OMGIRGenerator>* parser) { m_parser = parser; };
     ALWAYS_INLINE void willParseOpcode() { }
+    ALWAYS_INLINE void willParseExtendedOpcode() { }
     ALWAYS_INLINE void didParseOpcode() { }
     void didFinishParsingLocals() { }
     void didPopValueFromStack(ExpressionType expr, String msg)
@@ -5895,7 +5896,17 @@ auto OMGIRGenerator::origin() -> Origin
 {
     if (!m_parser)
         return Origin();
-    OpcodeOrigin origin(m_parser->currentOpcode(), m_parser->currentOpcodeStartingOffset());
+    OpcodeOrigin origin = OpcodeOrigin(m_parser->currentOpcode(), m_parser->currentOpcodeStartingOffset());
+    switch (m_parser->currentOpcode()) {
+    case OpType::Ext1:
+    case OpType::ExtGC:
+    case OpType::ExtAtomic:
+    case OpType::ExtSIMD:
+        origin = OpcodeOrigin(m_parser->currentOpcode(), m_parser->currentExtendedOpcode(), m_parser->currentOpcodeStartingOffset());
+        break;
+    default:
+        break;
+    }
     ASSERT(isValidOpType(static_cast<uint8_t>(origin.opcode())));
     return bitwise_cast<Origin>(origin);
 }

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -707,6 +707,7 @@ public:
     void dump(const ControlStack&, const Stack* expressionStack);
     void setParser(FunctionParser<OMGIRGenerator>* parser) { m_parser = parser; };
     ALWAYS_INLINE void willParseOpcode() { }
+    ALWAYS_INLINE void willParseExtendedOpcode() { }
     ALWAYS_INLINE void didParseOpcode() { }
     void didFinishParsingLocals() { }
     void didPopValueFromStack(ExpressionType expr, String msg)

--- a/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.cpp
@@ -34,7 +34,25 @@ namespace JSC { namespace Wasm {
 
 void OpcodeOrigin::dump(PrintStream& out) const
 {
-    out.print("{opcode: ", makeString(opcode()), ", location: ", RawHex(location()), "}");
+    switch (opcode()) {
+#if USE(JSVALUE64)
+    case OpType::ExtGC:
+        out.print("{opcode: ", makeString(gcOpcode()), ", location: ", RawHex(location()), "}");
+        break;
+    case OpType::Ext1:
+        out.print("{opcode: ", makeString(ext1Opcode()), ", location: ", RawHex(location()), "}");
+        break;
+    case OpType::ExtSIMD:
+        out.print("{opcode: ", makeString(simdOpcode()), ", location: ", RawHex(location()), "}");
+        break;
+    case OpType::ExtAtomic:
+        out.print("{opcode: ", makeString(atomicOpcode()), ", location: ", RawHex(location()), "}");
+        break;
+#endif
+    default:
+        out.print("{opcode: ", makeString(opcode()), ", location: ", RawHex(location()), "}");
+        break;
+    }
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h
@@ -46,14 +46,26 @@ public:
     OpcodeOrigin(OpType opcode, size_t offset)
     {
         ASSERT(static_cast<uint32_t>(offset) == offset);
+        ASSERT(static_cast<OpType>(static_cast<uint8_t>(opcode)) == opcode);
         packedData = (static_cast<uint64_t>(opcode) << 32) | offset;
+    }
+    OpcodeOrigin(OpType prefix, uint32_t opcode, size_t offset)
+    {
+        ASSERT(static_cast<uint32_t>(offset) == offset);
+        ASSERT(static_cast<OpType>(static_cast<uint8_t>(prefix)) == prefix);
+        ASSERT(static_cast<uint8_t>(opcode) == opcode);
+        packedData = (static_cast<uint64_t>(opcode) << 40) | (static_cast<uint64_t>(prefix) << 32) | offset;
     }
     OpcodeOrigin(B3::Origin origin)
         : packedData(bitwise_cast<uint64_t>(origin))
     {
     }
 
-    OpType opcode() const { return static_cast<OpType>(packedData >> 32); }
+    OpType opcode() const { return static_cast<OpType>(packedData >> 32 & 0xff); }
+    Ext1OpType ext1Opcode() const { return static_cast<Ext1OpType>(packedData >> 40 & 0xff); }
+    ExtSIMDOpType simdOpcode() const { return static_cast<ExtSIMDOpType>(packedData >> 40 & 0xff); }
+    ExtGCOpType gcOpcode() const { return static_cast<ExtGCOpType>(packedData >> 40 & 0xff); }
+    ExtAtomicOpType atomicOpcode() const { return static_cast<ExtAtomicOpType>(packedData >> 40 & 0xff); }
     size_t location() const { return static_cast<uint32_t>(packedData); }
 
 private:

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -66,6 +66,17 @@ enum class ExtSIMDOpType : uint32_t {
 };
 #undef CREATE_ENUM_VALUE
 
+#define CREATE_CASE(name, ...) case ExtSIMDOpType::name: return #name ## _s;
+inline ASCIILiteral makeString(ExtSIMDOpType op)
+{
+    switch (op) {
+        FOR_EACH_WASM_EXT_SIMD_OP(CREATE_CASE)
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return { };
+}
+#undef CREATE_CASE
+
 constexpr std::pair<size_t, size_t> countNumberOfWasmExtendedSIMDOpcodes()
 {
     uint8_t numberOfOpcodes = 0;

--- a/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
+++ b/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
@@ -513,6 +513,29 @@ inline ASCIILiteral makeString(OpType op)
 }
 #undef CREATE_CASE
 
+#define CREATE_CASE(name, ...) case Ext1OpType::name: return #name ## _s;
+inline ASCIILiteral makeString(Ext1OpType op)
+{
+    switch (op) {
+    FOR_EACH_WASM_TABLE_OP(CREATE_CASE)
+    FOR_EACH_WASM_TRUNC_SATURATED_OP(CREATE_CASE)
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return { };
+}
+#undef CREATE_CASE
+
+#define CREATE_CASE(name, ...) case ExtGCOpType::name: return #name ## _s;
+inline ASCIILiteral makeString(ExtGCOpType op)
+{
+    switch (op) {
+    FOR_EACH_WASM_GC_OP(CREATE_CASE)
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return { };
+}
+#undef CREATE_CASE
+
 #define CREATE_CASE(name, ...) case ExtAtomicOpType::name: return #name ## _s;
 inline ASCIILiteral makeString(ExtAtomicOpType op)
 {


### PR DESCRIPTION
#### d898a3cffd9c992980016cb1fbdba272cb0c992d
<pre>
[WASM] Prefixed opcodes should be printed in full in code origins and disassembly
<a href="https://bugs.webkit.org/show_bug.cgi?id=277089">https://bugs.webkit.org/show_bug.cgi?id=277089</a>
<a href="https://rdar.apple.com/132508220">rdar://132508220</a>

Reviewed by Keith Miller and Yusuke Suzuki.

Tracks the current extended opcode, not just the prefix, in the WASM function
parser and uses it to display extended opcodes correctly in B3 origins and the
BBQ disassembler.

* Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp:
(JSC::Wasm::makeString):
(JSC::Wasm::BBQDisassembler::dumpVectorForInstructions):
(JSC::Wasm::BBQDisassembler::dumpForInstructions):
* Source/JavaScriptCore/wasm/WasmBBQDisassembler.h:
(JSC::Wasm::PrefixedOpcode::PrefixedOpcode):
(JSC::Wasm::BBQDisassembler::setOpcode):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::willParseOpcode):
(JSC::Wasm::BBQJITImpl::BBQJIT::willParseExtendedOpcode):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprGenerator::willParseExtendedOpcode):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser::currentExtendedOpcode const):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::willParseExtendedOpcode):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::willParseExtendedOpcode):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::willParseExtendedOpcode):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::willParseExtendedOpcode):
* Source/JavaScriptCore/wasm/WasmOpcodeOrigin.cpp:
(JSC::Wasm::OpcodeOrigin::dump const):
* Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h:
(JSC::Wasm::OpcodeOrigin::OpcodeOrigin):
(JSC::Wasm::OpcodeOrigin::opcode const):
(JSC::Wasm::OpcodeOrigin::ext1Opcode const):
(JSC::Wasm::OpcodeOrigin::simdOpcode const):
(JSC::Wasm::OpcodeOrigin::gcOpcode const):
(JSC::Wasm::OpcodeOrigin::atomicOpcode const):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::makeString):
* Source/JavaScriptCore/wasm/generateWasmOpsHeader.py:

Canonical link: <a href="https://commits.webkit.org/281418@main">https://commits.webkit.org/281418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efd98960727663ee70e19849d03884688b2977b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63604 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10212 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48414 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7145 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29252 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8918 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9135 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/52782 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65335 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58933 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55758 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3627 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55890 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13265 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3000 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80690 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34847 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14000 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35930 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35675 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->