### PR TITLE
container-type does not force layout containment, but does force an independent formatting context

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/animation-container-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/animation-container-size-expected.txt
@@ -1,4 +1,4 @@
 Test
 
-PASS Animation affects container query evaluation
+FAIL Animation affects container query evaluation assert_equals: expected "rgb(0, 0, 255)" but got "rgb(0, 128, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/animation-container-type-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/animation-container-type-dynamic-expected.txt
@@ -1,4 +1,4 @@
 Test
 
-PASS Animated container creating new container
+FAIL Animated container creating new container assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/animation-nested-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/animation-nested-animation-expected.txt
@@ -1,4 +1,4 @@
 Test
 
-PASS Animated container can create inner animation
+FAIL Animated container can create inner animation assert_equals: expected "rgb(0, 0, 255)" but got "rgb(0, 128, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/animation-nested-transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/animation-nested-transition-expected.txt
@@ -1,4 +1,4 @@
 Test
 
-PASS Animated container size triggers transition
+FAIL Animated container size triggers transition assert_equals: expected "rgb(150, 150, 150)" but got "rgb(100, 100, 100)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/aspect-ratio-feature-evaluation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/aspect-ratio-feature-evaluation-expected.txt
@@ -1,4 +1,4 @@
 
-PASS @container queries with aspect-ratio and size containment
-PASS @container query with aspect-ratio change after resize
+FAIL @container queries with aspect-ratio and size containment assert_equals: Should match for block-size containment expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL @container query with aspect-ratio change after resize assert_equals: Should match 2/1 min-ratio expected "rgb(0, 255, 0)" but got "rgba(0, 0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/at-container-parsing-expected.txt
@@ -1,55 +1,55 @@
 
-PASS (width)
-PASS (min-width: 0px)
-PASS (max-width: 0px)
-PASS (height)
-PASS (min-height: 0px)
-PASS (max-height: 0px)
-PASS (aspect-ratio)
-PASS (min-aspect-ratio: 1/2)
-PASS (max-aspect-ratio: 1/2)
-PASS (orientation: portrait)
-PASS (inline-size)
-PASS (min-inline-size: 0px)
-PASS (max-inline-size: 0px)
-PASS (block-size)
-PASS (min-block-size: 0px)
-PASS (max-block-size: 0px)
-PASS (width: 100px)
-PASS ((width: 100px))
-PASS (not (width: 100px))
-PASS ((width: 100px) and (height: 100px))
-PASS (((width: 40px) or (width: 50px)) and (height: 100px))
-PASS ((width: 100px) and ((height: 40px) or (height: 50px)))
-PASS (((width: 40px) and (height: 50px)) or (height: 100px))
-PASS ((width: 50px) or ((width: 40px) and (height: 50px)))
-PASS ((width: 100px) and (not (height: 100px)))
-PASS (width < 100px)
-PASS (width <= 100px)
-PASS (width = 100px)
-PASS (width > 100px)
-PASS (width >= 100px)
-PASS (100px < width)
-PASS (100px <= width)
-PASS (100px = width)
-PASS (100px > width)
-PASS (100px >= width)
-PASS (100px < width < 200px)
-PASS (100px < width <= 200px)
-PASS (100px <= width < 200px)
-PASS (100px > width > 200px)
-PASS (100px > width >= 200px)
-PASS (100px >= width > 200px)
-PASS (width: calc(10px))
-PASS (width: calc(10em))
-PASS (width: calc(10px + 10em))
-PASS (width < calc(10px + 10em))
-PASS (width < max(10px, 10em))
-PASS (calc(10px + 10em) < width)
-PASS (calc(10px + 10em) < width < max(30px, 30em))
-PASS (width: 100px) and (height: 100px)
-PASS (width: 100px) or (height: 100px)
-PASS not (width: 100px)
+FAIL (width) assert_equals: expected "true" but got ""
+FAIL (min-width: 0px) assert_equals: expected "true" but got ""
+FAIL (max-width: 0px) assert_equals: expected "true" but got ""
+FAIL (height) assert_equals: expected "true" but got ""
+FAIL (min-height: 0px) assert_equals: expected "true" but got ""
+FAIL (max-height: 0px) assert_equals: expected "true" but got ""
+FAIL (aspect-ratio) assert_equals: expected "true" but got ""
+FAIL (min-aspect-ratio: 1/2) assert_equals: expected "true" but got ""
+FAIL (max-aspect-ratio: 1/2) assert_equals: expected "true" but got ""
+FAIL (orientation: portrait) assert_equals: expected "true" but got ""
+FAIL (inline-size) assert_equals: expected "true" but got ""
+FAIL (min-inline-size: 0px) assert_equals: expected "true" but got ""
+FAIL (max-inline-size: 0px) assert_equals: expected "true" but got ""
+FAIL (block-size) assert_equals: expected "true" but got ""
+FAIL (min-block-size: 0px) assert_equals: expected "true" but got ""
+FAIL (max-block-size: 0px) assert_equals: expected "true" but got ""
+FAIL (width: 100px) assert_equals: expected "true" but got ""
+FAIL ((width: 100px)) assert_equals: expected "true" but got ""
+FAIL (not (width: 100px)) assert_equals: expected "true" but got ""
+FAIL ((width: 100px) and (height: 100px)) assert_equals: expected "true" but got ""
+FAIL (((width: 40px) or (width: 50px)) and (height: 100px)) assert_equals: expected "true" but got ""
+FAIL ((width: 100px) and ((height: 40px) or (height: 50px))) assert_equals: expected "true" but got ""
+FAIL (((width: 40px) and (height: 50px)) or (height: 100px)) assert_equals: expected "true" but got ""
+FAIL ((width: 50px) or ((width: 40px) and (height: 50px))) assert_equals: expected "true" but got ""
+FAIL ((width: 100px) and (not (height: 100px))) assert_equals: expected "true" but got ""
+FAIL (width < 100px) assert_equals: expected "true" but got ""
+FAIL (width <= 100px) assert_equals: expected "true" but got ""
+FAIL (width = 100px) assert_equals: expected "true" but got ""
+FAIL (width > 100px) assert_equals: expected "true" but got ""
+FAIL (width >= 100px) assert_equals: expected "true" but got ""
+FAIL (100px < width) assert_equals: expected "true" but got ""
+FAIL (100px <= width) assert_equals: expected "true" but got ""
+FAIL (100px = width) assert_equals: expected "true" but got ""
+FAIL (100px > width) assert_equals: expected "true" but got ""
+FAIL (100px >= width) assert_equals: expected "true" but got ""
+FAIL (100px < width < 200px) assert_equals: expected "true" but got ""
+FAIL (100px < width <= 200px) assert_equals: expected "true" but got ""
+FAIL (100px <= width < 200px) assert_equals: expected "true" but got ""
+FAIL (100px > width > 200px) assert_equals: expected "true" but got ""
+FAIL (100px > width >= 200px) assert_equals: expected "true" but got ""
+FAIL (100px >= width > 200px) assert_equals: expected "true" but got ""
+FAIL (width: calc(10px)) assert_equals: expected "true" but got ""
+FAIL (width: calc(10em)) assert_equals: expected "true" but got ""
+FAIL (width: calc(10px + 10em)) assert_equals: expected "true" but got ""
+FAIL (width < calc(10px + 10em)) assert_equals: expected "true" but got ""
+FAIL (width < max(10px, 10em)) assert_equals: expected "true" but got ""
+FAIL (calc(10px + 10em) < width) assert_equals: expected "true" but got ""
+FAIL (calc(10px + 10em) < width < max(30px, 30em)) assert_equals: expected "true" but got ""
+FAIL (width: 100px) and (height: 100px) assert_equals: expected "true" but got ""
+FAIL (width: 100px) or (height: 100px) assert_equals: expected "true" but got ""
+FAIL not (width: 100px) assert_equals: expected "true" but got ""
 PASS foo(width)
 PASS size(width)
 PASS (asdf)

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/auto-scrollbars-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/auto-scrollbars-expected.txt
@@ -1,4 +1,4 @@
 
-PASS Initial layout - expecting a scrollbar without overflowing content instead of overflowing content without a scrollbar
-PASS Same result after a reflow
+FAIL Initial layout - expecting a scrollbar without overflowing content instead of overflowing content without a scrollbar assert_equals: Layout with a scrollbar means the container query applies expected "50px" but got "100px"
+FAIL Same result after a reflow assert_equals: Layout with a scrollbar means the container query applies expected "50px" but got "100px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/backdrop-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/backdrop-invalidation-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Pseudo-element ::backdrop responds to container size changes
+FAIL Pseudo-element ::backdrop responds to container size changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/calc-evaluation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/calc-evaluation-expected.txt
@@ -1,3 +1,3 @@
 
