### PR TITLE
Update JetStream2 signpost patch to only include measured period

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/JetStream2.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/JetStream2.patch
@@ -1,22 +1,76 @@
 diff --git a/PerformanceTests/JetStream2/JetStreamDriver.js b/PerformanceTests/JetStream2/JetStreamDriver.js
-index 0bc36c9e62a1..ec4aaa0c2f1d 100644
+index 9079f300cd95..2de6fad99aaa 100644
 --- a/JetStreamDriver.js
 +++ b/JetStreamDriver.js
-@@ -645,6 +645,8 @@ class Benchmark {
-         if (RAMification)
-             resetMemoryPeak();
+@@ -544,6 +544,7 @@ get runnerCode() {
+         return `
+             let __benchmark = new Benchmark(${this.iterations});
+             let results = [];
++            __signpostStart(${JSON.stringify(this.name)});
+             for (let i = 0; i < ${this.iterations}; i++) {
+                 if (__benchmark.prepareForNextIteration)
+                     __benchmark.prepareForNextIteration();
+@@ -554,6 +555,7 @@ get runnerCode() {
  
-+        __signpostStart(this.name)
-+
-         let magicFrame;
-         try {
-             magicFrame = JetStream.runCode(code);
-@@ -654,6 +656,8 @@ class Benchmark {
-         }
-         let results = await promise;
+                 results.push(Math.max(1, end - start));
+             }
++            __signpostStop(${JSON.stringify(this.name)});
+             if (__benchmark.validate)
+                 __benchmark.validate();
+             top.currentResolve(results);`;
+@@ -956,6 +958,7 @@ get runnerCode() {
+         return `
+         async function doRun() {
+             let __benchmark = new Benchmark();
++            __signpostStart(${JSON.stringify(this.name)});
+             let results = [];
+             for (let i = 0; i < ${this.iterations}; i++) {
+                 let start = Date.now();
+@@ -963,6 +966,7 @@ async function doRun() {
+                 let end = Date.now();
+                 results.push(Math.max(1, end - start));
+             }
++            __signpostStop(${JSON.stringify(this.name)});
+             if (__benchmark.validate)
+                 __benchmark.validate();
+             top.currentResolve(results);
+@@ -992,6 +996,7 @@ get runnerCode() {
+         return `
+             let benchmark = new Benchmark();
+             let results = [];
++            __signpostStart(${JSON.stringify(this.name)});
+             {
+                 let start = Date.now();
+                 benchmark.buildStdlib();
+@@ -1003,6 +1008,7 @@ get runnerCode() {
+                 benchmark.run();
+                 results.push(Date.now() - start);
+             }
++            __signpostStop(${JSON.stringify(this.name)});
  
-+        __signpostStop(this.name)
-+
-         this.endTime = new Date();
+             top.currentResolve(results);
+             `;
+@@ -1089,6 +1095,7 @@ get prerunCode() {
+                 if (runTime !== null)
+                     throw new Error("called report run time twice")
+                 runTime = t;
++                __signpostStop(${JSON.stringify(this.name)});
+                 top.currentResolve([compileTime, runTime]);
+             };
  
-         if (RAMification) {
+@@ -1130,6 +1137,7 @@ get runnerCode() {
+                 xhr.responseType = 'arraybuffer';
+                 xhr.onload = function() {
+                     Module.wasmBinary = xhr.response;
++                    __signpostStart(${JSON.stringify(this.name)});
+                     doRun();
+                 };
+                 xhr.send(null);
+@@ -1146,6 +1154,7 @@ get runnerCode() {
+             Module.monitorRunDependencies = null;
+ 
+             Promise.resolve(42).then(() => {
++                __signpostStart(${JSON.stringify(this.name)});
+                 try {
+                     doRun();
+                 } catch(e) {


### PR DESCRIPTION
#### ff66688336c778249eedbee2102cbfd7e2d90aad
<pre>
Update JetStream2 signpost patch to only include measured period
<a href="https://bugs.webkit.org/show_bug.cgi?id=277127">https://bugs.webkit.org/show_bug.cgi?id=277127</a>
<a href="https://rdar.apple.com/132553952">rdar://132553952</a>

Reviewed by Yijia Huang.

This patch fixes JetStream2.patch to only include measured period as the previous period was including non-measured period.

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/JetStream2.patch:

Canonical link: <a href="https://commits.webkit.org/281404@main">https://commits.webkit.org/281404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e85aeb776a1c99d441364207a11ba1d209f6a51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63677 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10285 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10448 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48468 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7191 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51739 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29309 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/59288 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8981 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9208 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55127 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65408 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55807 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3700 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55944 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3066 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8943 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34920 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36003 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37089 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->