### PR TITLE
Credential Management: more explicitly disallow multiple simultaneous requests.

### DIFF
--- a/LayoutTests/http/wpt/credential-management/credentialscontainer-get-basics.https-expected.txt
+++ b/LayoutTests/http/wpt/credential-management/credentialscontainer-get-basics.https-expected.txt
@@ -4,4 +4,7 @@ PASS navigator.credentials.get() with empty argument.
 PASS navigator.credentials.get() with bogus publicKey data
 PASS navigator.credentials.get() with bogus data
 PASS navigator.credentials.get() with abort signal set
+PASS navigator.credentials.get() with multiple request types.
+PASS navigator.credentials.get() with a single mediation argument.
+PASS navigator.credentials.get() with only a mediation and signal.
 

--- a/LayoutTests/http/wpt/credential-management/credentialscontainer-get-basics.https.html
+++ b/LayoutTests/http/wpt/credential-management/credentialscontainer-get-basics.https.html
@@ -2,6 +2,7 @@
 <title>Credential Management API: get() basics.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="../webauthn/resources/util.js"></script>
 <script>
 promise_test(function(t) {
     return promise_rejects_dom(t, "NotSupportedError",
@@ -31,4 +32,43 @@ promise_test(function(t) {
     return promise_rejects_dom(t, "AbortError",
         navigator.credentials.get(options));
 }, "navigator.credentials.get() with abort signal set");
+
+promise_test(async (t) => {
+    const options = {
+        digital: { providers: [] },
+        publicKey: {
+            challenge: Base64URL.parse("MTIzNDU2"),
+            timeout: 100
+        },
+    };
+    const p = navigator.credentials.get(options);
+    await promise_rejects_dom(t, "NotSupportedError", p);
+    try {
+        await p;
+    } catch (e) {
+        assert_equals(e.message, "Only one request type is supported at a time.");
+    }
+}, "navigator.credentials.get() with multiple request types.");
+
+promise_test(async (t) => {
+    const p =navigator.credentials.get({ mediation: "silent" });
+    await promise_rejects_dom(t, "NotSupportedError", p);
+    try {
+        await p;
+    } catch (e) {
+        assert_equals(e.message, "Missing request type.");
+    }
+}, "navigator.credentials.get() with a single mediation argument.");
+
+promise_test(async (t) => {
+    const {signal} = new AbortController();
+    const options = { signal, mediation: "silent" };
+    const p = navigator.credentials.get(options);
+    await promise_rejects_dom(t, "NotSupportedError", p);
+    try {
+        await p;
+    } catch (e) {
+        assert_equals(e.message, "Missing request type.");
+    }
+}, "navigator.credentials.get() with only a mediation and signal.");
 </script>

--- a/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html
+++ b/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html
@@ -39,7 +39,7 @@
         await promise_rejects_dom(
             test,
             "NotAllowedError",
-            navigator.identity.get({})
+            navigator.identity.get({ digital: { providers: [] } })
         );
     }, "navigator.identity.get() can't be used with hidden documents.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-user-activation.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-user-activation.https.html
@@ -6,28 +6,32 @@
 <script src="/resources/testharnessreport.js"></script>
 <body></body>
 <script>
-  promise_test(async (t) => {
-    assert_false(
-        navigator.userActivation.isActive,
-        "User activation should not be active"
-    );
-    await promise_rejects_dom(t, "NotAllowedError", navigator.identity.get({}));
-  }, "navigator.identity.get() calling the API without user activation should reject with NotAllowedError.");
+    promise_test(async (t) => {
+        assert_false(
+            navigator.userActivation.isActive,
+            "User activation should not be active"
+        );
+        await promise_rejects_dom(
+            t,
+            "NotAllowedError",
+            navigator.identity.get({ digital: { providers: [] } })
+        );
+    }, "navigator.identity.get() calling the API without user activation should reject with NotAllowedError.");
 
-  promise_test(async (t) => {
-    await test_driver.bless();
-    assert_true(
-        navigator.userActivation.isActive,
-        "User activation should be active after test_driver.bless()."
-    );
-    await promise_rejects_dom(
-        t,
-        "NotSupportedError",
-        navigator.identity.get({})
-    );
-    assert_false(
-        navigator.userActivation.isActive,
-        "User activation should be consumed after navigator.identity.get()."
-    );
-  }, "navigator.identity.get() consumes user activation.");
+    promise_test(async (t) => {
+        await test_driver.bless();
+        assert_true(
+            navigator.userActivation.isActive,
+            "User activation should be active after test_driver.bless()."
+        );
+        await promise_rejects_js(
+            t,
+            TypeError,
+            navigator.identity.get({ digital: { providers: [] } })
+        );
+        assert_false(
+            navigator.userActivation.isActive,
+            "User activation should be consumed after navigator.identity.get()."
+        );
+    }, "navigator.identity.get() consumes user activation.");
 </script>


### PR DESCRIPTION
#### 7bc20669060f916510721ead93752f24e7092753
<pre>
Credential Management: more explicitly disallow multiple simultaneous requests.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277129">https://bugs.webkit.org/show_bug.cgi?id=277129</a>
<a href="https://rdar.apple.com/132556068">rdar://132556068</a>

Reviewed by Pascoe.

Now more explicitly disallows empty requests and simultaneous requests.
This just continues to return a NotAllowedError as before, but now is more clear as to why.

* LayoutTests/http/wpt/credential-management/credentialscontainer-get-basics.https-expected.txt:
* LayoutTests/http/wpt/credential-management/credentialscontainer-get-basics.https.html:
* LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get-user-activation.https.html:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::performCommonChecks):

Canonical link: <a href="https://commits.webkit.org/281534@main">https://commits.webkit.org/281534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8f36113bbbf135d3c154552d2e2937b86a0bc2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10655 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48706 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7440 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62156 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36803 "Found 2 new test failures: fast/forms/datalist/datalist-option-labels.html fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29548 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9317 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9575 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55425 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65775 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56062 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56215 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13358 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3376 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35286 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36368 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37456 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->