### PR TITLE
Credential Management: use InvalidStateError for non-fully active docs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/credential-management/non-fully-active.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/credential-management/non-fully-active.https.html
@@ -42,28 +42,28 @@
     // Try to get credentials while not fully active...
     await promise_rejects_dom(
       t,
-      "NotAllowedError",
+      "InvalidStateError",
       DOMExceptionCtor,
       credentials.get({ signal }),
-      "Expected NotAllowedError for get() on non-fully-active document"
+      "Expected InvalidStateError for get() on non-fully-active document"
     );
 
     // Try to create credentials while not fully active...
     await promise_rejects_dom(
       t,
-      "NotAllowedError",
+      "InvalidStateError",
       DOMExceptionCtor,
       credentials.create({ signal }),
-      "Expected NotAllowedError for create() on non-fully-active document"
+      "Expected InvalidStateError for create() on non-fully-active document"
     );
 
     // Try to prevent silent access while not fully active...
     await promise_rejects_dom(
       t,
-      "NotAllowedError",
+      "InvalidStateError",
       DOMExceptionCtor,
       credentials.preventSilentAccess(),
-      "Expected NotAllowedError for preventSilentAccess() on non-fully-active document"
+      "Expected InvalidStateError for preventSilentAccess() on non-fully-active document"
     );
   }, "non-fully active document behavior for CredentialsContainer");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https.html
@@ -42,28 +42,28 @@
     // Try to get credentials while not fully active...
     await promise_rejects_dom(
       t,
-      "NotAllowedError",
+      "InvalidStateError",
       DOMExceptionCtor,
       identity.get({ signal }),
-      "Expected NotAllowedError for get() on non-fully-active document"
+      "Expected InvalidStateError for get() on non-fully-active document"
     );
 
     // Try to create credentials while not fully active...
     await promise_rejects_dom(
       t,
-      "NotAllowedError",
+      "InvalidStateError",
       DOMExceptionCtor,
       identity.create({ signal }),
-      "Expected NotAllowedError for create() on non-fully-active document"
+      "Expected InvalidStateError for create() on non-fully-active document"
     );
 
     // Try to prevent silent access while not fully active...
     await promise_rejects_dom(
       t,
-      "NotAllowedError",
+      "InvalidStateError",
       DOMExceptionCtor,
       identity.preventSilentAccess(),
-      "Expected NotAllowedError for preventSilentAccess() on non-fully-active document"
+      "Expected InvalidStateError for preventSilentAccess() on non-fully-active document"
     );
   }, "non-fully active document behavior for CredentialsContainer");
 </script>

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -128,7 +128,7 @@ void CredentialsContainer::isCreate(CredentialCreationOptions&& options, Credent
 void CredentialsContainer::preventSilentAccess(DOMPromiseDeferred<void>&& promise) const
 {
     if (document() && !document()->isFullyActive()) {
-        promise.reject(Exception { ExceptionCode::NotAllowedError, "The document is not fully active."_s });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "The document is not fully active."_s });
         return;
     }
     promise.resolve();
@@ -144,12 +144,12 @@ bool CredentialsContainer::performCommonChecks(const Options& options, Credentia
     }
 
     if (!document->isFullyActive()) {
-        promise.reject(Exception { ExceptionCode::NotAllowedError, "The document is not fully active."_s });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "The document is not fully active."_s });
         return false;
     }
 
     if (!document->page()) {
-        promise.reject(Exception { ExceptionCode::NotSupportedError, "No browsing context"_s });
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "No browsing context"_s });
         return false;
     }
 


### PR DESCRIPTION
#### 8dc19b669f6f22440c479ad7a1e1274640b3d2f3
<pre>
Credential Management: use InvalidStateError for non-fully active docs
<a href="https://bugs.webkit.org/show_bug.cgi?id=277125">https://bugs.webkit.org/show_bug.cgi?id=277125</a>
<a href="https://rdar.apple.com/132552299">rdar://132552299</a>

Reviewed by Pascoe.

Switched from NotAllowedError to InvalidStateError for non-fully active documents.
Spec change:
<a href="https://github.com/w3c/webappsec-credential-management/pull/245">https://github.com/w3c/webappsec-credential-management/pull/245</a>

* LayoutTests/imported/w3c/web-platform-tests/credential-management/non-fully-active.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https.html:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::preventSilentAccess const):
(WebCore::CredentialsContainer::performCommonChecks):

Canonical link: <a href="https://commits.webkit.org/281535@main">https://commits.webkit.org/281535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88f4560499df1bbd8660757bb6d6a804b322f390

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10596 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10810 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48661 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7395 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62097 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36752 "Found 1 new test failure: http/wpt/service-workers/fetch-service-worker-preload.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29503 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33457 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9264 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9516 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55374 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65716 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56015 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56166 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13361 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3321 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35227 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36309 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->