### PR TITLE
[Grid][Replaced] Invalidate replaced element grid items when their intrinsic size changes.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/img-src-changes-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/img-src-changes-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/img-src-changes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/img-src-changes.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Grid goes through layout when image src changes">
+<style>
+div {
+  display: grid;
+}
+img {
+  width: 100px;
+  height: 100%;
+}
+</style>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div>
+<img src="">
+</div>
+</body>
+<script>
+document.body.offsetHeight;
+document.querySelector("img").src = "grid-items/support/100x100-green.png";
+</script>
+</html>

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -406,8 +406,8 @@ bool RenderReplaced::setNeedsLayoutIfNeededAfterIntrinsicSizeChange()
         || style().logicalMaxWidth().isPercentOrCalculated()
         || style().logicalMinWidth().isPercentOrCalculated();
 
-    // Flex layout algorithm uses the intrinsic image width/height even if width/height are specified.
-    if (!imageSizeIsConstrained || containingBlockNeedsToRecomputePreferredSize || isFlexItem()) {
+    // Flex and grid layout use the intrinsic image width/height even if width/height are specified.
+    if (!imageSizeIsConstrained || containingBlockNeedsToRecomputePreferredSize || isFlexItem() || isGridItem()) {
         setNeedsLayout();
         return true;
     }


### PR DESCRIPTION
#### 3e491ebe446c1e012371e2180a4d63ae01b20df4
<pre>
[Grid][Replaced] Invalidate replaced element grid items when their intrinsic size changes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277093">https://bugs.webkit.org/show_bug.cgi?id=277093</a>
<a href="https://rdar.apple.com/problem/132512032">rdar://problem/132512032</a>

Reviewed by Alan Baradlay.

Currently we do not invalidate replaced elements which are grid items
if they are &quot;constrained.&quot; Constrained here means that they have a
specific width and height along with non-intrinsic min-width and
min-height.

For grid this may not be correct since grid&apos;s track sizing algorithm
may be influenced by a grid item&apos;s intrinsic sizes. The result of the
grid track sizing with the updated intrinsic sizes may have an impact
on the final geometry of the grid item.

To try and recover from this state we can invalidate the renderer and
its containing block chain so that we rerun layout even if it is
constrained.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/img-src-changes-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/img-src-changes.html: Added.
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::setNeedsLayoutIfNeededAfterIntrinsicSizeChange):

Canonical link: <a href="https://commits.webkit.org/283343@main">https://commits.webkit.org/283343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0a11ed9d7ea2564339fa7f75834f9e344a9af4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63609 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10217 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61822 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48416 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7150 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29254 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33135 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8921 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9140 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65340 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3621 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55757 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51662 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55889 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14564 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3002 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34852 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35935 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37021 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->