-PASS em relative inline-size
+FAIL em relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-005-expected.txt
@@ -2,5 +2,5 @@ Test passes if there is a filled green square.
 
 
 PASS Initially display:none, not focusable
-PASS Focusable after container size change
+FAIL Focusable after container size change assert_equals: expected Element node <div id="target" tabindex="1"></div> but got Element node <body><p>Test passes if there is a filled green square.</...
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-006-expected.txt
@@ -2,5 +2,5 @@ Test passes if there is a filled green square.
 
 
 PASS Initially display:none, not focusable
-PASS Focusable after container size change
+FAIL Focusable after container size change assert_equals: expected Element node <div id="target" tabindex="1"></div> but got Element node <body><p>Test passes if there is a filled green square.</...
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/column-spanner-in-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/column-spanner-in-container-expected.txt
@@ -1,5 +1,5 @@
 
-PASS #spanner matching container with column-width 300px, getting column-span:all
+FAIL #spanner matching container with column-width 300px, getting column-span:all assert_equals: expected "600px" but got "300px"
 PASS Reducing #multicol width means #spanner no longer gets column-span:all
-PASS Back to matching 300px and column-span:all
+FAIL Back to matching 300px and column-span:all assert_equals: expected "600px" but got "300px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/conditional-container-status-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/conditional-container-status-expected.txt
@@ -1,4 +1,4 @@
 You should see a green border around this text
 
-PASS Conditionally applying container-type:initial
+FAIL Conditionally applying container-type:initial assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom-expected.txt
@@ -1,21 +1,21 @@
 
-PASS Match container in outer tree
+FAIL Match container in outer tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL Match container in walking flat tree ancestors assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-PASS Match container in ::slotted selector's originating element tree
-PASS Match container in outer tree for :host
+FAIL Match container in ::slotted selector's originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Match container in outer tree for :host assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL Match container in ::part selector's originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL Match container for ::before in ::slotted selector's originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-PASS Match container in outer tree for :host::before
+FAIL Match container in outer tree for :host::before assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL Match container for ::before in ::part selector's originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL Match container for ::part selector's originating element tree for exportparts assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-PASS Match container for slot light tree child fallback
+FAIL Match container for slot light tree child fallback assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 FAIL Should not match container inside shadow tree for ::part() assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 FAIL A :host::part rule should match containers in the originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 PASS Container name set inside a shadow tree should not match query using ::part on the outside
-PASS Container name set with a ::part should match query inside the shadow tree
-PASS Container name set inside a shadow tree should match query for a ::slotted() rule inside the tree
+FAIL Container name set with a ::part should match query inside the shadow tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Container name set inside a shadow tree should match query for a ::slotted() rule inside the tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 PASS Container name set inside a shadow tree should not match query for host child on the outside
-PASS Container name set on :host from inside a shadow tree matching query inside the shadow tree
-PASS Container name set on :host from inside a shadow tree matching query for ::slotted inside the shadow tree
+FAIL Container name set on :host from inside a shadow tree matching query inside the shadow tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Container name set on :host from inside a shadow tree matching query for ::slotted inside the shadow tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 PASS Container name set on :host from inside a shadow tree not matching query for slotted from the outside of the shadow tree
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-inner-at-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-inner-at-rules-expected.txt
@@ -3,6 +3,6 @@ PASS @keyframes is defined regardless of evaluation
 PASS @property is defined regardless of evaluation
 PASS @layer order respected regardless of evaluation
 PASS @font-face is defined regardless of evaluation
-PASS @media works inside @container
-PASS @supports works inside @container
+FAIL @media works inside @container assert_equals: expected "true" but got ""
+FAIL @supports works inside @container assert_equals: expected "true" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-inside-multicol-with-table-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-inside-multicol-with-table-expected.txt
@@ -1,4 +1,4 @@
 
-PASS Matching size container inside table inside multicol
-PASS Matching size container inside multicol with table sibling
+FAIL Matching size container inside table inside multicol assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Matching size container inside multicol with table sibling assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-name-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-name-invalidation-expected.txt
@@ -1,5 +1,5 @@
 Test
 
-PASS Changing a named container invalidates relevant descendants
-PASS Changing container-name invalidates relevant descendants
+FAIL Changing a named container invalidates relevant descendants assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Changing container-name invalidates relevant descendants assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-name-tree-scoped-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-name-tree-scoped-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Outer scope query should not match container-name set by :host rule in shadow tree
 PASS Outer scope query should not match container-name set by ::slotted rule in shadow tree
-PASS Inner scope query should match container-name set by :host rule in shadow tree
-PASS Inner scope query containing ::slotted should match container-name set by :host rule in shadow tree
+FAIL Inner scope query should match container-name set by :host rule in shadow tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL Inner scope query containing ::slotted should match container-name set by :host rule in shadow tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-nested-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-nested-expected.txt
@@ -1,16 +1,16 @@
 
-PASS Implicit
+FAIL Implicit assert_equals: expected "true" but got ""
 PASS Implicit, outer failing
 PASS Implicit, inner failing
-PASS Outer named, inner named
-PASS Outer named, inner named (reverse)
+FAIL Outer named, inner named assert_equals: expected "true" but got ""
+FAIL Outer named, inner named (reverse) assert_equals: expected "true" but got ""
 PASS Failing outer name
 PASS Failing inner name
-PASS Outer named, inner implicit
-PASS Inner named, outer implicit
-PASS Inner named, outer implicit (reverse)
-PASS Three levels
+FAIL Outer named, inner implicit assert_equals: expected "true" but got ""
+FAIL Inner named, outer implicit assert_equals: expected "true" but got ""
+FAIL Inner named, outer implicit (reverse) assert_equals: expected "true" but got ""
+FAIL Three levels assert_equals: expected "true" but got ""
 PASS Three levels, middle fail
-PASS Named inner invalidation
-PASS Implicit outer invalidation
+FAIL Named inner invalidation assert_equals: expected "true" but got ""
+FAIL Implicit outer invalidation assert_equals: expected "true" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-selection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-selection-expected.txt
@@ -1,23 +1,23 @@
 
-PASS (width: 16px) for .size > .inline > span
-PASS (height: 16px) for .inline > .size > span
-PASS (width: 16px) for .inline > .size > span
-PASS (height: 32px) for .size > .inline > span
+FAIL (width: 16px) for .size > .inline > span assert_equals: expected "true" but got ""
+FAIL (height: 16px) for .inline > .size > span assert_equals: expected "true" but got ""
+FAIL (width: 16px) for .inline > .size > span assert_equals: expected "true" but got ""
+FAIL (height: 32px) for .size > .inline > span assert_equals: expected "true" but got ""
 PASS (height: 16px) for .size > .inline > span
-PASS a (width: 32px) for .a-size > .b-size > span
-PASS b (width: 16px) for .a-size > .b-size > span
+FAIL a (width: 32px) for .a-size > .b-size > span assert_equals: expected "true" but got ""
+FAIL b (width: 16px) for .a-size > .b-size > span assert_equals: expected "true" but got ""
 PASS c (width) for .a-size > .b-size > span
-PASS a (width: 16px) for .a-size > .a-size > span
-PASS a (width: 32px) for .a-size > .a > span
-PASS a (width: 32px) for .ab-size > .size > span
-PASS b (width: 32px) for .ab-size > .size > span
+FAIL a (width: 16px) for .a-size > .a-size > span assert_equals: expected "true" but got ""
+FAIL a (width: 32px) for .a-size > .a > span assert_equals: expected "true" but got ""
+FAIL a (width: 32px) for .ab-size > .size > span assert_equals: expected "true" but got ""
+FAIL b (width: 32px) for .ab-size > .size > span assert_equals: expected "true" but got ""
 PASS c (width) for .ab-size > .size > span
-PASS a (width: 8px) for .a-size > .b-size > .a-inline > span
-PASS b (width: 16px) for .a-size > .b-size > .a-inline > span
-PASS a (height: 32px) for .a-size > .b-size > .a-inline > span
+FAIL a (width: 8px) for .a-size > .b-size > .a-inline > span assert_equals: expected "true" but got ""
+FAIL b (width: 16px) for .a-size > .b-size > .a-inline > span assert_equals: expected "true" but got ""
+FAIL a (height: 32px) for .a-size > .b-size > .a-inline > span assert_equals: expected "true" but got ""
 PASS a (height) for .a-inline > .b-size
