### PR TITLE
[JSC] Register allocator should rematerialize constants

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirUseCounts.h
+++ b/Source/JavaScriptCore/b3/air/AirUseCounts.h
@@ -55,56 +55,94 @@ public:
             }
         }
 
+
         unsigned gpArraySize = AbsoluteTmpMapper<GP>::absoluteIndex(code.numTmps(GP));
         m_gpNumWarmUsesAndDefs = FixedVector<float>(gpArraySize, 0);
         m_gpConstDefs.ensureSize(gpArraySize);
+        BitVector gpNonConstDefs = m_gpConstDefs;
+        m_gpConstants = FixedVector<int64_t>(gpArraySize, 0);
+
         unsigned fpArraySize = AbsoluteTmpMapper<FP>::absoluteIndex(code.numTmps(FP));
         m_fpNumWarmUsesAndDefs = FixedVector<float>(fpArraySize, 0);
         m_fpConstDefs.ensureSize(fpArraySize);
+        BitVector fpNonConstDefs = m_fpConstDefs;
 
         for (BasicBlock* block : code) {
             double frequency = block->frequency();
             if (!fastWorklist.saw(block))
                 frequency *= Options::rareBlockPenalty();
             for (Inst& inst : *block) {
+                if ((inst.kind.opcode == Move || inst.kind.opcode == Move32) && inst.args[0].isSomeImm() && inst.args[1].is<Tmp>()) {
+                    Tmp tmp = inst.args[1].as<Tmp>();
+                    if (tmp.bank() == GP) {
+                        auto index = AbsoluteTmpMapper<GP>::absoluteIndex(tmp);
+                        if (!m_gpConstDefs.quickGet(index)) {
+                            m_gpConstDefs.quickSet(index);
+                            m_gpConstants[index] = inst.kind.opcode == Move32 ? static_cast<int64_t>(static_cast<uint64_t>(static_cast<uint32_t>(static_cast<uint64_t>(inst.args[0].value())))) : inst.args[0].value();
+                        } else
+                            gpNonConstDefs.quickSet(index);
+                        m_gpNumWarmUsesAndDefs[index] += frequency;
+                    } else {
+                        auto index = AbsoluteTmpMapper<FP>::absoluteIndex(tmp);
+                        if (!m_fpConstDefs.quickGet(index))
+                            m_fpConstDefs.quickSet(index);
+                        else
+                            fpNonConstDefs.quickSet(index);
+                        m_fpNumWarmUsesAndDefs[index] += frequency;
+                    }
+                    continue;
+                }
+
                 inst.forEach<Tmp>(
                     [&] (Tmp& tmp, Arg::Role role, Bank bank, Width) {
-
                         if (Arg::isWarmUse(role) || Arg::isAnyDef(role)) {
-                            if (bank == GP)
-                                m_gpNumWarmUsesAndDefs[AbsoluteTmpMapper<GP>::absoluteIndex(tmp)] += frequency;
-                            else
-                                m_fpNumWarmUsesAndDefs[AbsoluteTmpMapper<FP>::absoluteIndex(tmp)] += frequency;
+                            if (bank == GP) {
+                                auto index = AbsoluteTmpMapper<GP>::absoluteIndex(tmp);
+                                m_gpNumWarmUsesAndDefs[index] += frequency;
+                                if (Arg::isAnyDef(role))
+                                    gpNonConstDefs.quickSet(index);
+                            } else {
+                                auto index = AbsoluteTmpMapper<FP>::absoluteIndex(tmp);
+                                m_fpNumWarmUsesAndDefs[index] += frequency;
+                                if (Arg::isAnyDef(role))
+                                    fpNonConstDefs.quickSet(index);
+                            }
                         }
                     });
-
-                if ((inst.kind.opcode == Move || inst.kind.opcode == Move32)
-                    && inst.args[0].isSomeImm()
-                    && inst.args[1].is<Tmp>()) {
-                    Tmp tmp = inst.args[1].as<Tmp>();
-                    if (tmp.bank() == GP)
-                        m_gpConstDefs.quickSet(AbsoluteTmpMapper<GP>::absoluteIndex(tmp));
-                    else
-                        m_fpConstDefs.quickSet(AbsoluteTmpMapper<FP>::absoluteIndex(tmp));
-                }
             }
         }
+
+        m_gpConstDefs.exclude(gpNonConstDefs);
+        m_fpConstDefs.exclude(fpNonConstDefs);
     }
 
     template<Bank bank>
     bool isConstDef(unsigned absoluteIndex) const
     {
-        if (bank == GP)
+        if constexpr (bank == GP)
             return m_gpConstDefs.quickGet(absoluteIndex);
-        return m_fpConstDefs.quickGet(absoluteIndex);
+        else
+            return m_fpConstDefs.quickGet(absoluteIndex);
+    }
+
+    template<Bank bank>
+    decltype(auto) constant(unsigned absoluteIndex) const
+    {
+        if constexpr (bank == GP)
+            return m_gpConstants[absoluteIndex];
+        else {
+            RELEASE_ASSERT_NOT_REACHED();
+            return 0.0;
+        }
     }
 
     template<Bank bank>
     float numWarmUsesAndDefs(unsigned absoluteIndex) const
     {
-        if (bank == GP)
+        if constexpr (bank == GP)
             return m_gpNumWarmUsesAndDefs[absoluteIndex];
-        return m_fpNumWarmUsesAndDefs[absoluteIndex];
+        else
+            return m_fpNumWarmUsesAndDefs[absoluteIndex];
     }
 
     void dump(PrintStream& out) const
@@ -121,6 +159,7 @@ private:
     FixedVector<float> m_fpNumWarmUsesAndDefs;
     BitVector m_gpConstDefs;
     BitVector m_fpConstDefs;
+    FixedVector<int64_t> m_gpConstants;
 };
 
 } } } // namespace JSC::B3::Air


### PR DESCRIPTION
#### 3a144e8081a754700d635475cfae53b2b863fab0
<pre>
[JSC] Register allocator should rematerialize constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=277197">https://bugs.webkit.org/show_bug.cgi?id=277197</a>
<a href="https://rdar.apple.com/132619729">rdar://132619729</a>

Reviewed by Justin Michaud.

Our register allocator is not implementing rematerialization part of the
original paper: using constant rematerialization when we spill constants.
This patch implements this feature so that we can rematerialize constant.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp:
* Source/JavaScriptCore/b3/air/AirUseCounts.h:
(JSC::B3::Air::UseCounts::UseCounts):
(JSC::B3::Air::UseCounts::isConstDef const):
(JSC::B3::Air::UseCounts::constant const):
(JSC::B3::Air::UseCounts::numWarmUsesAndDefs const):

Canonical link: <a href="https://commits.webkit.org/281509@main">https://commits.webkit.org/281509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8733e70387a9f10cf0b3c659e311a3c670292ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63990 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10602 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48668 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7402 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29510 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33463 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9272 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9522 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/53166 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65722 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59317 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9425 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56023 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4020 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56175 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3327 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81075 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9008 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35233 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14086 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37403 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36059 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->