### PR TITLE
Update _WKWebExtensionTabCreationOptions and _WKWebExtensionWindowCreationOptions.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptions.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptions.h
@@ -37,7 +37,8 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @discussion This class holds the various options that influence the behavior and initial state of a newly created tab.
  The app retains the discretion to disregard any or all of these options, or even opt not to create a new tab.
  */
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_SWIFT_UI_ACTOR
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(_WKWebExtension.TabCreationOptions)
 @interface _WKWebExtensionTabCreationOptions : NSObject
 
 + (instancetype)new NS_UNAVAILABLE;
@@ -47,22 +48,22 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @abstract Indicates the window where the new tab should be opened.
  @discussion If this property is set to `nil`, no window was specified.
  */
-@property (nonatomic, nullable, readonly, strong) id <_WKWebExtensionWindow> desiredWindow;
+@property (nonatomic, nullable, readonly, strong) id <_WKWebExtensionWindow> window;
 
 /*! @abstract Indicates the position where the new tab should be opened within the window. */
-@property (nonatomic, readonly) NSUInteger desiredIndex;
+@property (nonatomic, readonly) NSUInteger index;
 
 /*!
  @abstract Indicates the parent tab with which the new tab should be related.
  @discussion If this property is set to `nil`, no parent tab was specified.
  */
-@property (nonatomic, nullable, readonly, strong) id <_WKWebExtensionTab> desiredParentTab;
+@property (nonatomic, nullable, readonly, strong) id <_WKWebExtensionTab> parentTab;
 
 /*!
  @abstract Indicates the initial URL for the new tab.
  @discussion If this property is set to `nil`, the app's default "start page" should appear in the new tab.
  */
-@property (nonatomic, nullable, readonly, copy) NSURL *desiredURL;
+@property (nonatomic, nullable, readonly, copy) NSURL *url;
 
 /*!
  @abstract Indicates whether the new tab should become the active tab.
@@ -70,7 +71,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  the frontmost tab. Being active implies the tab is also selected. If this property is set to `NO`,  the new tab shouldn't
  affect the currently active tab.
  */
-@property (nonatomic, readonly) BOOL shouldActivate;
+@property (nonatomic, readonly, getter=isActive) BOOL active;
 
 /*!
  @abstract Indicates whether the new tab should be added to the current tab selection.
@@ -78,16 +79,16 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  become the active tab unless `shouldActivate` is also `YES`. If this property is set to `NO`, the new tab shouldn't
  be part of the current selection.
  */
-@property (nonatomic, readonly) BOOL shouldSelect;
+@property (nonatomic, readonly, getter=isSelected) BOOL selected;
 
 /*! @abstract Indicates whether the new tab should be pinned. */
-@property (nonatomic, readonly) BOOL shouldPin;
+@property (nonatomic, readonly, getter=isPinned) BOOL pinned;
 
 /*! @abstract Indicates whether the new tab should be muted. */
-@property (nonatomic, readonly) BOOL shouldMute;
+@property (nonatomic, readonly, getter=isMuted) BOOL muted;
 
 /*! @abstract Indicates whether the new tab should be in reader mode. */
-@property (nonatomic, readonly) BOOL shouldShowReaderMode;
+@property (nonatomic, readonly, getter=isReaderModeShowing) BOOL readerModeShowing;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptionsInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptionsInternal.h
@@ -33,15 +33,15 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 - (instancetype)_init NS_DESIGNATED_INITIALIZER;
 
-@property (readwrite, setter=_setDesiredWindow:) id <_WKWebExtensionWindow> desiredWindow;
-@property (readwrite, setter=_setDesiredIndex:) NSUInteger desiredIndex;
-@property (readwrite, setter=_setDesiredParentTab:) id <_WKWebExtensionTab> desiredParentTab;
-@property (readwrite, setter=_setDesiredURL:) NSURL *desiredURL;
-@property (readwrite, setter=_setShouldActivate:) BOOL shouldActivate;
-@property (readwrite, setter=_setShouldSelect:) BOOL shouldSelect;
-@property (readwrite, setter=_setShouldPin:) BOOL shouldPin;
-@property (readwrite, setter=_setShouldMute:) BOOL shouldMute;
-@property (readwrite, setter=_setShouldShowReaderMode:) BOOL shouldShowReaderMode;
+@property (readwrite, setter=_setWindow:) id <_WKWebExtensionWindow> window;
+@property (readwrite, setter=_setIndex:) NSUInteger index;
+@property (readwrite, setter=_setParentTab:) id <_WKWebExtensionTab> parentTab;
+@property (readwrite, setter=_setURL:) NSURL *url;
+@property (readwrite, setter=_setActive:) BOOL active;
+@property (readwrite, setter=_setSelected:) BOOL selected;
+@property (readwrite, setter=_setPinned:) BOOL pinned;
+@property (readwrite, setter=_setMuted:) BOOL muted;
+@property (readwrite, setter=_setReaderModeShowing:) BOOL readerModeShowing;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptions.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptions.h
@@ -38,49 +38,50 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @discussion This class holds the various options that influence the behavior and initial state of a newly created window.
  The app retains the discretion to disregard any or all of these options, or even opt not to create a new window.
  */
-WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_SWIFT_UI_ACTOR
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_SWIFT_UI_ACTOR NS_SWIFT_NAME(_WKWebExtension.WindowCreationOptions)
 @interface _WKWebExtensionWindowCreationOptions : NSObject
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
 /*! @abstract Indicates the window type for the new window. */
-@property (nonatomic, readonly) _WKWebExtensionWindowType desiredWindowType;
+@property (nonatomic, readonly) _WKWebExtensionWindowType windowType;
 
 /*! @abstract Indicates the window state for the new window. */
-@property (nonatomic, readonly) _WKWebExtensionWindowState desiredWindowState;
+@property (nonatomic, readonly) _WKWebExtensionWindowState windowState;
 
 /*!
  @abstract Indicates the frame where the new window should be positioned on the main screen.
  @discussion This frame should override the app's default window position and size.
  Individual components (e.g., `origin.x`, `size.width`) will be `NaN` if not specified.
  */
-@property (nonatomic, readonly) CGRect desiredFrame;
+@property (nonatomic, readonly) CGRect frame;
 
 /*!
  @abstract Indicates a list of URLs that the new window should initially load as new tabs.
- @discussion If the array is empty, and `desiredTabs` is empty, the app's default "start page" should appear in a new tab.
- @seealso desiredTabs
+ @discussion If the array is empty, and `tabs` is empty, the app's default "start page" should appear in a new tab.
+ @seealso tabs
  */
-@property (nonatomic, readonly, copy) NSArray<NSURL *> *desiredURLs;
+@property (nonatomic, readonly, copy) NSArray<NSURL *> *tabURLs;
 
 /*!
  @abstract Indicates a list of existing tabs that should be moved to the new window.
- @discussion If the array is empty, and `desiredURLs` is empty, the app's default "start page" should appear in a new tab.
- @seealso desiredURLs
+ @discussion If the array is empty, and `tabURLs` is empty, the app's default "start page" should appear in a new tab.
+ @seealso URLs
  */
-@property (nonatomic, readonly, copy) NSArray<id <_WKWebExtensionTab>> *desiredTabs;
+@property (nonatomic, readonly, copy) NSArray<id <_WKWebExtensionTab>> *tabs;
 
 /*! @abstract Indicates whether the new window should be focused. */
-@property (nonatomic, readonly) BOOL shouldFocus;
+@property (nonatomic, readonly, getter=isFocused) BOOL focused;
 
 /*!
- @abstract Indicates whether the new window should be using private browsing.
+ @abstract Indicates whether the new window should use private browsing.
  @note To ensure proper isolation between private and non-private browsing, web views associated with private browsing windows must
  use a different `WKUserContentController`. Likewise, to be identified as a private web view and to ensure that cookies and other
  website data is not shared, private web views must be configured to use a non-persistent `WKWebsiteDataStore`.
  */
-@property (nonatomic, readonly) BOOL shouldUsePrivateBrowsing;
+@property (nonatomic, readonly) BOOL usePrivateBrowsing;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptionsInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptionsInternal.h
@@ -31,13 +31,13 @@
 
 - (instancetype)_init NS_DESIGNATED_INITIALIZER;
 