-PASS a (inline-size: 8px) for .a-size > .b-size > .a-inline > span
-PASS b (inline-size: 16px) for .a-size > .b-size > .a-inline > span
-PASS a (block-size: 32px) for .a-size > .b-size > .a-inline > span
+FAIL a (inline-size: 8px) for .a-size > .b-size > .a-inline > span assert_equals: expected "true" but got ""
+FAIL b (inline-size: 16px) for .a-size > .b-size > .a-inline > span assert_equals: expected "true" but got ""
+FAIL a (block-size: 32px) for .a-size > .b-size > .a-inline > span assert_equals: expected "true" but got ""
 PASS a (block-size) for .a-inline > .b-size
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-selection-unknown-features-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-selection-unknown-features-expected.txt
@@ -3,7 +3,7 @@ Green
 Green
 Green
 
-PASS width query with (foo: bar)
-PASS width query with foo(bar)
-PASS style query with (foo: bar)
+FAIL width query with (foo: bar) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL width query with foo(bar) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL style query with (foo: bar) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-size-invalidation-after-load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-size-invalidation-after-load-expected.txt
@@ -1,4 +1,4 @@
 Green
 
-PASS @container: invalidation of container size after load event
+FAIL @container: invalidation of container size after load event assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-size-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-size-invalidation-expected.txt
@@ -2,6 +2,6 @@ Test
 Deep
 
 
-PASS Children respond to changes in container size
-PASS Descendants respond to changes in container size
+FAIL Children respond to changes in container size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL Descendants respond to changes in container size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-size-nested-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-size-nested-invalidation-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Queries that skip a container are invalidated correctly
+FAIL Queries that skip a container are invalidated correctly assert_equals: expected "true" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-size-shadow-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-size-shadow-invalidation-expected.txt
@@ -1,6 +1,6 @@
 Green
 Green
 
-PASS Host container child invalidated with container in shadow tree
-PASS Non-host container child invalidated with container in shadow tree
+FAIL Host container child invalidated with container in shadow tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Non-host container child invalidated with container in shadow tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-type-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-type-invalidation-expected.txt
@@ -1,4 +1,4 @@
 Test
 
-PASS Changing the container type invalidates relevant descendants
+FAIL Changing the container type invalidates relevant descendants assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-animation-expected.txt
@@ -1,14 +1,14 @@
 
-PASS Animation using cqw unit
-PASS Animation using cqw unit responds to changing container size
-PASS Animation using cqh unit
-PASS Animation using cqh unit responds to changing container size
-PASS Animation using cqi unit
-PASS Animation using cqi unit responds to changing container size
-PASS Animation using cqb unit
-PASS Animation using cqb unit responds to changing container size
-PASS Animation using cqmin unit
-PASS Animation using cqmin unit responds to changing container size
-PASS Animation using cqmax unit
-PASS Animation using cqmax unit responds to changing container size
+FAIL Animation using cqw unit assert_equals: expected "60px" but got "240px"
+FAIL Animation using cqw unit responds to changing container size assert_equals: expected "60px" but got "240px"
+FAIL Animation using cqh unit assert_equals: expected "60px" but got "180px"
+FAIL Animation using cqh unit responds to changing container size assert_equals: expected "60px" but got "180px"
+FAIL Animation using cqi unit assert_equals: expected "60px" but got "240px"
+FAIL Animation using cqi unit responds to changing container size assert_equals: expected "60px" but got "240px"
+FAIL Animation using cqb unit assert_equals: expected "60px" but got "180px"
+FAIL Animation using cqb unit responds to changing container size assert_equals: expected "60px" but got "180px"
+FAIL Animation using cqmin unit assert_equals: expected "60px" but got "180px"
+FAIL Animation using cqmin unit responds to changing container size assert_equals: expected "60px" but got "180px"
+FAIL Animation using cqmax unit assert_equals: expected "60px" but got "240px"
+FAIL Animation using cqmax unit responds to changing container size assert_equals: expected "60px" but got "240px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-basic-expected.txt
@@ -1,5 +1,5 @@
 Test
 
-PASS Container relative units
-PASS Container relative units in math functions
+FAIL Container relative units assert_equals: expected "3px" but got "8px"
+FAIL Container relative units in math functions assert_equals: expected "30px" but got "80px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-content-box-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-content-box-expected.txt
@@ -1,4 +1,4 @@
 
-PASS Container units are relative to the content box of the container
-PASS Container units are relative to the content box of the container (box-sizing: border-box)
+FAIL Container units are relative to the content box of the container assert_equals: expected "10px" but got "80px"
+FAIL Container units are relative to the content box of the container (box-sizing: border-box) assert_equals: expected "6px" but got "80px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-in-at-container-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-in-at-container-dynamic-expected.txt
@@ -1,4 +1,4 @@
 Test
 
-PASS Query with container-relative units are responsive to changes
+FAIL Query with container-relative units are responsive to changes assert_equals: expected "true" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-in-at-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-in-at-container-expected.txt
@@ -1,22 +1,22 @@
 Test1
 Test1
 
-PASS cqw unit resolves against appropriate container
-PASS cqh unit resolves against appropriate container
-PASS cqi unit resolves against appropriate container
-PASS cqb unit resolves against appropriate container
-PASS cqmin unit resolves against appropriate container
-PASS cqmax unit resolves against appropriate container
-PASS cqw unit resolves against appropriate container (vertical writing-mode on subject)
-PASS cqh unit resolves against appropriate container (vertical writing-mode on subject)
-PASS cqi unit resolves against appropriate container (vertical writing-mode on subject)
-PASS cqb unit resolves against appropriate container (vertical writing-mode on subject)
-PASS cqmin unit resolves against appropriate container (vertical writing-mode on subject)
-PASS cqmax unit resolves against appropriate container (vertical writing-mode on subject)
-PASS cqw unit resolves against appropriate container (vertical writing-mode on container)
-PASS cqh unit resolves against appropriate container (vertical writing-mode on container)
-PASS cqi unit resolves against appropriate container (vertical writing-mode on container)
-PASS cqb unit resolves against appropriate container (vertical writing-mode on container)
-PASS cqmin unit resolves against appropriate container (vertical writing-mode on container)
-PASS cqmax unit resolves against appropriate container (vertical writing-mode on container)
+FAIL cqw unit resolves against appropriate container assert_equals: expected "true" but got ""
+FAIL cqh unit resolves against appropriate container assert_equals: expected "true" but got ""
+FAIL cqi unit resolves against appropriate container assert_equals: expected "true" but got ""
+FAIL cqb unit resolves against appropriate container assert_equals: expected "true" but got ""
+FAIL cqmin unit resolves against appropriate container assert_equals: expected "true" but got ""
+FAIL cqmax unit resolves against appropriate container assert_equals: expected "true" but got ""
+FAIL cqw unit resolves against appropriate container (vertical writing-mode on subject) assert_equals: expected "true" but got ""
+FAIL cqh unit resolves against appropriate container (vertical writing-mode on subject) assert_equals: expected "true" but got ""
+FAIL cqi unit resolves against appropriate container (vertical writing-mode on subject) assert_equals: expected "true" but got ""
+FAIL cqb unit resolves against appropriate container (vertical writing-mode on subject) assert_equals: expected "true" but got ""
+FAIL cqmin unit resolves against appropriate container (vertical writing-mode on subject) assert_equals: expected "true" but got ""
+FAIL cqmax unit resolves against appropriate container (vertical writing-mode on subject) assert_equals: expected "true" but got ""
+FAIL cqw unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
+FAIL cqh unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
+FAIL cqi unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
+FAIL cqb unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
+FAIL cqmin unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
+FAIL cqmax unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-in-at-container-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-in-at-container-fallback-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Use small viewport size as fallback assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 255)"
+FAIL Use small viewport size as fallback assert_equals: expected "rgb(0, 0, 255)" but got "rgb(0, 128, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-ineligible-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-ineligible-container-expected.txt
@@ -1,11 +1,11 @@
 
