### PR TITLE
[css-align] Fix serialization of place-content/items/self properties

### DIFF
--- a/LayoutTests/css3/parse-place-content.html
+++ b/LayoutTests/css3/parse-place-content.html
@@ -116,11 +116,11 @@ function checkPlaceContentInitialValue()
 {
    element = document.createElement("div");
    document.body.appendChild(element);
-   checkValues(element, "placeContent", "place-content", "", "normal normal");
+   checkValues(element, "placeContent", "place-content", "", "normal");
    element.style.placeContent = "center";
    checkPlaceContentValues(element, "center", "center", "center");
    element.style.placeContent = "initial";
-   checkValues(element, "placeContent", "place-content", "initial", "normal normal");
+   checkValues(element, "placeContent", "place-content", "initial", "normal");
    checkPlaceContentValues(element, "initial", "normal", "normal");
 }
 
@@ -136,32 +136,32 @@ function checkPlaceContentInheritValue()
 
 
 test(function() {
-    checkValues(placeContentNormal, "placeContent", "place-content", "", "normal normal");
+    checkValues(placeContentNormal, "placeContent", "place-content", "", "normal");
     checkPlaceContentValues(placeContentNormal, "", "normal", "normal");
 }, "Test getting the Computed Value of place-content's longhand properties when setting 'normal' value through CSS.");
 
 test(function() {
-    checkValues(placeContentStart, "placeContent", "place-content", "", "start start");
+    checkValues(placeContentStart, "placeContent", "place-content", "", "start");
     checkPlaceContentValues(placeContentStart, "", "start", "start");
 }, "Test getting the Computed Value of place-content's longhand properties when setting 'start' value through CSS.");
 
 test(function() {
-    checkValues(placeContentFlexStart, "placeContent", "place-content", "", "flex-start flex-start");
+    checkValues(placeContentFlexStart, "placeContent", "place-content", "", "flex-start");
     checkPlaceContentValues(placeContentFlexStart, "", "flex-start", "flex-start");
 }, "Test getting the Computed Value of place-content's longhand properties when setting 'flex-start' value through CSS.");
 
 test(function() {
-    checkValues(placeContentEnd, "placeContent", "place-content", "", "end end");
+    checkValues(placeContentEnd, "placeContent", "place-content", "", "end");
     checkPlaceContentValues(placeContentEnd, "", "end", "end");
 }, "Test getting the Computed Value of place-content's longhand properties when setting 'end' value through CSS.");
 
 test(function() {
-    checkValues(placeContentSpaceBetween, "placeContent", "place-content", "", "space-between space-between");
+    checkValues(placeContentSpaceBetween, "placeContent", "place-content", "", "space-between");
     checkPlaceContentValues(placeContentSpaceBetween, "", "space-between", "space-between");
 }, "Test getting the Computed Value of place-content's longhand properties when setting 'space-between' value through CSS.");
 
 test(function() {
-    checkValues(placeContentStretch, "placeContent", "place-content", "", "stretch stretch");
+    checkValues(placeContentStretch, "placeContent", "place-content", "", "stretch");
     checkPlaceContentValues(placeContentStretch, "", "stretch", "stretch");
 }, "Test getting the Computed Value of place-content's longhand properties when setting 'stretch' value through CSS.");
 
