### PR TITLE
Add CSSValue types for the shape() function

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -829,6 +829,7 @@ css/BasicShapeConversion.cpp
 css/CSSAnchorValue.cpp
 css/CSSAspectRatioValue.cpp
 css/CSSBackgroundRepeatValue.cpp
+css/CSSShapeSegmentValue.cpp
 css/CSSBasicShapes.cpp
 css/CSSBorderImage.cpp
 css/CSSBorderImageSliceValue.cpp

--- a/Source/WebCore/css/CSSBasicShapes.cpp
+++ b/Source/WebCore/css/CSSBasicShapes.cpp
@@ -130,6 +130,8 @@ bool CSSCircleValue::equals(const CSSCircleValue& other) const
         && compareCSSValuePtr(m_radius, other.m_radius);
 }
 
+// MARK: -
+
 CSSEllipseValue::CSSEllipseValue(RefPtr<CSSValue>&& radiusX, RefPtr<CSSValue>&& radiusY, RefPtr<CSSValue>&& centerX, RefPtr<CSSValue>&& centerY)
     : CSSValue(EllipseClass)
     , m_radiusX(WTFMove(radiusX))
@@ -198,6 +200,8 @@ bool CSSEllipseValue::equals(const CSSEllipseValue& other) const
         && compareCSSValuePtr(m_radiusX, other.m_radiusX)
         && compareCSSValuePtr(m_radiusY, other.m_radiusY);
 }
+
+// MARK: -
 
 CSSXywhValue::CSSXywhValue(Ref<CSSValue>&& insetX, Ref<CSSValue>&& insetY, Ref<CSSValue>&& width, Ref<CSSValue>&& height, RefPtr<CSSValue>&& topLeftRadius, RefPtr<CSSValue>&& topRightRadius, RefPtr<CSSValue>&& bottomRightRadius, RefPtr<CSSValue>&& bottomLeftRadius)
     : CSSValue(XywhShapeClass)
@@ -317,6 +321,8 @@ String CSSXywhValue::customCSSText() const
         bottomRightRadiusWidth, bottomRightRadiusHeight, bottomLeftRadiusWidth, bottomLeftRadiusHeight);
 }
 
+// MARK: -
+
 CSSRectShapeValue::CSSRectShapeValue(Ref<CSSValue>&& top, Ref<CSSValue>&& right, Ref<CSSValue>&& bottom, Ref<CSSValue>&& left, RefPtr<CSSValue>&& topLeftRadius, RefPtr<CSSValue>&& topRightRadius, RefPtr<CSSValue>&& bottomRightRadius, RefPtr<CSSValue>&& bottomLeftRadius)
     : CSSValue(RectShapeClass)
     , m_top(WTFMove(top))
@@ -383,6 +389,8 @@ String CSSRectShapeValue::customCSSText() const
         bottomRightRadiusWidth, bottomRightRadiusHeight, bottomLeftRadiusWidth, bottomLeftRadiusHeight);
 }
 
+// MARK: -
+
 CSSPathValue::CSSPathValue(SVGPathByteStream data, WindRule rule)
     : CSSValue(PathClass)
     , m_pathData(WTFMove(data))
@@ -414,13 +422,15 @@ bool CSSPathValue::equals(const CSSPathValue& other) const
     return m_pathData == other.m_pathData && m_windRule == other.m_windRule;
 }
 
-CSSPolygonValue::CSSPolygonValue(CSSValueListBuilder values, WindRule rule)
+// MARK: -
+
+CSSPolygonValue::CSSPolygonValue(CSSValueListBuilder&& values, WindRule rule)
     : CSSValueContainingVector(PolygonClass, SpaceSeparator, WTFMove(values))
     , m_windRule(rule)
 {
 }
 
-Ref<CSSPolygonValue> CSSPolygonValue::create(CSSValueListBuilder values, WindRule rule)
+Ref<CSSPolygonValue> CSSPolygonValue::create(CSSValueListBuilder&& values, WindRule rule)
 {
     return adoptRef(*new CSSPolygonValue(WTFMove(values), rule));
 }
@@ -443,6 +453,8 @@ bool CSSPolygonValue::equals(const CSSPolygonValue& other) const
 {
     return m_windRule == other.m_windRule && itemsEqual(other);
 }