-PASS /* basic */
-PASS display: table
-PASS display: table-cell
-PASS display: inline
-PASS display: contents
-PASS display: none
-PASS container-type: normal
-PASS container-type: inline-size
-PASS container-type: inline-size; writing-mode: vertical-lr
+FAIL /* basic */ assert_equals: width expected "20px" but got "80px"
+FAIL display: table assert_equals: width expected "30px" but got "80px"
+FAIL display: table-cell assert_equals: width expected "30px" but got "80px"
+FAIL display: inline assert_equals: width expected "30px" but got "80px"
+FAIL display: contents assert_equals: width expected "30px" but got "80px"
+FAIL display: none assert_equals: width expected "30px" but got "80px"
+FAIL container-type: normal assert_equals: width expected "30px" but got "80px"
+FAIL container-type: inline-size assert_equals: width expected "20px" but got "80px"
+FAIL container-type: inline-size; writing-mode: vertical-lr assert_equals: width expected "30px" but got "80px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-invalidation-expected.txt
@@ -1,9 +1,9 @@
 Test
 Test
 
-PASS cqi respond when selected container changes type (inline-size -> normal)
-PASS cqb respond when selected container changes type (size -> normal)
-PASS cqb respond when intermediate container changes type (inline-size -> size)
-PASS cqi respond when selected container changes inline-size
-PASS cqb respond when selected container changes block-size
+FAIL cqi respond when selected container changes type (inline-size -> normal) assert_equals: expected "30px" but got "80px"
+FAIL cqb respond when selected container changes type (size -> normal) assert_equals: expected "40px" but got "60px"
+FAIL cqb respond when intermediate container changes type (inline-size -> size) assert_equals: expected "40px" but got "60px"
+FAIL cqi respond when selected container changes inline-size assert_equals: expected "30px" but got "80px"
+FAIL cqb respond when selected container changes block-size assert_equals: expected "40px" but got "60px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-selection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-selection-expected.txt
@@ -1,5 +1,5 @@
 Test
 
-PASS Container units select the proper container
-PASS Units respond to the writing-mode of the element
+FAIL Container units select the proper container assert_equals: expected "10px" but got "80px"
+FAIL Units respond to the writing-mode of the element assert_equals: expected "30px" but got "80px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-shadow-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Direct slotted child queries flat tree assert_equals: expected "15px" but got "100px"
-FAIL Nondirect slotted child queries flat tree ancestors assert_equals: expected "1.5px" but got "10px"
+FAIL Direct slotted child queries flat tree assert_equals: expected "15px" but got "400px"
+FAIL Nondirect slotted child queries flat tree ancestors assert_equals: expected "1.5px" but got "80px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-small-viewport-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-small-viewport-fallback-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS Use small viewport size as fallback
+FAIL Use small viewport size as fallback assert_equals: expected "7px" but got "20px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/counters-flex-circular-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/counters-flex-circular-expected.txt
@@ -1,6 +1,6 @@
 
 PASS #item1, #container, and #inner should all have the same width: 150
-PASS The container query should match the layed out width
+FAIL The container query should match the layed out width assert_equals: expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
 PASS The sum of the item widths should match the flexbox width
 PASS The size of the flex item #2 should be given by its contents
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-queries-expected.txt
@@ -71,7 +71,7 @@ PASS Match registered <length> custom property with px.
 PASS Match registered <length> custom property with px via initial keyword.
 PASS Match registered <length> custom property with em in query.
 PASS Match registered <length> custom property with em in computed value.
-PASS Match registered <length> custom property with cqi unit.
+FAIL Match registered <length> custom property with cqi unit. assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 PASS Match registered <length> custom property with initial value.
 PASS Match registered <length> custom property with initial value via initial keyword.
 PASS Should only match exact string for numbers in non-registered custom properties

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/deep-nested-inline-size-containers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/deep-nested-inline-size-containers-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Test that all container widths match
+FAIL Test that all container widths match assert_equals: expected 199 but got 200
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/display-contents-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/display-contents-expected.txt
@@ -1,5 +1,5 @@
 
 PASS getComputedStyle when container is display:contents
-PASS getComputedStyle when container becomes display:contents
-PASS getComputedStyle when intermediate container becomes display:contents
+FAIL getComputedStyle when container becomes display:contents assert_equals: expected "30" but got ""
+FAIL getComputedStyle when intermediate container becomes display:contents assert_equals: expected "30" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/display-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/display-none-expected.txt
@@ -1,21 +1,21 @@
 
-PASS getComputedStyle when element is display:none
-PASS getComputedStyle when parent is display:none
-PASS getComputedStyle when ancestor is display:none
+FAIL getComputedStyle when element is display:none assert_equals: expected "30" but got ""
+FAIL getComputedStyle when parent is display:none assert_equals: expected "30" but got ""
+FAIL getComputedStyle when ancestor is display:none assert_equals: expected "30" but got ""
 PASS getComputedStyle when container is display:none
-PASS getComputedStyle when element in nested container is display:none
+FAIL getComputedStyle when element in nested container is display:none assert_equals: expected "30" but got ""
 PASS getComputedStyle when inner container is display:none
 PASS getComputedStyle when intermediate ancestor is display:none
 PASS getComputedStyle when outer container is display:none
-PASS getComputedStyle when element becomes display:none
-PASS getComputedStyle when parent becomes display:none
-PASS getComputedStyle when ancestor becomes display:none
-PASS getComputedStyle when container becomes display:none
-PASS getComputedStyle when intermediate container becomes display:none
-PASS getComputedStyle when ::before is display:none
-PASS getComputedStyle when originating element is display:none
-PASS getComputedStyle on ::before when ancestor element is display:none
+FAIL getComputedStyle when element becomes display:none assert_equals: expected "30" but got ""
+FAIL getComputedStyle when parent becomes display:none assert_equals: expected "30" but got ""
+FAIL getComputedStyle when ancestor becomes display:none assert_equals: expected "30" but got ""
+FAIL getComputedStyle when container becomes display:none assert_equals: expected "30" but got ""
+FAIL getComputedStyle when intermediate container becomes display:none assert_equals: expected "30" but got ""
+FAIL getComputedStyle when ::before is display:none assert_equals: expected "30" but got ""
+FAIL getComputedStyle when originating element is display:none assert_equals: expected "30" but got ""
+FAIL getComputedStyle on ::before when ancestor element is display:none assert_equals: expected "30" but got ""
 PASS getComputedStyle on ::before when container is display:none
-PASS getComputedStyle when in display:none with layout dirty outer element
+FAIL getComputedStyle when in display:none with layout dirty outer element assert_equals: expected "50" but got ""
 PASS getComputedStyle when display:none inner container has forced style
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/font-relative-calc-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/font-relative-calc-dynamic-expected.txt
@@ -1,3 +1,3 @@
 
-PASS font-relative calc() is responsive to container font-size changes
+FAIL font-relative calc() is responsive to container font-size changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/font-relative-units-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/font-relative-units-dynamic-expected.txt
@@ -1,14 +1,14 @@
 
-PASS em units respond to changes
-PASS rem units respond to changes
-PASS ex units respond to changes
-PASS rex units respond to changes
-PASS ch units respond to changes
+FAIL em units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL rem units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL ex units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL rex units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL ch units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 FAIL cap units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
-PASS rch units respond to changes
-PASS lh units respond to changes
-PASS rlh units respond to changes
-PASS ic units respond to changes
-PASS ric units respond to changes
+FAIL rch units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL lh units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL rlh units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL ic units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL ric units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 FAIL rcap units respond to changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/font-relative-units-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/font-relative-units-expected.txt
@@ -1,14 +1,14 @@
 
-PASS em relative inline-size
-PASS rem relative inline-size
-PASS ex relative inline-size
-PASS rex relative inline-size
-PASS ch relative inline-size
-PASS rch relative inline-size
-PASS ic relative inline-size
-PASS ric relative inline-size
-PASS lh relative inline-size
-PASS rlh relative inline-size
-PASS cap relative inline-size
-PASS rcap relative inline-size
+FAIL em relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL rem relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL ex relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL rex relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL ch relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL rch relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL ic relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL ric relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL lh relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL rlh relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL cap relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL rcap relative inline-size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/fragmented-container-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/fragmented-container-001-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Children of fragmented inline-size container should match inline-size of first fragment
+FAIL Children of fragmented inline-size container should match inline-size of first fragment assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/get-animations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/get-animations-expected.txt
@@ -1,4 +1,4 @@
 Green
 