@@ -181,52 +181,51 @@ test(function() {
 }, "Test getting the Computed Value of place-content's longhand properties when setting 'baseline start' value through CSS.");
 
 test(function() {
-    checkValues(placeContentAuto, "placeContent", "place-content", "", "normal normal");
+    checkValues(placeContentAuto, "placeContent", "place-content", "", "normal");
     checkPlaceContentValues(placeContentAuto, "", "normal", "normal");
 }, "Test setting '' as incorrect value through CSS.");
 
 test(function() {
-    checkValues(placeContentAuto, "placeContent", "place-content", "", "normal normal");
+    checkValues(placeContentAuto, "placeContent", "place-content", "", "normal");
     checkPlaceContentValues(placeContentAuto, "", "normal", "normal");
 }, "Test setting 'auto' as incorrect value through CSS.");
 
 test(function() {
-    checkValues(placeContentNone, "placeContent", "place-content", "", "normal normal");
+    checkValues(placeContentNone, "placeContent", "place-content", "", "normal");
     checkPlaceContentValues(placeContentNone, "", "normal", "normal");
 }, "Test setting 'none' as incorrect value through CSS.");
 
 test(function() {
-    checkValues(placeContentSafe, "placeContent", "place-content", "", "normal normal");
+    checkValues(placeContentSafe, "placeContent", "place-content", "", "normal");
     checkPlaceContentValues(placeContentSafe, "", "normal", "normal");
 }, "Test setting 'safe' as incorrect value through CSS.");
 
 test(function() {
-    checkValues(placeContentStartSafe, "placeContent", "place-content", "", "normal normal");
+    checkValues(placeContentStartSafe, "placeContent", "place-content", "", "normal");
     checkPlaceContentValues(placeContentStartSafe, "", "normal", "normal");
 }, "Test setting 'start safe' as incorrect value through CSS.");
 
 test(function() {
-    checkValues(placeContentBaseline, "placeContent", "place-content", "", "normal normal");
+    checkValues(placeContentBaseline, "placeContent", "place-content", "", "normal");
     checkPlaceContentValues(placeContentBaseline, "", "normal", "normal");
 }, "Test setting 'baseline' as incorrect value through CSS.");
 
 test(function() {
-    checkValues(placeContentBaselineSafe, "placeContent", "place-content", "", "normal normal");
+    checkValues(placeContentBaselineSafe, "placeContent", "place-content", "", "normal");
     checkPlaceContentValues(placeContentBaselineSafe, "", "normal", "normal");
 }, "Test setting 'baseline safe' as incorrect value through CSS.");
 
 test(function() {
-    checkValues(placeContentStartBaseline, "placeContent", "place-content", "", "normal normal");
+    checkValues(placeContentStartBaseline, "placeContent", "place-content", "", "normal");
     checkPlaceContentValues(placeContentStartBaseline, "", "normal", "normal");
 }, "Test setting 'start baseline' as incorrect value through CSS.");
 
 test(function() {
-    checkValues(placeContentStartEndLeft, "placeContent", "place-content", "", "normal normal");
+    checkValues(placeContentStartEndLeft, "placeContent", "place-content", "", "normal");
     checkPlaceContentValues(placeContentStartEndLeft, "", "normal", "normal");
 }, "Test setting 'start end left' as incorrect value through CSS.");
 
 test(function() {
-    checkPlaceContentValuesJS("center", "center", "center");
     checkPlaceContentValuesJS("center start", "center", "start");
     checkPlaceContentValuesJS("space-between end", "space-between", "end");
     checkPlaceContentValuesJS("normal end", "normal", "end");

--- a/LayoutTests/css3/parse-place-items.html
+++ b/LayoutTests/css3/parse-place-items.html
@@ -120,47 +120,47 @@ function checkPlaceItemsValuesBadJS(value)
 }
 
 test(function() {
-  checkValues(placeItemsNormal, "placeItems", "place-items", "", "normal normal");
+  checkValues(placeItemsNormal, "placeItems", "place-items", "", "normal");
   checkPlaceItemsValues(placeItemsNormal, "", "normal", "normal");
 }, "Test getting the Computed Value of place-items's longhand properties when setting 'normal' value through CSS.");
 
 test(function() {
-  checkValues(placeItemsBaseline, "placeItems", "place-items", "", "baseline baseline");
+  checkValues(placeItemsBaseline, "placeItems", "place-items", "", "baseline");
   checkPlaceItemsValues(placeItemsBaseline, "", "baseline", "baseline");
 }, "Test getting the Computed Value of place-items's longhand properties when setting 'baseline' value through CSS.");
 
 test(function() {
-  checkValues(placeItemsFirstBaseline, "placeItems", "place-items", "", "baseline baseline");
+  checkValues(placeItemsFirstBaseline, "placeItems", "place-items", "", "baseline");
   checkPlaceItemsValues(placeItemsFirstBaseline, "", "baseline", "baseline");
 }, "Test getting the Computed Value of place-items's longhand properties when setting 'first baseline' value through CSS.");
 
 test(function() {
-  checkValues(placeItemsLastBaseline, "placeItems", "place-items", "", "last baseline last baseline");
+  checkValues(placeItemsLastBaseline, "placeItems", "place-items", "", "last baseline");
   checkPlaceItemsValues(placeItemsLastBaseline, "", "last baseline", "last baseline");
 }, "Test getting the Computed Value of place-items's longhand properties when setting 'last baseline' value through CSS.");
 
 test(function() {
-  checkValues(placeItemsStart, "placeItems", "place-items", "", "start start");
+  checkValues(placeItemsStart, "placeItems", "place-items", "", "start");
   checkPlaceItemsValues(placeItemsStart, "", "start", "start");
 }, "Test getting the Computed Value of place-items's longhand properties when setting 'start' value through CSS.");
 
 test(function() {
-  checkValues(placeItemsFlexStart, "placeItems", "place-items", "", "flex-start flex-start");
+  checkValues(placeItemsFlexStart, "placeItems", "place-items", "", "flex-start");
   checkPlaceItemsValues(placeItemsFlexStart, "", "flex-start", "flex-start");
 }, "Test getting the Computed Value of place-items's longhand properties when setting 'flex-start' value through CSS.");
 
 test(function() {
-  checkValues(placeItemsEnd, "placeItems", "place-items", "", "end end");
+  checkValues(placeItemsEnd, "placeItems", "place-items", "", "end");
   checkPlaceItemsValues(placeItemsEnd, "", "end", "end");
 }, "Test getting the Computed Value of place-items's longhand properties when setting 'end' value through CSS.");
 
 test(function() {
-  checkValues(placeItemsSelfStart, "placeItems", "place-items", "", "self-start self-start");
+  checkValues(placeItemsSelfStart, "placeItems", "place-items", "", "self-start");
   checkPlaceItemsValues(placeItemsSelfStart, "", "self-start", "self-start");
 }, "Test getting the Computed Value of place-items's longhand properties when setting 'self-start' value through CSS.");
 
 test(function() {
-  checkValues(placeItemsStretch, "placeItems", "place-items", "", "stretch stretch");
+  checkValues(placeItemsStretch, "placeItems", "place-items", "", "stretch");
   checkPlaceItemsValues(placeItemsStretch, "", "stretch", "stretch");
 }, "Test getting the Computed Value of place-items's longhand properties when setting 'stretch' value through CSS.");
 
@@ -180,42 +180,41 @@ test(function() {
 }, "Test getting the Computed Value of place-items's longhand properties when setting 'start baseline' value through CSS.");
 
 test(function() {
-  checkValues(placeItemsAuto, "placeItems", "place-items", "", "normal normal");
+  checkValues(placeItemsAuto, "placeItems", "place-items", "", "normal");
   checkPlaceItemsValues(placeItemsAuto, "", "normal", "normal");
 }, "Test setting 'auto' as incorrect value through CSS.");
 
 test(function() {
-  checkValues(placeItemsCenterAuto, "placeItems", "place-items", "", "normal normal");
+  checkValues(placeItemsCenterAuto, "placeItems", "place-items", "", "normal");
   checkPlaceItemsValues(placeItemsCenterAuto, "", "normal", "normal");
 }, "Test setting 'center auto' as incorrect value through CSS.");
 
 test(function() {
-  checkValues(placeItemsNone, "placeItems", "place-items", "", "normal normal");
+  checkValues(placeItemsNone, "placeItems", "place-items", "", "normal");
   checkPlaceItemsValues(placeItemsNone, "", "normal", "normal");
 }, "Test setting 'none' as incorrect value through CSS.");
 
 test(function() {
-  checkValues(placeItemsSafe, "placeItems", "place-items", "", "normal normal");
+  checkValues(placeItemsSafe, "placeItems", "place-items", "", "normal");
   checkPlaceItemsValues(placeItemsSafe, "", "normal", "normal");
 }, "Test setting 'safe' as incorrect value through CSS.");
 
 test(function() {
-  checkValues(placeItemsStartSafe, "placeItems", "place-items", "", "normal normal");
+  checkValues(placeItemsStartSafe, "placeItems", "place-items", "", "normal");
   checkPlaceItemsValues(placeItemsStartSafe, "", "normal", "normal");
 }, "Test setting 'start safe' as incorrect value through CSS.");
 
 test(function() {
-  checkValues(placeItemsBaselineSafe, "placeItems", "place-items", "", "normal normal");
+  checkValues(placeItemsBaselineSafe, "placeItems", "place-items", "", "normal");
   checkPlaceItemsValues(placeItemsBaselineSafe, "", "normal", "normal");
 }, "Test setting 'baseline safe' as incorrect value through CSS.");
 
 test(function() {
-  checkValues(placeItemsStartEndLeft, "placeItems", "place-items", "", "normal normal");
+  checkValues(placeItemsStartEndLeft, "placeItems", "place-items", "", "normal");
   checkPlaceItemsValues(placeItemsStartEndLeft, "", "normal", "normal");
 }, "Test setting 'start end left' as incorrect value through CSS.");
 
 test(function() {
-  checkPlaceItemsValuesJS("center", "center", "center");
   checkPlaceItemsValuesJS("center start", "center", "start");
   checkPlaceItemsValuesJS("self-start end", "self-start", "end");
   checkPlaceItemsValuesJS("normal end", "normal", "end");
@@ -241,11 +240,11 @@ test(function() {
 test(function() {
   element = document.createElement("div");
   document.body.appendChild(element);
-  checkValues(element, "placeItems", "place-items", "", "normal normal");
+  checkValues(element, "placeItems", "place-items", "", "normal");
   element.style.placeItems = "center";
   checkPlaceItemsValues(element, "center", "center", "center");
   element.style.placeItems = "initial";
-  checkValues(element, "placeItems", "place-items", "initial", "normal normal");
+  checkValues(element, "placeItems", "place-items", "initial", "normal");
   checkPlaceItemsValues(element, "initial", "normal", "normal");
 }, "Test the 'initial' value of the place-items shorthand and its longhand properties' Computed value");
 

--- a/LayoutTests/css3/parse-place-self.html
+++ b/LayoutTests/css3/parse-place-self.html
@@ -120,7 +120,7 @@ function checkPlaceSelfValuesBadJS(value)
 }
 
 test(function() {
-  checkValues(placeSelfNormal, "placeSelf", "place-self", "", "normal normal");
+  checkValues(placeSelfNormal, "placeSelf", "place-self", "", "normal");
   checkPlaceSelfValues(placeSelfNormal, "", "normal", "normal");
 }, "Test getting the Computed Value of place-self's longhand properties when setting 'normal' value through CSS.");
 
@@ -130,42 +130,42 @@ test(function() {
 }, "Test getting the Computed Value of place-self's longhand properties when setting 'center auto' value through CSS.");
 
 test(function() {
-  checkValues(placeSelfBaseline, "placeSelf", "place-self", "", "baseline baseline");
+  checkValues(placeSelfBaseline, "placeSelf", "place-self", "", "baseline");
   checkPlaceSelfValues(placeSelfBaseline, "", "baseline", "baseline");
 }, "Test getting the Computed Value of place-self's longhand properties when setting 'baseline' value through CSS.");
 
 test(function() {
-  checkValues(placeSelfFirstBaseline, "placeSelf", "place-self", "", "baseline baseline");
+  checkValues(placeSelfFirstBaseline, "placeSelf", "place-self", "", "baseline");
   checkPlaceSelfValues(placeSelfFirstBaseline, "", "baseline", "baseline");
 }, "Test getting the Computed Value of place-self's longhand properties when setting 'first baseline' value through CSS.");
 
 test(function() {
-  checkValues(placeSelfLastBaseline, "placeSelf", "place-self", "", "last baseline last baseline");
+  checkValues(placeSelfLastBaseline, "placeSelf", "place-self", "", "last baseline");
   checkPlaceSelfValues(placeSelfLastBaseline, "", "last baseline", "last baseline");
 }, "Test getting the Computed Value of place-self's longhand properties when setting 'last baseline' value through CSS.");
 
 test(function() {
-  checkValues(placeSelfStart, "placeSelf", "place-self", "", "start start");
+  checkValues(placeSelfStart, "placeSelf", "place-self", "", "start");
   checkPlaceSelfValues(placeSelfStart, "", "start", "start");
 }, "Test getting the Computed Value of place-self's longhand properties when setting 'start' value through CSS.");
 
 test(function() {
-  checkValues(placeSelfFlexStart, "placeSelf", "place-self", "", "flex-start flex-start");
+  checkValues(placeSelfFlexStart, "placeSelf", "place-self", "", "flex-start");
   checkPlaceSelfValues(placeSelfFlexStart, "", "flex-start", "flex-start");
 }, "Test getting the Computed Value of place-self's longhand properties when setting 'flex-start' value through CSS.");
 
 test(function() {
-  checkValues(placeSelfEnd, "placeSelf", "place-self", "", "end end");
+  checkValues(placeSelfEnd, "placeSelf", "place-self", "", "end");
   checkPlaceSelfValues(placeSelfEnd, "", "end", "end");
 }, "Test getting the Computed Value of place-self's longhand properties when setting 'end' value through CSS.");
 
 test(function() {
-  checkValues(placeSelfSelfStart, "placeSelf", "place-self", "", "self-start self-start");
+  checkValues(placeSelfSelfStart, "placeSelf", "place-self", "", "self-start");
   checkPlaceSelfValues(placeSelfSelfStart, "", "self-start", "self-start");
 }, "Test getting the Computed Value of place-self's longhand properties when setting 'self-start' value through CSS.");
 
 test(function() {
-  checkValues(placeSelfStretch, "placeSelf", "place-self", "", "stretch stretch");
+  checkValues(placeSelfStretch, "placeSelf", "place-self", "", "stretch");
   checkPlaceSelfValues(placeSelfStretch, "", "stretch", "stretch");
 }, "Test getting the Computed Value of place-self's longhand properties when setting 'stretch' value through CSS.");
 
@@ -185,42 +185,41 @@ test(function() {
 }, "Test getting the Computed Value of place-self's longhand properties when setting 'start baseline' value through CSS.");
 
 test(function() {
-  checkValues(placeSelfEmpty, "placeSelf", "place-self", "", "auto auto");
+  checkValues(placeSelfEmpty, "placeSelf", "place-self", "", "auto");
   checkPlaceSelfValues(placeSelfEmpty, "", "auto", "auto");
 }, "Test setting '' as incorrect value through CSS.");
 
 test(function() {
-  checkValues(placeSelfAuto, "placeSelf", "place-self", "", "auto auto");
+  checkValues(placeSelfAuto, "placeSelf", "place-self", "", "auto");
   checkPlaceSelfValues(placeSelfAuto, "", "auto", "auto");
 }, "Test setting 'auto' as incorrect value through CSS.");
 
 test(function() {
-  checkValues(placeSelfNone, "placeSelf", "place-self", "", "auto auto");
+  checkValues(placeSelfNone, "placeSelf", "place-self", "", "auto");
   checkPlaceSelfValues(placeSelfNone, "", "auto", "auto");
 }, "Test setting 'none' as incorrect value through CSS.");
 
 test(function() {
-  checkValues(placeSelfSafe, "placeSelf", "place-self", "", "auto auto");
+  checkValues(placeSelfSafe, "placeSelf", "place-self", "", "auto");
   checkPlaceSelfValues(placeSelfSafe, "", "auto", "auto");
 }, "Test setting 'safe' as incorrect value through CSS.");
 
 test(function() {
-  checkValues(placeSelfStartSafe, "placeSelf", "place-self", "", "auto auto");
+  checkValues(placeSelfStartSafe, "placeSelf", "place-self", "", "auto");
   checkPlaceSelfValues(placeSelfStartSafe, "", "auto", "auto");
 }, "Test setting 'start safe' as incorrect value through CSS.");
 
 test(function() {
-  checkValues(placeSelfBaselineSafe, "placeSelf", "place-self", "", "auto auto");
+  checkValues(placeSelfBaselineSafe, "placeSelf", "place-self", "", "auto");
   checkPlaceSelfValues(placeSelfBaselineSafe, "", "auto", "auto");
 }, "Test setting 'baseline safe' as incorrect value through CSS.");
 
 test(function() {
-  checkValues(placeSelfStartEndLeft, "placeSelf", "place-self", "", "auto auto");
+  checkValues(placeSelfStartEndLeft, "placeSelf", "place-self", "", "auto");
   checkPlaceSelfValues(placeSelfStartEndLeft, "", "auto", "auto");
 }, "Test setting 'start end left' as incorrect value through CSS.");
 
 test(function() {
-  checkPlaceSelfValuesJS("center", "center", "center");
   checkPlaceSelfValuesJS("center start", "center", "start");
   checkPlaceSelfValuesJS("self-start end", "self-start", "end");
   checkPlaceSelfValuesJS("normal end", "normal", "end");
@@ -241,11 +240,11 @@ test(function() {
 test(function() {
   element = document.createElement("div");
   document.body.appendChild(element);
-  checkValues(element, "placeSelf", "place-self", "", "auto auto");
+  checkValues(element, "placeSelf", "place-self", "", "auto");
   element.style.placeSelf = "center";
   checkPlaceSelfValues(element, "center", "center", "center");
   element.style.placeSelf = "initial";
-  checkValues(element, "placeSelf", "place-self", "initial", "auto auto");
+  checkValues(element, "placeSelf", "place-self", "initial", "auto");
   checkPlaceSelfValues(element, "initial", "auto", "auto");
 }, "Test the 'initial' value of the place-self shorthand and its longhand properties' Computed value");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/content-distribution/place-content-shorthand-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/content-distribution/place-content-shorthand-006-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Checking place-content: normal normal assert_in_array: place-content resolved value value "normal normal" not in array ["", "normal"]
+PASS Checking place-content: normal normal
 PASS Checking place-content: normal left
 PASS Checking place-content: normal right
 PASS Checking place-content: normal start
@@ -14,7 +14,7 @@ PASS Checking place-content: normal space-evenly
 PASS Checking place-content: start normal
 PASS Checking place-content: start left
 PASS Checking place-content: start right
-FAIL Checking place-content: start start assert_in_array: place-content resolved value value "start start" not in array ["", "start"]
+PASS Checking place-content: start start
 PASS Checking place-content: start end
 PASS Checking place-content: start center
 PASS Checking place-content: start flex-start
@@ -27,7 +27,7 @@ PASS Checking place-content: end normal
 PASS Checking place-content: end left
 PASS Checking place-content: end right
 PASS Checking place-content: end start
-FAIL Checking place-content: end end assert_in_array: place-content resolved value value "end end" not in array ["", "end"]
+PASS Checking place-content: end end
 PASS Checking place-content: end center
 PASS Checking place-content: end flex-start
 PASS Checking place-content: end flex-end
@@ -40,7 +40,7 @@ PASS Checking place-content: center left
 PASS Checking place-content: center right
 PASS Checking place-content: center start
 PASS Checking place-content: center end
-FAIL Checking place-content: center center assert_in_array: place-content resolved value value "center center" not in array ["", "center"]
+PASS Checking place-content: center center
 PASS Checking place-content: center flex-start
 PASS Checking place-content: center flex-end
 PASS Checking place-content: center stretch
@@ -53,7 +53,7 @@ PASS Checking place-content: flex-start right
 PASS Checking place-content: flex-start start
 PASS Checking place-content: flex-start end
 PASS Checking place-content: flex-start center
-FAIL Checking place-content: flex-start flex-start assert_in_array: place-content resolved value value "flex-start flex-start" not in array ["", "flex-start"]
+PASS Checking place-content: flex-start flex-start
 PASS Checking place-content: flex-start flex-end
 PASS Checking place-content: flex-start stretch
 PASS Checking place-content: flex-start space-around
@@ -66,7 +66,7 @@ PASS Checking place-content: flex-end start
 PASS Checking place-content: flex-end end
 PASS Checking place-content: flex-end center
 PASS Checking place-content: flex-end flex-start
-FAIL Checking place-content: flex-end flex-end assert_in_array: place-content resolved value value "flex-end flex-end" not in array ["", "flex-end"]
+PASS Checking place-content: flex-end flex-end
 PASS Checking place-content: flex-end stretch
 PASS Checking place-content: flex-end space-around
 PASS Checking place-content: flex-end space-between
@@ -79,7 +79,7 @@ PASS Checking place-content: stretch end
 PASS Checking place-content: stretch center
 PASS Checking place-content: stretch flex-start
 PASS Checking place-content: stretch flex-end
-FAIL Checking place-content: stretch stretch assert_in_array: place-content resolved value value "stretch stretch" not in array ["", "stretch"]
+PASS Checking place-content: stretch stretch
 PASS Checking place-content: stretch space-around
 PASS Checking place-content: stretch space-between
 PASS Checking place-content: stretch space-evenly
@@ -92,7 +92,7 @@ PASS Checking place-content: space-around center
 PASS Checking place-content: space-around flex-start
 PASS Checking place-content: space-around flex-end
 PASS Checking place-content: space-around stretch
-FAIL Checking place-content: space-around space-around assert_in_array: place-content resolved value value "space-around space-around" not in array ["", "space-around"]
+PASS Checking place-content: space-around space-around
 PASS Checking place-content: space-around space-between
 PASS Checking place-content: space-around space-evenly
 PASS Checking place-content: space-between normal
@@ -105,7 +105,7 @@ PASS Checking place-content: space-between flex-start
 PASS Checking place-content: space-between flex-end
 PASS Checking place-content: space-between stretch
 PASS Checking place-content: space-between space-around
-FAIL Checking place-content: space-between space-between assert_in_array: place-content resolved value value "space-between space-between" not in array ["", "space-between"]
+PASS Checking place-content: space-between space-between
 PASS Checking place-content: space-between space-evenly
 PASS Checking place-content: space-evenly normal
 PASS Checking place-content: space-evenly left
@@ -118,7 +118,7 @@ PASS Checking place-content: space-evenly flex-end
 PASS Checking place-content: space-evenly stretch
 PASS Checking place-content: space-evenly space-around
 PASS Checking place-content: space-evenly space-between
-FAIL Checking place-content: space-evenly space-evenly assert_in_array: place-content resolved value value "space-evenly space-evenly" not in array ["", "space-evenly"]
+PASS Checking place-content: space-evenly space-evenly
 PASS Checking place-content: baseline normal
 PASS Checking place-content: baseline left
 PASS Checking place-content: baseline right

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/default-alignment/place-items-shorthand-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/default-alignment/place-items-shorthand-006-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Checking place-items: normal left
 PASS Checking place-items: normal right
-FAIL Checking place-items: normal normal assert_in_array: place-items resolved value value "normal normal" not in array ["", "normal"]
+PASS Checking place-items: normal normal
 PASS Checking place-items: normal stretch
 PASS Checking place-items: normal start
 PASS Checking place-items: normal end
@@ -16,7 +16,7 @@ PASS Checking place-items: normal last baseline
 PASS Checking place-items: stretch left
 PASS Checking place-items: stretch right
 PASS Checking place-items: stretch normal
-FAIL Checking place-items: stretch stretch assert_in_array: place-items resolved value value "stretch stretch" not in array ["", "stretch"]
+PASS Checking place-items: stretch stretch
 PASS Checking place-items: stretch start
 PASS Checking place-items: stretch end
 PASS Checking place-items: stretch self-start
@@ -31,7 +31,7 @@ PASS Checking place-items: start left
 PASS Checking place-items: start right
 PASS Checking place-items: start normal
 PASS Checking place-items: start stretch
-FAIL Checking place-items: start start assert_in_array: place-items resolved value value "start start" not in array ["", "start"]
+PASS Checking place-items: start start
 PASS Checking place-items: start end
 PASS Checking place-items: start self-start
 PASS Checking place-items: start self-end
@@ -46,7 +46,7 @@ PASS Checking place-items: end right
 PASS Checking place-items: end normal
 PASS Checking place-items: end stretch
 PASS Checking place-items: end start
-FAIL Checking place-items: end end assert_in_array: place-items resolved value value "end end" not in array ["", "end"]
+PASS Checking place-items: end end
 PASS Checking place-items: end self-start
 PASS Checking place-items: end self-end
 PASS Checking place-items: end center
@@ -61,7 +61,7 @@ PASS Checking place-items: self-start normal
 PASS Checking place-items: self-start stretch
 PASS Checking place-items: self-start start
 PASS Checking place-items: self-start end
-FAIL Checking place-items: self-start self-start assert_in_array: place-items resolved value value "self-start self-start" not in array ["", "self-start"]
+PASS Checking place-items: self-start self-start
 PASS Checking place-items: self-start self-end
 PASS Checking place-items: self-start center
 PASS Checking place-items: self-start flex-start
@@ -76,7 +76,7 @@ PASS Checking place-items: self-end stretch
 PASS Checking place-items: self-end start
 PASS Checking place-items: self-end end
 PASS Checking place-items: self-end self-start
-FAIL Checking place-items: self-end self-end assert_in_array: place-items resolved value value "self-end self-end" not in array ["", "self-end"]
+PASS Checking place-items: self-end self-end
 PASS Checking place-items: self-end center
 PASS Checking place-items: self-end flex-start
 PASS Checking place-items: self-end flex-end
@@ -91,7 +91,7 @@ PASS Checking place-items: center start
 PASS Checking place-items: center end
 PASS Checking place-items: center self-start
 PASS Checking place-items: center self-end
-FAIL Checking place-items: center center assert_in_array: place-items resolved value value "center center" not in array ["", "center"]
+PASS Checking place-items: center center
 PASS Checking place-items: center flex-start
 PASS Checking place-items: center flex-end
 PASS Checking place-items: center baseline
@@ -106,7 +106,7 @@ PASS Checking place-items: flex-start end
 PASS Checking place-items: flex-start self-start
 PASS Checking place-items: flex-start self-end
 PASS Checking place-items: flex-start center
-FAIL Checking place-items: flex-start flex-start assert_in_array: place-items resolved value value "flex-start flex-start" not in array ["", "flex-start"]
+PASS Checking place-items: flex-start flex-start
 PASS Checking place-items: flex-start flex-end
 PASS Checking place-items: flex-start baseline
 PASS Checking place-items: flex-start first baseline
@@ -121,7 +121,7 @@ PASS Checking place-items: flex-end self-start
 PASS Checking place-items: flex-end self-end
 PASS Checking place-items: flex-end center
 PASS Checking place-items: flex-end flex-start
-FAIL Checking place-items: flex-end flex-end assert_in_array: place-items resolved value value "flex-end flex-end" not in array ["", "flex-end"]
+PASS Checking place-items: flex-end flex-end
 PASS Checking place-items: flex-end baseline
 PASS Checking place-items: flex-end first baseline
 PASS Checking place-items: flex-end last baseline
@@ -136,8 +136,8 @@ PASS Checking place-items: baseline self-end
 PASS Checking place-items: baseline center
 PASS Checking place-items: baseline flex-start
 PASS Checking place-items: baseline flex-end
-FAIL Checking place-items: baseline baseline assert_in_array: place-items resolved value value "baseline baseline" not in array ["", "baseline"]
-FAIL Checking place-items: baseline first baseline assert_in_array: place-items resolved value value "baseline baseline" not in array ["", "baseline"]
+PASS Checking place-items: baseline baseline
+PASS Checking place-items: baseline first baseline
 PASS Checking place-items: baseline last baseline
 PASS Checking place-items: first baseline left
 PASS Checking place-items: first baseline right
@@ -150,8 +150,8 @@ PASS Checking place-items: first baseline self-end
 PASS Checking place-items: first baseline center
 PASS Checking place-items: first baseline flex-start
 PASS Checking place-items: first baseline flex-end
-FAIL Checking place-items: first baseline baseline assert_in_array: place-items resolved value value "baseline baseline" not in array ["", "baseline"]
-FAIL Checking place-items: first baseline first baseline assert_in_array: place-items resolved value value "baseline baseline" not in array ["", "baseline"]
+PASS Checking place-items: first baseline baseline
+PASS Checking place-items: first baseline first baseline
 PASS Checking place-items: first baseline last baseline
 PASS Checking place-items: last baseline left
 PASS Checking place-items: last baseline right
@@ -166,5 +166,5 @@ PASS Checking place-items: last baseline flex-start
 PASS Checking place-items: last baseline flex-end
 PASS Checking place-items: last baseline baseline
 PASS Checking place-items: last baseline first baseline
-FAIL Checking place-items: last baseline last baseline assert_in_array: place-items resolved value value "last baseline last baseline" not in array ["", "last baseline"]
+PASS Checking place-items: last baseline last baseline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/parsing/place-content-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/parsing/place-content-computed-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Property place-content value 'normal normal' assert_equals: expected "normal" but got "normal normal"
+PASS Property place-content value 'normal normal'
 FAIL Property place-content value 'first baseline' assert_true: 'first baseline' is a supported value for place-content. expected true got false
 FAIL Property place-content value 'baseline' assert_true: 'baseline' is a supported value for place-content. expected true got false
 PASS Property place-content value 'first baseline start'
@@ -7,15 +7,15 @@ FAIL Property place-content value 'last baseline' assert_true: 'last baseline' i
 PASS Property place-content value 'first baseline stretch'
 PASS Property place-content value 'last baseline flex-start'
 PASS Property place-content value 'baseline stretch'
-FAIL Property place-content value 'space-between' assert_equals: expected "space-between" but got "space-between space-between"
-FAIL Property place-content value 'space-around' assert_equals: expected "space-around" but got "space-around space-around"
-FAIL Property place-content value 'space-evenly' assert_equals: expected "space-evenly" but got "space-evenly space-evenly"
-FAIL Property place-content value 'stretch' assert_equals: expected "stretch" but got "stretch stretch"
-FAIL Property place-content value 'center' assert_equals: expected "center" but got "center center"
-FAIL Property place-content value 'end' assert_equals: expected "end" but got "end end"
-FAIL Property place-content value 'flex-start flex-start' assert_equals: expected "flex-start" but got "flex-start flex-start"
-FAIL Property place-content value 'unsafe end unsafe end' assert_equals: expected "unsafe end" but got "unsafe end unsafe end"
-FAIL Property place-content value 'safe flex-start' assert_equals: expected "safe flex-start" but got "safe flex-start safe flex-start"
+PASS Property place-content value 'space-between'
+PASS Property place-content value 'space-around'
+PASS Property place-content value 'space-evenly'
+PASS Property place-content value 'stretch'
+PASS Property place-content value 'center'
+PASS Property place-content value 'end'
+PASS Property place-content value 'flex-start flex-start'
+PASS Property place-content value 'unsafe end unsafe end'
+PASS Property place-content value 'safe flex-start'
 PASS Property place-content value 'normal stretch'
 PASS Property place-content value 'baseline space-around'
 PASS Property place-content value 'space-evenly unsafe end'

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/parsing/place-items-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/parsing/place-items-computed-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Property place-items value 'normal' assert_equals: expected "normal" but got "normal normal"
-FAIL Property place-items value 'stretch stretch' assert_equals: expected "stretch" but got "stretch stretch"
-FAIL Property place-items value 'first baseline' assert_equals: expected "baseline" but got "baseline baseline"
-FAIL Property place-items value 'last baseline last baseline' assert_equals: expected "last baseline" but got "last baseline last baseline"
-FAIL Property place-items value 'center' assert_equals: expected "center" but got "center center"
-FAIL Property place-items value 'end end' assert_equals: expected "end" but got "end end"
-FAIL Property place-items value 'self-start' assert_equals: expected "self-start" but got "self-start self-start"
-FAIL Property place-items value 'flex-end' assert_equals: expected "flex-end" but got "flex-end flex-end"
-FAIL Property place-items value 'unsafe center unsafe center' assert_equals: expected "unsafe center" but got "unsafe center unsafe center"
-FAIL Property place-items value 'safe self-end' assert_equals: expected "safe self-end" but got "safe self-end safe self-end"
+PASS Property place-items value 'normal'
+PASS Property place-items value 'stretch stretch'
+PASS Property place-items value 'first baseline'
+PASS Property place-items value 'last baseline last baseline'
+PASS Property place-items value 'center'
+PASS Property place-items value 'end end'
+PASS Property place-items value 'self-start'
+PASS Property place-items value 'flex-end'
+PASS Property place-items value 'unsafe center unsafe center'
+PASS Property place-items value 'safe self-end'
 PASS Property place-items value 'stretch baseline'
 PASS Property place-items value 'last baseline center'
 PASS Property place-items value 'safe self-end normal'

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/parsing/place-self-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/parsing/place-self-computed-expected.txt
@@ -1,15 +1,15 @@
 
-FAIL Property place-self value 'auto auto' assert_equals: expected "auto" but got "auto auto"
-FAIL Property place-self value 'normal' assert_equals: expected "normal" but got "normal normal"
-FAIL Property place-self value 'stretch' assert_equals: expected "stretch" but got "stretch stretch"
-FAIL Property place-self value 'first baseline' assert_equals: expected "baseline" but got "baseline baseline"
-FAIL Property place-self value 'last baseline last baseline' assert_equals: expected "last baseline" but got "last baseline last baseline"
-FAIL Property place-self value 'center center' assert_equals: expected "center" but got "center center"
-FAIL Property place-self value 'start' assert_equals: expected "start" but got "start start"
-FAIL Property place-self value 'self-start' assert_equals: expected "self-start" but got "self-start self-start"
-FAIL Property place-self value 'flex-end' assert_equals: expected "flex-end" but got "flex-end flex-end"
-FAIL Property place-self value 'unsafe center' assert_equals: expected "unsafe center" but got "unsafe center unsafe center"
-FAIL Property place-self value 'safe self-end safe self-end' assert_equals: expected "safe self-end" but got "safe self-end safe self-end"
+PASS Property place-self value 'auto auto'
+PASS Property place-self value 'normal'
+PASS Property place-self value 'stretch'
+PASS Property place-self value 'first baseline'
+PASS Property place-self value 'last baseline last baseline'
+PASS Property place-self value 'center center'
+PASS Property place-self value 'start'
+PASS Property place-self value 'self-start'
+PASS Property place-self value 'flex-end'
+PASS Property place-self value 'unsafe center'
+PASS Property place-self value 'safe self-end safe self-end'
 PASS Property place-self value 'auto last baseline'
 PASS Property place-self value 'baseline flex-end'
 PASS Property place-self value 'unsafe center stretch'

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/self-alignment/place-self-shorthand-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/self-alignment/place-self-shorthand-006-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Checking place-self: auto left
 PASS Checking place-self: auto right
-FAIL Checking place-self: auto auto assert_in_array: place-self resolved value value "auto auto" not in array ["", "auto"]
+PASS Checking place-self: auto auto
 PASS Checking place-self: auto normal
 PASS Checking place-self: auto stretch
 PASS Checking place-self: auto start
@@ -17,7 +17,7 @@ PASS Checking place-self: auto last baseline
 PASS Checking place-self: normal left
 PASS Checking place-self: normal right
 PASS Checking place-self: normal auto
-FAIL Checking place-self: normal normal assert_in_array: place-self resolved value value "normal normal" not in array ["", "normal"]
+PASS Checking place-self: normal normal
 PASS Checking place-self: normal stretch
 PASS Checking place-self: normal start
 PASS Checking place-self: normal end
@@ -33,7 +33,7 @@ PASS Checking place-self: stretch left
 PASS Checking place-self: stretch right
 PASS Checking place-self: stretch auto
 PASS Checking place-self: stretch normal
-FAIL Checking place-self: stretch stretch assert_in_array: place-self resolved value value "stretch stretch" not in array ["", "stretch"]
+PASS Checking place-self: stretch stretch
 PASS Checking place-self: stretch start
 PASS Checking place-self: stretch end
 PASS Checking place-self: stretch self-start
@@ -49,7 +49,7 @@ PASS Checking place-self: start right
 PASS Checking place-self: start auto
 PASS Checking place-self: start normal
 PASS Checking place-self: start stretch
-FAIL Checking place-self: start start assert_in_array: place-self resolved value value "start start" not in array ["", "start"]
+PASS Checking place-self: start start
 PASS Checking place-self: start end
 PASS Checking place-self: start self-start
 PASS Checking place-self: start self-end
@@ -65,7 +65,7 @@ PASS Checking place-self: end auto
 PASS Checking place-self: end normal
 PASS Checking place-self: end stretch
 PASS Checking place-self: end start
-FAIL Checking place-self: end end assert_in_array: place-self resolved value value "end end" not in array ["", "end"]
+PASS Checking place-self: end end
 PASS Checking place-self: end self-start
 PASS Checking place-self: end self-end
 PASS Checking place-self: end center
@@ -81,7 +81,7 @@ PASS Checking place-self: self-start normal
 PASS Checking place-self: self-start stretch
 PASS Checking place-self: self-start start
 PASS Checking place-self: self-start end
-FAIL Checking place-self: self-start self-start assert_in_array: place-self resolved value value "self-start self-start" not in array ["", "self-start"]
+PASS Checking place-self: self-start self-start
 PASS Checking place-self: self-start self-end
 PASS Checking place-self: self-start center
 PASS Checking place-self: self-start flex-start
@@ -97,7 +97,7 @@ PASS Checking place-self: self-end stretch
 PASS Checking place-self: self-end start
 PASS Checking place-self: self-end end
 PASS Checking place-self: self-end self-start
-FAIL Checking place-self: self-end self-end assert_in_array: place-self resolved value value "self-end self-end" not in array ["", "self-end"]
+PASS Checking place-self: self-end self-end
 PASS Checking place-self: self-end center
 PASS Checking place-self: self-end flex-start
 PASS Checking place-self: self-end flex-end
@@ -113,7 +113,7 @@ PASS Checking place-self: center start
 PASS Checking place-self: center end
 PASS Checking place-self: center self-start
 PASS Checking place-self: center self-end
-FAIL Checking place-self: center center assert_in_array: place-self resolved value value "center center" not in array ["", "center"]
+PASS Checking place-self: center center
 PASS Checking place-self: center flex-start
 PASS Checking place-self: center flex-end
 PASS Checking place-self: center baseline
@@ -129,7 +129,7 @@ PASS Checking place-self: flex-start end
 PASS Checking place-self: flex-start self-start
 PASS Checking place-self: flex-start self-end
 PASS Checking place-self: flex-start center
-FAIL Checking place-self: flex-start flex-start assert_in_array: place-self resolved value value "flex-start flex-start" not in array ["", "flex-start"]
+PASS Checking place-self: flex-start flex-start
 PASS Checking place-self: flex-start flex-end
 PASS Checking place-self: flex-start baseline
 PASS Checking place-self: flex-start first baseline
@@ -145,7 +145,7 @@ PASS Checking place-self: flex-end self-start
 PASS Checking place-self: flex-end self-end
 PASS Checking place-self: flex-end center
 PASS Checking place-self: flex-end flex-start
-FAIL Checking place-self: flex-end flex-end assert_in_array: place-self resolved value value "flex-end flex-end" not in array ["", "flex-end"]
+PASS Checking place-self: flex-end flex-end
 PASS Checking place-self: flex-end baseline
 PASS Checking place-self: flex-end first baseline
 PASS Checking place-self: flex-end last baseline
@@ -161,8 +161,8 @@ PASS Checking place-self: baseline self-end
 PASS Checking place-self: baseline center
 PASS Checking place-self: baseline flex-start
 PASS Checking place-self: baseline flex-end
-FAIL Checking place-self: baseline baseline assert_in_array: place-self resolved value value "baseline baseline" not in array ["", "baseline"]
-FAIL Checking place-self: baseline first baseline assert_in_array: place-self resolved value value "baseline baseline" not in array ["", "baseline"]
+PASS Checking place-self: baseline baseline
+PASS Checking place-self: baseline first baseline
 PASS Checking place-self: baseline last baseline
 PASS Checking place-self: first baseline left
 PASS Checking place-self: first baseline right
@@ -176,8 +176,8 @@ PASS Checking place-self: first baseline self-end
 PASS Checking place-self: first baseline center
 PASS Checking place-self: first baseline flex-start
 PASS Checking place-self: first baseline flex-end
-FAIL Checking place-self: first baseline baseline assert_in_array: place-self resolved value value "baseline baseline" not in array ["", "baseline"]
-FAIL Checking place-self: first baseline first baseline assert_in_array: place-self resolved value value "baseline baseline" not in array ["", "baseline"]
+PASS Checking place-self: first baseline baseline
+PASS Checking place-self: first baseline first baseline
 PASS Checking place-self: first baseline last baseline
 PASS Checking place-self: last baseline left
 PASS Checking place-self: last baseline right
@@ -193,5 +193,5 @@ PASS Checking place-self: last baseline flex-start
 PASS Checking place-self: last baseline flex-end
 PASS Checking place-self: last baseline baseline
 PASS Checking place-self: last baseline first baseline
-FAIL Checking place-self: last baseline last baseline assert_in_array: place-self resolved value value "last baseline last baseline" not in array ["", "last baseline"]
+PASS Checking place-self: last baseline last baseline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-content-alignment-with-abspos-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-content-alignment-with-abspos-001-expected.txt
@@ -1,7 +1,7 @@
 
 FAIL .grid 1 assert_equals:
 <div class="grid" data-expected-width="800" data-expected-height="600">
-    <div class="a" id="item" data-offset-x="329" data-offset-y="269" data-expected-width="142" data-expected-height="62" style="align-self: center; justify-self: center;"></div>
+    <div class="a" id="item" data-offset-x="329" data-offset-y="269" data-expected-width="142" data-expected-height="62" style="place-self: center;"></div>
   </div>
 offsetLeft expected 329 but got 0
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3608,11 +3608,11 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyJustifySelf:
         return valueForItemPositionWithOverflowAlignment(style.justifySelf());
     case CSSPropertyPlaceContent:
-        return getCSSPropertyValuesForShorthandProperties(placeContentShorthand());
+        return getCSSPropertyValuesFor2SidesShorthand(placeContentShorthand());
     case CSSPropertyPlaceItems:
-        return getCSSPropertyValuesForShorthandProperties(placeItemsShorthand());
+        return getCSSPropertyValuesFor2SidesShorthand(placeItemsShorthand());
     case CSSPropertyPlaceSelf:
-        return getCSSPropertyValuesForShorthandProperties(placeSelfShorthand());
+        return getCSSPropertyValuesFor2SidesShorthand(placeSelfShorthand());
     case CSSPropertyOrder:
         return CSSPrimitiveValue::createInteger(style.order());
     case CSSPropertyFloat:
@@ -3742,7 +3742,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         }
         return CSSGridTemplateAreasValue::create(style.namedGridArea(), style.namedGridAreaRowCount(), style.namedGridAreaColumnCount());
     case CSSPropertyGap:
-        return getCSSPropertyValuesForShorthandProperties(gapShorthand());
+        return getCSSPropertyValuesFor2SidesShorthand(gapShorthand());
     case CSSPropertyHeight:
         if (renderer && !renderer->isRenderOrLegacyRenderSVGModelObject()) {
             // According to http://www.w3.org/TR/CSS2/visudet.html#the-height-property,

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -256,9 +256,6 @@ static constexpr bool canUseShorthandForLonghand(CSSPropertyID shorthandID, CSSP
     case CSSPropertyGridRow:
     case CSSPropertyMaskPosition:
     case CSSPropertyOffset:
-    case CSSPropertyPlaceContent:
-    case CSSPropertyPlaceItems:
-    case CSSPropertyPlaceSelf:
     case CSSPropertyTextEmphasis:
     case CSSPropertyWebkitTextStroke:
         return false;


### PR DESCRIPTION
#### e095068eb230f338c178714fff1c77568ce522fe
<pre>
[css-align] Fix serialization of place-content/items/self properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=271706">https://bugs.webkit.org/show_bug.cgi?id=271706</a>
<a href="https://rdar.apple.com/125415088">rdar://125415088</a>

Reviewed by Darin Adler.

Use `getCSSPropertyValuesFor2SidesShorthand` instead of `getCSSPropertyValuesForShorthandProperties` since these shorthands have 2 longhands that can be identical.

If they are identical, serialize to the shortest form.

Also remove these shorthands from `canUseShorthandForLonghand`, so they are not treated as legacy shorthands and expanded to their longhands in `cssText`.

* LayoutTests/css3/parse-place-content.html:
* LayoutTests/css3/parse-place-items.html:
* LayoutTests/css3/parse-place-self.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/content-distribution/place-content-shorthand-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/default-alignment/place-items-shorthand-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/parsing/place-content-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/parsing/place-items-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/parsing/place-self-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/self-alignment/place-self-shorthand-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-content-alignment-with-abspos-001-expected.txt:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::canUseShorthandForLonghand):

Canonical link: <a href="https://commits.webkit.org/281476@main">https://commits.webkit.org/281476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b01c758ba1f25cbdb7979d174bb16093407897c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10590 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48657 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7391 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29499 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9259 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9510 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65710 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3990 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56011 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4008 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56162 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13310 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3317 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35221 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36303 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37391 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->