### PR TITLE
Fix border radius glitch

### DIFF
--- a/LayoutTests/fast/borders/borderRadiusMultiColors01-expected.txt
+++ b/LayoutTests/fast/borders/borderRadiusMultiColors01-expected.txt
@@ -1,0 +1,7 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x8
+  RenderBlock {HTML} at (0,0) size 800x8
+    RenderBody {BODY} at (8,8) size 784x0
+layer at (10,10) size 202x32
+  RenderBlock (positioned) {DIV} at (10,10) size 202x32 [border: (1px solid #FF0000) (1px solid #0000FF) (1px solid #000000) (1px solid #008000)]

--- a/LayoutTests/fast/borders/borderRadiusMultiColors01.html
+++ b/LayoutTests/fast/borders/borderRadiusMultiColors01.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html><body>
+<!--
+  This test checks for border coloring in extreme cases.
+  An diagonal arc should be colored in green and red.
+-->
+<div style="left: 10px; top: 10px; width: 200px; height: 30px; position: absolute; border: 1px solid black; border-top-color: red; border-top-left-radius: 95%; border-top-right-radius: 5%; border-left-color: green; border-right-color: blue; border-bottom-color: black; border-bottom-right-radius: 5%; border-bottom-left-radius: 5%;"></div>
+</body></html>

--- a/LayoutTests/fast/borders/borderRadiusMultiColors02-expected.txt
+++ b/LayoutTests/fast/borders/borderRadiusMultiColors02-expected.txt
@@ -1,0 +1,7 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x8
+  RenderBlock {HTML} at (0,0) size 800x8
+    RenderBody {BODY} at (8,8) size 784x0
+layer at (10,10) size 202x32
+  RenderBlock (positioned) {DIV} at (10,10) size 202x32 [border: (1px solid #FF0000) (1px solid #0000FF) (1px solid #000000) (1px solid #008000)]

--- a/LayoutTests/fast/borders/borderRadiusMultiColors02.html
+++ b/LayoutTests/fast/borders/borderRadiusMultiColors02.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html><body>
+<!--
+  This test checks for border coloring in extreme cases.
+  The two arcs should be colored in green/red and black/blue.
+-->
+<div style="left: 10px; top: 10px; width: 200px; height: 30px; position: absolute; border: 1px solid black; border-top-color: red; border-top-left-radius: 95%; border-top-right-radius: 5%; border-left-color: green; border-right-color: blue; border-bottom-color: black; border-bottom-right-radius: 95%; border-bottom-left-radius: 5%;"></div>
+</body></html>

--- a/LayoutTests/fast/borders/borderRadiusSlope-expected.txt
+++ b/LayoutTests/fast/borders/borderRadiusSlope-expected.txt
@@ -1,0 +1,7 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x8
+  RenderBlock {HTML} at (0,0) size 800x8
+    RenderBody {BODY} at (8,8) size 784x0
+layer at (10,10) size 301x16
+  RenderBlock (positioned) {DIV} at (10,10) size 301x16 [border: (1px solid #00AAAA) none (1px solid #00AAAA)]

--- a/LayoutTests/fast/borders/borderRadiusSlope.html
+++ b/LayoutTests/fast/borders/borderRadiusSlope.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html><body>
+<!--
+  This test checks for border drawing in extreme border-radius parameters.
+  An arc should be drawn without any discontinuity.
+-->
+<div style="left: 10px; top: 10px; width: 300px; height: 15px; position: absolute; border-width: 1px 0px 0px 1px; border-top-style: solid; border-left-style: solid; border-top-color: rgb(0, 170, 170); border-left-color: rgb(0, 170, 170); border-top-left-radius: 100%; border-top-right-radius: 0px; border-bottom-right-radius: 0px; border-bottom-left-radius: 0px;"></div>
+</body></html>

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -3,8 +3,8 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2005 Allan Sandfeld Jensen (kde@carewolf.com)
  *           (C) 2005, 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2013 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -1055,40 +1055,40 @@ void BorderPainter::clipBorderSidePolygon(const RoundedRect& outerBorder, const 
         quad = { outerRect.minXMinYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMinYCorner(), outerRect.maxXMinYCorner() };
 
         if (!innerBorder.radii().topLeft().isZero())
-            findIntersection(outerRect.minXMinYCorner(), innerRect.minXMinYCorner(), innerRect.minXMaxYCorner(), innerRect.maxXMinYCorner(), quad[1]);
+            findIntersection(quad[0], quad[1], FloatPoint(quad[1].x() + innerBorder.radii().topLeft().width(), quad[1].y()), FloatPoint(quad[1].x(), quad[1].y() + innerBorder.radii().topLeft().height()), quad[1]);
 
         if (!innerBorder.radii().topRight().isZero())
-            findIntersection(outerRect.maxXMinYCorner(), innerRect.maxXMinYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMaxYCorner(), quad[2]);
+            findIntersection(quad[3], quad[2], FloatPoint(quad[2].x() - innerBorder.radii().topRight().width(), quad[2].y()), FloatPoint(quad[2].x(), quad[2].y() + innerBorder.radii().topRight().height()), quad[2]);
         break;
 
     case BoxSide::Left:
         quad = { outerRect.minXMinYCorner(), innerRect.minXMinYCorner(), innerRect.minXMaxYCorner(), outerRect.minXMaxYCorner() };
 
         if (!innerBorder.radii().topLeft().isZero())
-            findIntersection(outerRect.minXMinYCorner(), innerRect.minXMinYCorner(), innerRect.minXMaxYCorner(), innerRect.maxXMinYCorner(), quad[1]);
+            findIntersection(quad[0], quad[1], FloatPoint(quad[1].x() + innerBorder.radii().topLeft().width(), quad[1].y()), FloatPoint(quad[1].x(), quad[1].y() + innerBorder.radii().topLeft().height()), quad[1]);
 
         if (!innerBorder.radii().bottomLeft().isZero())
-            findIntersection(outerRect.minXMaxYCorner(), innerRect.minXMaxYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMaxYCorner(), quad[2]);
+            findIntersection(quad[3], quad[2], FloatPoint(quad[2].x() + innerBorder.radii().bottomLeft().width(), quad[2].y()), FloatPoint(quad[2].x(), quad[2].y() - innerBorder.radii().bottomLeft().height()), quad[2]);
         break;
 
     case BoxSide::Bottom:
         quad = { outerRect.minXMaxYCorner(), innerRect.minXMaxYCorner(), innerRect.maxXMaxYCorner(), outerRect.maxXMaxYCorner() };
 
         if (!innerBorder.radii().bottomLeft().isZero())
-            findIntersection(outerRect.minXMaxYCorner(), innerRect.minXMaxYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMaxYCorner(), quad[1]);
+            findIntersection(quad[0], quad[1], FloatPoint(quad[1].x() + innerBorder.radii().bottomLeft().width(), quad[1].y()), FloatPoint(quad[1].x(), quad[1].y() - innerBorder.radii().bottomLeft().height()), quad[1]);
 
         if (!innerBorder.radii().bottomRight().isZero())
-            findIntersection(outerRect.maxXMaxYCorner(), innerRect.maxXMaxYCorner(), innerRect.maxXMinYCorner(), innerRect.minXMaxYCorner(), quad[2]);
+            findIntersection(quad[3], quad[2], FloatPoint(quad[2].x() - innerBorder.radii().bottomRight().width(), quad[2].y()), FloatPoint(quad[2].x(), quad[2].y() - innerBorder.radii().bottomRight().height()), quad[2]);
         break;
 
     case BoxSide::Right:
         quad = { outerRect.maxXMinYCorner(), innerRect.maxXMinYCorner(), innerRect.maxXMaxYCorner(), outerRect.maxXMaxYCorner() };
 
         if (!innerBorder.radii().topRight().isZero())
-            findIntersection(outerRect.maxXMinYCorner(), innerRect.maxXMinYCorner(), innerRect.minXMinYCorner(), innerRect.maxXMaxYCorner(), quad[1]);
+            findIntersection(quad[0], quad[1], FloatPoint(quad[1].x() - innerBorder.radii().topRight().width(), quad[1].y()), FloatPoint(quad[1].x(), quad[1].y() + innerBorder.radii().topRight().height()), quad[1]);
 
         if (!innerBorder.radii().bottomRight().isZero())
-            findIntersection(outerRect.maxXMaxYCorner(), innerRect.maxXMaxYCorner(), innerRect.maxXMinYCorner(), innerRect.minXMaxYCorner(), quad[2]);
+            findIntersection(quad[3], quad[2], FloatPoint(quad[2].x() - innerBorder.radii().bottomRight().width(), quad[2].y()), FloatPoint(quad[2].x(), quad[2].y() - innerBorder.radii().bottomRight().height()), quad[2]);
         break;
     }
 
@@ -1102,12 +1102,33 @@ void BorderPainter::clipBorderSidePolygon(const RoundedRect& outerBorder, const 
         return;
     }
 
-    // Square off the end which shouldn't be affected by antialiasing, and clip.
+    // If antialiasing settings for the first edge and second edge is different,
+    // they have to be addressed separately. We do this by breaking the quad into
+    // two parallelograms, made by moving quad[1] and quad[2].
+    float ax = quad[1].x() - quad[0].x();
+    float ay = quad[1].y() - quad[0].y();
+    float bx = quad[2].x() - quad[1].x();
+    float by = quad[2].y() - quad[1].y();
+    float cx = quad[3].x() - quad[2].x();
+    float cy = quad[3].y() - quad[2].y();
+
+    const static float epsilon = 1e-2f;
+    float r1, r2;
+    if (std::abs(bx) < epsilon && std::abs(by) < epsilon) {
+        // The quad was actually a triangle.
+        r1 = r2 = 1.0f;
+    } else {
+        // Extend parallelogram a bit to hide calculation error
+        const static float extendFill = 1e-2f;
+
+        r1 = (-ax * by + ay * bx) / (cx * by - cy * bx) + extendFill;
+        r2 = (-cx * by + cy * bx) / (ax * by - ay * bx) + extendFill;
+    }
+
     Vector<FloatPoint> firstQuad = {
         quad[0],
         quad[1],
-        quad[2],
-        side == BoxSide::Top || side == BoxSide::Bottom ? FloatPoint(quad[3].x(), quad[2].y()) : FloatPoint(quad[2].x(), quad[3].y()),
+        quad[2] = FloatPoint(quad[3].x() + r2 * ax, quad[3].y() + r2 * ay),
         quad[3]
     };
     bool wasAntialiased = graphicsContext.shouldAntialias();
@@ -1116,12 +1137,10 @@ void BorderPainter::clipBorderSidePolygon(const RoundedRect& outerBorder, const 
 
     Vector<FloatPoint> secondQuad = {
         quad[0],
-        side == BoxSide::Top || side == BoxSide::Bottom ? FloatPoint(quad[0].x(), quad[1].y()) : FloatPoint(quad[1].x(), quad[0].y()),
-        quad[1],
+        quad[1] = FloatPoint(quad[0].x() - r1 * cx, quad[0].y() - r1 * cy),
         quad[2],
         quad[3]
     };
-    // Antialiasing affects the second side.
     graphicsContext.setShouldAntialias(!secondEdgeMatches);
     graphicsContext.clipPath(Path(secondQuad), WindRule::NonZero);
 


### PR DESCRIPTION
<pre>
Fix border radius glitch
<a href="https://bugs.webkit.org/show_bug.cgi?id=118624">https://bugs.webkit.org/show_bug.cgi?id=118624</a>
rdar://problem/100420688

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/927872e324ae7520ab32567d07fb988b1733bec8">https://chromium.googlesource.com/chromium/blink/+/927872e324ae7520ab32567d07fb988b1733bec8</a>

This fixes the bug that the border radius partially disappeared or had wrong
color when it was too steep or too shallow.

Fix 1: Use the correct clipping quad, generated by intersecting border mitre lines
to diagonal lines of the corner ellipse arc.
BorderPainter::clipBorderSidePolygon was generating wrong clipping quad.
It was based on a wrong assumption that rounded border would not
cross {horizontal,vertical} line through the box center.

Fix 2: Correctly split a quad into two quads.
A clipping quad is split into "AND" of two quads to set anti-aliasing on both edges individually.
Generate these quads properly by extending a vertex parallel to the opposite edge.

* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::clipBorderSidePolygon):
* LayoutTests/fast/borders/borderRadiusMultiColors01-expected.txt:
* LayoutTests/fast/borders/borderRadiusMultiColors01.html:
* LayoutTests/fast/borders/borderRadiusMultiColors02-expected.txt:
* LayoutTests/fast/borders/borderRadiusMultiColors02.html:
* LayoutTests/fast/borders/borderRadiusSlope-expected.txt:
* LayoutTests/fast/borders/borderRadiusSlope.html:
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/226ca88fa3fc0851dd1d6680a619e8a9a0ea5cd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64067 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10679 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48722 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7453 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29564 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9339 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9599 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65799 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56077 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56231 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3396 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35310 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36392 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37480 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->