### PR TITLE
[scrollbar-styling] Implement scrollbar-width for iOS

### DIFF
--- a/LayoutTests/fast/scrolling/ios/scrollbar-width-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/scrollbar-width-expected.txt
@@ -1,0 +1,16 @@
+Test scrollbar-width on overflow and main document
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Overflow should have scrollbar-width:none
+
+none
+PASS Scrollbar state: none
+Document should have scrollbar-width:none
+PASS Scrollbar state:
+(none)
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/scrollbar-width-iframe-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/scrollbar-width-iframe-expected.txt
@@ -1,0 +1,12 @@
+
+Test scrollbar-width on overflow in iframe
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Overflow in iframe should have scrollbar-width:none
+PASS Scrollbar state: none
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/scrollbar-width-iframe.html
+++ b/LayoutTests/fast/scrolling/ios/scrollbar-width-iframe.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 1000px;
+        }
+    </style>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    
+    <script>
+        jsTestIsAsync = true;
+
+        if (window.internals)
+            internals.setUsesOverlayScrollbars(true);
+
+        async function doTest()
+        {
+            description('Test scrollbar-width on overflow in iframe');
+            if (!window.internals) {
+                finishJSTest();
+                return;
+            }
+            
+            const iframe = document.getElementsByTagName('iframe')[0];
+            const iframeWindow = iframe.contentWindow;
+
+            const scroller = iframe.contentDocument.querySelector('.scroller');
+
+            iframeWindow.internals.setUsesOverlayScrollbars(true);
+
+            debug('Overflow in iframe should have scrollbar-width:none');
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
+                let scrollbarWidth = state.indexOf('none') != -1;
+                if (scrollbarWidth)
+                    testPassed('Scrollbar state: ' + state);
+                return scrollbarWidth;
+            });
+
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            doTest();
+        }, false);
+    </script>
+</head>
+<body>
+
+    <iframe srcdoc="
+        <style>
+        body {
+            scrollbar-width: thin;
+            height: 1000px;
+        }
+        .scroller {
+            margin: 10px;
+            width: 200px;
+            height: 200px;
+            border: 1px solid black;
+            overflow: auto;
+            scrollbar-width: none;
+        }
+        .contents {
+            width: 100%;
+            height: 200%;
+        }
+        </style>
+        <div class='scroller'>
+            <div class='contents'></div>
+        </div>
+    "></iframe>
+    <div id="console"></div>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/ios/scrollbar-width.html
+++ b/LayoutTests/fast/scrolling/ios/scrollbar-width.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        html {
+            scrollbar-width: none;
+        }
+        body {
+            height: 1000px;
+        }
+        .scroller {
+            margin: 10px;
+            width: 200px;
+            height: 200px;
+            border: 1px solid black;
+            overflow: auto;
+            scrollbar-width: none;
+        }
+        .contents {
+            width: 100%;
+            height: 200%;
+        }
+    </style>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    
+    <script>
+        jsTestIsAsync = true;
+
+        async function doTest()
+        {
+            description('Test scrollbar-width on overflow and main document');
+            if (!window.internals) {
+                finishJSTest();
+                return;
+            }
+            
+            const scroller = document.querySelector('.scroller');
+
+            debug('Overflow should have scrollbar-width:none');
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState(scroller);
+                debug(state);
+                let scrollbarWidth = state.indexOf('none') != -1;
+                if (scrollbarWidth)
+                    testPassed('Scrollbar state: ' + state);
+                return scrollbarWidth;
+            });
+
+            debug('Document should have scrollbar-width:none');
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.verticalScrollbarState();
+                let scrollbarWidth = state.indexOf('none') != -1;
+                if (scrollbarWidth)
+                    testPassed('Scrollbar state: ' + state);
+                return scrollbarWidth;
+            });
+
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            doTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="contents"></div>
+    </div>
+    <div id="console"></div>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -905,12 +905,12 @@ window.UIHelper = class UIHelper {
     static scrollbarState(scroller, isVertical)
     {
         var internalFunctions = scroller ? scroller.ownerDocument.defaultView.internals : internals;
-        if (!this.isWebKit2() || this.isIOSFamily())
+        if (!this.isWebKit2())
             return Promise.resolve();
 
-            if (internals.isUsingUISideCompositing() && (!scroller || scroller.nodeName != "SELECT")) {
-                var scrollingNodeID = internalFunctions.scrollingNodeIDForNode(scroller);
-                return new Promise(resolve => {
+        if (internals.isUsingUISideCompositing() && (!scroller || scroller.nodeName != "SELECT")) {
+            var scrollingNodeID = internalFunctions.scrollingNodeIDForNode(scroller);
+            return new Promise(resolve => {
                 testRunner.runUIScript(`(function() {
                     uiController.doAfterNextStablePresentationUpdate(function() {
                         uiController.uiScriptComplete(uiController.scrollbarStateForScrollingNodeID(${scrollingNodeID[0]}, ${scrollingNodeID[1]}, ${isVertical}));

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -670,6 +670,13 @@ OverscrollBehavior ScrollingTree::mainFrameHorizontalOverscrollBehavior() const
     return m_rootNode ? m_rootNode->horizontalOverscrollBehavior() : OverscrollBehavior::Auto;
 }
 
+
+ScrollbarWidth ScrollingTree::mainFrameScrollbarWidth() const
+{
+    Locker locker { m_treeLock };
+    return m_rootNode ? m_rootNode->scrollbarWidthStyle() : ScrollbarWidth::Auto;
+}
+
 OverscrollBehavior ScrollingTree::mainFrameVerticalOverscrollBehavior() const
 {
     Locker locker { m_treeLock };

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -234,6 +234,8 @@ public:
 
     WEBCORE_EXPORT FloatPoint mainFrameScrollPosition() const;
 
+    WEBCORE_EXPORT ScrollbarWidth mainFrameScrollbarWidth() const;
+
     WEBCORE_EXPORT OverscrollBehavior mainFrameHorizontalOverscrollBehavior() const;
     WEBCORE_EXPORT OverscrollBehavior mainFrameVerticalOverscrollBehavior() const;
     

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -976,6 +976,10 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
     [_scrollView setMinimumZoomScale:minimumScaleFactor];
     [_scrollView setMaximumZoomScale:maximumScaleFactor];
     [_scrollView _setZoomEnabledInternal:allowsUserScaling];
+    if ([_scrollView showsHorizontalScrollIndicator] && [_scrollView showsVerticalScrollIndicator]) {
+        [_scrollView setShowsHorizontalScrollIndicator:(_page->scrollingCoordinatorProxy()->mainFrameScrollbarWidth() != WebCore::ScrollbarWidth::None)];
+        [_scrollView setShowsVerticalScrollIndicator:(_page->scrollingCoordinatorProxy()->mainFrameScrollbarWidth() != WebCore::ScrollbarWidth::None)];
+    }
 
     auto horizontalOverscrollBehavior = _page->scrollingCoordinatorProxy()->mainFrameHorizontalOverscrollBehavior();
     auto verticalOverscrollBehavior = _page->scrollingCoordinatorProxy()->mainFrameVerticalOverscrollBehavior();

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -94,6 +94,8 @@
 
 - (void)_doAfterNextVisibleContentRectAndStablePresentationUpdate:(void (^)(void))updateBlock;
 
+- (NSString *)_scrollbarState:(unsigned long long)scrollingNodeID processID: (unsigned long long)processID isVertical:(bool)isVertical;
+
 @end
 
 #endif // TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -298,6 +298,19 @@ static void dumpUIView(TextStream& ts, UIView *view)
     return ts.release();
 }
 
+- (NSString *)_scrollbarState:(unsigned long long)scrollingNodeID processID:(unsigned long long)processID isVertical:(bool)isVertical
+{
+    if (_page->scrollingCoordinatorProxy()->rootScrollingNodeID() == WebCore::ScrollingNodeID(ObjectIdentifier<WebCore::ScrollingNodeIDType>(scrollingNodeID), ObjectIdentifier<WebCore::ProcessIdentifierType>(processID))) {
+        TextStream ts(TextStream::LineMode::MultipleLine);
+        {
+            TextStream::GroupScope scope(ts);
+            ts << ([_scrollView showsHorizontalScrollIndicator] ? ""_s : "none"_s);
+        }
+        return ts.release();
+    }
+    return _page->scrollbarStateForScrollingNodeID(WebCore::ScrollingNodeID(ObjectIdentifier<WebCore::ScrollingNodeIDType>(scrollingNodeID), ObjectIdentifier<WebCore::ProcessIdentifierType>(processID)), isVertical);
+}
+
 - (NSNumber *)_stableStateOverride
 {
     // For subclasses to override.

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -263,6 +263,11 @@ bool RemoteScrollingCoordinatorProxy::hasScrollableMainFrame() const
     return rootNode && rootNode->canHaveScrollbars();
 }
 
+WebCore::ScrollbarWidth RemoteScrollingCoordinatorProxy::mainFrameScrollbarWidth() const
+{
+    return m_scrollingTree->mainFrameScrollbarWidth();
+}
+
 OverscrollBehavior RemoteScrollingCoordinatorProxy::mainFrameHorizontalOverscrollBehavior() const
 {
     return m_scrollingTree->mainFrameHorizontalOverscrollBehavior();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -123,6 +123,8 @@ public:
     bool hasScrollableMainFrame() const;
     bool hasScrollableOrZoomedMainFrame() const;
 
+    WebCore::ScrollbarWidth mainFrameScrollbarWidth() const;
+
     WebCore::OverscrollBehavior mainFrameHorizontalOverscrollBehavior() const;
     WebCore::OverscrollBehavior mainFrameVerticalOverscrollBehavior() const;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
@@ -41,6 +41,7 @@ public:
     virtual ~ScrollingTreeFrameScrollingNodeRemoteIOS();
 
     WKBaseScrollView *scrollView() const;
+    String scrollbarStateForOrientation(WebCore::ScrollbarOrientation) const override;
 
 private:
     ScrollingTreeFrameScrollingNodeRemoteIOS(WebCore::ScrollingTree&, WebCore::ScrollingNodeType, WebCore::ScrollingNodeID);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
@@ -157,5 +157,15 @@ void ScrollingTreeFrameScrollingNodeRemoteIOS::repositionRelatedLayers()
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
+String ScrollingTreeFrameScrollingNodeRemoteIOS::scrollbarStateForOrientation(ScrollbarOrientation orientation) const
+{
+    if (auto* scrollView = this->scrollView()) {
+        auto showsScrollbar = orientation == ScrollbarOrientation::Horizontal ?  [scrollView showsHorizontalScrollIndicator] :  [scrollView showsVerticalScrollIndicator];
+        return showsScrollbar ? ""_s : "none"_s;
+    }
+    return ""_s;
+}
+
+
 }
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
@@ -41,6 +41,7 @@ public:
     virtual ~ScrollingTreeOverflowScrollingNodeIOS();
 
     WKBaseScrollView *scrollView() const;
+    String scrollbarStateForOrientation(WebCore::ScrollbarOrientation) const override;
 
 private:
     ScrollingTreeOverflowScrollingNodeIOS(WebCore::ScrollingTree&, WebCore::ScrollingNodeID);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
@@ -92,6 +92,15 @@ void ScrollingTreeOverflowScrollingNodeIOS::repositionScrollingLayers()
     delegate().repositionScrollingLayers();
 }
 
+String ScrollingTreeOverflowScrollingNodeIOS::scrollbarStateForOrientation(ScrollbarOrientation orientation) const
+{
+    if (auto* scrollView = this->scrollView()) {
+        auto showsScrollbar = orientation == ScrollbarOrientation::Horizontal ?  [scrollView showsHorizontalScrollIndicator] :  [scrollView showsVerticalScrollIndicator];
+        return showsScrollbar ? ""_s : "none"_s;
+    }
+    return ""_s;
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -369,6 +369,18 @@ void ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren(const Scrol
         scrollingNode().handleScrollPositionRequest(scrollingStateNode.requestedScrollData());
         scrollingTree().setNeedsApplyLayerPositionsAfterCommit();
     }
+
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarWidth)) {
+        auto scrollbarWidth = scrollingStateNode.scrollbarWidth();
+
+        BEGIN_BLOCK_OBJC_EXCEPTIONS
+        UIScrollView *scrollView = this->scrollView();
+
+        [scrollView setShowsHorizontalScrollIndicator:(scrollbarWidth != ScrollbarWidth::None && scrollingNode().horizontalNativeScrollbarVisibility() != NativeScrollbarVisibility::HiddenByStyle)];
+        [scrollView setShowsVerticalScrollIndicator:(scrollbarWidth != ScrollbarWidth::None && scrollingNode().horizontalNativeScrollbarVisibility() != NativeScrollbarVisibility::HiddenByStyle)];
+
+        END_BLOCK_OBJC_EXCEPTIONS
+    }
 }
 
 bool ScrollingTreeScrollingNodeDelegateIOS::startAnimatedScrollToPosition(FloatPoint scrollPosition)

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -206,6 +206,8 @@ private:
 
     void clipSelectionViewRectToContentView(CGRect&) const;
 
+    JSRetainPtr<JSStringRef> scrollbarStateForScrollingNodeID(unsigned long long scrollingNodeID, unsigned long long processID, bool) const override;
+
 #if USE(BROWSERENGINEKIT)
     id<BETextInput> asyncTextInput() const;
 #endif

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1607,6 +1607,12 @@ UITextSelectionDisplayInteraction *UIScriptControllerIOS::textSelectionDisplayIn
 
 #endif
 
+
+JSRetainPtr<JSStringRef> UIScriptControllerIOS::scrollbarStateForScrollingNodeID(unsigned long long scrollingNodeID, unsigned long long processID, bool isVertical) const
+{
+    return adopt(JSStringCreateWithCFString((CFStringRef) [webView() _scrollbarState:scrollingNodeID processID:processID isVertical:isVertical]));
+}
+
 }
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### e3f070792f2ec7eff5fa3dabc4bde4732b70260d
<pre>
[scrollbar-styling] Implement scrollbar-width for iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=277167">https://bugs.webkit.org/show_bug.cgi?id=277167</a>
<a href="https://rdar.apple.com/132602608">rdar://132602608</a>

Reviewed by Simon Fraser.

Hide scrollbars on iOS for scrollbar-width:none.

* LayoutTests/fast/scrolling/ios/scrollbar-width-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/scrollbar-width-iframe-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/scrollbar-width-iframe.html: Added.
* LayoutTests/fast/scrolling/ios/scrollbar-width.html: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm:
(WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS::scrollbarStateForOrientation const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm:
(WebKit::ScrollingTreeOverflowScrollingNodeIOS::scrollbarStateForOrientation const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren):

Canonical link: <a href="https://commits.webkit.org/281717@main">https://commits.webkit.org/281717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e00285546f8e663d6f080073556e692659ac4ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64594 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11210 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49061 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7779 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37274 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29889 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9776 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10123 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55817 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66323 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4607 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56428 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52520 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56619 "Found 1 new API test failure: /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3818 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9140 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35827 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36909 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->