### PR TITLE
Only allow IPC messages to WebLockRegistryProxy when WebLock is enabled

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7777,6 +7777,7 @@ WebLocksAPIEnabled:
       default: true
     WebCore:
       default: true
+  sharedPreferenceForWebProcess: true
 
 WebMFormatReaderEnabled:
   type: bool

--- a/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb
@@ -28,18 +28,19 @@
 #include "config.h"
 #include "SharedPreferencesForWebProcess.h"
 
-#include "WebPreferences.h"
+#include "WebPreferencesKeys.h"
+#include "WebPreferencesStore.h"
 
 namespace WebKit {
 
-SharedPreferencesForWebProcess sharedPreferencesForWebProcess(const WebPreferences& preferences)
+SharedPreferencesForWebProcess sharedPreferencesForWebProcess(const WebPreferencesStore& preferencesStore)
 {
     SharedPreferencesForWebProcess sharedPreferences;
 <% for @pref in @sharedPreferencesForWebProcess do -%>
 <%- if @pref.condition -%>
 #if <%= @pref.condition %>
 <%- end -%>
-        sharedPreferences.<%= @pref.nameLower %> = preferences.<%= @pref.nameLower %>();
+        sharedPreferences.<%= @pref.nameLower %> = preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key());
 <%- if @pref.condition -%>
 #endif
 <%- end -%>
@@ -47,14 +48,14 @@ SharedPreferencesForWebProcess sharedPreferencesForWebProcess(const WebPreferenc
     return sharedPreferences;
 }
 
-bool updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess& sharedPreferences, const WebPreferences& preferences)
+bool updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess& sharedPreferences, const WebPreferencesStore& preferencesStore)
 {
     bool didChange = false;
 <% for @pref in @sharedPreferencesForWebProcess do -%>
 <%- if @pref.condition -%>
 #if <%= @pref.condition %>
 <%- end -%>
-    if (preferences.<%= @pref.nameLower %>() && !sharedPreferences.<%= @pref.nameLower %>) {
+    if (preferencesStore.getBoolValueForKey(WebPreferencesKey::<%= @pref.nameLower %>Key()) && !sharedPreferences.<%= @pref.nameLower %>) {
         sharedPreferences.<%= @pref.nameLower %> = true;
         didChange = true;
     }

--- a/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.h.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.h.erb
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-class WebPreferences;
+struct WebPreferencesStore;
 
 struct SharedPreferencesForWebProcess {
     uint64_t version { 0 };
@@ -46,7 +46,7 @@ struct SharedPreferencesForWebProcess {
     bool operator==(const SharedPreferencesForWebProcess&) const = default;
 };
 
-SharedPreferencesForWebProcess sharedPreferencesForWebProcess(const WebPreferences&);
-bool updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&, const WebPreferences&);
+SharedPreferencesForWebProcess sharedPreferencesForWebProcess(const WebPreferencesStore&);
+bool updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&, const WebPreferencesStore&);
 
 } // namespace WebKit

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1287,6 +1287,24 @@ def generate_header_includes_from_conditions(header_conditions):
     return result
 
 
