### PR TITLE
Limit shape detection IPCs by feature flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6055,6 +6055,7 @@ ShapeDetection:
       default: false
     WebCore:
       default: false
+  sharedPreferenceForWebProcess: true
 
 SharedWorkerEnabled:
   type: bool

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp
@@ -48,6 +48,11 @@ RemoteBarcodeDetector::RemoteBarcodeDetector(Ref<WebCore::ShapeDetection::Barcod
 
 RemoteBarcodeDetector::~RemoteBarcodeDetector() = default;
 
+const SharedPreferencesForWebProcess& RemoteBarcodeDetector::sharedPreferencesForWebProcess() const
+{
+    return m_backend->sharedPreferencesForWebProcess();
+}
+
 Ref<WebCore::ShapeDetection::BarcodeDetector> RemoteBarcodeDetector::protectedBacking()
 {
     return backing();

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h
@@ -45,6 +45,7 @@ struct DetectedBarcode;
 
 namespace WebKit {
 class RemoteRenderingBackend;
+struct SharedPreferencesForWebProcess;
 
 namespace ShapeDetection {
 class ObjectHeap;
@@ -59,6 +60,7 @@ public:
         return adoptRef(*new RemoteBarcodeDetector(WTFMove(barcodeDetector), objectHeap, backend, identifier, webProcessIdentifier));
     }
 
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
     virtual ~RemoteBarcodeDetector();
 
 private:

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.messages.in
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteBarcodeDetector NotRefCounted Stream {
-    void Detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<WebCore::ShapeDetection::DetectedBarcode> detectedBarcodes)
+    [EnabledBy=ShapeDetection] void Detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<WebCore::ShapeDetection::DetectedBarcode> detectedBarcodes)
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
@@ -47,6 +47,11 @@ RemoteFaceDetector::RemoteFaceDetector(Ref<WebCore::ShapeDetection::FaceDetector
 
 RemoteFaceDetector::~RemoteFaceDetector() = default;
 
+const SharedPreferencesForWebProcess& RemoteFaceDetector::sharedPreferencesForWebProcess() const
+{
+    return m_backend->sharedPreferencesForWebProcess();
+}
+
 void RemoteFaceDetector::detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&& completionHandler)
 {
     auto sourceImage = m_backend->imageBuffer(renderingResourceIdentifier);

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
@@ -44,6 +44,7 @@ class FaceDetector;
 
 namespace WebKit {
 class RemoteRenderingBackend;
+struct SharedPreferencesForWebProcess;
 
 namespace ShapeDetection {
 class ObjectHeap;
@@ -57,6 +58,8 @@ public:
     {
         return adoptRef(*new RemoteFaceDetector(WTFMove(faceDetector), objectHeap, backend, identifier, webProcessIdentifier));
     }
+
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
 
     virtual ~RemoteFaceDetector();
 

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.messages.in
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteFaceDetector NotRefCounted Stream {
-    void Detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<WebCore::ShapeDetection::DetectedFace> detectedFaces)
+    [EnabledBy=ShapeDetection] void Detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<WebCore::ShapeDetection::DetectedFace> detectedFaces)
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.cpp
@@ -47,6 +47,11 @@ RemoteTextDetector::RemoteTextDetector(Ref<WebCore::ShapeDetection::TextDetector
 
 RemoteTextDetector::~RemoteTextDetector() = default;
 
+const SharedPreferencesForWebProcess& RemoteTextDetector::sharedPreferencesForWebProcess() const
+{
+    return m_backend->sharedPreferencesForWebProcess();
+}
+
 Ref<WebCore::ShapeDetection::TextDetector> RemoteTextDetector::protectedBacking()
 {
     return backing();

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
@@ -44,6 +44,7 @@ class TextDetector;
 
 namespace WebKit {
 class RemoteRenderingBackend;
+struct SharedPreferencesForWebProcess;
 
 namespace ShapeDetection {
 class ObjectHeap;
@@ -57,6 +58,8 @@ public:
     {
         return adoptRef(*new RemoteTextDetector(WTFMove(textDetector), objectHeap, backend, identifier, webProcessIdentifier));
     }
+
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
 
     virtual ~RemoteTextDetector();
 

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.messages.in
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteTextDetector NotRefCounted Stream {
-    void Detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<WebCore::ShapeDetection::DetectedText> detectedText)
+    [EnabledBy=ShapeDetection] void Detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<WebCore::ShapeDetection::DetectedText> detectedText)
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -137,6 +137,11 @@ void RemoteRenderingBackend::stopListeningForIPC()
     });
 }
 
+const SharedPreferencesForWebProcess& RemoteRenderingBackend::sharedPreferencesForWebProcess() const
+{
+    return m_gpuConnectionToWebProcess->sharedPreferencesForWebProcess();
+}
+
 void RemoteRenderingBackend::workQueueInitialize()
 {
     assertIsCurrent(workQueue());

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -74,7 +74,6 @@ struct FaceDetectorOptions;
 
 namespace WebKit {
 
-
 class GPUConnectionToWebProcess;
 class RemoteDisplayListRecorder;
 class RemoteImageBuffer;
@@ -83,6 +82,7 @@ class RemoteSharedResourceCache;
 struct BufferIdentifierSet;
 struct ImageBufferSetPrepareBufferForDisplayInputData;
 struct ImageBufferSetPrepareBufferForDisplayOutputData;
+struct SharedPreferencesForWebProcess;
 enum class SwapBuffersDisplayRequirement : uint8_t;
 
 namespace ShapeDetection {
@@ -94,6 +94,8 @@ public:
     static Ref<RemoteRenderingBackend> create(GPUConnectionToWebProcess&, RenderingBackendIdentifier, Ref<IPC::StreamServerConnection>&&);
     virtual ~RemoteRenderingBackend();
     void stopListeningForIPC();
+
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
 
     RemoteResourceCache& remoteResourceCache() { return m_remoteResourceCache; }
     RemoteSharedResourceCache& sharedResourceCache() { return m_sharedResourceCache; }

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -63,13 +63,13 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     MoveToSerializedBuffer(WebCore::RenderingResourceIdentifier sourceImageBuffer)
     MoveToImageBuffer(WebCore::RenderingResourceIdentifier destinationImageBuffer)
 
-    CreateRemoteBarcodeDetector(WebKit::ShapeDetectionIdentifier identifier, WebCore::ShapeDetection::BarcodeDetectorOptions barcodeDetectorOptions) AllowedWhenWaitingForSyncReply
-    ReleaseRemoteBarcodeDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
-    GetRemoteBarcodeDetectorSupportedFormats() -> (Vector<WebCore::ShapeDetection::BarcodeFormat> formats) Async
-    CreateRemoteFaceDetector(WebKit::ShapeDetectionIdentifier identifier, WebCore::ShapeDetection::FaceDetectorOptions faceDetectorOptions) AllowedWhenWaitingForSyncReply
-    ReleaseRemoteFaceDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
-    CreateRemoteTextDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
-    ReleaseRemoteTextDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
+    [EnabledBy=ShapeDetection] CreateRemoteBarcodeDetector(WebKit::ShapeDetectionIdentifier identifier, WebCore::ShapeDetection::BarcodeDetectorOptions barcodeDetectorOptions) AllowedWhenWaitingForSyncReply
+    [EnabledBy=ShapeDetection] ReleaseRemoteBarcodeDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
+    [EnabledBy=ShapeDetection] GetRemoteBarcodeDetectorSupportedFormats() -> (Vector<WebCore::ShapeDetection::BarcodeFormat> formats) Async
+    [EnabledBy=ShapeDetection] CreateRemoteFaceDetector(WebKit::ShapeDetectionIdentifier identifier, WebCore::ShapeDetection::FaceDetectorOptions faceDetectorOptions) AllowedWhenWaitingForSyncReply
+    [EnabledBy=ShapeDetection] ReleaseRemoteFaceDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
+    [EnabledBy=ShapeDetection] CreateRemoteTextDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
+    [EnabledBy=ShapeDetection] ReleaseRemoteTextDetector(WebKit::ShapeDetectionIdentifier identifier) AllowedWhenWaitingForSyncReply
 }
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/Scripts/webkit/model.py
+++ b/Source/WebKit/Scripts/webkit/model.py
@@ -51,13 +51,15 @@ class MessageReceiver(object):
 
 
 class Message(object):
-    def __init__(self, name, parameters, reply_parameters, attributes, condition, runtime_enablement=None):
+    def __init__(self, name, parameters, reply_parameters, attributes, condition, enabled_if=None, enabled_by=None):
         self.name = name
         self.parameters = parameters
         self.reply_parameters = reply_parameters
         self.attributes = frozenset(attributes or [])
         self.condition = condition
-        self.runtime_enablement = runtime_enablement
+        assert(not enabled_if or not enabled_by)
+        self.enabled_if = enabled_if
+        self.enabled_by = enabled_by
 
     def has_attribute(self, attribute):
         return attribute in self.attributes

--- a/Source/WebKit/Scripts/webkit/parser.py
+++ b/Source/WebKit/Scripts/webkit/parser.py
@@ -85,14 +85,15 @@ def parse(file):
             else:
                 parameters = []
 
-            runtime_enablement = None
+            enabled_if = None
+            enabled_by = None
             if options_string:
                 match = re.search(r"(?:(?:, |^)+(?:EnabledIf='(.*)'))(?:, |$)?", options_string)
                 if match:
-                    runtime_enablement = match.groups()[0]
+                    enabled_if = match.groups()[0]
                 match = re.search(r"(?:(?:, |^)+(?:EnabledBy=([\w,]+)))(?:, |$)?", options_string)
                 if match:
-                    runtime_enablement = ' && '.join(['sharedPreferencesForWebProcess().' + preference[0].lower() + preference[1:] for preference in match.groups()[0].split(',')])
+                    enabled_by = map(lambda str: str.strip(), match.groups()[0].split(','))
 
             attributes = parse_attributes_string(attributes_string)
 
@@ -105,7 +106,7 @@ def parse(file):
             else:
                 reply_parameters = None
 
-            messages.append(model.Message(name, parameters, reply_parameters, attributes, combine_condition(conditions), runtime_enablement))
+            messages.append(model.Message(name, parameters, reply_parameters, attributes, combine_condition(conditions), enabled_if, enabled_by))
     return model.MessageReceiver(destination, superclass, receiver_attributes, messages, combine_condition(master_condition), namespace)
 
 


### PR DESCRIPTION
#### b58969a84c883ada3c15252aa121a59d5b8174ed
<pre>
Limit shape detection IPCs by feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=277112">https://bugs.webkit.org/show_bug.cgi?id=277112</a>

Reviewed by Sihui Liu.

Enable IPC message receivers in GPUProcess/ShapeDetection only when shape detection API is enabled.

This PR also refactors the code in the message receiver parser to generate header includes for
SharedPreferencesForWebProcess.h when at least one of the messages use [EnabledBy=X] attribute.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp:
(WebKit::RemoteBarcodeDetector::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.messages.in:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp:
(WebKit::RemoteFaceDetector::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.messages.in:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.cpp:
(WebKit::RemoteTextDetector::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(generate_runtime_enablement):
(async_message_statement):
(sync_message_statement):
(collect_header_conditions_for_receiver):
* Source/WebKit/Scripts/webkit/model.py:
(Message.__init__):
* Source/WebKit/Scripts/webkit/parser.py:
(parse):

Canonical link: <a href="https://commits.webkit.org/281448@main">https://commits.webkit.org/281448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c06c2835237b29e139c4ab0777612458650ab27d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63819 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10429 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48551 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7276 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36631 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/51894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29395 "Found 4 new API test failures: /TestWebKit:WebKit.ResizeWindowAfterCrash, /TestWebKit:WebKit.ReloadPageAfterCrash, /WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/security-error, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-alternate-html (failure)") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/59428 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33337 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9134 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9350 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/52995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65552 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59146 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3831 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9272 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55897 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56040 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3205 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80904 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8980 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35062 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14046 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36144 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37232 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->