+
+// MARK: -
 
 CSSInsetShapeValue::CSSInsetShapeValue(Ref<CSSValue>&& top, Ref<CSSValue>&& right, Ref<CSSValue>&& bottom, Ref<CSSValue>&& left, RefPtr<CSSValue>&& topLeftRadius, RefPtr<CSSValue>&& topRightRadius, RefPtr<CSSValue>&& bottomRightRadius, RefPtr<CSSValue>&& bottomLeftRadius)
     : CSSValue(InsetShapeClass)
@@ -520,6 +532,32 @@ bool CSSInsetShapeValue::equals(const CSSInsetShapeValue& other) const
         && compareCSSValuePtr(m_topRightRadius, other.m_topRightRadius)
         && compareCSSValuePtr(m_bottomRightRadius, other.m_bottomRightRadius)
         && compareCSSValuePtr(m_bottomLeftRadius, other.m_bottomLeftRadius);
+}
+
+// MARK: -
+
+Ref<CSSShapeValue> CSSShapeValue::create(WindRule windRule, Ref<CSSValuePair>&& fromCoordinates, CSSValueListBuilder&& shapeSegments)
+{
+    return adoptRef(*new CSSShapeValue(windRule, WTFMove(fromCoordinates), WTFMove(shapeSegments)));
+}
+
+CSSShapeValue::CSSShapeValue(WindRule windRule, Ref<CSSValuePair>&& fromCoordinates, CSSValueListBuilder&& shapeCommands)
+    : CSSValueContainingVector(ShapeClass, CommaSeparator, WTFMove(shapeCommands))
+    , m_fromCoordinates(WTFMove(fromCoordinates))
+    , m_windRule(windRule)
+{
+}
+
+String CSSShapeValue::customCSSText() const
+{
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return ""_s;
+}
+
+bool CSSShapeValue::equals(const CSSShapeValue&) const
+{
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSBasicShapes.h
+++ b/Source/WebCore/css/CSSBasicShapes.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "CSSValueList.h"
+#include "CSSValuePair.h"
 #include "SVGPathByteStream.h"
 #include <wtf/UniqueRef.h>
 
@@ -193,7 +194,7 @@ private:
 
 class CSSPolygonValue final : public CSSValueContainingVector {
 public:
-    static Ref<CSSPolygonValue> create(CSSValueListBuilder values, WindRule);
+    static Ref<CSSPolygonValue> create(CSSValueListBuilder&& values, WindRule);
 
     WindRule windRule() const { return m_windRule; }
 
@@ -201,7 +202,7 @@ public:
     bool equals(const CSSPolygonValue&) const;
 
 private:
-    explicit CSSPolygonValue(CSSValueListBuilder, WindRule);
+    explicit CSSPolygonValue(CSSValueListBuilder&&, WindRule);
 
     WindRule m_windRule { };
 };
@@ -299,7 +300,6 @@ public:
     String customCSSText() const;
     bool equals(const CSSXywhValue&) const;
 
-
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
     {
         if (func(m_insetX.get()) == IterationStatus::Done)
@@ -360,6 +360,25 @@ private:
     WindRule m_windRule { };
 };
 
+class CSSShapeValue final : public CSSValueContainingVector {
+public:
+    static Ref<CSSShapeValue> create(WindRule, Ref<CSSValuePair>&& fromCoordinates, CSSValueListBuilder&& shapeSegments);
+
+    WindRule windRule() const { return m_windRule; }
+
+    String customCSSText() const;
+    bool equals(const CSSShapeValue&) const;
+
+    const CSSValue& fromCoordinates() const { return m_fromCoordinates; }
+    Ref<CSSValue> protectedFromCoordinates() const { return m_fromCoordinates; }
+
+private:
+    CSSShapeValue(WindRule, Ref<CSSValuePair>&& fromCoordinates, CSSValueListBuilder&& shapeSegments);
+
+    Ref<CSSValue> m_fromCoordinates;
+    WindRule m_windRule { WindRule::NonZero };
+};
+
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSCircleValue, isCircle())
@@ -368,4 +387,5 @@ SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSInsetShapeValue, isInsetShape())
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSPolygonValue, isPolygon())
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSPathValue, isPath())
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSRectShapeValue, isRectShape())
+SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSShapeValue, isShape())
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSXywhValue, isXywhShape())

