### PR TITLE
[Remote Inspection] numberOfVisibilityAdjustmentRects returns 0 after loading from back/forward cache

### DIFF
--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "Document.h"
 #include "ElementIdentifier.h"
 #include "ElementTargetingTypes.h"
 #include "EventTarget.h"
@@ -59,8 +60,9 @@ public:
     void adjustVisibilityInRepeatedlyTargetedRegions(Document&);
 
     void reset();
+    void didChangeMainDocument(Document* newDocument);
 
-    WEBCORE_EXPORT uint64_t numberOfVisibilityAdjustmentRects() const;
+    WEBCORE_EXPORT uint64_t numberOfVisibilityAdjustmentRects();
     WEBCORE_EXPORT bool resetVisibilityAdjustments(const Vector<TargetedElementIdentifiers>&);
 
     WEBCORE_EXPORT RefPtr<Image> snapshotIgnoringVisibilityAdjustment(ElementIdentifier, ScriptExecutionContextIdentifier);
@@ -87,8 +89,11 @@ private:
 
     Vector<TargetedElementInfo> extractTargets(Vector<Ref<Node>>&&, RefPtr<Element>&& innerElement, bool canIncludeNearbyElements);
 
+    void recomputeAdjustedElementsIfNeeded();
+
     SingleThreadWeakPtr<Page> m_page;
     DeferrableOneShotTimer m_recentAdjustmentClientRectsCleanUpTimer;
+    WeakHashSet<Document, WeakPtrImplWithEventTargetData> m_documentsAffectedByVisibilityAdjustment;
     HashMap<ElementIdentifier, IntRect> m_recentAdjustmentClientRects;
     ApproximateTime m_startTimeForSelectorBasedVisibilityAdjustment;
     Timer m_selectorBasedVisibilityAdjustmentTimer;
@@ -100,6 +105,7 @@ private:
     FloatSize m_viewportSizeForVisibilityAdjustment;
     unsigned m_additionalAdjustmentCount { 0 };
     bool m_didCollectInitialAdjustments { false };
+    bool m_shouldRecomputeAdjustedElements { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -295,7 +295,7 @@ void LocalFrame::setDocument(RefPtr<Document>&& newDocument)
 
     if (isMainFrame()) {
         if (RefPtr page = this->page())
-            page->didChangeMainDocument();
+            page->didChangeMainDocument(newDocument.get());
         checkedLoader()->client().dispatchDidChangeMainDocument();
     }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3963,7 +3963,7 @@ void Page::enableICECandidateFiltering()
 #endif
 }
 
-void Page::didChangeMainDocument()
+void Page::didChangeMainDocument(Document* newDocument)
 {
 #if ENABLE(WEB_RTC)
     m_rtcController->reset(m_shouldEnableICECandidateFilteringByDefault);
@@ -3974,6 +3974,8 @@ void Page::didChangeMainDocument()
         m_sampledPageTopColor = std::nullopt;
         chrome().client().sampledPageTopColorChanged();
     }
+
+    checkedElementTargetingController()->didChangeMainDocument(newDocument);
 }
 
 RenderingUpdateScheduler& Page::renderingUpdateScheduler()

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -431,7 +431,7 @@ public:
 
     WEBCORE_EXPORT CheckedRef<ElementTargetingController> checkedElementTargetingController();
 
-    void didChangeMainDocument();
+    void didChangeMainDocument(Document* newDocument);
     void mainFrameDidChangeToNonInitialEmptyDocument();
 
     PerformanceMonitor* performanceMonitor() { return m_performanceMonitor.get(); }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -614,4 +614,24 @@ TEST(ElementTargeting, TargetedElementWithLargeImage)
     EXPECT_TRUE([element hasLargeReplacedDescendant]);
 }
 
