### PR TITLE
Update memcpySpan(A, B) to not require A and B to have the same size

### DIFF
--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -487,7 +487,7 @@ MappedFileData mapToFile(const String& path, size_t bytesSize, Function<void(con
     auto mapData = mappedFile.mutableSpan();
 
     apply([&mapData](std::span<const uint8_t> chunk) {
-        memcpySpan(mapData.first(chunk.size()), chunk);
+        memcpySpan(mapData, chunk);
         mapData = mapData.subspan(chunk.size());
         return true;
     });

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -723,11 +723,11 @@ bool equalSpans(std::span<T, TExtent> a, std::span<U, UExtent> b)
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
 void memcpySpan(std::span<T, TExtent> destination, std::span<U, UExtent> source)
 {
-    RELEASE_ASSERT(destination.size() == source.size());
     static_assert(sizeof(T) == sizeof(U));
     static_assert(std::is_trivially_copyable_v<T>);
     static_assert(std::is_trivially_copyable_v<U>);
-    memcpy(destination.data(), source.data(), destination.size_bytes());
+    RELEASE_ASSERT(destination.size() >= source.size());
+    memcpy(destination.data(), source.data(), source.size_bytes());
 }
 
 template<typename T, std::size_t Extent>

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
@@ -172,7 +172,7 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> GPUBuffer::getMappedRange(std::optional<GPUSi
 
     RefPtr<JSC::ArrayBuffer> result;
     m_backing->getMappedRange(offset, size, [&] (auto mappedRange) {
-        if (!mappedRange.source) {
+        if (!mappedRange.data()) {
             m_arrayBuffers.clear();
             if (m_mappedAtCreation || !size)
                 result = makeArrayBuffer(static_cast<size_t>(0U), 0, 1, m_arrayBuffers, m_device, *this);
@@ -180,7 +180,7 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> GPUBuffer::getMappedRange(std::optional<GPUSi
             return;
         }
 
-        result = makeArrayBuffer(mappedRange.source, offset, size, m_arrayBuffers, m_device, *this);
+        result = makeArrayBuffer(mappedRange.data(), offset, size, m_arrayBuffers, m_device, *this);
     });
 
     if (!result)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp
@@ -70,7 +70,7 @@ void BufferImpl::mapAsync(MapModeFlags mapModeFlags, Size64 offset, std::optiona
     wgpuBufferMapAsync(m_backing.get(), backingMapModeFlags, static_cast<size_t>(offset), static_cast<size_t>(usedSize), &mapAsyncCallback, Block_copy(blockPtr.get())); // Block_copy is matched with Block_release above in mapAsyncCallback().
 }
 
-void BufferImpl::getMappedRange(Size64 offset, std::optional<Size64> size, Function<void(MappedRange)>&& callback)
+void BufferImpl::getMappedRange(Size64 offset, std::optional<Size64> size, Function<void(std::span<uint8_t>)>&& callback)
 {
     auto usedSize = getMappedSize(m_backing.get(), size, offset);
 
@@ -83,10 +83,10 @@ void BufferImpl::getMappedRange(Size64 offset, std::optional<Size64> size, Funct
     callback({ static_cast<uint8_t*>(pointer) - actualOffset, actualSize });
 }
 
-auto BufferImpl::getBufferContents() -> MappedRange
+std::span<uint8_t> BufferImpl::getBufferContents()
 {
     if (!m_backing.get())
-        return { nullptr, 0 };
+        return { };
 
     auto* pointer = wgpuBufferGetBufferContents(m_backing.get());
     auto bufferSize = wgpuBufferGetCurrentSize(m_backing.get());

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h
@@ -59,8 +59,8 @@ private:
     WGPUBuffer backing() const { return m_backing.get(); }
 
     void mapAsync(MapModeFlags, Size64 offset, std::optional<Size64> sizeForMap, CompletionHandler<void(bool)>&&) final;
-    void getMappedRange(Size64 offset, std::optional<Size64>, Function<void(MappedRange)>&&) final;
-    MappedRange getBufferContents() final;
+    void getMappedRange(Size64 offset, std::optional<Size64>, Function<void(std::span<uint8_t>)>&&) final;
+    std::span<uint8_t> getBufferContents() final;
     void unmap() final;
     void copy(std::span<const uint8_t>, size_t offset) final;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
@@ -50,15 +50,11 @@ public:
     }
 
     virtual void mapAsync(MapModeFlags, Size64 offset, std::optional<Size64>, CompletionHandler<void(bool)>&&) = 0;
-    struct MappedRange {
-        uint8_t* source { nullptr };
-        size_t byteLength { 0 };
-    };
-    virtual void getMappedRange(Size64 offset, std::optional<Size64>, Function<void(MappedRange)>&&) = 0;
+    virtual void getMappedRange(Size64 offset, std::optional<Size64>, Function<void(std::span<uint8_t>)>&&) = 0;
     virtual void unmap() = 0;
 
     virtual void destroy() = 0;
-    virtual MappedRange getBufferContents() = 0;
+    virtual std::span<uint8_t> getBufferContents() = 0;
     virtual void copy(std::span<const uint8_t>, size_t offset) = 0;
 protected:
     Buffer() = default;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
@@ -43,7 +43,7 @@ ExceptionOr<void> WebCodecsEncodedAudioChunk::copyTo(BufferSource&& source)
     if (source.length() < byteLength())
         return Exception { ExceptionCode::TypeError, "buffer is too small"_s };
 
-    memcpySpan(source.mutableSpan().first(byteLength()), span());
+    memcpySpan(source.mutableSpan(), span());
     return { };
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
@@ -42,7 +42,7 @@ ExceptionOr<void> WebCodecsEncodedVideoChunk::copyTo(BufferSource&& source)
     if (source.length() < byteLength())
         return Exception { ExceptionCode::TypeError, "buffer is too small"_s };
 
-    memcpySpan(source.mutableSpan().first(byteLength()), span());
+    memcpySpan(source.mutableSpan(), span());
     return { };
 }
 

--- a/Source/WebCore/platform/SharedMemory.cpp
+++ b/Source/WebCore/platform/SharedMemory.cpp
@@ -49,7 +49,7 @@ RefPtr<SharedMemory> SharedMemory::copyBuffer(const FragmentedSharedBuffer& buff
 
     auto destination = sharedMemory->mutableSpan();
     buffer.forEachSegment([&] (std::span<const uint8_t> segment) mutable {
-        memcpySpan(destination.first(segment.size()), segment);
+        memcpySpan(destination, segment);
         destination = destination.subspan(segment.size());
     });
 
@@ -65,9 +65,7 @@ RefPtr<SharedMemory> SharedMemory::copySpan(std::span<const uint8_t> span)
     if (!sharedMemory)
         return nullptr;
 
-    auto destination = sharedMemory->mutableSpan();
-    memcpySpan(destination, span);
-
+    memcpySpan(sharedMemory->mutableSpan(), span);
     return sharedMemory;
 }
 

--- a/Source/WebCore/platform/audio/MultiChannelResampler.cpp
+++ b/Source/WebCore/platform/audio/MultiChannelResampler.cpp
@@ -105,7 +105,7 @@ void MultiChannelResampler::provideInputForChannel(std::span<float> buffer, size
     }
 
     // Copy the channel data from what we received from m_multiChannelProvider.
-    memcpySpan(buffer.first(framesToProcess), m_multiChannelBus->channel(channelIndex)->span().first(framesToProcess));
+    memcpySpan(buffer, m_multiChannelBus->channel(channelIndex)->span().first(framesToProcess));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/SincResampler.cpp
+++ b/Source/WebCore/platform/audio/SincResampler.cpp
@@ -209,7 +209,7 @@ void SincResampler::processBuffer(std::span<const float> source, std::span<float
         size_t framesToCopy = std::min(source.size(), framesToProcess);
 
         IGNORE_WARNINGS_BEGIN("restrict")
-        memcpySpan(buffer.first(framesToCopy), source.first(framesToCopy));
+        memcpySpan(buffer, source.first(framesToCopy));
         IGNORE_WARNINGS_END
 
         // Zero-pad if necessary.
@@ -278,7 +278,7 @@ void SincResampler::process(std::span<float> destination, size_t framesToProcess
 
         // Step (3) Copy r3 to r1.
         // This wraps the last input frames back to the start of the buffer.
-        memcpySpan(m_r1.first(kernelSize), m_r3.first(kernelSize));
+        memcpySpan(m_r1, m_r3.first(kernelSize));
 
         // Step (4) -- Reinitialize regions if necessary.
         if (m_r0.data() == m_r2.data())

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp
@@ -223,7 +223,7 @@ bool renameFont(const SharedBuffer& fontData, const String& fontName, Vector<uin
 
     rewrittenFontData.resize(fontData.size() + nameTableSize);
     auto dataSpan = rewrittenFontData.mutableSpan();
-    memcpySpan(dataSpan.first(fontData.size()), fontData.span());
+    memcpySpan(dataSpan, fontData.span());
 
     // Make the table directory entry point to the new 'name' table.
     sfntHeader* rewrittenSfnt = reinterpret_cast<sfntHeader*>(dataSpan.data());

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -141,7 +141,7 @@ static FileSystem::MappedFileData storeInMappedFileData(const String& path, std:
         return { };
     FileSystem::deleteFile(path);
 
-    memcpySpan(mappedFileData.mutableSpan().first(data.size()), data);
+    memcpySpan(mappedFileData.mutableSpan(), data);
 
     FileSystem::finalizeMappedFileData(mappedFileData, data.size());
     return mappedFileData;

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -230,7 +230,7 @@ void ComputePassEncoder::executePreDispatchCommands(const Buffer* indirectBuffer
         if (pcomputeOffsets && pcomputeOffsets->size()) {
             auto& computeOffsets = *pcomputeOffsets;
             auto startIndex = pipelineLayout.computeOffsetForBindGroup(bindGroupIndex);
-            memcpySpan(m_computeDynamicOffsets.mutableSpan().subspan(startIndex, computeOffsets.size()), computeOffsets.span());
+            memcpySpan(m_computeDynamicOffsets.mutableSpan().subspan(startIndex), computeOffsets.span());
         }
     }
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -524,7 +524,7 @@ bool RenderPassEncoder::executePreDrawCommands(const Buffer* indirectBuffer)
         if (pvertexOffsets && pvertexOffsets->size()) {
             auto& vertexOffsets = *pvertexOffsets;
             auto startIndex = pipelineLayout.vertexOffsetForBindGroup(bindGroupIndex);
-            memcpySpan(m_vertexDynamicOffsets.mutableSpan().subspan(startIndex, vertexOffsets.size()), vertexOffsets.span());
+            memcpySpan(m_vertexDynamicOffsets.mutableSpan().subspan(startIndex), vertexOffsets.span());
         }
 
         auto* pfragmentOffsets = pipelineLayout.fragmentOffsets(bindGroupIndex, kvp.value);
@@ -536,7 +536,7 @@ bool RenderPassEncoder::executePreDrawCommands(const Buffer* indirectBuffer)
                 makeInvalid(@"Invalid offset calculation");
                 return false;
             }
-            memcpySpan(m_fragmentDynamicOffsets.mutableSpan().subspan(startIndexWithOffset, fragmentOffsets.size()), fragmentOffsets.span());
+            memcpySpan(m_fragmentDynamicOffsets.mutableSpan().subspan(startIndexWithOffset), fragmentOffsets.span());
         }
     }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -96,7 +96,7 @@ void RemoteImageBuffer::getPixelBuffer(WebCore::PixelBufferFormat destinationFor
     IntRect srcRect(srcPoint, srcSize);
     if (auto pixelBuffer = m_imageBuffer->getPixelBuffer(destinationFormat, srcRect)) {
         MESSAGE_CHECK(pixelBuffer->bytes().size() <= memory->size(), "Shmem for return of getPixelBuffer is too small"_s);
-        memcpySpan(memory->mutableSpan().first(pixelBuffer->bytes().size()), pixelBuffer->bytes());
+        memcpySpan(memory->mutableSpan(), pixelBuffer->bytes());
     } else
         memsetSpan(memory->mutableSpan(), 0);
     completionHandler();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
@@ -95,7 +95,7 @@ Data concatenate(const Data& a, const Data& b)
         return a;
 
     Vector<uint8_t> buffer(a.size() + b.size());
-    memcpySpan(buffer.mutableSpan().first(a.size()), a.span());
+    memcpySpan(buffer.mutableSpan(), a.span());
     memcpySpan(buffer.mutableSpan().subspan(a.size()), b.span());
     return Data(WTFMove(buffer));
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -63,7 +63,7 @@ static bool offsetOrSizeExceedsBounds(size_t dataSize, WebCore::WebGPU::Size64 o
     return offset >= dataSize || (requestedSize.has_value() && requestedSize.value() + offset > dataSize);
 }
 
-void RemoteBufferProxy::getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size, Function<void(MappedRange)>&& callback)
+void RemoteBufferProxy::getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size, Function<void(std::span<uint8_t>)>&& callback)
 {
     // FIXME: Implement error handling.
     auto sendResult = sendSync(Messages::RemoteBuffer::GetMappedRange(offset, size));
@@ -74,10 +74,10 @@ void RemoteBufferProxy::getMappedRange(WebCore::WebGPU::Size64 offset, std::opti
         return;
     }
 
-    callback({ data->data() + offset, static_cast<size_t>(size.value_or(data->size() - offset)) });
+    callback(data->mutableSpan().subspan(offset));
 }
 
-auto RemoteBufferProxy::getBufferContents() -> MappedRange
+std::span<uint8_t> RemoteBufferProxy::getBufferContents()
 {
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -79,8 +79,8 @@ private:
     }
 
     void mapAsync(WebCore::WebGPU::MapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(bool)>&&) final;
-    void getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64>, Function<void(MappedRange)>&&) final;
-    MappedRange getBufferContents() final;
+    void getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64>, Function<void(std::span<uint8_t>)>&&) final;
+    std::span<uint8_t> getBufferContents() final;
     void unmap() final;
     void copy(std::span<const uint8_t>, size_t offset) final;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -618,7 +618,7 @@ size_t PDFIncrementalLoader::dataProviderGetBytesAtPosition(std::span<uint8_t> b
     }
 
     if (auto data = plugin->dataSpanForRange(position, buffer.size(), CheckValidRanges::Yes); data.data()) {
-        memcpySpan(buffer.first(data.size()), data);
+        memcpySpan(buffer, data);
 #if !LOG_DISABLED
         decrementThreadsWaitingOnCallback();
         incrementalLoaderLog(makeString("Satisfied range request for "_s, data.size(), " bytes at position "_s, position, " synchronously"_s));
@@ -639,7 +639,7 @@ size_t PDFIncrementalLoader::dataProviderGetBytesAtPosition(std::span<uint8_t> b
             if (dataSemaphore->wasSignaled())
                 return;
             RELEASE_ASSERT(bytes.size() <= buffer.size());
-            memcpySpan(buffer.first(bytes.size()), bytes);
+            memcpySpan(buffer, bytes);
             bytesProvided = bytes.size();
             dataSemaphore->signal();
         });

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -1637,7 +1637,7 @@ JSValueRef JSSharedMemory::writeBytes(JSContextRef context, JSObjectRef, JSObjec
         length = *lengthValue;
     }
 
-    memcpySpan(jsSharedMemory->m_sharedMemory->mutableSpan().subspan(offset, length), span.first(length));
+    memcpySpan(jsSharedMemory->m_sharedMemory->mutableSpan().subspan(offset), span.first(length));
 
     return JSValueMakeUndefined(context);
 }


### PR DESCRIPTION
#### cf877dfb88599f3a545d4144b8fa23737201964d
<pre>
Update memcpySpan(A, B) to not require A and B to have the same size
<a href="https://bugs.webkit.org/show_bug.cgi?id=277118">https://bugs.webkit.org/show_bug.cgi?id=277118</a>

Reviewed by Darin Adler.

Update memcpySpan(A, B) to not require A and B to have the same size. It is sufficient
for A&apos;s size to be greater or equal to B&apos;s. This makes memcpySpan() more convenient to
use.

* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::mapToFile):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::memcpySpan):
* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::GPUBuffer::getMappedRange):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp:
(WebCore::WebGPU::BufferImpl::getMappedRange):
(WebCore::WebGPU::BufferImpl::getBufferContents):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h:
(): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp:
(WebCore::WebCodecsEncodedAudioChunk::copyTo):
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp:
(WebCore::WebCodecsEncodedVideoChunk::copyTo):
* Source/WebCore/platform/SharedMemory.cpp:
(WebCore::SharedMemory::copyBuffer):
(WebCore::SharedMemory::copySpan):
* Source/WebCore/platform/audio/MultiChannelResampler.cpp:
(WebCore::MultiChannelResampler::provideInputForChannel):
* Source/WebCore/platform/audio/SincResampler.cpp:
(WebCore::SincResampler::processBuffer):
(WebCore::SincResampler::process):
* Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp:
(WebCore::renameFont):
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::storeInMappedFileData):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executePreDrawCommands):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::getPixelBuffer):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::getMappedRange):
(WebKit::RemoteBuffer::copy):
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp:
(WebKit::NetworkCache::concatenate):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
(WebKit::WebGPU::RemoteBufferProxy::getMappedRange):
(WebKit::WebGPU::RemoteBufferProxy::getBufferContents):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::PDFIncrementalLoader::dataProviderGetBytesAtPosition):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSSharedMemory::writeBytes):

Canonical link: <a href="https://commits.webkit.org/281423@main">https://commits.webkit.org/281423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d69310cc209a756bc9cb6d6989a46de0c77d9ac1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63770 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10377 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10551 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7260 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29378 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9065 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9300 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/52947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65500 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59098 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9210 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55875 "Found 1 new test failure: fast/css/text-overflow-input.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56016 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3141 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80856 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8962 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35012 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14032 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37181 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->