### PR TITLE
Use a CheckedPtr for NodeWithIndex::m_node

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6041,7 +6041,7 @@ void Document::textRemoved(Node& text, unsigned offset, unsigned length)
 void Document::textNodesMerged(Text& oldNode, unsigned offset)
 {
     if (!m_ranges.isEmpty()) {
-        NodeWithIndex oldNodeWithIndex(&oldNode);
+        NodeWithIndex oldNodeWithIndex(oldNode);
         for (auto& range : m_ranges)
             Ref { range.get() }->textNodesMerged(oldNodeWithIndex, offset);
     }

--- a/Source/WebCore/dom/NodeWithIndex.h
+++ b/Source/WebCore/dom/NodeWithIndex.h
@@ -33,13 +33,12 @@ namespace WebCore {
 // only want to walk the child list to figure out the index once.
 class NodeWithIndex {
 public:
-    explicit NodeWithIndex(Node* node)
-        : m_node(node)
+    explicit NodeWithIndex(Node& node)
+        : m_node(&node)
     {
-        ASSERT(node);
     }
 
-    Node* node() const { return m_node; }
+    Node* node() const { return m_node.get(); }
 
     int index() const
     {
@@ -51,7 +50,7 @@ public:
     }
 
 private:
-    Node* m_node;
+    CheckedPtr<Node> m_node;
     mutable Markable<int, IntegralMarkableTraits<int, -1>> m_index;
 };
 


### PR DESCRIPTION
#### 65925bb90abff410759c9ea3961441ef3fbfe5e9
<pre>
Use a CheckedPtr for NodeWithIndex::m_node
<a href="https://bugs.webkit.org/show_bug.cgi?id=277176">https://bugs.webkit.org/show_bug.cgi?id=277176</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::textNodesMerged):
* Source/WebCore/dom/NodeWithIndex.h:
(WebCore::NodeWithIndex::NodeWithIndex):
(WebCore::NodeWithIndex::node const):

Canonical link: <a href="https://commits.webkit.org/281562@main">https://commits.webkit.org/281562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b91abc4e71717e04e427d5df9131a109ceb847d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10466 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48553 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7299 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51854 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29397 "Found 5 new API test failures: /WPE/TestWebKitWebView:/webkit/WebKitWebView/terminate-web-process, /WPE/TestWebKitFindController:/webkit/WebKitFindController/text-not-found, /WPE/TestSSL:/webkit/WebKitWebView/tls-http-auth, /WPE/TestResources:/webkit/WebKitWebResource/get-data-error, /WPE/TestLoaderClient:/webkit/WebKitWebView/progress (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9093 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9337 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65537 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9264 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55893 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56036 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3168 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9049 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35051 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36133 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37221 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35877 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->