### PR TITLE
[CSS Quotes] Some CSS properties cause quotes to be reset

### DIFF
--- a/LayoutTests/fast/css/quotes-with-text-shadow-expected.html
+++ b/LayoutTests/fast/css/quotes-with-text-shadow-expected.html
@@ -1,0 +1,1 @@
+<span>start<span style="text-shadow: 2px 2px red">startend</span>end</span>

--- a/LayoutTests/fast/css/quotes-with-text-shadow.html
+++ b/LayoutTests/fast/css/quotes-with-text-shadow.html
@@ -1,0 +1,5 @@
+<style>
+q { 
+  quotes: "start" "end";
+}
+</style><q><q style="text-shadow: 2px 2px red"></q></q>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2169,12 +2169,12 @@ void RenderStyle::setCursorList(RefPtr<CursorList>&& list)
     m_rareInheritedData.access().cursorData = WTFMove(list);
 }
 
-void RenderStyle::setQuotes(RefPtr<QuotesData>&& q)
+void RenderStyle::setQuotes(RefPtr<QuotesData>&& quotes)
 {
-    if (m_rareInheritedData->quotes == q || (m_rareInheritedData->quotes && q && *m_rareInheritedData->quotes == *q))
+    if (arePointingToEqualData(m_rareInheritedData->quotes.get(), quotes.get()))
         return;
 
-    m_rareInheritedData.access().quotes = WTFMove(q);
+    m_rareInheritedData.access().quotes = WTFMove(quotes);
 }
 
 void RenderStyle::setWillChange(RefPtr<WillChangeData>&& willChangeData)

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -86,6 +86,7 @@ inline SVGRenderStyle::SVGRenderStyle(const SVGRenderStyle& other)
     , m_miscData(other.m_miscData)
     , m_layoutData(other.m_layoutData)
 {
+    ASSERT(other == *this, "SVGRenderStyle should be properly copied.");
 }
 
 Ref<SVGRenderStyle> SVGRenderStyle::copy() const

--- a/Source/WebCore/rendering/style/StyleInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleInheritedData.cpp
@@ -52,6 +52,7 @@ inline StyleInheritedData::StyleInheritedData(const StyleInheritedData& o)
     , color(o.color)
     , visitedLinkColor(o.visitedLinkColor)
 {
+    ASSERT(o == *this, "StyleInheritedData should be properly copied.");
 }
 
 Ref<StyleInheritedData> StyleInheritedData::copy() const

--- a/Source/WebCore/rendering/style/StyleNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleNonInheritedData.cpp
@@ -54,6 +54,7 @@ StyleNonInheritedData::StyleNonInheritedData(const StyleNonInheritedData& other)
     , miscData(other.miscData)
     , rareData(other.rareData)
 {
+    ASSERT(other == *this, "StyleNonInheritedData should be properly copied.");
 }
 
 Ref<StyleNonInheritedData> StyleNonInheritedData::create()

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -145,6 +145,7 @@ StyleRareInheritedData::StyleRareInheritedData()
 #if ENABLE(DARK_MODE_CSS)
     , colorScheme(RenderStyle::initialColorScheme())
 #endif
+    , quotes(RenderStyle::initialQuotes())
     , appleColorFilter(StyleFilterData::create())
     , lineGrid(RenderStyle::initialLineGrid())
     , tabSize(RenderStyle::initialTabSize())
@@ -244,6 +245,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , colorScheme(o.colorScheme)
 #endif
     , textEmphasisCustomMark(o.textEmphasisCustomMark)
+    , quotes(o.quotes)
     , appleColorFilter(o.appleColorFilter)
     , lineGrid(o.lineGrid)
     , tabSize(o.tabSize)
@@ -256,6 +258,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , listStyleType(o.listStyleType)
     , scrollbarColor(o.scrollbarColor)
 {
+    ASSERT(o == *this, "StyleRareInheritedData should be properly copied.");
 }
 
 Ref<StyleRareInheritedData> StyleRareInheritedData::copy() const


### PR DESCRIPTION
#### 1dd5907b5b49891a45360c515de06fa4f2338437
<pre>
[CSS Quotes] Some CSS properties cause quotes to be reset
<a href="https://bugs.webkit.org/show_bug.cgi?id=277154">https://bugs.webkit.org/show_bug.cgi?id=277154</a>
<a href="https://rdar.apple.com/132585704">rdar://132585704</a>

Reviewed by Simon Fraser.

Some RenderStyle setters trigger copy-on-write, so the copy constructors need to be accurate.

In this case, quotes were not being copied over.

To avoid future similar issues, add ASSERTs to the copy constructors for classes that RenderStyle directly refers too.

* LayoutTests/fast/css/quotes-with-text-shadow-expected.html: Added.
* LayoutTests/fast/css/quotes-with-text-shadow.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::setQuotes): Use arePointingToEqualData as it&apos;s easier to read and equivalent.
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
(WebCore::SVGRenderStyle::SVGRenderStyle):
* Source/WebCore/rendering/style/StyleInheritedData.cpp:
(WebCore::StyleInheritedData::StyleInheritedData):
* Source/WebCore/rendering/style/StyleNonInheritedData.cpp:
(WebCore::StyleNonInheritedData::StyleNonInheritedData):
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):

Canonical link: <a href="https://commits.webkit.org/281444@main">https://commits.webkit.org/281444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d469640eef3aa506eb80f5888d47278cfb2022e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63868 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/10480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10674 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/10480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36643 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/51909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33349 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/9150 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9399 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65600 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3880 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51903 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13285 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3219 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8976 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->