--- a/Source/WebCore/css/CSSShapeSegmentValue.cpp
+++ b/Source/WebCore/css/CSSShapeSegmentValue.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2022 Noam Rosenthal All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSShapeSegmentValue.h"
+
+#include "BasicShapes.h"
+#include "CSSPrimitiveValue.h"
+#include "CSSToLengthConversionData.h"
+#include "CSSValuePair.h"
+#include <wtf/text/StringBuilder.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+Ref<CSSShapeSegmentValue> CSSShapeSegmentValue::createMove(CoordinateAffinity affinity, Ref<CSSValue>&& offset)
+{
+    auto data = makeUnique<ShapeSegmentData>(SegmentDataType::Base, affinity, WTFMove(offset));
+    return CSSShapeSegmentValue::create(SegmentType::Move, WTFMove(data));
+}
+
+Ref<CSSShapeSegmentValue> CSSShapeSegmentValue::createLine(CoordinateAffinity affinity, Ref<CSSValue>&& offset)
+{
+    auto data = makeUnique<ShapeSegmentData>(SegmentDataType::Base, affinity, WTFMove(offset));
+    return CSSShapeSegmentValue::create(SegmentType::Line, WTFMove(data));
+}
+
+Ref<CSSShapeSegmentValue> CSSShapeSegmentValue::createHorizontalLine(CoordinateAffinity affinity, Ref<CSSValue>&& x)
+{
+    auto data = makeUnique<ShapeSegmentData>(SegmentDataType::Base, affinity, WTFMove(x));
+    return CSSShapeSegmentValue::create(SegmentType::HorizontalLine, WTFMove(data));
+}
+
+Ref<CSSShapeSegmentValue> CSSShapeSegmentValue::createVerticalLine(CoordinateAffinity affinity, Ref<CSSValue>&& y)
+{
+    auto data = makeUnique<ShapeSegmentData>(SegmentDataType::Base, affinity, WTFMove(y));
+    return CSSShapeSegmentValue::create(SegmentType::VerticalLine, WTFMove(data));
+}
+
+Ref<CSSShapeSegmentValue> CSSShapeSegmentValue::createCubicCurve(CoordinateAffinity affinity, Ref<CSSValue>&& offset, Ref<CSSValue>&& p1, Ref<CSSValue>&& p2)
+{
+    auto data = makeUnique<TwoPointData>(affinity, WTFMove(offset), WTFMove(p1), WTFMove(p2));
+    return CSSShapeSegmentValue::create(SegmentType::CubicCurve, WTFMove(data));
+}
+
+Ref<CSSShapeSegmentValue> CSSShapeSegmentValue::createQuadraticCurve(CoordinateAffinity affinity, Ref<CSSValue>&& offset, Ref<CSSValue>&& p1)
+{
+    auto data = makeUnique<OnePointData>(affinity, WTFMove(offset), WTFMove(p1));
+    return CSSShapeSegmentValue::create(SegmentType::QuadraticCurve, WTFMove(data));
+}
+
+Ref<CSSShapeSegmentValue> CSSShapeSegmentValue::createSmoothCubicCurve(CoordinateAffinity affinity, Ref<CSSValue>&& offset, Ref<CSSValue>&& p1)
+{
+    auto data = makeUnique<OnePointData>(affinity, WTFMove(offset), WTFMove(p1));
+    return CSSShapeSegmentValue::create(SegmentType::SmoothCubicCurve, WTFMove(data));
+}
+
+Ref<CSSShapeSegmentValue> CSSShapeSegmentValue::createSmoothQuadraticCurve(CoordinateAffinity affinity, Ref<CSSValue>&& offset)
+{
+    auto data = makeUnique<ShapeSegmentData>(SegmentDataType::Base, affinity, WTFMove(offset));
+    return CSSShapeSegmentValue::create(SegmentType::SmoothQuadraticCurve, WTFMove(data));
+}
+
+Ref<CSSShapeSegmentValue> CSSShapeSegmentValue::createArc(CoordinateAffinity affinity, Ref<CSSValue>&& offset, Ref<CSSValue>&& radius, CSSValueID sweep, CSSValueID size, Ref<CSSValue>&& angle)
+{
+    ASSERT(sweep == CSSValueCcw || sweep == CSSValueCw);
+    ASSERT(size == CSSValueSmall || size == CSSValueLarge);
+
+    auto data = makeUnique<ArcData>(affinity, WTFMove(offset), WTFMove(radius), sweep, size, WTFMove(angle));
+    return CSSShapeSegmentValue::create(SegmentType::Arc, WTFMove(data));
+}
+
+Ref<CSSShapeSegmentValue> CSSShapeSegmentValue::createClose()
+{
+    return CSSShapeSegmentValue::create(SegmentType::Close);
+}
+
+bool CSSShapeSegmentValue::equals(const CSSShapeSegmentValue& other) const
+{
+    if (type() != other.type())
+        return false;
+
+    if (m_type == SegmentType::Close)
+        return true;
+
+    ASSERT(m_data && other.m_data);
+    return *m_data == *other.m_data;
+}
+
+String CSSShapeSegmentValue::customCSSText() const
+{
+    if (m_type == SegmentType::Close)
+        return "close"_s;
+
+    ASSERT(m_data);
+
+    const auto command = [&]() {
+        switch (type()) {
+        case SegmentType::Move:
+            return "move"_s;
+        case SegmentType::Line:
+            return "line"_s;
+        case SegmentType::HorizontalLine:
+            return "hline"_s;
+        case SegmentType::VerticalLine:
+            return "vline"_s;
+        case SegmentType::CubicCurve:
+        case SegmentType::QuadraticCurve:
+            return "curve"_s;
+        case SegmentType::SmoothCubicCurve:
+        case SegmentType::SmoothQuadraticCurve:
+            return "smooth"_s;
+        case SegmentType::Arc:
+            return "arc"_s;
+        default:
+            ASSERT_NOT_REACHED();
+            return ""_s;
+        }
+    };
+
+    const auto conjunction = [&]() {
+        switch (type()) {
+        case SegmentType::Move:
+        case SegmentType::Line:
+        case SegmentType::HorizontalLine:
+        case SegmentType::VerticalLine:
+        case SegmentType::SmoothQuadraticCurve:
+            return ""_s;
+        case SegmentType::CubicCurve:
+        case SegmentType::QuadraticCurve:
+        case SegmentType::SmoothCubicCurve:
+            return " via "_s;
+        case SegmentType::Arc:
+            return " of "_s;
+        default:
+            ASSERT_NOT_REACHED();
+            return ""_s;
+        }
+    };
+
+    StringBuilder builder;
+    auto byTo = m_data->affinity == CoordinateAffinity::Absolute ? " to "_s : " by "_s;
+    builder.append(command(), byTo, m_data->offset->cssText(), conjunction());
+
+    switch (m_data->type) {
+    case SegmentDataType::Base:
+        break;
+    case SegmentDataType::OnePoint: {
+        auto& onePointData = static_cast<const OnePointData&>(*m_data);
+        builder.append(onePointData.p1->cssText());
+        break;
+    }
+    case SegmentDataType::TwoPoint: {
+        auto& twoPointData = static_cast<const TwoPointData&>(*m_data);
+        builder.append(twoPointData.p1->cssText(), " "_s, twoPointData.p2->cssText());
+        break;
+    }
+    case SegmentDataType::Arc: {
+        auto& arcData = static_cast<const ArcData&>(*m_data);
+        builder.append(arcData.radius->cssText());
+
+        if (arcData.arcSweep == CSSValueCw)
+            builder.append(" cw"_s);
+
+        if (arcData.arcSize == CSSValueLarge)
+            builder.append(" large"_s);
+
+        if (RefPtr angleValue = dynamicDowncast<CSSPrimitiveValue>(arcData.angle)) {
+            if (angleValue->computeDegrees())
+                builder.append(" rotate "_s, angleValue->cssText());
+        }
+        break;
+    }
+    }
+
+    return builder.toString();
+}
+
+} // namespace WebCore
+

