### PR TITLE
REGRESSION (280917@main): Crash when omitting a visibility:hidden RenderLayer from the z-order tree.

### DIFF
--- a/LayoutTests/compositing/visibility/omitted-hidden-layers-crash-expected.txt
+++ b/LayoutTests/compositing/visibility/omitted-hidden-layers-crash-expected.txt
@@ -1,0 +1,3 @@
+This test should not crash.
+
+

--- a/LayoutTests/compositing/visibility/omitted-hidden-layers-crash.html
+++ b/LayoutTests/compositing/visibility/omitted-hidden-layers-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+  <script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<p>This test should not crash.</p>
+
+<div style="width: 200px; height: 200px; overflow: scroll; border: 1px black solid" id="scroll">
+  <div style="position: fixed; width: 20px; height: 20px; background: green"></div>
+  <div style="position: relative; width: 150px; height: 400px; background-color: blue"></div>
+</div>
+
+</body>
+<script>
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async () => {
+    await new Promise(requestAnimationFrame);
+    document.getElementById("scroll").style.visibility = "hidden";
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+};
+</script>
+</html>

--- a/LayoutTests/compositing/visibility/omitted-hidden-layers-inserted-expected.html
+++ b/LayoutTests/compositing/visibility/omitted-hidden-layers-inserted-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <div id="visible" style="background: green; visibility:visible; width: 200px; height: 200px;"></div>
+</body>
+</html>

--- a/LayoutTests/compositing/visibility/omitted-hidden-layers-inserted.html
+++ b/LayoutTests/compositing/visibility/omitted-hidden-layers-inserted.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+  <div id="container" style="position: absolute; width: 200px; height: 200px; background: red; visibility:hidden"></div>
+  <div id="visible" style="background: green; visibility:visible; width: 200px; height: 200px;"></div>
+
+</body>
+<script>
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+}
+
+window.onload = async () => {
+    await new Promise(requestAnimationFrame);
+    
+    document.getElementById("container").append(document.getElementById("visible"));
+    
+    if (window.testRunner)
+        testRunner.notifyDone();
+};
+</script>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -749,6 +749,7 @@ void RenderLayer::updateNormalFlowList()
             if (!m_normalFlowList)
                 m_normalFlowList = makeUnique<Vector<RenderLayer*>>();
             m_normalFlowList->append(child);
+            child->setWasIncludedInZOrderTree();
         }
     }
 
@@ -827,10 +828,31 @@ void RenderLayer::rebuildZOrderLists(std::unique_ptr<Vector<RenderLayer*>>& posZ
     }
 }
 