-PASS Calling getAnimations updates layout of parent frame if needed
+FAIL Calling getAnimations updates layout of parent frame if needed assert_equals: expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/grid-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/grid-container-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Check that grid items can query grid container
+FAIL Check that grid items can query grid container assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/grid-item-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/grid-item-container-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Check that children can query grid item containers
+FAIL Check that children can query grid item containers assert_equals: First item container should be 200px wide expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/iframe-in-container-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/iframe-in-container-invalidation-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS @container-dependent elements respond to size changes of an @container-dependent iframe
+FAIL @container-dependent elements respond to size changes of an @container-dependent iframe assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/iframe-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/iframe-invalidation-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS @container-dependent elements respond to iframe size changes
+FAIL @container-dependent elements respond to iframe size changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/ineligible-containment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/ineligible-containment-expected.txt
@@ -4,5 +4,5 @@ Test1
 
 
 PASS Container ineligible for containment
-PASS Changing containment eligibility invalidates style
+FAIL Changing containment eligibility invalidates style assert_equals: expected "rgb(255, 0, 0)" but got "rgb(0, 128, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/inline-size-and-min-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/inline-size-and-min-width-expected.txt
@@ -1,4 +1,4 @@
 Green
 
-PASS min-width of inline-size container affects container size
+FAIL min-width of inline-size container affects container size assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/inline-size-containment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/inline-size-containment-expected.txt
@@ -1,3 +1,3 @@
 
-PASS inline-size containment only
+FAIL inline-size containment only assert_equals: expected 400 but got 50
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/inline-size-containment-vertical-rl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/inline-size-containment-vertical-rl-expected.txt
@@ -1,3 +1,3 @@
 
-PASS inline-size containment only
+FAIL inline-size containment only assert_equals: expected 400 but got 50
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/layout-dependent-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/layout-dependent-focus-expected.txt
@@ -1,3 +1,4 @@
 
-PASS Verify that onblur is called on hidden input
+
+FAIL Verify that onblur is called on hidden input assert_unreached: Event listener for 'blur' not called Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/multicol-container-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/multicol-container-001-expected.txt
@@ -1,5 +1,5 @@
 First
 Second
 
-PASS Children of multicol inline-size container should match inline-size of the container
+FAIL Children of multicol inline-size container should match inline-size of the container assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/nested-query-containers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/nested-query-containers-expected.txt
@@ -1,34 +1,34 @@
 
-PASS test1 - inline - 0b000
-PASS test2 - inline - 0b001
-PASS test3 - inline - 0b010
-PASS test4 - inline - 0b011
-PASS test5 - inline - 0b100
-PASS test6 - inline - 0b101
-PASS test7 - inline - 0b110
-PASS test8 - inline - 0b111
-PASS test9 - contents - 0b000
-PASS test10 - contents - 0b001
-PASS test11 - contents - 0b010
-PASS test12 - contents - 0b011
-PASS test13 - contents - 0b100
-PASS test14 - contents - 0b101
-PASS test15 - contents - 0b110
-PASS test16 - contents - 0b111
-PASS test17 - table-cell - 0b000
-PASS test18 - table-cell - 0b001
-PASS test19 - table-cell - 0b010
-PASS test20 - table-cell - 0b011
-PASS test21 - table-cell - 0b100
-PASS test22 - table-cell - 0b101
-PASS test23 - table-cell - 0b110
-PASS test24 - table-cell - 0b111
-PASS test25 - table - 0b000
-PASS test26 - table - 0b001
-PASS test27 - table - 0b010
-PASS test28 - table - 0b011
-PASS test29 - table - 0b100
-PASS test30 - table - 0b101
-PASS test31 - table - 0b110
-PASS test32 - table - 0b111
+FAIL test1 - inline - 0b000 assert_equals: expected "inline" but got "block"
+FAIL test2 - inline - 0b001 assert_equals: expected "inline" but got "block"
+FAIL test3 - inline - 0b010 assert_equals: expected "inline" but got "block"
+FAIL test4 - inline - 0b011 assert_equals: expected "inline" but got "block"
+FAIL test5 - inline - 0b100 assert_equals: expected "inline" but got "block"
+FAIL test6 - inline - 0b101 assert_equals: expected "inline" but got "block"
+FAIL test7 - inline - 0b110 assert_equals: expected "inline" but got "block"
+FAIL test8 - inline - 0b111 assert_equals: expected "inline" but got "block"
+FAIL test9 - contents - 0b000 assert_equals: expected "contents" but got "block"
+FAIL test10 - contents - 0b001 assert_equals: expected "contents" but got "block"
+FAIL test11 - contents - 0b010 assert_equals: expected "contents" but got "block"
+FAIL test12 - contents - 0b011 assert_equals: expected "contents" but got "block"
+FAIL test13 - contents - 0b100 assert_equals: expected "contents" but got "block"
+FAIL test14 - contents - 0b101 assert_equals: expected "contents" but got "block"
+FAIL test15 - contents - 0b110 assert_equals: expected "contents" but got "block"
+FAIL test16 - contents - 0b111 assert_equals: expected "contents" but got "block"
+FAIL test17 - table-cell - 0b000 assert_equals: expected "table-cell" but got "block"
+FAIL test18 - table-cell - 0b001 assert_equals: expected "table-cell" but got "block"
+FAIL test19 - table-cell - 0b010 assert_equals: expected "table-cell" but got "block"
+FAIL test20 - table-cell - 0b011 assert_equals: expected "table-cell" but got "block"
+FAIL test21 - table-cell - 0b100 assert_equals: expected "table-cell" but got "block"
+FAIL test22 - table-cell - 0b101 assert_equals: expected "table-cell" but got "block"
+FAIL test23 - table-cell - 0b110 assert_equals: expected "table-cell" but got "block"
+FAIL test24 - table-cell - 0b111 assert_equals: expected "table-cell" but got "block"
+FAIL test25 - table - 0b000 assert_equals: expected "table" but got "block"
+FAIL test26 - table - 0b001 assert_equals: expected "table" but got "block"
+FAIL test27 - table - 0b010 assert_equals: expected "table" but got "block"
+FAIL test28 - table - 0b011 assert_equals: expected "table" but got "block"
+FAIL test29 - table - 0b100 assert_equals: expected "table" but got "block"
+FAIL test30 - table - 0b101 assert_equals: expected "table" but got "block"
+FAIL test31 - table - 0b110 assert_equals: expected "table" but got "block"
+FAIL test32 - table - 0b111 assert_equals: expected "table" but got "block"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/nested-size-style-container-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/nested-size-style-container-invalidation-expected.txt
@@ -1,5 +1,5 @@
 Green?
 
 PASS Initially red
-PASS Green after reducing width
+FAIL Green after reducing width assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/no-layout-containment-scroll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/no-layout-containment-scroll-expected.txt
@@ -1,9 +1,3 @@
 
-FAIL #test 1 assert_equals:
-<div id="test" data-expected-scroll-height="200">
-    <div style="container-type: inline-size; height: 100px;">
-      <div style="height: 200px;"></div>
-    </div>
-  </div>
-scrollHeight expected 200 but got 100
+PASS #test 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/orthogonal-wm-container-query-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/orthogonal-wm-container-query-expected.txt
@@ -1,5 +1,5 @@
 XX
 
 PASS Initial non-orthogonal width
-PASS Orthogonal width
+FAIL Orthogonal width assert_equals: expected 50 but got 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-001-expected.txt
@@ -1,6 +1,6 @@
 test
 One
 
-PASS Pseudo-elements ::before and ::after respond to container size changes
-PASS Pseudo-element ::marker responds to container size changes
+FAIL Pseudo-elements ::before and ::after respond to container size changes assert_equals: expected "\"before\"" but got "none"
+FAIL Pseudo-element ::marker responds to container size changes assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-003-expected.txt
@@ -1,12 +1,12 @@
 First-line
 First-line
 
-PASS Originating element container for ::before
-PASS Originating element container for ::after
-PASS Originating element container for ::marker
-PASS Originating element container for ::first-line
-PASS Originating element container for ::first-letter
-PASS Originating element container for outer ::first-line
-PASS Originating element container for outer ::first-letter
-PASS Originating element container for ::backdrop
+FAIL Originating element container for ::before assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Originating element container for ::after assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Originating element container for ::marker assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Originating element container for ::first-line assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Originating element container for ::first-letter assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Originating element container for outer ::first-line assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Originating element container for outer ::first-letter assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Originating element container for ::backdrop assert_equals: ::backdrop rendered expected "rgb(0, 128, 0)" but got "rgb(0, 255, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-004-expected.txt
@@ -5,10 +5,10 @@ PASS Initial color for ::marker
 PASS Initial color for ::first-line
 PASS Initial color for ::first-letter
 PASS Initial color for ::backdrop
