### PR TITLE
Replace isValidEnum(bool) with annotations in *.serialization.in files

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IndexedDB.serialization.in
+++ b/Source/WebCore/Modules/indexeddb/IndexedDB.serialization.in
@@ -20,12 +20,27 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-enum class WebCore::IndexedDB::IndexRecordType : bool;
+enum class WebCore::IndexedDB::IndexRecordType : bool {
+    Key,
+    Value
+};
 
-enum class WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer : bool;
+enum class WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer : bool {
+    No,
+    Yes
+};
 
-enum class WebCore::IndexedDB::CursorIterateOption : bool;
+enum class WebCore::IndexedDB::CursorIterateOption : bool {
+    DoNotReply,
+    Reply
+};
 
-enum class WebCore::IndexedDB::CursorSource : bool;
+enum class WebCore::IndexedDB::CursorSource : bool {
+    Index,
+    ObjectStore
+};
 
-enum class WebCore::IndexedDB::CursorType : bool;
+enum class WebCore::IndexedDB::CursorType : bool {
+    KeyAndValue,
+    KeyOnly
+};

--- a/Source/WebCore/platform/ContextMenuItem.cpp
+++ b/Source/WebCore/platform/ContextMenuItem.cpp
@@ -298,7 +298,7 @@ static bool isValidContextMenuAction(WebCore::ContextMenuAction action)
 
 namespace WTF {
 
-template<> bool isValidEnum<WebCore::ContextMenuAction, void>(std::underlying_type_t<WebCore::ContextMenuAction> action)
+template<> bool isValidEnum<WebCore::ContextMenuAction>(std::underlying_type_t<WebCore::ContextMenuAction> action)
 {
     return WebCore::isValidContextMenuAction(static_cast<WebCore::ContextMenuAction>(action));
 }

--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -226,6 +226,6 @@ private:
 
 namespace WTF {
 
-template<> WEBCORE_EXPORT bool isValidEnum<WebCore::ContextMenuAction, void>(std::underlying_type_t<WebCore::ContextMenuAction>);
+template<> WEBCORE_EXPORT bool isValidEnum<WebCore::ContextMenuAction>(std::underlying_type_t<WebCore::ContextMenuAction>);
 
 } // namespace WTF

--- a/Source/WebCore/platform/audio/PlatformMediaSession.serialization.in
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.serialization.in
@@ -72,3 +72,33 @@ enum class WebCore::PlatformMediaSessionRemoteControlCommandType : uint8_t {
     NoFlags,
     MayResumePlaying,
 };
+
+#if PLATFORM(IOS_FAMILY)
+
+header: <WebCore/MediaSessionHelperIOS.h>
+[Nested] enum class WebCore::MediaSessionHelperClient::SuspendedUnderLock : bool {
+    No,
+    Yes
+};
+[Nested] enum class WebCore::MediaSessionHelperClient::HasAvailableTargets : bool {
+    No,
+    Yes
+};
+[Nested] enum class WebCore::MediaSessionHelperClient::PlayingToAutomotiveHeadUnit : bool {
+    No,
+    Yes
+};
+[Nested] enum class WebCore::MediaSessionHelperClient::ShouldPause : bool {
+    No,
+    Yes
+};
+[Nested] enum class WebCore::MediaSessionHelperClient::SupportsAirPlayVideo : bool {
+    No,
+    Yes
+};
+[Nested] enum class WebCore::MediaSessionHelperClient::SupportsSpatialAudioPlayback : bool {
+    No,
+    Yes
+};
+
+#endif

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
@@ -66,11 +66,43 @@ headers: "NetworkProcessCreationParameters.h" "AuxiliaryProcessCreationParameter
     Vector<WebCore::OrganizationStorageAccessPromptQuirk> storageAccessPromptQuirksData;
 }
 
-enum class WebKit::LoadedWebArchive : bool
-enum class WebKit::DidFilterKnownLinkDecoration : bool
-enum class WebKit::ShouldGrandfatherStatistics : bool
-enum class WebKit::PrivateRelayed : bool
-enum class WebKit::ContentAsStringIncludesChildFrames : bool
-enum class WebKit::CallDownloadDidStart : bool
-enum class WebKit::AllowOverwrite : bool
-enum class WebKit::UseDownloadPlaceholder : bool
+header: "LoadedWebArchive.h"
+enum class WebKit::LoadedWebArchive : bool {
+    No,
+    Yes
+};
+header: "DidFilterKnownLinkDecoration.h"
+enum class WebKit::DidFilterKnownLinkDecoration : bool {
+    No,
+    Yes
+};
+header: "ShouldGrandfatherStatistics.h"
+enum class WebKit::ShouldGrandfatherStatistics : bool {
+    No,
+    Yes
+};
+header: "PrivateRelayed.h"
+enum class WebKit::PrivateRelayed : bool {
+    No,
+    Yes
+};
+header: "ContentAsStringIncludesChildFrames.h"
+enum class WebKit::ContentAsStringIncludesChildFrames : bool {
+    No,
+    Yes
+};
+header: "DownloadManager.h"
+enum class WebKit::CallDownloadDidStart : bool {
+    No,
+    Yes
+};
+header: "DownloadID.h"
+enum class WebKit::AllowOverwrite : bool {
+    No,
+    Yes
+};
+header: "UseDownloadPlaceholder.h"
+enum class WebKit::UseDownloadPlaceholder : bool {
+    No,
+    Yes
+};

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -22,8 +22,10 @@
 
 headers: "NetworkResourceLoadParameters.h"
 
