### PR TITLE
Add Wasm Aliases for WebAssembly JSC Options

### DIFF
--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -647,6 +647,43 @@ enum OptionEquivalence {
     v(maximumFTLCandidateInstructionCount, maximumFTLCandidateBytecodeCost, SameOption) \
     v(maximumInliningCallerSize, maximumInliningCallerBytecodeCost, SameOption) \
     v(validateBCE, validateBoundsCheckElimination, SameOption) \
+    /* Wasm -> WebAssembly aliases */ \
+    v(maximumWasmDepthForInlining, maximumWebAssemblyDepthForInlining, SameOption) \
+    v(maximumWasmCalleeSizeForInlining, maximumWebAssemblyCalleeSizeForInlining, SameOption) \
+    v(maximumWasmCallerSizeForInlining, maximumWebAssemblyCallerSizeForInlining, SameOption) \
+    v(useWasm, useWebAssembly, SameOption) \
+    v(failToCompileWasmCode, failToCompileWebAssemblyCode, SameOption) \
+    v(wasmPartialCompileLimit, webAssemblyPartialCompileLimit, SameOption) \
+    v(wasmOMGOptimizationLevel, webAssemblyOMGOptimizationLevel, SameOption) \
+    v(useWasmOSR, useWebAssemblyOSR, SameOption) \
+    v(useWasmFastMemory, useWebAssemblyFastMemory, SameOption) \
+    v(logWasmMemory, logWebAssemblyMemory, SameOption) \
+    v(wasmFastMemoryRedzonePages, webAssemblyFastMemoryRedzonePages, SameOption) \
+    v(crashIfWasmCantFastMemory, crashIfWebAssemblyCantFastMemory, SameOption) \
+    v(crashOnFailedWasmValidate, crashOnFailedWebAssemblyValidate, SameOption) \
+    v(maxNumWasmFastMemories, maxNumWebAssemblyFastMemories, SameOption) \
+    v(useWasmLLInt, useWebAssemblyLLInt, SameOption) \
+    v(useWasmLLIntPrologueOSR, useWebAssemblyLLIntPrologueOSR, SameOption) \
+    v(useWasmLLIntLoopOSR, useWebAssemblyLLIntLoopOSR, SameOption) \
+    v(useWasmLLIntEpilogueOSR, useWebAssemblyLLIntEpilogueOSR, SameOption) \
+    v(wasmFunctionIndexRangeToCompile, webAssemblyFunctionIndexRangeToCompile, SameOption) \
+    v(wasmLLIntTiersUpToBBQ, webAssemblyLLIntTiersUpToBBQ, SameOption) \
+    v(useEagerWasmModuleHashing, useEagerWebAssemblyModuleHashing, SameOption) \
+    v(useWasmFaultSignalHandler, useWebAssemblyFaultSignalHandler, SameOption) \
+    v(dumpWasmOpcodeStatistics, dumpWebAssemblyOpcodeStatistics, SameOption) \
+    v(dumpWasmWarnings, dumpWebAssemblyWarnings, SameOption) \
+    v(useWasmIPInt, useWebAssemblyIPInt, SameOption) \
+    v(useWasmIPIntPrologueOSR, useWebAssemblyIPIntPrologueOSR, SameOption) \
+    v(useWasmIPIntLoopOSR, useWebAssemblyIPIntLoopOSR, SameOption) \
+    v(useWasmIPIntEpilogueOSR, useWebAssemblyIPIntEpilogueOSR, SameOption) \
+    v(wasmIPIntTiersUpToBBQ, webAssemblyIPIntTiersUpToBBQ, SameOption) \
+    v(wasmIPIntTiersUpToOMG, webAssemblyIPIntTiersUpToOMG, SameOption) \
+    v(useWasmTypedFunctionReferences, useWebAssemblyTypedFunctionReferences, SameOption) \
+    v(useWasmGC, useWebAssemblyGC, SameOption) \
+    v(useWasmSIMD, useWebAssemblySIMD, SameOption) \
+    v(useWasmRelaxedSIMD, useWebAssemblyRelaxedSIMD, SameOption) \
+    v(useWasmTailCalls, useWebAssemblyTailCalls, SameOption) \
+    v(useWasmExtendedConstantExpressions, useWebAssemblyExtendedConstantExpressions, SameOption) \
 
 
 enum ExperimentalOptionFlags {


### PR DESCRIPTION
#### 307024c54eb26631fcb0daf561f5b8244b4e5d39
<pre>
Add Wasm Aliases for WebAssembly JSC Options
<a href="https://bugs.webkit.org/show_bug.cgi?id=277173">https://bugs.webkit.org/show_bug.cgi?id=277173</a>
<a href="https://rdar.apple.com/132598037">rdar://132598037</a>

Reviewed by NOBODY (OOPS!).

This is kinda nice when manually typing jsc options on the command line since it&apos;s bit shorter.
We&apos;re keeping the WebAssembly name since it&apos;s a bit more descriptive in code.

* Source/JavaScriptCore/runtime/OptionsList.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/307024c54eb26631fcb0daf561f5b8244b4e5d39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59885 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/39232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12415 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/63802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/10409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10586 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/63802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/10409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61915 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/36587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/51850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/63802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/33293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/9089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/9332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/52979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/9370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/65532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59130 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/3813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/65532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/3824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/51831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/65532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/80888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/80888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->