### PR TITLE
REGRESSION(274519@main): "Open with Preview" context menu item does not work on locked PDF documents

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -217,8 +217,9 @@ public:
     virtual void zoomIn() = 0;
     virtual void zoomOut() = 0;
     void save(CompletionHandler<void(const String&, const URL&, std::span<const uint8_t>)>&&);
-    void openWithPreview(CompletionHandler<void(const String&, FrameInfoData&&, std::span<const uint8_t>, const String&)>&&);
 #endif
+
+    void openWithPreview(CompletionHandler<void(const String&, FrameInfoData&&, std::span<const uint8_t>, const String&)>&&);
 
     void notifyCursorChanged(WebCore::PlatformCursorType);
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(PDF_PLUGIN)
 
+#include "FrameInfoData.h"
 #include "PDFPlugin.h"
 #include "UnifiedPDFPlugin.h"
 #include "WebCoreArgumentCoders.h"
@@ -117,7 +118,7 @@ private:
     // True if the stream was explicitly cancelled by calling cancel().
     // (As opposed to being cancelled by the user hitting the stop button for example.
     bool m_streamWasCancelled;
-    
+
     RefPtr<NetscapePlugInStreamLoader> m_loader;
 };
 
@@ -127,7 +128,7 @@ PluginView::Stream::~Stream()
         m_loadCallback({ });
     ASSERT(!m_pluginView);
 }
-    
+
 void PluginView::Stream::start()
 {
     ASSERT(!m_loader);
@@ -382,12 +383,12 @@ id PluginView::accessibilityAssociatedPluginParentForElement(Element* element) c
 {
     return protectedPlugin()->accessibilityAssociatedPluginParentForElement(element);
 }
-    
+
 id PluginView::accessibilityObject() const
 {
     if (!m_isInitialized)
         return nil;
-    
+
     return protectedPlugin()->accessibilityObject();
 }
 
@@ -594,7 +595,7 @@ void PluginView::clipRectChanged()
 void PluginView::setParent(ScrollView* scrollView)
 {
     Widget::setParent(scrollView);
-    
+
     if (scrollView)
         initializePlugin();
 }
@@ -692,7 +693,7 @@ bool PluginView::handleEditingCommand(const String& commandName, const String& a
 
     return protectedPlugin()->handleEditingCommand(commandName, argument);
 }
-    
+
 bool PluginView::isEditingCommandEnabled(const String& commandName)
 {
     if (!m_isInitialized)
@@ -1050,6 +1051,16 @@ Vector<WebCore::FloatRect> PluginView::pdfAnnotationRectsForTesting() const
 void PluginView::registerPDFTestCallback(RefPtr<VoidCallback>&& callback)
 {
     protectedPlugin()->registerPDFTest(WTFMove(callback));
+}
+
+PDFPluginIdentifier PluginView::pdfPluginIdentifier() const
+{
+    return protectedPlugin()->identifier();
+}
+
+void PluginView::openWithPreview(CompletionHandler<void(const String&, FrameInfoData&&, std::span<const uint8_t>, const String&)>&& completionHandler)
+{
+    protectedPlugin()->openWithPreview(WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(PDF_PLUGIN)
 
+#include "PDFPluginIdentifier.h"
 #include <WebCore/FindOptions.h>
 #include <WebCore/PluginViewBase.h>
 #include <WebCore/ResourceResponse.h>
@@ -34,6 +35,7 @@
 #include <WebCore/TextIndicator.h>
 #include <WebCore/Timer.h>
 #include <memory>
+#include <wtf/CompletionHandler.h>
 #include <wtf/RunLoop.h>
 
 OBJC_CLASS NSDictionary;
@@ -53,6 +55,7 @@ namespace WebKit {
 class PDFPluginBase;
 class WebFrame;
 class WebPage;
+struct FrameInfoData;
 struct WebHitTestResultData;
 
 class PluginView final : public WebCore::PluginViewBase {
@@ -118,6 +121,10 @@ public:
     void windowActivityDidChange();
 
     void didSameDocumentNavigationForFrame(WebFrame&);
+
+    PDFPluginIdentifier pdfPluginIdentifier() const;
+
+    void openWithPreview(CompletionHandler<void(const String&, FrameInfoData&&, std::span<const uint8_t>, const String&)>&&);
 
 private:
     PluginView(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader, WebPage&);

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -1141,10 +1141,12 @@ void WebPage::savePDF(PDFPluginIdentifier identifier, CompletionHandler<void(con
 
 void WebPage::openPDFWithPreview(PDFPluginIdentifier identifier, CompletionHandler<void(const String&, FrameInfoData&&, std::span<const uint8_t>, const String&)>&& completionHandler)
 {
-    auto pdfPlugin = m_pdfPlugInsWithHUD.get(identifier);
-    if (!pdfPlugin)
-        return completionHandler({ }, { }, { }, { });
-    pdfPlugin->openWithPreview(WTFMove(completionHandler));
+    for (auto& pluginView : m_pluginViews) {
+        if (pluginView.pdfPluginIdentifier() == identifier)
+            return pluginView.openWithPreview(WTFMove(completionHandler));
+    }
+
+    completionHandler({ }, { }, { }, { });
 }
 
 void WebPage::createPDFHUD(PDFPluginBase& plugin, const IntRect& boundingBox)


### PR DESCRIPTION
#### 9f863a565d7fe45dff1f124af9fe38fb8942ffd7
<pre>
REGRESSION(274519@main): &quot;Open with Preview&quot; context menu item does not work on locked PDF documents
<a href="https://bugs.webkit.org/show_bug.cgi?id=277120">https://bugs.webkit.org/show_bug.cgi?id=277120</a>
<a href="https://rdar.apple.com/132033502">rdar://132033502</a>

Reviewed by Aditya Keerthi.

While it was always possible for WebPage::openPDFWithPreview to be
triggered through non-HUD paths (such as the context menu), we always
looked for an appropriate PDF plugin to act on by querying the web
page&apos;s m_pdfPlugInsWithHUD map. Despite the unsound assumption, this
method worked correctly prior to 274519@main, since the HUD was created
for all PDF documents, notably so for locked files.

After 274519@main, though, HUDs are no longer created for locked
documents, but openPDFWithPreview can still be triggered through the
context menu. This meant that the web page would look for a PDF plugin
in its map of plugins _with_ HUDs, which caused the old assumption to
break down and for &quot;Open with Preview&quot; to just not work for locked
documents.

In this patch, we decouple openPDFWithPreview from plugins with HUDs.
Instead, we provide plumbing to expose the identifier of a PluginView&apos;s
underlying PDFPlugin, using which we can find a relevant PDFPlugin to
act on from the web page&apos;s set of tracked PluginView objects. This is
correct because any plugin, regardless of whether it has a HUD, can be
interacted with to trigger the &quot;Open in Preview&quot; behavior.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::accessibilityObject const):
(WebKit::PluginView::setParent):
(WebKit::PluginView::pdfPluginIdentifier const):
(WebKit::PluginView::openWithPreview):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::openPDFWithPreview):

Canonical link: <a href="https://commits.webkit.org/281413@main">https://commits.webkit.org/281413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2fcf392da0d175a33fb0533d1d72e524fbe6085

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10274 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10436 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48459 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7183 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51736 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29300 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33183 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9197 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65397 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9125 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55799 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55936 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3061 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8955 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34909 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35992 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35737 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->