### PR TITLE
css/css-text-decor/text-underline-position-vertical* WPT fail

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3992,8 +3992,6 @@ webkit.org/b/203528 imported/w3c/web-platform-tests/css/css-text-decor/text-deco
 webkit.org/b/203528 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-vertical-001.html [ ImageOnlyFailure ]
 webkit.org/b/203528 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-vertical-002.html [ ImageOnlyFailure ]
 webkit.org/b/203528 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-percent-001.html [ ImageOnlyFailure ]
-webkit.org/b/203529 imported/w3c/web-platform-tests/css/css-text-decor/text-underline-position-vertical-ja.html [ ImageOnlyFailure ]
-webkit.org/b/203529 imported/w3c/web-platform-tests/css/css-text-decor/text-underline-position-vertical.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-display-contents.html [ ImageOnlyFailure ]
 webkit.org/b/230083 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-skip-ink-001.html [ ImageOnlyFailure ]
 webkit.org/b/230083 imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-skip-ink-004.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/inline/text-overline-underline-position-simple-expected.html
+++ b/LayoutTests/fast/inline/text-overline-underline-position-simple-expected.html
@@ -8,12 +8,12 @@
   font-family: Ahem;
 }
 </style>
-<div class=overline_content style="margin-left: 2px">  </div>
-<div class=overline_content style="margin-left: 3px;">  </div>
+<div class=overline_content>  </div>
+<div class=overline_content style="margin-left: 1px;">  </div>
 <div class=overline_content>    </div>
 
-<div style="position: absolute; top: 8px; left: -35px">
-  <div class=overline_content style="margin-left: 3px">    </div>
-  <div class=overline_content style="margin-left: 1px">  </div>
+<div style="position: absolute; top: 8px; left: -36px">
+  <div class=overline_content>    </div>
   <div class=overline_content>  </div>
+  <div class=overline_content style="margin-left: -1px">  </div>
 </div>

--- a/LayoutTests/fast/inline/text-underline-position-right-simple-expected.html
+++ b/LayoutTests/fast/inline/text-underline-position-right-simple-expected.html
@@ -7,8 +7,7 @@ div {
   white-space: pre;
   font-size: 40px;
   font-family: Ahem;
-  margin-left: 2px;
 }
 </style>
 <div>  </div>
-<div style="margin-left: 3px;">  </div>
+<div style="margin-left: 1px;">  </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-position-vertical-ja.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-position-vertical-ja.html
@@ -15,7 +15,7 @@
     </style>
 </head>
 <body lang="ja">
-    <div>In vertical writing mode with lang=ja, default overline will be same as underline (lang=en). However, when we set text-underline-position to "under left" it should be shifted.</div>
+    <div lang="en">In vertical writing mode with lang=ja, default overline will be same as underline (lang=en). However, when we set text-underline-position to "under left" it should be shifted.</div>
     <div class="underline" style="text-underline-position: under left">&#x56fd;&#x56fd;&#x56fd;&#x56fd;</div>
     <div class="overline">&#x56fd;&#x56fd;&#x56fd;&#x56fd;</div>
 </body>

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -328,7 +328,7 @@ float overlineOffsetForTextBoxPainting(const InlineIterator::InlineBox& inlineBo
             return style.typographicMode() == TypographicMode::Vertical || style.blockFlowDirection() == BlockFlowDirection::RightToLeft;
         return false;
     };
-    return overBecomesUnder() ? inlineBoxContentBoxHeight(inlineBox) : 0.f;
+    return overBecomesUnder() ? inlineBoxContentBoxHeight(inlineBox) + defaultGap(style) : (0.f - defaultGap(style));
 }
 
 }


### PR DESCRIPTION
#### 71497bb68971edc99d329d88b6bc8aa4dbb2fbec
<pre>
css/css-text-decor/text-underline-position-vertical* WPT fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=203529">https://bugs.webkit.org/show_bug.cgi?id=203529</a>
<a href="https://rdar.apple.com/132384098">rdar://132384098</a>

Reviewed by Alan Baradlay.

The tests expect the default gap (instead of 0) to be applied to the overline, similarly as it is to the underline.

They check that an overline on the flipped side renders at the same offset than an non-flipped underline.

Apply the default gap to the overline to make these tests pass.

* LayoutTests/TestExpectations:
* LayoutTests/fast/inline/text-overline-underline-position-simple-expected.html:
* LayoutTests/fast/inline/text-underline-position-right-simple-expected.html:

The new expectations account for this change, the rendering is now more similar to Chrome &amp; Firefox.

* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-underline-position-vertical-ja.html:

Avoid flaky paragraph difference by adding a lang=en to the test description (irrelevant to the test itself).

* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::overlineOffsetForTextBoxPainting):

Canonical link: <a href="https://commits.webkit.org/281456@main">https://commits.webkit.org/281456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1e6034332e706199d3ee75b9a1081ea1a4236af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63900 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10512 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10715 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48605 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7334 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36675 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/51936 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29447 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33380 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/9183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9432 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55292 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/9463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65632 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3912 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9323 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/55955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56106 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3244 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8982 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35143 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36225 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37313 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->