### PR TITLE
[Win] run-webkit-tests creates temporary files in the Windows directory

### DIFF
--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -753,16 +753,6 @@ class Port(object):
             'JSC_useKernTCSM',
             '__XPC_JSC_useKernTCSM',
 
-            # CYGWIN:
-            'HOMEDRIVE',
-            'HOMEPATH',
-
-            # Windows:
-            'COMSPEC',
-            'SYSTEMDRIVE',
-            'SYSTEMROOT',
-            'WEBKIT_LIBRARIES',
-
             # Most ports (?):
             'HOME',
             'PATH',

--- a/Tools/Scripts/webkitpy/port/win.py
+++ b/Tools/Scripts/webkitpy/port/win.py
@@ -117,6 +117,18 @@ class WinPort(ApplePort):
 
     def setup_environ_for_server(self, server_name=None):
         env = super(WinPort, self).setup_environ_for_server(server_name)
+        variables_to_copy = [
+            'COMSPEC',
+            'HOMEDRIVE',
+            'HOMEPATH',
+            'SYSTEMDRIVE',
+            'SYSTEMROOT',
+            'TEMP',
+            'TMP',
+            'WEBKIT_LIBRARIES',
+        ]
+        for variable in variables_to_copy:
+            self._copy_value_from_environ_if_set(env, variable)
         if 'WEBKIT_TESTFONTS' not in env:
             env['WEBKIT_TESTFONTS'] = self.path_from_webkit_base('Tools', 'WebKitTestRunner', 'fonts')
         if 'WEBKIT_LIBRARIES' in env:
@@ -126,17 +138,6 @@ class WinPort(ApplePort):
         env['PATH'] = lib + ';' + env['PATH']
         env['PYTHONUTF8'] = '1'
         env['XML_CATALOG_FILES'] = ''  # work around missing /etc/catalog <rdar://problem/4292995>
-        return env
-
-    def environment_for_api_tests(self):
-        env = super(WinPort, self).environment_for_api_tests()
-        variables_to_copy = [
-            'SYSTEMROOT',
-            'TEMP',
-            'TMP',
-        ]
-        for variable in variables_to_copy:
-            self._copy_value_from_environ_if_set(env, variable)
         return env
 
     def driver_name(self):


### PR DESCRIPTION
#### 458d9099e1b061628588569e212c198ba73e7313
<pre>
[Win] run-webkit-tests creates temporary files in the Windows directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=277096">https://bugs.webkit.org/show_bug.cgi?id=277096</a>

Reviewed by Ross Kirsling.

run-webkit-tests created temporary files in the windows directory
(ie C:\windows) because GetTempPath API returns the directory if certain
environment variables aren&apos;t set.
&lt;<a href="https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw">https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw</a>&gt;
run-webkit-tests should propagate TEMP and TMP environment variables
to WebKitTestRunner.

Moved the code of Windows specific environment variables from
setup_environ_for_server method of the base Port class to one of the
derived WinPort class.

Removed environment_for_api_tests method of WinPort class because
environment_for_api_tests method of the base class calls
setup_environ_for_server method.

* Tools/Scripts/webkitpy/port/base.py:
(Port.setup_environ_for_server):
* Tools/Scripts/webkitpy/port/win.py:
(WinPort.setup_environ_for_server):
(WinPort.setup_crash_log_saving):

Canonical link: <a href="https://commits.webkit.org/281384@main">https://commits.webkit.org/281384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0e948a3b7a3d52b1987963f44c5997b5c404570

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63636 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10244 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10403 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7159 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29270 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/59247 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33158 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8943 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9167 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65367 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3648 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3659 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55907 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3026 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8924 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34879 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37048 "Built successfully") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35707 "Failed to checkout and rebase branch from PR 31255") | | | 
<!--EWS-Status-Bubble-End-->