### PR TITLE
Route notification permission requests through webpushd

### DIFF
--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -76,6 +76,7 @@ private:
     void clearNotifications(const Vector<WTF::UUID>& notificationIDs) final;
     void didDestroyNotification(const WTF::UUID& notificationID) final;
     void pageWasNotifiedOfNotificationPermission() final { }
+    void requestPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&) final;
 
     NetworkSession& m_networkSession;
     std::unique_ptr<WebPushD::Connection> m_connection;

--- a/Source/WebKit/Platform/spi/Cocoa/UserNotificationsSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/UserNotificationsSPI.h
@@ -28,6 +28,7 @@
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <UserNotifications/UNNotificationContent_Private.h>
+#import <UserNotifications/UNNotificationSettings_Private.h>
 #import <UserNotifications/UNUserNotificationCenter_Private.h>
 
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
@@ -53,6 +54,11 @@
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
 @property (NS_NONATOMIC_IOSONLY, copy) UNNotificationIcon *icon;
 #endif
+@end
+
+@interface UNMutableNotificationSettings : UNNotificationSettings
++ (instancetype)emptySettings;
+@property (NS_NONATOMIC_IOSONLY, readwrite) UNAuthorizationStatus authorizationStatus;
 @end
 
 @interface UNUserNotificationCenter ()

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 class NotificationResources;
+class SecurityOriginData;
 struct NotificationData;
 }
 
@@ -46,6 +47,7 @@ public:
     virtual void clearNotifications(const Vector<WTF::UUID>& notificationIDs) = 0;
     virtual void didDestroyNotification(const WTF::UUID& notificationID) = 0;
     virtual void pageWasNotifiedOfNotificationPermission() = 0;
+    virtual void requestPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&) = 0;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
@@ -25,5 +25,6 @@ messages -> NotificationManagerMessageHandler NotRefCounted {
     CancelNotification(WTF::UUID notificationID)
     ClearNotifications(Vector<WTF::UUID> notificationIDs)
     DidDestroyNotification(WTF::UUID notificationID)
-    PageWasNotifiedOfNotificationPermission();
+    PageWasNotifiedOfNotificationPermission()
+    RequestPermission(WebCore::SecurityOriginData origin) -> (bool granted)
 }

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
@@ -83,4 +83,9 @@ void ServiceWorkerNotificationHandler::didDestroyNotification(const WTF::UUID& n
         dataStore->didDestroyServiceWorkerNotification(notificationID);
 }
 
+void ServiceWorkerNotificationHandler::requestPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
@@ -44,6 +44,7 @@ public:
     void clearNotifications(const Vector<WTF::UUID>& notificationIDs) final;
     void didDestroyNotification(const WTF::UUID& notificationID) final;
     void pageWasNotifiedOfNotificationPermission() final { }
+    void requestPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&) final;
 
     bool handlesNotification(WTF::UUID value) const { return m_notificationToSessionMap.contains(value); }
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
@@ -96,4 +96,9 @@ void WebNotificationManagerMessageHandler::pageWasNotifiedOfNotificationPermissi
     m_webPageProxy.pageWillLikelyUseNotifications();
 }
 
+void WebNotificationManagerMessageHandler::requestPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
@@ -41,6 +41,7 @@ private:
     void clearNotifications(const Vector<WTF::UUID>& notificationIDs) final;
     void didDestroyNotification(const WTF::UUID& notificationID) final;
     void pageWasNotifiedOfNotificationPermission() final;
+    void requestPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&) final;
 
     WebPageProxy& m_webPageProxy;
 };

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -85,7 +85,8 @@ template<typename U> static bool sendNotificationMessage(U&& message, WebPage* p
     });
 }
 
