### PR TITLE
[GTK][WPE] Add support for EGL fences

### DIFF
--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -99,7 +99,11 @@ if (ENABLE_WEBGL)
 endif ()
 
 if (USE_SKIA)
-    list(APPEND WebCore_SOURCES platform/graphics/egl/GLFence.cpp)
+    list(APPEND WebCore_SOURCES
+        platform/graphics/egl/GLFence.cpp
+        platform/graphics/egl/GLFenceEGL.cpp
+        platform/graphics/egl/GLFenceGL.cpp
+    )
 endif ()
 
 # Find the extras needed to copy for EGL besides the libraries

--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -57,6 +57,8 @@ list(APPEND WebCore_SOURCES
     platform/graphics/egl/GLContext.cpp
     platform/graphics/egl/GLContextWrapper.cpp
     platform/graphics/egl/GLFence.cpp
+    platform/graphics/egl/GLFenceEGL.cpp
+    platform/graphics/egl/GLFenceGL.cpp
 
     platform/graphics/opentype/OpenTypeUtilities.cpp
 

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -63,6 +63,8 @@ platform/graphics/angle/PlatformDisplayANGLE.cpp @no-unify
 platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextWrapper.cpp @no-unify
 platform/graphics/egl/GLFence.cpp @no-unify
+platform/graphics/egl/GLFenceEGL.cpp @no-unify
+platform/graphics/egl/GLFenceGL.cpp @no-unify
 platform/graphics/egl/PlatformDisplaySurfaceless.cpp @no-unify
 
 platform/graphics/gbm/DRMDeviceManager.cpp

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -64,6 +64,8 @@ platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextLibWPE.cpp @no-unify
 platform/graphics/egl/GLContextWrapper.cpp @no-unify
 platform/graphics/egl/GLFence.cpp @no-unify
+platform/graphics/egl/GLFenceEGL.cpp @no-unify
+platform/graphics/egl/GLFenceGL.cpp @no-unify
 platform/graphics/egl/PlatformDisplaySurfaceless.cpp @no-unify
 
 platform/graphics/gbm/DRMDeviceManager.cpp

--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -310,6 +310,9 @@ void PlatformDisplay::initializeEGLDisplay()
 
         m_eglExtensions.KHR_image_base = findExtension("EGL_KHR_image_base"_s);
         m_eglExtensions.KHR_surfaceless_context = findExtension("EGL_KHR_surfaceless_context"_s);
+        m_eglExtensions.KHR_fence_sync = findExtension("EGL_KHR_fence_sync"_s);
+        m_eglExtensions.KHR_wait_sync = findExtension("EGL_KHR_wait_sync"_s);
+        m_eglExtensions.ANDROID_native_fence_sync = findExtension("EGL_ANDROID_native_fence_sync"_s);
         m_eglExtensions.EXT_image_dma_buf_import = findExtension("EGL_EXT_image_dma_buf_import"_s);
         m_eglExtensions.EXT_image_dma_buf_import_modifiers = findExtension("EGL_EXT_image_dma_buf_import_modifiers"_s);
         m_eglExtensions.MESA_image_dma_buf_export = findExtension("EGL_MESA_image_dma_buf_export"_s);

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -102,10 +102,13 @@ public:
 
     struct EGLExtensions {
         bool KHR_image_base { false };
+        bool KHR_fence_sync { false };
         bool KHR_surfaceless_context { false };
+        bool KHR_wait_sync { false };
         bool EXT_image_dma_buf_import { false };
         bool EXT_image_dma_buf_import_modifiers { false };
         bool MESA_image_dma_buf_export { false };
+        bool ANDROID_native_fence_sync { false };
     };
     const EGLExtensions& eglExtensions() const;
 

--- a/Source/WebCore/platform/graphics/egl/GLFenceEGL.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLFenceEGL.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#include "config.h"
+#include "GLFenceEGL.h"
+
+#include "PlatformDisplay.h"
+#include <wtf/Vector.h>
+
+#if USE(LIBEPOXY)
+#include <epoxy/egl.h>
+#else
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <GLES2/gl2.h>
+#endif
+
+namespace WebCore {
+
+static std::unique_ptr<GLFence> createEGLFence(EGLenum type, const Vector<EGLAttrib>& attributes)
+{
+    EGLSync sync = nullptr;
+    auto& display = PlatformDisplay::sharedDisplay();
+    if (display.eglCheckVersion(1, 5))
+        sync = eglCreateSync(display.eglDisplay(), type, attributes.isEmpty() ? nullptr : attributes.data());
+    else {
+        Vector<EGLint> intAttributes = attributes.map<Vector<EGLint>>([] (EGLAttrib value) {
+            return value;
+        });
+        sync = eglCreateSyncKHR(display.eglDisplay(), type, intAttributes.isEmpty() ? nullptr : intAttributes.data());
+    }
+    if (sync == EGL_NO_SYNC)
+        return nullptr;
+
+    glFlush();
+
+#if OS(LINUX)
+    bool isExportable = type == EGL_SYNC_NATIVE_FENCE_ANDROID;
+#else
+    bool isExportable = false;
+#endif
+    return makeUnique<GLFenceEGL>(sync, isExportable);
+}
+
+std::unique_ptr<GLFence> GLFenceEGL::create()
+{
+    return createEGLFence(EGL_SYNC_FENCE_KHR, { });
+}
+
+#if OS(LINUX)
+std::unique_ptr<GLFence> GLFenceEGL::createExportable()
+{
+    return createEGLFence(EGL_SYNC_NATIVE_FENCE_ANDROID, { });
+}
+
+std::unique_ptr<GLFence> GLFenceEGL::importFD(UnixFileDescriptor&& fd)
+{
+    Vector<EGLAttrib> attributes = {
+        EGL_SYNC_NATIVE_FENCE_FD_ANDROID, fd.release(),
+        EGL_NONE
+    };
+    return createEGLFence(EGL_SYNC_NATIVE_FENCE_ANDROID, attributes);
+}
+#endif
+
+GLFenceEGL::GLFenceEGL(EGLSyncKHR sync, bool isExportable)
+    : m_sync(sync)
+    , m_isExportable(isExportable)
+{
+}
+
+GLFenceEGL::~GLFenceEGL()
+{
+    auto& display = PlatformDisplay::sharedDisplay();
+    if (display.eglCheckVersion(1, 5))
+        eglDestroySync(display.eglDisplay(), m_sync);
+    else
+        eglDestroySyncKHR(display.eglDisplay(), m_sync);
+}
+
+void GLFenceEGL::clientWait()
+{
+    auto& display = PlatformDisplay::sharedDisplay();
+    if (display.eglCheckVersion(1, 5))
+        eglClientWaitSync(display.eglDisplay(), m_sync, 0, EGL_FOREVER);
+    else
+        eglClientWaitSyncKHR(display.eglDisplay(), m_sync, 0, EGL_FOREVER_KHR);
+}
+
+void GLFenceEGL::serverWait()
+{
+    if (!capabilities().eglServerWaitSupported) {
+        clientWait();
+        return;
+    }
+
+    auto& display = PlatformDisplay::sharedDisplay();
+    if (display.eglCheckVersion(1, 5))
+        eglWaitSync(display.eglDisplay(), m_sync, 0);
+    else
+        eglWaitSyncKHR(display.eglDisplay(), m_sync, 0);
+}
+
+#if OS(LINUX)
+UnixFileDescriptor GLFenceEGL::exportFD()
+{
+    if (!m_isExportable)
+        return { };
+
+    return UnixFileDescriptor { eglDupNativeFenceFDANDROID(PlatformDisplay::sharedDisplay().eglDisplay(), m_sync), UnixFileDescriptor::Adopt };
+}
+#endif
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/egl/GLFenceEGL.h
+++ b/Source/WebCore/platform/graphics/egl/GLFenceEGL.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#pragma once
+
+#include "GLFence.h"
+
+typedef void* EGLSync;
+
+namespace WebCore {
+
+class GLFenceEGL final : public GLFence {
+public:
+    static std::unique_ptr<GLFence> create();
+#if OS(LINUX)
+    static std::unique_ptr<GLFence> createExportable();
+    static std::unique_ptr<GLFence> importFD(WTF::UnixFileDescriptor&&);
+#endif
+    GLFenceEGL(EGLSync, bool);
+    virtual ~GLFenceEGL();
+
+private:
+    void clientWait() override;
+    void serverWait() override;
+#if OS(LINUX)
+    WTF::UnixFileDescriptor exportFD() override;
+#endif
+
+    EGLSync m_sync { nullptr };
+    bool m_isExportable { false };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/egl/GLFenceGL.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLFenceGL.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#include "config.h"
+#include "GLFenceGL.h"
+
+#if USE(LIBEPOXY)
+#include <epoxy/gl.h>
+#else
+#include <GLES3/gl3.h>
+#endif
+
+namespace WebCore {
+
+std::unique_ptr<GLFence> GLFenceGL::create()
+{
+    if (auto* sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)) {
+        glFlush();
+        return makeUnique<GLFenceGL>(sync);
+    }
+
+    return nullptr;
+}
+
+GLFenceGL::GLFenceGL(GLsync sync)
+    : m_sync(sync)
+{
+}
+
+GLFenceGL::~GLFenceGL()
+{
+    glDeleteSync(m_sync);
+}
+
+void GLFenceGL::clientWait()
+{
+    glClientWaitSync(m_sync, 0, GL_TIMEOUT_IGNORED);
+}
+
+void GLFenceGL::serverWait()
+{
+    glWaitSync(m_sync, 0, GL_TIMEOUT_IGNORED);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/egl/GLFenceGL.h
+++ b/Source/WebCore/platform/graphics/egl/GLFenceGL.h
@@ -19,45 +19,23 @@
 
 #pragma once
 
-#include <wtf/FastMalloc.h>
-#include <wtf/Noncopyable.h>
-
-#if OS(LINUX)
-#include <wtf/unix/UnixFileDescriptor.h>
-#endif
+#include "GLFence.h"
 
 typedef struct __GLsync* GLsync;
 
 namespace WebCore {
 
-class GLFence {
-    WTF_MAKE_NONCOPYABLE(GLFence);
-    WTF_MAKE_FAST_ALLOCATED;
+class GLFenceGL final : public GLFence {
 public:
-    static bool isSupported();
     WEBCORE_EXPORT static std::unique_ptr<GLFence> create();
-#if OS(LINUX)
-    WEBCORE_EXPORT static std::unique_ptr<GLFence> createExportable();
-    WEBCORE_EXPORT static std::unique_ptr<GLFence> importFD(WTF::UnixFileDescriptor&&);
-#endif
-    virtual ~GLFence() = default;
+    explicit GLFenceGL(GLsync);
+    virtual ~GLFenceGL();
 
-    virtual void clientWait() = 0;
-    virtual void serverWait() = 0;
-#if OS(LINUX)
-    virtual WTF::UnixFileDescriptor exportFD() { return { }; }
-#endif
+private:
+    void clientWait() override;
+    void serverWait() override;
 
-protected:
-    GLFence() = default;
-
-    struct Capabilities {
-        bool eglSupported { false };
-        bool eglServerWaitSupported { false };
-        bool eglExportableSupported { false };
-        bool glSupported { false };
-    };
-    static const Capabilities& capabilities();
+    GLsync m_sync { nullptr };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### a258d90c0cadfb539a4472069a4874ecd646ac64
<pre>
[GTK][WPE] Add support for EGL fences
<a href="https://bugs.webkit.org/show_bug.cgi?id=277141">https://bugs.webkit.org/show_bug.cgi?id=277141</a>

Reviewed by Miguel Gomez.

For explicit sync support we need to use the EGL API to create the
fences to be able to use the EGL_ANDROID_native_fence_sync extension.
So, we can make it possible to create a GLFence with either gl or egl
APIs depending on what we need and what&apos;s available.
There&apos;s no change in behavior in this patch, but now that we have EGL
fences we prefer to use them when available if server wait is supported.

* Source/WebCore/PlatformPlayStation.cmake:
* Source/WebCore/PlatformWin.cmake:
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::initializeEGLDisplay):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/egl/GLFence.cpp:
(WebCore::GLFence::capabilities):
(WebCore::GLFence::isSupported):
(WebCore::GLFence::create):
(WebCore::GLFence::createExportable):
(WebCore::GLFence::importFD):
(WebCore::GLFence::GLFence): Deleted.
(WebCore::GLFence::~GLFence): Deleted.
(WebCore::GLFence::wait): Deleted.
* Source/WebCore/platform/graphics/egl/GLFence.h:
(WebCore::GLFence::exportFD):
* Source/WebCore/platform/graphics/egl/GLFenceEGL.cpp: Added.
(WebCore::createEGLFence):
(WebCore::GLFenceEGL::create):
(WebCore::GLFenceEGL::createExportable):
(WebCore::GLFenceEGL::importFD):
(WebCore::GLFenceEGL::GLFenceEGL):
(WebCore::GLFenceEGL::~GLFenceEGL):
(WebCore::GLFenceEGL::clientWait):
(WebCore::GLFenceEGL::serverWait):
(WebCore::GLFenceEGL::exportFD):
* Source/WebCore/platform/graphics/egl/GLFenceEGL.h: Added.
* Source/WebCore/platform/graphics/egl/GLFenceGL.cpp: Added.
(WebCore::GLFenceGL::create):
(WebCore::GLFenceGL::GLFenceGL):
(WebCore::GLFenceGL::~GLFenceGL):
(WebCore::GLFenceGL::clientWait):
(WebCore::GLFenceGL::serverWait):
* Source/WebCore/platform/graphics/egl/GLFenceGL.h: Added.

Canonical link: <a href="https://commits.webkit.org/281558@main">https://commits.webkit.org/281558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc735cbaee5a4ace18a1107bcdd5b3942db27cf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10867 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62465 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11100 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48850 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7568 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62366 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/36992 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/52274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33690 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/9500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9784 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/9787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65987 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4269 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56211 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4287 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/52247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56379 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/3559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9045 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37668 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->