--- a/Source/WebCore/css/CSSShapeSegmentValue.h
+++ b/Source/WebCore/css/CSSShapeSegmentValue.h
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2022 Noam Rosenthal All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveValue.h"
+#include "CSSValueKeywords.h"
+#include "CSSValueList.h"
+#include <wtf/Ref.h>
+#include <wtf/TypeCasts.h>
+#include <wtf/text/StringBuilder.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class CSSToLengthConversionData;
+
+enum class CoordinateAffinity : uint8_t;
+
+class CSSShapeSegmentValue : public CSSValue {
+public:
+    enum class SegmentType : uint8_t {
+        Move,
+        Line,
+        HorizontalLine,
+        VerticalLine,
+        CubicCurve,
+        QuadraticCurve,
+        SmoothCubicCurve,
+        SmoothQuadraticCurve,
+        Arc,
+        Close
+    };
+
+    SegmentType type() const { return m_type; }
+
+    bool equals(const CSSShapeSegmentValue& other) const;
+    String customCSSText() const;
+
+    static Ref<CSSShapeSegmentValue> createClose();
+    static Ref<CSSShapeSegmentValue> createMove(CoordinateAffinity, Ref<CSSValue>&& offset);
+    static Ref<CSSShapeSegmentValue> createLine(CoordinateAffinity, Ref<CSSValue>&& offset);
+    static Ref<CSSShapeSegmentValue> createHorizontalLine(CoordinateAffinity, Ref<CSSValue>&& length);
+    static Ref<CSSShapeSegmentValue> createVerticalLine(CoordinateAffinity, Ref<CSSValue>&& length);
+
+    static Ref<CSSShapeSegmentValue> createCubicCurve(CoordinateAffinity, Ref<CSSValue>&& offset, Ref<CSSValue>&& p1, Ref<CSSValue>&& p2);
+    static Ref<CSSShapeSegmentValue> createQuadraticCurve(CoordinateAffinity, Ref<CSSValue>&& offset, Ref<CSSValue>&& p1);
+
+    static Ref<CSSShapeSegmentValue> createSmoothCubicCurve(CoordinateAffinity, Ref<CSSValue>&& offset, Ref<CSSValue>&& p1);
+    static Ref<CSSShapeSegmentValue> createSmoothQuadraticCurve(CoordinateAffinity, Ref<CSSValue>&& offset);
+
+    static Ref<CSSShapeSegmentValue> createArc(CoordinateAffinity, Ref<CSSValue>&& offset, Ref<CSSValue>&& radius, CSSValueID sweep, CSSValueID size, Ref<CSSValue>&& angle);
+
+private:
+    enum class SegmentDataType : uint8_t { Base, OnePoint, TwoPoint, Arc };
+
+    struct ShapeSegmentData {
+        WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+        const SegmentDataType type;
+        const CoordinateAffinity affinity;
+        Ref<CSSValue> offset; // CSSValuePair for x,y offsets, or CSSPrimitiveValue for horizontal/vertical line segments.
+
+        ShapeSegmentData(SegmentDataType dataType, CoordinateAffinity affinity, Ref<CSSValue>&& offset)
+            : type(dataType)
+            , affinity(affinity)
+            , offset(WTFMove(offset))
+        { }
+
+        virtual ~ShapeSegmentData() = default;
+
+        virtual bool operator==(const ShapeSegmentData& other) const
+        {
+            return type == other.type
+                && affinity == other.affinity
+                && compareCSSValue(offset, other.offset);
+        }
+    };
+
+    struct OnePointData : public ShapeSegmentData {
+        Ref<CSSValue> p1;
+
+        OnePointData(CoordinateAffinity affinity, Ref<CSSValue>&& offset, Ref<CSSValue>&& p1)
+            : ShapeSegmentData(SegmentDataType::OnePoint, affinity, WTFMove(offset))
+            , p1(WTFMove(p1))
+        { }
+
+        bool operator==(const ShapeSegmentData& other) const override
+        {
+            if (!ShapeSegmentData::operator==(other))
+                return false;
+
+            auto& otherOnePoint = static_cast<const OnePointData&>(other);
+            return compareCSSValue(p1, otherOnePoint.p1);
+        }
+    };
+
+    struct TwoPointData : public ShapeSegmentData {
+        Ref<CSSValue> p1;
+        Ref<CSSValue> p2;
+
+        TwoPointData(CoordinateAffinity affinity, Ref<CSSValue>&& offset, Ref<CSSValue>&& p1, Ref<CSSValue>&& p2)
+            : ShapeSegmentData(SegmentDataType::TwoPoint, affinity, WTFMove(offset))
+            , p1(WTFMove(p1))
+            , p2(WTFMove(p2))
+        { }
+
+        bool operator==(const ShapeSegmentData& other) const override
+        {
+            if (!ShapeSegmentData::operator==(other))
+                return false;
+
+            auto& otherTwoPoint = static_cast<const TwoPointData&>(other);
+            return compareCSSValue(p1, otherTwoPoint.p1)
+                && compareCSSValue(p2, otherTwoPoint.p2);
+        }
+    };
+
+    struct ArcData : public ShapeSegmentData {
+        CSSValueID arcSweep;
+        CSSValueID arcSize;
+        Ref<CSSValue> radius;
+        Ref<CSSValue> angle;
+
+        ArcData(CoordinateAffinity affinity, Ref<CSSValue>&& offset, Ref<CSSValue>&& radius, CSSValueID arcSweep, CSSValueID arcSize, Ref<CSSValue>&& angle)
+            : ShapeSegmentData(SegmentDataType::Arc, affinity, WTFMove(offset))
+            , arcSweep(arcSweep)
+            , arcSize(arcSize)
+            , radius(WTFMove(radius))
+            , angle(WTFMove(angle))
+        { }
+
+        bool operator==(const ShapeSegmentData& other) const override
+        {
+            if (!ShapeSegmentData::operator==(other))
+                return false;
+
+            auto& otherArc = static_cast<const ArcData&>(other);
+            return arcSweep == otherArc.arcSweep
+                && arcSize == otherArc.arcSize
+                && compareCSSValue(radius, otherArc.radius)
+                && compareCSSValue(angle, otherArc.angle);
+        }
+    };
+
+    static Ref<CSSShapeSegmentValue> create(SegmentType type, std::unique_ptr<ShapeSegmentData>&& data = nullptr)
+    {
+        return adoptRef(*new CSSShapeSegmentValue(type, WTFMove(data)));
+    }
+
+    CSSShapeSegmentValue(SegmentType type, std::unique_ptr<ShapeSegmentData>&& data)
+        : CSSValue(ShapeSegmentClass)
+        , m_type(type)
+        , m_data(WTFMove(data))
+    {
+    }
+
+    const SegmentType m_type;
+    std::unique_ptr<ShapeSegmentData> m_data;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSShapeSegmentValue, isShapeSegment())

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -72,6 +72,7 @@
 #include "CSSReflectValue.h"
 #include "CSSScrollValue.h"
 #include "CSSShadowValue.h"
