### PR TITLE
Rename WebAssembly JSC options to Wasm

### DIFF
--- a/JSTests/microbenchmarks/exceptions-simd.js
+++ b/JSTests/microbenchmarks/exceptions-simd.js
@@ -1,6 +1,6 @@
 //@ skip unless $isWasmPlatform
 //@ skip unless $isSIMDPlatform
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ requireOptions("--useExecutableAllocationFuzz=false")
 
 // The purpose of this test is to compare SIMD and non-SIMD versions of this code.

--- a/JSTests/microbenchmarks/wasm-cc-int-to-int.js
+++ b/JSTests/microbenchmarks/wasm-cc-int-to-int.js
@@ -1,6 +1,6 @@
 //@ skip
 //@ $skipModes << :lockdown
-//@ runDefaultWasm("--useWebAssembly=1")
+//@ runDefaultWasm("--useWasm=1")
 
 var wasm_code;
 try {

--- a/JSTests/wasm/extended-const/extended-const.js
+++ b/JSTests/wasm/extended-const/extended-const.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyExtendedConstantExpressions=true")
+//@ runWebAssemblySuite("--useWasmExtendedConstantExpressions=true")
 import * as assert from "../assert.js";
 import { instantiate } from "../wabt-wrapper.js";
 

--- a/JSTests/wasm/extended-const/flag-turned-off.js
+++ b/JSTests/wasm/extended-const/flag-turned-off.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyExtendedConstantExpressions=false")
+//@ runWebAssemblySuite("--useWasmExtendedConstantExpressions=false")
 import * as assert from "../assert.js";
 
 function module(bytes, valid = true) {

--- a/JSTests/wasm/function-references/block_signature.js
+++ b/JSTests/wasm/function-references/block_signature.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true")
 import * as assert from '../assert.js';
 
 function module(bytes, valid = true) {

--- a/JSTests/wasm/function-references/br_on_null.js
+++ b/JSTests/wasm/function-references/br_on_null.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true")
 import * as assert from '../assert.js';
 import { instantiate } from "../wabt-wrapper.js";
 

--- a/JSTests/wasm/function-references/bug243265.js
+++ b/JSTests/wasm/function-references/bug243265.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true")
 
 import * as assert from '../assert.js';
 

--- a/JSTests/wasm/function-references/call_ref.js
+++ b/JSTests/wasm/function-references/call_ref.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true")
 import * as assert from '../assert.js';
 import { instantiate } from "../wabt-wrapper.js";
 

--- a/JSTests/wasm/function-references/local_init.js
+++ b/JSTests/wasm/function-references/local_init.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true")
 
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/function-references/ref_as_non_null.js
+++ b/JSTests/wasm/function-references/ref_as_non_null.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true")
 import * as assert from '../assert.js';
 import { instantiate } from "../wabt-wrapper.js";
 

--- a/JSTests/wasm/function-references/ref_types.js
+++ b/JSTests/wasm/function-references/ref_types.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true")
 import * as assert from "../assert.js";
 import { instantiate } from "../wabt-wrapper.js";
 

--- a/JSTests/wasm/function-references/table.js
+++ b/JSTests/wasm/function-references/table.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true")
 import * as assert from "../assert.js";
 
 function module(bytes, valid = true) {

--- a/JSTests/wasm/function-references/table_init.js
+++ b/JSTests/wasm/function-references/table_init.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true")
 
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/gc/any.js
+++ b/JSTests/wasm/gc/any.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/array_new_data.js
+++ b/JSTests/wasm/gc/array_new_data.js
@@ -1,5 +1,5 @@
 //@ $skipModes << :wasm_aggressive_inline if $memoryLimited
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 // This tests in the :wasm_aggressive_inline test configuration will use more than the
 // 600M that $memoryLimited devices are capped at due JSCTEST_memoryLimit. Skip it

--- a/JSTests/wasm/gc/array_new_elem.js
+++ b/JSTests/wasm/gc/array_new_elem.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/array_new_fixed.js
+++ b/JSTests/wasm/gc/array_new_fixed.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/array_new_fixed_long.js
+++ b/JSTests/wasm/gc/array_new_fixed_long.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/arrays.js
+++ b/JSTests/wasm/gc/arrays.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/block.js
+++ b/JSTests/wasm/gc/block.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/br_on_cast.js
+++ b/JSTests/wasm/gc/br_on_cast.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/bug247874.js
+++ b/JSTests/wasm/gc/bug247874.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--collectContinuously=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true", "--collectContinuously=true")
 
 import { compile, instantiate } from "./wast-wrapper.js";
 

--- a/JSTests/wasm/gc/bug250613.js
+++ b/JSTests/wasm/gc/bug250613.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--slowPathAllocsBetweenGCs=8")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true", "--slowPathAllocsBetweenGCs=8")
 
 // Test for https://bugs.webkit.org/show_bug.cgi?id=250613
 // Note: without the --slowPathAllocsBetweenGCs=8 flag, this test only fails approximately every 1 in 10 executions.

--- a/JSTests/wasm/gc/bug252299.js
+++ b/JSTests/wasm/gc/bug252299.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/bug252538.js
+++ b/JSTests/wasm/gc/bug252538.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/bug252719.js
+++ b/JSTests/wasm/gc/bug252719.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/bug254226.js
+++ b/JSTests/wasm/gc/bug254226.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/bug254412.js
+++ b/JSTests/wasm/gc/bug254412.js
@@ -1,5 +1,5 @@
 //@ skip unless $isSIMDPlatform
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/gc/bug254413.js
+++ b/JSTests/wasm/gc/bug254413.js
@@ -1,5 +1,5 @@
 //@ skip unless $isSIMDPlatform
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 function module(bytes, valid = true) {
   let buffer = new ArrayBuffer(bytes.length);

--- a/JSTests/wasm/gc/bug254414.js
+++ b/JSTests/wasm/gc/bug254414.js
@@ -1,5 +1,5 @@
 //@ skip if !$isSIMDPlatform
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 function module(bytes, valid = true) {
   let buffer = new ArrayBuffer(bytes.length);

--- a/JSTests/wasm/gc/bug258127.js
+++ b/JSTests/wasm/gc/bug258127.js
@@ -1,5 +1,5 @@
 //@ skip unless $isSIMDPlatform
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 function module(bytes, valid = true) {
   let buffer = new ArrayBuffer(bytes.length);

--- a/JSTests/wasm/gc/bug258128.js
+++ b/JSTests/wasm/gc/bug258128.js
@@ -1,5 +1,5 @@
 //@ skip if !$isSIMDPlatform
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 function module(bytes, valid = true) {
   let buffer = new ArrayBuffer(bytes.length);

--- a/JSTests/wasm/gc/bug258499.js
+++ b/JSTests/wasm/gc/bug258499.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/gc/bug258795.js
+++ b/JSTests/wasm/gc/bug258795.js
@@ -1,5 +1,5 @@
 //@ skip if !$isSIMDPlatform
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 function module(bytes, valid = true) {
   let buffer = new ArrayBuffer(bytes.length);

--- a/JSTests/wasm/gc/bug258796.js
+++ b/JSTests/wasm/gc/bug258796.js
@@ -1,5 +1,5 @@
 //@ skip if !$isSIMDPlatform
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/gc/bug258801.js
+++ b/JSTests/wasm/gc/bug258801.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 function module(bytes, valid = true) {

--- a/JSTests/wasm/gc/bug258804.js
+++ b/JSTests/wasm/gc/bug258804.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/gc/bug258805.js
+++ b/JSTests/wasm/gc/bug258805.js
@@ -1,5 +1,5 @@
 //@ skip unless $isSIMDPlatform
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 

--- a/JSTests/wasm/gc/bug260516.js
+++ b/JSTests/wasm/gc/bug260516.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import { compile, instantiate } from "./wast-wrapper.js";
 

--- a/JSTests/wasm/gc/bug262862.js
+++ b/JSTests/wasm/gc/bug262862.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 function module(bytes, valid = true) {
   let buffer = new ArrayBuffer(bytes.length);

--- a/JSTests/wasm/gc/bug262863.js
+++ b/JSTests/wasm/gc/bug262863.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 function module(bytes, valid = true) {
   let buffer = new ArrayBuffer(bytes.length);

--- a/JSTests/wasm/gc/bug265721.js
+++ b/JSTests/wasm/gc/bug265721.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 // Test for https://bugs.webkit.org/show_bug.cgi?id=265721
 

--- a/JSTests/wasm/gc/bug265742.js
+++ b/JSTests/wasm/gc/bug265742.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import { instantiate } from "./wast-wrapper.js";
 

--- a/JSTests/wasm/gc/bug265927.js
+++ b/JSTests/wasm/gc/bug265927.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 function module(bytes, valid = true) {
   let buffer = new ArrayBuffer(bytes.length);

--- a/JSTests/wasm/gc/bug266043.js
+++ b/JSTests/wasm/gc/bug266043.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/bug266056.js
+++ b/JSTests/wasm/gc/bug266056.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/bug266127.js
+++ b/JSTests/wasm/gc/bug266127.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/bug266167.js
+++ b/JSTests/wasm/gc/bug266167.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/bug266249.js
+++ b/JSTests/wasm/gc/bug266249.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--useWebAssemblyExtendedConstantExpressions=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true", "--useWasmExtendedConstantExpressions=true")
 
 import { compile, instantiate } from "./wast-wrapper.js";
 

--- a/JSTests/wasm/gc/bug267381.js
+++ b/JSTests/wasm/gc/bug267381.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--useWebAssemblyExtendedConstantExpressions=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true", "--useWasmExtendedConstantExpressions=true")
 
 import * as assert from "../assert.js";
 import { instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/bulk-array.js
+++ b/JSTests/wasm/gc/bulk-array.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/call_indirect.js
+++ b/JSTests/wasm/gc/call_indirect.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/call_ref.js
+++ b/JSTests/wasm/gc/call_ref.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/casts.js
+++ b/JSTests/wasm/gc/casts.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/const-exprs-flag-off.js
+++ b/JSTests/wasm/gc/const-exprs-flag-off.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--useWebAssemblyExtendedConstantExpressions=false")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true", "--useWasmExtendedConstantExpressions=false")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/const-exprs.js
+++ b/JSTests/wasm/gc/const-exprs.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--useWebAssemblyExtendedConstantExpressions=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true", "--useWasmExtendedConstantExpressions=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/eq.js
+++ b/JSTests/wasm/gc/eq.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/exception.js
+++ b/JSTests/wasm/gc/exception.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/extern.js
+++ b/JSTests/wasm/gc/extern.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/i31.js
+++ b/JSTests/wasm/gc/i31.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/js-api.js
+++ b/JSTests/wasm/gc/js-api.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--useWebAssemblyExtendedConstantExpressions=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true", "--useWasmExtendedConstantExpressions=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/limits.js
+++ b/JSTests/wasm/gc/limits.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/linking.js
+++ b/JSTests/wasm/gc/linking.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/packed-arrays.js
+++ b/JSTests/wasm/gc/packed-arrays.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/rec.js
+++ b/JSTests/wasm/gc/rec.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/simd.js
+++ b/JSTests/wasm/gc/simd.js
@@ -1,5 +1,5 @@
 //@ skip unless $isSIMDPlatform
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/structs.js
+++ b/JSTests/wasm/gc/structs.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--useWebAssemblyExtendedConstantExpressions=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true", "--useWasmExtendedConstantExpressions=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/sub.js
+++ b/JSTests/wasm/gc/sub.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/subtyping.js
+++ b/JSTests/wasm/gc/subtyping.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/gc/table_init.js
+++ b/JSTests/wasm/gc/table_init.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--useWebAssemblyExtendedConstantExpressions=true")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=true", "--useWasmGC=true", "--useWasmExtendedConstantExpressions=true")
 
 import * as assert from "../assert.js";
 import { compile, instantiate } from "./wast-wrapper.js";

--- a/JSTests/wasm/ipint-tests/perf.py
+++ b/JSTests/wasm/ipint-tests/perf.py
@@ -16,10 +16,10 @@ COMMONENV = {
     'JS_SHELL_WAIT_FOR_SIGUSR2_TO_EXIT': '1'
 }
 
-JSCRELEASE = ['/Volumes/WebKit/DebugVersion/OpenSource/WebKitBuild/Release/jsc', '--validateOptions=1', '--useWebAssemblySIMD=0']
-IPINT_RUNS = ['--useWebAssemblyIPInt=1', '--useBBQJIT=0', '--useOMGJIT=0']
+JSCRELEASE = ['/Volumes/WebKit/DebugVersion/OpenSource/WebKitBuild/Release/jsc', '--validateOptions=1', '--useWasmSIMD=0']
+IPINT_RUNS = ['--useWasmIPInt=1', '--useBBQJIT=0', '--useOMGJIT=0']
 LLINT_RUNS = ['--useBBQJIT=0', '--useOMGJIT=0']
-BBQJIT_RUNS = ['--useWebAssemblyLLInt=0', '--useBBQJIT=1', '--useOMGJIT=0']
+BBQJIT_RUNS = ['--useWasmLLInt=0', '--useBBQJIT=1', '--useOMGJIT=0']
 FILE = ['-m', sys.argv[1]]
 
 MEMORY_SLEEP = 0

--- a/JSTests/wasm/references/element_active_mod.js
+++ b/JSTests/wasm/references/element_active_mod.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=false", "--useWebAssemblyGC=false")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=false", "--useWasmGC=false")
 
 import * as assert from '../assert.js';
 

--- a/JSTests/wasm/references/func_ref.js
+++ b/JSTests/wasm/references/func_ref.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=false", "--useWebAssemblyGC=false")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=false", "--useWasmGC=false")
 
 import * as assert from '../assert.js';
 import Builder from '../Builder.js';

--- a/JSTests/wasm/references/is_null.js
+++ b/JSTests/wasm/references/is_null.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=false", "--useWebAssemblyGC=false")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=false", "--useWasmGC=false")
 
 import * as assert from '../assert.js';
 import Builder from '../Builder.js';

--- a/JSTests/wasm/references/table_misc.js
+++ b/JSTests/wasm/references/table_misc.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=false", "--useWebAssemblyGC=false")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=false", "--useWasmGC=false")
 
 import * as assert from '../assert.js';
 import Builder from '../Builder.js';

--- a/JSTests/wasm/references/validation.js
+++ b/JSTests/wasm/references/validation.js
@@ -1,4 +1,4 @@
-//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=false", "--useWebAssemblyGC=false")
+//@ runWebAssemblySuite("--useWasmTypedFunctionReferences=false", "--useWasmGC=false")
 
 import * as assert from '../assert.js';
 import Builder from '../Builder.js';

--- a/JSTests/wasm/regress/llint-callee-saves-with-fast-memory.js
+++ b/JSTests/wasm/regress/llint-callee-saves-with-fast-memory.js
@@ -1,5 +1,5 @@
 //@ skip if $addressBits <= 32
-//@ requireOptions("--useWebAssemblyFastMemory=true")
+//@ requireOptions("--useWasmFastMemory=true")
 
 import * as assert from '../assert.js';
 import { instantiate } from '../wabt-wrapper.js';

--- a/JSTests/wasm/regress/llint-callee-saves-without-fast-memory.js
+++ b/JSTests/wasm/regress/llint-callee-saves-without-fast-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblyFastMemory=false")
+//@ requireOptions("--useWasmFastMemory=false")
 
 import * as assert from '../assert.js';
 import { instantiate } from '../wabt-wrapper.js';

--- a/JSTests/wasm/stress/big-try-simd.js
+++ b/JSTests/wasm/stress/big-try-simd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/big-try.js
+++ b/JSTests/wasm/stress/big-try.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/big-tuple-args.js
+++ b/JSTests/wasm/stress/big-tuple-args.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/big-tuple.js
+++ b/JSTests/wasm/stress/big-tuple.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
+++ b/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
@@ -1,7 +1,7 @@
 //@ skip
 //@ skip unless $isWasmPlatform
 //@ requireOptions("--useJITCage=0") # temporary workaround for rdar://127308350
-//@ runDefaultWasm("-m", "--webAssemblyFunctionIndexRangeToCompile=0:5", "--useOMGJIT=0", "--useInterpretedJSEntryWrappers=1")
+//@ runDefaultWasm("-m", "--wasmFunctionIndexRangeToCompile=0:5", "--useOMGJIT=0", "--useInterpretedJSEntryWrappers=1")
 
 // This tests will use more than the 600M that $memoryLimited devices are capped
 // at due JSCTEST_memoryLimit. Skip it to avoid the crash as a result of exceeding

--- a/JSTests/wasm/stress/cc-int-to-int-jit-to-llint.js
+++ b/JSTests/wasm/stress/cc-int-to-int-jit-to-llint.js
@@ -1,5 +1,5 @@
 //@ skip
-//@ runDefaultWasm("-m", "--webAssemblyFunctionIndexRangeToCompile=1:2")
+//@ runDefaultWasm("-m", "--wasmFunctionIndexRangeToCompile=1:2")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-no-jit.js
+++ b/JSTests/wasm/stress/cc-int-to-int-no-jit.js
@@ -1,5 +1,5 @@
 //@ skip
-//@ runDefaultWasm("-m", "--useJIT=0", "--useWebAssembly=1", "--useInterpretedJSEntryWrappers=1")
+//@ runDefaultWasm("-m", "--useJIT=0", "--useWasm=1", "--useInterpretedJSEntryWrappers=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/cc-int-to-int-tail-call.js
+++ b/JSTests/wasm/stress/cc-int-to-int-tail-call.js
@@ -1,5 +1,5 @@
 //@ skip
-//@ requireOptions("--useIPIntWrappers=1", "--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSIzeForInlining=0")
+//@ requireOptions("--useIPIntWrappers=1", "--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
 //@ skip if $architecture != "arm64" && $architecture != "x86_64"
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/dont-stack-overflow-in-air.js
+++ b/JSTests/wasm/stress/dont-stack-overflow-in-air.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--maxPerThreadStackUsage=512000", "--useWebAssemblySIMD=false")
+//@ requireOptions("--maxPerThreadStackUsage=512000", "--useWasmSIMD=false")
 
 import Builder from '../Builder.js'
 import * as assert from '../assert.js'

--- a/JSTests/wasm/stress/simd-big-tuple.js
+++ b/JSTests/wasm/stress/simd-big-tuple.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-f32-madd.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f32-madd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblyRelaxedSIMD=1")
+//@ requireOptions("--useWasmRelaxedSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblyRelaxedSIMD=1")
+//@ requireOptions("--useWasmRelaxedSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-f64-madd.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f64-madd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblyRelaxedSIMD=1")
+//@ requireOptions("--useWasmRelaxedSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblyRelaxedSIMD=1")
+//@ requireOptions("--useWasmRelaxedSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-relaxed-swizzle.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-swizzle.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblyRelaxedSIMD=1")
+//@ requireOptions("--useWasmRelaxedSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const-spill.js
+++ b/JSTests/wasm/stress/simd-const-spill.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-const.js
+++ b/JSTests/wasm/stress/simd-const.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-exception-throwing-v128-clobbers-fp.js
+++ b/JSTests/wasm/stress/simd-exception-throwing-v128-clobbers-fp.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 var wasm_code = read('./simd-exception-throwing-v128-clobbers-fp.wasm', 'binary')
 var wasm_module = new WebAssembly.Module(wasm_code);

--- a/JSTests/wasm/stress/simd-exception.js
+++ b/JSTests/wasm/stress/simd-exception.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-global-get.js
+++ b/JSTests/wasm/stress/simd-global-get.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-global-set.js
+++ b/JSTests/wasm/stress/simd-global-set.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-import-global-2.js
+++ b/JSTests/wasm/stress/simd-import-global-2.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-kitchen-sink.js
+++ b/JSTests/wasm/stress/simd-kitchen-sink.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-load.js
+++ b/JSTests/wasm/stress/simd-load.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-no-fast-mem-load-lane.js
+++ b/JSTests/wasm/stress/simd-no-fast-mem-load-lane.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useWebAssemblyFastMemory=0")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmFastMemory=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-no-fast-mem-load-splat.js
+++ b/JSTests/wasm/stress/simd-no-fast-mem-load-splat.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useWebAssemblyFastMemory=0")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmFastMemory=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-no-fast-mem-store-lane.js
+++ b/JSTests/wasm/stress/simd-no-fast-mem-store-lane.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useWebAssemblyFastMemory=0")
+//@ requireOptions("--useWasmSIMD=1", "--useWasmFastMemory=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-osr-many-vectors.js
+++ b/JSTests/wasm/stress/simd-osr-many-vectors.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useConcurrentJIT=0")
+//@ requireOptions("--useWasmSIMD=1", "--useConcurrentJIT=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-osr.js
+++ b/JSTests/wasm/stress/simd-osr.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useConcurrentJIT=0")
+//@ requireOptions("--useWasmSIMD=1", "--useConcurrentJIT=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-regalloc-stress-2.js
+++ b/JSTests/wasm/stress/simd-regalloc-stress-2.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=0", "--useWebAssemblyLLInt=1")
+//@ requireOptions("--useWasmSIMD=1", "--useBBQJIT=0", "--useWasmLLInt=1")
 //@ skip if !$isSIMDPlatform or $memoryLimited
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-regalloc-stress.js
+++ b/JSTests/wasm/stress/simd-regalloc-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--thresholdForOMGOptimizeSoon=1", "--thresholdForOMGOptimizeAfterWarmUp=1")
+//@ requireOptions("--useWasmSIMD=1", "--thresholdForOMGOptimizeSoon=1", "--thresholdForOMGOptimizeAfterWarmUp=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-register-allocation.js
+++ b/JSTests/wasm/stress/simd-register-allocation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-regress.js
+++ b/JSTests/wasm/stress/simd-regress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-return-value-alignment.js
+++ b/JSTests/wasm/stress/simd-return-value-alignment.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 
 /*

--- a/JSTests/wasm/stress/simd-select.js
+++ b/JSTests/wasm/stress/simd-select.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-shuffle.js
+++ b/JSTests/wasm/stress/simd-shuffle.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-tail-call-simple.js
+++ b/JSTests/wasm/stress/simd-tail-call-simple.js
@@ -1,5 +1,5 @@
 //@ skip
-//@ requireOptions("--useWebAssemblyTailCalls=1")
+//@ requireOptions("--useWasmTailCalls=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-tail-calls-throw.js
+++ b/JSTests/wasm/stress/simd-tail-calls-throw.js
@@ -1,5 +1,5 @@
 //@ skip
-//@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSIzeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simd-tiny-loop.js
+++ b/JSTests/wasm/stress/simd-tiny-loop.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--watchdog=1000", "--watchdog-exception-ok")
+//@ requireOptions("--useWasmSIMD=1", "--watchdog=1000", "--watchdog-exception-ok")
 //@ skip if !$isSIMDPlatform
 //@ skip
 //FIXME: this test is currently broken.

--- a/JSTests/wasm/stress/simd-unreachable.js
+++ b/JSTests/wasm/stress/simd-unreachable.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWasmSIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simple-inline-stacktrace-2.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace-2.js
@@ -1,6 +1,6 @@
 //@ skip if !$isWasmPlatform
 //@ skip if $memoryLimited
-//@ runDefault("--maximumWebAssemblyDepthForInlining=10", "--maximumWebAssemblyCalleeSizeForInlining=10000000", "--maximumWebAssemblyCallerSizeForInlining=10000000", "--useBBQJIT=0")
+//@ runDefault("--maximumWasmDepthForInlining=10", "--maximumWasmCalleeSizeForInlining=10000000", "--maximumWasmCallerSizeForInlining=10000000", "--useBBQJIT=0")
 var wasm_code = read('simple-inline-stacktrace.wasm', 'binary')
 var wasm_module = new WebAssembly.Module(wasm_code);
 var wasm_instance = new WebAssembly.Instance(wasm_module, { a: { doThrow: () => { throw new Error() } } });

--- a/JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js
@@ -1,5 +1,5 @@
 //@ skip if !$isWasmPlatform
-//@ runDefault("--maximumWebAssemblyDepthForInlining=10", "--maximumWebAssemblyCalleeSizeForInlining=10000000", "--maximumWebAssemblyCallerSizeForInlining=10000000", "--useBBQJIT=0")
+//@ runDefault("--maximumWasmDepthForInlining=10", "--maximumWasmCalleeSizeForInlining=10000000", "--maximumWasmCallerSizeForInlining=10000000", "--useBBQJIT=0")
 var wasm_code = read('simple-inline-stacktrace-with-catch.wasm', 'binary')
 var wasm_module = new WebAssembly.Module(wasm_code);
 let throwCounter = 0

--- a/JSTests/wasm/stress/tag-return.js
+++ b/JSTests/wasm/stress/tag-return.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/tail-call-double.js
+++ b/JSTests/wasm/stress/tail-call-double.js
@@ -1,5 +1,5 @@
 //@ skip
-//@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSIzeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/tail-call-js-inline.js
+++ b/JSTests/wasm/stress/tail-call-js-inline.js
@@ -1,5 +1,5 @@
 //@ skip
-//@ requireOptions("--useWebAssemblyTailCalls=true")
+//@ requireOptions("--useWasmTailCalls=true")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/tail-call-js.js
+++ b/JSTests/wasm/stress/tail-call-js.js
@@ -1,5 +1,5 @@
 //@ skip
-//@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSIzeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/tail-call-simple-int.js
+++ b/JSTests/wasm/stress/tail-call-simple-int.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSIzeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/tail-call-simple.js
+++ b/JSTests/wasm/stress/tail-call-simple.js
@@ -1,5 +1,5 @@
 //@ skip
-//@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSIzeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSIzeForInlining=0")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/tail-call.js
+++ b/JSTests/wasm/stress/tail-call.js
@@ -1,5 +1,5 @@
 //@ skip
-//@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSizeForInlining=0")
+//@ requireOptions("--useWasmTailCalls=true", "--maximumWasmCalleeSizeForInlining=0")
 import * as assert from "../assert.js";
 import Builder from "../Builder.js";
 

--- a/JSTests/wasm/stress/tuple-and-simd.js
+++ b/JSTests/wasm/stress/tuple-and-simd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 import * as assert from '../assert.js';
 

--- a/JSTests/wasm/v8/adapter-frame.js
+++ b/JSTests/wasm/v8/adapter-frame.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/add-getters.js
+++ b/JSTests/wasm/v8/add-getters.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/anyfunc.js
+++ b/JSTests/wasm/v8/anyfunc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/array-copy-benchmark.js
+++ b/JSTests/wasm/v8/array-copy-benchmark.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/array-init-from-segment.js
+++ b/JSTests/wasm/v8/array-init-from-segment.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/asm-wasm-copy.js
+++ b/JSTests/wasm/v8/asm-wasm-copy.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/asm-wasm-deopt.js
+++ b/JSTests/wasm/v8/asm-wasm-deopt.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeoptimizeFunction()

--- a/JSTests/wasm/v8/asm-wasm-exception-in-tonumber.js
+++ b/JSTests/wasm/v8/asm-wasm-exception-in-tonumber.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (line 0):

--- a/JSTests/wasm/v8/asm-wasm-expr.js
+++ b/JSTests/wasm/v8/asm-wasm-expr.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-f32.js
+++ b/JSTests/wasm/v8/asm-wasm-f32.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-f64.js
+++ b/JSTests/wasm/v8/asm-wasm-f64.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-heap.js
+++ b/JSTests/wasm/v8/asm-wasm-heap.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-i32.js
+++ b/JSTests/wasm/v8/asm-wasm-i32.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-imports.js
+++ b/JSTests/wasm/v8/asm-wasm-imports.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-literals.js
+++ b/JSTests/wasm/v8/asm-wasm-literals.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-math-intrinsic.js
+++ b/JSTests/wasm/v8/asm-wasm-math-intrinsic.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-memory.js
+++ b/JSTests/wasm/v8/asm-wasm-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-names.js
+++ b/JSTests/wasm/v8/asm-wasm-names.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/asm-wasm-stack.js
+++ b/JSTests/wasm/v8/asm-wasm-stack.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-stdlib.js
+++ b/JSTests/wasm/v8/asm-wasm-stdlib.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-switch.js
+++ b/JSTests/wasm/v8/asm-wasm-switch.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-u32.js
+++ b/JSTests/wasm/v8/asm-wasm-u32.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm.js
+++ b/JSTests/wasm/v8/asm-wasm.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-with-wasm-off.js
+++ b/JSTests/wasm/v8/asm-with-wasm-off.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DisallowWasmCodegen()

--- a/JSTests/wasm/v8/atomics-non-shared.js
+++ b/JSTests/wasm/v8/atomics-non-shared.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Module@[native code]

--- a/JSTests/wasm/v8/atomics-stress.js
+++ b/JSTests/wasm/v8/atomics-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: Worker

--- a/JSTests/wasm/v8/atomics.js
+++ b/JSTests/wasm/v8/atomics.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (Error message):

--- a/JSTests/wasm/v8/atomics64-stress.js
+++ b/JSTests/wasm/v8/atomics64-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: Worker

--- a/JSTests/wasm/v8/bigint-i64-to-imported-js-func.js
+++ b/JSTests/wasm/v8/bigint-i64-to-imported-js-func.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/bigint-opt.js
+++ b/JSTests/wasm/v8/bigint-opt.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %OptimizeFunctionOnNextCall()

--- a/JSTests/wasm/v8/bigint-rematerialize.js
+++ b/JSTests/wasm/v8/bigint-rematerialize.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/bigint.js
+++ b/JSTests/wasm/v8/bigint.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/bit-shift-right.js
+++ b/JSTests/wasm/v8/bit-shift-right.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/bounds-check-64bit.js
+++ b/JSTests/wasm/v8/bounds-check-64bit.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/bounds-check-turbofan.js
+++ b/JSTests/wasm/v8/bounds-check-turbofan.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %WasmTierUpFunction()

--- a/JSTests/wasm/v8/bulk-memory.js
+++ b/JSTests/wasm/v8/bulk-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/call-ref.js
+++ b/JSTests/wasm/v8/call-ref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: undefined is not a constructor (evaluating 'new WebAssembly.Function(

--- a/JSTests/wasm/v8/call_indirect.js
+++ b/JSTests/wasm/v8/call_indirect.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 10: invalid opcode 19, in function at index 0 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/calls.js
+++ b/JSTests/wasm/v8/calls.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/code-space-overflow.js
+++ b/JSTests/wasm/v8/code-space-overflow.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/committed-code-exhaustion.js
+++ b/JSTests/wasm/v8/committed-code-exhaustion.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/compare-exchange-stress.js
+++ b/JSTests/wasm/v8/compare-exchange-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 90: byte alignment 1 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(builder.toBuffer())')

--- a/JSTests/wasm/v8/compare-exchange64-stress.js
+++ b/JSTests/wasm/v8/compare-exchange64-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 94: byte alignment 1 does not match against atomic op's natural alignment 8, in function at index 0 (evaluating 'new WebAssembly.Module(builder.toBuffer())')

--- a/JSTests/wasm/v8/compilation-hints-async-compilation.js
+++ b/JSTests/wasm/v8/compilation-hints-async-compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: unreachable - [object WebAssembly.Module]

--- a/JSTests/wasm/v8/compilation-hints-decoder.js
+++ b/JSTests/wasm/v8/compilation-hints-decoder.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Did not throw exception, expected CompileError

--- a/JSTests/wasm/v8/compilation-hints-ignored.js
+++ b/JSTests/wasm/v8/compilation-hints-ignored.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.

--- a/JSTests/wasm/v8/compilation-hints-lazy-validation.js
+++ b/JSTests/wasm/v8/compilation-hints-lazy-validation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't validate: I32Mul right value type mismatch, in function at index 0 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/compilation-hints-streaming-compilation.js
+++ b/JSTests/wasm/v8/compilation-hints-streaming-compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: WebAssembly.instantiateStreaming is not a function. (In 'WebAssembly.instantiateStreaming(Promise.resolve(bytes),

--- a/JSTests/wasm/v8/compilation-hints-streaming-lazy-validation.js
+++ b/JSTests/wasm/v8/compilation-hints-streaming-lazy-validation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: WebAssembly.instantiateStreaming is not a function. (In 'WebAssembly.instantiateStreaming(Promise.resolve(bytes))', 'WebAssembly.instantiateStreaming' is undefined)

--- a/JSTests/wasm/v8/compilation-hints-sync-compilation.js
+++ b/JSTests/wasm/v8/compilation-hints-sync-compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Did not throw exception, expected CompileError

--- a/JSTests/wasm/v8/compilation-limits-asm.js
+++ b/JSTests/wasm/v8/compilation-limits-asm.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/compilation-limits.js
+++ b/JSTests/wasm/v8/compilation-limits.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %AbortJS()

--- a/JSTests/wasm/v8/compiled-module-management.js
+++ b/JSTests/wasm/v8/compiled-module-management.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %WasmGetNumberOfInstances()

--- a/JSTests/wasm/v8/compiled-module-serialization.js
+++ b/JSTests/wasm/v8/compiled-module-serialization.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeserializeWasmModule()

--- a/JSTests/wasm/v8/data-segments.js
+++ b/JSTests/wasm/v8/data-segments.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/disable-trap-handler.js
+++ b/JSTests/wasm/v8/disable-trap-handler.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsWasmTrapHandlerEnabled()

--- a/JSTests/wasm/v8/disallow-codegen.js
+++ b/JSTests/wasm/v8/disallow-codegen.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DisallowWasmCodegen()

--- a/JSTests/wasm/v8/divrem-trap.js
+++ b/JSTests/wasm/v8/divrem-trap.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/element-segments-with-reftypes.js
+++ b/JSTests/wasm/v8/element-segments-with-reftypes.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 79: opcode for exp in element section's should be either ref.func or ref.null 0th element's 0th index (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/empirical_max_memory.js
+++ b/JSTests/wasm/v8/empirical_max_memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/ensure-wasm-binaries-up-to-date.js
+++ b/JSTests/wasm/v8/ensure-wasm-binaries-up-to-date.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: readbuffer

--- a/JSTests/wasm/v8/errors.js
+++ b/JSTests/wasm/v8/errors.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DebugTrace()

--- a/JSTests/wasm/v8/exceptions-simd.js
+++ b/JSTests/wasm/v8/exceptions-simd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/export-global.js
+++ b/JSTests/wasm/v8/export-global.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/export-identity.js
+++ b/JSTests/wasm/v8/export-identity.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <function () {

--- a/JSTests/wasm/v8/export-mutable-global.js
+++ b/JSTests/wasm/v8/export-mutable-global.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/export-table.js
+++ b/JSTests/wasm/v8/export-table.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/expose-wasm.js
+++ b/JSTests/wasm/v8/expose-wasm.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Did not throw exception

--- a/JSTests/wasm/v8/extended-constants.js
+++ b/JSTests/wasm/v8/extended-constants.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 35: init_expr should end with end, ended with 35 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/externref-globals.js
+++ b/JSTests/wasm/v8/externref-globals.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <null> found <undefined>

--- a/JSTests/wasm/v8/externref-table.js
+++ b/JSTests/wasm/v8/externref-table.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (Error message):

--- a/JSTests/wasm/v8/externref.js
+++ b/JSTests/wasm/v8/externref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/ffi-error.js
+++ b/JSTests/wasm/v8/ffi-error.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/ffi.js
+++ b/JSTests/wasm/v8/ffi.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %GetCallable()

--- a/JSTests/wasm/v8/float-constant-folding.js
+++ b/JSTests/wasm/v8/float-constant-folding.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/function-names.js
+++ b/JSTests/wasm/v8/function-names.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (should start with 'at exec_unreachable (': '<?>.wasm-function[1]@[wasm code]'): expected <true> found <false>

--- a/JSTests/wasm/v8/function-prototype.js
+++ b/JSTests/wasm/v8/function-prototype.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/futex.js
+++ b/JSTests/wasm/v8/futex.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %AtomicsNumWaitersForTesting()

--- a/JSTests/wasm/v8/gc-buffer.js
+++ b/JSTests/wasm/v8/gc-buffer.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/gc-casts-from-any.js
+++ b/JSTests/wasm/v8/gc-casts-from-any.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 13: 0th type failed to parse because rec types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/gc-casts-invalid.js
+++ b/JSTests/wasm/v8/gc-casts-invalid.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (Error message):

--- a/JSTests/wasm/v8/gc-casts-subtypes.js
+++ b/JSTests/wasm/v8/gc-casts-subtypes.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 13: 0th type failed to parse because rec types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/gc-experimental-string-conversions.js
+++ b/JSTests/wasm/v8/gc-experimental-string-conversions.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %OptimizeFunctionOnNextCall()

--- a/JSTests/wasm/v8/gc-experiments.js
+++ b/JSTests/wasm/v8/gc-experiments.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/gc-frame.js
+++ b/JSTests/wasm/v8/gc-frame.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/gc-js-interop-async-debugger.js
+++ b/JSTests/wasm/v8/gc-js-interop-async-debugger.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to db.debugger.enable()

--- a/JSTests/wasm/v8/gc-js-interop-collections.js
+++ b/JSTests/wasm/v8/gc-js-interop-collections.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses gc-js-interop-helpers.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/gc-js-interop-export.mjs
+++ b/JSTests/wasm/v8/gc-js-interop-export.mjs
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // gc-js-interop-helpers.js needs to have %function remapping and then we can add it to run-jsc-stress-test loading..
 

--- a/JSTests/wasm/v8/gc-js-interop-global-constructors.js
+++ b/JSTests/wasm/v8/gc-js-interop-global-constructors.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses gc-js-interop-helpers.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/gc-js-interop-import.mjs
+++ b/JSTests/wasm/v8/gc-js-interop-import.mjs
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: Module specifier, 'gc-js-interop-export.mjs' is not absolute and does not start with "./" or "../".

--- a/JSTests/wasm/v8/gc-js-interop-numeric.js
+++ b/JSTests/wasm/v8/gc-js-interop-numeric.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses gc-js-interop-helpers.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/gc-js-interop-objects.js
+++ b/JSTests/wasm/v8/gc-js-interop-objects.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses gc-js-interop-helpers.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/gc-js-interop-wasm.js
+++ b/JSTests/wasm/v8/gc-js-interop-wasm.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses gc-js-interop-helpers.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/gc-js-interop.js
+++ b/JSTests/wasm/v8/gc-js-interop.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses gc-js-interop-helpers.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/gc-memory.js
+++ b/JSTests/wasm/v8/gc-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/gc-nominal.js
+++ b/JSTests/wasm/v8/gc-nominal.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/gc-optimizations.js
+++ b/JSTests/wasm/v8/gc-optimizations.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/gc-stress.js
+++ b/JSTests/wasm/v8/gc-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/gc-typecheck-reducer.js
+++ b/JSTests/wasm/v8/gc-typecheck-reducer.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/gdbjit.js
+++ b/JSTests/wasm/v8/gdbjit.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/generic-wrapper.js
+++ b/JSTests/wasm/v8/generic-wrapper.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeoptimizeFunction()

--- a/JSTests/wasm/v8/globals-import-export-identity.js
+++ b/JSTests/wasm/v8/globals-import-export-identity.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/globals.js
+++ b/JSTests/wasm/v8/globals.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/graceful_shutdown.js
+++ b/JSTests/wasm/v8/graceful_shutdown.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/graceful_shutdown_during_tierup.js
+++ b/JSTests/wasm/v8/graceful_shutdown_during_tierup.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/grow-huge-memory.js
+++ b/JSTests/wasm/v8/grow-huge-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $memoryLimited or ($architecture != "arm64" && $architecture != "x86_64")
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/grow-memory-detaching.js
+++ b/JSTests/wasm/v8/grow-memory-detaching.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/grow-memory-in-branch.js
+++ b/JSTests/wasm/v8/grow-memory-in-branch.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/grow-memory-in-call.js
+++ b/JSTests/wasm/v8/grow-memory-in-call.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/grow-memory-in-loop.js
+++ b/JSTests/wasm/v8/grow-memory-in-loop.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/grow-memory.js
+++ b/JSTests/wasm/v8/grow-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if ($architecture != "arm64" && $architecture != "x86_64")
 //@ skip if $memoryLimited
 // Copyright 2016 the V8 project authors. All rights reserved.

--- a/JSTests/wasm/v8/grow-shared-memory.js
+++ b/JSTests/wasm/v8/grow-shared-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: Worker

--- a/JSTests/wasm/v8/huge-memory.js
+++ b/JSTests/wasm/v8/huge-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $memoryLimited or $addressBits <= 32
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/huge-typedarray.js
+++ b/JSTests/wasm/v8/huge-typedarray.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip if $memoryLimited or $addressBits <= 32
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/i31ref.js
+++ b/JSTests/wasm/v8/i31ref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 3: can't get Function local's type in group 0, in function at index 0 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/import-function.js
+++ b/JSTests/wasm/v8/import-function.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/import-memory.js
+++ b/JSTests/wasm/v8/import-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/import-mutable-global.js
+++ b/JSTests/wasm/v8/import-mutable-global.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/import-table.js
+++ b/JSTests/wasm/v8/import-table.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/imported-function-types.js
+++ b/JSTests/wasm/v8/imported-function-types.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 25: can't get 0th argument Type (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/indirect-call-non-zero-table.js
+++ b/JSTests/wasm/v8/indirect-call-non-zero-table.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/indirect-calls.js
+++ b/JSTests/wasm/v8/indirect-calls.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/indirect-sig-mismatch.js
+++ b/JSTests/wasm/v8/indirect-sig-mismatch.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/indirect-tables.js
+++ b/JSTests/wasm/v8/indirect-tables.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <"2"> found <"">

--- a/JSTests/wasm/v8/inlining.js
+++ b/JSTests/wasm/v8/inlining.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 7: invalid opcode 18, in function at index 0 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/instance-gc.js
+++ b/JSTests/wasm/v8/instance-gc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/instance-memory-gc-stress.js
+++ b/JSTests/wasm/v8/instance-memory-gc-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/instantiate-module-basic.js
+++ b/JSTests/wasm/v8/instantiate-module-basic.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/instantiate-run-basic.js
+++ b/JSTests/wasm/v8/instantiate-run-basic.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/js-api.js
+++ b/JSTests/wasm/v8/js-api.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/large-offset.js
+++ b/JSTests/wasm/v8/large-offset.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/lazy-compilation.js
+++ b/JSTests/wasm/v8/lazy-compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %FreezeWasmLazyCompilation()

--- a/JSTests/wasm/v8/lazy-feedback-vector-allocation.js
+++ b/JSTests/wasm/v8/lazy-feedback-vector-allocation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/liftoff-debug.js
+++ b/JSTests/wasm/v8/liftoff-debug.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %ScheduleGCInStackCheck()

--- a/JSTests/wasm/v8/liftoff-simd-params.js
+++ b/JSTests/wasm/v8/liftoff-simd-params.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/liftoff-trap-handler.js
+++ b/JSTests/wasm/v8/liftoff-trap-handler.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/liftoff.js
+++ b/JSTests/wasm/v8/liftoff.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsLiftoffFunction()

--- a/JSTests/wasm/v8/load-immutable.js
+++ b/JSTests/wasm/v8/load-immutable.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because array types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/log-code-after-post-message.js
+++ b/JSTests/wasm/v8/log-code-after-post-message.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to db.profiler.*()

--- a/JSTests/wasm/v8/loop-rotation.js
+++ b/JSTests/wasm/v8/loop-rotation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/loop-unrolling.js
+++ b/JSTests/wasm/v8/loop-unrolling.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failed:
 //  Exception: CompileError: WebAssembly.Module doesn't parse at byte 10: invalid opcode 18, in function at index 1 (evaluating 'new WebAssembly.Module(builder.toBuffer())')

--- a/JSTests/wasm/v8/many-memories-no-trap-handler.js
+++ b/JSTests/wasm/v8/many-memories-no-trap-handler.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1", "--useWebAssemblyFastMemory=0")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1", "--useWasmFastMemory=0")
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/many-memories.js
+++ b/JSTests/wasm/v8/many-memories.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/many-modules.js
+++ b/JSTests/wasm/v8/many-modules.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/many-parameters.js
+++ b/JSTests/wasm/v8/many-parameters.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/max-module-size-flag.js
+++ b/JSTests/wasm/v8/max-module-size-flag.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Did not throw exception, expected RangeError

--- a/JSTests/wasm/v8/max-wasm-functions.js
+++ b/JSTests/wasm/v8/max-wasm-functions.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 23: Function section's count is too big 1000010 maximum 1000000 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/memory-external-call.js
+++ b/JSTests/wasm/v8/memory-external-call.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/memory-instance-validation.js
+++ b/JSTests/wasm/v8/memory-instance-validation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/memory-size.js
+++ b/JSTests/wasm/v8/memory-size.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/memory.js
+++ b/JSTests/wasm/v8/memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/memory64.js
+++ b/JSTests/wasm/v8/memory64.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 30: resizable limits flag should be 0x00, 0x01, or 0x03 but 0x05 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/memory_1gb_oob.js
+++ b/JSTests/wasm/v8/memory_1gb_oob.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/memory_2gb_oob.js
+++ b/JSTests/wasm/v8/memory_2gb_oob.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/memory_4gb_oob.js
+++ b/JSTests/wasm/v8/memory_4gb_oob.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 //  RuntimeError: Out of bounds memory access (evaluating 'a.store(i, f(i))')

--- a/JSTests/wasm/v8/module-memory.js
+++ b/JSTests/wasm/v8/module-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %GetWasmRecoveredTrapCount()

--- a/JSTests/wasm/v8/multi-table-element-section.js
+++ b/JSTests/wasm/v8/multi-table-element-section.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/multi-value-simd.js
+++ b/JSTests/wasm/v8/multi-value-simd.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/multiple-code-spaces.js
+++ b/JSTests/wasm/v8/multiple-code-spaces.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %WasmNumCodeSpaces()

--- a/JSTests/wasm/v8/mutable-globals.js
+++ b/JSTests/wasm/v8/mutable-globals.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/names.js
+++ b/JSTests/wasm/v8/names.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/parallel_compilation.js
+++ b/JSTests/wasm/v8/parallel_compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/params.js
+++ b/JSTests/wasm/v8/params.js
@@ -1,5 +1,5 @@
 //@ skip if $architecture == "arm" and !$cloop
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/print-code.js
+++ b/JSTests/wasm/v8/print-code.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeserializeWasmModule()

--- a/JSTests/wasm/v8/prototype.js
+++ b/JSTests/wasm/v8/prototype.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/receiver.js
+++ b/JSTests/wasm/v8/receiver.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/reference-globals-import.js
+++ b/JSTests/wasm/v8/reference-globals-import.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/reference-globals.js
+++ b/JSTests/wasm/v8/reference-globals.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because rec types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/reference-table-js-interop.js
+++ b/JSTests/wasm/v8/reference-table-js-interop.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: WebAssembly.Table expects its 'element' field to be the string 'funcref' or 'externref'

--- a/JSTests/wasm/v8/reference-tables.js
+++ b/JSTests/wasm/v8/reference-tables.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 37: Table type should be funcref or anyref, got -20 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/regress/regress-10309.js
+++ b/JSTests/wasm/v8/regress/regress-10309.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1054466.js
+++ b/JSTests/wasm/v8/regress/regress-1054466.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1065599.js
+++ b/JSTests/wasm/v8/regress/regress-1065599.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1070078.js
+++ b/JSTests/wasm/v8/regress/regress-1070078.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1081030.js
+++ b/JSTests/wasm/v8/regress/regress-1081030.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-10831.js
+++ b/JSTests/wasm/v8/regress/regress-10831.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1111522.js
+++ b/JSTests/wasm/v8/regress/regress-1111522.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1112124.js
+++ b/JSTests/wasm/v8/regress/regress-1112124.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1116019.js
+++ b/JSTests/wasm/v8/regress/regress-1116019.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1124885.js
+++ b/JSTests/wasm/v8/regress/regress-1124885.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1132461.js
+++ b/JSTests/wasm/v8/regress/regress-1132461.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1161555.js
+++ b/JSTests/wasm/v8/regress/regress-1161555.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1161654.js
+++ b/JSTests/wasm/v8/regress/regress-1161654.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1161954.js
+++ b/JSTests/wasm/v8/regress/regress-1161954.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1165966.js
+++ b/JSTests/wasm/v8/regress/regress-1165966.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1187831.js
+++ b/JSTests/wasm/v8/regress/regress-1187831.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1188975.js
+++ b/JSTests/wasm/v8/regress/regress-1188975.js
@@ -1,6 +1,6 @@
 //@ skip
 //@ skip if $architecture != "arm64" && $architecture != "x86_64"
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1199662.js
+++ b/JSTests/wasm/v8/regress/regress-1199662.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1231950.js
+++ b/JSTests/wasm/v8/regress/regress-1231950.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1242300.js
+++ b/JSTests/wasm/v8/regress/regress-1242300.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1242689.js
+++ b/JSTests/wasm/v8/regress/regress-1242689.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1254675.js
+++ b/JSTests/wasm/v8/regress/regress-1254675.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=0")
+//@ requireOptions("--useWasmSIMD=0")
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-1264462.js
+++ b/JSTests/wasm/v8/regress/regress-1264462.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1271244.js
+++ b/JSTests/wasm/v8/regress/regress-1271244.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1271538.js
+++ b/JSTests/wasm/v8/regress/regress-1271538.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1282224.js
+++ b/JSTests/wasm/v8/regress/regress-1282224.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1283042.js
+++ b/JSTests/wasm/v8/regress/regress-1283042.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1283395.js
+++ b/JSTests/wasm/v8/regress/regress-1283395.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1284980.js
+++ b/JSTests/wasm/v8/regress/regress-1284980.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1286253.js
+++ b/JSTests/wasm/v8/regress/regress-1286253.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1289678.js
+++ b/JSTests/wasm/v8/regress/regress-1289678.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1290079.js
+++ b/JSTests/wasm/v8/regress/regress-1290079.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-1364036.js
+++ b/JSTests/wasm/v8/regress/regress-1364036.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblyTypedFunctionReferences=1")
+//@ requireOptions("--useWasmTypedFunctionReferences=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-763697.js
+++ b/JSTests/wasm/v8/regress/regress-763697.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=0")
+//@ requireOptions("--useWasmSIMD=0")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-9017.js
+++ b/JSTests/wasm/v8/regress/regress-9017.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblyLLInt=true")
+//@ requireOptions("--useWasmLLInt=true")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/regress/regress-9447.js
+++ b/JSTests/wasm/v8/regress/regress-9447.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-crbug-1338980.js
+++ b/JSTests/wasm/v8/regress/regress-crbug-1338980.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-crbug-1355070.js
+++ b/JSTests/wasm/v8/regress/regress-crbug-1355070.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/regress/regress-crbug-1356718.js
+++ b/JSTests/wasm/v8/regress/regress-crbug-1356718.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/resizablearraybuffer-growablesharedarraybuffer-wasm.js
+++ b/JSTests/wasm/v8/resizablearraybuffer-growablesharedarraybuffer-wasm.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/return-calls.js
+++ b/JSTests/wasm/v8/return-calls.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 6: invalid opcode 18, in function at index 1 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/runtime-type-canonicalization.js
+++ b/JSTests/wasm/v8/runtime-type-canonicalization.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/serialization-with-compilation-hints.js
+++ b/JSTests/wasm/v8/serialization-with-compilation-hints.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeserializeWasmModule()

--- a/JSTests/wasm/v8/serialize-lazy-module.js
+++ b/JSTests/wasm/v8/serialize-lazy-module.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeserializeWasmModule()

--- a/JSTests/wasm/v8/shared-arraybuffer-worker-simple-gc.js
+++ b/JSTests/wasm/v8/shared-arraybuffer-worker-simple-gc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failed because  Exception: ReferenceError: Can't find variable: Worker
 

--- a/JSTests/wasm/v8/shared-memory-gc-stress.js
+++ b/JSTests/wasm/v8/shared-memory-gc-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/shared-memory-worker-explicit-gc-stress.js
+++ b/JSTests/wasm/v8/shared-memory-worker-explicit-gc-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses worker-ping-test.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/shared-memory-worker-gc-stress.js
+++ b/JSTests/wasm/v8/shared-memory-worker-gc-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses worker-ping-test.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/shared-memory-worker-gc.js
+++ b/JSTests/wasm/v8/shared-memory-worker-gc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: Worker

--- a/JSTests/wasm/v8/shared-memory-worker-simple-gc.js
+++ b/JSTests/wasm/v8/shared-memory-worker-simple-gc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: Worker

--- a/JSTests/wasm/v8/shared-memory-worker-stress.js
+++ b/JSTests/wasm/v8/shared-memory-worker-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses worker-ping-test.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/shared-memory.js
+++ b/JSTests/wasm/v8/shared-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: WebAssembly.Memory 'initial' and 'minimum' options are specified at the same time

--- a/JSTests/wasm/v8/simd-call.js
+++ b/JSTests/wasm/v8/simd-call.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/simd-errors.js
+++ b/JSTests/wasm/v8/simd-errors.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/simd-globals.js
+++ b/JSTests/wasm/v8/simd-globals.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/simd-i64x2-mul.js
+++ b/JSTests/wasm/v8/simd-i64x2-mul.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1")
+//@ requireOptions("--useWasmSIMD=1")
 //@ skip if !$isSIMDPlatform
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/single-threaded-compilation.js
+++ b/JSTests/wasm/v8/single-threaded-compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/speculative-inlining.js
+++ b/JSTests/wasm/v8/speculative-inlining.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %WasmTierUpFunction()

--- a/JSTests/wasm/v8/stack-switching-export.js
+++ b/JSTests/wasm/v8/stack-switching-export.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeoptimizeFunction()

--- a/JSTests/wasm/v8/stack-switching.js
+++ b/JSTests/wasm/v8/stack-switching.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: undefined is not a constructor (evaluating 'new WebAssembly.Suspender()')

--- a/JSTests/wasm/v8/stack.js
+++ b/JSTests/wasm/v8/stack.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure:

--- a/JSTests/wasm/v8/stackwalk.js
+++ b/JSTests/wasm/v8/stackwalk.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeoptimizeFunction()

--- a/JSTests/wasm/v8/start-function.js
+++ b/JSTests/wasm/v8/start-function.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/streaming-api.js
+++ b/JSTests/wasm/v8/streaming-api.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: WebAssembly.compileStreaming is not a function. (In 'WebAssembly.compileStreaming(Promise.resolve(bytes))', 'WebAssembly.compileStreaming' is undefined)

--- a/JSTests/wasm/v8/streaming-compile.js
+++ b/JSTests/wasm/v8/streaming-compile.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (Error message):

--- a/JSTests/wasm/v8/streaming-error-position.js
+++ b/JSTests/wasm/v8/streaming-error-position.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (Error message):

--- a/JSTests/wasm/v8/streaming-trap-location.js
+++ b/JSTests/wasm/v8/streaming-trap-location.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Failure (trap reason):

--- a/JSTests/wasm/v8/stringrefs-exec-gc.js
+++ b/JSTests/wasm/v8/stringrefs-exec-gc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because array types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/stringrefs-exec.js
+++ b/JSTests/wasm/v8/stringrefs-exec.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 17: can't get 0th Type's return value (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/stringrefs-invalid.js
+++ b/JSTests/wasm/v8/stringrefs-invalid.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (Error message):

--- a/JSTests/wasm/v8/stringrefs-js.js
+++ b/JSTests/wasm/v8/stringrefs-js.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 14: can't get 0th argument Type (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/stringrefs-regressions.js
+++ b/JSTests/wasm/v8/stringrefs-regressions.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %WasmTierUpFunction()

--- a/JSTests/wasm/v8/stringrefs-valid.js
+++ b/JSTests/wasm/v8/stringrefs-valid.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <true> found <false>

--- a/JSTests/wasm/v8/table-access.js
+++ b/JSTests/wasm/v8/table-access.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-copy-externref.js
+++ b/JSTests/wasm/v8/table-copy-externref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-copy.js
+++ b/JSTests/wasm/v8/table-copy.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-fill.js
+++ b/JSTests/wasm/v8/table-fill.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-get.js
+++ b/JSTests/wasm/v8/table-get.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <Object()> found <undefined>

--- a/JSTests/wasm/v8/table-grow-from-wasm.js
+++ b/JSTests/wasm/v8/table-grow-from-wasm.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-grow.js
+++ b/JSTests/wasm/v8/table-grow.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-limits.js
+++ b/JSTests/wasm/v8/table-limits.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Did not throw exception, expected RangeError

--- a/JSTests/wasm/v8/tagged-stack-parameters.js
+++ b/JSTests/wasm/v8/tagged-stack-parameters.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/test-partial-serialization.js
+++ b/JSTests/wasm/v8/test-partial-serialization.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeserializeWasmModule()

--- a/JSTests/wasm/v8/test-serialization-with-lazy-compilation.js
+++ b/JSTests/wasm/v8/test-serialization-with-lazy-compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeserializeWasmModule()

--- a/JSTests/wasm/v8/test-wasm-module-builder.js
+++ b/JSTests/wasm/v8/test-wasm-module-builder.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 2022: can't get 0th Type's return value (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/tier-down-to-liftoff.js
+++ b/JSTests/wasm/v8/tier-down-to-liftoff.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsLiftoffFunction()

--- a/JSTests/wasm/v8/tier-up-testing-flag.js
+++ b/JSTests/wasm/v8/tier-up-testing-flag.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsLiftoffFunction()

--- a/JSTests/wasm/v8/type-based-optimizations.js
+++ b/JSTests/wasm/v8/type-based-optimizations.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because rec types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/type-reflection-with-externref.js
+++ b/JSTests/wasm/v8/type-reflection-with-externref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: undefined is not a constructor (evaluating 'new WebAssembly.Function({parameters:[], results:["i32"]}, _ => 7)')

--- a/JSTests/wasm/v8/type-reflection-with-mv.js
+++ b/JSTests/wasm/v8/type-reflection-with-mv.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: undefined is not a constructor (evaluating 'new WebAssembly.Function({parameters:p, results:r}, testFun)')

--- a/JSTests/wasm/v8/type-reflection.js
+++ b/JSTests/wasm/v8/type-reflection.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <true> found <false>

--- a/JSTests/wasm/v8/typed-funcref.js
+++ b/JSTests/wasm/v8/typed-funcref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: WebAssembly.Table.prototype.grow expects the second argument to be null or an instance of WebAssembly.Function

--- a/JSTests/wasm/v8/unicode-validation.js
+++ b/JSTests/wasm/v8/unicode-validation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure:

--- a/JSTests/wasm/v8/unicode.js
+++ b/JSTests/wasm/v8/unicode.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/unreachable-validation.js
+++ b/JSTests/wasm/v8/unreachable-validation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <true> found <false>

--- a/JSTests/wasm/v8/unreachable.js
+++ b/JSTests/wasm/v8/unreachable.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure:

--- a/JSTests/wasm/v8/user-properties-constructed.js
+++ b/JSTests/wasm/v8/user-properties-constructed.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/user-properties-exported.js
+++ b/JSTests/wasm/v8/user-properties-exported.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/user-properties-module.js
+++ b/JSTests/wasm/v8/user-properties-module.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/user-properties-reexport.js
+++ b/JSTests/wasm/v8/user-properties-reexport.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/verify-module-basic-errors.js
+++ b/JSTests/wasm/v8/verify-module-basic-errors.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/wasm-api-overloading.js
+++ b/JSTests/wasm/v8/wasm-api-overloading.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/wasm-default.js
+++ b/JSTests/wasm/v8/wasm-default.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/wasm-dynamic-tiering.js
+++ b/JSTests/wasm/v8/wasm-dynamic-tiering.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsLiftoffFunction()

--- a/JSTests/wasm/v8/wasm-gc-externalize-internalize.js
+++ b/JSTests/wasm/v8/wasm-gc-externalize-internalize.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/wasm-gc-js-ref.js
+++ b/JSTests/wasm/v8/wasm-gc-js-ref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/wasm-gc-js-roundtrip.js
+++ b/JSTests/wasm/v8/wasm-gc-js-roundtrip.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 13: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/wasm-invalid-local.js
+++ b/JSTests/wasm/v8/wasm-invalid-local.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/wasm-math-intrinsic.js
+++ b/JSTests/wasm/v8/wasm-math-intrinsic.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/wasm-object-api.js
+++ b/JSTests/wasm/v8/wasm-object-api.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/worker-memory.js
+++ b/JSTests/wasm/v8/worker-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 //  Exception: ReferenceError: Can't find variable: Worker

--- a/JSTests/wasm/v8/worker-module.js
+++ b/JSTests/wasm/v8/worker-module.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failed because Exception: ReferenceError: Can't find variable: Worker
 

--- a/JSTests/wasm/v8/worker-running-empty-loop-interruptible.js
+++ b/JSTests/wasm/v8/worker-running-empty-loop-interruptible.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: Worker

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/casts.tentative.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/casts.tentative.any.html
@@ -1,2 +1,2 @@
-<!-- webkit-test-runner [ jscOptions=--useWebAssemblyTypedFunctionReferences=true,--useWebAssemblyGC=true ] -->
+<!-- webkit-test-runner [ jscOptions=--useWasmTypedFunctionReferences=true,--useWasmGC=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/exported-object.tentative.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/exported-object.tentative.any.html
@@ -1,2 +1,2 @@
-<!-- webkit-test-runner [ jscOptions=--useWebAssemblyTypedFunctionReferences=true,--useWebAssemblyGC=true ] -->
+<!-- webkit-test-runner [ jscOptions=--useWasmTypedFunctionReferences=true,--useWasmGC=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/global-import.tentative.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/global-import.tentative.any.html
@@ -1,2 +1,2 @@
-<!-- webkit-test-runner [ jscOptions=--useWebAssemblyTypedFunctionReferences=true,--useWebAssemblyGC=true ] -->
+<!-- webkit-test-runner [ jscOptions=--useWasmTypedFunctionReferences=true,--useWasmGC=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/i31.tentative.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/i31.tentative.any.html
@@ -1,2 +1,2 @@
-<!-- webkit-test-runner [ jscOptions=--useWebAssemblyTypedFunctionReferences=true,--useWebAssemblyGC=true,--useWebAssemblyExtendedConstantExpressions=true ] -->
+<!-- webkit-test-runner [ jscOptions=--useWasmTypedFunctionReferences=true,--useWasmGC=true,--useWasmExtendedConstantExpressions=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -451,7 +451,7 @@ private:
     FINALIZE_CODE_IF(JSC::Options::asyncDisassembly() || JSC::Options::dumpDisassembly() || Options::dumpRegExpDisassembly(), linkBufferReference, resultPtrTag, simpleName, dataLogFArgumentsForHeading)
 
 #define FINALIZE_WASM_CODE(linkBufferReference, resultPtrTag, simpleName, ...)  \
-    FINALIZE_CODE_IF((JSC::Options::asyncDisassembly() || JSC::Options::dumpDisassembly() || Options::dumpWebAssemblyDisassembly()), linkBufferReference, resultPtrTag, simpleName, __VA_ARGS__)
+    FINALIZE_CODE_IF((JSC::Options::asyncDisassembly() || JSC::Options::dumpDisassembly() || Options::dumpWasmDisassembly()), linkBufferReference, resultPtrTag, simpleName, __VA_ARGS__)
 
 #define FINALIZE_WASM_CODE_FOR_MODE(mode, linkBufferReference, resultPtrTag, simpleName, ...)  \
     FINALIZE_CODE_IF(shouldDumpDisassemblyFor(mode), linkBufferReference, resultPtrTag, simpleName, __VA_ARGS__)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -3254,7 +3254,7 @@ public:
     
     void storeVector(FPRegisterID src, Address address)
     {
-        ASSERT(Options::useWebAssemblySIMD());
+        ASSERT(Options::useWasmSIMD());
         if (tryStoreWithOffset<128>(src, address.base, address.offset))
             return;
 
@@ -3264,14 +3264,14 @@ public:
 
     void storeVector(FPRegisterID src, TrustedImmPtr address)
     {
-        ASSERT(Options::useWebAssemblySIMD());
+        ASSERT(Options::useWasmSIMD());
         moveToCachedReg(address, cachedMemoryTempRegister());
         m_assembler.str<128>(src, memoryTempRegister, ARM64Registers::zr);
     }
 
     void storeVector(FPRegisterID src, BaseIndex address)
     {
-        ASSERT(Options::useWebAssemblySIMD());
+        ASSERT(Options::useWasmSIMD());
         if (address.scale == TimesOne || address.scale == TimesEight) {
             if (auto baseGPR = tryFoldBaseAndOffsetPart(address)) {
                 m_assembler.str<128>(src, baseGPR.value(), address.index, indexExtendType(address), address.scale);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.cpp
@@ -62,7 +62,7 @@ bool shouldDumpDisassemblyFor(CodeBlock* codeBlock)
 
 bool shouldDumpDisassemblyFor(Wasm::CompilationMode mode)
 {
-    if (Options::asyncDisassembly() || Options::dumpDisassembly() || Options::dumpWebAssemblyDisassembly())
+    if (Options::asyncDisassembly() || Options::dumpDisassembly() || Options::dumpWasmDisassembly())
         return true;
     if (Wasm::isAnyBBQ(mode))
         return Options::dumpBBQDisassembly();

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -1408,14 +1408,14 @@ public:
     void storeVector(FPRegisterID src, Address address)
     {
         ASSERT(supportsAVX());
-        ASSERT(Options::useWebAssemblySIMD());
+        ASSERT(Options::useWasmSIMD());
         m_assembler.vmovups_rm(src, address.offset, address.base);
     }
     
     void storeVector(FPRegisterID src, BaseIndex address)
     {
         ASSERT(supportsAVX());
-        ASSERT(Options::useWebAssemblySIMD());
+        ASSERT(Options::useWasmSIMD());
         m_assembler.vmovups_rm(src, address.offset, address.base, address.index, address.scale);
     }
 

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -1299,7 +1299,7 @@ private:
             }
             break;
         case Width128:
-            RELEASE_ASSERT(is64Bit() && Options::useWebAssemblySIMD());
+            RELEASE_ASSERT(is64Bit() && Options::useWasmSIMD());
             RELEASE_ASSERT(bank == FP);
             return MoveVector;
         }

--- a/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
@@ -1372,7 +1372,7 @@ private:
             }
             break;
         case Width128:
-            RELEASE_ASSERT(is64Bit() && Options::useWebAssemblySIMD());
+            RELEASE_ASSERT(is64Bit() && Options::useWasmSIMD());
             RELEASE_ASSERT(bank == FP);
             return MoveVector;
         }

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -286,18 +286,18 @@ public:
 
     void setUsessSIMD()
     { 
-        RELEASE_ASSERT(Options::useWebAssemblySIMD());
+        RELEASE_ASSERT(Options::useWasmSIMD());
         m_usesSIMD = true;
     }
     bool usesSIMD() const
     {
         // See also: WasmModuleInformation::usesSIMD().
-        if (!Options::useWebAssemblySIMD())
+        if (!Options::useWasmSIMD())
             return false;
         if (Options::forceAllFunctionsToUseSIMD())
             return true;
         // The LLInt discovers this value.
-        ASSERT(Options::useWebAssemblyLLInt() || Options::useWebAssemblyIPInt());
+        ASSERT(Options::useWasmLLInt() || Options::useWasmIPInt());
         return m_usesSIMD;
     }
 

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -173,7 +173,7 @@ public:
                 VALIDATE(value->type() == Float, ("At ", *value));
                 break;
             case Const128:
-                RELEASE_ASSERT(Options::useWebAssemblySIMD());
+                RELEASE_ASSERT(Options::useWasmSIMD());
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                 VALIDATE(!value->numChildren(), ("At ", *value));
                 VALIDATE(value->type() == V128, ("At ", *value));

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -741,7 +741,7 @@ void GenerateAndAllocateRegisters::generate(CCallHelpers& jit)
             checkConsistency();
 
             inst.forEachTmp([&] (const Tmp& tmp, Arg::Role role, Bank, Width width) {
-                ASSERT(width <= Width64 || Options::useWebAssemblySIMD());
+                ASSERT(width <= Width64 || Options::useWasmSIMD());
                 if (tmp.isReg() && isDisallowedRegister(tmp.reg()))
                     return;
 
@@ -754,7 +754,7 @@ void GenerateAndAllocateRegisters::generate(CCallHelpers& jit)
             });
 
             inst.forEachArg([&] (Arg& arg, Arg::Role role, Bank, Width width) {
-                ASSERT_UNUSED(width, width <= Width64 || Options::useWebAssemblySIMD());
+                ASSERT_UNUSED(width, width <= Width64 || Options::useWasmSIMD());
                 if (!arg.isTmp())
                     return;
 

--- a/Source/JavaScriptCore/b3/air/AirHelpers.h
+++ b/Source/JavaScriptCore/b3/air/AirHelpers.h
@@ -43,7 +43,7 @@ inline Air::Opcode moveForType(Type type)
     case Double:
         return MoveDouble;
     case V128:
-        ASSERT(Options::useWebAssemblySIMD());
+        ASSERT(Options::useWasmSIMD());
         return MoveVector;
     case Void:
     case Tuple:

--- a/Source/JavaScriptCore/b3/air/AirLogRegisterPressure.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLogRegisterPressure.cpp
@@ -59,7 +59,7 @@ void logRegisterPressure(Code& code)
             Inst::forEachDefWithExtraClobberedRegs<Reg>(
                 prevInst, &inst,
                 [&] (Reg reg, Arg::Role, Bank, Width width, PreservedWidth) {
-                    ASSERT(width <= Width64 || Options::useWebAssemblySIMD());
+                    ASSERT(width <= Width64 || Options::useWasmSIMD());
                     set.add(reg, width);
                 });
 

--- a/Source/JavaScriptCore/b3/air/AirRegLiveness.cpp
+++ b/Source/JavaScriptCore/b3/air/AirRegLiveness.cpp
@@ -70,7 +70,7 @@ RegLiveness::RegLiveness(Code& code)
             
         block->last().forEach<Reg>(
             [&] (Reg& reg, Arg::Role role, Bank, Width width) {
-                ASSERT(width <= Width64 || Options::useWebAssemblySIMD());
+                ASSERT(width <= Width64 || Options::useWasmSIMD());
                 if (Arg::isLateUse(role))
                     liveAtTail.add(reg, width);
             });

--- a/Source/JavaScriptCore/b3/air/AirValidate.cpp
+++ b/Source/JavaScriptCore/b3/air/AirValidate.cpp
@@ -96,7 +96,7 @@ public:
                         VALIDATE(&arg <= &inst.args.last(), ("At ", arg, " in ", inst, " in ", *block));
 
                         // FIXME: replace with a check for wasm simd instructions.
-                        VALIDATE(Options::useWebAssemblySIMD()
+                        VALIDATE(Options::useWasmSIMD()
                             || !Arg::isAnyUse(role)
                             || width <= Width64, ("At ", inst, " in ", *block, " arg ", arg));
                     });

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -783,7 +783,7 @@ void run(const TestConfig* config)
     RUN(testTrappingStoreElimination());
     RUN(testMoveConstants());
     RUN(testMoveConstantsWithLargeOffsets());
-    if (Options::useWebAssemblySIMD())
+    if (Options::useWasmSIMD())
         RUN(testMoveConstantsSIMD());
     RUN(testPCOriginMapDoesntInsertNops());
     RUN(testPinRegisters());

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -167,7 +167,7 @@ void linkPolymorphicCall(VM& vm, JSCell* owner, CallFrame* callFrame, CallLinkIn
     // If we are over the limit, just use a normal virtual call.
     unsigned maxPolymorphicCallVariantListSize;
     if (isWebAssembly)
-        maxPolymorphicCallVariantListSize = Options::maxPolymorphicCallVariantListSizeForWebAssemblyToJS();
+        maxPolymorphicCallVariantListSize = Options::maxPolymorphicCallVariantListSizeForWasmToJS();
     else if (callerCodeBlock->jitType() == JITCode::topTierJIT())
         maxPolymorphicCallVariantListSize = Options::maxPolymorphicCallVariantListSizeForTopTier();
     else

--- a/Source/JavaScriptCore/jit/RegisterAtOffset.h
+++ b/Source/JavaScriptCore/jit/RegisterAtOffset.h
@@ -44,7 +44,7 @@ public:
         , m_offsetBits((offset >> 2) & 0xFFFFFFFFFFFFFF)
     {
         ASSERT(!(offset & 0b11));
-        ASSERT(width == conservativeWidthWithoutVectors(reg) || Options::useWebAssemblySIMD());
+        ASSERT(width == conservativeWidthWithoutVectors(reg) || Options::useWasmSIMD());
         ASSERT(reg.index() < (1 << 6));
         ASSERT(Reg::last().index() < (1 << 6));
         ASSERT(this->reg() == reg);

--- a/Source/JavaScriptCore/jit/RegisterAtOffsetList.cpp
+++ b/Source/JavaScriptCore/jit/RegisterAtOffsetList.cpp
@@ -39,13 +39,13 @@ RegisterAtOffsetList::RegisterAtOffsetList() { }
 RegisterAtOffsetList::RegisterAtOffsetList(RegisterSet registerSetBuilder, OffsetBaseType offsetBaseType)
     : m_registers(registerSetBuilder.numberOfSetRegisters())
 {
-    ASSERT(!registerSetBuilder.hasAnyWideRegisters() || Options::useWebAssemblySIMD());
+    ASSERT(!registerSetBuilder.hasAnyWideRegisters() || Options::useWasmSIMD());
 
     size_t sizeOfAreaInBytes = registerSetBuilder.byteSizeOfSetRegisters();
     m_sizeOfAreaInBytes = sizeOfAreaInBytes;
 #if USE(JSVALUE64)
     static_assert(sizeof(CPURegister) == sizeof(double));
-    ASSERT(this->sizeOfAreaInBytes() == registerCount() * sizeof(CPURegister) || Options::useWebAssemblySIMD());
+    ASSERT(this->sizeOfAreaInBytes() == registerCount() * sizeof(CPURegister) || Options::useWasmSIMD());
 #endif    
 
     ptrdiff_t startOffset = 0;

--- a/Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp
@@ -162,7 +162,7 @@ unsigned ScratchRegisterAllocator::preserveRegistersToStackForCall(AssemblyHelpe
     RELEASE_ASSERT(extraBytesAtTopOfStack % sizeof(void*) == 0);
     if (!usedRegisters.numberOfSetRegisters())
         return 0;
-    ASSERT(!usedRegisters.hasAnyWideRegisters() || Options::useWebAssemblySIMD());
+    ASSERT(!usedRegisters.hasAnyWideRegisters() || Options::useWasmSIMD());
     JIT_COMMENT(jit, "Preserve registers to stack for call: ", usedRegisters, "; Extra bytes at top of stack: ", extraBytesAtTopOfStack);
 
     unsigned byteSizeOfSetRegisters = usedRegisters.byteSizeOfSetRegisters();
@@ -211,7 +211,7 @@ void ScratchRegisterAllocator::restoreRegistersFromStackForCall(AssemblyHelpers&
         RELEASE_ASSERT(numberOfStackBytesUsedForRegisterPreservation == 0);
         return;
     }
-    ASSERT(!usedRegisters.hasAnyWideRegisters() || Options::useWebAssemblySIMD());
+    ASSERT(!usedRegisters.hasAnyWideRegisters() || Options::useWasmSIMD());
     JIT_COMMENT(jit, "Restore registers from stack for call: ", usedRegisters, "; Extra bytes at top of stack: ", extraBytesAtTopOfStack);
 
     AssemblyHelpers::LoadRegSpooler spooler(jit, MacroAssembler::stackPointerRegister);

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
@@ -54,7 +54,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(BufferMemoryManager);
 
 size_t BufferMemoryHandle::fastMappedRedzoneBytes()
 {
-    return static_cast<size_t>(PageCount::pageSize) * Options::webAssemblyFastMemoryRedzonePages();
+    return static_cast<size_t>(PageCount::pageSize) * Options::wasmFastMemoryRedzonePages();
 }
 
 size_t BufferMemoryHandle::fastMappedBytes()
@@ -102,7 +102,7 @@ BufferMemoryResult BufferMemoryManager::tryAllocateFastMemory()
             m_fastMemories.size() >= m_maxFastMemoryCount / 2 ? BufferMemoryResult::SuccessAndNotifyMemoryPressure : BufferMemoryResult::Success);
     }();
 
-    dataLogLnIf(Options::logWebAssemblyMemory(), "Allocated virtual: ", result, "; state: ", *this);
+    dataLogLnIf(Options::logWasmMemory(), "Allocated virtual: ", result, "; state: ", *this);
 
     return result;
 }
@@ -115,7 +115,7 @@ void BufferMemoryManager::freeFastMemory(void* basePtr)
         m_fastMemories.removeFirst(basePtr);
     }
 
-    dataLogLnIf(Options::logWebAssemblyMemory(), "Freed virtual; state: ", *this);
+    dataLogLnIf(Options::logWasmMemory(), "Freed virtual; state: ", *this);
 }
 
 BufferMemoryResult BufferMemoryManager::tryAllocateGrowableBoundsCheckingMemory(size_t mappedCapacity)
@@ -131,7 +131,7 @@ BufferMemoryResult BufferMemoryManager::tryAllocateGrowableBoundsCheckingMemory(
         return BufferMemoryResult(result, BufferMemoryResult::Success);
     }();
 
-    dataLogLnIf(Options::logWebAssemblyMemory(), "Allocated virtual: ", result, "; state: ", *this);
+    dataLogLnIf(Options::logWasmMemory(), "Allocated virtual: ", result, "; state: ", *this);
 
     return result;
 }
@@ -144,7 +144,7 @@ void BufferMemoryManager::freeGrowableBoundsCheckingMemory(void* basePtr, size_t
         m_growableBoundsCheckingMemories.erase(std::make_pair(bitwise_cast<uintptr_t>(basePtr), mappedCapacity));
     }
 
-    dataLogLnIf(Options::logWebAssemblyMemory(), "Freed virtual; state: ", *this);
+    dataLogLnIf(Options::logWasmMemory(), "Freed virtual; state: ", *this);
 }
 
 bool BufferMemoryManager::isInGrowableOrFastMemory(void* address)
@@ -186,7 +186,7 @@ BufferMemoryResult::Kind BufferMemoryManager::tryAllocatePhysicalBytes(size_t by
         return BufferMemoryResult::Success;
     }();
 
-    dataLogLnIf(Options::logWebAssemblyMemory(), "Allocated physical: ", bytes, ", ", BufferMemoryResult::toString(result), "; state: ", *this);
+    dataLogLnIf(Options::logWasmMemory(), "Allocated physical: ", bytes, ", ", BufferMemoryResult::toString(result), "; state: ", *this);
 
     return result;
 }
@@ -198,7 +198,7 @@ void BufferMemoryManager::freePhysicalBytes(size_t bytes)
         m_physicalBytes -= bytes;
     }
 
-    dataLogLnIf(Options::logWebAssemblyMemory(), "Freed physical: ", bytes, "; state: ", *this);
+    dataLogLnIf(Options::logWasmMemory(), "Freed physical: ", bytes, "; state: ", *this);
 }
 
 void BufferMemoryManager::dump(PrintStream& out) const

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -118,7 +118,7 @@ private:
     BufferMemoryManager() = default;
 
     Lock m_lock;
-    unsigned m_maxFastMemoryCount { Options::maxNumWebAssemblyFastMemories() };
+    unsigned m_maxFastMemoryCount { Options::maxNumWasmFastMemories() };
     Vector<void*> m_fastMemories;
     StdSet<std::pair<uintptr_t, size_t>> m_growableBoundsCheckingMemories;
     size_t m_physicalBytes { 0 };

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -116,7 +116,7 @@ void initialize()
 
         AssemblyCommentRegistry::initialize();
 #if ENABLE(WEBASSEMBLY)
-        if (Options::useWebAssemblyIPInt() || Options::useInterpretedJSEntryWrappers())
+        if (Options::useWasmIPInt() || Options::useInterpretedJSEntryWrappers())
             IPInt::initialize();
 #endif
         LLInt::initialize();

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -164,7 +164,7 @@ constexpr bool typeExposedByDefault = true;
 
 #if ENABLE(WEBASSEMBLY)
 #define FOR_EACH_WEBASSEMBLY_CONSTRUCTOR_TYPE(macro) \
-    macro(WebAssemblyArray,        webAssemblyArray,        webAssemblyArray,        JSWebAssemblyArray,        Array,        object, Options::useWebAssemblyGC()) \
+    macro(WebAssemblyArray,        webAssemblyArray,        webAssemblyArray,        JSWebAssemblyArray,        Array,        object, Options::useWasmGC()) \
     macro(WebAssemblyCompileError, webAssemblyCompileError, webAssemblyCompileError, ErrorInstance,             CompileError, error,  typeExposedByDefault) \
     macro(WebAssemblyException,    webAssemblyException,    webAssemblyException,    JSWebAssemblyException,    Exception,    object, typeExposedByDefault) \
     macro(WebAssemblyGlobal,       webAssemblyGlobal,       webAssemblyGlobal,       JSWebAssemblyGlobal,       Global,       object, typeExposedByDefault) \
@@ -173,7 +173,7 @@ constexpr bool typeExposedByDefault = true;
     macro(WebAssemblyMemory,       webAssemblyMemory,       webAssemblyMemory,       JSWebAssemblyMemory,       Memory,       object, typeExposedByDefault) \
     macro(WebAssemblyModule,       webAssemblyModule,       webAssemblyModule,       JSWebAssemblyModule,       Module,       object, typeExposedByDefault) \
     macro(WebAssemblyRuntimeError, webAssemblyRuntimeError, webAssemblyRuntimeError, ErrorInstance,             RuntimeError, error,  typeExposedByDefault) \
-    macro(WebAssemblyStruct,       webAssemblyStruct,       webAssemblyStruct,       JSWebAssemblyStruct,       Struct,       object, Options::useWebAssemblyGC()) \
+    macro(WebAssemblyStruct,       webAssemblyStruct,       webAssemblyStruct,       JSWebAssemblyStruct,       Struct,       object, Options::useWasmGC()) \
     macro(WebAssemblyTable,        webAssemblyTable,        webAssemblyTable,        JSWebAssemblyTable,        Table,        object, typeExposedByDefault) \
     macro(WebAssemblyTag,          webAssemblyTag,          webAssemblyTag,          JSWebAssemblyTag,          Tag,          object, typeExposedByDefault) 
 #else

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -113,7 +113,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, initialRepatchBufferingCountdown, 6, Normal, nullptr) \
     \
     v(Bool, dumpGeneratedBytecodes, false, Normal, nullptr) \
-    v(Bool, dumpGeneratedWebAssemblyBytecodes, false, Normal, nullptr) \
+    v(Bool, dumpGeneratedWasmBytecodes, false, Normal, nullptr) \
     v(Bool, dumpBytecodeLivenessResults, false, Normal, nullptr) \
     v(Bool, validateBytecode, false, Normal, nullptr) \
     v(Bool, forceDebuggerBytecodeGeneration, false, Normal, nullptr) \
@@ -139,9 +139,9 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, dumpDFGDisassembly, false, Normal, "dumps disassembly of DFG function upon compilation"_s) \
     v(Bool, dumpFTLDisassembly, false, Normal, "dumps disassembly of FTL function upon compilation"_s) \
     v(Bool, dumpRegExpDisassembly, false, Normal, "dumps disassembly of RegExp upon compilation"_s) \
-    v(Bool, dumpWebAssemblyDisassembly, false, Normal, "dumps disassembly of all wasm code upon compilation"_s) \
-    v(OptionString, dumpWebAssemblySourceFileName, nullptr, Normal, "log every wasm module validation, and dump source bytes to <filename>.0.wasm, <filename>.1.wasm, etc..."_s) \
-    v(OptionString, webAssemblyOMGFunctionsToDump, nullptr, Normal, "file with newline separated list of function indices to dump IR/disassembly for, if no such file exists, the function index itself"_s) \
+    v(Bool, dumpWasmDisassembly, false, Normal, "dumps disassembly of all wasm code upon compilation"_s) \
+    v(OptionString, dumpWasmSourceFileName, nullptr, Normal, "log every wasm module validation, and dump source bytes to <filename>.0.wasm, <filename>.1.wasm, etc..."_s) \
+    v(OptionString, wasmOMGFunctionsToDump, nullptr, Normal, "file with newline separated list of function indices to dump IR/disassembly for, if no such file exists, the function index itself"_s) \
     v(Bool, dumpBBQDisassembly, false, Normal, "dumps disassembly of BBQ wasm code upon compilation"_s) \
     v(Bool, dumpOMGDisassembly, false, Normal, "dumps disassembly of OMG wasm code upon compilation"_s) \
     v(Bool, logJITCodeForPerf, false, Configurable, nullptr) \
@@ -254,7 +254,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, usePolymorphicCallInliningForNonStubStatus, false, Normal, nullptr) \
     v(Unsigned, maxPolymorphicCallVariantListSize, 8, Normal, nullptr) \
     v(Unsigned, maxPolymorphicCallVariantListSizeForTopTier, 5, Normal, nullptr) \
-    v(Unsigned, maxPolymorphicCallVariantListSizeForWebAssemblyToJS, 5, Normal, nullptr) \
+    v(Unsigned, maxPolymorphicCallVariantListSizeForWasmToJS, 5, Normal, nullptr) \
     v(Unsigned, maxPolymorphicCallVariantsForInlining, 5, Normal, nullptr) \
     v(Unsigned, frequentCallThreshold, 2, Normal, nullptr) \
     v(Double, minimumCallToKnownRate, 0.51, Normal, nullptr) \
@@ -271,10 +271,10 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, numberOfWorklistThreads, computeNumberOfWorkerThreads(3, 2), Normal, nullptr) \
     v(Unsigned, numberOfDFGCompilerThreads, computeNumberOfWorkerThreads(3, 2) - 1, Normal, nullptr) \
     v(Unsigned, numberOfFTLCompilerThreads, computeNumberOfWorkerThreads(MAXIMUM_NUMBER_OF_FTL_COMPILER_THREADS, 2) - 1, Normal, nullptr) \
-    v(Unsigned, numberOfWebAssemblyCompilerThreads, computeNumberOfWorkerThreads(INT32_MAX, 2) - 1, Normal, nullptr) \
+    v(Unsigned, numberOfWasmCompilerThreads, computeNumberOfWorkerThreads(INT32_MAX, 2) - 1, Normal, nullptr) \
     v(Int32, priorityDeltaOfDFGCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
     v(Int32, priorityDeltaOfFTLCompilerThreads, computePriorityDeltaOfWorkerThreads(-2, 0), Normal, nullptr) \
-    v(Int32, priorityDeltaOfWebAssemblyCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
+    v(Int32, priorityDeltaOfWasmCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
     \
     v(Bool, useProfiler, false, Normal, nullptr) \
     v(Bool, dumpProfilerDataAtExit, false, Normal, nullptr) \
@@ -310,9 +310,9 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maximumBinaryStringSwitchTotalLength, 2000, Normal, nullptr) \
     v(Unsigned, maximumRegExpTestInlineCodesize, 500, Normal, "Maximum code size in bytes for inlined RegExp.test JIT code."_s) \
     \
-    v(Unsigned, maximumWebAssemblyDepthForInlining, isIOS() ? 2 : 8, Normal, "Maximum inlining depth to consider inlining a wasm function."_s) \
-    v(Unsigned, maximumWebAssemblyCalleeSizeForInlining, 200, Normal, "Maximum wasm size in bytes to consider inlining a wasm function."_s) \
-    v(Unsigned, maximumWebAssemblyCallerSizeForInlining, 10000, Normal, "Maximum wasm size in bytes for the caller of an inlined function."_s) \
+    v(Unsigned, maximumWasmDepthForInlining, isIOS() ? 2 : 8, Normal, "Maximum inlining depth to consider inlining a wasm function."_s) \
+    v(Unsigned, maximumWasmCalleeSizeForInlining, 200, Normal, "Maximum wasm size in bytes to consider inlining a wasm function."_s) \
+    v(Unsigned, maximumWasmCallerSizeForInlining, 10000, Normal, "Maximum wasm size in bytes for the caller of an inlined function."_s) \
     \
     v(Double, jitPolicyScale, 1.0, Normal, "scale JIT thresholds to this specified ratio between 0.0 (compile ASAP) and 1.0 (compile like normal)."_s) \
     v(Bool, forceEagerCompilation, false, Normal, nullptr) \
@@ -497,37 +497,37 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useSourceProviderCache, true, Normal, "If false, the parser will not use the source provider cache. It's good to verify everything works when this is false. Because the cache is so successful, it can mask bugs."_s) \
     v(Bool, useCodeCache, true, Normal, "If false, the unlinked byte code cache will not be used."_s) \
     \
-    v(Bool, useWebAssembly, true, Normal, "Expose the WebAssembly global object."_s) \
+    v(Bool, useWasm, true, Normal, "Expose the Wasm global object."_s) \
     \
-    v(Bool, failToCompileWebAssemblyCode, false, Normal, "If true, no Wasm::Plan will sucessfully compile a function."_s) \
-    v(Size, webAssemblyPartialCompileLimit, 5000, Normal, "Limit on the number of bytes a Wasm::Plan::compile should attempt before checking for other work."_s) \
-    v(Unsigned, webAssemblyOMGOptimizationLevel, Options::defaultB3OptLevel(), Normal, "B3 Optimization level for OMG Web Assembly module compilations."_s) \
+    v(Bool, failToCompileWasmCode, false, Normal, "If true, no Wasm::Plan will sucessfully compile a function."_s) \
+    v(Size, wasmPartialCompileLimit, 5000, Normal, "Limit on the number of bytes a Wasm::Plan::compile should attempt before checking for other work."_s) \
+    v(Unsigned, wasmOMGOptimizationLevel, Options::defaultB3OptLevel(), Normal, "B3 Optimization level for OMG Web Assembly module compilations."_s) \
     \
     v(Bool, useBBQTierUpChecks, true, Normal, "Enables tier up checks for our BBQ code."_s) \
-    v(Bool, useWebAssemblyOSR, true, Normal, nullptr) \
+    v(Bool, useWasmOSR, true, Normal, nullptr) \
     v(Int32, thresholdForBBQOptimizeAfterWarmUp, 150, Normal, "The count before we tier up a function to BBQ."_s) \
     v(Int32, thresholdForBBQOptimizeSoon, 50, Normal, nullptr) \
     v(Int32, thresholdForOMGOptimizeAfterWarmUp, 50000, Normal, "The count before we tier up a function to OMG."_s) \
     v(Int32, thresholdForOMGOptimizeSoon, 500, Normal, nullptr) \
     v(Int32, omgTierUpCounterIncrementForLoop, 1, Normal, "The amount the tier up counter is incremented on each loop backedge."_s) \
     v(Int32, omgTierUpCounterIncrementForEntry, 15, Normal, "The amount the tier up counter is incremented on each function entry."_s) \
-    v(Bool, useWebAssemblyFastMemory, true, Normal, "If true, we will try to use a 32-bit address space with a signal handler to bounds check wasm memory."_s) \
-    v(Bool, logWebAssemblyMemory, false, Normal, nullptr) \
-    v(Unsigned, webAssemblyFastMemoryRedzonePages, 128, Normal, "WebAssembly fast memories use 4GiB virtual allocations, plus a redzone (counted as multiple of 64KiB WebAssembly pages) at the end to catch reg+imm accesses which exceed 32-bit, anything beyond the redzone is explicitly bounds-checked"_s) \
-    v(Bool, crashIfWebAssemblyCantFastMemory, false, Normal, "If true, we will crash if we can't obtain fast memory for wasm."_s) \
-    v(Bool, crashOnFailedWebAssemblyValidate, false, Normal, "If true, we will crash if we can't validate a wasm module instead of throwing an exception."_s) \
-    v(Unsigned, maxNumWebAssemblyFastMemories, hasCapacityToUseLargeGigacage() ? 8 : 3, Normal, nullptr) \
+    v(Bool, useWasmFastMemory, true, Normal, "If true, we will try to use a 32-bit address space with a signal handler to bounds check wasm memory."_s) \
+    v(Bool, logWasmMemory, false, Normal, nullptr) \
+    v(Unsigned, wasmFastMemoryRedzonePages, 128, Normal, "Wasm fast memories use 4GiB virtual allocations, plus a redzone (counted as multiple of 64KiB Wasm pages) at the end to catch reg+imm accesses which exceed 32-bit, anything beyond the redzone is explicitly bounds-checked"_s) \
+    v(Bool, crashIfWasmCantFastMemory, false, Normal, "If true, we will crash if we can't obtain fast memory for wasm."_s) \
+    v(Bool, crashOnFailedWasmValidate, false, Normal, "If true, we will crash if we can't validate a wasm module instead of throwing an exception."_s) \
+    v(Unsigned, maxNumWasmFastMemories, hasCapacityToUseLargeGigacage() ? 8 : 3, Normal, nullptr) \
     v(Bool, verboseBBQJITAllocation, false, Normal, "Logs extra information about register allocation during BBQ JIT"_s) \
     v(Bool, verboseBBQJITInstructions, false, Normal, "Logs instruction information during BBQ JIT"_s) \
-    v(Bool, useWebAssemblyLLInt, true, Normal, nullptr) \
+    v(Bool, useWasmLLInt, true, Normal, nullptr) \
     v(Bool, useBBQJIT, true, Normal, "allows the BBQ JIT to be used if true"_s) \
     v(Bool, useOMGJIT, !isARM_THUMB2(), Normal, "allows the OMG JIT to be used if true"_s) \
-    v(Bool, useWebAssemblyLLIntPrologueOSR, true, Normal, "allows prologue OSR from wasm LLInt if true"_s) \
-    v(Bool, useWebAssemblyLLIntLoopOSR, true, Normal, "allows loop OSR from wasm LLInt if true"_s) \
-    v(Bool, useWebAssemblyLLIntEpilogueOSR, true, Normal, "allows epilogue OSR from wasm LLInt if true"_s) \
-    v(OptionRange, webAssemblyFunctionIndexRangeToCompile, nullptr, Normal, "wasm function index range to allow compilation on, e.g. 1:100"_s) \
-    v(Bool, webAssemblyLLIntTiersUpToBBQ, true, Normal, nullptr) \
-    v(Bool, useEagerWebAssemblyModuleHashing, false, Normal, "Unnamed WebAssembly modules are identified in backtraces through their hash, if available."_s) \
+    v(Bool, useWasmLLIntPrologueOSR, true, Normal, "allows prologue OSR from wasm LLInt if true"_s) \
+    v(Bool, useWasmLLIntLoopOSR, true, Normal, "allows loop OSR from wasm LLInt if true"_s) \
+    v(Bool, useWasmLLIntEpilogueOSR, true, Normal, "allows epilogue OSR from wasm LLInt if true"_s) \
+    v(OptionRange, wasmFunctionIndexRangeToCompile, nullptr, Normal, "wasm function index range to allow compilation on, e.g. 1:100"_s) \
+    v(Bool, wasmLLIntTiersUpToBBQ, true, Normal, nullptr) \
+    v(Bool, useEagerWasmModuleHashing, false, Normal, "Unnamed Wasm modules are identified in backtraces through their hash, if available."_s) \
     v(Bool, useArrayAllocationProfiling, true, Normal, "If true, we will use our normal array allocation profiling. If false, the allocation profile will always claim to be undecided."_s) \
     v(Bool, forcePolyProto, false, Normal, "If true, create_this will always create an object with a poly proto structure."_s) \
     v(Bool, forceMiniVMMode, false, Normal, "If true, it will force mini VM mode on."_s) \
@@ -566,18 +566,18 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useLLIntICs, true, Normal, "Use property and call ICs in LLInt code."_s) \
     v(Bool, useBaselineJITCodeSharing, is64Bit(), Normal, nullptr) \
     v(Bool, libpasScavengeContinuously, false, Normal, nullptr) \
-    v(Bool, useWebAssemblyFaultSignalHandler, true, Normal, nullptr) \
+    v(Bool, useWasmFaultSignalHandler, true, Normal, nullptr) \
     v(Bool, dumpUnlinkedDFGValidation, false, Normal, nullptr) \
-    v(Bool, dumpWebAssemblyOpcodeStatistics, false, Normal, nullptr) \
-    v(Bool, dumpWebAssemblyWarnings, false, Normal, nullptr) \
+    v(Bool, dumpWasmOpcodeStatistics, false, Normal, nullptr) \
+    v(Bool, dumpWasmWarnings, false, Normal, nullptr) \
     v(Bool, useRecursiveJSONParse, true, Normal, nullptr) \
     v(Unsigned, thresholdForStringReplaceCache, 0x1000, Normal, nullptr) \
-    v(Bool, useWebAssemblyIPInt, false, Normal, "Use the in-place interpereter for WASM instead of LLInt."_s) \
-    v(Bool, useWebAssemblyIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues"_s) \
-    v(Bool, useWebAssemblyIPIntLoopOSR, true, Normal, "Allow IPInt to tier up during loop iterations"_s) \
-    v(Bool, useWebAssemblyIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues"_s) \
-    v(Bool, webAssemblyIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ"_s) \
-    v(Bool, webAssemblyIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG"_s) \
+    v(Bool, useWasmIPInt, false, Normal, "Use the in-place interpereter for WASM instead of LLInt."_s) \
+    v(Bool, useWasmIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues"_s) \
+    v(Bool, useWasmIPIntLoopOSR, true, Normal, "Allow IPInt to tier up during loop iterations"_s) \
+    v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues"_s) \
+    v(Bool, wasmIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ"_s) \
+    v(Bool, wasmIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG"_s) \
     v(Bool, useInterpretedJSEntryWrappers, false, Normal, "Allow some JS->wasm wrappers to be replaced by jit-less versions."_s) \
     v(Bool, forceAllFunctionsToUseSIMD, false, Normal, "Force all functions to act conservatively w.r.t fp/vector registers for testing."_s) \
     \
@@ -600,12 +600,12 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object."_s) \
     v(Bool, useTrustedTypes, false, Normal, "Enable trusted types eval protection feature."_s) \
     v(Bool, useUint8ArrayBase64Methods, false, Normal, "Expose methods for converting Uint8Array to/from base64 and hex."_s) \
-    v(Bool, useWebAssemblyTypedFunctionReferences, true, Normal, "Allow function types from the wasm typed function references spec."_s) \
-    v(Bool, useWebAssemblyGC, false, Normal, "Allow gc types from the wasm gc proposal."_s) \
-    v(Bool, useWebAssemblySIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
-    v(Bool, useWebAssemblyRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec."_s) \
-    v(Bool, useWebAssemblyTailCalls, false, Normal, "Allow the new instructions from the wasm tail calls spec."_s) \
-    v(Bool, useWebAssemblyExtendedConstantExpressions, true, Normal, "Allow the use of global, element, and data init expressions from the extended constant expressions proposal."_s) \
+    v(Bool, useWasmTypedFunctionReferences, true, Normal, "Allow function types from the wasm typed function references spec."_s) \
+    v(Bool, useWasmGC, false, Normal, "Allow gc types from the wasm gc proposal."_s) \
+    v(Bool, useWasmSIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
+    v(Bool, useWasmRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec."_s) \
+    v(Bool, useWasmTailCalls, false, Normal, "Allow the new instructions from the wasm tail calls spec."_s) \
+    v(Bool, useWasmExtendedConstantExpressions, true, Normal, "Allow the use of global, element, and data init expressions from the extended constant expressions proposal."_s) \
 
 
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -2894,7 +2894,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addRefEq(Value ref0, Value ref1, Value&
 PartialResult WARN_UNUSED_RETURN BBQJIT::addRefFunc(uint32_t index, Value& result)
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
-    TypeKind returnType = Options::useWebAssemblyTypedFunctionReferences() ? TypeKind::Ref : TypeKind::Funcref;
+    TypeKind returnType = Options::useWasmTypedFunctionReferences() ? TypeKind::Ref : TypeKind::Funcref;
 
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -3213,7 +3213,7 @@ StackMap BBQJIT::makeStackMap(const ControlData& data, Stack& enclosingStack)
     for (unsigned i = 0; i < m_locals.size(); i ++)
         stackMap[stackMapIndex ++] = OSREntryValue(toB3Rep(m_locals[i]), toB3Type(m_localTypes[i]));
 
-    if (Options::useWebAssemblyIPInt()) {
+    if (Options::useWasmIPInt()) {
         // Do rethrow slots first because IPInt has them in a shadow stack.
         for (const ControlEntry& entry : m_parser->controlStack()) {
             for (unsigned i = 0; i < entry.controlData.implicitSlots(); i ++) {
@@ -4068,7 +4068,7 @@ void BBQJIT::addRTTSlowPathJump(TypeIndex signature, GPRReg calleeRTT)
 
 void BBQJIT::emitSlowPathRTTCheck(MacroAssembler::Label returnLabel, TypeIndex typeIndex, GPRReg calleeRTT)
 {
-    ASSERT(Options::useWebAssemblyGC());
+    ASSERT(Options::useWasmGC());
 
     auto signatureRTT = TypeInformation::getCanonicalRTT(typeIndex);
     GPRReg rttSize = wasmScratchGPR;
@@ -4197,7 +4197,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addCallIndirect(unsigned tableIndex, co
             static_assert(static_cast<ptrdiff_t>(WasmToWasmImportableFunction::offsetOfSignatureIndex() + sizeof(void*)) == WasmToWasmImportableFunction::offsetOfEntrypointLoadLocation());
 
             // Save the table entry in calleeRTT if needed for the subtype check.
-            bool needsSubtypeCheck = Options::useWebAssemblyGC() && !originalSignature.isFinalType();
+            bool needsSubtypeCheck = Options::useWasmGC() && !originalSignature.isFinalType();
             if (needsSubtypeCheck)
                 m_jit.move(calleeSignatureIndex, calleeRTT);
 

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -201,7 +201,7 @@ void BBQPlan::work(CompilationEffort effort)
         m_calleeGroup->callsiteCollection().updateCallsitesToCallUs(locker, *m_calleeGroup, CodeLocationLabel<WasmEntryPtrTag>(entrypoint), m_functionIndex, functionIndexSpace);
 
         {
-            if (Options::useWebAssemblyIPInt()) {
+            if (Options::useWasmIPInt()) {
                 IPIntCallee& ipintCallee = m_calleeGroup->m_ipintCallees->at(m_functionIndex).get();
                 Locker locker { ipintCallee.tierUpCounter().m_lock };
                 ipintCallee.setReplacement(callee.copyRef(), mode());

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -764,7 +764,7 @@ public:
     ALWAYS_INLINE uint64_t getConstant(VirtualRegister reg) const { return m_constants[reg.toConstantIndex()]; }
     ALWAYS_INLINE Type getConstantType(VirtualRegister reg) const
     {
-        ASSERT(Options::dumpGeneratedWebAssemblyBytecodes());
+        ASSERT(Options::dumpGeneratedWasmBytecodes());
         return m_constantTypes[reg.toConstantIndex()];
     }
 

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -76,7 +76,7 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
     , m_callsiteCollection(m_calleeCount)
 {
     RefPtr<CalleeGroup> protectedThis = this;
-    if (Options::useWebAssemblyLLInt()) {
+    if (Options::useWasmLLInt()) {
         m_plan = adoptRef(*new LLIntPlan(vm, moduleInformation, m_llintCallees->data(), createSharedTask<Plan::CallbackType>([this, protectedThis = WTFMove(protectedThis)] (Plan&) {
             if (!m_plan) {
                 m_errorMessage = makeString("Out of memory while creating LLInt CalleeGroup"_s);
@@ -150,7 +150,7 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
     , m_callsiteCollection(m_calleeCount)
 {
     RefPtr<CalleeGroup> protectedThis = this;
-    if (Options::useWebAssemblyIPInt()) {
+    if (Options::useWasmIPInt()) {
         m_plan = adoptRef(*new IPIntPlan(vm, moduleInformation, m_ipintCallees->data(), createSharedTask<Plan::CallbackType>([this, protectedThis = WTFMove(protectedThis)] (Plan&) {
             Locker locker { m_lock };
             if (m_plan->failed()) {

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -102,7 +102,7 @@ public:
         if (!m_bbqCallees.isEmpty() && m_bbqCallees[calleeIndex])
             return *m_bbqCallees[calleeIndex].get();
 #endif
-        if (Options::useWebAssemblyIPInt())
+        if (Options::useWasmIPInt())
             return m_ipintCallees->at(calleeIndex).get();
         return m_llintCallees->at(calleeIndex).get();
     }

--- a/Source/JavaScriptCore/wasm/WasmCapabilities.h
+++ b/Source/JavaScriptCore/wasm/WasmCapabilities.h
@@ -35,7 +35,7 @@ namespace Wasm {
 
 inline bool isSupported()
 {
-    return Options::useWebAssembly();
+    return Options::useWasm();
 }
 
 #else

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -258,7 +258,7 @@ public:
     {
         // Note that this check works for table initializers too, because no globals are registered when the table section is read and the count is 0.
         WASM_COMPILE_FAIL_IF(index >= m_info.globals.size(), "get_global's index ", index, " exceeds the number of globals ", m_info.globals.size());
-        if (!Options::useWebAssemblyGC())
+        if (!Options::useWasmGC())
             WASM_COMPILE_FAIL_IF(index >= m_info.firstInternalGlobal, "get_global import kind index ", index, " exceeds the first internal global ", m_info.firstInternalGlobal);
         WASM_COMPILE_FAIL_IF(m_info.globals[index].mutability != Mutability::Immutable, "get_global import kind index ", index, " is mutable ");
 
@@ -315,7 +315,7 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType value, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
+        WASM_PARSER_FAIL_IF(!Options::useWasmGC(), "Wasm GC is not enabled"_s);
 
         if (m_mode == Mode::Evaluate) {
             result = createNewArray(typeIndex, static_cast<uint32_t>(size.getValue()), value);
@@ -327,7 +327,7 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
+        WASM_PARSER_FAIL_IF(!Options::useWasmGC(), "Wasm GC is not enabled"_s);
 
         if (m_mode == Mode::Evaluate) {
             Ref<TypeDefinition> typeDef = m_info.typeSignatures[typeIndex];
@@ -347,7 +347,7 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addArrayNewFixed(uint32_t typeIndex, Vector<ExpressionType>& args, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
+        WASM_PARSER_FAIL_IF(!Options::useWasmGC(), "Wasm GC is not enabled"_s);
 
         if (m_mode == Mode::Evaluate) {
             auto* arrayType = m_info.typeSignatures[typeIndex]->expand().as<ArrayType>();
@@ -391,7 +391,7 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
+        WASM_PARSER_FAIL_IF(!Options::useWasmGC(), "Wasm GC is not enabled"_s);
 
         if (m_mode == Mode::Evaluate) {
             result = createNewStruct(typeIndex);
@@ -403,7 +403,7 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addStructNew(uint32_t typeIndex, Vector<ExpressionType>& args, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
+        WASM_PARSER_FAIL_IF(!Options::useWasmGC(), "Wasm GC is not enabled"_s);
 
         if (m_mode == Mode::Evaluate) {
             result = createNewStruct(typeIndex);
@@ -427,7 +427,7 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addAnyConvertExtern(ExpressionType reference, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
+        WASM_PARSER_FAIL_IF(!Options::useWasmGC(), "Wasm GC is not enabled"_s);
         if (m_mode == Mode::Evaluate) {
             if (reference.type() == ConstExprValue::Numeric)
                 result = ConstExprValue(externInternalize(reference.getValue()));
@@ -442,7 +442,7 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addExternConvertAny(ExpressionType reference, ExpressionType& result)
     {
-        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled"_s);
+        WASM_PARSER_FAIL_IF(!Options::useWasmGC(), "Wasm GC is not enabled"_s);
         result = reference;
         return { };
     }
@@ -695,7 +695,7 @@ public:
     PartialResult WARN_UNUSED_RETURN addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
     ExpressionType WARN_UNUSED_RETURN addConstant(v128_t vector)
     {
-        RELEASE_ASSERT(Options::useWebAssemblySIMD());
+        RELEASE_ASSERT(Options::useWasmSIMD());
         if (m_mode == Mode::Evaluate)
             return ConstExprValue(vector);
         return { };
@@ -734,7 +734,7 @@ private:
 
 Expected<void, String> parseExtendedConstExpr(std::span<const uint8_t> source, size_t offsetInSource, size_t& offset, ModuleInformation& info, Type expectedType)
 {
-    RELEASE_ASSERT_WITH_MESSAGE(Options::useWebAssemblyExtendedConstantExpressions(), "Wasm extended const expressions not enabled");
+    RELEASE_ASSERT_WITH_MESSAGE(Options::useWasmExtendedConstantExpressions(), "Wasm extended const expressions not enabled");
     ConstExprGenerator generator(ConstExprGenerator::Mode::Validate, offsetInSource, info);
     FunctionParser<ConstExprGenerator> parser(generator, source, *TypeInformation::typeDefinitionForFunction({ expectedType }, { }), info);
     WASM_FAIL_IF_HELPER_FAILS(parser.parseConstantExpression());
@@ -748,7 +748,7 @@ Expected<void, String> parseExtendedConstExpr(std::span<const uint8_t> source, s
 
 Expected<uint64_t, String> evaluateExtendedConstExpr(const Vector<uint8_t>& constantExpression, JSWebAssemblyInstance* instance, const ModuleInformation& info, Type expectedType)
 {
-    RELEASE_ASSERT_WITH_MESSAGE(Options::useWebAssemblyExtendedConstantExpressions(), "Wasm extended const expressions not enabled");
+    RELEASE_ASSERT_WITH_MESSAGE(Options::useWasmExtendedConstantExpressions(), "Wasm extended const expressions not enabled");
     ConstExprGenerator generator(ConstExprGenerator::Mode::Evaluate, info, instance);
     FunctionParser<ConstExprGenerator> parser(generator, constantExpression, *TypeInformation::typeDefinitionForFunction({ expectedType }, { }), info);
     WASM_FAIL_IF_HELPER_FAILS(parser.parseConstantExpression());

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -185,7 +185,7 @@ void EntryPlan::compileFunctions(CompilationEffort effort)
 
     size_t bytesCompiled = 0;
     while (true) {
-        if (effort == Partial && bytesCompiled >= Options::webAssemblyPartialCompileLimit())
+        if (effort == Partial && bytesCompiled >= Options::wasmPartialCompileLimit())
             return;
 
         uint32_t functionIndex;
@@ -203,7 +203,7 @@ void EntryPlan::compileFunctions(CompilationEffort effort)
             functionIndexEnd = m_numberOfFunctions;
             for (uint32_t index = functionIndex; index < m_numberOfFunctions; ++index) {
                 bytesCompiled += m_moduleInformation->functions[index].data.size();
-                if (bytesCompiled >= Options::webAssemblyPartialCompileLimit()) {
+                if (bytesCompiled >= Options::wasmPartialCompileLimit()) {
                     functionIndexEnd = index + 1;
                     break;
                 }

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -124,7 +124,7 @@ void activateSignalingMemory()
         if (!Wasm::isSupported())
             return;
 
-        if (!Options::useWebAssemblyFaultSignalHandler())
+        if (!Options::useWasmFaultSignalHandler())
             return;
 
         activateSignalHandlersFor(Signal::AccessFault);
@@ -138,7 +138,7 @@ void prepareSignalingMemory()
         if (!Wasm::isSupported())
             return;
 
-        if (!Options::useWebAssemblyFaultSignalHandler())
+        if (!Options::useWasmFaultSignalHandler())
             return;
 
 #if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -77,12 +77,12 @@ inline bool isValueType(Type type)
         return true;
     case TypeKind::Externref:
     case TypeKind::Funcref:
-        return !Options::useWebAssemblyTypedFunctionReferences();
+        return !Options::useWasmTypedFunctionReferences();
     case TypeKind::Ref:
     case TypeKind::RefNull:
-        return Options::useWebAssemblyTypedFunctionReferences() && type.index != TypeDefinition::invalidIndex;
+        return Options::useWasmTypedFunctionReferences() && type.index != TypeDefinition::invalidIndex;
     case TypeKind::V128:
-        return Options::useWebAssemblySIMD();
+        return Options::useWasmSIMD();
     default:
         break;
     }
@@ -91,7 +91,7 @@ inline bool isValueType(Type type)
 
 inline bool isRefType(Type type)
 {
-    if (Options::useWebAssemblyTypedFunctionReferences())
+    if (Options::useWasmTypedFunctionReferences())
         return type.isRef() || type.isRefNull();
     return type.isFuncref() || type.isExternref();
 }
@@ -106,56 +106,56 @@ inline bool isRefType(StorageType type)
 
 inline bool isExternref(Type type)
 {
-    if (Options::useWebAssemblyTypedFunctionReferences())
+    if (Options::useWasmTypedFunctionReferences())
         return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Externref);
     return type.kind == TypeKind::Externref;
 }
 
 inline bool isFuncref(Type type)
 {
-    if (Options::useWebAssemblyTypedFunctionReferences())
+    if (Options::useWasmTypedFunctionReferences())
         return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Funcref);
     return type.kind == TypeKind::Funcref;
 }
 
 inline bool isEqref(Type type)
 {
-    if (!Options::useWebAssemblyGC())
+    if (!Options::useWasmGC())
         return false;
     return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Eqref);
 }
 
 inline bool isAnyref(Type type)
 {
-    if (!Options::useWebAssemblyGC())
+    if (!Options::useWasmGC())
         return false;
     return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Anyref);
 }
 
 inline bool isNullref(Type type)
 {
-    if (!Options::useWebAssemblyGC())
+    if (!Options::useWasmGC())
         return false;
     return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Nullref);
 }
 
 inline bool isNullfuncref(Type type)
 {
-    if (!Options::useWebAssemblyGC())
+    if (!Options::useWasmGC())
         return false;
     return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Nullfuncref);
 }
 
 inline bool isNullexternref(Type type)
 {
-    if (!Options::useWebAssemblyGC())
+    if (!Options::useWasmGC())
         return false;
     return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Nullexternref);
 }
 
 inline bool isInternalref(Type type)
 {
-    if (!Options::useWebAssemblyGC() || !isRefType(type))
+    if (!Options::useWasmGC() || !isRefType(type))
         return false;
     if (typeIndexIsType(type.index)) {
         switch (static_cast<TypeKind>(type.index)) {
@@ -175,21 +175,21 @@ inline bool isInternalref(Type type)
 
 inline bool isI31ref(Type type)
 {
-    if (!Options::useWebAssemblyGC())
+    if (!Options::useWasmGC())
         return false;
     return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::I31ref);
 }
 
 inline bool isArrayref(Type type)
 {
-    if (!Options::useWebAssemblyGC())
+    if (!Options::useWasmGC())
         return false;
     return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Arrayref);
 }
 
 inline bool isStructref(Type type)
 {
-    if (!Options::useWebAssemblyGC())
+    if (!Options::useWasmGC())
         return false;
     return isRefType(type) && type.index == static_cast<TypeIndex>(TypeKind::Structref);
 }
@@ -221,14 +221,14 @@ inline JSString* typeToJSAPIString(VM& vm, Type type)
 
 inline Type funcrefType()
 {
-    if (Options::useWebAssemblyTypedFunctionReferences())
+    if (Options::useWasmTypedFunctionReferences())
         return Wasm::Type { Wasm::TypeKind::RefNull, static_cast<Wasm::TypeIndex>(Wasm::TypeKind::Funcref) };
     return Types::Funcref;
 }
 
 inline Type externrefType(bool isNullable = true)
 {
-    if (Options::useWebAssemblyTypedFunctionReferences())
+    if (Options::useWasmTypedFunctionReferences())
         return Wasm::Type { isNullable ? Wasm::TypeKind::RefNull : Wasm::TypeKind::Ref, static_cast<Wasm::TypeIndex>(Wasm::TypeKind::Externref) };
     ASSERT(isNullable);
     return Types::Externref;
@@ -236,19 +236,19 @@ inline Type externrefType(bool isNullable = true)
 
 inline Type eqrefType()
 {
-    ASSERT(Options::useWebAssemblyGC());
+    ASSERT(Options::useWasmGC());
     return Wasm::Type { Wasm::TypeKind::RefNull, static_cast<Wasm::TypeIndex>(Wasm::TypeKind::Eqref) };
 }
 
 inline Type anyrefType(bool isNullable = true)
 {
-    ASSERT(Options::useWebAssemblyGC());
+    ASSERT(Options::useWasmGC());
     return Wasm::Type { isNullable ? Wasm::TypeKind::RefNull : Wasm::TypeKind::Ref, static_cast<Wasm::TypeIndex>(Wasm::TypeKind::Anyref) };
 }
 
 inline Type arrayrefType(bool isNullable = true)
 {
-    ASSERT(Options::useWebAssemblyGC());
+    ASSERT(Options::useWasmGC());
     // Returns a non-null ref type, since this is used for the return types of array operations
     // that are guaranteed to return a non-null array reference
     return Wasm::Type { isNullable ? Wasm::TypeKind::RefNull : Wasm::TypeKind::Ref, static_cast<Wasm::TypeIndex>(Wasm::TypeKind::Arrayref) };
@@ -256,7 +256,7 @@ inline Type arrayrefType(bool isNullable = true)
 
 inline bool isRefWithTypeIndex(Type type)
 {
-    if (!Options::useWebAssemblyTypedFunctionReferences())
+    if (!Options::useWasmTypedFunctionReferences())
         return false;
 
     return isRefType(type) && !typeIndexIsType(type.index);
@@ -266,7 +266,7 @@ inline bool isRefWithTypeIndex(Type type)
 // for an unresolved recursive reference in a recursion group.
 inline bool isRefWithRecursiveReference(Type type)
 {
-    if (!Options::useWebAssemblyGC())
+    if (!Options::useWasmGC())
         return false;
 
     if (isRefWithTypeIndex(type)) {
@@ -288,7 +288,7 @@ inline bool isRefWithRecursiveReference(StorageType storageType)
 
 inline bool isTypeIndexHeapType(int32_t heapType)
 {
-    if (!Options::useWebAssemblyTypedFunctionReferences())
+    if (!Options::useWasmTypedFunctionReferences())
         return false;
 
     return heapType >= 0;
@@ -300,7 +300,7 @@ inline bool isSubtypeIndex(TypeIndex sub, TypeIndex parent)
         return true;
 
     // When Wasm GC is off, RTTs are not registered and there is no subtyping on typedefs.
-    if (!Options::useWebAssemblyGC())
+    if (!Options::useWasmGC())
         return false;
 
     auto subRTT = TypeInformation::tryGetCanonicalRTT(sub);
@@ -313,7 +313,7 @@ inline bool isSubtypeIndex(TypeIndex sub, TypeIndex parent)
 inline bool isSubtype(Type sub, Type parent)
 {
     // Before the typed funcref proposal there is no non-trivial subtyping.
-    if (!Options::useWebAssemblyTypedFunctionReferences())
+    if (!Options::useWasmTypedFunctionReferences())
         return sub == parent;
 
     if (sub.isNullable() && !parent.isNullable())
@@ -380,7 +380,7 @@ inline bool isValidHeapTypeKind(intptr_t kind)
     case static_cast<intptr_t>(TypeKind::Nullref):
     case static_cast<intptr_t>(TypeKind::Nullfuncref):
     case static_cast<intptr_t>(TypeKind::Nullexternref):
-        return Options::useWebAssemblyGC();
+        return Options::useWasmGC();
     default:
         break;
     }

--- a/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h
@@ -95,7 +95,7 @@ public:
     ALWAYS_INLINE uint64_t getConstant(VirtualRegister reg) const { return m_constants[reg.toConstantIndex()]; }
     ALWAYS_INLINE Type getConstantType(VirtualRegister reg) const
     {
-        ASSERT(Options::dumpGeneratedWebAssemblyBytecodes());
+        ASSERT(Options::dumpGeneratedWasmBytecodes());
         return m_constantTypes[reg.toConstantIndex()];
     }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -205,7 +205,7 @@ public:
     // SIMD
 
     bool usesSIMD() { return m_usesSIMD; }
-    void notifyFunctionUsesSIMD() { ASSERT(Options::useWebAssemblySIMD()); m_usesSIMD = true; }
+    void notifyFunctionUsesSIMD() { ASSERT(Options::useWasmSIMD()); m_usesSIMD = true; }
     PartialResult WARN_UNUSED_RETURN addSIMDLoad(ExpressionType, uint32_t, ExpressionType&);
     PartialResult WARN_UNUSED_RETURN addSIMDStore(ExpressionType, ExpressionType, uint32_t);
     PartialResult WARN_UNUSED_RETURN addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&);

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -109,7 +109,7 @@ void IPIntPlan::compileFunction(uint32_t functionIndex)
         return;
     }
 
-    if (Options::useWebAssemblyTailCalls()) {
+    if (Options::useWasmTailCalls()) {
         Locker locker { m_lock };
 
         for (auto successor : parseAndCompileResult->get()->tailCallSuccessors())

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -79,14 +79,14 @@ static inline bool shouldJIT(Wasm::IPIntCallee* callee, RequiredWasmJIT required
         if (!Options::useOMGJIT() || !Wasm::OMGPlan::ensureGlobalOMGAllowlist().containsWasmFunction(callee->functionIndex()))
             return false;
     } else {
-        if (Options::webAssemblyIPIntTiersUpToBBQ()
+        if (Options::wasmIPIntTiersUpToBBQ()
             && (!Options::useBBQJIT() || !Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(callee->functionIndex())))
             return false;
-        if (!Options::webAssemblyIPIntTiersUpToOMG()
+        if (!Options::wasmIPIntTiersUpToOMG()
             && (!Options::useOMGJIT() || !Wasm::OMGPlan::ensureGlobalOMGAllowlist().containsWasmFunction(callee->functionIndex())))
             return false;
     }
-    if (!Options::webAssemblyFunctionIndexRangeToCompile().isInRange(callee->functionIndex()))
+    if (!Options::wasmFunctionIndexRangeToCompile().isInRange(callee->functionIndex()))
         return false;
     return true;
 }
@@ -127,7 +127,7 @@ static inline bool jitCompileAndSetHeuristics(Wasm::IPIntCallee* callee, JSWebAs
     if (compile) {
         uint32_t functionIndex = callee->functionIndex();
         RefPtr<Wasm::Plan> plan;
-        if (Options::webAssemblyIPIntTiersUpToBBQ() && Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(functionIndex))
+        if (Options::wasmIPIntTiersUpToBBQ() && Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(functionIndex))
             plan = adoptRef(*new Wasm::BBQPlan(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), instance->calleeGroup(), Wasm::Plan::dontFinalize()));
         else // No need to check OMG allow list: if we didn't want to compile this function, shouldJIT should have returned false.
             plan = adoptRef(*new Wasm::OMGPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), functionIndex, callee->hasExceptionHandlers(), memoryMode, Wasm::Plan::dontFinalize()));
@@ -151,7 +151,7 @@ WASM_IPINT_EXTERN_CPP_DECL(prologue_osr, CallFrame* callFrame)
         WASM_RETURN_TWO(nullptr, nullptr);
     }
 
-    if (!Options::useWebAssemblyIPIntPrologueOSR())
+    if (!Options::useWasmIPIntPrologueOSR())
         WASM_RETURN_TWO(nullptr, nullptr);
 
     dataLogLnIf(Options::verboseOSR(), *callee, ": Entered prologue_osr with tierUpCounter = ", callee->tierUpCounter());
@@ -166,7 +166,7 @@ WASM_IPINT_EXTERN_CPP_DECL(loop_osr, CallFrame* callFrame, uint32_t pc, uint64_t
     Wasm::IPIntCallee* callee = IPINT_CALLEE();
     Wasm::IPIntTierUpCounter& tierUpCounter = callee->tierUpCounter();
 
-    if (!Options::useWebAssemblyOSR() || !Options::useWebAssemblyIPIntLoopOSR() || !shouldJIT(callee, RequiredWasmJIT::OMG)) {
+    if (!Options::useWasmOSR() || !Options::useWasmIPIntLoopOSR() || !shouldJIT(callee, RequiredWasmJIT::OMG)) {
         ipint_extern_prologue_osr(instance, callFrame);
         WASM_RETURN_TWO(nullptr, nullptr);
     }
@@ -181,7 +181,7 @@ WASM_IPINT_EXTERN_CPP_DECL(loop_osr, CallFrame* callFrame, uint32_t pc, uint64_t
     unsigned loopOSREntryBytecodeOffset = pc;
     const auto& osrEntryData = tierUpCounter.osrEntryDataForLoop(loopOSREntryBytecodeOffset);
 
-    if (Options::webAssemblyIPIntTiersUpToBBQ() && Options::useBBQJIT()) {
+    if (Options::wasmIPIntTiersUpToBBQ() && Options::useBBQJIT()) {
         if (!jitCompileAndSetHeuristics(callee, instance))
             WASM_RETURN_TWO(nullptr, nullptr);
 
@@ -290,7 +290,7 @@ WASM_IPINT_EXTERN_CPP_DECL(epilogue_osr, CallFrame* callFrame)
         callee->tierUpCounter().deferIndefinitely();
         WASM_RETURN_TWO(nullptr, nullptr);
     }
-    if (!Options::useWebAssemblyIPIntEpilogueOSR())
+    if (!Options::useWasmIPIntEpilogueOSR())
         WASM_RETURN_TWO(nullptr, nullptr);
 
     dataLogLnIf(Options::verboseOSR(), *callee, ": Entered epilogue_osr with tierUpCounter = ", callee->tierUpCounter());

--- a/Source/JavaScriptCore/wasm/WasmIPIntTierUpCounter.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntTierUpCounter.h
@@ -63,7 +63,7 @@ public:
 
     void optimizeAfterWarmUp()
     {
-        if (Options::webAssemblyLLIntTiersUpToBBQ())
+        if (Options::wasmLLIntTiersUpToBBQ())
             setNewThreshold(Options::thresholdForBBQOptimizeAfterWarmUp());
         else
             setNewThreshold(Options::thresholdForOMGOptimizeAfterWarmUp());
@@ -76,7 +76,7 @@ public:
 
     void optimizeSoon()
     {
-        if (Options::webAssemblyLLIntTiersUpToBBQ())
+        if (Options::wasmLLIntTiersUpToBBQ())
             setNewThreshold(Options::thresholdForBBQOptimizeSoon());
         else
             setNewThreshold(Options::thresholdForOMGOptimizeSoon());

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -259,7 +259,7 @@ public:
 
     void didPopValueFromStack(ExpressionType, String) { --m_stackSize; }
     bool usesSIMD() { return m_usesSIMD; }
-    void notifyFunctionUsesSIMD() { ASSERT(Options::useWebAssemblySIMD()); m_usesSIMD = true; }
+    void notifyFunctionUsesSIMD() { ASSERT(Options::useWasmSIMD()); m_usesSIMD = true; }
 
     PartialResult WARN_UNUSED_RETURN addDrop(ExpressionType);
 
@@ -426,7 +426,7 @@ private:
         if (UNLIKELY(!m_jsNullConstant.isValid())) {
             m_jsNullConstant = VirtualRegister(FirstConstantRegisterIndex + m_codeBlock->m_constants.size());
             m_codeBlock->m_constants.append(JSValue::encode(jsNull()));
-            if (UNLIKELY(Options::dumpGeneratedWebAssemblyBytecodes()))
+            if (UNLIKELY(Options::dumpGeneratedWasmBytecodes()))
                 m_codeBlock->m_constantTypes.append(Types::Externref);
         }
         return m_jsNullConstant;
@@ -437,7 +437,7 @@ private:
         if (UNLIKELY(!m_zeroConstant.isValid())) {
             m_zeroConstant = VirtualRegister(FirstConstantRegisterIndex + m_codeBlock->m_constants.size());
             m_codeBlock->m_constants.append(0);
-            if (UNLIKELY(Options::dumpGeneratedWebAssemblyBytecodes()))
+            if (UNLIKELY(Options::dumpGeneratedWasmBytecodes()))
                 m_codeBlock->m_constantTypes.append(Types::I32);
         }
         return m_zeroConstant;
@@ -973,7 +973,7 @@ auto LLIntGenerator::addConstantWithoutPush(Type type, int64_t value) -> Express
     if (!result.isNewEntry)
         return result.iterator->value;
     m_codeBlock->m_constants.append(value);
-    if (UNLIKELY(Options::dumpGeneratedWebAssemblyBytecodes()))
+    if (UNLIKELY(Options::dumpGeneratedWasmBytecodes()))
         m_codeBlock->m_constantTypes.append(type);
     return source;
 }

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -111,7 +111,7 @@ void LLIntPlan::compileFunction(uint32_t functionIndex)
         return;
     }
 
-    if (Options::useWebAssemblyTailCalls()) {
+    if (Options::useWasmTailCalls()) {
         Locker locker { m_lock };
 
         for (auto successor : parseAndCompileResult->get()->tailCallSuccessors())
@@ -322,7 +322,7 @@ void LLIntPlan::didCompleteCompilation()
 
     unsigned functionCount = m_wasmInternalFunctions.size();
     if (!m_callees && functionCount) {
-        if (UNLIKELY(Options::dumpGeneratedWebAssemblyBytecodes())) {
+        if (UNLIKELY(Options::dumpGeneratedWasmBytecodes())) {
             for (unsigned i = 0; i < functionCount; ++i)
                 BytecodeDumper::dumpBlock(m_wasmInternalFunctions[i].get(), m_moduleInformation, WTF::dataFile());
         }

--- a/Source/JavaScriptCore/wasm/WasmLLIntTierUpCounter.h
+++ b/Source/JavaScriptCore/wasm/WasmLLIntTierUpCounter.h
@@ -61,7 +61,7 @@ public:
 
     void optimizeAfterWarmUp()
     {
-        if (Options::webAssemblyLLIntTiersUpToBBQ())
+        if (Options::wasmLLIntTiersUpToBBQ())
             setNewThreshold(Options::thresholdForBBQOptimizeAfterWarmUp());
         else
             setNewThreshold(Options::thresholdForOMGOptimizeAfterWarmUp());
@@ -74,7 +74,7 @@ public:
 
     void optimizeSoon()
     {
-        if (Options::webAssemblyLLIntTiersUpToBBQ())
+        if (Options::wasmLLIntTiersUpToBBQ())
             setNewThreshold(Options::thresholdForBBQOptimizeSoon());
         else
             setNewThreshold(Options::thresholdForOMGOptimizeSoon());

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -170,7 +170,7 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
         return nullptr;
         
     char* fastMemory = nullptr;
-    if (Options::useWebAssemblyFastMemory()) {
+    if (Options::useWasmFastMemory()) {
 #if CPU(ADDRESS32)
         RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("32-bit platforms don't support fast memory.");
 #endif
@@ -201,7 +201,7 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
         return nullptr;
     }
 
-    if (UNLIKELY(Options::crashIfWebAssemblyCantFastMemory()))
+    if (UNLIKELY(Options::crashIfWasmCantFastMemory()))
         webAssemblyCouldntGetFastMemory();
 
     switch (sharingMode) {

--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -78,7 +78,7 @@ static Plan::CompletionTask makeValidationCallback(Module::AsyncValidationCallba
 {
     return createSharedTask<Plan::CallbackType>([callback = WTFMove(callback)] (Plan& plan) {
         ASSERT(!plan.hasWork());
-        if (Options::useWebAssemblyIPInt())
+        if (Options::useWasmIPInt())
             callback->run(makeValidationResult(static_cast<IPIntPlan&>(plan)));
         else
             callback->run(makeValidationResult(static_cast<LLIntPlan&>(plan)));
@@ -87,7 +87,7 @@ static Plan::CompletionTask makeValidationCallback(Module::AsyncValidationCallba
 
 Module::ValidationResult Module::validateSync(VM& vm, Vector<uint8_t>&& source)
 {
-    if (Options::useWebAssemblyIPInt()) {
+    if (Options::useWasmIPInt()) {
         Ref<IPIntPlan> plan = adoptRef(*new IPIntPlan(vm, WTFMove(source), CompilerMode::Validation, Plan::dontFinalize()));
         Wasm::ensureWorklist().enqueue(plan.get());
         plan->waitForCompletion();
@@ -101,7 +101,7 @@ Module::ValidationResult Module::validateSync(VM& vm, Vector<uint8_t>&& source)
 
 void Module::validateAsync(VM& vm, Vector<uint8_t>&& source, Module::AsyncValidationCallback&& callback)
 {
-    if (Options::useWebAssemblyIPInt()) {
+    if (Options::useWasmIPInt()) {
         Ref<Plan> plan = adoptRef(*new IPIntPlan(vm, WTFMove(source), CompilerMode::Validation, makeValidationCallback(WTFMove(callback))));
         Wasm::ensureWorklist().enqueue(WTFMove(plan));
     } else {
@@ -121,9 +121,9 @@ Ref<CalleeGroup> Module::getOrCreateCalleeGroup(VM& vm, MemoryMode mode)
     // FIXME: We might want to back off retrying at some point:
     // https://bugs.webkit.org/show_bug.cgi?id=170607
     if (!calleeGroup || (calleeGroup->compilationFinished() && !calleeGroup->runnable())) {
-        if (Options::useWebAssemblyIPInt())
+        if (Options::useWasmIPInt())
             m_calleeGroups[static_cast<uint8_t>(mode)] = calleeGroup = CalleeGroup::createFromIPInt(vm, mode, const_cast<ModuleInformation&>(moduleInformation()), m_ipintCallees.copyRef());
-        else if (Options::useWebAssemblyLLInt())
+        else if (Options::useWasmLLInt())
             m_calleeGroups[static_cast<uint8_t>(mode)] = calleeGroup = CalleeGroup::createFromLLInt(vm, mode, const_cast<ModuleInformation&>(moduleInformation()), m_llintCallees.copyRef());
         else
             m_calleeGroups[static_cast<uint8_t>(mode)] = calleeGroup = CalleeGroup::createFromLLInt(vm, mode, const_cast<ModuleInformation&>(moduleInformation()), nullptr);

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -135,12 +135,12 @@ struct ModuleInformation : public ThreadSafeRefCounted<ModuleInformation> {
         ASSERT(functions[index].finishedValidating);
 
         // See also: B3Procedure::usesSIMD().
-        if (!Options::useWebAssemblySIMD())
+        if (!Options::useWasmSIMD())
             return false;
         if (Options::forceAllFunctionsToUseSIMD())
             return true;
         // The LLInt discovers this value.
-        ASSERT(Options::useWebAssemblyLLInt() || Options::useWebAssemblyIPInt());
+        ASSERT(Options::useWasmLLInt() || Options::useWasmIPInt());
 
         return functions[index].usesSIMD;
     }

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -4022,7 +4022,7 @@ void OMGIRGenerator::emitLoopTierUpCheck(uint32_t loopIndex, const Stack& enclos
     for (auto& local : m_locals)
         stackmap.append(get(local));
 
-    if (Options::useWebAssemblyIPInt()) {
+    if (Options::useWasmIPInt()) {
         // Do rethrow slots first because IPInt has them in a shadow stack.
         for (unsigned controlIndex = 0; controlIndex < m_parser->controlStack().size(); ++controlIndex) {
             auto& data = m_parser->controlStack()[controlIndex].controlData;
@@ -4803,8 +4803,8 @@ auto OMGIRGenerator::createTailCallPatchpoint(BasicBlock* block, CallInformation
 bool OMGIRGenerator::canInline() const
 {
     ASSERT(!m_inlinedBytes || !m_inlineParent);
-    return m_inlineDepth < Options::maximumWebAssemblyDepthForInlining()
-        && m_inlineRoot->m_inlinedBytes.value() < Options::maximumWebAssemblyCallerSizeForInlining()
+    return m_inlineDepth < Options::maximumWasmDepthForInlining()
+        && m_inlineRoot->m_inlinedBytes.value() < Options::maximumWasmCallerSizeForInlining()
         && (m_inlineDepth <= 1 || StackCheck().isSafeToRecurse());
 }
 
@@ -5009,7 +5009,7 @@ auto OMGIRGenerator::addCall(uint32_t functionIndex, const TypeDefinition& signa
 
     if (callType == CallType::Call
         && functionIndex - m_numImportFunctions != m_functionIndex
-        && m_info.functionWasmSizeImportSpace(functionIndex) < Options::maximumWebAssemblyCalleeSizeForInlining()
+        && m_info.functionWasmSizeImportSpace(functionIndex) < Options::maximumWasmCalleeSizeForInlining()
         && isAnyOMG(m_compilationMode)
         && canInline()
         && !m_info.callCanClobberInstance(functionIndex)) {
@@ -5114,7 +5114,7 @@ auto OMGIRGenerator::addCallIndirect(unsigned tableIndex, const TypeDefinition& 
 
     BasicBlock* throwBlock = m_proc.addBlock();
     // The subtype check can be omitted as an optimization for final types, but is needed otherwise if GC is on.
-    if (Options::useWebAssemblyGC() && !originalSignature.isFinalType()) {
+    if (Options::useWasmGC() && !originalSignature.isFinalType()) {
         // We don't need to check the RTT kind because by validation both RTTs must be for functions.
         Value* rttSize = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, origin(), calleeRTT, safeCast<uint32_t>(RTT::offsetOfDisplaySize()));
                 Value* rttPayloadPointer = m_currentBlock->appendNew<Value>(m_proc, Add, pointerType(), origin(), calleeRTT, constant(pointerType(), RTT::offsetOfPayload()));
@@ -5255,7 +5255,7 @@ static bool shouldDumpIRFor(uint32_t functionIndex)
     static LazyNeverDestroyed<FunctionAllowlist> dumpAllowlist;
     static std::once_flag initializeAllowlistFlag;
     std::call_once(initializeAllowlistFlag, [] {
-        const char* functionAllowlistFile = Options::webAssemblyOMGFunctionsToDump();
+        const char* functionAllowlistFile = Options::wasmOMGFunctionsToDump();
         dumpAllowlist.construct(functionAllowlistFile);
     });
     return dumpAllowlist->shouldDumpWasmFunction(functionIndex);
@@ -5296,7 +5296,7 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(Compilati
     // optLevel=1.
     procedure.setNeedsUsedRegisters(false);
 
-    procedure.setOptLevel(Options::webAssemblyOMGOptimizationLevel());
+    procedure.setOptLevel(Options::wasmOMGOptimizationLevel());
 
     procedure.code().setForceIRCRegisterAllocation();
 

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -184,13 +184,13 @@ void OMGPlan::work(CompilationEffort)
                 bbqCallee->setReplacement(callee.copyRef());
                 bbqCallee->tierUpCount()->setCompilationStatusForOMG(mode(), TierUpCount::CompilationStatus::Compiled);
             }
-            if (Options::useWebAssemblyIPInt() && m_calleeGroup->m_ipintCallees) {
+            if (Options::useWasmIPInt() && m_calleeGroup->m_ipintCallees) {
                 IPIntCallee& ipintCallee = m_calleeGroup->m_ipintCallees->at(m_functionIndex).get();
                 Locker locker { ipintCallee.tierUpCounter().m_lock };
                 ipintCallee.setReplacement(callee.copyRef(), mode());
                 ipintCallee.tierUpCounter().setCompilationStatus(mode(), IPIntTierUpCounter::CompilationStatus::Compiled);
             }
-            if (!Options::useWebAssemblyIPInt() && m_calleeGroup->m_llintCallees) {
+            if (!Options::useWasmIPInt() && m_calleeGroup->m_llintCallees) {
                 LLIntCallee& llintCallee = m_calleeGroup->m_llintCallees->at(m_functionIndex).get();
                 Locker locker { llintCallee.tierUpCounter().m_lock };
                 llintCallee.setReplacement(callee.copyRef(), mode());

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -119,7 +119,7 @@ static void triggerOMGReplacementCompile(TierUpCount& tierUp, OMGCallee* replace
 
 void loadValuesIntoBuffer(Probe::Context& context, const StackMap& values, uint64_t* buffer, SavedFPWidth savedFPWidth)
 {
-    ASSERT(Options::useWebAssemblySIMD() || savedFPWidth == SavedFPWidth::DontSaveVectors);
+    ASSERT(Options::useWasmSIMD() || savedFPWidth == SavedFPWidth::DontSaveVectors);
     unsigned valueSize = (savedFPWidth == SavedFPWidth::SaveVectors) ? 2 : 1;
 
     dataLogLnIf(WasmOperationsInternal::verbose, "loadValuesIntoBuffer: valueSize = ", valueSize, "; values.size() = ", values.size());
@@ -266,7 +266,7 @@ static void doOSREntry(JSWebAssemblyInstance* instance, Probe::Context& context,
 
 inline bool shouldJIT(unsigned functionIndex)
 {
-    if (!Options::webAssemblyFunctionIndexRangeToCompile().isInRange(functionIndex))
+    if (!Options::wasmFunctionIndexRangeToCompile().isInRange(functionIndex))
         return false;
     return true;
 }
@@ -353,7 +353,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmTriggerOSREntryNow, void, (Probe:
 
     dataLogLnIf(Options::verboseOSR(), "Consider OSREntryPlan for [", functionIndex, "] loopIndex#", loopIndex, " with executeCounter = ", tierUp, " ", RawPointer(callee.replacement()));
 
-    if (!Options::useWebAssemblyOSR()) {
+    if (!Options::useWasmOSR()) {
         if (shouldTriggerOMGCompile(tierUp, callee.replacement(), functionIndex))
             triggerOMGReplacementCompile(tierUp, callee.replacement(), instance, calleeGroup, functionIndex, callee.hasExceptionHandlers());
 
@@ -748,9 +748,9 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationIterateResults, void, (JSWebAssemblyI
         default: {
             if (Wasm::isRefType(returnType)) {
                 if (isExternref(returnType))
-                    ASSERT_IMPLIES(!Options::useWebAssemblyTypedFunctionReferences(), returnType.isNullable());
-                else if (isFuncref(returnType) || (!Options::useWebAssemblyGC() && isRefWithTypeIndex(returnType))) {
-                    ASSERT_IMPLIES(!Options::useWebAssemblyTypedFunctionReferences(), returnType.isNullable());
+                    ASSERT_IMPLIES(!Options::useWasmTypedFunctionReferences(), returnType.isNullable());
+                else if (isFuncref(returnType) || (!Options::useWasmGC() && isRefWithTypeIndex(returnType))) {
+                    ASSERT_IMPLIES(!Options::useWasmTypedFunctionReferences(), returnType.isNullable());
                     WebAssemblyFunction* wasmFunction = nullptr;
                     WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
                     if (UNLIKELY(!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && !value.isNull())) {
@@ -766,7 +766,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationIterateResults, void, (JSWebAssemblyI
                         }
                     }
                 } else {
-                    ASSERT(Options::useWebAssemblyGC());
+                    ASSERT(Options::useWasmGC());
                     value = Wasm::internalizeExternref(value);
                     if (UNLIKELY(!Wasm::TypeInformation::castReference(value, returnType.isNullable(), returnType.index))) {
                         throwTypeError(globalObject, scope, "Argument value did not match reference type"_s);

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -294,7 +294,7 @@ ALWAYS_INLINE typename ParserBase::PartialResult ParserBase::parseBlockSignature
     if (peekInt7(kindByte) && isValidTypeKind(kindByte)) {
         TypeKind typeKind = static_cast<TypeKind>(kindByte);
 
-        if (UNLIKELY(Options::useWebAssemblyTypedFunctionReferences())) {
+        if (UNLIKELY(Options::useWasmTypedFunctionReferences())) {
             if ((isValidHeapTypeKind(kindByte) || typeKind == TypeKind::Ref || typeKind == TypeKind::RefNull))
                 return parseReftypeSignature(info, result);
         }
@@ -331,7 +331,7 @@ inline typename ParserBase::PartialResult ParserBase::parseReftypeSignature(cons
 
 ALWAYS_INLINE bool ParserBase::parseHeapType(const ModuleInformation& info, int32_t& result)
 {
-    if (!Options::useWebAssemblyTypedFunctionReferences())
+    if (!Options::useWasmTypedFunctionReferences())
         return false;
 
     int32_t heapType;
@@ -363,7 +363,7 @@ ALWAYS_INLINE bool ParserBase::parseValueType(const ModuleInformation& info, Typ
 
     TypeKind typeKind = static_cast<TypeKind>(kind);
     TypeIndex typeIndex = 0;
-    if (Options::useWebAssemblyTypedFunctionReferences() && isValidHeapTypeKind(kind)) {
+    if (Options::useWasmTypedFunctionReferences() && isValidHeapTypeKind(kind)) {
         typeIndex = static_cast<TypeIndex>(typeKind);
         typeKind = TypeKind::RefNull;
     } else if (typeKind == TypeKind::Ref || typeKind == TypeKind::RefNull) {

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -56,7 +56,7 @@ private:
     NEVER_INLINE UnexpectedResult WARN_UNUSED_RETURN fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in namespace above.
-        if (UNLIKELY(ASSERT_ENABLED && Options::crashOnFailedWebAssemblyValidate()))
+        if (UNLIKELY(ASSERT_ENABLED && Options::crashOnFailedWasmValidate()))
             CRASH();
 
         return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, String::number(m_offset + m_offsetInSource), ": "_s, makeString(args)...));

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -75,7 +75,7 @@ NEVER_INLINE auto WARN_UNUSED_RETURN StreamingParser::fail(Args... args) -> Stat
 static void dumpWasmSource(const Vector<uint8_t>& source)
 {
     static int count = 0;
-    const char* file = Options::dumpWebAssemblySourceFileName();
+    const char* file = Options::dumpWasmSourceFileName();
     if (!file)
         return;
     auto fileHandle = FileSystem::openFile(WTF::makeString(span(file), (count++), ".wasm"_s),
@@ -99,9 +99,9 @@ StreamingParser::StreamingParser(ModuleInformation& info, StreamingParserClient&
     dataLogLnIf(WasmStreamingParserInternal::verbose, "starting validation");
 
 #if ASSERT_ENABLED
-    dataLogLnIf(!!Options::dumpWebAssemblySourceFileName(), "Wasm streaming parser created, capturing source.");
+    dataLogLnIf(!!Options::dumpWasmSourceFileName(), "Wasm streaming parser created, capturing source.");
 #else
-    dataLogLnIf(!!Options::dumpWebAssemblySourceFileName(), "Wasm streaming parser created, but we can only dump source in debug builds.");
+    dataLogLnIf(!!Options::dumpWasmSourceFileName(), "Wasm streaming parser created, but we can only dump source in debug builds.");
 #endif
 }
 
@@ -281,7 +281,7 @@ auto StreamingParser::consumeVarUInt32(std::span<const uint8_t> bytes, size_t& o
 auto StreamingParser::addBytes(std::span<const uint8_t> bytes, IsEndOfStream isEndOfStream) -> State
 {
 #if ASSERT_ENABLED
-    if (Options::dumpWebAssemblySourceFileName()) {
+    if (Options::dumpWasmSourceFileName()) {
         m_buffer.append(bytes);
 
         if (isEndOfStream == IsEndOfStream::Yes) {
@@ -299,7 +299,7 @@ auto StreamingParser::addBytes(std::span<const uint8_t> bytes, IsEndOfStream isE
         return m_state;
     }
 
-    if (UNLIKELY(Options::useEagerWebAssemblyModuleHashing()))
+    if (UNLIKELY(Options::useEagerWasmModuleHashing()))
         m_hasher.addBytes(bytes);
 
     size_t offsetInBytes = 0;
@@ -441,7 +441,7 @@ auto StreamingParser::finalize() -> State
         }
 
         if (m_remaining.isEmpty()) {
-            if (UNLIKELY(Options::useEagerWebAssemblyModuleHashing()))
+            if (UNLIKELY(Options::useEagerWasmModuleHashing()))
                 m_info->nameSection->setHash(m_hasher.computeHexDigest());
 
             m_state = State::Finished;

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -234,7 +234,7 @@ FuncRefTable* Table::asFuncrefTable()
 ExternRefTable::ExternRefTable(uint32_t initial, std::optional<uint32_t> maximum, Type wasmType)
     : Table(initial, maximum, wasmType, TableElementType::Externref)
 {
-    RELEASE_ASSERT(isExternref(wasmType) || (Options::useWebAssemblyGC() && isSubtype(wasmType, anyrefType())));
+    RELEASE_ASSERT(isExternref(wasmType) || (Options::useWasmGC() && isSubtype(wasmType, anyrefType())));
     // FIXME: It might be worth trying to pre-allocate maximum here. The spec recommends doing so.
     // But for now, we're not doing that.
     // FIXME this over-allocates and could be smarter about not committing all of that memory https://bugs.webkit.org/show_bug.cgi?id=181425
@@ -256,7 +256,7 @@ void ExternRefTable::set(uint32_t index, JSValue value)
 FuncRefTable::FuncRefTable(uint32_t initial, std::optional<uint32_t> maximum, Type wasmType)
     : Table(initial, maximum, wasmType, TableElementType::Funcref)
 {
-    RELEASE_ASSERT(isFuncref(wasmType) || Options::useWebAssemblyTypedFunctionReferences());
+    RELEASE_ASSERT(isFuncref(wasmType) || Options::useWasmTypedFunctionReferences());
     ASSERT(isSubtype(wasmType, funcrefType()));
     // FIXME: It might be worth trying to pre-allocate maximum here. The spec recommends doing so.
     // But for now, we're not doing that.

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -899,7 +899,7 @@ TypeInformation::TypeInformation()
     m_Void_I32I32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key;
     m_Void_I32I32I32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key;
     m_I32_I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { Wasm::Types::I32 }, { Wasm::Types::I32 } }).iterator->key;
-    if (!Options::useWebAssemblyGC())
+    if (!Options::useWasmGC())
         return;
     m_I32_RefI32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { Wasm::Types::I32 }, { anyrefType(), Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key;
     m_Ref_RefI32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { anyrefType() }, { anyrefType(), Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key;
@@ -1062,7 +1062,7 @@ std::optional<RefPtr<const RTT>> TypeInformation::tryGetCanonicalRTT(TypeIndex t
 
 RefPtr<const RTT> TypeInformation::getCanonicalRTT(TypeIndex type)
 {
-    if (Options::useWebAssemblyGC()) {
+    if (Options::useWasmGC()) {
         const auto result = TypeInformation::tryGetCanonicalRTT(type);
         ASSERT(result.has_value());
         return result.value();

--- a/Source/JavaScriptCore/wasm/WasmWorklist.cpp
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.cpp
@@ -224,7 +224,7 @@ Worklist::Worklist()
     : m_lock(Box<Lock>::create())
     , m_planEnqueued(AutomaticThreadCondition::create())
 {
-    unsigned numberOfCompilationThreads = Options::useConcurrentJIT() ? Options::numberOfWebAssemblyCompilerThreads() : 1;
+    unsigned numberOfCompilationThreads = Options::useConcurrentJIT() ? Options::numberOfWasmCompilerThreads() : 1;
     Locker locker { *m_lock };
     m_threads = Vector<Ref<Thread>>(numberOfCompilationThreads, [&](size_t) {
         return Worklist::Thread::create(locker, *this);

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -263,7 +263,7 @@ std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers& jit, JSEnt
     // https://webassembly.github.io/spec/js-api/index.html#exported-function-exotic-objects
     // If parameters or results contain v128, throw a TypeError.
     // Note: the above error is thrown each time the [[Call]] method is invoked.
-    if (Options::useWebAssemblySIMD() && (wasmFrameConvention.argumentsOrResultsIncludeV128)) {
+    if (Options::useWasmSIMD() && (wasmFrameConvention.argumentsOrResultsIncludeV128)) {
         jit.loadPtr(CCallHelpers::addressFor(CallFrameSlot::codeBlock), GPRInfo::wasmContextInstancePointer);
         JIT_COMMENT(jit, "Throw an exception because this function uses v128");
         emitThrowWasmToJSException(jit, GPRInfo::wasmContextInstancePointer, ExceptionType::TypeErrorInvalidV128Use);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
@@ -157,7 +157,7 @@ ALWAYS_INLINE JSValue defaultValueForReferenceType(const Wasm::Type type)
     ASSERT(Wasm::isRefType(type));
     if (Wasm::isExternref(type))
         return jsUndefined();
-    ASSERT_IMPLIES(!Options::useWebAssemblyTypedFunctionReferences(), Wasm::isFuncref(type));
+    ASSERT_IMPLIES(!Options::useWasmTypedFunctionReferences(), Wasm::isFuncref(type));
     return jsNull();
 }
 
@@ -209,7 +209,7 @@ ALWAYS_INLINE uint64_t fromJSValue(JSGlobalObject* globalObject, const Wasm::Typ
         if (Wasm::isExternref(type)) {
             if (!type.isNullable() && value.isNull())
                 return throwVMTypeError(globalObject, scope, "Non-null Externref cannot be null"_s);
-        } else if (Wasm::isFuncref(type) || (!Options::useWebAssemblyGC() && isRefWithTypeIndex(type))) {
+        } else if (Wasm::isFuncref(type) || (!Options::useWasmGC() && isRefWithTypeIndex(type))) {
             WebAssemblyFunction* wasmFunction = nullptr;
             WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
             if (!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && (!type.isNullable() || !value.isNull()))
@@ -221,7 +221,7 @@ ALWAYS_INLINE uint64_t fromJSValue(JSGlobalObject* globalObject, const Wasm::Typ
                     return throwVMTypeError(globalObject, scope, "Argument function did not match the reference type"_s);
             }
         } else {
-            ASSERT(Options::useWebAssemblyGC());
+            ASSERT(Options::useWasmGC());
             value = Wasm::internalizeExternref(value);
             if (!Wasm::TypeInformation::castReference(value, type.isNullable(), type.index)) {
                 // FIXME: provide a better error message here

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -182,7 +182,7 @@ void JSWebAssemblyInstance::finalizeCreation(VM& vm, JSGlobalObject* globalObjec
     // results, so that later when memory imports become available, the appropriate CalleeGroup can be used.
     // If LLInt is disabled, we instead defer compilation to module evaluation.
     // If the code is already compiled, e.g. the module was already instantiated before, we do not re-initialize.
-    if (Options::useWebAssemblyLLInt() && module().moduleInformation().hasMemoryImport())
+    if (Options::useWasmLLInt() && module().moduleInformation().hasMemoryImport())
         module().copyInitialCalleeGroupToAllMemoryModes(memoryMode());
 
     for (unsigned importFunctionNum = 0; importFunctionNum < numImportFunctions(); ++importFunctionNum) {

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -103,7 +103,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(TypeIn
     // https://webassembly.github.io/spec/js-api/index.html#exported-function-exotic-objects
     // If parameters or results contain v128, throw a TypeError.
     // Note: the above error is thrown each time the [[Call]] method is invoked.
-    if (Options::useWebAssemblySIMD() && (wasmCallInfo.argumentsOrResultsIncludeV128))
+    if (Options::useWasmSIMD() && (wasmCallInfo.argumentsOrResultsIncludeV128))
         return handleBadImportTypeUse(jit, importIndex, ExceptionType::TypeErrorInvalidV128Use);
 
     // Here we assume that the JS calling convention saves at least all the wasm callee saved. We therefore don't need to save and restore more registers since the wasm callee already took care of this.
@@ -436,16 +436,16 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(TypeIn
         default:  {
             if (Wasm::isRefType(returnType)) {
                 if (Wasm::isExternref(returnType))
-                    ASSERT_IMPLIES(!Options::useWebAssemblyTypedFunctionReferences(), returnType.isNullable());
-                else if (Wasm::isFuncref(returnType) || (!Options::useWebAssemblyGC() && isRefWithTypeIndex(returnType))) {
-                    ASSERT_IMPLIES(!Options::useWebAssemblyTypedFunctionReferences(), returnType.isNullable());
+                    ASSERT_IMPLIES(!Options::useWasmTypedFunctionReferences(), returnType.isNullable());
+                else if (Wasm::isFuncref(returnType) || (!Options::useWasmGC() && isRefWithTypeIndex(returnType))) {
+                    ASSERT_IMPLIES(!Options::useWasmTypedFunctionReferences(), returnType.isNullable());
                     jit.prepareWasmCallOperation(GPRInfo::wasmContextInstancePointer);
                     jit.setupArguments<decltype(operationConvertToFuncref)>(GPRInfo::wasmContextInstancePointer, CCallHelpers::TrustedImmPtr(&typeDefinition), JSRInfo::returnValueJSR);
                     jit.callOperation<OperationPtrTag>(operationConvertToFuncref);
                     jit.loadPtr(CCallHelpers::Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfVM()), GPRInfo::nonPreservedNonReturnGPR);
                     exceptionChecks.append(jit.branchTestPtr(CCallHelpers::NonZero, CCallHelpers::Address(GPRInfo::nonPreservedNonReturnGPR, VM::exceptionOffset())));
                 } else {
-                    ASSERT(Options::useWebAssemblyGC());
+                    ASSERT(Options::useWasmGC());
                     jit.prepareWasmCallOperation(GPRInfo::wasmContextInstancePointer);
                     jit.setupArguments<decltype(operationConvertToAnyref)>(GPRInfo::wasmContextInstancePointer, CCallHelpers::TrustedImmPtr(&typeDefinition), JSRInfo::returnValueJSR);
                     jit.callOperation<OperationPtrTag>(operationConvertToAnyref);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
@@ -110,7 +110,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyMemory, (JSGlobalObject* globalOb
     // Even though Options::useSharedArrayBuffer() is false, we can create SharedArrayBuffer through wasm shared memory.
     // But we cannot send SharedArrayBuffer to the other workers, so it is not effective.
     MemorySharingMode sharingMode = MemorySharingMode::Default;
-    if (LIKELY(Options::useWebAssemblyFaultSignalHandler())) {
+    if (LIKELY(Options::useWasmFaultSignalHandler())) {
         JSValue sharedValue = memoryDescriptor->get(globalObject, Identifier::fromString(vm, "shared"_s));
         RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
         bool shared = sharedValue.toBoolean(globalObject);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -268,7 +268,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                             if (!global.type.isNullable() && value.isNull())
                                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "non-null externref cannot be null"_s)));
                             m_instance->setGlobal(import.kindIndex, value);
-                        } else if (Wasm::isFuncref(declaredGlobalType) || (!Options::useWebAssemblyGC() && isRefWithTypeIndex(declaredGlobalType))) {
+                        } else if (Wasm::isFuncref(declaredGlobalType) || (!Options::useWasmGC() && isRefWithTypeIndex(declaredGlobalType))) {
                             WebAssemblyFunction* wasmFunction = nullptr;
                             WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
                             value = globalValue->global()->get(globalObject);
@@ -287,7 +287,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
 
                             m_instance->setGlobal(import.kindIndex, value);
                         } else {
-                            RELEASE_ASSERT(Options::useWebAssemblyGC());
+                            RELEASE_ASSERT(Options::useWasmGC());
                             value = Wasm::internalizeExternref(globalValue->global()->get(globalObject));
                             if (!Wasm::TypeInformation::castReference(value, declaredGlobalType.isNullable(), declaredGlobalType.index))
                                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "Argument value did not match the reference type"_s)));
@@ -332,7 +332,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                             if (!globalType.isNullable() && value.isNull())
                                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "must be a non-null value"_s)));
                             m_instance->setGlobal(import.kindIndex, value);
-                        } else if (Wasm::isFuncref(globalType) || (!Options::useWebAssemblyGC() && Wasm::isRefWithTypeIndex(globalType))) {
+                        } else if (Wasm::isFuncref(globalType) || (!Options::useWasmGC() && Wasm::isRefWithTypeIndex(globalType))) {
                             WebAssemblyFunction* wasmFunction = nullptr;
                             WebAssemblyWrapperFunction* wasmWrapperFunction = nullptr;
                             if (!isWebAssemblyHostFunction(value, wasmFunction, wasmWrapperFunction) && (!globalType.isNullable() || !value.isNull())) {
@@ -349,7 +349,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
 
                             m_instance->setGlobal(import.kindIndex, value);
                         } else {
-                            RELEASE_ASSERT(Options::useWebAssemblyGC());
+                            RELEASE_ASSERT(Options::useWasmGC());
                             value = Wasm::internalizeExternref(value);
                             if (!Wasm::TypeInformation::castReference(value, global.type.isNullable(), global.type.index))
                                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "Argument value did not match the reference type"_s)));
@@ -592,7 +592,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
 
                 if (global.initializationType == Wasm::GlobalInformation::FromGlobalImport) {
                     ASSERT(global.initialBits.initialBitsOrImportNumber < m_instance->module().moduleInformation().globals.size());
-                    ASSERT_IMPLIES(!Options::useWebAssemblyGC(), global.initialBits.initialBitsOrImportNumber < moduleInformation.firstInternalGlobal);
+                    ASSERT_IMPLIES(!Options::useWasmGC(), global.initialBits.initialBitsOrImportNumber < moduleInformation.firstInternalGlobal);
                     initialVector = m_instance->loadV128Global(global.initialBits.initialBitsOrImportNumber);
                 } else if (global.initializationType == Wasm::GlobalInformation::FromExpression)
                     initialVector = global.initialBits.initialVector;
@@ -619,7 +619,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
             uint64_t initialBits = 0;
             if (global.initializationType == Wasm::GlobalInformation::FromGlobalImport) {
                 ASSERT(global.initialBits.initialBitsOrImportNumber < m_instance->module().moduleInformation().globals.size());
-                ASSERT_IMPLIES(!Options::useWebAssemblyGC(), global.initialBits.initialBitsOrImportNumber < moduleInformation.firstInternalGlobal);
+                ASSERT_IMPLIES(!Options::useWasmGC(), global.initialBits.initialBitsOrImportNumber < moduleInformation.firstInternalGlobal);
                 initialBits = m_instance->loadI64Global(global.initialBits.initialBitsOrImportNumber);
             } else if (global.initializationType == Wasm::GlobalInformation::FromRefFunc) {
                 ASSERT(global.initialBits.initialBitsOrImportNumber < moduleInformation.functionIndexSpaceSize());

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp
@@ -105,7 +105,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncGrow, (JSGlobalObject* globalO
     if (table->table()->isFuncrefTable() && !defaultValue.isNull() && !isWebAssemblyHostFunction(defaultValue))
         return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table.prototype.grow expects the second argument to be null or an instance of WebAssembly.Function"_s);
     else if (table->table()->isExternrefTable() && !isExternref(table->table()->wasmType())) {
-        RELEASE_ASSERT(Options::useWebAssemblyGC());
+        RELEASE_ASSERT(Options::useWasmGC());
         JSValue internalValue = Wasm::internalizeExternref(defaultValue);
         if (!Wasm::TypeInformation::castReference(internalValue, true, table->table()->wasmType().index))
             return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table.prototype.grow failed to cast the second argument to the table's element type"_s);
@@ -175,7 +175,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyTableProtoFuncSet, (JSGlobalObject* globalOb
         if (isExternref(table->table()->wasmType()))
             table->set(index, value);
         else {
-            RELEASE_ASSERT(Options::useWebAssemblyGC());
+            RELEASE_ASSERT(Options::useWasmGC());
             JSValue internalValue = Wasm::internalizeExternref(value);
             if (!Wasm::TypeInformation::castReference(internalValue, true, table->table()->wasmType().index))
                 return throwVMTypeError(globalObject, throwScope, "WebAssembly.Table.prototype.set failed to cast the second argument to the table's element type"_s);

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -1813,15 +1813,15 @@ def runWebAssembly
         run("wasm-no-cjit", "-m", *(FTL_OPTIONS + NO_CJIT_OPTIONS))
         run("wasm-eager", "-m", "--useRandomizingExecutableIslandAllocation=true", *(FTL_OPTIONS + EAGER_OPTIONS))
         run("wasm-eager-jettison", "-m", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *FTL_OPTIONS)
-        run("wasm-slow-memory", "-m", "--useWebAssemblyFastMemory=false", *FTL_OPTIONS)
+        run("wasm-slow-memory", "-m", "--useWasmFastMemory=false", *FTL_OPTIONS)
         run("wasm-collect-continuously", "-m", "--collectContinuously=true", "--verifyGC=true", *FTL_OPTIONS) if shouldCollectContinuously?
-        run("wasm-bbq", "-m", "--useWebAssemblyLLInt=false", *FTL_OPTIONS)
+        run("wasm-bbq", "-m", "--useWasmLLInt=false", *FTL_OPTIONS)
         if $isOMGPlatform
-            run("wasm-omg", "-m", "--useWebAssemblyLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *FTL_OPTIONS)
+            run("wasm-omg", "-m", "--useWasmLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *FTL_OPTIONS)
         end
         if $isFTLPlatform
-            run("wasm-simd", "-m", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "-m", "--maximumWebAssemblyCalleeSizeForInlining=2147483647", "--maximumWebAssemblyCallerSizeForInlining=2147483647", "--maximumWebAssemblyDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-simd", "-m", "--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
+            run("wasm-aggressive-inline", "-m", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
         end
     end
 end
@@ -1844,15 +1844,15 @@ def runWebAssemblyJetStream2
         run("wasm-no-cjit", *(FTL_OPTIONS + NO_CJIT_OPTIONS))
         run("wasm-eager", "--useRandomizingExecutableIslandAllocation=true", *(FTL_OPTIONS + EAGER_OPTIONS))
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--verifyGC=true", *FTL_OPTIONS)
-        run("wasm-slow-memory", "--useWebAssemblyFastMemory=false", *FTL_OPTIONS)
+        run("wasm-slow-memory", "--useWasmFastMemory=false", *FTL_OPTIONS)
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *FTL_OPTIONS) if shouldCollectContinuously?
-        run("wasm-bbq", "--useWebAssemblyLLInt=false", *FTL_OPTIONS)
+        run("wasm-bbq", "--useWasmLLInt=false", *FTL_OPTIONS)
         if $isOMGPlatform
-            run("wasm-omg", "--useWebAssemblyLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *FTL_OPTIONS)
+            run("wasm-omg", "--useWasmLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *FTL_OPTIONS)
         end
         if $isFTLPlatform
-            run("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "--maximumWebAssemblyCalleeSizeForInlining=2147483647", "--maximumWebAssemblyCallerSizeForInlining=2147483647", "--maximumWebAssemblyDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-simd", "--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
+            run("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
         end
     end
 end
@@ -1877,15 +1877,15 @@ def runWebAssemblySuite(*optionalTestSpecificOptions)
         run("wasm-no-cjit", *(FTL_OPTIONS + NO_CJIT_OPTIONS + optionalTestSpecificOptions))
         run("wasm-eager", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions))
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
-        run("wasm-slow-memory", "--useWebAssemblyFastMemory=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        run("wasm-slow-memory", "--useWasmFastMemory=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
-        run("wasm-bbq", "--useWebAssemblyLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        run("wasm-bbq", "--useWasmLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         if $isOMGPlatform
-            run("wasm-omg", "--useWebAssemblyLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
+            run("wasm-omg", "--useWasmLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
         end
         if $isFTLPlatform
-            run("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "--maximumWebAssemblyCalleeSizeForInlining=2147483647", "--maximumWebAssemblyCallerSizeForInlining=2147483647", "--maximumWebAssemblyDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-simd", "--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless !$isSIMDPlatform
+            run("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?(:wasm_aggressive_inline)
         end
     end
 end
@@ -1903,15 +1903,15 @@ def runV8WebAssemblySuite(*optionalTestSpecificOptions)
         run("wasm-no-cjit", *(FTL_OPTIONS + NO_CJIT_OPTIONS + optionalTestSpecificOptions))
         run("wasm-eager", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions))
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
-        run("wasm-slow-memory", "--useWebAssemblyFastMemory=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        run("wasm-slow-memory", "--useWasmFastMemory=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
-        run("wasm-bbq", "--useWebAssemblyLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        run("wasm-bbq", "--useWasmLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         if $isOMGPlatform
-            run("wasm-omg", "--useWebAssemblyLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
+            run("wasm-omg", "--useWasmLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
         end        
         if $isFTLPlatform
-            run("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "--maximumWebAssemblyCalleeSizeForInlining=2147483647", "--maximumWebAssemblyCallerSizeForInlining=2147483647", "--maximumWebAssemblyDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-simd", "--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless !$isSIMDPlatform
+            run("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?(:wasm_aggressive_inline)
         end
     end
 end
@@ -1950,15 +1950,15 @@ def runWebAssemblyWithHarness(*optionalTestSpecificOptions)
         runWasmHarnessTest("wasm-no-cjit", *(FTL_OPTIONS + NO_CJIT_OPTIONS + optionalTestSpecificOptions))
         runWasmHarnessTest("wasm-eager", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions))
         runWasmHarnessTest("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
-        runWasmHarnessTest("wasm-slow-memory", "--useWebAssemblyFastMemory=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        runWasmHarnessTest("wasm-slow-memory", "--useWasmFastMemory=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         runWasmHarnessTest("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
-        runWasmHarnessTest("wasm-bbq", "--useWebAssemblyLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions)) # Doesn't actually depend on FTL, but we enable it on the same platforms for now.
+        runWasmHarnessTest("wasm-bbq", "--useWasmLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions)) # Doesn't actually depend on FTL, but we enable it on the same platforms for now.
         if $isOMGPlatform
-            runWasmHarnessTest("wasm-omg", "--useWebAssemblyLLInt=true", "--useBBQJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+            runWasmHarnessTest("wasm-omg", "--useWasmLLInt=true", "--useBBQJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         end
         if $isFTLPlatform
-            runWasmHarnessTest("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
-            runWasmHarnessTest("wasm-aggressive-inline", "--maximumWebAssemblyCalleeSizeForInlining=2147483647", "--maximumWebAssemblyCallerSizeForInlining=2147483647", "--maximumWebAssemblyDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
+            runWasmHarnessTest("wasm-simd", "--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
+            runWasmHarnessTest("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
         end
     end
 end
@@ -1976,13 +1976,13 @@ def runWebAssemblyEmscripten(mode)
         run("wasm-no-cjit", *(FTL_OPTIONS + NO_CJIT_OPTIONS))
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *FTL_OPTIONS)
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *FTL_OPTIONS) if shouldCollectContinuously?
-        run("wasm-bbq", "--useWebAssemblyLLInt=false", *FTL_OPTIONS) # Doesn't actually depend on FTL, but we enable it on the same platforms for now.
+        run("wasm-bbq", "--useWasmLLInt=false", *FTL_OPTIONS) # Doesn't actually depend on FTL, but we enable it on the same platforms for now.
         if $isOMGPlatform
-            run("wasm-omg", "--useWebAssemblyLLInt=true", "--useBBQJIT=false", *FTL_OPTIONS)
+            run("wasm-omg", "--useWasmLLInt=true", "--useBBQJIT=false", *FTL_OPTIONS)
         end
         if $isFTLPlatform
-            run("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "--maximumWebAssemblyCalleeSizeForInlining=2147483647", "--maximumWebAssemblyCallerSizeForInlining=2147483647", "--maximumWebAssemblyDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-simd", "--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
+            run("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
         end
     end
 end
@@ -2007,12 +2007,12 @@ def runWebAssemblySpecTestBase(mode, specHarnessPath, postfix, *optionalTestSpec
         runWithOutputHandler("wasm-no-cjit" + (postfix || ''), noisyOutputHandler, specHarnessJsPath,  *(FTL_OPTIONS + NO_CJIT_OPTIONS + optionalTestSpecificOptions))
         runWithOutputHandler("wasm-eager-jettison" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
         runWithOutputHandler("wasm-collect-continuously" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
-        runWithOutputHandler("wasm-bbq" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWebAssemblyLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        runWithOutputHandler("wasm-bbq" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWasmLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         if $isOMGPlatform
-            runWithOutputHandler("wasm-omg" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWebAssemblyLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
+            runWithOutputHandler("wasm-omg" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWasmLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
         end
         if $isFTLPlatform
-            runWithOutputHandler("wasm-simd" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions))
+            runWithOutputHandler("wasm-simd" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWasmSIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions))
         end
     end
 end
@@ -2022,11 +2022,11 @@ def runWebAssemblySpecTest(mode)
 end
 
 def runWebAssemblyFunctionReferenceSpecTest(mode)
-    runWebAssemblySpecTestBase(mode, "funcref-spec-harness", nil, "--useWebAssemblyTypedFunctionReferences=true")
+    runWebAssemblySpecTestBase(mode, "funcref-spec-harness", nil, "--useWasmTypedFunctionReferences=true")
 end
 
 def runWebAssemblyGCSpecTest(mode)
-    runWebAssemblySpecTestBase(mode, "gc-spec-harness", nil, "--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--useWebAssemblyExtendedConstantExpressions=true")
+    runWebAssemblySpecTestBase(mode, "gc-spec-harness", nil, "--useWasmTypedFunctionReferences=true", "--useWasmGC=true", "--useWasmExtendedConstantExpressions=true")
 end
 
 def runWebAssemblyThreadsSpecTest(mode)
@@ -2035,16 +2035,16 @@ end
 
 def runWebAssemblySIMDSpecTest(mode)
     return if !$isSIMDPlatform
-    runWebAssemblySpecTestBase(mode, "spec-harness", nil, "--useWebAssemblySIMD=true")
-    runWebAssemblySpecTestBase(mode, "spec-harness", "-eager", "--useWebAssemblySIMD=true", "--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0")
+    runWebAssemblySpecTestBase(mode, "spec-harness", nil, "--useWasmSIMD=true")
+    runWebAssemblySpecTestBase(mode, "spec-harness", "-eager", "--useWasmSIMD=true", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0")
 end
 
 def runWebAssemblyTailCallSpecTest(mode)
-    runWebAssemblySpecTestBase(mode, "tail-call-spec-harness", nil, "--useWebAssemblyTailCalls=true")
+    runWebAssemblySpecTestBase(mode, "tail-call-spec-harness", nil, "--useWasmTailCalls=true")
 end
 
 def runWebAssemblyExtendedConstSpecTest(mode)
-    runWebAssemblySpecTestBase(mode, "spec-harness", nil, "--useWebAssemblyExtendedConstantExpressions=true")
+    runWebAssemblySpecTestBase(mode, "spec-harness", nil, "--useWasmExtendedConstantExpressions=true")
 end
 
 def runWebAssemblyLowExecutableMemory(*optionalTestSpecificOptions)

--- a/Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp
+++ b/Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp
@@ -4338,13 +4338,13 @@ static void testsJSCOptions()
     g_assert_cmpuint(maxPerThreadStackUsage, ==, 4096);
     g_assert_true(jsc_options_set_uint("maxPerThreadStackUsage", 5242880));
 
-    gsize webAssemblyPartialCompileLimit;
-    g_assert_true(jsc_options_get_size("webAssemblyPartialCompileLimit", &webAssemblyPartialCompileLimit));
-    g_assert_cmpuint(webAssemblyPartialCompileLimit, ==, 5000);
-    g_assert_true(jsc_options_set_size("webAssemblyPartialCompileLimit", 6000));
-    g_assert_true(jsc_options_get_size("webAssemblyPartialCompileLimit", &webAssemblyPartialCompileLimit));
-    g_assert_cmpuint(webAssemblyPartialCompileLimit, ==, 6000);
-    g_assert_true(jsc_options_set_size("webAssemblyPartialCompileLimit", 5000));
+    gsize wasmPartialCompileLimit;
+    g_assert_true(jsc_options_get_size("wasmPartialCompileLimit", &wasmPartialCompileLimit));
+    g_assert_cmpuint(wasmPartialCompileLimit, ==, 5000);
+    g_assert_true(jsc_options_set_size("wasmPartialCompileLimit", 6000));
+    g_assert_true(jsc_options_get_size("wasmPartialCompileLimit", &wasmPartialCompileLimit));
+    g_assert_cmpuint(wasmPartialCompileLimit, ==, 6000);
+    g_assert_true(jsc_options_set_size("wasmPartialCompileLimit", 5000));
 
     gdouble criticalGCMemoryThreshold;
     g_assert_true(jsc_options_get_double("criticalGCMemoryThreshold", &criticalGCMemoryThreshold));
@@ -4433,7 +4433,7 @@ static void testsJSCOptions()
             g_assert_true(type == JSC_OPTION_INT);
         else if (!g_strcmp0(option, "maxPerThreadStackUsage"))
             g_assert_true(type == JSC_OPTION_UINT);
-        else if (!g_strcmp0(option, "webAssemblyPartialCompileLimit"))
+        else if (!g_strcmp0(option, "wasmPartialCompileLimit"))
             g_assert_true(type == JSC_OPTION_SIZE);
         else if (!g_strcmp0(option, "smallHeapRAMFraction"))
             g_assert_true(type == JSC_OPTION_DOUBLE);
@@ -4456,7 +4456,7 @@ static void testsJSCOptions()
         "--jsc-useJIT=false",
         "--jsc-thresholdForJITAfterWarmUp=2000",
         "--jsc-maxPerThreadStackUsage=1024",
-        "--jsc-webAssemblyPartialCompileLimit=4000",
+        "--jsc-wasmPartialCompileLimit=4000",
         "--jsc-criticalGCMemoryThreshold=0.95",
         "--jsc-configFile=/tmp/bar",
         "--jsc-bytecodeRangeToJITCompile=100:300",
@@ -4475,8 +4475,8 @@ static void testsJSCOptions()
     g_assert_cmpint(thresholdForJITAfterWarmUp, ==, 2000);
     g_assert_true(jsc_options_get_uint("maxPerThreadStackUsage", &maxPerThreadStackUsage));
     g_assert_cmpuint(maxPerThreadStackUsage, ==, 1024);
-    g_assert_true(jsc_options_get_size("webAssemblyPartialCompileLimit", &webAssemblyPartialCompileLimit));
-    g_assert_cmpuint(webAssemblyPartialCompileLimit, ==, 4000);
+    g_assert_true(jsc_options_get_size("wasmPartialCompileLimit", &wasmPartialCompileLimit));
+    g_assert_cmpuint(wasmPartialCompileLimit, ==, 4000);
     g_assert_true(jsc_options_get_double("criticalGCMemoryThreshold", &criticalGCMemoryThreshold));
     g_assert_cmpfloat(criticalGCMemoryThreshold, ==, 0.95);
     g_assert_true(jsc_options_get_string("configFile", &configFile.outPtr()));
@@ -4490,7 +4490,7 @@ static void testsJSCOptions()
     g_assert_true(jsc_options_set_boolean(JSC_OPTIONS_USE_JIT, TRUE));
     g_assert_true(jsc_options_set_int("thresholdForJITAfterWarmUp", 500));
     g_assert_true(jsc_options_set_uint("maxPerThreadStackUsage", 5242880));
-    g_assert_true(jsc_options_set_size("webAssemblyPartialCompileLimit", 5000));
+    g_assert_true(jsc_options_set_size("wasmPartialCompileLimit", 5000));
     g_assert_true(jsc_options_set_double("smallHeapRAMFraction", 0.25));
     g_assert_true(jsc_options_set_string("configFile", nullptr));
     g_assert_true(jsc_options_set_range_string("bytecodeRangeToJITCompile", nullptr));


### PR DESCRIPTION
#### f8d5c15c07d820de1adb9b11f5923d9e8479565d
<pre>
Rename WebAssembly JSC options to Wasm
<a href="https://bugs.webkit.org/show_bug.cgi?id=277175">https://bugs.webkit.org/show_bug.cgi?id=277175</a>
<a href="https://rdar.apple.com/problem/132599412">rdar://problem/132599412</a>

Reviewed by Yusuke Suzuki.

We&apos;re making this change for a few reasons:

1) Wasm is the term most folks use when discussing WebAssembly and is well known amongst WebKit and web devs
2) Wasm is shorter thus easier to pass when debugging in the CLI
3) For folks that don&apos;t know what Wasm means the first Google/DuckDuckGo/Bing/Siri result is WebAssembly
4) Wasm is the standard file extension/mime type for wasm binaries.
5) Wasm is the name of the WebAssembly specific directories in WebKit.

* JSTests/microbenchmarks/exceptions-simd.js:
* JSTests/microbenchmarks/wasm-cc-int-to-int.js:
* JSTests/wasm/extended-const/extended-const.js:
* JSTests/wasm/extended-const/flag-turned-off.js:
* JSTests/wasm/function-references/block_signature.js:
* JSTests/wasm/function-references/br_on_null.js:
* JSTests/wasm/function-references/bug243265.js:
* JSTests/wasm/function-references/call_ref.js:
* JSTests/wasm/function-references/local_init.js:
* JSTests/wasm/function-references/ref_as_non_null.js:
* JSTests/wasm/function-references/ref_types.js:
* JSTests/wasm/function-references/table.js:
* JSTests/wasm/function-references/table_init.js:
* JSTests/wasm/gc/any.js:
* JSTests/wasm/gc/array_new_data.js:
* JSTests/wasm/gc/array_new_elem.js:
* JSTests/wasm/gc/array_new_fixed.js:
* JSTests/wasm/gc/array_new_fixed_long.js:
* JSTests/wasm/gc/arrays.js:
* JSTests/wasm/gc/block.js:
* JSTests/wasm/gc/br_on_cast.js:
* JSTests/wasm/gc/bug247874.js:
* JSTests/wasm/gc/bug250613.js:
* JSTests/wasm/gc/bug252299.js:
* JSTests/wasm/gc/bug252538.js:
* JSTests/wasm/gc/bug252719.js:
* JSTests/wasm/gc/bug254226.js:
* JSTests/wasm/gc/bug254412.js:
* JSTests/wasm/gc/bug254413.js:
* JSTests/wasm/gc/bug254414.js:
* JSTests/wasm/gc/bug258127.js:
* JSTests/wasm/gc/bug258128.js:
* JSTests/wasm/gc/bug258499.js:
* JSTests/wasm/gc/bug258795.js:
* JSTests/wasm/gc/bug258796.js:
* JSTests/wasm/gc/bug258801.js:
* JSTests/wasm/gc/bug258804.js:
* JSTests/wasm/gc/bug258805.js:
* JSTests/wasm/gc/bug260516.js:
* JSTests/wasm/gc/bug262862.js:
* JSTests/wasm/gc/bug262863.js:
* JSTests/wasm/gc/bug265721.js:
* JSTests/wasm/gc/bug265742.js:
* JSTests/wasm/gc/bug265927.js:
* JSTests/wasm/gc/bug266043.js:
* JSTests/wasm/gc/bug266056.js:
* JSTests/wasm/gc/bug266127.js:
* JSTests/wasm/gc/bug266167.js:
* JSTests/wasm/gc/bug266249.js:
* JSTests/wasm/gc/bug267381.js:
* JSTests/wasm/gc/bulk-array.js:
* JSTests/wasm/gc/call_indirect.js:
* JSTests/wasm/gc/call_ref.js:
* JSTests/wasm/gc/casts.js:
* JSTests/wasm/gc/const-exprs-flag-off.js:
* JSTests/wasm/gc/const-exprs.js:
* JSTests/wasm/gc/eq.js:
* JSTests/wasm/gc/exception.js:
* JSTests/wasm/gc/extern.js:
* JSTests/wasm/gc/i31.js:
* JSTests/wasm/gc/js-api.js:
* JSTests/wasm/gc/limits.js:
* JSTests/wasm/gc/linking.js:
* JSTests/wasm/gc/packed-arrays.js:
* JSTests/wasm/gc/rec.js:
* JSTests/wasm/gc/simd.js:
* JSTests/wasm/gc/structs.js:
* JSTests/wasm/gc/sub.js:
* JSTests/wasm/gc/subtyping.js:
* JSTests/wasm/gc/table_init.js:
* JSTests/wasm/ipint-tests/perf.py:
* JSTests/wasm/references/element_active_mod.js:
* JSTests/wasm/references/func_ref.js:
* JSTests/wasm/references/is_null.js:
* JSTests/wasm/references/table_misc.js:
* JSTests/wasm/references/validation.js:
* JSTests/wasm/regress/llint-callee-saves-with-fast-memory.js:
* JSTests/wasm/regress/llint-callee-saves-without-fast-memory.js:
* JSTests/wasm/stress/big-try-simd.js:
* JSTests/wasm/stress/big-try.js:
* JSTests/wasm/stress/big-tuple-args.js:
* JSTests/wasm/stress/big-tuple.js:
* JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js:
* JSTests/wasm/stress/cc-int-to-int-jit-to-llint.js:
* JSTests/wasm/stress/cc-int-to-int-no-jit.js:
* JSTests/wasm/stress/cc-int-to-int-tail-call.js:
* JSTests/wasm/stress/dont-stack-overflow-in-air.js:
* JSTests/wasm/stress/simd-big-tuple.js:
* JSTests/wasm/stress/simd-const-relaxed-f32-madd.js:
* JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js:
* JSTests/wasm/stress/simd-const-relaxed-f64-madd.js:
* JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js:
* JSTests/wasm/stress/simd-const-relaxed-swizzle.js:
* JSTests/wasm/stress/simd-const-spill.js:
* JSTests/wasm/stress/simd-const.js:
* JSTests/wasm/stress/simd-exception-throwing-v128-clobbers-fp.js:
* JSTests/wasm/stress/simd-exception.js:
* JSTests/wasm/stress/simd-global-get.js:
* JSTests/wasm/stress/simd-global-set.js:
* JSTests/wasm/stress/simd-import-global-2.js:
* JSTests/wasm/stress/simd-kitchen-sink.js:
* JSTests/wasm/stress/simd-load.js:
* JSTests/wasm/stress/simd-no-fast-mem-load-lane.js:
* JSTests/wasm/stress/simd-no-fast-mem-load-splat.js:
* JSTests/wasm/stress/simd-no-fast-mem-store-lane.js:
* JSTests/wasm/stress/simd-osr-many-vectors.js:
* JSTests/wasm/stress/simd-osr.js:
* JSTests/wasm/stress/simd-regalloc-stress-2.js:
* JSTests/wasm/stress/simd-regalloc-stress.js:
* JSTests/wasm/stress/simd-register-allocation.js:
* JSTests/wasm/stress/simd-regress.js:
* JSTests/wasm/stress/simd-return-value-alignment.js:
* JSTests/wasm/stress/simd-select.js:
* JSTests/wasm/stress/simd-shuffle.js:
* JSTests/wasm/stress/simd-tail-call-simple.js:
* JSTests/wasm/stress/simd-tail-calls-throw.js:
* JSTests/wasm/stress/simd-tiny-loop.js:
* JSTests/wasm/stress/simd-unreachable.js:
* JSTests/wasm/stress/simple-inline-stacktrace-2.js:
* JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js:
* JSTests/wasm/stress/tag-return.js:
* JSTests/wasm/stress/tail-call-double.js:
* JSTests/wasm/stress/tail-call-js-inline.js:
* JSTests/wasm/stress/tail-call-js.js:
* JSTests/wasm/stress/tail-call-simple-int.js:
* JSTests/wasm/stress/tail-call-simple.js:
* JSTests/wasm/stress/tail-call.js:
* JSTests/wasm/stress/tuple-and-simd.js:
* JSTests/wasm/v8/adapter-frame.js:
* JSTests/wasm/v8/add-getters.js:
* JSTests/wasm/v8/anyfunc.js:
* JSTests/wasm/v8/array-copy-benchmark.js:
* JSTests/wasm/v8/array-init-from-segment.js:
* JSTests/wasm/v8/asm-wasm-copy.js:
* JSTests/wasm/v8/asm-wasm-deopt.js:
* JSTests/wasm/v8/asm-wasm-exception-in-tonumber.js:
* JSTests/wasm/v8/asm-wasm-expr.js:
* JSTests/wasm/v8/asm-wasm-f32.js:
* JSTests/wasm/v8/asm-wasm-f64.js:
* JSTests/wasm/v8/asm-wasm-heap.js:
* JSTests/wasm/v8/asm-wasm-i32.js:
* JSTests/wasm/v8/asm-wasm-imports.js:
* JSTests/wasm/v8/asm-wasm-literals.js:
* JSTests/wasm/v8/asm-wasm-math-intrinsic.js:
* JSTests/wasm/v8/asm-wasm-memory.js:
* JSTests/wasm/v8/asm-wasm-names.js:
* JSTests/wasm/v8/asm-wasm-stack.js:
* JSTests/wasm/v8/asm-wasm-stdlib.js:
* JSTests/wasm/v8/asm-wasm-switch.js:
* JSTests/wasm/v8/asm-wasm-u32.js:
* JSTests/wasm/v8/asm-wasm.js:
* JSTests/wasm/v8/asm-with-wasm-off.js:
* JSTests/wasm/v8/atomics-non-shared.js:
* JSTests/wasm/v8/atomics-stress.js:
* JSTests/wasm/v8/atomics.js:
* JSTests/wasm/v8/atomics64-stress.js:
* JSTests/wasm/v8/bigint-i64-to-imported-js-func.js:
* JSTests/wasm/v8/bigint-opt.js:
* JSTests/wasm/v8/bigint-rematerialize.js:
* JSTests/wasm/v8/bigint.js:
* JSTests/wasm/v8/bit-shift-right.js:
* JSTests/wasm/v8/bounds-check-64bit.js:
* JSTests/wasm/v8/bounds-check-turbofan.js:
* JSTests/wasm/v8/bulk-memory.js:
* JSTests/wasm/v8/call-ref.js:
* JSTests/wasm/v8/call_indirect.js:
* JSTests/wasm/v8/calls.js:
* JSTests/wasm/v8/code-space-overflow.js:
* JSTests/wasm/v8/committed-code-exhaustion.js:
* JSTests/wasm/v8/compare-exchange-stress.js:
* JSTests/wasm/v8/compare-exchange64-stress.js:
* JSTests/wasm/v8/compilation-hints-async-compilation.js:
* JSTests/wasm/v8/compilation-hints-decoder.js:
* JSTests/wasm/v8/compilation-hints-ignored.js:
* JSTests/wasm/v8/compilation-hints-lazy-validation.js:
* JSTests/wasm/v8/compilation-hints-streaming-compilation.js:
* JSTests/wasm/v8/compilation-hints-streaming-lazy-validation.js:
* JSTests/wasm/v8/compilation-hints-sync-compilation.js:
* JSTests/wasm/v8/compilation-limits-asm.js:
* JSTests/wasm/v8/compilation-limits.js:
* JSTests/wasm/v8/compiled-module-management.js:
* JSTests/wasm/v8/compiled-module-serialization.js:
* JSTests/wasm/v8/data-segments.js:
* JSTests/wasm/v8/disable-trap-handler.js:
* JSTests/wasm/v8/disallow-codegen.js:
* JSTests/wasm/v8/divrem-trap.js:
* JSTests/wasm/v8/element-segments-with-reftypes.js:
* JSTests/wasm/v8/empirical_max_memory.js:
* JSTests/wasm/v8/ensure-wasm-binaries-up-to-date.js:
* JSTests/wasm/v8/errors.js:
* JSTests/wasm/v8/exceptions-simd.js:
* JSTests/wasm/v8/export-global.js:
* JSTests/wasm/v8/export-identity.js:
* JSTests/wasm/v8/export-mutable-global.js:
* JSTests/wasm/v8/export-table.js:
* JSTests/wasm/v8/expose-wasm.js:
* JSTests/wasm/v8/extended-constants.js:
* JSTests/wasm/v8/externref-globals.js:
* JSTests/wasm/v8/externref-table.js:
* JSTests/wasm/v8/externref.js:
* JSTests/wasm/v8/ffi-error.js:
* JSTests/wasm/v8/ffi.js:
* JSTests/wasm/v8/float-constant-folding.js:
* JSTests/wasm/v8/function-names.js:
* JSTests/wasm/v8/function-prototype.js:
* JSTests/wasm/v8/futex.js:
* JSTests/wasm/v8/gc-buffer.js:
* JSTests/wasm/v8/gc-casts-from-any.js:
* JSTests/wasm/v8/gc-casts-invalid.js:
* JSTests/wasm/v8/gc-casts-subtypes.js:
* JSTests/wasm/v8/gc-experimental-string-conversions.js:
* JSTests/wasm/v8/gc-experiments.js:
* JSTests/wasm/v8/gc-frame.js:
* JSTests/wasm/v8/gc-js-interop-async-debugger.js:
* JSTests/wasm/v8/gc-js-interop-collections.js:
* JSTests/wasm/v8/gc-js-interop-export.mjs:
* JSTests/wasm/v8/gc-js-interop-global-constructors.js:
* JSTests/wasm/v8/gc-js-interop-import.mjs:
* JSTests/wasm/v8/gc-js-interop-numeric.js:
* JSTests/wasm/v8/gc-js-interop-objects.js:
* JSTests/wasm/v8/gc-js-interop-wasm.js:
* JSTests/wasm/v8/gc-js-interop.js:
* JSTests/wasm/v8/gc-memory.js:
* JSTests/wasm/v8/gc-nominal.js:
* JSTests/wasm/v8/gc-optimizations.js:
* JSTests/wasm/v8/gc-stress.js:
* JSTests/wasm/v8/gc-typecheck-reducer.js:
* JSTests/wasm/v8/gdbjit.js:
* JSTests/wasm/v8/generic-wrapper.js:
* JSTests/wasm/v8/globals-import-export-identity.js:
* JSTests/wasm/v8/globals.js:
* JSTests/wasm/v8/graceful_shutdown.js:
* JSTests/wasm/v8/graceful_shutdown_during_tierup.js:
* JSTests/wasm/v8/grow-huge-memory.js:
* JSTests/wasm/v8/grow-memory-detaching.js:
* JSTests/wasm/v8/grow-memory-in-branch.js:
* JSTests/wasm/v8/grow-memory-in-call.js:
* JSTests/wasm/v8/grow-memory-in-loop.js:
* JSTests/wasm/v8/grow-memory.js:
* JSTests/wasm/v8/grow-shared-memory.js:
* JSTests/wasm/v8/huge-memory.js:
* JSTests/wasm/v8/huge-typedarray.js:
* JSTests/wasm/v8/i31ref.js:
* JSTests/wasm/v8/import-function.js:
* JSTests/wasm/v8/import-memory.js:
* JSTests/wasm/v8/import-mutable-global.js:
* JSTests/wasm/v8/import-table.js:
* JSTests/wasm/v8/imported-function-types.js:
* JSTests/wasm/v8/indirect-call-non-zero-table.js:
* JSTests/wasm/v8/indirect-calls.js:
* JSTests/wasm/v8/indirect-sig-mismatch.js:
* JSTests/wasm/v8/indirect-tables.js:
* JSTests/wasm/v8/inlining.js:
* JSTests/wasm/v8/instance-gc.js:
* JSTests/wasm/v8/instance-memory-gc-stress.js:
* JSTests/wasm/v8/instantiate-module-basic.js:
* JSTests/wasm/v8/instantiate-run-basic.js:
* JSTests/wasm/v8/js-api.js:
* JSTests/wasm/v8/large-offset.js:
* JSTests/wasm/v8/lazy-compilation.js:
* JSTests/wasm/v8/lazy-feedback-vector-allocation.js:
* JSTests/wasm/v8/liftoff-debug.js:
* JSTests/wasm/v8/liftoff-simd-params.js:
* JSTests/wasm/v8/liftoff-trap-handler.js:
* JSTests/wasm/v8/liftoff.js:
* JSTests/wasm/v8/load-immutable.js:
* JSTests/wasm/v8/log-code-after-post-message.js:
* JSTests/wasm/v8/loop-rotation.js:
* JSTests/wasm/v8/loop-unrolling.js:
* JSTests/wasm/v8/many-memories-no-trap-handler.js:
* JSTests/wasm/v8/many-memories.js:
* JSTests/wasm/v8/many-modules.js:
* JSTests/wasm/v8/many-parameters.js:
* JSTests/wasm/v8/max-module-size-flag.js:
* JSTests/wasm/v8/max-wasm-functions.js:
* JSTests/wasm/v8/memory-external-call.js:
* JSTests/wasm/v8/memory-instance-validation.js:
* JSTests/wasm/v8/memory-size.js:
* JSTests/wasm/v8/memory.js:
* JSTests/wasm/v8/memory64.js:
* JSTests/wasm/v8/memory_1gb_oob.js:
* JSTests/wasm/v8/memory_2gb_oob.js:
* JSTests/wasm/v8/memory_4gb_oob.js:
* JSTests/wasm/v8/module-memory.js:
* JSTests/wasm/v8/multi-table-element-section.js:
* JSTests/wasm/v8/multi-value-simd.js:
* JSTests/wasm/v8/multiple-code-spaces.js:
* JSTests/wasm/v8/mutable-globals.js:
* JSTests/wasm/v8/names.js:
* JSTests/wasm/v8/parallel_compilation.js:
* JSTests/wasm/v8/params.js:
* JSTests/wasm/v8/print-code.js:
* JSTests/wasm/v8/prototype.js:
* JSTests/wasm/v8/receiver.js:
* JSTests/wasm/v8/reference-globals-import.js:
* JSTests/wasm/v8/reference-globals.js:
* JSTests/wasm/v8/reference-table-js-interop.js:
* JSTests/wasm/v8/reference-tables.js:
* JSTests/wasm/v8/regress/regress-10309.js:
* JSTests/wasm/v8/regress/regress-1054466.js:
* JSTests/wasm/v8/regress/regress-1065599.js:
* JSTests/wasm/v8/regress/regress-1070078.js:
* JSTests/wasm/v8/regress/regress-1081030.js:
* JSTests/wasm/v8/regress/regress-10831.js:
* JSTests/wasm/v8/regress/regress-1111522.js:
* JSTests/wasm/v8/regress/regress-1112124.js:
* JSTests/wasm/v8/regress/regress-1116019.js:
* JSTests/wasm/v8/regress/regress-1124885.js:
* JSTests/wasm/v8/regress/regress-1132461.js:
* JSTests/wasm/v8/regress/regress-1161555.js:
* JSTests/wasm/v8/regress/regress-1161654.js:
* JSTests/wasm/v8/regress/regress-1161954.js:
* JSTests/wasm/v8/regress/regress-1165966.js:
* JSTests/wasm/v8/regress/regress-1187831.js:
* JSTests/wasm/v8/regress/regress-1188975.js:
* JSTests/wasm/v8/regress/regress-1199662.js:
* JSTests/wasm/v8/regress/regress-1231950.js:
* JSTests/wasm/v8/regress/regress-1242300.js:
* JSTests/wasm/v8/regress/regress-1242689.js:
* JSTests/wasm/v8/regress/regress-1254675.js:
* JSTests/wasm/v8/regress/regress-1264462.js:
* JSTests/wasm/v8/regress/regress-1271244.js:
* JSTests/wasm/v8/regress/regress-1271538.js:
* JSTests/wasm/v8/regress/regress-1282224.js:
* JSTests/wasm/v8/regress/regress-1283042.js:
* JSTests/wasm/v8/regress/regress-1283395.js:
* JSTests/wasm/v8/regress/regress-1284980.js:
* JSTests/wasm/v8/regress/regress-1286253.js:
* JSTests/wasm/v8/regress/regress-1289678.js:
* JSTests/wasm/v8/regress/regress-1290079.js:
* JSTests/wasm/v8/regress/regress-1364036.js:
* JSTests/wasm/v8/regress/regress-763697.js:
* JSTests/wasm/v8/regress/regress-9017.js:
* JSTests/wasm/v8/regress/regress-9447.js:
* JSTests/wasm/v8/regress/regress-crbug-1338980.js:
* JSTests/wasm/v8/regress/regress-crbug-1355070.js:
* JSTests/wasm/v8/regress/regress-crbug-1356718.js:
* JSTests/wasm/v8/resizablearraybuffer-growablesharedarraybuffer-wasm.js:
* JSTests/wasm/v8/return-calls.js:
* JSTests/wasm/v8/runtime-type-canonicalization.js:
* JSTests/wasm/v8/serialization-with-compilation-hints.js:
* JSTests/wasm/v8/serialize-lazy-module.js:
* JSTests/wasm/v8/shared-arraybuffer-worker-simple-gc.js:
* JSTests/wasm/v8/shared-memory-gc-stress.js:
* JSTests/wasm/v8/shared-memory-worker-explicit-gc-stress.js:
* JSTests/wasm/v8/shared-memory-worker-gc-stress.js:
* JSTests/wasm/v8/shared-memory-worker-gc.js:
* JSTests/wasm/v8/shared-memory-worker-simple-gc.js:
* JSTests/wasm/v8/shared-memory-worker-stress.js:
* JSTests/wasm/v8/shared-memory.js:
* JSTests/wasm/v8/simd-call.js:
* JSTests/wasm/v8/simd-errors.js:
* JSTests/wasm/v8/simd-globals.js:
* JSTests/wasm/v8/simd-i64x2-mul.js:
* JSTests/wasm/v8/single-threaded-compilation.js:
* JSTests/wasm/v8/speculative-inlining.js:
* JSTests/wasm/v8/stack-switching-export.js:
* JSTests/wasm/v8/stack-switching.js:
* JSTests/wasm/v8/stack.js:
* JSTests/wasm/v8/stackwalk.js:
* JSTests/wasm/v8/start-function.js:
* JSTests/wasm/v8/streaming-api.js:
* JSTests/wasm/v8/streaming-compile.js:
* JSTests/wasm/v8/streaming-error-position.js:
* JSTests/wasm/v8/streaming-trap-location.js:
* JSTests/wasm/v8/stringrefs-exec-gc.js:
* JSTests/wasm/v8/stringrefs-exec.js:
* JSTests/wasm/v8/stringrefs-invalid.js:
* JSTests/wasm/v8/stringrefs-js.js:
* JSTests/wasm/v8/stringrefs-regressions.js:
* JSTests/wasm/v8/stringrefs-valid.js:
* JSTests/wasm/v8/table-access.js:
* JSTests/wasm/v8/table-copy-externref.js:
* JSTests/wasm/v8/table-copy.js:
* JSTests/wasm/v8/table-fill.js:
* JSTests/wasm/v8/table-get.js:
* JSTests/wasm/v8/table-grow-from-wasm.js:
* JSTests/wasm/v8/table-grow.js:
* JSTests/wasm/v8/table-limits.js:
* JSTests/wasm/v8/tagged-stack-parameters.js:
* JSTests/wasm/v8/test-partial-serialization.js:
* JSTests/wasm/v8/test-serialization-with-lazy-compilation.js:
* JSTests/wasm/v8/test-wasm-module-builder.js:
* JSTests/wasm/v8/tier-down-to-liftoff.js:
* JSTests/wasm/v8/tier-up-testing-flag.js:
* JSTests/wasm/v8/type-based-optimizations.js:
* JSTests/wasm/v8/type-reflection-with-externref.js:
* JSTests/wasm/v8/type-reflection-with-mv.js:
* JSTests/wasm/v8/type-reflection.js:
* JSTests/wasm/v8/typed-funcref.js:
* JSTests/wasm/v8/unicode-validation.js:
* JSTests/wasm/v8/unicode.js:
* JSTests/wasm/v8/unreachable-validation.js:
* JSTests/wasm/v8/unreachable.js:
* JSTests/wasm/v8/user-properties-constructed.js:
* JSTests/wasm/v8/user-properties-exported.js:
* JSTests/wasm/v8/user-properties-module.js:
* JSTests/wasm/v8/user-properties-reexport.js:
* JSTests/wasm/v8/verify-module-basic-errors.js:
* JSTests/wasm/v8/wasm-api-overloading.js:
* JSTests/wasm/v8/wasm-default.js:
* JSTests/wasm/v8/wasm-dynamic-tiering.js:
* JSTests/wasm/v8/wasm-gc-externalize-internalize.js:
* JSTests/wasm/v8/wasm-gc-js-ref.js:
* JSTests/wasm/v8/wasm-gc-js-roundtrip.js:
* JSTests/wasm/v8/wasm-invalid-local.js:
* JSTests/wasm/v8/wasm-math-intrinsic.js:
* JSTests/wasm/v8/wasm-object-api.js:
* JSTests/wasm/v8/worker-memory.js:
* JSTests/wasm/v8/worker-module.js:
* JSTests/wasm/v8/worker-running-empty-loop-interruptible.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/casts.tentative.any.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/exported-object.tentative.any.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/global-import.tentative.any.html:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/gc/i31.tentative.any.html:
* Source/JavaScriptCore/assembler/LinkBuffer.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::storeVector):
* Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.cpp:
(JSC::shouldDumpDisassemblyFor):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::storeVector):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp:
* Source/JavaScriptCore/b3/B3Procedure.h:
(JSC::B3::Procedure::setUsessSIMD):
(JSC::B3::Procedure::usesSIMD const):
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::GenerateAndAllocateRegisters::generate):
* Source/JavaScriptCore/b3/air/AirHelpers.h:
(JSC::B3::Air::moveForType):
* Source/JavaScriptCore/b3/air/AirLogRegisterPressure.cpp:
(JSC::B3::Air::logRegisterPressure):
* Source/JavaScriptCore/b3/air/AirRegLiveness.cpp:
(JSC::B3::Air::RegLiveness::RegLiveness):
* Source/JavaScriptCore/b3/air/AirValidate.cpp:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::linkPolymorphicCall):
* Source/JavaScriptCore/jit/RegisterAtOffset.h:
(JSC::RegisterAtOffset::RegisterAtOffset):
* Source/JavaScriptCore/jit/RegisterAtOffsetList.cpp:
(JSC::RegisterAtOffsetList::RegisterAtOffsetList):
* Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp:
(JSC::ScratchRegisterAllocator::preserveRegistersToStackForCall):
(JSC::ScratchRegisterAllocator::restoreRegistersFromStackForCall):
* Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp:
(JSC::BufferMemoryHandle::fastMappedRedzoneBytes):
(JSC::BufferMemoryManager::tryAllocateFastMemory):
(JSC::BufferMemoryManager::freeFastMemory):
(JSC::BufferMemoryManager::tryAllocateGrowableBoundsCheckingMemory):
(JSC::BufferMemoryManager::freeGrowableBoundsCheckingMemory):
(JSC::BufferMemoryManager::tryAllocatePhysicalBytes):
(JSC::BufferMemoryManager::freePhysicalBytes):
* Source/JavaScriptCore/runtime/BufferMemoryHandle.h:
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::overrideDefaults):
(JSC::disableAllJITOptions):
(JSC::Options::notifyOptionsChanged):
(JSC::Options::assertOptionsAreCoherent):
(JSC::hasCapacityToUseLargeGigacage):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefFunc):
(JSC::Wasm::BBQJITImpl::BBQJIT::makeStackMap):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitSlowPathRTTCheck):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::CalleeGroup):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmCapabilities.h:
(JSC::Wasm::isSupported):
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprGenerator::getGlobal):
(JSC::Wasm::ConstExprGenerator::addArrayNew):
(JSC::Wasm::ConstExprGenerator::addArrayNewDefault):
(JSC::Wasm::ConstExprGenerator::addArrayNewFixed):
(JSC::Wasm::ConstExprGenerator::addStructNewDefault):
(JSC::Wasm::ConstExprGenerator::addStructNew):
(JSC::Wasm::ConstExprGenerator::addAnyConvertExtern):
(JSC::Wasm::ConstExprGenerator::addExternConvertAny):
(JSC::Wasm::ConstExprGenerator::addConstant):
(JSC::Wasm::parseExtendedConstExpr):
(JSC::Wasm::evaluateExtendedConstExpr):
* Source/JavaScriptCore/wasm/WasmEntryPlan.cpp:
(JSC::Wasm::EntryPlan::compileFunctions):
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp:
(JSC::Wasm::activateSignalingMemory):
(JSC::Wasm::prepareSignalingMemory):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::isValueType):
(JSC::Wasm::isRefType):
(JSC::Wasm::isExternref):
(JSC::Wasm::isFuncref):
(JSC::Wasm::isEqref):
(JSC::Wasm::isAnyref):
(JSC::Wasm::isNullref):
(JSC::Wasm::isNullfuncref):
(JSC::Wasm::isNullexternref):
(JSC::Wasm::isInternalref):
(JSC::Wasm::isI31ref):
(JSC::Wasm::isArrayref):
(JSC::Wasm::isStructref):
(JSC::Wasm::funcrefType):
(JSC::Wasm::externrefType):
(JSC::Wasm::eqrefType):
(JSC::Wasm::anyrefType):
(JSC::Wasm::arrayrefType):
(JSC::Wasm::isRefWithTypeIndex):
(JSC::Wasm::isRefWithRecursiveReference):
(JSC::Wasm::isTypeIndexHeapType):
(JSC::Wasm::isSubtypeIndex):
(JSC::Wasm::isSubtype):
(JSC::Wasm::isValidHeapTypeKind):
* Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h:
(JSC::Wasm::FunctionCodeBlockGenerator::getConstantType const):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser::pushLocalInitialized):
(JSC::Wasm::FunctionParser::resetLocalInitStackToHeight):
(JSC::Wasm::FunctionParser::validationFail const):
(JSC::Wasm::FunctionParser::typeToStringModuleRelative const):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parse):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseBody):
(JSC::Wasm::FunctionParser&lt;Context&gt;::simd):
(JSC::Wasm::FunctionParser&lt;Context&gt;::checkLocalInitialized):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::notifyFunctionUsesSIMD):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::shouldJIT):
(JSC::IPInt::jitCompileAndSetHeuristics):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntTierUpCounter.h:
(JSC::Wasm::IPIntTierUpCounter::optimizeAfterWarmUp):
(JSC::Wasm::IPIntTierUpCounter::optimizeSoon):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::notifyFunctionUsesSIMD):
(JSC::Wasm::LLIntGenerator::jsNullConstant):
(JSC::Wasm::LLIntGenerator::zeroConstant):
(JSC::Wasm::LLIntGenerator::addConstantWithoutPush):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::compileFunction):
(JSC::Wasm::LLIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmLLIntTierUpCounter.h:
(JSC::Wasm::LLIntTierUpCounter::optimizeAfterWarmUp):
(JSC::Wasm::LLIntTierUpCounter::optimizeSoon):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::tryCreate):
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::makeValidationCallback):
(JSC::Wasm::Module::validateSync):
(JSC::Wasm::Module::validateAsync):
(JSC::Wasm::Module::getOrCreateCalleeGroup):
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
(JSC::Wasm::ModuleInformation::usesSIMD const):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitLoopTierUpCheck):
(JSC::Wasm::OMGIRGenerator::canInline const):
(JSC::Wasm::OMGIRGenerator::addCall):
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
(JSC::Wasm::shouldDumpIRFor):
(JSC::Wasm::parseAndCompileOMG):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::emitLoopTierUpCheck):
(JSC::Wasm::OMGIRGenerator::canInline const):
(JSC::Wasm::OMGIRGenerator::addCall):
(JSC::Wasm::OMGIRGenerator::addCallIndirect):
(JSC::Wasm::shouldDumpIRFor):
(JSC::Wasm::parseAndCompileOMG):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::loadValuesIntoBuffer):
(JSC::Wasm::shouldJIT):
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::ParserBase::parseBlockSignature):
(JSC::Wasm::ParserBase::parseHeapType):
(JSC::Wasm::ParserBase::parseValueType):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseType):
(JSC::Wasm::SectionParser::parseResizableLimits):
(JSC::Wasm::SectionParser::parseTableHelper):
(JSC::Wasm::SectionParser::parseElement):
(JSC::Wasm::SectionParser::parseInitExpr):
(JSC::Wasm::SectionParser::parseStorageType):
(JSC::Wasm::SectionParser::parseStructType):
(JSC::Wasm::SectionParser::parseArrayType):
(JSC::Wasm::SectionParser::parseRecursionGroup):
(JSC::Wasm::SectionParser::parseSubtype):
(JSC::Wasm::SectionParser::parseCustom):
* Source/JavaScriptCore/wasm/WasmSectionParser.h:
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::shouldJIT):
(JSC::LLInt::jitCompileAndSetHeuristics):
(JSC::LLInt::jitCompileSIMDFunction):
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::dumpWasmSource):
(JSC::Wasm::StreamingParser::StreamingParser):
(JSC::Wasm::StreamingParser::addBytes):
(JSC::Wasm::StreamingParser::finalize):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::ExternRefTable::ExternRefTable):
(JSC::Wasm::FuncRefTable::FuncRefTable):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeInformation::TypeInformation):
(JSC::Wasm::TypeInformation::getCanonicalRTT):
* Source/JavaScriptCore/wasm/WasmWorklist.cpp:
(JSC::Wasm::Worklist::Worklist):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::createJSToWasmWrapper):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h:
(JSC::defaultValueForReferenceType):
(JSC::fromJSValue):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::finalizeCreation):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):
(JSC::WebAssemblyModuleRecord::initializeExports):
* Source/JavaScriptCore/wasm/js/WebAssemblyTablePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/281459@main">https://commits.webkit.org/281459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef4f0aaa61e7c2b9807a212b54094fc1a817ae24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59978 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63896 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48601 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7329 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29443 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33375 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9180 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/preload-type-match.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9428 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/53072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55287 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65628 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59223 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55950 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56100 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3240 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/80981 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8984 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35139 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14067 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37309 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->