### PR TITLE
Update a request's SameSiteDisposition before using it for memory cache matching

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3289,8 +3289,6 @@ webkit.org/b/205216 imported/w3c/web-platform-tests/content-security-policy/repo
 
 webkit.org/b/207769 crypto/subtle/rsa-indexeddb-non-exportable.html [ Pass Timeout ]
 
-webkit.org/b/207770 http/tests/cache/disk-cache/disk-cache-vary-cookie.html [ Pass Timeout ]
-
 webkit.org/b/207858 fast/canvas/webgl/context-attributes-alpha.html [ Pass Failure ImageOnlyFailure ]
 # webkit.org/b/207858 fast/canvas/webgl/match-page-color-space.html [ Pass Failure ImageOnlyFailure ]
 webkit.org/b/207858 webgl/smell-test.html [ Pass Failure ImageOnlyFailure ]
@@ -6220,8 +6218,6 @@ quicklook/multi-sheet-numbers-09.html [ Failure ]
 http/tests/quicklook/secure-document-with-subresources.html [ ImageOnlyFailure ]
 
 webkit.org/b/209446 imported/w3c/web-platform-tests/navigation-timing/test_timing_attributes_order.html [ Pass Failure ]
-
-webkit.org/b/209512 http/tests/cache/disk-cache/disk-cache-vary-cookie-private.html [ Pass Timeout ]
 
 webkit.org/b/231630 http/tests/cache/disk-cache/redirect-chain-limits.html [ Slow ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1796,8 +1796,6 @@ webkit.org/b/275873 storage/indexeddb/database-transaction-cycle.html [ Pass Fai
 # Some of these tests have expectations set elsewhere (marked with inline comment). Please uncomment those when this issue is resolved.
 [ Sequoia+ ] http/tests/resourceLoadStatistics/do-not-remove-blocking-in-redirect.html [ Failure ]
 [ Sequoia+ ] http/tests/resourceLoadStatistics/set-all-cookies-to-same-site-strict.html [ Failure Timeout ] # expectation exists above
-[ Sequoia+ ] http/tests/cache/disk-cache/disk-cache-vary-cookie-private.html [ Failure ]
-[ Sequoia+ ] http/tests/cache/disk-cache/disk-cache-vary-cookie.html [ Failure ]
 [ Sequoia+ ] http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
 [ Sequoia+ ] http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html [ Failure Timeout ]
 [ Sequoia+ ] http/tests/privateClickMeasurement/send-attribution-conversion-request.html [ Failure Timeout ]

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -812,7 +812,6 @@ fullscreen/fullscreen-enter-bottom-padding-animation.html [ Pass ]
 ### (4) Features that are not supported in WebKit2 and likely never will be
 ### (5) Progressions, expected successes that are expected failures in WebKit1.
 
-webkit.org/b/172662 [ Debug ] http/tests/cache/disk-cache/disk-cache-vary-cookie.html [ Pass Failure ]
 webkit.org/b/172662 [ Debug ] http/tests/cache/disk-cache/redirect-chain-limits.html [ Pass Failure ]
 
 webkit.org/b/183139 fast/events/blur-focus-window-should-blur-focus-element.html

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1219,6 +1219,8 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
 
     Ref cookieJar = page->cookieJar();
 
+    FrameLoader::addSameSiteInfoToRequestIfNeeded(request.resourceRequest(), document());
+
     auto mayAddToMemoryCache = computeMayAddToMemoryCache(request, resource.get()) ? MayAddToMemoryCache::Yes : MayAddToMemoryCache::No;
     RevalidationPolicy policy = determineRevalidationPolicy(type, request, resource.get(), forPreload, imageLoading);
     switch (policy) {


### PR DESCRIPTION
#### 73b60062710e53db813763debaa06aa0defb1140
<pre>
Update a request&apos;s SameSiteDisposition before using it for memory cache matching
<a href="https://bugs.webkit.org/show_bug.cgi?id=277186">https://bugs.webkit.org/show_bug.cgi?id=277186</a>
<a href="https://rdar.apple.com/131857779">rdar://131857779</a>

Reviewed by Matthew Finkel.

In macOS Sequoia and iOS 18, CFNetwork&apos;s default cookie samesite attribute changed from none to lax
along with other browsers.  This exposed an issue in our checking for Vary: Cookie header matching
when considering whether to use the memory cache or not.  This was found by a failure in two layout
tests, http/tests/cache/disk-cache/disk-cache-vary-cookie-private.html and
http/tests/cache/disk-cache/disk-cache-vary-cookie.html which showed a resource being loaded from the
disk cache instead of the memory cache.

After reduction and investigation and assistance from the CFNetwork team, I found we were using the
SameSiteDisposition from a ResourceRequest with this stack trace:

WebCore::cookieRequestHeaderFieldValue(WebCore::CookieJar const*, WebCore::ResourceRequest const&amp;)
WebCore::verifyVaryingRequestHeaders(WebCore::CookieJar const*, WTF::Vector&lt;std::__1::pair&lt;WTF::String, WTF::String&gt;, 0ul, WTF::CrashOnOverflow, 16ul, WTF::FastMalloc&gt; const&amp;, WebCore::ResourceRequest const&amp;)::$_0::operator()(WTF::String const&amp;) const::&apos;lambda&apos;()::operator()() const
WTF::Detail::CallableWrapper&lt;WebCore::verifyVaryingRequestHeaders(WebCore::CookieJar const*, WTF::Vector&lt;std::__1::pair&lt;WTF::String, WTF::String&gt;, 0ul, WTF::CrashOnOverflow, 16ul, WTF::FastMalloc&gt; const&amp;, WebCore::ResourceRequest const&amp;)::$_0::operator()(WTF::String const&amp;) const::&apos;lambda&apos;(), WTF::String&gt;::call()
WTF::Function&lt;WTF::String ()&gt;::operator()() const
WebCore::headerValueForVary(WebCore::ResourceRequest const&amp;, WTF::StringView, WTF::Function&lt;WTF::String ()&gt;&amp;&amp;)
WebCore::verifyVaryingRequestHeaders(WebCore::CookieJar const*, WTF::Vector&lt;std::__1::pair&lt;WTF::String, WTF::String&gt;, 0ul, WTF::CrashOnOverflow, 16ul, WTF::FastMalloc&gt; const&amp;, WebCore::ResourceRequest const&amp;)::$_0::operator()(WTF::String const&amp;) const
WTF::Detail::CallableWrapper&lt;WebCore::verifyVaryingRequestHeaders(WebCore::CookieJar const*, WTF::Vector&lt;std::__1::pair&lt;WTF::String, WTF::String&gt;, 0ul, WTF::CrashOnOverflow, 16ul, WTF::FastMalloc&gt; const&amp;, WebCore::ResourceRequest const&amp;)::$_0, WTF::String, WTF::String const&amp;&gt;::call(WTF::String const&amp;)
WTF::Function&lt;WTF::String (WTF::String const&amp;)&gt;::operator()(WTF::String const&amp;) const
WebCore::verifyVaryingRequestHeadersInternal(WTF::Vector&lt;std::__1::pair&lt;WTF::String, WTF::String&gt;, 0ul, WTF::CrashOnOverflow, 16ul, WTF::FastMalloc&gt; const&amp;, WTF::Function&lt;WTF::String (WTF::String const&amp;)&gt;&amp;&amp;)
WebCore::verifyVaryingRequestHeaders(WebCore::CookieJar const*, WTF::Vector&lt;std::__1::pair&lt;WTF::String, WTF::String&gt;, 0ul, WTF::CrashOnOverflow, 16ul, WTF::FastMalloc&gt; const&amp;, WebCore::ResourceRequest const&amp;)
WebCore::CachedResource::varyHeaderValuesMatch(WebCore::ResourceRequest const&amp;)
WebCore::CachedResourceLoader::determineRevalidationPolicy(WebCore::CachedResource::Type, WebCore::CachedResourceRequest&amp;, WebCore::CachedResource*, WebCore::CachedResourceLoader::ForPreload, WebCore::ImageLoading) const
WebCore::CachedResourceLoader::requestResource(WebCore::CachedResource::Type, WebCore::CachedResourceRequest&amp;&amp;, WebCore::CachedResourceLoader::ForPreload, WebCore::ImageLoading)
...
WebCore::XMLHttpRequest::send(WTF::String const&amp;)

Before we were correctly setting the SameSiteDisposition with this stack trace:

WebCore::ResourceRequestBase::setIsSameSite(bool)
WebCore::FrameLoader::addSameSiteInfoToRequestIfNeeded(WebCore::ResourceRequest&amp;, WebCore::Document const*, WebCore::Page const*)
WebCore::FrameLoader::updateRequestAndAddExtraFields(WebCore::Frame&amp;, WebCore::ResourceRequest&amp;, WebCore::IsMainResource, WebCore::FrameLoadType, WebCore::ShouldUpdateAppInitiatedValue, WebCore::FrameLoader::IsServiceWorkerNavigationLoad, WebCore::FrameLoader::WillOpenInNewWindow, WebCore::Document*)
WebCore::FrameLoader::updateRequestAndAddExtraFields(WebCore::ResourceRequest&amp;, WebCore::IsMainResource, WebCore::FrameLoadType, WebCore::ShouldUpdateAppInitiatedValue, WebCore::FrameLoader::IsServiceWorkerNavigationLoad, WebCore::FrameLoader::WillOpenInNewWindow, WebCore::Document*)
WebCore::CachedResource::load(WebCore::CachedResourceLoader&amp;)
WebCore::CachedResourceLoader::requestResource(WebCore::CachedResource::Type, WebCore::CachedResourceRequest&amp;&amp;, WebCore::CachedResourceLoader::ForPreload, WebCore::ImageLoading)
...
WebCore::XMLHttpRequest::send(WTF::String const&amp;)

The result was that when we called SameSiteInfo::create, ResourceRequestBase::isSameSite() was returning
false when it should have been returning true, causing us to give CFNetwork a dictionary with a key of
_kCFHTTPCookiePolicyPropertySiteForCookies and a value of an empty URL instead of the non-empty URL, which,
when combined with the samesite attribute change caused them to give us fewer cookies than they should,
which caused us to incorrectly determine that we can&apos;t use the memory cache.

The fix is to call FrameLoader::addSameSiteInfoToRequestIfNeeded before calling determineRevalidationPolicy.
Calling FrameLoader::addSameSiteInfoToRequestIfNeeded multiple times in the loading flow is not an issue
because if it has already been called it returns early.

The test had been marked as failing and timing out on several Cocoa platforms. Since the tests seem
to be passing quite reliably on released OSes and this fixes it on Sequoia, I updated test expectations
to expect the tests to pass reliably on all Cocoa platforms.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/wk2/TestExpectations:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):

Canonical link: <a href="https://commits.webkit.org/281441@main">https://commits.webkit.org/281441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebbd71e4a28d16f9c1a50823572b96102e7a9dde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10456 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10640 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7289 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36612 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/51877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33319 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9119 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9377 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65578 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9259 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3870 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51862 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56062 "Build is in progress. Recent messages:") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3189 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8973 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35089 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/35915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->