-template<typename U> static bool sendNotificationMessageWithAsyncReply(U&& message, WebPage* page, CompletionHandler<void()>&& callback)
+template<typename U, typename C>
+static bool sendNotificationMessageWithAsyncReply(U&& message, WebPage* page, C&& callback)
 {
     return sendMessage(page, [&] (auto& connection, auto destinationIdentifier) {
         return !!connection.sendWithAsyncReply(std::forward<U>(message), WTFMove(callback), destinationIdentifier);
@@ -208,6 +209,18 @@ void WebNotificationManager::cancel(NotificationData&& notification, WebPage* pa
 #else
     UNUSED_PARAM(notification);
     UNUSED_PARAM(page);
+#endif
+}
+
+void WebNotificationManager::requestPermission(WebCore::SecurityOriginData&& origin, RefPtr<WebPage> page, CompletionHandler<void(bool)>&& callback)
+{
+    ASSERT(isMainRunLoop());
+
+#if ENABLE(NOTIFICATIONS)
+    sendNotificationMessageWithAsyncReply(Messages::NotificationManagerMessageHandler::RequestPermission(WTFMove(origin)), page.get(), WTFMove(callback));
+#else
+    UNUSED_PARAM(origin);
+    callback(false);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
@@ -40,6 +40,7 @@
 
 namespace WebCore {
 class SecurityOrigin;
+class SecurityOriginData;
 
 struct NotificationData;
 }
@@ -60,6 +61,8 @@ public:
     
     bool show(WebCore::NotificationData&&, RefPtr<WebCore::NotificationResources>&&, WebPage*, CompletionHandler<void()>&&);
     void cancel(WebCore::NotificationData&&, WebPage*);
+
+    void requestPermission(WebCore::SecurityOriginData&&, RefPtr<WebPage>, CompletionHandler<void(bool)>&&);
 
     // This callback comes from WebCore, not messaged from the UI process.
     void didDestroyNotification(WebCore::NotificationData&&, WebPage*);

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -112,7 +112,8 @@ private:
     void removePushSubscriptionsForOrigin(WebCore::SecurityOriginData&&, CompletionHandler<void(unsigned)>&&);
     void setPublicTokenForTesting(const String& publicToken, CompletionHandler<void()>&&);
     void updateConnectionConfiguration(WebPushDaemonConnectionConfiguration&&);
-    void getPushPermissionState(URL&& scopeURL, CompletionHandler<void(WebCore::PushPermissionState)>&&);
+    void getPushPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&);
+    void requestPushPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&);
     void setHostAppAuditTokenData(const Vector<uint8_t>&);
     void getPushTopicsForTesting(CompletionHandler<void(Vector<String>, Vector<String>)>&&);
     void didShowNotificationForTesting(URL&& scopeURL, CompletionHandler<void()>&&);

--- a/Source/WebKit/webpushd/PushClientConnection.messages.in
+++ b/Source/WebKit/webpushd/PushClientConnection.messages.in
@@ -32,7 +32,7 @@ messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     SubscribeToPushService(URL scopeURL, Vector<uint8_t> vapidPublicKey) -> (Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData> result)
     UnsubscribeFromPushService(URL scopeURL, std::optional<WebCore::PushSubscriptionIdentifier> identifier) -> (Expected<bool, WebCore::ExceptionData> result)
     GetPushSubscription(URL scopeURL) -> (Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData> result)
-    GetPushPermissionState(URL scopeURL) -> (enum:uint8_t WebCore::PushPermissionState result)
+    GetPushPermissionState(WebCore::SecurityOriginData origin) -> (enum:uint8_t WebCore::PushPermissionState result)
     IncrementSilentPushCount(WebCore::SecurityOriginData origin) -> (unsigned newCount)
     RemoveAllPushSubscriptions()  -> (unsigned removed)
     RemovePushSubscriptionsForOrigin(WebCore::SecurityOriginData origin) -> (unsigned removed)
@@ -43,6 +43,7 @@ messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     GetNotifications(URL registrationURL, String tag) -> (Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData> result)
     EnableMockUserNotificationCenterForTesting() -> ()
     CancelNotification(WTF::UUID notificationID)
+    RequestPushPermission(WebCore::SecurityOriginData origin) -> (bool granted)
 }
 
 #endif // ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -244,12 +244,23 @@ void PushClientConnection::didShowNotificationForTesting(URL&& scopeURL, Complet
     WebPushDaemon::singleton().didShowNotificationForTesting(*this, WTFMove(scopeURL), WTFMove(replySender));
 }
 
