### PR TITLE
[UnifiedPDF] AsyncPDFRenderer should not communicate with the PDF plugin

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -86,7 +86,7 @@ template<> struct DefaultHash<WebKit::TileForGrid> : TileForGridHash { };
 
 namespace WebKit {
 
-class UnifiedPDFPlugin;
+class PDFPresentationController;
 
 struct PDFTileRenderType;
 using PDFTileRenderIdentifier = ObjectIdentifier<PDFTileRenderType>;
@@ -96,7 +96,7 @@ class AsyncPDFRenderer final : public WebCore::TiledBackingClient,
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(AsyncPDFRenderer);
 public:
-    static Ref<AsyncPDFRenderer> create(UnifiedPDFPlugin&);
+    static Ref<AsyncPDFRenderer> create(PDFPresentationController&);
 
     virtual ~AsyncPDFRenderer();
 
@@ -122,7 +122,7 @@ public:
     void setShowDebugBorders(bool);
 
 private:
-    AsyncPDFRenderer(UnifiedPDFPlugin&);
+    AsyncPDFRenderer(PDFPresentationController&);
 
     WebCore::GraphicsLayer* layerForTileGrid(WebCore::TileGridIdentifier) const;
 
@@ -173,7 +173,7 @@ private:
 
     void paintPagePreviewOnWorkQueue(RetainPtr<PDFDocument>&&, const PagePreviewRequest&);
     void didCompletePagePreviewRender(RefPtr<WebCore::ImageBuffer>&&, const PagePreviewRequest&);
-    void removePagePreviewsOutsideCoverageRect(const WebCore::FloatRect&);
+    void removePagePreviewsOutsideCoverageRect(const WebCore::FloatRect&, const std::optional<PDFLayoutRow>& = { });
 
     void paintPDFPageIntoBuffer(RetainPtr<PDFDocument>&&, Ref<WebCore::ImageBuffer>, PDFDocumentLayout::PageIndex, const WebCore::FloatRect& pageBounds);
 
@@ -181,8 +181,7 @@ private:
     static WebCore::AffineTransform tileToPaintingTransform(float tilingScaleFactor);
     static WebCore::AffineTransform paintingToTileTransform(float tilingScaleFactor);
 
-    // FIXME: <https://webkit.org/b/276981> Point to the presentation controller.
-    ThreadSafeWeakPtr<UnifiedPDFPlugin> m_plugin;
+    ThreadSafeWeakPtr<PDFPresentationController> m_presentationController;
 
     HashMap<WebCore::PlatformLayerIdentifier, Ref<WebCore::GraphicsLayer>> m_layerIDtoLayerMap;
     HashMap<WebCore::TileGridIdentifier, WebCore::PlatformLayerIdentifier> m_tileGridToLayerIDMap;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
@@ -36,6 +36,8 @@ class PlatformWheelEvent;
 
 namespace WebKit {
 
+class UnifiedPDFPlugin;
+
 enum class PageTransitionState : uint8_t {
     Idle,
     DeterminingStretchAxis,

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -80,7 +80,7 @@ public:
 
     RetainPtr<PDFPage> pageAtIndex(PageIndex) const;
     std::optional<PageIndex> indexForPage(RetainPtr<PDFPage>) const;
-    PageIndex nearestPageIndexForDocumentPoint(WebCore::FloatPoint, std::optional<PDFLayoutRow>) const;
+    PageIndex nearestPageIndexForDocumentPoint(WebCore::FloatPoint, const std::optional<PDFLayoutRow>&) const;
 
     // For the given Y offset, return a page index and page point for the page at this offset. Returns the leftmost
     // page if two-up and both pages intersect that offset, otherwise the right page if only it intersects the offset.

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -88,7 +88,7 @@ auto PDFDocumentLayout::indexForPage(RetainPtr<PDFPage> page) const -> std::opti
     return std::nullopt;
 }
 
-PDFDocumentLayout::PageIndex PDFDocumentLayout::nearestPageIndexForDocumentPoint(FloatPoint documentSpacePoint, std::optional<PDFLayoutRow> visibleRow) const
+PDFDocumentLayout::PageIndex PDFDocumentLayout::nearestPageIndexForDocumentPoint(FloatPoint documentSpacePoint, const std::optional<PDFLayoutRow>& visibleRow) const
 {
     auto pageCount = this->pageCount();
     ASSERT(pageCount);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
@@ -30,19 +30,20 @@
 
 #include "AsyncPDFRenderer.h"
 #include "PDFDiscretePresentationController.h"
+#include "PDFKitSPI.h"
 #include "PDFScrollingPresentationController.h"
 #include <WebCore/GraphicsLayer.h>
 
 namespace WebKit {
 using namespace WebCore;
 
-std::unique_ptr<PDFPresentationController> PDFPresentationController::createForMode(PDFDocumentLayout::DisplayMode mode, UnifiedPDFPlugin& plugin)
+RefPtr<PDFPresentationController> PDFPresentationController::createForMode(PDFDocumentLayout::DisplayMode mode, UnifiedPDFPlugin& plugin)
 {
     if (PDFDocumentLayout::isScrollingDisplayMode(mode))
-        return makeUnique<PDFScrollingPresentationController>(plugin);
+        return adoptRef(*new PDFScrollingPresentationController { plugin });
 
     if (PDFDocumentLayout::isDiscreteDisplayMode(mode))
-        return makeUnique<PDFDiscretePresentationController>(plugin);
+        return adoptRef(*new PDFDiscretePresentationController { plugin });
 
     ASSERT_NOT_REACHED();
     return nullptr;
@@ -66,7 +67,7 @@ Ref<AsyncPDFRenderer> PDFPresentationController::asyncRenderer()
     if (m_asyncRenderer)
         return *m_asyncRenderer;
 
-    m_asyncRenderer = AsyncPDFRenderer::create(m_plugin.get());
+    m_asyncRenderer = AsyncPDFRenderer::create(*this);
     return *m_asyncRenderer;
 }
 
@@ -149,6 +150,21 @@ void PDFPresentationController::releaseMemory()
 {
     if (RefPtr asyncRenderer = asyncRendererIfExists())
         asyncRenderer->releaseMemory();
+}
+
+RetainPtr<PDFDocument> PDFPresentationController::pluginPDFDocument() const
+{
+    return m_plugin->pdfDocument();
+}
+
+FloatRect PDFPresentationController::layoutBoundsForPageAtIndex(PDFDocumentLayout::PageIndex pageIndex) const
+{
+    return m_plugin->layoutBoundsForPageAtIndex(pageIndex);
+}
+
+bool PDFPresentationController::pluginShouldCachePagePreviews() const
+{
+    return m_plugin->shouldCachePagePreviews();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -101,6 +101,9 @@ bool PDFScrollingPresentationController::handleKeyboardCommand(const WebKeyboard
 
 PDFPageCoverage PDFScrollingPresentationController::pageCoverageForContentsRect(const FloatRect& contentsRect, std::optional<PDFLayoutRow>) const
 {
+    if (m_plugin->visibleOrDocumentSizeIsEmpty())
+        return { };
+
     auto drawingRect = IntRect { { }, m_plugin->documentSize() };
     drawingRect.intersect(enclosingIntRect(contentsRect));
     auto rectInPDFLayoutCoordinates = m_plugin->convertDown(UnifiedPDFPlugin::CoordinateSpace::Contents, UnifiedPDFPlugin::CoordinateSpace::PDFDocumentLayout, FloatRect { drawingRect });
@@ -112,7 +115,7 @@ PDFPageCoverage PDFScrollingPresentationController::pageCoverageForContentsRect(
         if (!page)
             continue;
 
-        auto pageBounds = documentLayout.layoutBoundsForPageAtIndex(i);
+        auto pageBounds = layoutBoundsForPageAtIndex(i);
         if (!pageBounds.intersects(rectInPDFLayoutCoordinates))
             continue;
 
@@ -124,6 +127,9 @@ PDFPageCoverage PDFScrollingPresentationController::pageCoverageForContentsRect(
 
 PDFPageCoverageAndScales PDFScrollingPresentationController::pageCoverageAndScalesForContentsRect(const FloatRect& clipRect, std::optional<PDFLayoutRow> row, float tilingScaleFactor) const
 {
+    if (m_plugin->visibleOrDocumentSizeIsEmpty())
+        return { { }, { }, 1, 1, 1 };
+
     auto pageCoverageAndScales = PDFPageCoverageAndScales { pageCoverageForContentsRect(clipRect, row) };
 
     pageCoverageAndScales.deviceScaleFactor = m_plugin->deviceScaleFactor();
@@ -197,7 +203,7 @@ void PDFScrollingPresentationController::updatePageBackgroundLayers()
     // buffer of the same size. On zooming, this layer just gets scaled, to avoid repainting.
 
     for (PDFDocumentLayout::PageIndex i = 0; i < documentLayout.pageCount(); ++i) {
-        auto pageBoundsRect = documentLayout.layoutBoundsForPageAtIndex(i);
+        auto pageBoundsRect = layoutBoundsForPageAtIndex(i);
         auto destinationRect = pageBoundsRect;
         destinationRect.scale(documentLayout.scale());
 
@@ -335,8 +341,7 @@ void PDFScrollingPresentationController::setNeedsRepaintInDocumentRect(OptionSet
 
 void PDFScrollingPresentationController::paintBackgroundLayerForPage(const GraphicsLayer*, GraphicsContext& context, const FloatRect& clipRect, PDFDocumentLayout::PageIndex pageIndex)
 {
-    auto& documentLayout = m_plugin->documentLayout();
-    auto destinationRect = documentLayout.layoutBoundsForPageAtIndex(pageIndex);
+    auto destinationRect = layoutBoundsForPageAtIndex(pageIndex);
     destinationRect.setLocation({ });
 
     if (RefPtr asyncRenderer = asyncRendererIfExists())

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -270,6 +270,7 @@ private:
 
     WebCore::IntSize documentSize() const;
     WebCore::IntSize contentsSize() const override;
+    bool visibleOrDocumentSizeIsEmpty() const { return m_size.isEmpty() || documentSize().isEmpty(); }
     unsigned firstPageHeight() const override;
     unsigned heightForPageAtIndex(PDFDocumentLayout::PageIndex) const;
     WebCore::FloatRect layoutBoundsForPageAtIndex(PDFDocumentLayout::PageIndex) const;
@@ -434,18 +435,12 @@ private:
     void paintContents(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect&, OptionSet<WebCore::GraphicsLayerPaintBehavior>) override;
     float pageScaleFactor() const override;
 
-    // Package up the data needed to paint a set of pages for the given clip, for use by UnifiedPDFPlugin::paintPDFContent and async rendering.
-    PDFPageCoverage pageCoverageForContentsRect(const WebCore::FloatRect& clipRect, std::optional<PDFLayoutRow>) const;
-    PDFPageCoverageAndScales pageCoverageAndScalesForContentsRect(const WebCore::FloatRect& clipRect, std::optional<PDFLayoutRow>, float tilingScaleFactor) const;
-
     enum class PaintingBehavior : bool { All, PageContentsOnly };
-    void paintPDFContent(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect, std::optional<PDFLayoutRow> = { }, PaintingBehavior = PaintingBehavior::All, AsyncPDFRenderer* = nullptr);
+    void paintPDFContent(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect, const std::optional<PDFLayoutRow>& = { }, PaintingBehavior = PaintingBehavior::All, AsyncPDFRenderer* = nullptr);
 #if ENABLE(UNIFIED_PDF_SELECTION_LAYER)
     void paintPDFSelection(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect, std::optional<PDFLayoutRow> = { });
 #endif
     bool canPaintSelectionIntoOwnedLayer() const;
-
-    std::optional<PDFLayoutRow> rowForLayerID(WebCore::PlatformLayerIdentifier) const;
 
     void willChangeVisibleRow();
     void didChangeVisibleRow();
@@ -554,7 +549,6 @@ private:
     bool shouldShowDebugIndicators() const;
 
     float scaleForPagePreviews() const;
-    void didGeneratePreviewForPage(PDFDocumentLayout::PageIndex);
 
 #if PLATFORM(MAC)
     void createPasswordEntryForm();
@@ -565,11 +559,11 @@ private:
 
     WebCore::PlatformWheelEvent wheelEventCopyWithVelocity(const WebCore::PlatformWheelEvent&) const;
 
-    void setPresentationController(std::unique_ptr<PDFPresentationController>&&);
+    void setPresentationController(RefPtr<PDFPresentationController>&&);
 
     WebCore::FloatRect pageBoundsInContentsSpace(PDFDocumentLayout::PageIndex) const;
 
-    std::unique_ptr<PDFPresentationController> m_presentationController;
+    RefPtr<PDFPresentationController> m_presentationController;
 
     PDFDocumentLayout m_documentLayout;
     RefPtr<WebCore::GraphicsLayer> m_rootLayer;


### PR DESCRIPTION
#### 4e6afee99ec042dde4ed258a4d655e44cd70e371
<pre>
[UnifiedPDF] AsyncPDFRenderer should not communicate with the PDF plugin
<a href="https://bugs.webkit.org/show_bug.cgi?id=277205">https://bugs.webkit.org/show_bug.cgi?id=277205</a>
<a href="https://rdar.apple.com/132633659">rdar://132633659</a>

Reviewed by Simon Fraser.

The async renderer is owned by the presentation controller. The PDF
plugin owns (and creates/destroys on demand) different presentation
controllers over its lifecycle.

In this patch, we choose not to couple the async renderer to a PDF
plugin, but instead to query the presentation controller about
information such as layout, or to delegate some work to the presentation
controller, such as painting background layers. The controller can
choose to gather this data or pass on the work as it sees fit, often in
coordination with the PDF plugin.

This change makes the architecture simpler to reason about, since there
is a plugin that interacts with the web content process, and said plugin
manages, at a time, a single presentation controller and renderer entity,
with no reason for the renderer or the plugin to communicate with each
other.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::create):
(WebKit::AsyncPDFRenderer::AsyncPDFRenderer):
(WebKit::AsyncPDFRenderer::releaseMemory):
(WebKit::AsyncPDFRenderer::generatePreviewImageForPage):
(WebKit::AsyncPDFRenderer::didCompletePagePreviewRender):
(WebKit::AsyncPDFRenderer::coverageRectDidChange):
(WebKit::AsyncPDFRenderer::removePagePreviewsOutsideCoverageRect):
(WebKit::AsyncPDFRenderer::renderInfoForTile const):
(WebKit::AsyncPDFRenderer::enqueuePaintWithClip):
(WebKit::AsyncPDFRenderer::serviceRequestQueue):
(WebKit::AsyncPDFRenderer::transferBufferToMainThread):
(WebKit::AsyncPDFRenderer::pdfContentChangedInRect):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::pageCoverageForContentsRect const):
(WebKit::PDFDiscretePresentationController::pageCoverageAndScalesForContentsRect const):
(WebKit::PDFDiscretePresentationController::updateLayersOnLayoutChange):
(WebKit::PDFDiscretePresentationController::paintBackgroundLayerForRow):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::nearestPageIndexForDocumentPoint const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm:
(WebKit::PDFPresentationController::createForMode):
(WebKit::PDFPresentationController::asyncRenderer):
(WebKit::PDFPresentationController::pluginPDFDocument const):
(WebKit::PDFPresentationController::layoutBoundsForPageAtIndex const):
(WebKit::PDFPresentationController::pluginShouldCachePagePreviews const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::pageCoverageForContentsRect const):
(WebKit::PDFScrollingPresentationController::pageCoverageAndScalesForContentsRect const):
(WebKit::PDFScrollingPresentationController::updatePageBackgroundLayers):
(WebKit::PDFScrollingPresentationController::paintBackgroundLayerForPage):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::setPresentationController):
(WebKit::UnifiedPDFPlugin::paintPDFContent):
(WebKit::UnifiedPDFPlugin::paintPDFSelection):

Account for the deleted plugin methods by replacing calls with namesake
methods exposed through the PDFPresentationController.

(WebKit::UnifiedPDFPlugin::didGeneratePreviewForPage): Deleted.
(WebKit::UnifiedPDFPlugin::pageCoverageForContentsRect const): Deleted.
(WebKit::UnifiedPDFPlugin::pageCoverageAndScalesForContentsRect const): Deleted.
(WebKit::UnifiedPDFPlugin::rowForLayerID const): Deleted.

Remove these methods that are not called anymore. The presentation
controller has enough information, and can ask enough questions to the
plugin, to be able to field these requests itself.

Canonical link: <a href="https://commits.webkit.org/281515@main">https://commits.webkit.org/281515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43a5c3678a7933c6374fe8b863505b2fb502f3c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64002 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10614 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48678 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7412 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29520 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33474 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9534 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65734 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9434 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56033 "Found 2 new test failures: fast/editing/document-leak-altered-text-field.html webgl/2.0.0/conformance/canvas/rapid-resizing.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56185 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3338 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9012 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35245 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36327 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36071 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->