-@property (readwrite, setter=_setDesiredFrame:) CGRect desiredFrame;
-@property (readwrite, setter=_setDesiredWindowType:) _WKWebExtensionWindowType desiredWindowType;
-@property (readwrite, setter=_setDesiredWindowState:) _WKWebExtensionWindowState desiredWindowState;
-@property (readwrite, setter=_setDesiredURLs:) NSArray<NSURL *> *desiredURLs;
-@property (readwrite, setter=_setDesiredTabs:) NSArray<id <_WKWebExtensionTab>> *desiredTabs;
-@property (readwrite, setter=_setShouldFocus:) BOOL shouldFocus;
-@property (readwrite, setter=_setSouldUsePrivateBrowsing:) BOOL shouldUsePrivateBrowsing;
+@property (readwrite, setter=_setFrame:) CGRect frame;
+@property (readwrite, setter=_setWindowType:) _WKWebExtensionWindowType windowType;
+@property (readwrite, setter=_setWindowState:) _WKWebExtensionWindowState windowState;
+@property (readwrite, setter=_setTabURLs:) NSArray<NSURL *> *tabURLs;
+@property (readwrite, setter=_setTabs:) NSArray<id <_WKWebExtensionTab>> *tabs;
+@property (readwrite, setter=_setFocused:) BOOL focused;
+@property (readwrite, setter=_setUsePrivateBrowsing:) BOOL usePrivateBrowsing;
 
 @end
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -90,11 +90,11 @@ void WebExtensionContext::runtimeOpenOptionsPage(CompletionHandler<void(Expected
     auto frontmostWindow = this->frontmostWindow();
 
     auto *creationOptions = [[_WKWebExtensionTabCreationOptions alloc] _init];
-    creationOptions.shouldActivate = YES;
-    creationOptions.shouldSelect = YES;
-    creationOptions.desiredWindow = frontmostWindow ? frontmostWindow->delegate() : nil;
-    creationOptions.desiredIndex = frontmostWindow ? frontmostWindow->tabs().size() : 0;
-    creationOptions.desiredURL = optionsPageURL();
+    creationOptions.active = YES;
+    creationOptions.selected = YES;
+    creationOptions.window = frontmostWindow ? frontmostWindow->delegate() : nil;
+    creationOptions.index = frontmostWindow ? frontmostWindow->tabs().size() : 0;
+    creationOptions.url = optionsPageURL();
 
     [delegate webExtensionController:extensionController()->wrapper() openNewTabWithOptions:creationOptions forExtensionContext:wrapper() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](id<_WKWebExtensionTab> newTab, NSError *error) mutable {
         if (error) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -70,11 +70,11 @@ void WebExtensionContext::tabsCreate(std::optional<WebPageProxyIdentifier> webPa
     }
 
     auto *creationOptions = [[_WKWebExtensionTabCreationOptions alloc] _init];
-    creationOptions.shouldActivate = parameters.active.value_or(true);
-    creationOptions.shouldSelect = creationOptions.shouldActivate ?: parameters.selected.value_or(false);
-    creationOptions.shouldPin = parameters.pinned.value_or(false);
-    creationOptions.shouldMute = parameters.muted.value_or(false);
-    creationOptions.shouldShowReaderMode = parameters.showingReaderMode.value_or(false);
+    creationOptions.active = parameters.active.value_or(true);
+    creationOptions.selected = creationOptions.active ?: parameters.selected.value_or(false);
+    creationOptions.pinned = parameters.pinned.value_or(false);
+    creationOptions.muted = parameters.muted.value_or(false);
+    creationOptions.readerModeShowing = parameters.showingReaderMode.value_or(false);
 
     RefPtr window = getWindow(parameters.windowIdentifier.value_or(WebExtensionWindowConstants::CurrentIdentifier), webPageProxyIdentifier);
     if (parameters.windowIdentifier && !window) {
@@ -82,8 +82,8 @@ void WebExtensionContext::tabsCreate(std::optional<WebPageProxyIdentifier> webPa
         return;
     }
 
-    creationOptions.desiredWindow = window ? window->delegate() : nil;
-    creationOptions.desiredIndex = parameters.index.value_or(window ? window->tabs().size() : 0);
+    creationOptions.window = window ? window->delegate() : nil;
+    creationOptions.index = parameters.index.value_or(window ? window->tabs().size() : 0);
 
     if (parameters.parentTabIdentifier) {
         RefPtr tab = getTab(parameters.parentTabIdentifier.value());
@@ -92,11 +92,11 @@ void WebExtensionContext::tabsCreate(std::optional<WebPageProxyIdentifier> webPa
             return;
         }
 
-        creationOptions.desiredParentTab = tab->delegate();
+        creationOptions.parentTab = tab->delegate();
     }
 
     if (parameters.url)
-        creationOptions.desiredURL = parameters.url.value();
+        creationOptions.url = parameters.url.value();
 
     [delegate webExtensionController:extensionController()->wrapper() openNewTabWithOptions:creationOptions forExtensionContext:wrapper() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<_WKWebExtensionTab> newTab, NSError *error) mutable {
         if (error) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
@@ -57,10 +57,10 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
     static constexpr CGRect CGRectNaN = { { NaN, NaN }, { NaN, NaN } };
 
     auto *creationOptions = [[_WKWebExtensionWindowCreationOptions alloc] _init];
-    creationOptions.desiredWindowType = toAPI(creationParameters.type.value_or(WebExtensionWindow::Type::Normal));
-    creationOptions.desiredWindowState = toAPI(creationParameters.state.value_or(WebExtensionWindow::State::Normal));
-    creationOptions.shouldFocus = creationParameters.focused.value_or(true);
-    creationOptions.shouldUsePrivateBrowsing = creationParameters.privateBrowsing.value_or(false);
+    creationOptions.windowType = toAPI(creationParameters.type.value_or(WebExtensionWindow::Type::Normal));
+    creationOptions.windowState = toAPI(creationParameters.state.value_or(WebExtensionWindow::State::Normal));
+    creationOptions.focused = creationParameters.focused.value_or(true);
+    creationOptions.usePrivateBrowsing = creationParameters.privateBrowsing.value_or(false);
 
     if (creationParameters.frame) {
         CGRect desiredFrame = creationParameters.frame.value();
@@ -76,9 +76,9 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
             desiredFrame.origin.y = screenFrame.size.height + screenFrame.origin.y - desiredFrame.size.height - desiredFrame.origin.y;
 #endif
 
-        creationOptions.desiredFrame = desiredFrame;
+        creationOptions.frame = desiredFrame;
     } else
-        creationOptions.desiredFrame = CGRectNaN;
+        creationOptions.frame = CGRectNaN;
 
     NSMutableArray<NSURL *> *urls = [NSMutableArray array];
     NSMutableArray<id<_WKWebExtensionTab>> *tabs = [NSMutableArray array];
@@ -98,8 +98,8 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
         }
     }
 
-    creationOptions.desiredURLs = [urls copy];
-    creationOptions.desiredTabs = [tabs copy];
+    creationOptions.tabURLs = [urls copy];
+    creationOptions.tabs = [tabs copy];
 
     [delegate webExtensionController:extensionController()->wrapper() openNewWindowWithOptions:creationOptions forExtensionContext:wrapper() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<_WKWebExtensionWindow> newWindow, NSError *error) mutable {
         if (error) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -773,10 +773,10 @@ void WebExtensionTab::duplicate(const WebExtensionTabParameters& parameters, Com
         index = currentIndex + 1;
 
     _WKWebExtensionTabCreationOptions *duplicateOptions = [[_WKWebExtensionTabCreationOptions alloc] _init];
-    duplicateOptions.shouldActivate = parameters.active.value_or(true);
-    duplicateOptions.shouldSelect = duplicateOptions.shouldActivate ?: parameters.selected.value_or(false);
-    duplicateOptions.desiredWindow = window ? window->delegate() : nil;
-    duplicateOptions.desiredIndex = index;
+    duplicateOptions.active = parameters.active.value_or(true);
+    duplicateOptions.selected = duplicateOptions.active ?: parameters.selected.value_or(false);
+    duplicateOptions.window = window ? window->delegate() : nil;
+    duplicateOptions.index = index;
 
     [m_delegate duplicateForWebExtensionContext:m_extensionContext->wrapper() withOptions:duplicateOptions completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<_WKWebExtensionTab> duplicatedTab, NSError *error) mutable {
         if (error) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -1283,10 +1283,10 @@ TEST(WKWebExtensionAPIAction, NavigationOpensInNewTab)
     };
 
     manager.get().internalDelegate.openNewTab = ^(_WKWebExtensionTabCreationOptions *options, _WKWebExtensionContext *context, void (^completionHandler)(id<_WKWebExtensionTab>, NSError *)) {
-        EXPECT_NS_EQUAL(options.desiredURL, localhostRequest.URL);
-        EXPECT_NS_EQUAL(options.desiredWindow, manager.get().defaultWindow);
-        EXPECT_EQ(options.desiredIndex, 1ul);
-        EXPECT_EQ(options.shouldActivate, YES);
+        EXPECT_NS_EQUAL(options.url, localhostRequest.URL);
+        EXPECT_NS_EQUAL(options.window, manager.get().defaultWindow);
+        EXPECT_EQ(options.index, 1ul);
+        EXPECT_EQ(options.active, YES);
 
         originalOpenNewTab(options, context, completionHandler);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -236,17 +236,17 @@ TEST(WKWebExtensionAPITabs, Create)
     auto originalOpenNewTab = manager.get().internalDelegate.openNewTab;
 
     manager.get().internalDelegate.openNewTab = ^(_WKWebExtensionTabCreationOptions *options, _WKWebExtensionContext *context, void (^completionHandler)(id<_WKWebExtensionTab>, NSError *)) {
-        EXPECT_NS_EQUAL(options.desiredWindow, window);
-        EXPECT_EQ(options.desiredIndex, window.tabs.count);
+        EXPECT_NS_EQUAL(options.window, window);
+        EXPECT_EQ(options.index, window.tabs.count);
 
-        EXPECT_NULL(options.desiredParentTab);
-        EXPECT_NULL(options.desiredURL);
+        EXPECT_NULL(options.parentTab);
+        EXPECT_NULL(options.url);
 
-        EXPECT_TRUE(options.shouldActivate);
-        EXPECT_TRUE(options.shouldSelect);
-        EXPECT_FALSE(options.shouldPin);
-        EXPECT_FALSE(options.shouldMute);
-        EXPECT_FALSE(options.shouldShowReaderMode);
+        EXPECT_TRUE(options.active);
+        EXPECT_TRUE(options.selected);
+        EXPECT_FALSE(options.pinned);
+        EXPECT_FALSE(options.muted);
+        EXPECT_FALSE(options.readerModeShowing);
 
         originalOpenNewTab(options, context, completionHandler);
     };
@@ -287,17 +287,17 @@ TEST(WKWebExtensionAPITabs, CreateWithSpecifiedOptions)
     auto originalOpenNewTab = manager.get().internalDelegate.openNewTab;
 
     manager.get().internalDelegate.openNewTab = ^(_WKWebExtensionTabCreationOptions *options, _WKWebExtensionContext *context, void (^completionHandler)(id<_WKWebExtensionTab>, NSError *)) {
-        EXPECT_NS_EQUAL(options.desiredWindow, window);
-        EXPECT_EQ(options.desiredIndex, 1lu);
+        EXPECT_NS_EQUAL(options.window, window);
+        EXPECT_EQ(options.index, 1lu);
 
-        EXPECT_NS_EQUAL(options.desiredParentTab, tab);
-        EXPECT_NS_EQUAL(options.desiredURL, [NSURL URLWithString:@"https://example.com/"]);
+        EXPECT_NS_EQUAL(options.parentTab, tab);
+        EXPECT_NS_EQUAL(options.url, [NSURL URLWithString:@"https://example.com/"]);
 
-        EXPECT_FALSE(options.shouldActivate);
-        EXPECT_FALSE(options.shouldSelect);
-        EXPECT_TRUE(options.shouldPin);
-        EXPECT_TRUE(options.shouldMute);
-        EXPECT_TRUE(options.shouldShowReaderMode);
+        EXPECT_FALSE(options.active);
+        EXPECT_FALSE(options.selected);
+        EXPECT_TRUE(options.pinned);
+        EXPECT_TRUE(options.muted);
+        EXPECT_TRUE(options.readerModeShowing);
 
         originalOpenNewTab(options, context, completionHandler);
     };
@@ -323,7 +323,7 @@ TEST(WKWebExtensionAPITabs, CreateWithRelativeURL)
     auto originalOpenNewTab = manager.get().internalDelegate.openNewTab;
 
     manager.get().internalDelegate.openNewTab = ^(_WKWebExtensionTabCreationOptions *options, _WKWebExtensionContext *context, void (^completionHandler)(id<_WKWebExtensionTab>, NSError *)) {
-        EXPECT_NS_EQUAL(options.desiredURL, [NSURL URLWithString:@"test.html" relativeToURL:manager.get().context.baseURL].absoluteURL);
+        EXPECT_NS_EQUAL(options.url, [NSURL URLWithString:@"test.html" relativeToURL:manager.get().context.baseURL].absoluteURL);
 
         originalOpenNewTab(options, context, completionHandler);
     };
@@ -355,17 +355,17 @@ TEST(WKWebExtensionAPITabs, Duplicate)
     auto originalDuplicate = tab.duplicate;
 
     tab.duplicate = ^(_WKWebExtensionTabCreationOptions *options, void (^completionHandler)(TestWebExtensionTab *, NSError *)) {
-        EXPECT_NS_EQUAL(options.desiredWindow, window);
-        EXPECT_EQ(options.desiredIndex, window.tabs.count);
+        EXPECT_NS_EQUAL(options.window, window);
+        EXPECT_EQ(options.index, window.tabs.count);
 
-        EXPECT_NULL(options.desiredParentTab);
-        EXPECT_NULL(options.desiredURL);
+        EXPECT_NULL(options.parentTab);
+        EXPECT_NULL(options.url);
 
-        EXPECT_TRUE(options.shouldActivate);
-        EXPECT_TRUE(options.shouldSelect);
-        EXPECT_FALSE(options.shouldPin);
-        EXPECT_FALSE(options.shouldMute);
-        EXPECT_FALSE(options.shouldShowReaderMode);
+        EXPECT_TRUE(options.active);
+        EXPECT_TRUE(options.selected);
+        EXPECT_FALSE(options.pinned);
+        EXPECT_FALSE(options.muted);
+        EXPECT_FALSE(options.readerModeShowing);
 
         originalDuplicate(options, completionHandler);
     };
@@ -401,17 +401,17 @@ TEST(WKWebExtensionAPITabs, DuplicateWithOptions)
     auto originalDuplicate = tab.duplicate;
 
     tab.duplicate = ^(_WKWebExtensionTabCreationOptions *options, void (^completionHandler)(TestWebExtensionTab *, NSError *)) {
-        EXPECT_NS_EQUAL(options.desiredWindow, window);
-        EXPECT_EQ(options.desiredIndex, 1lu);
+        EXPECT_NS_EQUAL(options.window, window);
+        EXPECT_EQ(options.index, 1lu);
 
-        EXPECT_NULL(options.desiredParentTab);
-        EXPECT_NULL(options.desiredURL);
+        EXPECT_NULL(options.parentTab);
+        EXPECT_NULL(options.url);
 
-        EXPECT_FALSE(options.shouldActivate);
-        EXPECT_FALSE(options.shouldSelect);
-        EXPECT_FALSE(options.shouldPin);
-        EXPECT_FALSE(options.shouldMute);
-        EXPECT_FALSE(options.shouldShowReaderMode);
+        EXPECT_FALSE(options.active);
+        EXPECT_FALSE(options.selected);
+        EXPECT_FALSE(options.pinned);
+        EXPECT_FALSE(options.muted);
+        EXPECT_FALSE(options.readerModeShowing);
 
         originalDuplicate(options, completionHandler);
     };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
@@ -432,21 +432,21 @@ TEST(WKWebExtensionAPIWindows, Create)
     auto originalOpenNewWindow = manager.get().internalDelegate.openNewWindow;
 
     manager.get().internalDelegate.openNewWindow = ^(_WKWebExtensionWindowCreationOptions *options, _WKWebExtensionContext *context, void (^completionHandler)(id<_WKWebExtensionWindow>, NSError *)) {
-        EXPECT_EQ(options.desiredFrame.origin.x, 300);
-        EXPECT_EQ(options.desiredFrame.size.height, 400);
-        EXPECT_TRUE(std::isnan(options.desiredFrame.origin.y));
-        EXPECT_TRUE(std::isnan(options.desiredFrame.size.width));
+        EXPECT_EQ(options.frame.origin.x, 300);
+        EXPECT_EQ(options.frame.size.height, 400);
+        EXPECT_TRUE(std::isnan(options.frame.origin.y));
+        EXPECT_TRUE(std::isnan(options.frame.size.width));
 
-        EXPECT_TRUE(options.shouldFocus);
-        EXPECT_FALSE(options.shouldUsePrivateBrowsing);
+        EXPECT_TRUE(options.focused);
+        EXPECT_FALSE(options.usePrivateBrowsing);
 
-        EXPECT_EQ(options.desiredWindowType, _WKWebExtensionWindowTypePopup);
-        EXPECT_EQ(options.desiredWindowState, _WKWebExtensionWindowStateNormal);
+        EXPECT_EQ(options.windowType, _WKWebExtensionWindowTypePopup);
+        EXPECT_EQ(options.windowState, _WKWebExtensionWindowStateNormal);
 
-        EXPECT_EQ(options.desiredTabs.count, 0lu);
+        EXPECT_EQ(options.tabs.count, 0lu);
 
-        EXPECT_EQ(options.desiredURLs.count, 1lu);
-        EXPECT_NS_EQUAL(options.desiredURLs.firstObject, [NSURL URLWithString:@"http://example.com/"]);
+        EXPECT_EQ(options.tabURLs.count, 1lu);
+        EXPECT_NS_EQUAL(options.tabURLs.firstObject, [NSURL URLWithString:@"http://example.com/"]);
 
         originalOpenNewWindow(options, context, completionHandler);
     };
@@ -477,8 +477,8 @@ TEST(WKWebExtensionAPIWindows, CreateWithRelativeURL)
     auto originalOpenNewWindow = manager.get().internalDelegate.openNewWindow;
 
     manager.get().internalDelegate.openNewWindow = ^(_WKWebExtensionWindowCreationOptions *options, _WKWebExtensionContext *context, void (^completionHandler)(id<_WKWebExtensionWindow>, NSError *)) {
-        EXPECT_EQ(options.desiredURLs.count, 1lu);
-        EXPECT_NS_EQUAL(options.desiredURLs.firstObject, [NSURL URLWithString:@"test.html" relativeToURL:manager.get().context.baseURL].absoluteURL);
+        EXPECT_EQ(options.tabURLs.count, 1lu);
+        EXPECT_NS_EQUAL(options.tabURLs.firstObject, [NSURL URLWithString:@"test.html" relativeToURL:manager.get().context.baseURL].absoluteURL);
 
         originalOpenNewWindow(options, context, completionHandler);
     };
@@ -508,9 +508,9 @@ TEST(WKWebExtensionAPIWindows, CreateWithRelativeURLs)
     auto originalOpenNewWindow = manager.get().internalDelegate.openNewWindow;
 
     manager.get().internalDelegate.openNewWindow = ^(_WKWebExtensionWindowCreationOptions *options, _WKWebExtensionContext *context, void (^completionHandler)(id<_WKWebExtensionWindow>, NSError *)) {
-        EXPECT_EQ(options.desiredURLs.count, 2lu);
-        EXPECT_NS_EQUAL(options.desiredURLs.firstObject, [NSURL URLWithString:@"one.html" relativeToURL:manager.get().context.baseURL].absoluteURL);
-        EXPECT_NS_EQUAL(options.desiredURLs.lastObject, [NSURL URLWithString:@"two.html" relativeToURL:manager.get().context.baseURL].absoluteURL);
+        EXPECT_EQ(options.tabURLs.count, 2lu);
+        EXPECT_NS_EQUAL(options.tabURLs.firstObject, [NSURL URLWithString:@"one.html" relativeToURL:manager.get().context.baseURL].absoluteURL);
+        EXPECT_NS_EQUAL(options.tabURLs.lastObject, [NSURL URLWithString:@"two.html" relativeToURL:manager.get().context.baseURL].absoluteURL);
 
         originalOpenNewWindow(options, context, completionHandler);
     };

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -88,13 +88,13 @@
     };
 
     _internalDelegate.openNewWindow = ^(_WKWebExtensionWindowCreationOptions *options, _WKWebExtensionContext *, void (^completionHandler)(id<_WKWebExtensionWindow>, NSError *)) {
-        auto *newWindow = [weakSelf openNewWindowUsingPrivateBrowsing:options.shouldUsePrivateBrowsing];
+        auto *newWindow = [weakSelf openNewWindowUsingPrivateBrowsing:options.usePrivateBrowsing];
 
-        newWindow.windowType = options.desiredWindowType;
-        newWindow.windowState = options.desiredWindowState;
+        newWindow.windowType = options.windowType;
+        newWindow.windowState = options.windowState;
 
         CGRect currentFrame = newWindow.frame;
-        CGRect desiredFrame = options.desiredFrame;
+        CGRect desiredFrame = options.frame;
 
         if (std::isnan(desiredFrame.size.width))
             desiredFrame.size.width = currentFrame.size.width;
@@ -124,21 +124,21 @@
     };
 
     _internalDelegate.openNewTab = ^(_WKWebExtensionTabCreationOptions *options, _WKWebExtensionContext *context, void (^completionHandler)(id<_WKWebExtensionTab>, NSError *)) {
-        auto *desiredWindow = dynamic_objc_cast<TestWebExtensionWindow>(options.desiredWindow) ?: window;
-        auto *newTab = [desiredWindow openNewTabAtIndex:options.desiredIndex];
+        auto *desiredWindow = dynamic_objc_cast<TestWebExtensionWindow>(options.window) ?: window;
+        auto *newTab = [desiredWindow openNewTabAtIndex:options.index];
 
-        if (options.desiredURL) {
-            [newTab changeWebViewIfNeededForURL:options.desiredURL forExtensionContext:context];
-            [newTab.mainWebView loadRequest:[NSURLRequest requestWithURL:options.desiredURL]];
+        if (options.url) {
+            [newTab changeWebViewIfNeededForURL:options.url forExtensionContext:context];
+            [newTab.mainWebView loadRequest:[NSURLRequest requestWithURL:options.url]];
         }
 
-        newTab.parentTab = options.desiredParentTab;
-        newTab.pinned = options.shouldPin;
-        newTab.muted = options.shouldMute;
-        newTab.showingReaderMode = options.shouldShowReaderMode;
-        newTab.selected = options.shouldSelect;
+        newTab.parentTab = options.parentTab;
+        newTab.pinned = options.pinned;
+        newTab.muted = options.muted;
+        newTab.showingReaderMode = options.readerModeShowing;
+        newTab.selected = options.selected;
 
-        if (options.shouldActivate)
+        if (options.isActive)
             desiredWindow.activeTab = newTab;
 
         completionHandler(newTab, nil);
@@ -685,14 +685,14 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     __weak TestWebExtensionTab *weakTab = newTab;
 
     newTab.duplicate = ^(_WKWebExtensionTabCreationOptions *options, void (^completionHandler)(TestWebExtensionTab *, NSError *)) {
-        auto *desiredWindow = dynamic_objc_cast<TestWebExtensionWindow>(options.desiredWindow) ?: weakTab.window;
-        auto *duplicatedTab = [desiredWindow openNewTabAtIndex:options.desiredIndex];
+        auto *desiredWindow = dynamic_objc_cast<TestWebExtensionWindow>(options.window) ?: weakTab.window;
+        auto *duplicatedTab = [desiredWindow openNewTabAtIndex:options.index];
 
         [duplicatedTab.mainWebView loadRequest:[NSURLRequest requestWithURL:weakTab.mainWebView.URL]];
 
-        duplicatedTab.selected = options.shouldSelect;
+        duplicatedTab.selected = options.selected;
 
-        if (options.shouldActivate)
+        if (options.isActive)
             desiredWindow.activeTab = duplicatedTab;
 
         completionHandler(duplicatedTab, nil);


### PR DESCRIPTION
#### c8ea30e4b6ff204b8a058973840720d567406c73
<pre>
Update _WKWebExtensionTabCreationOptions and _WKWebExtensionWindowCreationOptions.
<a href="https://webkit.org/b/277091">https://webkit.org/b/277091</a>
<a href="https://rdar.apple.com/problem/132511753">rdar://problem/132511753</a>

Reviewed by Brian Weinstein.

Drop the &quot;waffle&quot; word prefixes from the properties on `_WKWebExtensionTabCreationOptions` and
`_WKWebExtensionWindowCreationOptions`, since the class clearly communicates these are options.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptions.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTabCreationOptionsInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptions.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptionsInternal.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeOpenOptionsPage):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsCreate):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsCreate):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::duplicate):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, NavigationOpensInNewTab)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, Create)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, CreateWithSpecifiedOptions)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, CreateWithRelativeURL)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, Duplicate)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, DuplicateWithOptions)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIWindows, Create)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWindows, CreateWithRelativeURL)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWindows, CreateWithRelativeURLs)):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:]):
(-[TestWebExtensionWindow openNewTabAtIndex:]):

Canonical link: <a href="https://commits.webkit.org/281405@main">https://commits.webkit.org/281405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d634587a31ca8bd9b45f7b1a9ec43c08dc591cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63602 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10210 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48420 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7142 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51669 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29258 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8915 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9133 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65333 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9079 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55756 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55888 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2997 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8946 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34845 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35928 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35673 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->