-void PushClientConnection::getPushPermissionState(URL&& scopeURL, CompletionHandler<void(WebCore::PushPermissionState)>&& replySender)
+void PushClientConnection::getPushPermissionState(WebCore::SecurityOriginData&& origin, CompletionHandler<void(WebCore::PushPermissionState)>&& replySender)
 {
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
-    WebPushDaemon::singleton().getPushPermissionState(*this, WTFMove(scopeURL), WTFMove(replySender));
+    WebPushDaemon::singleton().getPushPermissionState(*this, WTFMove(origin), WTFMove(replySender));
 #else
+    UNUSED_PARAM(origin);
     replySender({ });
+#endif
+}
+
+void PushClientConnection::requestPushPermission(WebCore::SecurityOriginData&& origin, CompletionHandler<void(bool)>&& replySender)
+{
+#if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
+    WebPushDaemon::singleton().requestPushPermission(*this, WTFMove(origin), WTFMove(replySender));
+#else
+    UNUSED_PARAM(origin);
+    replySender(false);
 #endif
 }
 
@@ -258,6 +269,8 @@ void PushClientConnection::showNotification(const WebCore::NotificationData& not
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
     WebPushDaemon::singleton().showNotification(*this, notificationData, notificationResources, WTFMove(completionHandler));
 #else
+    UNUSED_PARAM(notificationData);
+    UNUSED_PARAM(notificationResources);
     completionHandler();
 #endif
 }
@@ -267,6 +280,8 @@ void PushClientConnection::getNotifications(const URL& registrationURL, const St
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
     WebPushDaemon::singleton().getNotifications(*this, registrationURL, tag, WTFMove(completionHandler));
 #else
+    UNUSED_PARAM(registrationURL);
+    UNUSED_PARAM(tag);
     completionHandler({ });
 #endif
 }

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -97,7 +97,9 @@ public:
     void getNotifications(PushClientConnection&, const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&&);
     void cancelNotification(PushClientConnection&, const WTF::UUID& notificationID);
 
-    void getPushPermissionState(PushClientConnection&, const URL& scopeURL, CompletionHandler<void(WebCore::PushPermissionState)>&&);
+    void getPushPermissionState(PushClientConnection&, const WebCore::SecurityOriginData&, CompletionHandler<void(WebCore::PushPermissionState)>&&);
+    void requestPushPermission(PushClientConnection&, const WebCore::SecurityOriginData&, CompletionHandler<void(bool)>&&);
+
     void enableMockUserNotificationCenterForTesting(PushClientConnection&);
 #endif // HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
 

--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.h
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.h
@@ -33,6 +33,8 @@
 - (void)getDeliveredNotificationsWithCompletionHandler:(void(^)(NSArray<UNNotification *> *notifications))completionHandler;
 - (void)removePendingNotificationRequestsWithIdentifiers:(NSArray<NSString *> *) identifiers;
 - (void)removeDeliveredNotificationsWithIdentifiers:(NSArray<NSString *> *) identifiers;
+- (void)getNotificationSettingsWithCompletionHandler:(void(^)(UNNotificationSettings *settings))completionHandler;
+- (void)requestAuthorizationWithOptions:(UNAuthorizationOptions)options completionHandler:(void (^)(BOOL granted, NSError *))completionHandler;
 @end
 
 #endif

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
@@ -69,6 +69,7 @@ public:
 
     void sendPushMessage(PushMessageForTesting&&, CompletionHandler<void(String)>&&);
     void getPushPermissionState(const String& scope, CompletionHandler<void(WebCore::PushPermissionState)>&&);
+    void requestPushPermission(const String& scope, CompletionHandler<void(bool)>&&);
 
 private:
     void sendAuditToken();

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -32,6 +32,7 @@
 #import "PushClientConnectionMessages.h"
 #import "WebPushDaemonConnectionConfiguration.h"
 #import "WebPushDaemonConstants.h"
+#import <WebCore/SecurityOriginData.h>
 #import <mach/mach_init.h>
 #import <mach/task.h>
 #import <pal/spi/cocoa/ServersSPI.h>
