### PR TITLE
Don't consider an empty array of DNR rule resources a parsing error

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -1879,7 +1879,7 @@ void WebExtension::populateDeclarativeNetRequestPropertiesIfNeeded()
         return;
     }
 
-    NSArray<NSDictionary *> *declarativeNetRequestRulesets = objectForKey<NSArray>(declarativeNetRequestManifestDictionary, declarativeNetRequestRulesManifestKey, true, NSDictionary.class);
+    NSArray<NSDictionary *> *declarativeNetRequestRulesets = objectForKey<NSArray>(declarativeNetRequestManifestDictionary, declarativeNetRequestRulesManifestKey, false, NSDictionary.class);
     if (!declarativeNetRequestRulesets) {
         if ([m_manifest objectForKey:declarativeNetRequestManifestKey])
             recordError(createError(Error::InvalidDeclarativeNetRequest));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -1468,6 +1468,17 @@ TEST(WKWebExtension, DeclarativeNetRequestParsing)
     EXPECT_TRUE(testExtension.hasContentModificationRules);
     // But also an error.
     EXPECT_EQ(testExtension.errors.count, 1ul);
+
+    // No rule sets
+    testManifestDictionary[@"declarative_net_request"] = @{
+        @"rule_resources": @[ ]
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    // There shouldn't be any rules.
+    EXPECT_FALSE(testExtension.hasContentModificationRules);
+    // Or any errors.
+    EXPECT_EQ(testExtension.errors.count, 0ul);
 }
 
 TEST(WKWebExtension, ExternallyConnectableParsing)


### PR DESCRIPTION
#### 20549e656a50a04c0fe5998a0ea0debcd85f0259
<pre>
Don&apos;t consider an empty array of DNR rule resources a parsing error
<a href="https://bugs.webkit.org/show_bug.cgi?id=277151">https://bugs.webkit.org/show_bug.cgi?id=277151</a>
<a href="https://rdar.apple.com/130861213">rdar://130861213</a>

Reviewed by Timothy Hatcher.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::populateDeclarativeNetRequestPropertiesIfNeeded): We shouldn&apos;t pass `emptyIfNil` to
the `objectForKey` call parsing the declarativeNetRequest rulesets. This led to a reported parsing error when
passing an empty array of rulesets like the &quot;Unagent&quot; extension did.

Canonical link: <a href="https://commits.webkit.org/281416@main">https://commits.webkit.org/281416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/293bc33bcd9d8d9dd5ace2f1bec2130d632f79ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63764 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10371 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48527 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7254 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51822 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29371 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9060 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9294 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65494 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3775 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9204 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55869 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3786 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56010 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13264 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3132 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35006 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36089 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37175 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->