+#include "CSSShapeSegmentValue.h"
 #include "CSSSubgridValue.h"
 #include "CSSTimingFunctionValue.h"
 #include "CSSTransformListValue.h"
@@ -211,6 +212,10 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSScrollValue>(*this));
     case ShadowClass:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSShadowValue>(*this));
+    case ShapeClass:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSShapeValue>(*this));
+    case ShapeSegmentClass:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSShapeSegmentValue>(*this));
     case SubgridClass:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<CSSSubgridValue>(*this));
     case StepsTimingFunctionClass:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -128,6 +128,8 @@ public:
     bool isReflectValue() const { return m_classType == ReflectClass; }
     bool isScrollValue() const { return m_classType == ScrollClass; }
     bool isShadowValue() const { return m_classType == ShadowClass; }
+    bool isShape() const { return m_classType == ShapeClass; }
+    bool isShapeSegment() const { return m_classType == ShapeSegmentClass; }
     bool isSpringTimingFunctionValue() const { return m_classType == SpringTimingFunctionClass; }
     bool isStepsTimingFunctionValue() const { return m_classType == StepsTimingFunctionClass; }
     bool isSubgridValue() const { return m_classType == SubgridClass; }
@@ -271,6 +273,7 @@ protected:
         ReflectClass,
         ScrollClass,
         ShadowClass,