-PASS Color for ::before depending on container
-PASS Color for ::after depending on container
-PASS Color for ::marker depending on container
-PASS Color for ::first-line depending on container
-PASS Color for ::first-letter depending on container
-PASS Color for ::backdrop depending on container
+FAIL Color for ::before depending on container assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL Color for ::after depending on container assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL Color for ::marker depending on container assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL Color for ::first-line depending on container assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL Color for ::first-letter depending on container assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL Color for ::backdrop depending on container assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-006-expected.txt
@@ -1,12 +1,12 @@
 First-line
 First-line
 
-PASS Originating element container for ::before
-PASS Originating element container for ::after
-PASS Originating element container for ::marker
-PASS Originating element container for ::first-line
-PASS Originating element container for ::first-letter
-PASS Originating element container for outer ::first-line
-PASS Originating element container for outer ::first-letter
-PASS Originating element container for ::backdrop
+FAIL Originating element container for ::before assert_equals: expected "20px" but got "16px"
+FAIL Originating element container for ::after assert_equals: expected "20px" but got "16px"
+FAIL Originating element container for ::marker assert_equals: expected "20px" but got "16px"
+FAIL Originating element container for ::first-line assert_equals: expected "20px" but got "16px"
+FAIL Originating element container for ::first-letter assert_equals: expected "20px" but got "16px"
+FAIL Originating element container for outer ::first-line assert_equals: expected "30px" but got "16px"
+FAIL Originating element container for outer ::first-letter assert_equals: expected "30px" but got "16px"
+FAIL Originating element container for ::backdrop assert_equals: ::backdrop rendered expected "10px" but got "0px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-007-expected.txt
@@ -5,10 +5,10 @@ PASS Initial font-size for ::marker
 PASS Initial font-size for ::first-line
 PASS Initial font-size for ::first-letter
 PASS Initial font-size for ::backdrop
-PASS font-size for ::before depending on container
-PASS font-size for ::after depending on container
-PASS font-size for ::marker depending on container
-PASS font-size for ::first-line depending on container
-PASS font-size for ::first-letter depending on container
-PASS font-size for ::backdrop depending on container
+FAIL font-size for ::before depending on container assert_equals: expected "30px" but got "0px"
+FAIL font-size for ::after depending on container assert_equals: expected "30px" but got "0px"
+FAIL font-size for ::marker depending on container assert_equals: expected "30px" but got "0px"
+FAIL font-size for ::first-line depending on container assert_equals: expected "30px" but got "0px"
+FAIL font-size for ::first-letter depending on container assert_equals: expected "30px" but got "0px"
+FAIL font-size for ::backdrop depending on container assert_equals: expected "30px" but got "0px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-008-expected.txt
@@ -1,13 +1,13 @@
 First-line
 First-line
 
-PASS Originating element container for ::before
-PASS Originating element container for ::after
-PASS Originating element container for ::marker
-PASS Originating element container for ::first-line
-PASS Originating element container for ::first-letter
-PASS Originating element container  for ::highlight
-PASS Originating element container for outer ::first-line
-PASS Originating element container for outer ::first-letter
-PASS Originating element container for ::backdrop
+FAIL Originating element container for ::before assert_equals: expected "20px" but got "80px"
+FAIL Originating element container for ::after assert_equals: expected "20px" but got "80px"
+FAIL Originating element container for ::marker assert_equals: expected "20px" but got "80px"
+FAIL Originating element container for ::first-line assert_equals: expected "20px" but got "80px"
+FAIL Originating element container for ::first-letter assert_equals: expected "20px" but got "80px"
+FAIL Originating element container  for ::highlight assert_equals: expected "20px" but got "80px"
+FAIL Originating element container for outer ::first-line assert_equals: expected "30px" but got "80px"
+FAIL Originating element container for outer ::first-letter assert_equals: expected "30px" but got "80px"
+FAIL Originating element container for ::backdrop assert_equals: ::backdrop not rendered expected "30px" but got "80px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-013-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-013-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Initial text-decoration-thickness for highlight pseudo
-PASS text-decoration-thickness for highlight pseudo depending on container
-PASS text-decoration-thickness for highlight pseudo depending on container only defined in a query
+FAIL text-decoration-thickness for highlight pseudo depending on container assert_equals: expected "30px" but got "0px"
+FAIL text-decoration-thickness for highlight pseudo depending on container only defined in a query assert_equals: expected "30px" but got "auto"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/query-content-box-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/query-content-box-expected.txt
@@ -1,8 +1,8 @@
 
-PASS Size queries with content-box sizing
-PASS Size queries with border-box sizing
-PASS Size queries with content-box sizing and overflow:scroll
-PASS Size queries with border-box sizing and overflow:scroll
-PASS Size queries with content-box sizing and scrollbar-gutter:stable
-PASS Size queries with border-box sizing and scrollbar-gutter:stable
+FAIL Size queries with content-box sizing assert_equals: expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
+FAIL Size queries with border-box sizing assert_equals: expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
+FAIL Size queries with content-box sizing and overflow:scroll assert_equals: expected "rgb(0, 0, 255)" but got "rgba(0, 0, 0, 0)"
+FAIL Size queries with border-box sizing and overflow:scroll assert_equals: expected "rgb(0, 0, 255)" but got "rgba(0, 0, 0, 0)"
+FAIL Size queries with content-box sizing and scrollbar-gutter:stable assert_equals: expected "rgb(0, 0, 255)" but got "rgba(0, 0, 0, 0)"
+FAIL Size queries with border-box sizing and scrollbar-gutter:stable assert_equals: expected "rgb(0, 0, 255)" but got "rgba(0, 0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/query-evaluation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/query-evaluation-expected.txt
@@ -1,20 +1,20 @@
 
-PASS (width)
+FAIL (width) assert_equals: expected "true" but got "false"
 PASS (height)
 PASS (unknown)
 PASS unknown(width)
-PASS ((width))
+FAIL ((width)) assert_equals: expected "true" but got "false"
 PASS ((height))
 PASS ((unknown))
-PASS ((((width))))
+FAIL ((((width)))) assert_equals: expected "true" but got "false"
 PASS ((((height))))
 PASS ((((unknown))))
 PASS (not (width))
-PASS (not (height))
+FAIL (not (height)) assert_equals: expected "true" but got "false"
 PASS (not (unknown))
 PASS (not unknown(width))
-PASS ((width) and (width))
-PASS ((width) and (width) and (width))
+FAIL ((width) and (width)) assert_equals: expected "true" but got "false"
+FAIL ((width) and (width) and (width)) assert_equals: expected "true" but got "false"
 PASS ((height) and (height))
 PASS ((height) and (width) and (width))
 PASS ((width) and (height) and (width))
@@ -22,19 +22,19 @@ PASS ((width) and (width) and (height))
 PASS ((unknown) and (width) and (width))
 PASS ((width) and (unknown) and (width))
 PASS ((width) and (width) and (unknown))
-PASS ((width) or (width))
-PASS ((width) or (width) or (width))
+FAIL ((width) or (width)) assert_equals: expected "true" but got "false"
+FAIL ((width) or (width) or (width)) assert_equals: expected "true" but got "false"
 PASS ((height) or (height))
-PASS ((height) or (width) or (width))
-PASS ((width) or (height) or (width))
-PASS ((width) or (width) or (height))
+FAIL ((height) or (width) or (width)) assert_equals: expected "true" but got "false"
+FAIL ((width) or (height) or (width)) assert_equals: expected "true" but got "false"
+FAIL ((width) or (width) or (height)) assert_equals: expected "true" but got "false"
 PASS ((unknown) or (width) or (width))
 PASS ((width) or (unknown) or (width))
 PASS ((width) or (width) or (unknown))
 PASS ((unknown) or (height) or (width))
 PASS (not ((width) and (width)))
-PASS (not ((width) and (height)))
+FAIL (not ((width) and (height))) assert_equals: expected "true" but got "false"
 PASS ((width) and (not ((height) or (width))))
-PASS ((height) or (not ((height) and (width))))
+FAIL ((height) or (not ((height) and (width)))) assert_equals: expected "true" but got "false"
 PASS ((height) or ((height) and (width)))
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/reattach-container-with-dirty-child-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/reattach-container-with-dirty-child-expected.txt
@@ -1,5 +1,5 @@
 XXX
 
