### PR TITLE
[GTK][WPE] Add the capability to perform server waits to GLFence

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLFence.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLFence.cpp
@@ -50,15 +50,14 @@ bool GLFence::isSupported()
     return supported;
 }
 
-std::unique_ptr<GLFence> GLFence::create(ShouldFlush shouldFlush)
+std::unique_ptr<GLFence> GLFence::create()
 {
     if (!GLContextWrapper::currentContext())
         return nullptr;
 
     if (isSupported()) {
         if (auto* sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)) {
-            if (shouldFlush == ShouldFlush::Yes)
-                glFlush();
+            glFlush();
             return makeUnique<GLFence>(sync);
         }
         return nullptr;
@@ -78,9 +77,14 @@ GLFence::~GLFence()
         glDeleteSync(m_sync);
 }
 
-unsigned GLFence::wait(FlushCommands flushCommands)
+void GLFence::serverWait()
 {
-    return glClientWaitSync(m_sync, flushCommands == FlushCommands::Yes ? GL_SYNC_FLUSH_COMMANDS_BIT : 0, GL_TIMEOUT_IGNORED);
+    glWaitSync(m_sync, 0, GL_TIMEOUT_IGNORED);
+}
+
+void GLFence::clientWait()
+{
+    glClientWaitSync(m_sync, 0, GL_TIMEOUT_IGNORED);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/egl/GLFence.h
+++ b/Source/WebCore/platform/graphics/egl/GLFence.h
@@ -31,13 +31,12 @@ class GLFence {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static bool isSupported();
-    enum class ShouldFlush : bool { No, Yes };
-    WEBCORE_EXPORT static std::unique_ptr<GLFence> create(ShouldFlush = ShouldFlush::Yes);
+    WEBCORE_EXPORT static std::unique_ptr<GLFence> create();
     explicit GLFence(GLsync);
     ~GLFence();
 
-    enum class FlushCommands : bool { No, Yes };
-    unsigned wait(FlushCommands);
+    void serverWait();
+    void clientWait();
 
 private:
     GLsync m_sync;

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
@@ -192,7 +192,7 @@ void AcceleratedBuffer::waitUntilPaintingComplete()
     if (!m_fence)
         return;
 
-    m_fence->wait(WebCore::GLFence::FlushCommands::No);
+    m_fence->serverWait();
     m_fence = nullptr;
 }
 #endif

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPlaceholderRenderingContextSource.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPlaceholderRenderingContextSource.cpp
@@ -183,7 +183,7 @@ void NicosiaPlaceholderRenderingContextSource::setPlaceholderBuffer(ImageBuffer&
                 auto image = nativeImage->platformImage();
                 if (image->isTextureBacked()) {
 #if PLATFORM(GTK) || PLATFORM(WPE)
-                    fence->wait(WebCore::GLFence::FlushCommands::No);
+                    fence->serverWait();
 #endif // PLATFORM(GTK) || PLATFORM(WPE)
                     texture->copyFromExternalTexture(textureID);
 #if PLATFORM(GTK) || PLATFORM(WPE)

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -176,7 +176,7 @@ void ImageBufferSkiaAcceleratedBackend::swapBuffersIfNeeded()
     IntSize textureSize(info.width(), info.height());
     if (!m_texture.back)
         m_texture.back = BitmapTexture::create(textureSize, BitmapTexture::Flags::SupportsAlpha);
-    fence->wait(GLFence::FlushCommands::No);
+    fence->serverWait();
     m_texture.back->copyFromExternalTexture(textureInfo.fID);
     fence = GLFence::create();
     std::swap(m_texture.back, m_texture.front);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
@@ -98,7 +98,7 @@ void TextureMapperPlatformLayerBuffer::paintToTextureMapper(TextureMapper& textu
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
     if (m_fence) {
-        m_fence->wait(WebCore::GLFence::FlushCommands::No);
+        m_fence->serverWait();
         m_fence = nullptr;
     }
 #endif

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
@@ -191,7 +191,7 @@ void TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper(Te
         return;
 
     if (m_fence) {
-        m_fence->wait(WebCore::GLFence::FlushCommands::No);
+        m_fence->serverWait();
         m_fence = nullptr;
     }
 

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -606,8 +606,8 @@ void AcceleratedSurfaceDMABuf::didRenderFrame(WebCore::Region&& damage)
     if (!m_target)
         return;
 
-    if (auto fence = WebCore::GLFence::create(WebCore::GLFence::ShouldFlush::No))
-        fence->wait(WebCore::GLFence::FlushCommands::Yes);
+    if (auto fence = WebCore::GLFence::create())
+        fence->clientWait();
     else
         glFlush();
 


### PR DESCRIPTION
#### 0d5cd3489c087f813f8a711c2ac347cfbe4dfec2
<pre>
[GTK][WPE] Add the capability to perform server waits to GLFence
<a href="https://bugs.webkit.org/show_bug.cgi?id=277134">https://bugs.webkit.org/show_bug.cgi?id=277134</a>

Reviewed by NOBODY (OOPS!).

Add both waitServer() and waitClient() methods to GLFence, so it can perform
client or server waits. Replace the former calls to wait() with the appropriate
new one depending on the case.

* Source/WebCore/platform/graphics/egl/GLFence.cpp:
(WebCore::GLFence::create):
(WebCore::GLFence::serverWait):
(WebCore::GLFence::clientWait):
(WebCore::GLFence::wait): Deleted.
* Source/WebCore/platform/graphics/egl/GLFence.h:
* Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp:
(Nicosia::AcceleratedBuffer::waitUntilPaintingComplete):
* Source/WebCore/platform/graphics/nicosia/NicosiaPlaceholderRenderingContextSource.cpp:
(Nicosia::NicosiaPlaceholderRenderingContextSource::setPlaceholderBuffer):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::swapBuffersIfNeeded):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp:
(WebCore::TextureMapperPlatformLayerBuffer::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp:
(WebCore::TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d5cd3489c087f813f8a711c2ac347cfbe4dfec2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63697 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10305 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48479 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7204 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9002 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9228 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65428 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3709 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9147 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-smooth-positions.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55820 "Found 1 new test failure: fast/css/text-overflow-input.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55958 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3082 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34940 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36023 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->