+        ShapeSegmentClass,
         UnicodeRangeClass,
         ValuePairClass,
         VariableReferenceClass,
@@ -284,6 +287,7 @@ protected:
         GridIntegerRepeatClass,
         ImageSetClass,
         PolygonClass,
+        ShapeClass,
         SubgridClass,
         TransformListClass,
         // Do not append classes here unless they derive from CSSValueContainingVector.

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1341,6 +1341,24 @@ rect
 
 // shapes
 polygon
+shape
+
+// shape function
+line
+// move
+hline
+vline
+curve
+// smooth
+arc
+cw
+ccw
+// large
+// small
+by
+close
+via
+of
 
 // @font-face src
 format

--- a/Source/WebCore/rendering/style/BasicShapes.h
+++ b/Source/WebCore/rendering/style/BasicShapes.h
@@ -50,6 +50,10 @@ class Path;
 class RenderBox;
 class SVGPathByteStream;
 
+enum class CoordinateAffinity : uint8_t {
+    Relative, Absolute
+};
+
 class BasicShape : public RefCounted<BasicShape> {
 public:
     virtual ~BasicShape() = default;


### PR DESCRIPTION
#### 5b3fbae5a519afb6ea1fa38df0bad5e6e4b724b9
<pre>
Add CSSValue types for the shape() function
<a href="https://bugs.webkit.org/show_bug.cgi?id=277211">https://bugs.webkit.org/show_bug.cgi?id=277211</a>
<a href="https://rdar.apple.com/132644760">rdar://132644760</a>

Reviewed by Tim Nguyen.

To support the CSS shape() function[1] we need two new CSSValue subclasses.

CSSShapeValue subclasses CSSValueContainingVector, since the segments form a list.
Those segments are represented by CSSShapeSegmentValue. The spec calls these &quot;commands&quot;,
but I chose to use &quot;segment&quot; to match terminology in Path and SVG code.

Internally CSSShapeSegmentValue uses one of several data types to store the segment
data, based on how many lengths or points need to be stored.

These classes are not yet instantiated.

Based on code by Noam Rosenthal.

[1] <a href="https://drafts.csswg.org/css-shapes-2/#shape-function">https://drafts.csswg.org/css-shapes-2/#shape-function</a>

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSBasicShapes.cpp:
(WebCore::CSSPolygonValue::CSSPolygonValue): Use r-value reference for the CSSValueListBuilder argument.
(WebCore::CSSPolygonValue::create):
(WebCore::CSSShapeValue::create):
(WebCore::CSSShapeValue::CSSShapeValue):
(WebCore::CSSShapeValue::customCSSText const):
(WebCore::CSSShapeValue::equals const):
* Source/WebCore/css/CSSBasicShapes.h:
* Source/WebCore/css/CSSShapeSegmentValue.cpp: Added.
(WebCore::CSSShapeSegmentValue::createMove):
(WebCore::CSSShapeSegmentValue::createLine):
(WebCore::CSSShapeSegmentValue::createHorizontalLine):
(WebCore::CSSShapeSegmentValue::createVerticalLine):
(WebCore::CSSShapeSegmentValue::createCubicCurve):
(WebCore::CSSShapeSegmentValue::createQuadraticCurve):
(WebCore::CSSShapeSegmentValue::createSmoothCubicCurve):
(WebCore::CSSShapeSegmentValue::createSmoothQuadraticCurve):
(WebCore::CSSShapeSegmentValue::createArc):
(WebCore::CSSShapeSegmentValue::createClose):
(WebCore::CSSShapeSegmentValue::equals const):
(WebCore::CSSShapeSegmentValue::customCSSText const):
* Source/WebCore/css/CSSShapeSegmentValue.h: Added.
(WebCore::CSSShapeSegmentValue::type const):
(WebCore::CSSShapeSegmentValue::ShapeSegmentData::ShapeSegmentData):
(WebCore::CSSShapeSegmentValue::ShapeSegmentData::operator== const):
(WebCore::CSSShapeSegmentValue::OnePointData::OnePointData):
(WebCore::CSSShapeSegmentValue::TwoPointData::TwoPointData):
(WebCore::CSSShapeSegmentValue::ArcData::ArcData):
(WebCore::CSSShapeSegmentValue::create):
(WebCore::CSSShapeSegmentValue::CSSShapeSegmentValue):
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::visitDerived):
* Source/WebCore/css/CSSValue.h:
(WebCore::CSSValue::isShape const):
(WebCore::CSSValue::isShapeSegment const):
* Source/WebCore/css/CSSValueKeywords.in: Add shape-related keywords.
* Source/WebCore/rendering/style/BasicShapes.h:

Canonical link: <a href="https://commits.webkit.org/281462@main">https://commits.webkit.org/281462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/047f258b144aa15dadad91d51915a35cbd78cbb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10524 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48614 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7342 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29456 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33389 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9194 "Found 1 new test failure: imported/w3c/web-platform-tests/preload/preload-type-match.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9444 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65644 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55964 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56114 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13297 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3254 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35155 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36237 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->