+def generate_enabled_by_for_receiver(receiver, ignore_invalid_message_for_testing, return_value=None):
+    enabled_by = receiver.receiver_enabled_by
+    if not enabled_by:
+        return []
+    runtime_enablement = ' && '.join(['sharedPreferencesForWebProcess().' + preference[0].lower() + preference[1:] for preference in enabled_by])
+    return_statement_line = 'return %s' % return_value if return_value else 'return'
+    return [
+        '    if (!%s) {\n' % ('(%s)' % runtime_enablement if len(enabled_by) > 1 else runtime_enablement),
+        '#if ENABLE(IPC_TESTING_API)\n',
+        '        if (%s)\n' % ignore_invalid_message_for_testing,
+        '            %s;\n' % return_statement_line,
+        '#endif // ENABLE(IPC_TESTING_API)\n',
+        '        ASSERT_NOT_REACHED_WITH_MESSAGE("Message received by a disabled message receiver %s");\n' % receiver.name,
+        '        %s;\n' % return_statement_line,
+        '    }\n',
+    ]
+
+
 def generate_message_handler(receiver):
     header_conditions = {
         '"%s"' % messages_header_filename(receiver): [None],
@@ -1339,6 +1357,7 @@ def generate_message_handler(receiver):
     if receiver.has_attribute(STREAM_ATTRIBUTE):
         result.append('void %s::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Decoder& decoder)\n' % (receiver.name))
         result.append('{\n')
+        result += generate_enabled_by_for_receiver(receiver, 'connection.protectedConnection()->ignoreInvalidMessageForTesting()')
         assert(receiver.has_attribute(NOT_REFCOUNTED_RECEIVER_ATTRIBUTE))
         assert(not receiver.has_attribute(WANTS_DISPATCH_MESSAGE_ATTRIBUTE))
         assert(not receiver.has_attribute(WANTS_ASYNC_DISPATCH_MESSAGE_ATTRIBUTE))
@@ -1362,6 +1381,7 @@ def generate_message_handler(receiver):
         else:
             result.append('void %s::didReceive%sMessage(IPC::Connection& connection, IPC::Decoder& decoder)\n' % (receiver.name, receive_variant))
         result.append('{\n')
+        result += generate_enabled_by_for_receiver(receiver, 'connection.ignoreInvalidMessageForTesting()')
         if not (receiver.has_attribute(NOT_REFCOUNTED_RECEIVER_ATTRIBUTE) or receiver.has_attribute(STREAM_ATTRIBUTE)):
             result.append('    Ref protectedThis { *this };\n')
         result += async_message_statements
@@ -1386,6 +1406,7 @@ def generate_message_handler(receiver):
         result.append('\n')
         result.append('bool %s::didReceiveSync%sMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)\n' % (receiver.name, receiver.name if receiver.has_attribute(LEGACY_RECEIVER_ATTRIBUTE) else ''))
         result.append('{\n')
+        result += generate_enabled_by_for_receiver(receiver, 'connection.ignoreInvalidMessageForTesting()', 'false')
         if not receiver.has_attribute(NOT_REFCOUNTED_RECEIVER_ATTRIBUTE):
             result.append('    Ref protectedThis { *this };\n')
         result += sync_message_statements

--- a/Source/WebKit/Scripts/webkit/model.py
+++ b/Source/WebKit/Scripts/webkit/model.py
@@ -33,14 +33,14 @@ SYNCHRONOUS_ATTRIBUTE = 'Synchronous'
 STREAM_ATTRIBUTE = "Stream"
 
 class MessageReceiver(object):
-    def __init__(self, name, superclass, attributes, messages, condition, namespace):
+    def __init__(self, name, superclass, attributes, receiver_enabled_by, messages, condition, namespace):
         self.name = name
         self.superclass = superclass
         self.attributes = frozenset(attributes or [])
+        self.receiver_enabled_by = receiver_enabled_by
         self.messages = messages
         self.condition = condition
         self.namespace = namespace
-
 
     def iterparameters(self):
         return itertools.chain((parameter for message in self.messages for parameter in message.parameters),
@@ -77,7 +77,7 @@ class Parameter(object):
         return attribute in self.attributes
 
 
-ipc_receiver = MessageReceiver(name="IPC", superclass=None, attributes=[BUILTIN_ATTRIBUTE], messages=[
+ipc_receiver = MessageReceiver(name="IPC", superclass=None, attributes=[BUILTIN_ATTRIBUTE], receiver_enabled_by=None, messages=[
     Message('WrappedAsyncMessageForTesting', [], [], attributes=[BUILTIN_ATTRIBUTE, SYNCHRONOUS_ATTRIBUTE, ALLOWEDWHENWAITINGFORSYNCREPLY_ATTRIBUTE], condition=None),
     Message('SyncMessageReply', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
     Message('InitializeConnection', [], [], attributes=[BUILTIN_ATTRIBUTE], condition="PLATFORM(COCOA)"),
@@ -118,6 +118,6 @@ def generate_global_model(receivers):
         for message in receiver.messages:
             if message.reply_parameters is not None and not message.has_attribute(SYNCHRONOUS_ATTRIBUTE):
                 async_reply_messages.append(Message(name='%s_%sReply' % (receiver.name, message.name), parameters=message.reply_parameters, reply_parameters=[], attributes=None, condition=message.condition))
-    async_reply_receiver = MessageReceiver(name='AsyncReply', superclass='None', attributes=[BUILTIN_ATTRIBUTE], messages=async_reply_messages, condition=None, namespace='WebKit')
+    async_reply_receiver = MessageReceiver(name='AsyncReply', superclass='None', attributes=[BUILTIN_ATTRIBUTE], receiver_enabled_by=None, messages=async_reply_messages, condition=None, namespace='WebKit')
 
     return [ipc_receiver, async_reply_receiver] + receivers

--- a/Source/WebKit/Scripts/webkit/parser.py
+++ b/Source/WebKit/Scripts/webkit/parser.py
@@ -43,6 +43,7 @@ def bracket_if_needed(condition):
 
 
 def parse(file):
+    receiver_enabled_by = None
     receiver_attributes = None
     destination = None
     messages = []
@@ -52,6 +53,10 @@ def parse(file):
     namespace = "WebKit"
     for line in file:
         line = line.strip()
+        match = re.search(r'\s*\[\s*EnabledBy\s*=\s*(?P<enabledby>.*?)\s*\]\s*', line)
+        if match and not receiver_attributes:
+            receiver_enabled_by = match.group('enabledby').split(',')
+            continue
         match = re.search(r'messages -> (?P<namespace>[A-Za-z]+)::(?P<destination>[A-Za-z_0-9]+) \s*(?::\s*(?P<superclass>.*?) \s*)?(?:(?P<attributes>.*?)\s+)?{', line)
         if not match:
             match = re.search(r'messages -> (?P<destination>[A-Za-z_0-9]+) \s*(?::\s*(?P<superclass>.*?) \s*)?(?:(?P<attributes>.*?)\s+)?{', line)
@@ -62,6 +67,8 @@ def parse(file):
             receiver_attributes = parse_attributes_string(match.group('attributes'))
             if match.group('superclass'):
                 superclass = match.group('superclass')
+                if receiver_enabled_by:
+                    raise Exception("ERROR: EnabledBy is not supported for a message receiver with a superclass")
             if conditions:
                 master_condition = conditions
                 conditions = []
@@ -107,7 +114,7 @@ def parse(file):
                 reply_parameters = None
 
             messages.append(model.Message(name, parameters, reply_parameters, attributes, combine_condition(conditions), enabled_if, enabled_by))
-    return model.MessageReceiver(destination, superclass, receiver_attributes, messages, combine_condition(master_condition), namespace)
+    return model.MessageReceiver(destination, superclass, receiver_attributes, receiver_enabled_by, messages, combine_condition(master_condition), namespace)
 
 
 def parse_attributes_string(attributes_string):

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIf.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIf.messages.in
@@ -20,6 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[EnabledBy=SomeFeature]
 messages -> TestWithEnabledIf {
     AlwaysEnabled(String url)
     [EnabledIf='featureEnabled()'] OnlyEnabledIfFeatureEnabled(String url)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp
@@ -39,6 +39,14 @@ namespace WebKit {
 
 void TestWithEnabledIf::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
+    if (!sharedPreferencesForWebProcess().someFeature) {
+#if ENABLE(IPC_TESTING_API)
+        if (connection.ignoreInvalidMessageForTesting())
+            return;
+#endif // ENABLE(IPC_TESTING_API)
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Message received by a disabled message receiver TestWithEnabledIf");
+        return;
+    }
     Ref protectedThis { *this };
     if (decoder.messageName() == Messages::TestWithEnabledIf::AlwaysEnabled::name())
         return IPC::handleMessage<Messages::TestWithEnabledIf::AlwaysEnabled>(connection, decoder, this, &TestWithEnabledIf::alwaysEnabled);

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.h
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.h
@@ -26,13 +26,10 @@
 #pragma once
 
 #include "MessageReceiver.h"
+#include "WebProcessProxy.h"
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <WebCore/WebLockIdentifier.h>
 #include <WebCore/WebLockMode.h>
-
-namespace WebKit {
-class WebLockRegistryProxy;
-}
 
 namespace WTF {
 template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
@@ -46,13 +43,16 @@ struct WebLockManagerSnapshot;
 
 namespace WebKit {
 
-class WebProcessProxy;
+class WebLockRegistryProxy;
+struct SharedPreferencesForWebProcess;
 
 class WebLockRegistryProxy final : public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit WebLockRegistryProxy(WebProcessProxy&);
     ~WebLockRegistryProxy();
+
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() { return *m_process.sharedPreferencesForWebProcess(); }
 
     void processDidExit();
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.messages.in
@@ -20,6 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[EnabledBy=WebLocksAPIEnabled]
 messages -> WebLockRegistryProxy NotRefCounted {
     RequestLock(struct WebCore::ClientOrigin clientOrigin, WebCore::WebLockIdentifier identifier, WebCore::ScriptExecutionContextIdentifier clientID, String name, enum:bool WebCore::WebLockMode mode, bool steal, bool ifAvailable)
     ReleaseLock(struct WebCore::ClientOrigin clientOrigin, WebCore::WebLockIdentifier identifier, WebCore::ScriptExecutionContextIdentifier clientID, String name)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1178,8 +1178,8 @@ void WebPageProxy::handleSynchronousMessage(IPC::Connection& connection, const S
 
 bool WebPageProxy::hasSameGPUAndNetworkProcessPreferencesAs(const API::PageConfiguration& configuration) const
 {
-    auto sharedPreferences = sharedPreferencesForWebProcess(preferences());
-    return !updateSharedPreferencesForWebProcess(sharedPreferences, configuration.preferences());
+    auto sharedPreferences = sharedPreferencesForWebProcess(preferences().store());
+    return !updateSharedPreferencesForWebProcess(sharedPreferences, configuration.preferences().store());
 }
 
 void WebPageProxy::launchProcess(const RegistrableDomain& registrableDomain, ProcessLaunchReason reason)
@@ -5888,7 +5888,7 @@ void WebPageProxy::preferencesDidChange()
     // Preferences need to be updated during synchronous printing to make "print backgrounds" preference work when toggled from a print dialog checkbox.
     forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         std::optional<uint64_t> sharedPreferencesVersion;
-        if (auto sharedPreferences = webProcess.updateSharedPreferencesForWebProcess(preferences())) {
+        if (auto sharedPreferences = webProcess.updateSharedPreferencesForWebProcess(preferences().store())) {
             sharedPreferencesVersion = sharedPreferences->version;
             if (RefPtr networkProcess = websiteDataStore().networkProcessIfExists()) {
                 networkProcess->sharedPreferencesForWebProcessDidChange(webProcess, WTFMove(*sharedPreferences), [weakWebProcess = WeakPtr { webProcess }, syncedVersion = sharedPreferences->version]() {

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -475,12 +475,12 @@ void WebProcessProxy::initializeWebProcess(WebProcessCreationParameters&& parame
 void WebProcessProxy::initializePreferencesForGPUAndNetworkProcesses(const WebPageProxy& page)
 {
     if (!m_sharedPreferencesForWebProcess) {
-        updateSharedPreferencesForWebProcess(page.preferences());
+        updateSharedPreferencesForWebProcess(page.preferences().store());
         ASSERT(m_sharedPreferencesForWebProcess);
     } else {
 #if ASSERT_ENABLED
         auto sharedPreferencesForWebProcess = *m_sharedPreferencesForWebProcess;
-        ASSERT(!WebKit::updateSharedPreferencesForWebProcess(sharedPreferencesForWebProcess, page.preferences()));
+        ASSERT(!WebKit::updateSharedPreferencesForWebProcess(sharedPreferencesForWebProcess, page.preferences().store()));
 #endif
     }
 
@@ -490,7 +490,7 @@ bool WebProcessProxy::hasSameGPUAndNetworkProcessPreferencesAs(const API::PageCo
 {
     if (m_sharedPreferencesForWebProcess) {
         auto sharedPreferencesForWebProcess = *m_sharedPreferencesForWebProcess;
-        if (WebKit::updateSharedPreferencesForWebProcess(sharedPreferencesForWebProcess, pageConfiguration.preferences()))
+        if (WebKit::updateSharedPreferencesForWebProcess(sharedPreferencesForWebProcess, pageConfiguration.preferences().store()))
             return false;
     }
     return true;
@@ -2181,14 +2181,14 @@ Ref<WebProcessPool> WebProcessProxy::protectedProcessPool() const
     return processPool();
 }
 
-std::optional<SharedPreferencesForWebProcess> WebProcessProxy::updateSharedPreferencesForWebProcess(const WebPreferences& preferences)
+std::optional<SharedPreferencesForWebProcess> WebProcessProxy::updateSharedPreferencesForWebProcess(const WebPreferencesStore& preferencesStore)
 {
     if (!m_sharedPreferencesForWebProcess) {
-        m_sharedPreferencesForWebProcess = WebKit::sharedPreferencesForWebProcess(preferences);
+        m_sharedPreferencesForWebProcess = WebKit::sharedPreferencesForWebProcess(preferencesStore);
         m_sharedPreferencesForWebProcess->version = 1;
         return m_sharedPreferencesForWebProcess;
     }
-    if (WebKit::updateSharedPreferencesForWebProcess(*m_sharedPreferencesForWebProcess, preferences)) {
+    if (WebKit::updateSharedPreferencesForWebProcess(*m_sharedPreferencesForWebProcess, preferencesStore)) {
         ++m_sharedPreferencesForWebProcess->version;
         return m_sharedPreferencesForWebProcess;
     }
@@ -2365,6 +2365,8 @@ void WebProcessProxy::endBackgroundActivityForFullscreenInput()
 
 void WebProcessProxy::establishRemoteWorkerContext(RemoteWorkerType workerType, const WebPreferencesStore& store, const RegistrableDomain& registrableDomain, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, CompletionHandler<void()>&& completionHandler)
 {
+    if (!m_sharedPreferencesForWebProcess)
+        updateSharedPreferencesForWebProcess(store);
     WEBPROCESSPROXY_RELEASE_LOG(Loading, "establishRemoteWorkerContext: Started (workerType=%" PUBLIC_LOG_STRING ")", workerType == RemoteWorkerType::ServiceWorker ? "service" : "shared");
     markProcessAsRecentlyUsed();
     auto& remoteWorkerInformation = workerType == RemoteWorkerType::ServiceWorker ? m_serviceWorkerInformation : m_sharedWorkerInformation;

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -190,7 +190,7 @@ public:
     Ref<WebProcessPool> protectedProcessPool() const;
 
     const std::optional<SharedPreferencesForWebProcess>& sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
-    std::optional<SharedPreferencesForWebProcess> updateSharedPreferencesForWebProcess(const WebPreferences&);
+    std::optional<SharedPreferencesForWebProcess> updateSharedPreferencesForWebProcess(const WebPreferencesStore&);
     void didSyncSharedPreferencesForWebProcessWithNetworkProcess(uint64_t syncedPreferencesVersion);
 #if ENABLE(GPU_PROCESS)
     void didSyncSharedPreferencesForWebProcessWithGPUProcess(uint64_t syncedPreferencesVersion);


### PR DESCRIPTION
#### ead5451c43452e5fd76242d7eb0859bffd804794
<pre>
Only allow IPC messages to WebLockRegistryProxy when WebLock is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=277201">https://bugs.webkit.org/show_bug.cgi?id=277201</a>

Reviewed by Sihui Liu.

This PR adds the support for specifying a runtime enablement of a message receiver and deploys
it in WebLockRegistryProxy so that it accepts IPC messages only when WebLock is enabled.

This PR also fixes a bug in WebProcessProxy that it could send/receive messages before
SharedPreferencesForWebProcess is initialized for a service worker&apos;s WebContent process by
ensuring the shared preferences are set in WebProcessProxy::establishRemoteWorkerContext.

Because we don&apos;t sometimes have access to WebPreferences (in particular, when it&apos;s establishing
remote worker context in WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess)
when initializing service worker&apos;s WebContent process, this PR also updates
SharedPreferencesForWebProcess to take WebPreferencesStore instead of WebPreferences.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.cpp.erb:
* Source/WebKit/Scripts/PreferencesTemplates/SharedPreferencesForWebProcess.h.erb:
* Source/WebKit/Scripts/webkit/messages.py:
(generate_enabled_by_for_receiver):
(generate_message_handler):
* Source/WebKit/Scripts/webkit/model.py:
(MessageReceiver.__init__):
(generate_global_model):
* Source/WebKit/Scripts/webkit/parser.py:
(parse):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledIf.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp:
(WebKit::TestWithEnabledIf::didReceiveMessage):
* Source/WebKit/UIProcess/WebLockRegistryProxy.h:
* Source/WebKit/UIProcess/WebLockRegistryProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::hasSameGPUAndNetworkProcessPreferencesAs const):
(WebKit::WebPageProxy::preferencesDidChange):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::initializePreferencesForGPUAndNetworkProcesses):
(WebKit::WebProcessProxy::hasSameGPUAndNetworkProcessPreferencesAs const):
(WebKit::WebProcessProxy::updateSharedPreferencesForWebProcess):
(WebKit::WebProcessProxy::establishRemoteWorkerContext):
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/281517@main">https://commits.webkit.org/281517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09cf5bc2cba7a0ec8568eaa91087fa309be77931

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64063 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10675 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48720 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7456 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29562 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/59672 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9335 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9595 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/53239 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65795 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59390 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56076 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56230 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3392 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81148 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9014 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35306 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14097 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37476 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->