@@ -112,7 +113,14 @@ void Connection::getPushPermissionState(const String& scope, CompletionHandler<v
 {
     printf("Getting push permission state\n");
 
-    sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushPermissionState(URL(scope)), WTFMove(completionHandler));
+    sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushPermissionState(WebCore::SecurityOriginData::fromURL(URL { scope })), WTFMove(completionHandler));
+}
+
+void Connection::requestPushPermission(const String& scope, CompletionHandler<void(bool)>&& completionHandler)
+{
+    printf("Request push permission state for %s\n", scope.utf8().data());
+
+    sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::RequestPushPermission(WebCore::SecurityOriginData::fromURL(URL { scope })), WTFMove(completionHandler));
 }
 
 void Connection::sendAuditToken()


### PR DESCRIPTION
#### b37edf6d5b9ef66cda7e8f9246c7d06225888c0d
<pre>
Route notification permission requests through webpushd
<a href="https://bugs.webkit.org/show_bug.cgi?id=277101">https://bugs.webkit.org/show_bug.cgi?id=277101</a>
<a href="https://rdar.apple.com/131367050">rdar://131367050</a>

Reviewed by Brady Eidson.

When running in built-in notifications mode, we should route push and notification permission
requests through webpushd rather than through the embedder.

We want to centralize notification and permission management in webpushd because it reduces the
amount of duplicate boilerplate code to write in each embedder, and it makes it much easier to keep
the state of permissions and push subscriptions in sync.

Testing is currently through an app that toggles on the built-in notification setting, as well as
via webpushtool. This patch is hooked up to use _WKMockUserNotificationCenter though, so it should
be easy to add an integration test for this in a future patch when I actually hook up
Notification.permission and PushManager.permissionState to webpushd.

* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::requestPermission):
(WebKit::NetworkNotificationManager::getPushPermissionState):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/Platform/spi/Cocoa/UserNotificationsSPI.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in:
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp:
(WebKit::ServiceWorkerNotificationHandler::requestPermission):
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp:
(WebKit::WebNotificationManagerMessageHandler::requestPermission):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::sendNotificationMessageWithAsyncReply):
(WebKit::WebNotificationManager::requestPermission):
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp:
(WebKit::WebNotificationClient::requestPermission):
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/PushClientConnection.messages.in:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::getPushPermissionState):
(WebPushD::PushClientConnection::requestPushPermission):
(WebPushD::PushClientConnection::showNotification):
(WebPushD::PushClientConnection::getNotifications):
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::getPushPermissionState):
(WebPushD::WebPushDaemon::requestPushPermission):
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.h:
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm:
(notificationPermissions):
(-[_WKMockUserNotificationCenter initWithBundleIdentifier:]):
(-[_WKMockUserNotificationCenter addNotificationRequest:withCompletionHandler:]):
(-[_WKMockUserNotificationCenter getDeliveredNotificationsWithCompletionHandler:]):
(-[_WKMockUserNotificationCenter getNotificationSettingsWithCompletionHandler:]):
(-[_WKMockUserNotificationCenter requestAuthorizationWithOptions:completionHandler:]):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::getPushPermissionState):
(WebPushTool::Connection::requestPushPermission):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
(printUsageAndTerminate):
(WebKit::WebPushToolVerb::done):
(WebKit::InjectPushMessageVerb::InjectPushMessageVerb):
(WebKit::GetPushPermissionStateVerb::GetPushPermissionStateVerb):
(WebKit::RequestPushPermissionVerb::RequestPushPermissionVerb):
(WebKit::WebPushToolMain):

Canonical link: <a href="https://commits.webkit.org/281654@main">https://commits.webkit.org/281654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bb3c04afdbed8f05fbd14e3903eb385e2de86a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64409 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11023 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48941 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7683 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29774 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33803 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9938 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55685 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66140 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9747 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56309 "Found 1 new test failure: media/media-session/play-after-seek.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4443 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52369 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56477 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13484 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3671 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35649 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36731 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37822 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->