+TEST(ElementTargeting, CountVisibilityAdjustmentsAfterNavigatingBack)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    [webView synchronouslyLoadTestPageNamed:@"element-targeting-1"];
+
+    RetainPtr element = [[webView targetedElementInfoAt:CGPointMake(150, 150)] firstObject];
+    EXPECT_WK_STREQ("DIV.fixed.container", [[[element selectorsIncludingShadowHosts] firstObject] firstObject]);
+    [webView adjustVisibilityForTargets:@[ element.get() ]];
+    EXPECT_EQ(1U, [webView numberOfVisibilityAdjustmentRects]);
+
+    [webView synchronouslyLoadTestPageNamed:@"element-targeting-2"];
+    EXPECT_EQ(0U, [webView numberOfVisibilityAdjustmentRects]);
+
+    [webView synchronouslyGoBack];
+    EXPECT_EQ(1U, [webView numberOfVisibilityAdjustmentRects]);
+
+    [webView synchronouslyGoForward];
+    EXPECT_EQ(0U, [webView numberOfVisibilityAdjustmentRects]);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 38771c35ceb476acc7d75e856add5df546ec8db3
<pre>
[Remote Inspection] numberOfVisibilityAdjustmentRects returns 0 after loading from back/forward cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=277187">https://bugs.webkit.org/show_bug.cgi?id=277187</a>
<a href="https://rdar.apple.com/132521358">rdar://132521358</a>

Reviewed by Richard Robinson.

`ElementTargetingController`&apos;s set of `m_adjustedElements` is currently reset whenever a load is
committed. This causes `numberOfVisibilityAdjustmentRects()` to always return 0 when the current
document has been restored from the back/forward cache, since adjustment state persists on the DOM
nodes in the new document, but `m_adjustedElements` is empty.

To address this, we:

1.  Keep track of a `WeakSet` of documents wherein we&apos;ve previously applied adjustments.

2.  Add plumbing to inform `ElementTargetingController` when the main document will change; if the
    new document is one where we&apos;ve previously applied adjustments, then set a boolean flag,
    `m_shouldRecomputeAdjustedElements`, to indicate that we need to lazily compute
    `m_adjustedElements` if the client ever asks for the adjusted rect count.

3.  If `m_shouldRecomputeAdjustedElements` is set and

This design ensures that we do no additional work (i.e. the full tree traversal) in the following
scenarios:

(a) No element has ever been adjusted in the document we&apos;re loading.
(b) The client never requests the adjustment rect count.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::adjustVisibility):
(WebCore::ElementTargetingController::adjustVisibilityInRepeatedlyTargetedRegions):
(WebCore::ElementTargetingController::applyVisibilityAdjustmentFromSelectors):
(WebCore::ElementTargetingController::didChangeMainDocument):
(WebCore::ElementTargetingController::numberOfVisibilityAdjustmentRects):
(WebCore::ElementTargetingController::recomputeAdjustedElementsIfNeeded):

Collect the set of elements with active visibility adjustments, if necessary. See above for more
details.

(WebCore::ElementTargetingController::numberOfVisibilityAdjustmentRects const): Deleted.

Make this non-const, now that it invokes `recomputeAdjustedElementsIfNeeded`.

* Source/WebCore/page/ElementTargetingController.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::setDocument):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didChangeMainDocument):

Additionally plumb the new document through `didChangeMainDocument()`. Perhaps counterintuitively,
`didChangeMainDocument` is invoked *before* the main frame&apos;s document has actually changed to the
new value.

* Source/WebCore/page/Page.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(TestWebKitAPI::TEST(ElementTargeting, CountVisibilityAdjustmentsAfterNavigatingBack)):

Add a new API test to exercise the change.

Canonical link: <a href="https://commits.webkit.org/281452@main">https://commits.webkit.org/281452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/323a34bb60edc6488dc29631bf96fae5cac577b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63850 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10460 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48573 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7295 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29415 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9123 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9381 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65582 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55915 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3876 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56065 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13288 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3195 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35093 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36175 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37263 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->