### PR TITLE
Outline messaging scheme between WebProcess and UIProcess for sidePanel / sidebarAction.

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -288,6 +288,7 @@ $(PROJECT_DIR)/Shared/Extensions/WebExtensionFrameParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionMatchedRuleParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionMenuItem.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in
+$(PROJECT_DIR)/Shared/Extensions/WebExtensionSidebarParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionStorage.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionTab.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionTabParameters.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -616,6 +616,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Extensions/WebExtensionMatchedRuleParameters.serialization.in \
 	Shared/Extensions/WebExtensionMenuItem.serialization.in \
 	Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in \
+	Shared/Extensions/WebExtensionSidebarParameters.serialization.in \
 	Shared/Extensions/WebExtensionStorage.serialization.in \
 	Shared/Extensions/WebExtensionTab.serialization.in \
 	Shared/Extensions/WebExtensionWindow.serialization.in \

--- a/Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.h
@@ -23,21 +23,18 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WK_WEB_EXTENSIONS_SIDEBAR,
-    MainWorldOnly,
-    ReturnsPromiseWhenCallbackIsOmitted,
-] interface WebExtensionAPISidebarAction {
+#pragma once
 
-    [RaisesException] void open([Optional, CallbackHandler] function callback);
-    [RaisesException] void close([Optional, CallbackHandler] function callback);
-    [RaisesException] void toggle([Optional, CallbackHandler] function callback);
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
-    [RaisesException] void isOpen([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
-    [RaisesException] void getPanel([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
-    [RaisesException] void setPanel([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
-    [RaisesException] void getTitle([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
-    [RaisesException] void setTitle([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
-    [RaisesException] void setIcon([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+namespace WebKit {
 
+struct WebExtensionSidebarParameters {
+    bool enabled { false };
+    String panelPath;
+    std::optional<WebExtensionTabIdentifier> tabIdentifier;
 };
+
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)

--- a/Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.serialization.in
@@ -1,0 +1,33 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
+struct WebKit::WebExtensionSidebarParameters {
+    bool enabled;
+    String panelPath;
+    std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier;
+};
+
+#endif

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionContext.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
+namespace WebKit {
+
+void WebExtensionContext::sidebarOpen(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, const std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
+{
+
+}
+
+void WebExtensionContext::sidebarClose(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
+{
+
+}
+
+void WebExtensionContext::sidebarIsOpen(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, CompletionHandler<void(Expected<bool, WebExtensionError>&&)>&& tabIdentifier)
+{
+
+}
+
+void WebExtensionContext::sidebarToggle(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
+{
+
+}
+
+void WebExtensionContext::sidebarSetIcon(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, const std::optional<WebExtensionTabIdentifier> tabIdentifier, const String& iconJSON, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
+{
+
+}
+
+void WebExtensionContext::sidebarGetTitle(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, const std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&& completionHandler)
+{
+
+}
+
+void WebExtensionContext::sidebarSetTitle(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, const std::optional<WebExtensionTabIdentifier> tabIdentifier, const std::optional<String>& title, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
+{
+
+}
+
+void WebExtensionContext::sidebarGetOptions(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, const std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(Expected<WebExtensionSidebarParameters, WebExtensionError>&&)>&& completionHandler)
+{
+
+}
+
+void WebExtensionContext::sidebarSetOptions(const std::optional<WebExtensionWindowIdentifier> windowIdentifier, const std::optional<WebExtensionTabIdentifier> tabIdentifier, const std::optional<String>& panelSourcePath, const std::optional<bool> enabled, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
+{
+
+}
+
+bool WebExtensionContext::isSidebarMessageAllowed()
+{
+    return false;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -79,6 +79,10 @@
 #include "WebInspectorUIProxy.h"
 #endif
 
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+#include "WebExtensionSidebarParameters.h"
+#endif
+
 OBJC_CLASS NSArray;
 OBJC_CLASS NSDate;
 OBJC_CLASS NSDictionary;
@@ -798,6 +802,20 @@ private:
     void scriptingGetRegisteredScripts(const Vector<String>&, CompletionHandler<void(Expected<Vector<WebExtensionRegisteredScriptParameters>, WebExtensionError>&&)>&&);
     void scriptingUnregisterContentScripts(const Vector<String>&, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
     bool createInjectedContentForScripts(const Vector<WebExtensionRegisteredScriptParameters>&, WebExtensionDynamicScripts::WebExtensionRegisteredScript::FirstTimeRegistration, DynamicInjectedContentsMap&, NSString *callingAPIName, NSString **errorMessage);
+
+    // Sidebar APIs
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+    bool isSidebarMessageAllowed();
+    void sidebarOpen(const std::optional<WebExtensionWindowIdentifier>, const std::optional<WebExtensionTabIdentifier>, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void sidebarIsOpen(const std::optional<WebExtensionWindowIdentifier>, CompletionHandler<void(Expected<bool, WebExtensionError>&&)>&&);
+    void sidebarClose(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void sidebarToggle(CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void sidebarGetOptions(const std::optional<WebExtensionWindowIdentifier>, const std::optional<WebExtensionTabIdentifier>, CompletionHandler<void(Expected<WebExtensionSidebarParameters, WebExtensionError>&&)>&&);
+    void sidebarSetOptions(const std::optional<WebExtensionWindowIdentifier>, const std::optional<WebExtensionTabIdentifier>, const std::optional<String>& panelSourcePath, const std::optional<bool> enabled, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void sidebarGetTitle(const std::optional<WebExtensionWindowIdentifier>, const std::optional<WebExtensionTabIdentifier>, CompletionHandler<void(Expected<String, WebExtensionError>&&)>&&);
+    void sidebarSetTitle(const std::optional<WebExtensionWindowIdentifier>, const std::optional<WebExtensionTabIdentifier>, const std::optional<String>& title, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void sidebarSetIcon(const std::optional<WebExtensionWindowIdentifier>, const std::optional<WebExtensionTabIdentifier>, const String& iconJSON, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+#endif
 
     // Storage APIs
     bool isStorageMessageAllowed();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -116,6 +116,19 @@ messages -> WebExtensionContext {
     [EnabledIf='isScriptingMessageAllowed()'] ScriptingGetRegisteredScripts(Vector<String> scriptIDs) -> (Expected<Vector<WebKit::WebExtensionRegisteredScriptParameters>, WebKit::WebExtensionError> result)
     [EnabledIf='isScriptingMessageAllowed()'] ScriptingUnregisterContentScripts(Vector<String> scriptIDs) -> (Expected<void, WebKit::WebExtensionError> result)
 
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+    // Sidebar APIs
+    [EnabledIf='isSidebarMessageAllowed()'] SidebarOpen(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<void, WebKit::WebExtensionError> result)
+    [EnabledIf='isSidebarMessageAllowed()'] SidebarIsOpen(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier) -> (Expected<bool, WebKit::WebExtensionError> result)
+    [EnabledIf='isSidebarMessageAllowed()'] SidebarClose() -> (Expected<void, WebKit::WebExtensionError> result)
+    [EnabledIf='isSidebarMessageAllowed()'] SidebarToggle() -> (Expected<void, WebKit::WebExtensionError> result)
+    [EnabledIf='isSidebarMessageAllowed()'] SidebarGetOptions(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<WebKit::WebExtensionSidebarParameters, WebKit::WebExtensionError> result)
+    [EnabledIf='isSidebarMessageAllowed()'] SidebarSetOptions(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<String> panelSourcePath, std::optional<bool> enabled) -> (Expected<void, WebKit::WebExtensionError> result)
+    [EnabledIf='isSidebarMessageAllowed()'] SidebarGetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<String, WebKit::WebExtensionError> result)
+    [EnabledIf='isSidebarMessageAllowed()'] SidebarSetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<String> title) -> (Expected<void, WebKit::WebExtensionError> result)
+    [EnabledIf='isSidebarMessageAllowed()'] SidebarSetIcon(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String iconDictionaryJSON) -> (Expected<void, WebKit::WebExtensionError> result)
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
     // Storage APIs
     [EnabledIf='isStorageMessageAllowed()'] StorageGet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, Vector<String> keys) -> (Expected<String, WebKit::WebExtensionError> result)
     [EnabledIf='isStorageMessageAllowed()'] StorageGetBytesInUse(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionDataType dataType, Vector<String> keys) -> (Expected<size_t, WebKit::WebExtensionError> result)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -120,6 +120,8 @@
 		00B9661A18E25AE100CE1F88 /* FindClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B9661818E25AE100CE1F88 /* FindClient.h */; };
 		0201B9522C238F4800227220 /* WebPageProxyTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 0201B9512C238EFE00227220 /* WebPageProxyTesting.h */; };
 		0201B9552C238FA800227220 /* WebPageTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 0201B9532C238F8500227220 /* WebPageTesting.h */; };
+		0237F5EA2C4B40E800AD23EF /* WebExtensionSidebarParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 0237F5E92C4B27F500AD23EF /* WebExtensionSidebarParameters.h */; };
+		0237F5EC2C4EC77300AD23EF /* WebExtensionContextAPISidebarCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0237F5EB2C4EC76800AD23EF /* WebExtensionContextAPISidebarCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		0250C2512B5DCB2000D05C0B /* FindStringCallbackAggregator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */; };
 		02660A7C2C4099370074EDC5 /* WebExtensionAPISidebarActionCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 02660A7B2C40992C0074EDC5 /* WebExtensionAPISidebarActionCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		02660A7E2C4099B50074EDC5 /* WebExtensionAPISidePanelCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 02660A7D2C4099AD0074EDC5 /* WebExtensionAPISidePanelCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -3140,6 +3142,9 @@
 		0214701A2995D2FE0077AFD6 /* DrawingAreaCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DrawingAreaCocoa.mm; sourceTree = "<group>"; };
 		0214701B2995D3860077AFD6 /* DrawingArea.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DrawingArea.cpp; sourceTree = "<group>"; };
 		0237C21428C168D10018A851 /* WebGPUSupportedFeatures.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUSupportedFeatures.serialization.in; sourceTree = "<group>"; };
+		0237F5E82C4B27DC00AD23EF /* WebExtensionSidebarParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionSidebarParameters.serialization.in; sourceTree = "<group>"; };
+		0237F5E92C4B27F500AD23EF /* WebExtensionSidebarParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionSidebarParameters.h; sourceTree = "<group>"; };
+		0237F5EB2C4EC76800AD23EF /* WebExtensionContextAPISidebarCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPISidebarCocoa.mm; sourceTree = "<group>"; };
 		024C319E2C23915300786A67 /* WebPageTesting.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebPageTesting.messages.in; sourceTree = "<group>"; };
 		0250C24E2B5DCAFB00D05C0B /* FindStringCallbackAggregator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FindStringCallbackAggregator.cpp; sourceTree = "<group>"; };
 		0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FindStringCallbackAggregator.h; sourceTree = "<group>"; };
@@ -9718,6 +9723,7 @@
 				1C9A15D22ABE2F4B002CC12A /* WebExtensionContextAPIPortCocoa.mm */,
 				1C4A14C72ABBBA3900A1018C /* WebExtensionContextAPIRuntimeCocoa.mm */,
 				B624FF142ABE4CB000F6EDF6 /* WebExtensionContextAPIScriptingCocoa.mm */,
+				0237F5EB2C4EC76800AD23EF /* WebExtensionContextAPISidebarCocoa.mm */,
 				B6B156602B5E2618004F9894 /* WebExtensionContextAPIStorageCocoa.mm */,
 				1C1D9C862AAA4143007DE31E /* WebExtensionContextAPITabsCocoa.mm */,
 				33B5A80E2AFD5DE800A15D40 /* WebExtensionContextAPIWebNavigationCocoa.mm */,
@@ -13645,6 +13651,8 @@
 				B69E1A672AFF5F0B000FB98E /* WebExtensionRegisteredScriptParameters.h */,
 				B6D031082AC1F631006C8E0B /* WebExtensionScriptInjectionParameters.h */,
 				B624FF1A2ABE503000F6EDF6 /* WebExtensionScriptInjectionResultParameters.h */,
+				0237F5E92C4B27F500AD23EF /* WebExtensionSidebarParameters.h */,
+				0237F5E82C4B27DC00AD23EF /* WebExtensionSidebarParameters.serialization.in */,
 				B6B156592B5E1779004F9894 /* WebExtensionStorage.serialization.in */,
 				B6B1565A2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h */,
 				1C4957A22A983E39007D0B64 /* WebExtensionTab.serialization.in */,
@@ -16965,6 +16973,7 @@
 				B69E1A682AFF5F0C000FB98E /* WebExtensionRegisteredScriptParameters.h in Headers */,
 				B6D0310A2AC1F631006C8E0B /* WebExtensionScriptInjectionParameters.h in Headers */,
 				B624FF1B2ABE503000F6EDF6 /* WebExtensionScriptInjectionResultParameters.h in Headers */,
+				0237F5EA2C4B40E800AD23EF /* WebExtensionSidebarParameters.h in Headers */,
 				B6B1565E2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h in Headers */,
 				1C66BDDC2A8ADB94009D4452 /* WebExtensionTab.h in Headers */,
 				1C66BDDA2A8ADB8A009D4452 /* WebExtensionTabIdentifier.h in Headers */,
@@ -19869,6 +19878,7 @@
 				1C9A15D32ABE2F4B002CC12A /* WebExtensionContextAPIPortCocoa.mm in Sources */,
 				1C4A14C82ABBBA3900A1018C /* WebExtensionContextAPIRuntimeCocoa.mm in Sources */,
 				B624FF152ABE4CB100F6EDF6 /* WebExtensionContextAPIScriptingCocoa.mm in Sources */,
+				0237F5EC2C4EC77300AD23EF /* WebExtensionContextAPISidebarCocoa.mm in Sources */,
 				B6B156612B5E2618004F9894 /* WebExtensionContextAPIStorageCocoa.mm in Sources */,
 				1C1D9C872AAA4143007DE31E /* WebExtensionContextAPITabsCocoa.mm in Sources */,
 				33B5A80F2AFD5DE800A15D40 /* WebExtensionContextAPIWebNavigationCocoa.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
@@ -39,11 +39,6 @@ void WebExtensionAPISidebarAction::open(Ref<WebExtensionCallbackHandler>&& callb
     callback->reportError(@"unimplemented");
 }
 
-void WebExtensionAPISidebarAction::isOpen(Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
-{
-    callback->reportError(@"unimplemented");
-}
-
 void WebExtensionAPISidebarAction::close(Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     callback->reportError(@"unimplemented");
@@ -53,6 +48,12 @@ void WebExtensionAPISidebarAction::toggle(Ref<WebExtensionCallbackHandler>&& cal
 {
     callback->reportError(@"unimplemented");
 }
+
+void WebExtensionAPISidebarAction::isOpen(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    callback->reportError(@"unimplemented");
+}
+
 
 void WebExtensionAPISidebarAction::getPanel(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidebarAction.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidebarAction.h
@@ -41,10 +41,10 @@ class WebExtensionAPISidebarAction : public WebExtensionAPIObject, public JSWebE
 public:
 #if PLATFORM(COCOA)
     void open(Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void isOpen(Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void close(Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void toggle(Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
+    void isOpen(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void getPanel(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void setPanel(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void getTitle(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);


### PR DESCRIPTION
#### 1e8ea6e4777297ce82e6c911caa7cce2cc32e6a9
<pre>
Outline messaging scheme between WebProcess and UIProcess for sidePanel / sidebarAction.
<a href="https://webkit.org/b/277169">https://webkit.org/b/277169</a>
<a href="https://rdar.apple.com/132595403">rdar://132595403</a>

Reviewed by Timothy Hatcher.

This PR adds several messages and receiver functions on
WebExtensionContext, and one associated serializable type, in order to
facilitate the messaging between the Web and UI processes necessary for
sidePanel / sidebarAction.

* Source/WebKit/DerivedSources-input.xcfilelist: Add
  WebExtensionSidebarParameters.serialization.in
* Source/WebKit/DerivedSources.make: Add
  WebExtensionWidebarParameters.serialization.in
* Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.h:
  Added.
* Source/WebKit/Shared/Extensions/WebExtensionSidebarParameters.serialization.in: Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm: Added.
(WebKit::WebExtensionContext::sidebarOpen): Added stub.
(WebKit::WebExtensionContext::sidebarClose): Added stub.
(WebKit::WebExtensionContext::sidebarIsOpen): Added stub.
(WebKit::WebExtensionContext::sidebarToggle): Added stub.
(WebKit::WebExtensionContext::sidebarSetIcon): Added stub.
(WebKit::WebExtensionContext::sidebarGetTitle): Added stub.
(WebKit::WebExtensionContext::sidebarSetTitle): Added stub.
(WebKit::WebExtensionContext::sidebarGetOptions): Added stub.
(WebKit::WebExtensionContext::sidebarSetOptions): Added stub.
(WebKit::WebExtensionContext::isSidebarMessageAllowed): Added stub which
returns false always.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h: Added
  declaration of sidebar message receivers.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
  Added sidebar messages.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj: Added
  WebExtensionSidebarParameters.h and
WebExtensionSidebarParameters.serialization.in
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm:
(WebKit::WebExtensionAPISidebarAction::close): No change.
(WebKit::WebExtensionAPISidebarAction::toggle): No change.
(WebKit::WebExtensionAPISidebarAction::isOpen): Add `details` object
which was originally omitted erroneously.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidebarAction.h: Amend signature of `isOpen` to include `details` object.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPISidebarAction.idl: Amend signature of `isOpen` to include `details` object.

Canonical link: <a href="https://commits.webkit.org/281519@main">https://commits.webkit.org/281519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be227265bc9a5fe000772ed0b76a8663710a0e42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63832 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10442 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48558 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7281 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29430 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33334 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9363 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65564 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9281 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55904 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56057 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3180 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9016 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35075 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36157 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37245 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->