-PASS Initially wider than 200px
-PASS Container query changed and inner.style applied
+FAIL Initially wider than 200px assert_equals: expected "rgb(255, 0, 0)" but got "rgb(0, 0, 0)"
+FAIL Container query changed and inner.style applied assert_equals: expected "rgb(0, 255, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/sibling-layout-dependency-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/sibling-layout-dependency-expected.txt
@@ -1,7 +1,7 @@
-XXXX
+XX
 
-PASS Sibling style mutation
-PASS Sibling style mutation, parent is affected
-PASS Sibling style mutation, ancestor is affected
-PASS Sibling text mutation
+FAIL Sibling style mutation assert_equals: expected "20" but got ""
+FAIL Sibling style mutation, parent is affected assert_equals: expected "20" but got ""
+FAIL Sibling style mutation, ancestor is affected assert_equals: expected "20" but got ""
+FAIL Sibling text mutation assert_equals: expected "20" but got ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/size-container-no-principal-box-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/size-container-no-principal-box-expected.txt
@@ -1,8 +1,8 @@
 
-PASS (min-width: 0) can match a container with a principal box
+FAIL (min-width: 0) can match a container with a principal box assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 PASS (min-width: 0) does not match a container without a principal box (display:none)
 PASS (min-width: 0) does not match a container without a principal box (display:contents)
-PASS not (max-width: 0) can match a container with a principal box
+FAIL not (max-width: 0) can match a container with a principal box assert_equals: expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
 PASS not (max-width: 0) does not match a container without a principal box (display:none)
 PASS not (max-width: 0) does not match a container without a principal box (display:contents)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/size-feature-evaluation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/size-feature-evaluation-expected.txt
@@ -1,59 +1,59 @@
 Test
 
 PASS (width < 100px) (.horizontal)
-PASS (width >= 100px) (.horizontal)
-PASS (min-width: 100px) (.horizontal)
+FAIL (width >= 100px) (.horizontal) assert_equals: expected "true" but got ""
+FAIL (min-width: 100px) (.horizontal) assert_equals: expected "true" but got ""
 PASS (min-width: 101px) (.horizontal)
-PASS (max-width: 100px) (.horizontal)
+FAIL (max-width: 100px) (.horizontal) assert_equals: expected "true" but got ""
 PASS (max-width: 99px) (.horizontal)
 PASS (height < 200px) (.horizontal)
-PASS (height >= 200px) (.horizontal)
-PASS (min-height: 200px) (.horizontal)
+FAIL (height >= 200px) (.horizontal) assert_equals: expected "true" but got ""
+FAIL (min-height: 200px) (.horizontal) assert_equals: expected "true" but got ""
 PASS (min-height: 201px) (.horizontal)
-PASS (max-height: 200px) (.horizontal)
+FAIL (max-height: 200px) (.horizontal) assert_equals: expected "true" but got ""
 PASS (max-height: 199px) (.horizontal)
 PASS (inline-size < 100px) (.horizontal)
-PASS (inline-size >= 100px) (.horizontal)
-PASS (min-inline-size: 100px) (.horizontal)
+FAIL (inline-size >= 100px) (.horizontal) assert_equals: expected "true" but got ""
+FAIL (min-inline-size: 100px) (.horizontal) assert_equals: expected "true" but got ""
 PASS (min-inline-size: 101px) (.horizontal)
-PASS (max-inline-size: 100px) (.horizontal)
+FAIL (max-inline-size: 100px) (.horizontal) assert_equals: expected "true" but got ""
 PASS (max-inline-size: 99px) (.horizontal)
 PASS (block-size < 200px) (.horizontal)
-PASS (block-size >= 200px) (.horizontal)
-PASS (min-block-size: 200px) (.horizontal)
+FAIL (block-size >= 200px) (.horizontal) assert_equals: expected "true" but got ""
+FAIL (min-block-size: 200px) (.horizontal) assert_equals: expected "true" but got ""
 PASS (min-block-size: 201px) (.horizontal)
-PASS (max-block-size: 200px) (.horizontal)
+FAIL (max-block-size: 200px) (.horizontal) assert_equals: expected "true" but got ""
 PASS (max-block-size: 199px) (.horizontal)
 PASS (orientation: landscape) (.horizontal)
-PASS (orientation: portrait) (.horizontal)
-PASS (aspect-ratio: 1/2) (.horizontal)
+FAIL (orientation: portrait) (.horizontal) assert_equals: expected "true" but got ""
+FAIL (aspect-ratio: 1/2) (.horizontal) assert_equals: expected "true" but got ""
 PASS (aspect-ratio: 2/1) (.horizontal)
 PASS (width < 100px) (.vertical)
-PASS (width >= 100px) (.vertical)
-PASS (min-width: 100px) (.vertical)
+FAIL (width >= 100px) (.vertical) assert_equals: expected "true" but got ""
+FAIL (min-width: 100px) (.vertical) assert_equals: expected "true" but got ""
 PASS (min-width: 101px) (.vertical)
-PASS (max-width: 100px) (.vertical)
+FAIL (max-width: 100px) (.vertical) assert_equals: expected "true" but got ""
 PASS (max-width: 99px) (.vertical)
 PASS (height < 200px) (.vertical)
-PASS (height >= 200px) (.vertical)
-PASS (min-height: 200px) (.vertical)
+FAIL (height >= 200px) (.vertical) assert_equals: expected "true" but got ""
+FAIL (min-height: 200px) (.vertical) assert_equals: expected "true" but got ""
 PASS (min-height: 201px) (.vertical)
-PASS (max-height: 200px) (.vertical)
+FAIL (max-height: 200px) (.vertical) assert_equals: expected "true" but got ""
 PASS (max-height: 199px) (.vertical)
 PASS (block-size < 100px) (.vertical)
-PASS (block-size >= 100px) (.vertical)
-PASS (min-block-size: 100px) (.vertical)
+FAIL (block-size >= 100px) (.vertical) assert_equals: expected "true" but got ""
+FAIL (min-block-size: 100px) (.vertical) assert_equals: expected "true" but got ""
 PASS (min-block-size: 101px) (.vertical)
-PASS (max-block-size: 100px) (.vertical)
+FAIL (max-block-size: 100px) (.vertical) assert_equals: expected "true" but got ""
 PASS (max-block-size: 99px) (.vertical)
 PASS (inline-size < 200px) (.vertical)
-PASS (inline-size >= 200px) (.vertical)
-PASS (min-inline-size: 200px) (.vertical)
+FAIL (inline-size >= 200px) (.vertical) assert_equals: expected "true" but got ""
+FAIL (min-inline-size: 200px) (.vertical) assert_equals: expected "true" but got ""
 PASS (min-inline-size: 201px) (.vertical)
-PASS (max-inline-size: 200px) (.vertical)
+FAIL (max-inline-size: 200px) (.vertical) assert_equals: expected "true" but got ""
 PASS (max-inline-size: 199px) (.vertical)
 PASS (orientation: landscape) (.vertical)
-PASS (orientation: portrait) (.vertical)
-PASS (aspect-ratio: 1/2) (.vertical)
+FAIL (orientation: portrait) (.vertical) assert_equals: expected "true" but got ""
+FAIL (aspect-ratio: 1/2) (.vertical) assert_equals: expected "true" but got ""
 PASS (aspect-ratio: 2/1) (.vertical)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-change-in-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-change-in-container-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Basic test for container query evaluation stability
+FAIL Basic test for container query evaluation stability assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-not-sharing-float-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-not-sharing-float-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Check that style is not sharing in the case of Container Queries
+FAIL Check that style is not sharing in the case of Container Queries assert_equals: Second item container should be 100px wide expected "rgb(0, 255, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/svg-foreignobject-child-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/svg-foreignobject-child-container-expected.txt
@@ -1,4 +1,4 @@
 Green
 
-PASS #inner querying #container inside foreignObject
+FAIL #inner querying #container inside foreignObject assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/svg-root-size-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/svg-root-size-container-expected.txt
@@ -1,6 +1,6 @@
 Green
 Green
 
-PASS SVG text querying SVG root size container
-PASS div in foreignObject querying SVG root size container
+FAIL SVG text querying SVG root size container assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL div in foreignObject querying SVG root size container assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/top-layer-dialog-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/top-layer-dialog-container-expected.txt
@@ -1,4 +1,4 @@
 
 PASS #dialog initially sized by #containing-block
