### PR TITLE
AX: role="menu" elements should allow child groups with menuitem children

### DIFF
--- a/LayoutTests/accessibility/menu-with-menuitem-grandchildren-expected.txt
+++ b/LayoutTests/accessibility/menu-with-menuitem-grandchildren-expected.txt
@@ -1,0 +1,30 @@
+This test ensures that we compute the right final role for a role='menu' item with menuitem grandchildren.
+
+PASS: accessibilityController.accessibleElementById('menu').role.toLowerCase().includes('menu') === true
+
+{#menu AXRole: AXMenu}
+
+{AXRole: AXGroup}
+
+{AXRole: AXMenuItem}
+
+{AXRole: AXMenuItem}
+
+{AXRole: AXMenuItem}
+
+{AXRole: AXGroup}
+
+{AXRole: AXMenuItem}
+
+{AXRole: AXMenuItem}
+
+{AXRole: AXMenuItem}
+
+{AXRole: AXGroup}
+
+{AXRole: AXMenuItem}
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Inbox Archive Trash Custom Folder 1 Custom Folder 2 Custom Folder 3 New Folder

--- a/LayoutTests/accessibility/menu-with-menuitem-grandchildren.html
+++ b/LayoutTests/accessibility/menu-with-menuitem-grandchildren.html
@@ -1,0 +1,73 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<axe-menu id="menu" aria-label="Test menu">
+    <axe-group aria-label="Test group 1">
+        <axe-menuitem>Inbox</axe-menuitem>
+        <axe-menuitem>Archive</axe-menuitem>
+        <axe-menuitem>Trash</axe-menuitem>
+    </axe-group>
+    <axe-group aria-label="Test group 2">
+        <axe-menuitem>Custom Folder 1</axe-menuitem>
+        <axe-menuitem>Custom Folder 2</axe-menuitem>
+        <axe-menuitem>Custom Folder 3</axe-menuitem>
+     </axe-group>
+     <axe-group aria-label="Test group 3">
+         <axe-menuitem>New Folder</axe-menuitem>
+     </axe-group>
+</axe-menu>
+
+<script>
+var output = "This test ensures that we compute the right final role for a role='menu' item with menuitem grandchildren.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        const platform = accessibilityController.platformName;
+        if (platform !== "ios")
+            output += await expectAsync("accessibilityController.accessibleElementById('menu').role.toLowerCase().includes('menu')", "true");
+        if (platform === "ios" || platform === "mac")
+            output += dumpAXSearchTraversal(accessibilityController.rootElement.childAtIndex(0));
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+
+class Menu extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.role = 'menu';
+    this.internals_.ariaOrientation = 'vertical';
+  }
+}
+customElements.define('axe-menu', Menu);
+
+class Group extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.role = 'group';
+  }
+}
+customElements.define('axe-group', Group);
+
+class MenuItem extends HTMLElement {
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+    this.internals_.role = 'menuitem';
+  }
+}
+customElements.define('axe-menuitem', MenuItem);
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/glib/accessibility/menu-with-menuitem-grandchildren-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/menu-with-menuitem-grandchildren-expected.txt
@@ -1,0 +1,8 @@
+This test ensures that we compute the right final role for a role='menu' item with menuitem grandchildren.
+
+PASS: accessibilityController.accessibleElementById('menu').role.toLowerCase().includes('menu') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Inbox Archive Trash Custom Folder 1 Custom Folder 2 Custom Folder 3 New Folder

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2353,6 +2353,7 @@ accessibility/insert-text-into-password-field.html [ Pass ]
 accessibility/list-with-dynamically-changing-content.html [ Pass ]
 accessibility/live-region-attributes-update-after-dynamic-change.html [ Pass ]
 accessibility/menu-list-crash2.html [ Pass ]
+accessibility/menu-with-menuitem-grandchildren.html [ Pass ]
 # rdar://132587324 These two tests have been flakey on iOS since they were introduced — temporarily disable them for now.
 # accessibility/mixed-contenteditable-visible-character-range-hang.html [ Pass ]
 # accessibility/mixed-contenteditable-double-br-visible-character-range-hang.html [ Pass ]

--- a/LayoutTests/platform/ios/accessibility/menu-with-menuitem-grandchildren-expected.txt
+++ b/LayoutTests/platform/ios/accessibility/menu-with-menuitem-grandchildren-expected.txt
@@ -1,0 +1,21 @@
+This test ensures that we compute the right final role for a role='menu' item with menuitem grandchildren.
+
+
+{MenuItem}
+
+{MenuItem}
+
+{MenuItem}
+
+{MenuItem}
+
+{MenuItem}
+
+{MenuItem}
+
+{MenuItem}
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Inbox Archive Trash Custom Folder 1 Custom Folder 2 Custom Folder 3 New Folder

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2490,15 +2490,26 @@ void AccessibilityRenderObject::updateRoleAfterChildrenCreation()
     auto role = roleValue();
     if (role == AccessibilityRole::Menu) {
         // Elements marked as menus must have at least one menu item child.
-        size_t menuItemCount = 0;
+        bool hasMenuItemDescendant = false;
         for (const auto& child : children()) {
             if (child->isMenuItem()) {
-                menuItemCount++;
+                hasMenuItemDescendant = true;
                 break;
+            }
+
+            // Per the ARIA spec, groups with menuitem children are allowed as children of menus.
+            // https://w3c.github.io/aria/#menu
+            if (child->isGroup()) {
+                for (const auto& grandchild : child->children()) {
+                    if (grandchild->isMenuItem()) {
+                        hasMenuItemDescendant = true;
+                        break;
+                    }
+                }
             }
         }
 
-        if (!menuItemCount)
+        if (!hasMenuItemDescendant)
             m_role = AccessibilityRole::Generic;
     }
     if (role == AccessibilityRole::SVGRoot && !children().size())


### PR DESCRIPTION
#### 82f243e3dea5201fc1805e6df23120f46ae9471f
<pre>
AX: role=&quot;menu&quot; elements should allow child groups with menuitem children
<a href="https://bugs.webkit.org/show_bug.cgi?id=276658">https://bugs.webkit.org/show_bug.cgi?id=276658</a>
<a href="https://rdar.apple.com/131838275">rdar://131838275</a>

Reviewed by Chris Fleizach.

Per the ARIA spec:

<a href="https://w3c.github.io/aria/#menu">https://w3c.github.io/aria/#menu</a>

Menus should allow child groups with menuitem children. This patch fixes that.

* LayoutTests/accessibility/menu-with-menuitem-grandchildren-expected.txt: Added.
* LayoutTests/accessibility/menu-with-menuitem-grandchildren.html: Added.
* LayoutTests/platform/ios/TestExpectations: Enable new test.
* LayoutTests/platform/ios/accessibility/menu-with-menuitem-grandchildren-expected.txt: Added.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::updateRoleAfterChildrenCreation):

Canonical link: <a href="https://commits.webkit.org/281481@main">https://commits.webkit.org/281481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00fd5f18b8c063d2ad70058a4df793e54b0eee7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10534 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48620 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7350 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29462 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9207 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9454 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55313 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65654 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55971 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56121 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13311 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3265 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35165 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36247 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->