-enum class WebKit::PreconnectOnly : bool;
-enum class WebKit::NavigatingToAppBoundDomain : bool;
+enum class WebKit::PreconnectOnly : bool {
+    No,
+    Yes
+};
 
 class WebKit::NetworkLoadParameters {
     Markable<WebKit::WebPageProxyIdentifier> webPageProxyID;

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -20,7 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-enum class WebKit::AllowsCellularAccess : bool;
+enum class WebKit::AllowsCellularAccess : bool {
+    No,
+    Yes
+};
 
 [RValue] struct WebKit::NetworkSessionCreationParameters {
     PAL::SessionID sessionID;
@@ -108,3 +111,11 @@ enum class WebKit::AllowsCellularAccess : bool;
 #endif
     WebKit::ResourceLoadStatisticsParameters resourceLoadStatisticsParameters;
 };
+
+#if USE(SOUP)
+header: "SoupCookiePersistentStorageType.h"
+enum class WebKit::SoupCookiePersistentStorageType : bool {
+    Text,
+    SQLite
+};
+#endif

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.serialization.in
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.serialization.in
@@ -21,6 +21,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 header: "PrivateClickMeasurementManagerInterface.h"
+
+enum class WebKit::PrivateClickMeasurementAttributionType : bool {
+    Unattributed,
+    Attributed
+};
+
 enum class WebKit::PCM::MessageType : uint8_t {
     StoreUnattributed,
     HandleAttribution,

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1595,7 +1595,7 @@ def generate_message_names_header(receivers):
     result.append('\n')
     result.append('namespace WTF {\n')
     result.append('\n')
-    result.append('template<> constexpr bool isValidEnum<IPC::MessageName, void>(std::underlying_type_t<IPC::MessageName> messageName)\n')
+    result.append('template<> constexpr bool isValidEnum<IPC::MessageName>(std::underlying_type_t<IPC::MessageName> messageName)\n')
     result.append('{\n')
     result.append('    return messageName <= WTF::enumToUnderlyingType(IPC::MessageName::Last);\n')
     result.append('}\n')

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -1491,7 +1491,7 @@ std::optional<WebCore::RectEdges<bool>> ArgumentCoder<WebCore::RectEdges<bool>>:
 
 namespace WTF {
 
-template<> bool isValidEnum<IPC::WebCore_TimingFunction_Subclass, void>(IPC::EncodedVariantIndex value)
+template<> bool isValidEnum<IPC::WebCore_TimingFunction_Subclass>(IPC::EncodedVariantIndex value)
 {
 IGNORE_WARNINGS_BEGIN("switch-unreachable")
     switch (static_cast<IPC::WebCore_TimingFunction_Subclass>(value)) {
@@ -1507,7 +1507,7 @@ IGNORE_WARNINGS_END
     return false;
 }
 
-template<> bool isValidEnum<IPC::WebCore_MoveOnlyBaseClass_Subclass, void>(IPC::EncodedVariantIndex value)
+template<> bool isValidEnum<IPC::WebCore_MoveOnlyBaseClass_Subclass>(IPC::EncodedVariantIndex value)
 {
 IGNORE_WARNINGS_BEGIN("switch-unreachable")
     switch (static_cast<IPC::WebCore_MoveOnlyBaseClass_Subclass>(value)) {
@@ -1518,7 +1518,7 @@ IGNORE_WARNINGS_END
     return false;
 }
 
-template<> bool isValidEnum<EnumWithoutNamespace, void>(uint8_t value)
+template<> bool isValidEnum<EnumWithoutNamespace>(uint8_t value)
 {
     switch (static_cast<EnumWithoutNamespace>(value)) {
     case EnumWithoutNamespace::Value1:
@@ -1531,7 +1531,7 @@ template<> bool isValidEnum<EnumWithoutNamespace, void>(uint8_t value)
 }
 
 #if ENABLE(UINT16_ENUM)
-template<> bool isValidEnum<EnumNamespace::EnumType, void>(uint16_t value)
+template<> bool isValidEnum<EnumNamespace::EnumType>(uint16_t value)
 {
     switch (static_cast<EnumNamespace::EnumType>(value)) {
     case EnumNamespace::EnumType::FirstValue:
@@ -1601,7 +1601,7 @@ template<> bool isValidOptionSet<OptionSetEnumAllCondition>(OptionSet<OptionSetE
 }
 
 #if (ENABLE(OUTER_CONDITION)) && (ENABLE(INNER_CONDITION))
-template<> bool isValidEnum<EnumNamespace::InnerEnumType, void>(uint8_t value)
+template<> bool isValidEnum<EnumNamespace::InnerEnumType>(uint8_t value)
 {
     switch (static_cast<EnumNamespace::InnerEnumType>(value)) {
     case EnumNamespace::InnerEnumType::InnerValue:

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -415,15 +415,15 @@ template<> struct ArgumentCoder<WebCore::RectEdges<bool>> {
 
 namespace WTF {
 
-template<> bool isValidEnum<EnumWithoutNamespace, void>(uint8_t);
+template<> bool isValidEnum<EnumWithoutNamespace>(uint8_t);
 #if ENABLE(UINT16_ENUM)
-template<> bool isValidEnum<EnumNamespace::EnumType, void>(uint16_t);
+template<> bool isValidEnum<EnumNamespace::EnumType>(uint16_t);
 #endif
 template<> bool isValidOptionSet<OptionSetEnumFirstCondition>(OptionSet<OptionSetEnumFirstCondition>);
 template<> bool isValidOptionSet<OptionSetEnumLastCondition>(OptionSet<OptionSetEnumLastCondition>);
 template<> bool isValidOptionSet<OptionSetEnumAllCondition>(OptionSet<OptionSetEnumAllCondition>);
 #if (ENABLE(OUTER_CONDITION)) && (ENABLE(INNER_CONDITION))
-template<> bool isValidEnum<EnumNamespace::InnerEnumType, void>(uint8_t);
+template<> bool isValidEnum<EnumNamespace::InnerEnumType>(uint8_t);
 #endif
 
 } // namespace WTF

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -278,7 +278,7 @@ constexpr bool messageIsSync(MessageName name)
 
 namespace WTF {
 
-template<> constexpr bool isValidEnum<IPC::MessageName, void>(std::underlying_type_t<IPC::MessageName> messageName)
+template<> constexpr bool isValidEnum<IPC::MessageName>(std::underlying_type_t<IPC::MessageName> messageName)
 {
     return messageName <= WTF::enumToUnderlyingType(IPC::MessageName::Last);
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -58,7 +58,10 @@ class WebCore::InheritanceGrandchild : WebCore::InheritsFrom {
 }
 
 #if ENABLE(BOOL_ENUM)
-enum class EnumNamespace::BoolEnumType : bool
+enum class EnumNamespace::BoolEnumType : bool {
+    No,
+    Yes
+};
 #endif
 
 enum class EnumWithoutNamespace : uint8_t {
@@ -317,7 +320,10 @@ enum class EnumNamespace::InnerEnumType : uint8_t {
 #endif
 }
 #else
-enum class EnumNamespace::InnerBoolType : bool
+enum class EnumNamespace::InnerBoolType : bool {
+    No,
+    Yes
+};
 #endif
 
 #else

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in
@@ -63,7 +63,10 @@ header: "CoreIPCNSURLRequest.h"
 };
 
 header: "CoreIPCNSURLRequest.h"
-[CustomHeader, WebKitPlatform] enum class WebKit::NSURLRequestAttribution : bool;
+[CustomHeader, WebKitPlatform] enum class WebKit::NSURLRequestAttribution : bool {
+    Developer,
+    User
+};
 
 header: "CoreIPCNSURLRequest.h"
 [OptionSet, CustomHeader, WebKitPlatform] enum class WebKit::NSURLRequestFlags : int16_t {

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -149,7 +149,10 @@ header: <WebCore/AttributedString.h>
 }
 
 header: <WebCore/AttributedString.h>
-[CustomHeader] enum class WebCore::TextTableLayoutAlgorithm : bool;
+[CustomHeader] enum class WebCore::TextTableLayoutAlgorithm : bool {
+    Automatic,
+    Fixed
+};
 
 header: <WebCore/AttributedString.h>
 [CustomHeader] struct WebCore::ParagraphStyleTextList {
@@ -306,7 +309,10 @@ class WebCore::PaymentSessionError {
     bool phoneticName;
 };
 
-[Nested] enum class WebCore::ApplePaySessionPaymentRequest::Requester : bool;
+[Nested] enum class WebCore::ApplePaySessionPaymentRequest::Requester : bool {
+    ApplePayJS,
+    PaymentRequest
+};
 
 [CustomHeader] class WebCore::ApplePaySessionPaymentRequest {
     String countryCode();

--- a/Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in
@@ -217,6 +217,11 @@ headers: <WebCore/DisplayListItems.h>
     WebCore::Color color();
 };
 
+[Nested] enum class WebCore::GraphicsContext::RequiresClipToRect : bool {
+    No,
+    Yes
+};
+
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::FillRect {
     WebCore::FloatRect rect();
     WebCore::GraphicsContext::RequiresClipToRect requiresClipToRect();

--- a/Source/WebKit/Shared/Extensions/WebExtensionContext.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContext.serialization.in
@@ -31,6 +31,9 @@ enum class WebKit::WebExtensionContextInstallReason : uint8_t {
     BrowserUpdate,
 };
 
-[Nested] enum class WebKit::WebExtensionContext::WindowIsClosing : bool;
+[Nested] enum class WebKit::WebExtensionContext::WindowIsClosing : bool {
+    No,
+    Yes
+};
 
 #endif

--- a/Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in
@@ -71,6 +71,9 @@ enum class WebKit::WebExtensionTabImageFormat : uint8_t {
     JPEG,
 }
 
-[Nested] enum class WebKit::WebExtensionContext::ReloadFromOrigin : bool;
+[Nested] enum class WebKit::WebExtensionTab::ReloadFromOrigin : bool {
+    No,
+    Yes
+};
 
 #endif

--- a/Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in
@@ -38,7 +38,10 @@ struct WebKit::WebExtensionWindowParameters {
     std::optional<bool> privateBrowsing;
 };
 
-[Nested] enum class WebKit::WebExtensionWindow::PopulateTabs : bool;
+[Nested] enum class WebKit::WebExtensionWindow::PopulateTabs : bool {
+    No,
+    Yes
+};
 
 [Nested] enum class WebKit::WebExtensionWindow::Type : uint8_t {
     Normal,

--- a/Source/WebKit/Shared/FocusedElementInformation.serialization.in
+++ b/Source/WebKit/Shared/FocusedElementInformation.serialization.in
@@ -118,4 +118,7 @@ enum class WebKit::InputType : uint8_t {
 }
 #endif
 
-enum class WebKit::ColorControlSupportsAlpha : bool
+enum class WebKit::ColorControlSupportsAlpha : bool {
+    Yes,
+    No
+};

--- a/Source/WebKit/Shared/FrameInfoData.serialization.in
+++ b/Source/WebKit/Shared/FrameInfoData.serialization.in
@@ -22,7 +22,10 @@
 
 headers: "FrameInfoData.h" "WebCoreArgumentCoders.h"
 
-enum class WebKit::FrameType : bool
+enum class WebKit::FrameType : bool {
+    Local,
+    Remote
+};
 
 struct WebKit::FrameInfoData {
     bool isMainFrame

--- a/Source/WebKit/Shared/InspectorExtensionTypes.serialization.in
+++ b/Source/WebKit/Shared/InspectorExtensionTypes.serialization.in
@@ -32,6 +32,9 @@ enum class Inspector::ExtensionError : uint8_t {
     NotImplemented,
 };
 
-enum class Inspector::ExtensionAppearance : bool;
+enum class Inspector::ExtensionAppearance : bool {
+    Light,
+    Dark
+};
 
 #endif // ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/Shared/JavaScriptCore.serialization.in
+++ b/Source/WebKit/Shared/JavaScriptCore.serialization.in
@@ -58,7 +58,10 @@ enum class JSC::SourceTaintedOrigin : uint8_t {
 };
 
 header: <JavaScriptCore/InspectorFrontendChannel.h>
-[Nested] enum class Inspector::FrontendChannel::ConnectionType : bool;
+[Nested] enum class Inspector::FrontendChannel::ConnectionType : bool {
+    Remote,
+    Local
+};
 
 header: <JavaScriptCore/InspectorTarget.h>
 enum class Inspector::InspectorTargetType : uint8_t {

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -20,9 +20,18 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-enum class WebCore::LockHistory : bool;
-enum class WebCore::LockBackForwardList : bool;
-enum class WebKit::NavigatingToAppBoundDomain : bool;
+enum class WebCore::LockHistory : bool {
+    No,
+    Yes
+};
+enum class WebCore::LockBackForwardList : bool {
+    No,
+    Yes
+};
+enum class WebKit::NavigatingToAppBoundDomain : bool {
+    No,
+    Yes
+};
 
 [RValue] struct WebKit::LoadParameters {
     WebCore::PublicSuffix publicSuffix;

--- a/Source/WebKit/Shared/NavigationActionData.serialization.in
+++ b/Source/WebKit/Shared/NavigationActionData.serialization.in
@@ -20,9 +20,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-enum class WebCore::LockHistory : bool;
-enum class WebCore::LockBackForwardList : bool;
-
 struct WebKit::NavigationActionData {
     WebCore::NavigationType navigationType;
     OptionSet<WebKit::WebEventModifier> modifiers;

--- a/Source/WebKit/Shared/PolicyDecision.serialization.in
+++ b/Source/WebKit/Shared/PolicyDecision.serialization.in
@@ -20,8 +20,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-enum class WebKit::NavigatingToAppBoundDomain : bool;
-
 [RValue] struct WebKit::PolicyDecision {
     std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain;
     WebCore::PolicyAction policyAction;

--- a/Source/WebKit/Shared/PushMessageForTesting.serialization.in
+++ b/Source/WebKit/Shared/PushMessageForTesting.serialization.in
@@ -22,7 +22,10 @@
 
 webkit_platform_headers: "ArgumentCoders.h" "PushMessageForTesting.h"
 
-enum class WebKit::WebPushD::PushMessageDisposition : bool;
+[CustomHeader, WebKitPlatform] enum class WebKit::WebPushD::PushMessageDisposition : bool {
+    Legacy,
+    Notification
+};
 
 [CustomHeader, WebKitPlatform] struct WebKit::WebPushD::PushMessageForTesting {
     String targetAppCodeSigningIdentifier;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -94,7 +94,10 @@ enum class WebKit::LayerContentsType : uint8_t {
 };
 
 header: "RemoteLayerBackingStore.h"
-[Nested] enum class WebKit::RemoteLayerBackingStore::Type : bool;
+[Nested] enum class WebKit::RemoteLayerBackingStore::Type : bool {
+    IOSurface,
+    Bitmap
+};
 
 [CustomEncoder, CustomHeader, LegacyPopulateFromEmptyConstructor, Nested] class WebKit::RemoteLayerBackingStoreProperties {
     bool m_isOpaque;

--- a/Source/WebKit/Shared/ResourceLoadStatisticsParameters.serialization.in
+++ b/Source/WebKit/Shared/ResourceLoadStatisticsParameters.serialization.in
@@ -20,7 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-enum class WebCore::SameSiteStrictEnforcementEnabled : bool;
+enum class WebCore::SameSiteStrictEnforcementEnabled : bool {
+    No,
+    Yes
+};
 
 [RValue] struct WebKit::ResourceLoadStatisticsParameters {
     String directory;

--- a/Source/WebKit/Shared/TextFlags.serialization.in
+++ b/Source/WebKit/Shared/TextFlags.serialization.in
@@ -33,14 +33,20 @@ enum class WebCore::Kerning : uint8_t {
     NoShift
 };
 
-enum class WebCore::FontOpticalSizing : bool;
+enum class WebCore::FontOpticalSizing : bool {
+    Enabled,
+    Disabled
+};
 
 enum class WebCore::FontStyleAxis : uint8_t {
     slnt,
     ital
 };
 
-enum class WebCore::AllowUserInstalledFonts : bool;
+enum class WebCore::AllowUserInstalledFonts : bool {
+    No,
+    Yes
+};
 
 enum class WebCore::FontVariantEastAsianVariant : uint8_t {
     Normal,
@@ -129,9 +135,27 @@ enum class WebCore::FontSmoothingMode : uint8_t {
 #endif
 };
 
-enum class WebCore::FontOrientation : bool
-enum class WebCore::NonCJKGlyphOrientation : bool
-enum class WebCore::FontVariantNumericOrdinal : bool
-enum class WebCore::FontVariantNumericSlashedZero : bool
-enum class WebCore::FontSynthesisLonghandValue : bool
-enum class WebCore::FontSmallCaps : bool
+enum class WebCore::FontOrientation : bool {
+    Horizontal,
+    Vertical
+};
+enum class WebCore::NonCJKGlyphOrientation : bool {
+    Mixed,
+    Upright
+};
+enum class WebCore::FontVariantNumericOrdinal : bool {
+    Normal,
+    Yes
+};
+enum class WebCore::FontVariantNumericSlashedZero : bool {
+    Normal,
+    Yes
+};
+enum class WebCore::FontSynthesisLonghandValue : bool {
+    None,
+    Auto
+};
+enum class WebCore::FontSmallCaps : bool {
+    Off,
+    On
+};

--- a/Source/WebKit/Shared/UndoOrRedo.serialization.in
+++ b/Source/WebKit/Shared/UndoOrRedo.serialization.in
@@ -22,4 +22,7 @@
 
 header: "UndoOrRedo.h"
 
-enum class WebKit::UndoOrRedo : bool;
+enum class WebKit::UndoOrRedo : bool {
+    Undo,
+    Redo
+};

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -217,7 +217,11 @@ enum class WebCore::RTCErrorDetailType : uint8_t {
     SdpSyntaxError
 };
 
-enum class WebCore::NotificationEventType : bool;
+header: <WebCore/NotificationEventType.h>
+enum class WebCore::NotificationEventType : bool {
+    Click,
+    Close
+};
 
 enum class WebCore::PermissionName : uint8_t {
     Accelerometer,
@@ -321,7 +325,10 @@ enum class WebCore::AutofillFieldName : uint8_t {
     DeviceIMEI,
 };
 
-enum class WebCore::NonAutofillCredentialType : bool;
+enum class WebCore::NonAutofillCredentialType : bool {
+    None,
+    WebAuthn
+};
 
 enum class WebCore::EnterKeyHint : uint8_t {
     Unspecified,
@@ -407,8 +414,14 @@ struct WebCore::TranslationContextMenuInfo {
 };
 
 header: <WebCore/TranslationContextMenuInfo.h>
-enum class WebCore::TranslationContextMenuMode : bool;
-enum class WebCore::TranslationContextMenuSource : bool;
+enum class WebCore::TranslationContextMenuMode : bool {
+    NonEditable,
+    Editable
+};
+enum class WebCore::TranslationContextMenuSource : bool {
+    Unspecified,
+    Image
+};
 #endif // HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)
 
 #if USE(APPKIT)
@@ -433,7 +446,10 @@ header: <WebCore/ListStyleType.h>
 }
 
 header: <WebCore/ScrollTypes.h>
-enum class WebCore::ScrollIsAnimated : bool;
+enum class WebCore::ScrollIsAnimated : bool {
+    No,
+    Yes
+};
 
 enum class WebCore::ScrollGranularity : uint8_t {
     Line,
@@ -584,7 +600,10 @@ class WebCore::IDBTransactionInfo {
     std::unique_ptr<WebCore::IDBDatabaseInfo> originalDatabaseInfo();
 };
 
-enum class WebCore::IDBGetRecordDataType : bool;
+enum class WebCore::IDBGetRecordDataType : bool {
+    KeyOnly,
+    KeyAndValue
+};
 
 struct WebCore::IDBGetRecordData {
     WebCore::IDBKeyRangeData keyRangeData;
@@ -910,7 +929,10 @@ struct WebCore::ShareData {
     [NotSerialized] Vector<Ref<WebCore::File>> files;
 };
 
-enum class WebCore::ShareDataOriginator : bool
+enum class WebCore::ShareDataOriginator : bool {
+    Web,
+    User
+};
 
 using WebCore::TargetedElementIdentifiers = std::pair<WebCore::ElementIdentifier, WebCore::ScriptExecutionContextIdentifier>;
 using WebCore::TargetedElementSelectors = Vector<HashSet<String>>;
@@ -1014,8 +1036,14 @@ struct WebCore::DictionaryPopupInfo {
 #endif
 };
 
-enum class WebCore::PCM::AttributionEphemeral : bool
-enum class WebCore::PCM::WasSent : bool
+enum class WebCore::PCM::AttributionEphemeral : bool {
+    No,
+    Yes
+};
+enum class WebCore::PCM::WasSent : bool {
+    No,
+    Yes
+};
 
 class WebCore::PrivateClickMeasurement {
     uint8_t sourceID()
@@ -1138,7 +1166,10 @@ struct WebCore::ApplePaySetupConfiguration {
     Vector<String> signedFields;
 };
 
-[Nested] enum class WebCore::ApplePayLineItem::Type : bool;
+[Nested] enum class WebCore::ApplePayLineItem::Type : bool {
+    Pending,
+    Final
+};
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
 [Nested] enum class WebCore::ApplePayLineItem::DisbursementLineItemType : uint8_t {
     Disbursement,
@@ -1192,7 +1223,10 @@ struct WebCore::ApplePayShippingMethod {
     std::optional<WebCore::ApplePayError::Domain> domain();
 }
 
-enum class WebCore::ApplePayLogoStyle : bool
+enum class WebCore::ApplePayLogoStyle : bool {
+    White,
+    Black
+};
 [RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ApplePayLogoSystemImage {
     WebCore::ApplePayLogoStyle applePayLogoStyle()
 }
@@ -1319,7 +1353,10 @@ struct WebCore::ApplePayInstallmentItem {
     String apr;
     String programTerms;
 };
-enum class WebCore::ApplePaySetupFeatureType : bool
+enum class WebCore::ApplePaySetupFeatureType : bool {
+    ApplePay,
+    AppleCard
+};
 enum class WebCore::ApplePayInstallmentItemType : uint8_t {
     Generic,
     Phone,
@@ -1459,7 +1496,10 @@ struct WebCore::DetachedRTCDataChannel {
 
 header: <WebCore/WebCodecsEncodedVideoChunk.h>
 #if ENABLE(WEB_CODECS)
-enum class WebCore::WebCodecsEncodedVideoChunkType : bool;
+enum class WebCore::WebCodecsEncodedVideoChunkType : bool {
+    Key,
+    Delta
+};
 struct WebCore::WebCodecsEncodedVideoChunkData {
     WebCore::WebCodecsEncodedVideoChunkType type;
     int64_t timestamp;
@@ -1470,7 +1510,10 @@ struct WebCore::WebCodecsEncodedVideoChunkData {
 
 header: <WebCore/WebCodecsEncodedAudioChunk.h>
 #if ENABLE(WEB_CODECS)
-enum class WebCore::WebCodecsEncodedAudioChunkType : bool;
+enum class WebCore::WebCodecsEncodedAudioChunkType : bool {
+    Key,
+    Delta
+};
 struct WebCore::WebCodecsEncodedAudioChunkData {
     WebCore::WebCodecsEncodedAudioChunkType type;
     int64_t timestamp;
@@ -1583,7 +1626,10 @@ struct WebCore::WebLockManagerSnapshot {
     Vector<WebCore::WebLockManagerSnapshot::Info> pending;
 };
 
-enum class WebCore::WebLockMode : bool;
+enum class WebCore::WebLockMode : bool {
+    Shared,
+    Exclusive
+};
 
 [Nested] struct WebCore::WebLockManagerSnapshot::Info {
     String name;
@@ -1805,7 +1851,10 @@ struct WebCore::NavigationPreloadState {
     String headerValue;
 };
 
-enum class WebCore::RenderingMode : bool
+enum class WebCore::RenderingMode : bool {
+    Unaccelerated,
+    Accelerated
+};
 
 enum class WebCore::RenderingPurpose : uint8_t {
     Unspecified,
@@ -1829,7 +1878,10 @@ enum class WebCore::ContentsFormat : uint8_t {
 #endif
 };
 
-enum class WebCore::RotationDirection : bool
+enum class WebCore::RotationDirection : bool {
+    Counterclockwise,
+    Clockwise
+};
 
 #if ENABLE(CONTENT_FILTERING)
 [LegacyPopulateFromEmptyConstructor] class WebCore::MockContentFilterSettings {
@@ -1848,7 +1900,10 @@ enum class WebCore::RotationDirection : bool
     AfterFinishedAddingData,
     Never
 };
-[Nested] enum class WebCore::MockContentFilterSettings::Decision : bool
+[Nested] enum class WebCore::MockContentFilterSettings::Decision : bool {
+    Allow,
+    Block
+};
 #endif
 
 header: <WebCore/IsLoggedIn.h>
@@ -1858,7 +1913,10 @@ enum class WebCore::IsLoggedIn : uint8_t {
 };
 
 header: <WebCore/LoginStatus.h>
-[Nested] enum class WebCore::LoginStatus::CredentialTokenType : bool
+[Nested] enum class WebCore::LoginStatus::CredentialTokenType : bool {
+    LegacyCookie,
+    HTTPStateToken
+};
 
 header: <WebCore/LoginStatus.h>
 [Nested] enum class WebCore::LoginStatus::AuthenticationType : uint8_t {
@@ -1896,9 +1954,15 @@ enum class WebCore::InputMode : uint8_t {
     Search
 };
 
-enum class WebCore::IndexedDB::GetAllType : bool
+enum class WebCore::IndexedDB::GetAllType : bool {
+    Keys,
+    Values
+};
 
-enum class WebCore::WorkerType : bool
+enum class WebCore::WorkerType : bool {
+    Classic,
+    Module
+};
 
 enum class WebCore::StoredCredentialsPolicy : uint8_t {
     DoNotUse,
@@ -1906,10 +1970,22 @@ enum class WebCore::StoredCredentialsPolicy : uint8_t {
     EphemeralStateless
 };
 
-enum class WebCore::ContentSniffingPolicy : bool;
-enum class WebCore::ContentEncodingSniffingPolicy : bool;
-enum class WebCore::ClientCredentialPolicy : bool;
-enum class WebCore::ShouldRelaxThirdPartyCookieBlocking : bool;
+enum class WebCore::ContentSniffingPolicy : bool {
+    SniffContent,
+    DoNotSniffContent
+};
+enum class WebCore::ContentEncodingSniffingPolicy : bool {
+    Default,
+    Disable
+};
+enum class WebCore::ClientCredentialPolicy : bool {
+    CannotAskClientForCredentials,
+    MayAskClientForCredentials
+};
+enum class WebCore::ShouldRelaxThirdPartyCookieBlocking : bool {
+    No,
+    Yes
+};
 
 enum class WebCore::PreflightPolicy : uint8_t {
     Consider,
@@ -2071,7 +2147,6 @@ header: <WebCore/ResourceRequest.h>
     [BitField] bool m_useAdvancedPrivacyProtections;
     [BitField] bool m_didFilterLinkDecoration;
     [BitField] bool m_isPrivateTokenUsageByThirdPartyAllowed;
-    [BitField] bool m_wasSchemeOptimisticallyUpgraded;
 };
 
 #if USE(SOUP)
@@ -2184,7 +2259,10 @@ struct WebCore::WindowFeatures {
     [NotSerialized] Vector<String> additionalFeatures;
 };
 
-[Nested] enum class WebCore::CompositionUnderlineColor : bool
+[Nested] enum class WebCore::CompositionUnderlineColor : bool {
+    GivenColor,
+    TextColor
+};
 
 struct WebCore::CompositionUnderline {
     unsigned startOffset;
@@ -2255,7 +2333,10 @@ header: <WebCore/TextChecking.h>
 };
 
 header: <WebCore/TextChecking.h>
-[CustomHeader] enum class WebCore::TextCheckingProcessType : bool
+[CustomHeader] enum class WebCore::TextCheckingProcessType : bool {
+    TextCheckingProcessBatch,
+    TextCheckingProcessIncremental
+};
 
 header: <WebCore/TextChecking.h>
 [CustomHeader] class WebCore::TextCheckingRequestData {
@@ -2415,7 +2496,10 @@ header: <WebCore/NetworkLoadInformation.h>
     WebCore::NetworkLoadMetrics metrics;
 };
 
-[Nested] enum class WebCore::NetworkTransactionInformation::Type : bool
+[Nested] enum class WebCore::NetworkTransactionInformation::Type : bool {
+    Redirection,
+    Preflight
+};
 
 class WebCore::ContentType {
     String raw();
@@ -2505,16 +2589,22 @@ enum class WebCore::AuthenticatorTransport : uint8_t {
     SmartCard
 };
 
-enum class WebCore::PublicKeyCredentialType : bool
+enum class WebCore::PublicKeyCredentialType : bool {
+    PublicKey
+};
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-enum class WebCore::SelectionRenderingBehavior : bool;
+enum class WebCore::SelectionRenderingBehavior : bool {
+    CoalesceBoundingRects,
+    UseIndividualQuads
+};
 #endif
 
-#if PLATFORM(IOS_FAMILY)
-enum class WebCore::TextDirection : bool;
-#endif
+enum class WebCore::TextDirection : bool {
+    LTR,
+    RTL
+};
 
 #if PLATFORM(IOS_FAMILY)
 class WebCore::SelectionGeometry {
@@ -2723,7 +2813,10 @@ struct WebCore::EventTrackingRegions {
     HashMap<WebCore::EventTrackingRegions::EventType, WebCore::Region, WTF::IntHash<WebCore::EventTrackingRegions::EventType>, WTF::StrongEnumHashTraits<WebCore::EventTrackingRegions::EventType>> eventSpecificSynchronousDispatchRegions;
 };
 
-enum class WebCore::HasInsecureContent : bool
+enum class WebCore::HasInsecureContent : bool {
+    No,
+    Yes
+};
 
 struct WebCore::TextManipulationItem {
     Markable<WebCore::FrameIdentifier> frameID;
@@ -3028,7 +3121,10 @@ struct WebCore::GraphicsContextGLAttributes {
     WebCore::GraphicsContextGLSimulatedCreationFailure failContextCreationForTesting;
 };
 
-enum class WebCore::GraphicsContextGLFlipY : bool
+enum class WebCore::GraphicsContextGLFlipY : bool {
+    No,
+    Yes
+};
 
 enum class WebCore::GraphicsContextGLSimulatedEventForTesting : uint8_t {
     GPUStatusFailure,
@@ -3390,6 +3486,11 @@ using WebCore::Style::RaySize = std::variant<WebCore::Style::ClosestCorner, WebC
     std::optional<WebCore::Style::Position> position;
 };
 
+enum class WebCore::WindRule : bool {
+    NonZero,
+    EvenOdd
+};
+
 using WebCore::Style::BasicShape = std::variant<WebCore::Style::CircleFunction, WebCore::Style::EllipseFunction, WebCore::Style::InsetFunction, WebCore::Style::PathFunction, WebCore::Style::PolygonFunction, WebCore::Style::ShapeFunction>;
 
 [AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::PixelBuffer subclasses {
@@ -3573,8 +3674,14 @@ class WebCore::ResourceResponse : WebCore::ResourceResponseBase {
 }
 
 header: <WebCore/ResourceResponseBase.h>
-enum class WebCore::UsedLegacyTLS : bool;
-enum class WebCore::WasPrivateRelayed : bool;
+enum class WebCore::UsedLegacyTLS : bool {
+    No,
+    Yes
+};
+enum class WebCore::WasPrivateRelayed : bool {
+    No,
+    Yes
+};
 
 [CustomHeader] struct WebCore::ResourceResponseData {
     URL url;
@@ -4123,8 +4230,6 @@ header: <WebCore/SVGFilterExpression.h>
     WebCore::SVGPreserveAspectRatioValue::SVGMeetOrSliceType m_meetOrSlice;
 };
 
-enum class WebCore::HasInsecureContent : bool
-
 header: <WebCore/ModalContainerTypes.h>
 [CustomHeader] enum class WebCore::ModalContainerDecision : uint8_t {
     Show,
@@ -4206,7 +4311,10 @@ header: <WebCore/ExceptionDetails.h>
 };
 
 header: <WebCore/SecurityPolicyViolationEventDisposition.h>
-enum class WebCore::SecurityPolicyViolationEventDisposition : bool
+enum class WebCore::SecurityPolicyViolationEventDisposition : bool {
+    Enforce,
+    Report
+};
 
 header: <WebCore/FontAttributeChanges.h>
 enum class WebCore::VerticalAlignChange : uint8_t {
@@ -4239,9 +4347,18 @@ header: <pal/SessionID.h>
     [Validator='PAL::SessionID::isValidSessionIDValue(*toUInt64)'] uint64_t toUInt64();
 }
 
-enum class WebCore::RunAsAsyncFunction : bool;
-enum class WebCore::ForceUserGesture : bool;
-enum class WebCore::RemoveTransientActivation : bool;
+enum class WebCore::RunAsAsyncFunction : bool {
+    No,
+    Yes
+};
+enum class WebCore::ForceUserGesture : bool {
+    No,
+    Yes
+};
+enum class WebCore::RemoveTransientActivation : bool {
+    No,
+    Yes
+};
 
 struct WebCore::RunJavaScriptParameters {
     String source;
@@ -4345,7 +4462,10 @@ enum class WebCore::AutocapitalizeType : uint8_t {
     AllCharacters
 };
 
-enum class WebCore::CrossOriginEmbedderPolicyValue : bool
+enum class WebCore::CrossOriginEmbedderPolicyValue : bool {
+    UnsafeNone,
+    RequireCORP
+};
 
 struct WebCore::CrossOriginEmbedderPolicy {
     WebCore::CrossOriginEmbedderPolicyValue value;
@@ -4373,7 +4493,10 @@ struct WebCore::SameSiteInfo {
     bool m_isLocal;
 }
 
-enum class WebCore::IncludeSecureCookies : bool;
+enum class WebCore::IncludeSecureCookies : bool {
+    No,
+    Yes
+};
 
 struct WebCore::CookieRequestHeaderFieldProxy {
     URL firstParty;
@@ -4452,8 +4575,14 @@ header: <WebCore/ScrollingStateNode.h>
 };
 #endif
 
-enum class WebCore::ScrollClamping : bool;
-enum class WebCore::ScrollType : bool;
+enum class WebCore::ScrollClamping : bool {
+    Unclamped,
+    Clamped
+};
+enum class WebCore::ScrollType : bool {
+    User,
+    Programmatic
+};
 
 [CustomHeader] struct WebCore::RequestedScrollData {
     WebCore::ScrollRequestType requestType;
@@ -4472,7 +4601,10 @@ enum class WebCore::ScrollType : bool;
     Vector<WebCore::ElementIdentifier> snapAreasIDs;
 }
 
-enum class WebCore::ScrollSnapStop : bool;
+enum class WebCore::ScrollSnapStop : bool {
+    Normal,
+    Always
+};
 
 [Alias=struct SnapOffset<float>, CustomHeader] alias WebCore::FloatSnapOffset {
     float offset;
@@ -4485,9 +4617,16 @@ enum class WebCore::ScrollSnapStop : bool;
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
-enum class WebCore::CDMEncryptionScheme : bool;
+enum class WebCore::CDMEncryptionScheme : bool {
+    cenc,
+    cbcs
+};
 
-enum class WebCore::CDMKeyGroupingStrategy : bool;
+header: <WebCore/CDMKeyGroupingStrategy.h>
+enum class WebCore::CDMKeyGroupingStrategy : bool {
+    Platform,
+    BuiltIn
+};
 
 struct WebCore::CDMMediaCapability {
     String contentType;
@@ -4538,7 +4677,10 @@ enum class WebCore::MediaDecodingType : uint8_t {
     WebRTC
 };
 
-enum class WebCore::MediaEncodingType : bool;
+enum class WebCore::MediaEncodingType : bool {
+    Record,
+    WebRTC
+};
 
 class WebCore::BufferSource {
     std::span<const uint8_t> span();
@@ -4785,9 +4927,15 @@ class WebCore::GeolocationPositionData {
 };
 
 #if ENABLE(APP_HIGHLIGHTS)
-enum class WebCore::CreateNewGroupForHighlight : bool
+enum class WebCore::CreateNewGroupForHighlight : bool {
+    No,
+    Yes
+};
 
-enum class WebCore::HighlightRequestOriginatedInApp : bool
+enum class WebCore::HighlightRequestOriginatedInApp : bool {
+    No,
+    Yes
+};
 
 struct WebCore::AppHighlight {
     Ref<WebCore::FragmentedSharedBuffer> highlight;
@@ -4925,7 +5073,10 @@ header: <WebCore/ImageBuffer.h>
     WebCore::RenderingPurpose purpose;
 };
 
-enum class WebCore::PreserveResolution : bool;
+enum class WebCore::PreserveResolution : bool {
+    No,
+    Yes
+};
 
 [RValue] class WebCore::ProcessIdentity {
 #if HAVE(TASK_IDENTITY_TOKEN)
@@ -5027,7 +5178,10 @@ enum class WebCore::AudioSessionSoundStageSize : uint8_t {
     Large,
 };
 
-[Nested] enum class WebCore::AudioSession::MayResume : bool;
+[Nested] enum class WebCore::AudioSession::MayResume : bool {
+    No,
+    Yes
+};
 
 enum class WebCore::AudioSessionRoutingArbitrationError : uint8_t {
     None,
@@ -5035,7 +5189,10 @@ enum class WebCore::AudioSessionRoutingArbitrationError : uint8_t {
     Cancelled
 };
 
-[Nested] enum class WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteChanged : bool;
+[Nested] enum class WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteChanged : bool {
+    No,
+    Yes
+};
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)
@@ -5151,7 +5308,10 @@ header: <WebCore/GraphicsTypesGL.h>
 using PlatformGLObject = GCGLuint
 using GCGLuint = unsigned
 
-[Nested, AdditionalEncoder=StreamConnectionEncoder]  enum class WebCore::ShadowRadiusMode : bool;
+[Nested, AdditionalEncoder=StreamConnectionEncoder]  enum class WebCore::ShadowRadiusMode : bool {
+    Default,
+    Legacy
+};
 
 header: <WebCore/GraphicsStyle.h>
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::GraphicsDropShadow {
@@ -5318,7 +5478,10 @@ struct WebCore::PolicyContainer {
     WebCore::ReferrerPolicy referrerPolicy;
 };
 
-[Nested] enum class WebCore::SubstituteData::SessionHistoryVisibility : bool
+[Nested] enum class WebCore::SubstituteData::SessionHistoryVisibility : bool {
+    Visible,
+    Hidden
+};
 
 class WebCore::SubstituteData {
     RefPtr<WebCore::FragmentedSharedBuffer> content();
@@ -5421,8 +5584,14 @@ enum class WebCore::ServiceWorkerClientFrameType : uint8_t {
     None
 };
 
-enum class WebCore::ServiceWorkerIsInspectable : bool
-enum class WebCore::ShouldNotifyWhenResolved : bool
+enum class WebCore::ServiceWorkerIsInspectable : bool {
+    No,
+    Yes
+};
+enum class WebCore::ShouldNotifyWhenResolved : bool {
+    No,
+    Yes
+};
 
 enum class WebCore::ServiceWorkerUpdateViaCache : uint8_t {
     Imports,
@@ -5430,7 +5599,10 @@ enum class WebCore::ServiceWorkerUpdateViaCache : uint8_t {
     None,
 };
 
-enum class WebCore::LastNavigationWasAppInitiated : bool;
+enum class WebCore::LastNavigationWasAppInitiated : bool {
+    No,
+    Yes
+};
 
 struct WebCore::ServiceWorkerClientData {
     WebCore::ScriptExecutionContextIdentifier identifier;
@@ -5504,11 +5676,20 @@ enum class WebCore::StorageAccessWasGranted : uint8_t {
     YesWithException
 };
 
-enum class WebCore::StorageAccessPromptWasShown : bool
+enum class WebCore::StorageAccessPromptWasShown : bool {
+    No,
+    Yes
+};
 
-enum class WebCore::StorageAccessScope : bool
+enum class WebCore::StorageAccessScope : bool {
+    PerFrame,
+    PerPage
+};
 
-enum class WebCore::StorageAccessQuickResult : bool
+enum class WebCore::StorageAccessQuickResult : bool {
+    Grant,
+    Reject
+};
 
 header: <WebCore/DocumentStorageAccess.h>
 [CustomHeader] struct WebCore::RequestStorageAccessResult {
@@ -5668,7 +5849,10 @@ class WebCore::RealtimeMediaSourceSupportedConstraints {
     bool supportsPowerEfficient();
 };
 
-[Nested] enum class WebCore::RealtimeMediaSource::Type : bool;
+[Nested] enum class WebCore::RealtimeMediaSource::Type : bool {
+    Audio,
+    Video
+};
 
 enum class WebCore::VideoFacingMode : uint8_t {
     Unknown,
@@ -5742,7 +5926,10 @@ struct WebCore::CaptureDeviceWithCapabilities {
     WebCore::RealtimeMediaSourceCapabilities capabilities;
 };
 
-[Nested] enum class WebCore::RealtimeMediaSourceCapabilities::EchoCancellation : bool
+[Nested] enum class WebCore::RealtimeMediaSourceCapabilities::EchoCancellation : bool {
+    ReadOnly,
+    ReadWrite
+};
 [Nested] enum class WebCore::RealtimeMediaSourceCapabilities::BackgroundBlur : uint8_t {
     Off,
     On,
@@ -5986,9 +6173,15 @@ enum class WebCore::ColorSchemePreference : uint8_t {
     Dark
 };
 
-enum class WebCore::ModalContainerObservationPolicy : bool
+enum class WebCore::ModalContainerObservationPolicy : bool {
+    Disabled,
+    Prompt
+};
 
-enum class WebCore::AllowsContentJavaScript : bool
+enum class WebCore::AllowsContentJavaScript : bool {
+    No,
+    Yes
+};
 
 [OptionSet] enum class WebCore::AdvancedPrivacyProtections : uint16_t {
     BaselineProtections,
@@ -6013,7 +6206,10 @@ enum class WebCore::ViolationReportType : uint8_t {
     Test
 };
 
-enum class WebCore::COEPDisposition : bool;
+enum class WebCore::COEPDisposition : bool {
+    Reporting,
+    Enforce
+};
 
 [RefCounted] class WebCore::COEPInheritenceViolationReportBody {
     WebCore::COEPDisposition m_disposition;
@@ -6298,7 +6494,10 @@ struct WebCore::GlobalWindowIdentifier {
     MinXMaxYCorner
     MaxXMaxYCorner
 };
-[Nested] enum class WebCore::InteractionRegion::ContentHint : bool;
+[Nested] enum class WebCore::InteractionRegion::ContentHint : bool {
+    Default,
+    Photo
+};
 
 struct WebCore::InteractionRegion {
     WebCore::InteractionRegion::Type type;
@@ -6357,9 +6556,15 @@ header: <WebCore/ISOVTTCue.h>
     String preferredCredentialIdBase64;
 };
 
-[Nested] enum class WebCore::MockWebAuthenticationConfiguration::HidStage : bool;
+[Nested] enum class WebCore::MockWebAuthenticationConfiguration::HidStage : bool {
+    Info,
+    Request
+};
 
-[Nested] enum class WebCore::MockWebAuthenticationConfiguration::HidSubStage : bool;
+[Nested] enum class WebCore::MockWebAuthenticationConfiguration::HidSubStage : bool {
+    Init,
+    Msg
+};
 
 [Nested] enum class WebCore::MockWebAuthenticationConfiguration::HidError : uint8_t {
     Success,
@@ -7033,7 +7238,11 @@ enum class WebCore::WebGPU::TextureAspect : uint8_t {
     DepthOnly,
 };
 
-enum class WebCore::WebGPU::PowerPreference : bool
+header: <WebCore/WebGPUPowerPreference.h>
+enum class WebCore::WebGPU::PowerPreference : bool {
+    LowPower,
+    HighPerformance
+};
 
 header: <WebCore/WebGPUPredefinedColorSpace.h>
 enum class WebCore::WebGPU::PredefinedColorSpace : uint8_t {
@@ -7452,11 +7661,20 @@ header: <WebCore/FontTaggedSettings.h>
     Vector<WebCore::IntFontTaggedSetting> m_list;
 };
 
-enum class WebCore::UserScriptInjectionTime : bool;
+enum class WebCore::UserScriptInjectionTime : bool {
+    DocumentStart,
+    DocumentEnd
+};
 
-enum class WebCore::WaitForNotificationBeforeInjecting : bool;
+enum class WebCore::WaitForNotificationBeforeInjecting : bool {
+    No,
+    Yes
+};
 
-enum class WebCore::UserContentInjectedFrames : bool;
+enum class WebCore::UserContentInjectedFrames : bool {
+    InjectInAllFrames,
+    InjectInTopFrameOnly
+};
 
 class WebCore::UserScript {
     String source();
@@ -7523,14 +7741,15 @@ header: <WebCore/GraphicsContextState.h>
     WebCore::GraphicsContextState::Purpose m_purpose;
 };
 
-enum class WebCore::WindRule : bool
-
 [AdditionalEncoder=StreamConnectionEncoder] struct WebCore::SourceBrushLogicalGradient {
     std::variant<Ref<WebCore::Gradient>, WebCore::RenderingResourceIdentifier> serializableGradient();
     WebCore::AffineTransform spaceTransform;
 };
 
-enum class WebCore::ContentSecurityPolicyHeaderType : bool;
+enum class WebCore::ContentSecurityPolicyHeaderType : bool {
+    Report,
+    Enforce
+};
 
 class WebCore::ContentSecurityPolicyResponseHeaders {
     Vector<std::pair<String, WebCore::ContentSecurityPolicyHeaderType>> headers();
@@ -7595,7 +7814,10 @@ class WebCore::FilterOperations {
     WebCore::FloatRect filterRegion();
 }
 
-[Nested] enum class WebCore::UserStyleLevel : bool;
+[Nested] enum class WebCore::UserStyleLevel : bool {
+    User,
+    Author
+};
 
 header: <WebCore/WheelEventTestMonitor.h>
 [OptionSet] enum class WebCore::WheelEventTestMonitorDeferReason : uint16_t {
@@ -7688,6 +7910,11 @@ enum class WebCore::ResourceErrorBaseType : uint8_t {
      Timeout,
 }
 
+[Nested] enum class WebCore::ResourceErrorBase::IsSanitized : bool {
+    No,
+    Yes
+};
+
 enum class WebCore::CredentialPersistence : uint8_t {
      None,
      ForSession,
@@ -7703,7 +7930,10 @@ enum class WebCore::PaginationMode : uint8_t {
 };
 
 header: <WebCore/RenderObject.h>
-enum class WebCore::RepaintRectCalculation : bool;
+enum class WebCore::RepaintRectCalculation : bool {
+    Fast,
+    Accurate
+};
 
 [Nested] enum class WebCore::HdrMetadataType : uint8_t {
     SmpteSt2086,
@@ -7818,10 +8048,22 @@ struct WebCore::MarkupExclusionRule {
 };
 
 header: <WebCore/Font.h>
-[Nested] enum class WebCore::FontOrigin : bool;
-[Nested] enum class WebCore::FontIsInterstitial : bool;
-[Nested] enum class WebCore::FontVisibility : bool;
-[Nested] enum class WebCore::FontIsOrientationFallback : bool;
+[Nested] enum class WebCore::FontOrigin : bool {
+    Remote,
+    Local
+};
+[Nested] enum class WebCore::FontIsInterstitial : bool {
+    No,
+    Yes
+};
+[Nested] enum class WebCore::FontVisibility : bool {
+    Visible,
+    Invisible
+};
+[Nested] enum class WebCore::FontIsOrientationFallback : bool {
+    No,
+    Yes
+};
 
 #if ENABLE(VIDEO)
 header: <WebCore/CaptionUserPreferences.h>
@@ -8278,9 +8520,15 @@ enum class WebCore::TransformOperationType : uint8_t {
     None
 };
 
-enum class WebCore::GraphicsContextGLSurfaceBuffer : bool;
+enum class WebCore::GraphicsContextGLSurfaceBuffer : bool {
+    DrawingBuffer,
+    DisplayBuffer
+};
 
-[Nested] enum class WebCore::GraphicsLayer::CustomAppearance : bool;
+[Nested] enum class WebCore::GraphicsLayer::CustomAppearance : bool {
+    None,
+    ScrollingShadow
+};
 
 [OptionSet] enum class GCGLErrorCode : uint8_t {
     ContextLost,
@@ -8513,7 +8761,10 @@ using WebCore::MediaProducerMutedStateFlags = OptionSet<WebCore::MediaProducerMu
 using WebCore::FramesPerSecond = unsigned
 using WebCore::PlatformGPUID = uint64_t
 using WebCore::GraphicsStyle = std::variant<WebCore::GraphicsDropShadow, WebCore::GraphicsGaussianBlur, WebCore::GraphicsColorMatrix>
-enum class WebCore::ScrollBehaviorForFixedElements : bool
+enum class WebCore::ScrollBehaviorForFixedElements : bool {
+    StickToDocumentBounds,
+    StickToViewportBounds
+};
 #if USE(CG)
 using WebCore::GlyphBufferGlyph = CGGlyph
 using WebCore::GlyphBufferAdvance = CGSize
@@ -8523,7 +8774,10 @@ using WebCore::GlyphBufferAdvance = WebCore::FloatSize
 #endif
 using WebCore::Glyph = unsigned short
 
-enum class WebCore::ContentExtensionDefaultEnablement : bool
+enum class WebCore::ContentExtensionDefaultEnablement : bool {
+    Disabled,
+    Enabled
+};
 using WebCore::ContentExtensionEnablement = std::pair<WebCore::ContentExtensionDefaultEnablement, HashSet<String>>;
 
 #if USE(CG)
@@ -8565,9 +8819,10 @@ using WebCore::EpochTimeStamp = uint64_t
 using WebCore::SharedMemory::Handle = WebCore::SharedMemoryHandle
 using WebCore::ServiceWorkerOrClientIdentifier = std::variant<WebCore::ScriptExecutionContextIdentifier, WebCore::ServiceWorkerIdentifier>
 
-[Nested] enum class WebCore::GraphicsContext::RequiresClipToRect : bool
-
-enum class WebCore::HighlightVisibility : bool
+enum class WebCore::HighlightVisibility : bool {
+    Hidden,
+    Visible
+};
 
 #if OS(WINDOWS)
 using ProcessID = int;
@@ -8645,7 +8900,10 @@ using Inspector::ExtensionTabID = String
 using WebCore::ArgumentWireBytesMap = HashMap<String, Vector<uint8_t>>
 using WebCore::IDBKeyPath = std::variant<String, Vector<String>>;
 using WebCore::ServiceWorkerOrClientData = std::variant<WebCore::ServiceWorkerData, WebCore::ServiceWorkerClientData>
-enum class WebCore::CrossOriginMode : bool
+enum class WebCore::CrossOriginMode : bool {
+    Shared,
+    Isolated
+};
 
 [CreateUsing=fromRawString] class WebCore::PublicSuffix {
     String string();
@@ -8661,15 +8919,34 @@ struct WebCore::WrappedCryptoKey {
 using WebCore::RenderThemeIOS::CSSValueToSystemColorMap = HashMap<WebCore::CSSValueKey, WebCore::Color>
 #endif
 
-enum class WebCore::WorkerThreadMode : bool
-enum class WebCore::WillContinueLoading : bool
+header: <WebCore/WorkerThreadMode.h>
+enum class WebCore::WorkerThreadMode : bool {
+    UseMainThread,
+    CreateNewThread
+};
+enum class WebCore::WillContinueLoading : bool {
+    No,
+    Yes
+};
 
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 header: <WebCore/CDMPrivate.h>
-[Nested] enum class WebCore::CDMPrivate::LocalStorageAccess : bool
-[Nested] enum class WebCore::CDMInstance::AllowPersistentState : bool
-[Nested] enum class WebCore::CDMInstance::SuccessValue : bool
-[Nested] enum class WebCore::CDMInstance::AllowDistinctiveIdentifiers : bool
+[Nested] enum class WebCore::CDMPrivate::LocalStorageAccess : bool {
+    NotAllowed,
+    Allowed
+};
+[Nested] enum class WebCore::CDMInstance::AllowPersistentState : bool {
+    No,
+    Yes
+};
+[Nested] enum class WebCore::CDMInstance::SuccessValue : bool {
+    Failed,
+    Succeeded
+};
+[Nested] enum class WebCore::CDMInstance::AllowDistinctiveIdentifiers : bool {
+    No,
+    Yes
+};
 #endif
 
 #if ENABLE(GPU_PROCESS) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
@@ -8679,21 +8956,43 @@ using WebCore::LegacyCDMSessionClient::MediaKeyErrorCode = unsigned short
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 # FIXME: This should be an OptionSet<LoadOption>
 using WebCore::PlatformMediaResourceLoader::LoadOptions = unsigned
-enum class WebCore::ShouldContinuePolicyCheck : bool
+enum class WebCore::ShouldContinuePolicyCheck : bool {
+    No,
+    Yes
+};
 #endif
 
 #if ENABLE(GAMEPAD)
-enum class WebCore::EventMakesGamepadsVisible : bool
+header: <WebCore/GamepadProviderClient.h>
+enum class WebCore::EventMakesGamepadsVisible : bool {
+    No,
+    Yes
+};
 
 #if PLATFORM(VISION)
-enum class WebCore::ShouldRequireExplicitConsentForGamepadAccess : bool;
+enum class WebCore::ShouldRequireExplicitConsentForGamepadAccess : bool {
+    No,
+    Yes
+};
 #endif
 #endif
 
-enum class WebCore::WillInternallyHandleFailure : bool
-enum class WebCore::ApplyTrackingPrevention : bool
-enum class WebCore::ShouldSample : bool
-enum class WebCore::FromDownloadAttribute : bool
+enum class WebCore::WillInternallyHandleFailure : bool {
+    No,
+    Yes
+};
+enum class WebCore::ApplyTrackingPrevention : bool {
+    No,
+    Yes
+};
+enum class WebCore::ShouldSample : bool {
+    No,
+    Yes
+};
+enum class WebCore::FromDownloadAttribute : bool {
+    No,
+    Yes
+};
 
 [Nested] struct WebCore::Allowlist::AllowAllOrigins {
 };

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -94,7 +94,10 @@ class WebKit::WebKeyboardEvent : WebKit::WebEvent {
 };
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(IOS_TOUCH_EVENTS)
-[Nested] enum class WebKit::WebPlatformTouchPoint::TouchType : bool
+[Nested] enum class WebKit::WebPlatformTouchPoint::TouchType : bool {
+    Direct,
+    Stylus
+};
 #endif
 
 #if ENABLE(TOUCH_EVENTS)
@@ -160,7 +163,17 @@ class WebKit::WebTouchEvent : WebKit::WebEvent {
     TwoFingerTap
 };
 
-enum class WebKit::GestureWasCancelled : bool;
+enum class WebKit::GestureWasCancelled : bool {
+    No,
+    Yes
+};
+
+#if !PLATFORM(MAC) && PLATFORM(GTK)
+[Nested] enum class WebCore::PlatformMouseEvent::IsTouch : bool {
+    No,
+    Yes
+};
+#endif
 
 class WebKit::WebMouseEvent : WebKit::WebEvent {
     WebKit::WebMouseEventButton button();

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -22,7 +22,10 @@
 
 headers: "ArgumentCoders.h"
 
-enum class WebCore::UserInterfaceLayoutDirection : bool;
+enum class WebCore::UserInterfaceLayoutDirection : bool {
+    LTR,
+    RTL
+};
 
 [RValue, DebugDecodingFailure] struct WebKit::WebPageCreationParameters {
     WebCore::IntSize viewSize;

--- a/Source/WebKit/Shared/WebPopupItem.serialization.in
+++ b/Source/WebKit/Shared/WebPopupItem.serialization.in
@@ -20,9 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[Nested] enum class WebKit::WebPopupItem::Type : bool
-
-enum class WebCore::TextDirection : bool;
+[Nested] enum class WebKit::WebPopupItem::Type : bool {
+    Separator,
+    Item
+};
 
 struct WebKit::WebPopupItem {
     WebKit::WebPopupItem::Type m_type;

--- a/Source/WebKit/Shared/ios/GestureTypes.serialization.in
+++ b/Source/WebKit/Shared/ios/GestureTypes.serialization.in
@@ -59,4 +59,9 @@ enum class WebKit::SelectionTouch : uint8_t {
     EndedNotMoving
 };
 
+enum class WebKit::RespectSelectionAnchor : bool {
+    No,
+    Yes
+};
+
 #endif

--- a/Source/WebKit/Shared/mac/PDFContextMenuItem.serialization.in
+++ b/Source/WebKit/Shared/mac/PDFContextMenuItem.serialization.in
@@ -23,9 +23,18 @@
 
 #if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
 
-enum class WebKit::ContextMenuItemEnablement : bool;
-enum class WebKit::ContextMenuItemHasAction : bool;
-enum class WebKit::ContextMenuItemIsSeparator : bool;
+enum class WebKit::ContextMenuItemEnablement : bool {
+    Disabled,
+    Enabled
+};
+enum class WebKit::ContextMenuItemHasAction : bool {
+    No,
+    Yes
+};
+enum class WebKit::ContextMenuItemIsSeparator : bool {
+    No,
+    Yes
+};
 
 [CustomHeader] struct WebKit::PDFContextMenuItem {
     String title;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
@@ -36,14 +36,3 @@ struct WebKit::RemoteAudioSessionConfiguration {
 };
     
 #endif
-
-#if ENABLE(GPU_PROCESS) && PLATFORM(IOS_FAMILY)
-header: "RemoteMediaSessionHelper.h"
-[Nested] enum class WebKit::RemoteMediaSessionHelper::ShouldPause : bool
-[Nested] enum class WebKit::RemoteMediaSessionHelper::HasAvailableTargets : bool
-[Nested] enum class WebKit::RemoteMediaSessionHelper::SupportsAirPlayVideo : bool
-[Nested] enum class WebKit::RemoteMediaSessionHelper::PlayingToAutomotiveHeadUnit : bool
-[Nested] enum class WebKit::RemoteMediaSessionHelper::SuspendedUnderLock : bool
-[Nested] enum class WebKit::RemoteMediaSessionHelper::SupportsSpatialAudioPlayback : bool
-enum class WebKit::RespectSelectionAnchor : bool
-#endif

--- a/Source/WebKit/WebProcess/UserContent/InjectUserScriptImmediately.serialization.in
+++ b/Source/WebKit/WebProcess/UserContent/InjectUserScriptImmediately.serialization.in
@@ -22,4 +22,7 @@
 
 header: "InjectUserScriptImmediately.h"
 
-enum class WebKit::InjectUserScriptImmediately : bool;
+enum class WebKit::InjectUserScriptImmediately : bool {
+    No,
+    Yes
+};


### PR DESCRIPTION
#### 84e9e3fac3457d6c2b93202eb238dd546e4daa44
<pre>
Replace isValidEnum(bool) with annotations in *.serialization.in files
<a href="https://bugs.webkit.org/show_bug.cgi?id=277619">https://bugs.webkit.org/show_bug.cgi?id=277619</a>
<a href="https://rdar.apple.com/124008366">rdar://124008366</a>

Reviewed by NOBODY (OOPS!).

Serialization annotations are useful to the fuzzer, and were not
provided for bool-based enums.

This patch includes the following changes:
- Add annotations to fully specify all bool-based enums
  (they used to just be declarations assuming 0 and 1 values);
- Reorganize a few annotations which were not in their ideal
  serialization.in file.
- Remove special-case for bool-based enums in generate-serializers.py.
- Remove the second template parameter for isValidEnum, which was only
  used to specialize on bool underlying type.
- Forward-declare generic isValidEnum (with no EnumTraits), this is
  necessary for &quot;[Nested]&quot; enums that themselves cannot be forward-
  declared.
- Simplify EnumValueChecker to remove template recursion, using a fold
  expression instead.

* Source/WTF/wtf/EnumTraits.h:
(WTF::isValidEnum):
* Source/WebCore/Modules/indexeddb/IndexedDB.serialization.in:
* Source/WebCore/platform/ContextMenuItem.cpp:
(WTF::isValidEnum&lt;WebCore::ContextMenuAction&gt;):
* Source/WebCore/platform/ContextMenuItem.h:
* Source/WebCore/platform/audio/PlatformMediaSession.serialization.in:
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.serialization.in:
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedEnum.function_name):
(generate_header):
(generate_impl):
(generate_serialized_type_info):
(parse_serialized_types):
(SerializedEnum.additional_template_parameter): Deleted.
* Source/WebKit/Scripts/webkit/messages.py:
(generate_message_names_header):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(WTF::isValidEnum&lt;IPC::WebCore_TimingFunction_Subclass&gt;):
(WTF::isValidEnum&lt;IPC::WebCore_MoveOnlyBaseClass_Subclass&gt;):
(WTF::isValidEnum&lt;EnumWithoutNamespace&gt;):
(WTF::isValidEnum&lt;EnumNamespace::EnumType&gt;):
(WTF::isValidEnum&lt;EnumNamespace::InnerEnumType&gt;):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
(WTF::isValidEnum&lt;IPC::MessageName&gt;):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in:
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionContext.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionTab.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in:
* Source/WebKit/Shared/FrameInfoData.serialization.in:
* Source/WebKit/Shared/InspectorExtensionTypes.serialization.in:
* Source/WebKit/Shared/JavaScriptCore.serialization.in:
* Source/WebKit/Shared/LoadParameters.serialization.in:
* Source/WebKit/Shared/NavigationActionData.serialization.in:
* Source/WebKit/Shared/PolicyDecision.serialization.in:
* Source/WebKit/Shared/PushMessageForTesting.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/ResourceLoadStatisticsParameters.serialization.in:
* Source/WebKit/Shared/TextFlags.serialization.in:
* Source/WebKit/Shared/UndoOrRedo.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/Shared/WebPopupItem.serialization.in:
* Source/WebKit/Shared/ios/GestureTypes.serialization.in:
* Source/WebKit/Shared/mac/PDFContextMenuItem.serialization.in:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in:
* Source/WebKit/WebProcess/UserContent/InjectUserScriptImmediately.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84e9e3fac3457d6c2b93202eb238dd546e4daa44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/75115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/54554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/27955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/79571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/26371 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/77232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/63694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/2339 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/58968 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/17216 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/78182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/49136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/64535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/39345 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/74623 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/46501 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/22036 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/24695 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/68262 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/67590 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/22375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/81048 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/74378 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/2445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/1511 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/67235 "Found 2 new test failures: imported/blink/compositing/animation/hidden-animated-layer-should-not-have-scrollbars.html imported/w3c/web-platform-tests/css/css-animations/translation-animation-subpixel-offset.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/2595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/64540 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/66521 "Found 1 new API test failure: /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/10455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/8628 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/96646 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/2406 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/5384 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/21119 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/2431 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/3360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/2440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->