### PR TITLE
Have BasicShapes return Paths by value, and other cleanup

### DIFF
--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1863,10 +1863,10 @@ static Ref<CSSValue> valueForPathOperation(const RenderStyle& style, const PathO
         return CSSPrimitiveValue::create(CSSValueNone);
 
     switch (operation->type()) {
-    case PathOperation::Reference:
+    case PathOperation::Type::Reference:
         return CSSPrimitiveValue::createURI(uncheckedDowncast<ReferencePathOperation>(*operation).url());
 
-    case PathOperation::Shape: {
+    case PathOperation::Type::Shape: {
         auto& shapeOperation = uncheckedDowncast<ShapePathOperation>(*operation);
         if (shapeOperation.referenceBox() == CSSBoxType::BoxMissing)
             return CSSValueList::createSpaceSeparated(valueForBasicShape(style, shapeOperation.basicShape(), conversion));
@@ -1874,10 +1874,10 @@ static Ref<CSSValue> valueForPathOperation(const RenderStyle& style, const PathO
             createConvertingToCSSValueID(shapeOperation.referenceBox()));
     }
 
-    case PathOperation::Box:
+    case PathOperation::Type::Box:
         return createConvertingToCSSValueID(uncheckedDowncast<BoxPathOperation>(*operation).referenceBox());
 
-    case PathOperation::Ray: {
+    case PathOperation::Type::Ray: {
         auto& ray = uncheckedDowncast<RayPathOperation>(*operation);
         auto angle = CSSPrimitiveValue::create(ray.angle(), CSSUnitType::CSS_DEG);
         RefPtr<CSSValuePair> position = ray.position().x().isAuto() ? nullptr : RefPtr { CSSValuePair::createNoncoalescing(Ref { ComputedStyleExtractor::zoomAdjustedPixelValueForLength(ray.position().x(), style) }, Ref { ComputedStyleExtractor::zoomAdjustedPixelValueForLength(ray.position().y(), style) }) };

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -477,7 +477,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     auto& style = regionRenderer.style();
     RefPtr styleClipPath = style.clipPath();
 
-    if (!hasRotationOrShear && styleClipPath && styleClipPath->type() == PathOperation::OperationType::Shape && originalElement) {
+    if (!hasRotationOrShear && styleClipPath && styleClipPath->type() == PathOperation::Type::Shape && originalElement) {
         auto size = boundingSize(regionRenderer, transform);
         auto path = styleClipPath->getPath(TransformOperationData(FloatRect(FloatPoint(), size)));
 

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -54,7 +54,7 @@ Ref<PathOperation> ReferencePathOperation::clone() const
 }
 
 ReferencePathOperation::ReferencePathOperation(const String& url, const AtomString& fragment, const RefPtr<SVGElement> element)
-    : PathOperation(Reference)
+    : PathOperation(Type::Reference)
     , m_url(url)
     , m_fragment(fragment)
 {
@@ -63,7 +63,7 @@ ReferencePathOperation::ReferencePathOperation(const String& url, const AtomStri
 }
 
 ReferencePathOperation::ReferencePathOperation(std::optional<Path>&& path)
-    : PathOperation(Reference)
+    : PathOperation(Type::Reference)
     , m_path(WTFMove(path))
 {
 }
@@ -92,7 +92,7 @@ RefPtr<PathOperation> RayPathOperation::blend(const PathOperation* to, const Ble
     return RayPathOperation::create(WebCore::blend(m_angle, toRayPathOperation.angle(), context), m_size, m_isContaining, WebCore::blend(m_position, toRayPathOperation.position(), context), m_referenceBox);
 }
 
-const std::optional<Path> RayPathOperation::getPath(const TransformOperationData& data) const
+std::optional<Path> RayPathOperation::getPath(const TransformOperationData& data) const
 {
     return MotionPath::computePathForRay(*this, data);
 }

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1526,14 +1526,14 @@ bool RenderBox::hitTestClipPath(const HitTestLocation& hitTestLocation, const La
     };
 
     switch (style().clipPath()->type()) {
-    case PathOperation::Shape: {
+    case PathOperation::Type::Shape: {
         auto& clipPath = uncheckedDowncast<ShapePathOperation>(*style().clipPath());
         auto referenceBoxRect = this->referenceBoxRect(clipPath.referenceBox());
         if (!clipPath.pathForReferenceRect(referenceBoxRect).contains(hitTestLocationInLocalCoordinates, clipPath.windRule()))
             return false;
         break;
     }
-    case PathOperation::Reference: {
+    case PathOperation::Type::Reference: {
         const auto& referencePathOperation = uncheckedDowncast<ReferencePathOperation>(*style().clipPath());
         RefPtr element = document().getElementById(referencePathOperation.fragment());
         if (!element || !element->renderer())
@@ -1544,9 +1544,9 @@ bool RenderBox::hitTestClipPath(const HitTestLocation& hitTestLocation, const La
             return false;
         break;
     }
-    case PathOperation::Box:
+    case PathOperation::Type::Box:
         break;
-    case PathOperation::Ray:
+    case PathOperation::Type::Ray:
         ASSERT_NOT_REACHED("clip-path does not support Ray shape");
         break;
     }
@@ -1927,7 +1927,7 @@ void RenderBox::paintClippingMask(PaintInfo& paintInfo, const LayoutPoint& paint
 
     LayoutRect paintRect = LayoutRect(paintOffset, size());
 
-    if (document().settings().layerBasedSVGEngineEnabled() && style().clipPath() && style().clipPath()->type() == PathOperation::Reference) {
+    if (document().settings().layerBasedSVGEngineEnabled() && style().clipPath() && style().clipPath()->type() == PathOperation::Type::Reference) {
         paintSVGClippingMask(paintInfo, paintRect);
         return;
     }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -721,7 +721,7 @@ bool RenderLayer::willCompositeClipPath() const
     if (renderer().hasMask())
         return false;
 
-    return (clipPath->type() != PathOperation::Shape || clipPath->type() == PathOperation::Shape) && GraphicsLayer::supportsLayerType(GraphicsLayer::Type::Shape);
+    return (clipPath->type() != PathOperation::Type::Shape || clipPath->type() == PathOperation::Type::Shape) && GraphicsLayer::supportsLayerType(GraphicsLayer::Type::Shape);
 }
 
 void RenderLayer::dirtyNormalFlowList()

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1746,7 +1746,7 @@ void RenderLayerBacking::updateMaskingLayerGeometry()
     
     if (!m_maskLayer->drawsContent()) {
         if (renderer().hasClipPath()) {
-            ASSERT(renderer().style().clipPath()->type() != PathOperation::Reference);
+            ASSERT(renderer().style().clipPath()->type() != PathOperation::Type::Reference);
 
             // FIXME: Use correct reference box for inlines: https://bugs.webkit.org/show_bug.cgi?id=129047, https://github.com/w3c/csswg-drafts/issues/6383
             LayoutRect boundingBox = m_owningLayer.boundingBox(&m_owningLayer);
@@ -2524,7 +2524,7 @@ bool RenderLayerBacking::updateMaskingLayer(bool hasMask, bool hasClipPath)
         
         if (hasClipPath) {
             // If we have a mask, we need to paint the combined clip-path and mask into the mask layer.
-            if (hasMask || renderer().style().clipPath()->type() == PathOperation::Reference || !GraphicsLayer::supportsLayerType(GraphicsLayer::Type::Shape))
+            if (hasMask || renderer().style().clipPath()->type() == PathOperation::Type::Reference || !GraphicsLayer::supportsLayerType(GraphicsLayer::Type::Shape))
                 maskPhases.add(GraphicsLayerPaintingPhase::ClipPath);
         }
 

--- a/Source/WebCore/rendering/style/BasicShapes.cpp
+++ b/Source/WebCore/rendering/style/BasicShapes.cpp
@@ -187,13 +187,13 @@ float BasicShapeCircle::floatValueForRadiusInBox(float boxWidth, float boxHeight
     return std::max(std::max(std::abs(center.x()), widthDelta), std::max(std::abs(center.y()), heightDelta));
 }
 
-const Path& BasicShapeCircle::pathForCenterCoordinate(const FloatRect& boundingBox, FloatPoint center) const
+Path BasicShapeCircle::pathForCenterCoordinate(const FloatRect& boundingBox, FloatPoint center) const
 {
     float radius = floatValueForRadiusInBox(boundingBox.width(), boundingBox.height(),  center);
     return cachedEllipsePath(FloatRect(center.x() - radius + boundingBox.x(), center.y() - radius + boundingBox.y(), radius * 2, radius * 2));
 }
 
-const Path& BasicShapeCircle::path(const FloatRect& boundingBox)
+Path BasicShapeCircle::path(const FloatRect& boundingBox) const
 {
     return pathForCenterCoordinate(boundingBox, { floatValueForCenterCoordinate(m_centerX, boundingBox.width()), floatValueForCenterCoordinate(m_centerY, boundingBox.height()) });
 }
@@ -274,7 +274,7 @@ float BasicShapeEllipse::floatValueForRadiusInBox(const BasicShapeRadius& radius
     return std::max(std::abs(center), widthOrHeightDelta);
 }
 
-const Path& BasicShapeEllipse::pathForCenterCoordinate(const FloatRect& boundingBox, FloatPoint center) const
+Path BasicShapeEllipse::pathForCenterCoordinate(const FloatRect& boundingBox, FloatPoint center) const
 {
     float radiusX = floatValueForRadiusInBox(m_radiusX, center.x(), boundingBox.width());
     float radiusY = floatValueForRadiusInBox(m_radiusY, center.y(), boundingBox.height());
@@ -282,7 +282,7 @@ const Path& BasicShapeEllipse::pathForCenterCoordinate(const FloatRect& bounding
     return cachedEllipsePath(FloatRect(center.x() - radiusX + boundingBox.x(), center.y() - radiusY + boundingBox.y(), radiusX * 2, radiusY * 2));
 }
 
-const Path& BasicShapeEllipse::path(const FloatRect& boundingBox)
+Path BasicShapeEllipse::path(const FloatRect& boundingBox) const
 {
     return pathForCenterCoordinate(boundingBox, { floatValueForCenterCoordinate(m_centerX, boundingBox.width()), floatValueForCenterCoordinate(m_centerY, boundingBox.height()) });
 }
@@ -375,7 +375,7 @@ bool BasicShapeRect::operator==(const BasicShape& other) const
         && m_bottomLeftRadius == otherRect.m_bottomLeftRadius;
 }
 
-const Path& BasicShapeRect::path(const FloatRect& boundingBox)
+Path BasicShapeRect::path(const FloatRect& boundingBox) const
 {
     auto top = m_edges.top().isAuto() ? 0 : floatValueForLength(m_edges.top(), boundingBox.height());
     auto right = m_edges.right().isAuto() ? boundingBox.width() : floatValueForLength(m_edges.right(), boundingBox.width());
@@ -482,7 +482,7 @@ bool BasicShapeXywh::operator==(const BasicShape& other) const
         && m_bottomLeftRadius == otherXywh.m_bottomLeftRadius;
 }
 
-const Path& BasicShapeXywh::path(const FloatRect& boundingBox)
+Path BasicShapeXywh::path(const FloatRect& boundingBox) const
 {
     auto insetX = floatValueForLength(m_insetX, boundingBox.width());
     auto insetY = floatValueForLength(m_insetY, boundingBox.height());
@@ -566,7 +566,7 @@ bool BasicShapePolygon::operator==(const BasicShape& other) const
         && m_values == otherPolygon.m_values;
 }
 
-const Path& BasicShapePolygon::path(const FloatRect& boundingBox)
+Path BasicShapePolygon::path(const FloatRect& boundingBox) const
 {
     ASSERT(!(m_values.size() % 2));
     size_t length = m_values.size();
@@ -644,7 +644,7 @@ Ref<BasicShape> BasicShapePath::clone() const
     return adoptRef(*new BasicShapePath(WTFMove(byteStream), m_zoom, m_windRule));
 }
 
-const Path& BasicShapePath::path(const FloatRect& boundingBox)
+Path BasicShapePath::path(const FloatRect& boundingBox) const
 {
     return cachedTransformedByteStreamPath(*m_byteStream, m_zoom, boundingBox.location());
 }
@@ -733,7 +733,7 @@ bool BasicShapeInset::operator==(const BasicShape& other) const
         && m_bottomLeftRadius == otherInset.m_bottomLeftRadius;
 }
 
-const Path& BasicShapeInset::path(const FloatRect& boundingBox)
+Path BasicShapeInset::path(const FloatRect& boundingBox) const
 {
     float left = floatValueForLength(m_left, boundingBox.width());
     float top = floatValueForLength(m_top, boundingBox.height());

--- a/Source/WebCore/rendering/style/BasicShapes.h
+++ b/Source/WebCore/rendering/style/BasicShapes.h
@@ -68,7 +68,7 @@ public:
 
     virtual Type type() const = 0;
 
-    virtual const Path& path(const FloatRect&) = 0;
+    virtual Path path(const FloatRect&) const = 0;
     virtual WindRule windRule() const { return WindRule::NonZero; }
 
     virtual bool canBlend(const BasicShape&) const = 0;
@@ -176,7 +176,7 @@ class BasicShapeCircleOrEllipse : public BasicShape {
 public:
     void setPositionWasOmitted(bool flag) { m_centerWasOmitted = flag; }
     bool positionWasOmitted() const { return m_centerWasOmitted; }
-    virtual const Path& pathForCenterCoordinate(const FloatRect&, FloatPoint) const = 0;
+    virtual Path pathForCenterCoordinate(const FloatRect&, FloatPoint) const = 0;
 
 private:
     bool m_centerWasOmitted = false;
@@ -204,8 +204,8 @@ private:
 
     Type type() const final { return Type::Circle; }
 
-    const Path& path(const FloatRect&) final;
-    const Path& pathForCenterCoordinate(const FloatRect&, FloatPoint) const final;
+    Path path(const FloatRect&) const final;
+    Path pathForCenterCoordinate(const FloatRect&, FloatPoint) const final;
 
     bool canBlend(const BasicShape&) const final;
     Ref<BasicShape> blend(const BasicShape& from, const BlendingContext&) const final;
@@ -243,8 +243,8 @@ private:
 
     Type type() const final { return Type::Ellipse; }
 
-    const Path& path(const FloatRect&) final;
-    const Path& pathForCenterCoordinate(const FloatRect&, FloatPoint) const final;
+    Path path(const FloatRect&) const final;
+    Path pathForCenterCoordinate(const FloatRect&, FloatPoint) const final;
 
     bool canBlend(const BasicShape&) const final;
     Ref<BasicShape> blend(const BasicShape& from, const BlendingContext&) const final;
@@ -281,7 +281,7 @@ private:
 
     Type type() const final { return Type::Polygon; }
 
-    const Path& path(const FloatRect&) final;
+    Path path(const FloatRect&) const final;
 
     bool canBlend(const BasicShape&) const final;
     Ref<BasicShape> blend(const BasicShape& from, const BlendingContext&) const final;
@@ -314,7 +314,7 @@ public:
     const SVGPathByteStream* pathData() const { return m_byteStream.get(); }
     const std::unique_ptr<SVGPathByteStream>& byteStream() const { return m_byteStream; }
 
-    const Path& path(const FloatRect&) final;
+    Path path(const FloatRect&) const final;
 
     bool canBlend(const BasicShape&) const final;
     Ref<BasicShape> blend(const BasicShape& from, const BlendingContext&) const final;
@@ -367,7 +367,7 @@ private:
 
     Type type() const override { return Type::Inset; }
 
-    const Path& path(const FloatRect&) override;
+    Path path(const FloatRect&) const override;
 
     bool canBlend(const BasicShape&) const override;
     Ref<BasicShape> blend(const BasicShape& from, const BlendingContext&) const override;
@@ -421,7 +421,7 @@ private:
 
     Type type() const final { return Type::Rect; }
 
-    const Path& path(const FloatRect&) final;
+    Path path(const FloatRect&) const final;
 
     bool canBlend(const BasicShape&) const final;
     Ref<BasicShape> blend(const BasicShape& from, const BlendingContext&) const final;
@@ -471,7 +471,7 @@ private:
 
     Type type() const final { return Type::Xywh; }
 
-    const Path& path(const FloatRect&) final;
+    Path path(const FloatRect&) const final;
 
     bool canBlend(const BasicShape&) const final;
     Ref<BasicShape> blend(const BasicShape& from, const BlendingContext&) const final;


### PR DESCRIPTION
#### 4d256e34311ea7f00a85409f2f05be31fb888d35
<pre>
Have BasicShapes return Paths by value, and other cleanup
<a href="https://bugs.webkit.org/show_bug.cgi?id=277193">https://bugs.webkit.org/show_bug.cgi?id=277193</a>
<a href="https://rdar.apple.com/132615912">rdar://132615912</a>

Reviewed by Tim Nguyen.

The primary change here is to have BasicShape::path() return a path by value, not by
reference. This allows an implementation to construct a path and return it without
having to store it somewhere. Path copies are cheap, because internally they use a DataRef&lt;&gt;.

Also make PathOperation::OperationType an enum class named Type, and other whitespace
and const cleanup.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForPathOperation):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::ReferencePathOperation::ReferencePathOperation):
(WebCore::RayPathOperation::getPath const):
* Source/WebCore/rendering/PathOperation.h:
(WebCore::PathOperation::type const):
(WebCore::PathOperation::PathOperation):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::hitTestClipPath const):
(WebCore::RenderBox::paintClippingMask):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::willCompositeClipPath const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateMaskingLayerGeometry):
(WebCore::RenderLayerBacking::updateMaskingLayer):
* Source/WebCore/rendering/style/BasicShapes.cpp:
(WebCore::BasicShapeCircle::pathForCenterCoordinate const):
(WebCore::BasicShapeCircle::path const):
(WebCore::BasicShapeEllipse::pathForCenterCoordinate const):
(WebCore::BasicShapeEllipse::path const):
(WebCore::BasicShapeRect::path const):
(WebCore::BasicShapeXywh::path const):
(WebCore::BasicShapePolygon::path const):
(WebCore::BasicShapePath::path const):
(WebCore::BasicShapeInset::path const):
(WebCore::BasicShapeCircle::path): Deleted.
(WebCore::BasicShapeEllipse::path): Deleted.
(WebCore::BasicShapeRect::path): Deleted.
(WebCore::BasicShapeXywh::path): Deleted.
(WebCore::BasicShapePolygon::path): Deleted.
(WebCore::BasicShapePath::path): Deleted.
(WebCore::BasicShapeInset::path): Deleted.
* Source/WebCore/rendering/style/BasicShapes.h:

Canonical link: <a href="https://commits.webkit.org/281453@main">https://commits.webkit.org/281453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0496ee7647da4e629c27aa283e6c5ea6e50ffda5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63864 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10476 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48581 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7304 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29422 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33346 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9157 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/preload-type-match.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9395 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55260 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65596 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55925 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56075 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13289 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3211 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35107 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36189 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->