+void RenderLayer::removeSelfAndDescendantsFromCompositor()
+{
+    if (parent())
+        compositor().layerWillBeRemoved(*parent(), *this);
+    clearBacking();
+
+    for (RenderLayer* child = firstChild(); child; child = child->nextSibling())
+        child->removeSelfAndDescendantsFromCompositor();
+}
+
+void RenderLayer::setWasOmittedFromZOrderTree()
+{
+    if (m_wasOmittedFromZOrderTree)
+        return;
+
+    removeSelfAndDescendantsFromCompositor();
+
+    if (compositor().hasContentCompositingLayers() && parent())
+        parent()->setDescendantsNeedCompositingRequirementsTraversal();
+
+    m_wasOmittedFromZOrderTree = true;
+}
+
 void RenderLayer::collectLayers(std::unique_ptr<Vector<RenderLayer*>>& positiveZOrderList, std::unique_ptr<Vector<RenderLayer*>>& negativeZOrderList, OptionSet<Compositing>& accumulatedDirtyFlags)
 {
-    updateDescendantDependentFlags();
-
     if (establishesTopLayer())
         return;
 
@@ -838,12 +860,16 @@ void RenderLayer::collectLayers(std::unique_ptr<Vector<RenderLayer*>>& positiveZ
     // Overflow layers are just painted by their enclosing layers, so they don't get put in zorder lists.
     bool includeHiddenLayer = (m_hasVisibleContent || m_intrinsicallyComposited) || ((m_hasVisibleDescendant || m_hasIntrinsicallyCompositedDescendants) && isStacking);
     includeHiddenLayer |= page().hasEverSetVisibilityAdjustment();
-    if (includeHiddenLayer && !isNormalFlowOnly()) {
-        auto& layerList = (zIndex() >= 0) ? positiveZOrderList : negativeZOrderList;
-        if (!layerList)
-            layerList = makeUnique<Vector<RenderLayer*>>();
-        layerList->append(this);
-        accumulatedDirtyFlags.add(m_compositingDirtyBits);
+    if (!isNormalFlowOnly()) {
+        if (includeHiddenLayer) {
+            auto& layerList = (zIndex() >= 0) ? positiveZOrderList : negativeZOrderList;
+            if (!layerList)
+                layerList = makeUnique<Vector<RenderLayer*>>();
+            layerList->append(this);
+            accumulatedDirtyFlags.add(m_compositingDirtyBits);
+            setWasIncludedInZOrderTree();
+        } else
+            setWasOmittedFromZOrderTree();
     }
 
     // Recur into our children to collect more layers, but only if we don't establish
@@ -868,6 +894,7 @@ void RenderLayer::setAncestorsHaveCompositingDirtyFlag(Compositing flag)
 
 void RenderLayer::updateLayerListsIfNeeded()
 {
+    updateDescendantDependentFlags();
     updateZOrderLists();
     updateNormalFlowList();
 
@@ -1660,7 +1687,16 @@ void RenderLayer::updateDescendantDependentFlags()
         //  We need the parent to know if we have skipped content or content-visibility root.
         if (renderer().style().hasSkippedContent() && !renderer().parent())
             return;
-        m_hasVisibleContent = computeHasVisibleContent();
+        bool hasVisibleContent = computeHasVisibleContent();
+        if (hasVisibleContent != m_hasVisibleContent) {
+            m_hasVisibleContent = hasVisibleContent;
+            if (!isNormalFlowOnly()) {
+                // We don't collect invisible layers in z-order lists if they are not composited.
+                // As we change visibility, we need to dirty our stacking containers ancestors to be properly
+                // collected.
+                dirtyHiddenStackingContextAncestorZOrderLists();
+            }
+        }
         m_visibleContentStatusDirty = false;
     }
 }

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1185,6 +1185,10 @@ private:
 
     void updatePagination();
 
+    void setWasOmittedFromZOrderTree();
+    void setWasIncludedInZOrderTree() { m_wasOmittedFromZOrderTree = false; }
+    void removeSelfAndDescendantsFromCompositor();
+
     void setHasCompositingDescendant(bool b)  { m_hasCompositingDescendant = b; }
     void setHasCompositedNonContainedDescendants(bool value) { m_hasCompositedNonContainedDescendants = value; }
 
@@ -1275,6 +1279,8 @@ private:
     bool m_intrinsicallyComposited : 1;
     bool m_hasIntrinsicallyCompositedDescendants : 1;
     bool m_hasIntrinsicallyCompositedDescendantsStatusDirty : 1;
+
+    bool m_wasOmittedFromZOrderTree : 1 { false };
 
     RenderLayerModelObject& m_renderer;
 


### PR DESCRIPTION
#### 0d9d9b7200189cbcf56cd043089e2ec6a7ac93fd
<pre>
REGRESSION (280917@main): Crash when omitting a visibility:hidden RenderLayer from the z-order tree.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277115">https://bugs.webkit.org/show_bug.cgi?id=277115</a>
&lt;<a href="https://rdar.apple.com/132358145">rdar://132358145</a>&gt;

Reviewed by Simon Fraser.

If we decide we can newly omit a RenderLayer in the z-order tree due to not
being visible, we need to also notify the compositor that these layers are
&apos;gone&apos; so that state can be updated correctly.

* LayoutTests/compositing/visibility/omitted-hidden-layers-crash-expected.txt: Added.
* LayoutTests/compositing/visibility/omitted-hidden-layers-crash.html: Added.
* LayoutTests/compositing/visibility/omitted-hidden-layers-inserted-expected.html: Added.
* LayoutTests/compositing/visibility/omitted-hidden-layers-inserted.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateNormalFlowList):
(WebCore::RenderLayer::removeSelfAndDescendantsFromCompositor):
(WebCore::RenderLayer::setWasOmittedFromZOrderTree):
(WebCore::RenderLayer::collectLayers):
(WebCore::RenderLayer::updateLayerListsIfNeeded):
(WebCore::RenderLayer::updateDescendantDependentFlags):
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/281636@main">https://commits.webkit.org/281636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e79a73522018b4abecea7bceb0f2a07895dec06a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64439 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11059 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11284 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/7690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37144 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/52422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9655 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9968 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66173 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4454 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56496 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13449 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3696 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->