### PR TITLE
Avoid unaligned FP memory accesses on ARMv7

### DIFF
--- a/Source/JavaScriptCore/assembler/CPU.h
+++ b/Source/JavaScriptCore/assembler/CPU.h
@@ -51,6 +51,11 @@ constexpr bool isARM_THUMB2()
 #endif
 }
 
+constexpr bool hasUnalignedFPMemoryAccess()
+{
+    return !isARM_THUMB2();
+}
+
 constexpr bool isARM64()
 {
 #if CPU(ARM64)

--- a/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
@@ -976,9 +976,13 @@ private:
         //     b = Op a
 
         ArgPromise addr = loadPromise(value);
-        if (isValidForm(opcode, addr.kind(), Arg::Tmp)) {
-            append(addr.inst(opcode, m_value, addr.consume(*this), result));
-            return;
+        // Don't use this form for FP loads/stores on on platforms where it may
+        // fault.
+        if (hasUnalignedFPMemoryAccess() || (opcode32 != Air::Move32ToFloat && opcodeFloat != Air::MoveFloatTo32)) {
+            if (isValidForm(opcode, addr.kind(), Arg::Tmp)) {
+                append(addr.inst(opcode, m_value, addr.consume(*this), result));
+                return;
+            }
         }
 
         if (isValidForm(opcode, Arg::Tmp, Arg::Tmp)) {


### PR DESCRIPTION
#### c7b5b3ef99964513d4572a5c4196b83fcff9b53a
<pre>
Avoid unaligned FP memory accesses on ARMv7
<a href="https://bugs.webkit.org/show_bug.cgi?id=277135">https://bugs.webkit.org/show_bug.cgi?id=277135</a>

Reviewed by Yusuke Suzuki.

On ARMv7 loads/stores of Float/Double values may fault on unaligned
accesses.  Currently, the ARMv7 assembler assumes that can&apos;t happen
(which is the case for JS). Instead of penalizing JS code, leave that
assumption in and convert B3 loads/stores of Float/Double to use Int32
memory accesses.

* Source/JavaScriptCore/assembler/CPU.h:
(JSC::hasUnalignedFPMemoryAccess):
* Source/JavaScriptCore/b3/B3LowerInt64.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp:

Canonical link: <a href="https://commits.webkit.org/281684@main">https://commits.webkit.org/281684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/803d86131b197cf3880b56b252584e9a185f7560

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64010 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10622 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48691 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7424 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52053 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29533 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9290 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9542 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/53186 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55401 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65742 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59337 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56046 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4040 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52034 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56199 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13517 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3348 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81095 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35253 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14088 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36335 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37423 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->