### PR TITLE
[Pointer Events] Implement `getCoalescedEvents` API (iOS)

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2869,17 +2869,17 @@ GenericCueAPIEnabled:
 
 GetCoalescedEventsEnabled:
   type: bool
-  status: testable
+  status: stable
   category: dom
   humanReadableName: "Pointer Events getCoalescedEvents API"
   humanReadableDescription: "Enable the `getCoalescedEvents` function of the Pointer Events API"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 GetUserMediaRequiresFocus:
   type: bool

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -89,8 +89,9 @@ public:
     static Ref<PointerEvent> create(const AtomString& type, PointerID, const String& pointerType, IsPrimary = IsPrimary::No);
 
 #if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
-    static Ref<PointerEvent> create(const PlatformTouchEvent&, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
-    static Ref<PointerEvent> create(const AtomString& type, const PlatformTouchEvent&, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
+    static Ref<PointerEvent> create(const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
+    static Ref<PointerEvent> create(const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, CanBubble, IsCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta = { });
+    static Ref<PointerEvent> create(const AtomString& type, const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
 #endif
 
     virtual ~PointerEvent();
@@ -147,7 +148,7 @@ private:
     PointerEvent(const AtomString& type, MouseButton, const MouseEvent&, PointerID, const String& pointerType, CanBubble, IsCancelable);
     PointerEvent(const AtomString& type, PointerID, const String& pointerType, IsPrimary);
 #if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
-    PointerEvent(const AtomString& type, const PlatformTouchEvent&, IsCancelable isCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
+    PointerEvent(const AtomString& type, const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
 #endif
 
     PointerID m_pointerId { mousePointerID };

--- a/Source/WebCore/dom/wpe/PointerEventWPE.cpp
+++ b/Source/WebCore/dom/wpe/PointerEventWPE.cpp
@@ -54,25 +54,32 @@ static const AtomString& pointerEventType(PlatformTouchPoint::State state)
     return nullAtom();
 }
 
-Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
 {
     const auto& type = pointerEventType(event.touchPoints().at(index).state());
-    return adoptRef(*new PointerEvent(type, event, typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
+    return adoptRef(*new PointerEvent(type, event, coalescedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
 }
 
-Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTouchEvent& event, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
 {
-    return adoptRef(*new PointerEvent(type, event, typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
+    const auto& type = pointerEventType(event.touchPoints().at(index).state());
+    return adoptRef(*new PointerEvent(type, event, coalescedEvents, canBubble, isCancelable, index, isPrimary, WTFMove(view), touchDelta));
 }
 
-PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
-    : MouseEvent(EventInterfaceType::PointerEvent, type, typeCanBubble(type), isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchPoints().at(index).pos(), event.touchPoints().at(index).pos(), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, IsSimulated::No, IsTrusted::Yes)
+Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+{
+    return adoptRef(*new PointerEvent(type, event, coalescedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
+}
+
+PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+    : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchPoints().at(index).pos(), event.touchPoints().at(index).pos(), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, IsSimulated::No, IsTrusted::Yes)
     , m_pointerId(event.touchPoints().at(index).id())
     , m_width(2 * event.touchPoints().at(index).radiusX())
     , m_height(2 * event.touchPoints().at(index).radiusY())
     , m_pressure(event.touchPoints().at(index).force())
     , m_pointerType(touchPointerEventType())
     , m_isPrimary(isPrimary)
+    , m_coalescedEvents(coalescedEvents)
 {
 }
 

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -210,7 +210,7 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
     RELEASE_ASSERT(is<Element>(target));
 
     auto dispatchOverOrOutEvent = [&](const AtomString& type, EventTarget* target) {
-        dispatchEvent(PointerEvent::create(type, platformTouchEvent, index, isPrimary, view, touchDelta), target);
+        dispatchEvent(PointerEvent::create(type, platformTouchEvent, { }, index, isPrimary, view, touchDelta), target);
     };
 
     auto dispatchEnterOrLeaveEvent = [&](const AtomString& type, Element& targetElement) {
@@ -230,14 +230,23 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
 
         if (type == eventNames().pointerenterEvent) {
             for (auto& element : makeReversedRange(targetChain))
-                dispatchEvent(PointerEvent::create(type, platformTouchEvent, index, isPrimary, view, touchDelta), element.ptr());
+                dispatchEvent(PointerEvent::create(type, platformTouchEvent, { }, index, isPrimary, view, touchDelta), element.ptr());
         } else {
             for (auto& element : targetChain)
-                dispatchEvent(PointerEvent::create(type, platformTouchEvent, index, isPrimary, view, touchDelta), element.ptr());
+                dispatchEvent(PointerEvent::create(type, platformTouchEvent, { }, index, isPrimary, view, touchDelta), element.ptr());
         }
     };
 
-    auto pointerEvent = PointerEvent::create(platformTouchEvent, index, isPrimary, view, touchDelta);
+    auto coalescedEvents = [&] -> Vector<Ref<PointerEvent>> {
+        if (index)
+            return { PointerEvent::create(platformTouchEvent, { }, Event::CanBubble::No, Event::IsCancelable::No, index, isPrimary, view, touchDelta) };
+
+        return WTF::map(platformTouchEvent.coalescedEvents(), [&](const auto& event) {
+            return PointerEvent::create(event, { }, Event::CanBubble::No, Event::IsCancelable::No, index, isPrimary, view, touchDelta);
+        });
+    }();
+
+    auto pointerEvent = PointerEvent::create(platformTouchEvent, coalescedEvents, index, isPrimary, view, touchDelta);
 
     Ref capturingData = ensureCapturingDataForPointerEvent(pointerEvent);
 
@@ -278,7 +287,7 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
 
         for (auto& chain : leftElementsChain) {
             if (hasCapturingPointerLeaveListener || chain->hasEventListeners(eventNames().pointerleaveEvent))
-                dispatchEvent(PointerEvent::create(eventNames().pointerleaveEvent, platformTouchEvent, index, isPrimary, view, touchDelta), chain.ptr());
+                dispatchEvent(PointerEvent::create(eventNames().pointerleaveEvent, platformTouchEvent, coalescedEvents, index, isPrimary, view, touchDelta), chain.ptr());
         }
 
         if (currentTarget)
@@ -286,7 +295,7 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
 
         for (auto& chain : makeReversedRange(enteredElementsChain)) {
             if (hasCapturingPointerEnterListener || chain->hasEventListeners(eventNames().pointerenterEvent))
-                dispatchEvent(PointerEvent::create(eventNames().pointerenterEvent, platformTouchEvent, index, isPrimary, view, touchDelta), chain.ptr());
+                dispatchEvent(PointerEvent::create(eventNames().pointerenterEvent, platformTouchEvent, coalescedEvents, index, isPrimary, view, touchDelta), chain.ptr());
         }
     }
 

--- a/Source/WebCore/platform/PlatformTouchEvent.h
+++ b/Source/WebCore/platform/PlatformTouchEvent.h
@@ -38,6 +38,8 @@ public:
 
     const Vector<PlatformTouchPoint>& touchPoints() const { return m_touchPoints; }
 
+    const Vector<PlatformTouchEvent>& coalescedEvents() const { return m_coalescedEvents; }
+
 #if PLATFORM(WPE)
     // FIXME: since WPE currently does not send touch stationary events, we need to be able to set
     // TouchCancelled touchPoints subsequently
@@ -46,6 +48,7 @@ public:
 
 protected:
     Vector<PlatformTouchPoint> m_touchPoints;
+    Vector<PlatformTouchEvent> m_coalescedEvents;
 };
 
 }

--- a/Source/WebCore/platform/ios/WebEvent.h
+++ b/Source/WebCore/platform/ios/WebEvent.h
@@ -131,7 +131,7 @@ WEBCORE_EXPORT @interface WebEvent : NSObject {
     NSArray *_touchLocations;
     NSArray *_touchIdentifiers;
     NSArray *_touchPhases;
-    
+
     BOOL _isGesture;
     float _gestureScale;
     float _gestureRotation;

--- a/Source/WebKit/Shared/NativeWebTouchEvent.h
+++ b/Source/WebKit/Shared/NativeWebTouchEvent.h
@@ -76,7 +76,8 @@ public:
 
 private:
 #if PLATFORM(IOS_FAMILY) && defined(__OBJC__)
-    Vector<WebPlatformTouchPoint> extractWebTouchPoint(const WKTouchEvent&);
+    Vector<WebPlatformTouchPoint> extractWebTouchPoints(const WKTouchEvent&);
+    Vector<WebTouchEvent> extractCoalescedWebTouchEvents(const WKTouchEvent&, UIKeyModifierFlags);
 #endif
 
 #if PLATFORM(GTK) && USE(GTK4)

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -100,6 +100,7 @@ class WebKit::WebKeyboardEvent : WebKit::WebEvent {
 #if ENABLE(TOUCH_EVENTS)
 class WebKit::WebTouchEvent : WebKit::WebEvent {
     Vector<WebKit::WebPlatformTouchPoint> touchPoints();
+    Vector<WebKit::WebTouchEvent> coalescedEvents();
 #if PLATFORM(IOS_FAMILY)
     WebCore::IntPoint position();
     bool isPotentialTap();

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -359,6 +359,10 @@ public:
             return WebKit2PlatformTouchPoint(touchPoint);
         });
 
+        m_coalescedEvents = WTF::map(webEvent.coalescedEvents(), [&](auto& event) {
+            return platform(event);
+        });
+
         m_gestureScale = webEvent.gestureScale();
         m_gestureRotation = webEvent.gestureRotation();
         m_canPreventNativeGestures = webEvent.canPreventNativeGestures();

--- a/Source/WebKit/Shared/WebTouchEvent.cpp
+++ b/Source/WebKit/Shared/WebTouchEvent.cpp
@@ -34,9 +34,10 @@ namespace WebKit {
 
 #if !PLATFORM(IOS_FAMILY)
 
-WebTouchEvent::WebTouchEvent(WebEvent&& event, Vector<WebPlatformTouchPoint>&& touchPoints)
+WebTouchEvent::WebTouchEvent(WebEvent&& event, Vector<WebPlatformTouchPoint>&& touchPoints, Vector<WebTouchEvent>&& coalescedEvents)
     : WebEvent(WTFMove(event))
     , m_touchPoints(WTFMove(touchPoints))
+    , m_coalescedEvents(WTFMove(coalescedEvents))
 {
     ASSERT(isTouchEventType(type()));
 }

--- a/Source/WebKit/Shared/WebTouchEvent.h
+++ b/Source/WebKit/Shared/WebTouchEvent.h
@@ -114,9 +114,10 @@ private:
 
 class WebTouchEvent : public WebEvent {
 public:
-    WebTouchEvent(WebEvent&& event, const Vector<WebPlatformTouchPoint>& touchPoints, WebCore::IntPoint position, bool isPotentialTap, bool isGesture, float gestureScale, float gestureRotation, bool canPreventNativeGestures = true)
+    WebTouchEvent(WebEvent&& event, const Vector<WebPlatformTouchPoint>& touchPoints, const Vector<WebTouchEvent>& coalescedEvents, WebCore::IntPoint position, bool isPotentialTap, bool isGesture, float gestureScale, float gestureRotation, bool canPreventNativeGestures = true)
         : WebEvent(WTFMove(event))
         , m_touchPoints(touchPoints)
+        , m_coalescedEvents(coalescedEvents)
         , m_position(position)
         , m_canPreventNativeGestures(canPreventNativeGestures)
         , m_isPotentialTap(isPotentialTap)
@@ -128,6 +129,9 @@ public:
     }
 
     const Vector<WebPlatformTouchPoint>& touchPoints() const { return m_touchPoints; }
+
+    const Vector<WebTouchEvent>& coalescedEvents() const { return m_coalescedEvents; }
+    void setCoalescedEvents(const Vector<WebTouchEvent>& coalescedEvents) { m_coalescedEvents = coalescedEvents; }
 
     WebCore::IntPoint position() const { return m_position; }
     void setPosition(WebCore::IntPoint position) { m_position = position; }
@@ -145,7 +149,8 @@ public:
     
 private:
     Vector<WebPlatformTouchPoint> m_touchPoints;
-    
+    Vector<WebTouchEvent> m_coalescedEvents;
+
     WebCore::IntPoint m_position;
     bool m_canPreventNativeGestures { false };
     bool m_isPotentialTap { false };
@@ -196,9 +201,11 @@ private:
 
 class WebTouchEvent : public WebEvent {
 public:
-    WebTouchEvent(WebEvent&&, Vector<WebPlatformTouchPoint>&&);
+    WebTouchEvent(WebEvent&&, Vector<WebPlatformTouchPoint>&&, Vector<WebTouchEvent>&&);
 
     const Vector<WebPlatformTouchPoint>& touchPoints() const { return m_touchPoints; }
+
+    const Vector<WebTouchEvent>& coalescedEvents() const { return m_coalescedEvents; }
 
     bool allTouchPointsAreReleased() const;
 
@@ -206,6 +213,7 @@ private:
     static bool isTouchEventType(WebEventType);
 
     Vector<WebPlatformTouchPoint> m_touchPoints;
+    Vector<WebTouchEvent> m_coalescedEvents;
 };
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/gtk/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/gtk/WebEventFactory.cpp
@@ -289,7 +289,7 @@ WebTouchEvent WebEventFactory::createWebTouchEvent(const GdkEvent* event, Vector
         ASSERT_NOT_REACHED();
     }
 
-    return WebTouchEvent({ type, modifiersForEvent(event), wallTimeForEvent(event) }, WTFMove(touchPoints));
+    return WebTouchEvent({ type, modifiersForEvent(event), wallTimeForEvent(event) }, WTFMove(touchPoints), { });
 }
 #endif
 

--- a/Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm
+++ b/Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm
@@ -96,7 +96,7 @@ static CGFloat radiusForTouchPoint(const WKTouchPoint& touchPoint)
 #endif
 }
 
-Vector<WebPlatformTouchPoint> NativeWebTouchEvent::extractWebTouchPoint(const WKTouchEvent& event)
+Vector<WebPlatformTouchPoint> NativeWebTouchEvent::extractWebTouchPoints(const WKTouchEvent& event)
 {
     return event.touchPoints.map([](auto& touchPoint) {
         unsigned identifier = touchPoint.identifier;
@@ -118,10 +118,18 @@ Vector<WebPlatformTouchPoint> NativeWebTouchEvent::extractWebTouchPoint(const WK
     });
 }
 
+Vector<WebTouchEvent> NativeWebTouchEvent::extractCoalescedWebTouchEvents(const WKTouchEvent& event, UIKeyModifierFlags flags)
+{
+    return event.coalescedEvents.map([&](auto& event) -> WebTouchEvent {
+        return NativeWebTouchEvent { event, flags };
+    });
+}
+
 NativeWebTouchEvent::NativeWebTouchEvent(const WKTouchEvent& event, UIKeyModifierFlags flags)
     : WebTouchEvent(
         { webEventTypeForWKTouchEventType(event.type), webEventModifierFlags(flags), WallTime::fromRawSeconds(event.timestamp) },
-        extractWebTouchPoint(event),
+        extractWebTouchPoints(event),
+        extractCoalescedWebTouchEvents(event, flags),
         positionForCGPoint(event.locationInDocumentCoordinates),
         event.isPotentialTap,
         event.inJavaScriptGesture,

--- a/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
@@ -347,7 +347,7 @@ WebTouchEvent WebEventFactory::createWebTouchEvent(struct wpe_input_touch_event*
                 pointCoordinates, pointCoordinates));
     }
 
-    return WebTouchEvent({ type, OptionSet<WebEventModifier> { }, wallTimeForEventTime(event->time) }, WTFMove(touchPoints));
+    return WebTouchEvent({ type, OptionSet<WebEventModifier> { }, wallTimeForEventTime(event->time) }, WTFMove(touchPoints), { });
 }
 #endif // ENABLE(TOUCH_EVENTS)
 

--- a/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
+++ b/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
@@ -231,7 +231,7 @@ WebTouchEvent WebEventFactory::createWebTouchEvent(WPEEvent* event, Vector<WebPl
         RELEASE_ASSERT_NOT_REACHED();
     }
 
-    return WebTouchEvent({ type.value(), modifiersFromWPEModifiers(wpe_event_get_modifiers(event)), wallTimeForEvent(event) }, WTFMove(touchPoints));
+    return WebTouchEvent({ type.value(), modifiersFromWPEModifiers(wpe_event_get_modifiers(event)), wallTimeForEvent(event) }, WTFMove(touchPoints), { });
 }
 #endif // ENABLE(TOUCH_EVENTS)
 

--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h
@@ -56,6 +56,7 @@ struct WKTouchEvent {
     bool inJavaScriptGesture { false };
 
     Vector<WKTouchPoint> touchPoints;
+    Vector<WKTouchEvent> coalescedEvents;
     bool isPotentialTap { false };
 };
 

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -91,7 +91,7 @@ public:
         CompletionHandler<void(bool, std::optional<WebCore::RemoteUserInputEventData>)> completionHandler;
     };
     using TouchEventQueue = Vector<TouchEventData, 1>;
-    void takeQueuedTouchEventsForPage(const WebPage&, TouchEventQueue&);
+    void takeQueuedTouchEventsForPage(const WebPage&, UniqueRef<TouchEventQueue>&);
 #endif
 
     void initializeConnection(IPC::Connection&);
@@ -159,7 +159,7 @@ private:
     std::unique_ptr<WebCore::WheelEventDeltaFilter> m_recentWheelEventDeltaFilter;
 #if ENABLE(IOS_TOUCH_EVENTS)
     Lock m_touchEventsLock;
-    HashMap<WebCore::PageIdentifier, TouchEventQueue> m_touchEvents WTF_GUARDED_BY_LOCK(m_touchEventsLock);
+    HashMap<WebCore::PageIdentifier, UniqueRef<TouchEventQueue>> m_touchEvents WTF_GUARDED_BY_LOCK(m_touchEventsLock);
 #endif
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7690,7 +7690,7 @@ void WebPage::didCommitLoad(WebFrame* frame)
     m_lastLayerTreeTransactionIdAndPageScaleBeforeScalingPage = std::nullopt;
 
 #if ENABLE(IOS_TOUCH_EVENTS)
-    EventDispatcher::TouchEventQueue queuedEvents;
+    auto queuedEvents = makeUniqueRef<EventDispatcher::TouchEventQueue>();
     WebProcess::singleton().eventDispatcher().takeQueuedTouchEventsForPage(*this, queuedEvents);
     cancelAsynchronousTouchEvents(WTFMove(queuedEvents));
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1001,8 +1001,8 @@ public:
     void didChangeSelectionForAccessibility() { m_isChangingSelectionForAccessibility = false; }
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(IOS_TOUCH_EVENTS)
-    void dispatchAsynchronousTouchEvents(Vector<EventDispatcher::TouchEventData, 1>&&);
-    void cancelAsynchronousTouchEvents(Vector<EventDispatcher::TouchEventData, 1>&&);
+    void dispatchAsynchronousTouchEvents(UniqueRef<EventDispatcher::TouchEventQueue>&&);
+    void cancelAsynchronousTouchEvents(UniqueRef<EventDispatcher::TouchEventQueue>&&);
 #endif
 
     bool hasRichlyEditableSelection() const;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4774,18 +4774,18 @@ void WebPage::willStartUserTriggeredZooming()
 }
 
 #if ENABLE(IOS_TOUCH_EVENTS)
-void WebPage::dispatchAsynchronousTouchEvents(Vector<EventDispatcher::TouchEventData, 1>&& queue)
+void WebPage::dispatchAsynchronousTouchEvents(UniqueRef<EventDispatcher::TouchEventQueue>&& queue)
 {
-    for (auto& touchEventData : queue) {
+    for (auto& touchEventData : queue.get()) {
         auto handleTouchEventResult = dispatchTouchEvent(touchEventData.frameID, touchEventData.event);
         if (auto& completionHandler = touchEventData.completionHandler)
             completionHandler(handleTouchEventResult.wasHandled(), handleTouchEventResult.remoteUserInputEventData());
     }
 }
 
-void WebPage::cancelAsynchronousTouchEvents(Vector<EventDispatcher::TouchEventData, 1>&& queue)
+void WebPage::cancelAsynchronousTouchEvents(UniqueRef<EventDispatcher::TouchEventQueue>&& queue)
 {
-    for (auto& touchEventData : queue) {
+    for (auto& touchEventData : queue.get()) {
         if (auto& completionHandler = touchEventData.completionHandler)
             completionHandler(true, std::nullopt);
     }

--- a/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
@@ -90,7 +90,7 @@ static Class touchEventsGestureRecognizerClass()
 namespace TestWebKitAPI {
 
 static WebKit::WKTouchPoint globalTouchPoint { CGPointZero, CGPointZero, 100, UITouchPhaseBegan, 1, 0, 0, 0, WebKit::WKTouchPointType::Direct };
-static WebKit::WKTouchEvent globalTouchEvent { WebKit::WKTouchEventType::Begin, CACurrentMediaTime(), CGPointZero, CGPointZero, 1, 0, false, { globalTouchPoint }, true };
+static WebKit::WKTouchEvent globalTouchEvent { WebKit::WKTouchEventType::Begin, CACurrentMediaTime(), CGPointZero, CGPointZero, 1, 0, false, { globalTouchPoint }, { }, true };
 static void updateSimulatedTouchEvent(CGPoint location, UITouchPhase phase)
 {
     globalTouchPoint.locationInScreenCoordinates = location;


### PR DESCRIPTION
#### 40e9a7696bca6ae8f53e5f7828c963a9a1e8749b
<pre>
[Pointer Events] Implement `getCoalescedEvents` API (iOS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=277185">https://bugs.webkit.org/show_bug.cgi?id=277185</a>
<a href="https://rdar.apple.com/132210576">rdar://132210576</a>

Reviewed by Abrar Rahman Protyasha.

Implements the necessary logic so that iOS also supports the `getCoalescedEvents` function.
This uses UIKit&apos;s `coalescedTouchesForTouch` method to facilitate getting the events that
are coalesced at the system level.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::getCoalescedEvents const):
* Source/WebCore/dom/PointerEvent.h:
* Source/WebCore/dom/ios/PointerEventIOS.cpp:
(WebCore::PointerEvent::create):
(WebCore::PointerEvent::PointerEvent):
(WebCore::m_coalescedEvents):
(WebCore::m_isPrimary): Deleted.
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::dispatchEventForTouchAtIndex):
* Source/WebCore/platform/ios/WebEvent.h:
* Source/WebKit/Shared/NativeWebTouchEvent.h:
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformTouchEvent::WebKit2PlatformTouchEvent):
* Source/WebKit/Shared/WebTouchEvent.h:
(WebKit::WebTouchEvent::WebTouchEvent):
(WebKit::WebTouchEvent::coalescedEvents const):
(WebKit::WebTouchEvent::setCoalescedEvents):
* Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm:
(WebKit::NativeWebTouchEvent::extractWebTouchPoints):
(WebKit::NativeWebTouchEvent::extractCoalescedWebTouchEvents):
(WebKit::NativeWebTouchEvent::extractWebTouchPoint): Deleted.
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h:
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm:
(-[WKTouchEventsGestureRecognizer reset]):
(-[WKTouchEventsGestureRecognizer _coalescedTouchEventForTouch:]):
(-[WKTouchEventsGestureRecognizer _recordTouches:type:coalescedTouches:]):
(-[WKTouchEventsGestureRecognizer _processTouches:withEvent:type:]):
(-[WKTouchEventsGestureRecognizer _recordTouches:type:]): Deleted.
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::takeQueuedTouchEventsForPage):
(WebKit::EventDispatcher::touchEvent):
(WebKit::EventDispatcher::dispatchTouchEvents):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didCommitLoad):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::dispatchAsynchronousTouchEvents):
(WebKit::WebPage::cancelAsynchronousTouchEvents):
* Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm:

Canonical link: <a href="https://commits.webkit.org/281520@main">https://commits.webkit.org/281520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4931fa4d6edc35cfb8d2bda9b51e758e0a235025

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60017 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63935 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62147 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48625 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7359 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29467 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33409 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9248 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9467 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/53111 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55323 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65667 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59262 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55979 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56129 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3275 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81020 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9017 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35178 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14076 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37348 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->