### PR TITLE
Handle Notification.close in webpushd

### DIFF
--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -101,10 +101,12 @@ void NetworkNotificationManager::getNotifications(const URL& registrationURL, co
     m_connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetNotifications { registrationURL, tag }, WTFMove(completionHandler));
 }
 
-void NetworkNotificationManager::cancelNotification(const WTF::UUID&)
+void NetworkNotificationManager::cancelNotification(const WTF::UUID& notificationID)
 {
     if (!m_connection)
         return;
+
+    m_connection->sendWithoutUsingIPCConnection(Messages::PushClientConnection::CancelNotification { notificationID });
 }
 
 void NetworkNotificationManager::clearNotifications(const Vector<WTF::UUID>&)

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -119,6 +119,7 @@ private:
 
     void showNotification(const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>, CompletionHandler<void()>&&);
     void getNotifications(const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&&);
+    void cancelNotification(const WTF::UUID& notificationID);
     void enableMockUserNotificationCenterForTesting(CompletionHandler<void()>&&);
 
     String bundleIdentifierFromAuditToken(audit_token_t);

--- a/Source/WebKit/webpushd/PushClientConnection.messages.in
+++ b/Source/WebKit/webpushd/PushClientConnection.messages.in
@@ -42,6 +42,7 @@ messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     ShowNotification(struct WebCore::NotificationData notificationData, RefPtr<WebCore::NotificationResources> notificationResources) -> ()
     GetNotifications(URL registrationURL, String tag) -> (Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData> result)
     EnableMockUserNotificationCenterForTesting() -> ()
+    CancelNotification(WTF::UUID notificationID)
 }
 
 #endif // ENABLE(WEB_PUSH_NOTIFICATIONS)

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -271,6 +271,13 @@ void PushClientConnection::getNotifications(const URL& registrationURL, const St
 #endif
 }
 
+void PushClientConnection::cancelNotification(const WTF::UUID& notificationID)
+{
+#if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
+    WebPushDaemon::singleton().cancelNotification(*this, notificationID);
+#endif
+}
+
 #if PLATFORM(IOS)
 String PushClientConnection::associatedWebClipTitle() const
 {

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -95,6 +95,7 @@ public:
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
     void showNotification(PushClientConnection&, const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>, CompletionHandler<void()>&&);
     void getNotifications(PushClientConnection&, const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&&);
+    void cancelNotification(PushClientConnection&, const WTF::UUID& notificationID);
 
     void getPushPermissionState(PushClientConnection&, const URL& scopeURL, CompletionHandler<void(WebCore::PushPermissionState)>&&);
     void enableMockUserNotificationCenterForTesting(PushClientConnection&);

--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.h
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.h
@@ -31,6 +31,8 @@
 - (instancetype)initWithBundleIdentifier:(NSString *)bundleIdentifier;
 - (void)addNotificationRequest:(UNNotificationRequest *)request withCompletionHandler:(void(^)(NSError *error))completionHandler;
 - (void)getDeliveredNotificationsWithCompletionHandler:(void(^)(NSArray<UNNotification *> *notifications))completionHandler;
+- (void)removePendingNotificationRequestsWithIdentifiers:(NSArray<NSString *> *) identifiers;
+- (void)removeDeliveredNotificationsWithIdentifiers:(NSArray<NSString *> *) identifiers;
 @end
 
 #endif

--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
@@ -74,6 +74,23 @@ static NSMutableArray *notificationsByBundleIdentifier(NSString *bundleIdentifie
     });
 }
 
+- (void)removePendingNotificationRequestsWithIdentifiers:(NSArray<NSString *> *) identifiers
+{
+    RetainPtr toRemove = adoptNS([NSMutableArray new]);
+    for (UNNotification *notification in notifications.get()) {
+        if ([identifiers containsObject:notification.request.identifier])
+            [toRemove addObject:notification];
+    }
+
+    [notifications removeObjectsInArray:toRemove.get()];
+}
+
+- (void)removeDeliveredNotificationsWithIdentifiers:(NSArray<NSString *> *) identifiers
+{
+    // For now, the mock UNUserNotificationCenter doesn't distinguish between pending and delivered notifications.
+    [self removePendingNotificationRequestsWithIdentifiers:identifiers];
+}
+
 @end
 
 #endif // HAVE(FULL_FEATURED_USER_NOTIFICATIONS)


### PR DESCRIPTION
#### 0794e187a8ecab72143d0a90c889977676da3f86
<pre>
Handle Notification.close in webpushd
<a href="https://rdar.apple.com/131363011">rdar://131363011</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=277171">https://bugs.webkit.org/show_bug.cgi?id=277171</a>

Reviewed by Chris Dumez.

IPC message plumbing and a little new code inside webpushd itself.

* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::cancelNotification):
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/PushClientConnection.messages.in:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::cancelNotification):
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::cancelNotification):
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.h:
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm:
(-[_WKMockUserNotificationCenter removePendingNotificationRequestsWithIdentifiers:]):
(-[_WKMockUserNotificationCenter removeDeliveredNotificationsWithIdentifiers:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/281438@main">https://commits.webkit.org/281438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fc614a3e25bf636c2bcac6bb4194693104c1404

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63815 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10425 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10655 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48549 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7275 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51862 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29393 "Found 7 new API test failures: /WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception, /WPE/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed, /WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/security-error, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-request, /WPE/TestWebKitFindController:/webkit/WebKitFindController/max-match-count, /WPE/TestWebKitFindController:/webkit/WebKitFindController/match-count, /WPE/TestResources:/webkit/WebKitWebResource/get-data-empty (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33326 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9100 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9346 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65554 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3827 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55898 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51842 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3194 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35058 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36140 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37228 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->