-PASS #dialog sized by viewport
+FAIL #dialog sized by viewport assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/top-layer-dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/top-layer-dialog-expected.txt
@@ -1,6 +1,6 @@
 
 PASS #container initially wider than 200px
-PASS #container changed to 200px
-PASS Modal dialog still has parent as query container while in top layer
-PASS Container changes width while dialog is in top layer
+FAIL #container changed to 200px assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL Modal dialog still has parent as query container while in top layer assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL Container changes width while dialog is in top layer assert_equals: expected "rgb(0, 255, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/top-layer-nested-dialog-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/top-layer-nested-dialog-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Dialogs initially not matching for container queries
 PASS Dialogs still not matching after showModal
-PASS @container queries start matching
+FAIL @container queries start matching assert_equals: expected "rgb(0, 255, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/transition-scrollbars-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/transition-scrollbars-expected.txt
@@ -1,4 +1,4 @@
 Foo bar foo bar foo Foo bar foo bar foo Foo bar foo bar foo Foo bar foo bar foo Foo bar foo bar foo
 
-FAIL Scrollbars do not cause a transition of background-color assert_equals: expected "rgb(0, 0, 255)" but got "rgb(0, 64, 128)"
+FAIL Scrollbars do not cause a transition of background-color assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/transition-style-change-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/transition-style-change-event-expected.txt
@@ -1,4 +1,4 @@
 Green
 
-PASS Container Queries - Style Change Event for transitions
+FAIL Container Queries - Style Change Event for transitions assert_equals: @container queries supported expected "rgb(255, 0, 0)" but got "rgb(0, 128, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/unsupported-axis-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/unsupported-axis-expected.txt
@@ -1,6 +1,6 @@
 Test
 
-PASS (width > 0px)
+FAIL (width > 0px) assert_equals: expected "true" but got ""
 PASS (height > 0px)
 PASS ((height > 0px) or (width > 0px))
 PASS ((width > 0px) or (height > 0px))
@@ -8,12 +8,12 @@ PASS ((orientation: landscape) or (width > 0px))
 PASS ((width > 0px) or (orientation: landscape))
 PASS ((height > 0px) or (orientation: landscape))
 PASS ((height > 0px) or (orientation: landscape)), with contain:size
-PASS (inline-size > 0px)
+FAIL (inline-size > 0px) assert_equals: expected "true" but got ""
 PASS (block-size > 0px)
 PASS (block-size > 0px), with writing-mode:vertical-rl
-PASS not (width < 0px)
+FAIL not (width < 0px) assert_equals: expected "true" but got ""
 PASS not (height < 0px)
-PASS not (inline-size < 0px)
+FAIL not (inline-size < 0px) assert_equals: expected "true" but got ""
 PASS not (block-size < 0px)
 PASS not (orientation)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/viewport-units-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/viewport-units-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL CSS Container Queries Test: @container-dependent elements respond to viewport unit changes assert_equals: vw after width resize expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL CSS Container Queries Test: @container-dependent elements respond to viewport unit changes assert_equals: vw before resize expected "rgb(255, 0, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/viewport-units-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/viewport-units-expected.txt
@@ -1,6 +1,6 @@
 Green
 Green
 
-PASS Match width with vw
-PASS Match width with vh
+FAIL Match width with vw assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+FAIL Match width with vh assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2406,7 +2406,7 @@ bool RenderElement::createsNewFormattingContext() const
 
 bool RenderElement::establishesIndependentFormattingContext() const
 {
-    return isFloatingOrOutOfFlowPositioned() || (isBlockBox() && hasPotentiallyScrollableOverflow()) || style().containsLayout() || paintContainmentApplies() || (style().isDisplayBlockLevel() && style().blockStepSize());
+    return style().containerType() != ContainerType::Normal || isFloatingOrOutOfFlowPositioned() || (isBlockBox() && hasPotentiallyScrollableOverflow()) || style().containsLayout() || paintContainmentApplies() || (style().isDisplayBlockLevel() && style().blockStepSize());
 }
 
 FloatRect RenderElement::referenceBoxRect(CSSBoxType boxType) const

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -324,10 +324,10 @@ OptionSet<Containment> StyleRareNonInheritedData::usedContain() const
     case ContainerType::Normal:
         break;
     case ContainerType::Size:
-        containment.add({ Containment::Layout, Containment::Style, Containment::Size });
+        containment.add({ Containment::Style, Containment::Size });
         break;
     case ContainerType::InlineSize:
-        containment.add({ Containment::Layout, Containment::Style, Containment::InlineSize });
+        containment.add({ Containment::Style, Containment::InlineSize });
         break;
     };
 


### PR DESCRIPTION
#### 8e37e86df7eba152d1f8ad18012f237a5d2b2884
<pre>
container-type does not force layout containment, but does force an independent formatting context
<a href="https://bugs.webkit.org/show_bug.cgi?id=277122">https://bugs.webkit.org/show_bug.cgi?id=277122</a>
<a href="https://rdar.apple.com/132549134">rdar://132549134</a>

Reviewed by NOBODY (OOPS!).

container-type does not force layout containment, but does force
an independent formatting context by CSS WG resolution on
<a href="https://github.com/w3c/csswg-drafts/issues/10544">https://github.com/w3c/csswg-drafts/issues/10544</a>

This takes into account the latest import for container queries
WPT tests formatting
<a href="https://github.com/WebKit/WebKit/pull/31273">https://github.com/WebKit/WebKit/pull/31273</a>
<a href="https://github.com/web-platform-tests/wpt/commit/27c89c6f06af177cbd8f2ba5517be3c110fa50a0">https://github.com/web-platform-tests/wpt/commit/27c89c6f06af177cbd8f2ba5517be3c110fa50a0</a>

* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::establishesIndependentFormattingContext const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::usedContain const):
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/*
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e37e86df7eba152d1f8ad18012f237a5d2b2884

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63983 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10595 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10809 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48662 "Found 26 new test failures: fast/css/container-query-style-sharing.html http/tests/media/track/track-webvtt-vertical-multi-line.html imported/w3c/web-platform-tests/css/css-cascade/scope-container.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-004.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/change-display-in-container.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-gradient-invalidation.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-gradient.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-rule-cache.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-sharing-via-rule-node.html ... (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7396 "Found 1 new test failure: fast/css/container-query-style-sharing.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62096 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36749 "Found 4 new test failures: fast/css/container-query-style-sharing.html media/track/track-webvtt-no-snap-to-lines-overlap.html media/track/track-webvtt-snap-to-lines-inline-style.html media/track/track-webvtt-snap-to-lines-left-right.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29504 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33454 "Found 26 new test failures: imported/w3c/web-platform-tests/css/css-cascade/scope-container.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-004.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/change-display-in-container.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-gradient-invalidation.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-gradient.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-rule-cache.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-sharing-via-rule-node.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/counters-in-container-dynamic.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/counters-in-container.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9266 "Found 60 new test failures: fast/css/container-query-style-sharing.html fast/repaint/inline-box-with-self-paint-layer.html fonts/font-weight-invalid-crash.html fonts/ligature.html fullscreen/full-screen-document-background-color.html http/tests/media/track/track-webvtt-vertical-multi-line.html http/tests/performance/performance-resource-timing-cross-origin-media-with-cors.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html http/tests/xmlhttprequest/basic-auth.html imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55371 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9544 "Found 33 new test failures: fast/css/container-query-style-sharing.html http/tests/media/track/track-webvtt-vertical-multi-line.html imported/w3c/web-platform-tests/css/css-cascade/scope-container.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-004.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/change-display-in-container.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-gradient-invalidation.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-gradient.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-rule-cache.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-sharing-via-rule-node.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65715 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3995 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9411 "Found 33 new test failures: fast/css/container-query-style-sharing.html http/tests/media/media-element-frame-destroyed-crash.html http/tests/media/track/track-webvtt-vertical-multi-line.html imported/w3c/web-platform-tests/css/css-cascade/scope-container.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-004.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/change-display-in-container.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-gradient-invalidation.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-gradient.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-rule-cache.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56016 "Found 28 new test failures: fast/css/container-query-style-sharing.html http/tests/media/track/track-webvtt-vertical-multi-line.html imported/w3c/web-platform-tests/css/css-cascade/scope-container.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-004.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/change-display-in-container.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-gradient-invalidation.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-gradient.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-rule-cache.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-sharing-via-rule-node.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56167 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3320 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35226 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36308 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37396 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->