### PR TITLE
Rename BasicShapeFunctions.h/cpp to BasicShapeConversion.h/cpp

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -825,7 +825,7 @@ crypto/keys/CryptoKeyOKP.cpp
 crypto/keys/CryptoKeyRSA.cpp
 crypto/keys/CryptoKeyRSAComponents.cpp
 crypto/keys/CryptoKeyRaw.cpp
-css/BasicShapeFunctions.cpp
+css/BasicShapeConversion.cpp
 css/CSSAnchorValue.cpp
 css/CSSAspectRatioValue.cpp
 css/CSSBackgroundRepeatValue.cpp

--- a/Source/WebCore/css/BasicShapeConversion.cpp
+++ b/Source/WebCore/css/BasicShapeConversion.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "config.h"
-#include "BasicShapeFunctions.h"
+#include "BasicShapeConversion.h"
 
 #include "BasicShapes.h"
 #include "CSSBasicShapes.h"
@@ -303,8 +303,10 @@ Ref<BasicShape> basicShapeForValue(const CSSToLengthConversionData& conversionDa
         rect->setBottomLeftRadius(convertToLengthSize(conversionData, rectValue->protectedBottomLeftRadius().get()));
         return rect;
     }
+
     if (auto* pathValue = dynamicDowncast<CSSPathValue>(value))
         return basicShapePathForValue(*pathValue, zoom);
+
     RELEASE_ASSERT_NOT_REACHED();
 }
 
@@ -324,4 +326,4 @@ float floatValueForCenterCoordinate(const BasicShapeCenterCoordinate& center, fl
     return boxDimension - offset;
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/css/BasicShapeConversion.h
+++ b/Source/WebCore/css/BasicShapeConversion.h
@@ -45,8 +45,10 @@ enum class SVGPathConversion : bool { None, ForceAbsolute };
 
 Ref<CSSValue> valueForBasicShape(const RenderStyle&, const BasicShape&, SVGPathConversion = SVGPathConversion::None);
 Ref<CSSValue> valueForSVGPath(const BasicShapePath&, SVGPathConversion = SVGPathConversion::None);
+
 Ref<BasicShape> basicShapeForValue(const CSSToLengthConversionData&, const CSSValue&, float zoom = 1);
 Ref<BasicShapePath> basicShapePathForValue(const CSSPathValue&, float zoom = 1);
+
 float floatValueForCenterCoordinate(const BasicShapeCenterCoordinate&, float);
 
 }

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -25,7 +25,7 @@
 #include "config.h"
 #include "ComputedStyleExtractor.h"
 
-#include "BasicShapeFunctions.h"
+#include "BasicShapeConversion.h"
 #include "CSSBorderImage.h"
 #include "CSSBorderImageSliceValue.h"
 #include "CSSCounterValue.h"

--- a/Source/WebCore/rendering/shapes/Shape.cpp
+++ b/Source/WebCore/rendering/shapes/Shape.cpp
@@ -30,7 +30,7 @@
 #include "config.h"
 #include "Shape.h"
 
-#include "BasicShapeFunctions.h"
+#include "BasicShapeConversion.h"
 #include "BasicShapes.h"
 #include "BoxShape.h"
 #include "GraphicsContext.h"

--- a/Source/WebCore/rendering/style/BasicShapes.cpp
+++ b/Source/WebCore/rendering/style/BasicShapes.cpp
@@ -31,7 +31,7 @@
 #include "BasicShapes.h"
 
 #include "AnimationUtilities.h"
-#include "BasicShapeFunctions.h"
+#include "BasicShapeConversion.h"
 #include "CalculationValue.h"
 #include "FloatRect.h"
 #include "FloatRoundedRect.h"

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -28,7 +28,7 @@
 #pragma once
 
 #include "AnchorPositionEvaluator.h"
-#include "BasicShapeFunctions.h"
+#include "BasicShapeConversion.h"
 #include "CSSBasicShapes.h"
 #include "CSSCalcValue.h"
 #include "CSSContentDistributionValue.h"


### PR DESCRIPTION
#### b589ffe0d2ec9e6573b53ec450885ed410e2f066
<pre>
Rename BasicShapeFunctions.h/cpp to BasicShapeConversion.h/cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=277194">https://bugs.webkit.org/show_bug.cgi?id=277194</a>
<a href="https://rdar.apple.com/132616233">rdar://132616233</a>

Reviewed by Alan Baradlay.

BasicShapeFunctions.cpp contains code related to converting between CSSValues and BasicShapes,
so call it BasicShapeConversion. No code changes.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/BasicShapeConversion.cpp: Renamed from Source/WebCore/css/BasicShapeFunctions.cpp.
(WebCore::valueForCenterCoordinate):
(WebCore::basicShapeRadiusToCSSValue):
(WebCore::copySVGPathByteStream):
(WebCore::valueForSVGPath):
(WebCore::valueForBasicShape):
(WebCore::convertToLength):
(WebCore::convertToLengthOrAuto):
(WebCore::convertToLengthSize):
(WebCore::convertToCenterCoordinate):
(WebCore::cssValueToBasicShapeRadius):
(WebCore::basicShapeForValue):
(WebCore::basicShapePathForValue):
(WebCore::floatValueForCenterCoordinate):
* Source/WebCore/css/BasicShapeConversion.h: Renamed from Source/WebCore/css/BasicShapeFunctions.h.
* Source/WebCore/css/ComputedStyleExtractor.cpp:
* Source/WebCore/rendering/shapes/Shape.cpp:
* Source/WebCore/rendering/style/BasicShapes.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:

Canonical link: <a href="https://commits.webkit.org/281454@main">https://commits.webkit.org/281454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1a150e51ad4d9d6ebefe8978b1e10347526ef2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10475 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48577 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7302 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29419 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33347 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9146 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/preload-type-match.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9394 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65595 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9285 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55930 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56079 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13290 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3212 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35106 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36188 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->