### PR TITLE
Implement Observable#filter

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any-expected.txt
@@ -43,7 +43,7 @@ PASS Unsubscription lifecycle
 PASS Teardowns are called in upstream->downstream order on consumer-initiated unsubscription
 PASS Teardowns are called in downstream->upstream order on consumer-initiated unsubscription with pre-aborted Signal
 PASS Producer-initiated unsubscription in a downstream Observable fires abort events before each teardown, in downstream->upstream order
-FAIL Subscriber#error() value is stored as Subscriber's AbortSignal's reason assert_equals: Reason is set correctly expected (string) "calling error()" but got (object) object "AbortError: The operation was aborted."
+PASS Subscriber#error() value is stored as Subscriber's AbortSignal's reason
 PASS Aborting a subscription should stop emitting values
 PASS Calling subscribe should never throw an error synchronously, initializer throws error
 PASS Calling subscribe should never throw an error synchronously, subscriber pushes error

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.worker-expected.txt
@@ -30,7 +30,7 @@ PASS Unsubscription lifecycle
 PASS Teardowns are called in upstream->downstream order on consumer-initiated unsubscription
 PASS Teardowns are called in downstream->upstream order on consumer-initiated unsubscription with pre-aborted Signal
 PASS Producer-initiated unsubscription in a downstream Observable fires abort events before each teardown, in downstream->upstream order
-FAIL Subscriber#error() value is stored as Subscriber's AbortSignal's reason assert_equals: Reason is set correctly expected (string) "calling error()" but got (object) object "AbortError: The operation was aborted."
+PASS Subscriber#error() value is stored as Subscriber's AbortSignal's reason
 PASS Aborting a subscription should stop emitting values
 PASS Calling subscribe should never throw an error synchronously, initializer throws error
 PASS Calling subscribe should never throw an error synchronously, subscriber pushes error

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-filter.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-filter.any-expected.txt
@@ -1,16 +1,9 @@
+CONSOLE MESSAGE: Error: error while filtering
 
-FAIL filter(): Returned Observable filters out results based on predicate source
-    .filter is not a function. (In 'source
-    .filter(value => value % 2 === 0)', 'source
-    .filter' is undefined)
-FAIL filter(): Errors thrown in filter predicate are emitted to Observer error() handler source
-    .filter is not a function. (In 'source
-    .filter(() => {
-      throw error;
-    })', 'source
-    .filter' is undefined)
-FAIL filter(): Passes complete() through from source Observable source.filter is not a function. (In 'source.filter(v => ++predicateCalls)', 'source.filter' is undefined)
-FAIL filter(): Passes error() through from source Observable source.map is not a function. (In 'source.map(v => ++predicateCalls)', 'source.map' is undefined)
-FAIL filter(): Upon source completion, source Observable teardown sequence happens after downstream filter complete() is called source.filter is not a function. (In 'source.filter(() => results.push('filter predicate called'))', 'source.filter' is undefined)
-FAIL filter(): Index is passed correctly to predicate source.filter is not a function. (In 'source.filter((value, index) => indices.push(index))', 'source.filter' is undefined)
+PASS filter(): Returned Observable filters out results based on predicate
+PASS filter(): Errors thrown in filter predicate are emitted to Observer error() handler
+PASS filter(): Passes complete() through from source Observable
+PASS filter(): Passes error() through from source Observable
+PASS filter(): Upon source completion, source Observable teardown sequence happens after downstream filter complete() is called
+PASS filter(): Index is passed correctly to predicate
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-filter.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-filter.any.js
@@ -28,7 +28,7 @@ test(() => {
   const source = new Observable(subscriber => {
     subscriber.addTeardown(() => teardownCalled = true);
     subscriber.next(1);
-    assert_true(teardownCalled, "Teardown called once map unsubscribes due to error");
+    assert_true(teardownCalled, "Teardown called once filter unsubscribes due to error");
     assert_false(subscriber.active, "Unsubscription makes Subscriber inactive");
     results.push(subscriber.signal.reason);
     subscriber.next(2);
@@ -45,6 +45,7 @@ test(() => {
       complete: () => results.push("complete"),
     });
 
+  console.log(error, results);
   assert_array_equals(results, [error, error]);
 }, "filter(): Errors thrown in filter predicate are emitted to Observer error() handler");
 
@@ -76,7 +77,7 @@ test(() => {
 
   let predicateCalls = 0;
   const results = [];
-  source.map(v => ++predicateCalls).subscribe({
+  source.filter(v => ++predicateCalls).subscribe({
     next: v => results.push(v),
     error: e => results.push(e),
     complete: () => results.push('complete'),

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-filter.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-filter.any.worker-expected.txt
@@ -1,16 +1,8 @@
 
-FAIL filter(): Returned Observable filters out results based on predicate source
-    .filter is not a function. (In 'source
-    .filter(value => value % 2 === 0)', 'source
-    .filter' is undefined)
-FAIL filter(): Errors thrown in filter predicate are emitted to Observer error() handler source
-    .filter is not a function. (In 'source
-    .filter(() => {
-      throw error;
-    })', 'source
-    .filter' is undefined)
-FAIL filter(): Passes complete() through from source Observable source.filter is not a function. (In 'source.filter(v => ++predicateCalls)', 'source.filter' is undefined)
-FAIL filter(): Passes error() through from source Observable source.map is not a function. (In 'source.map(v => ++predicateCalls)', 'source.map' is undefined)
-FAIL filter(): Upon source completion, source Observable teardown sequence happens after downstream filter complete() is called source.filter is not a function. (In 'source.filter(() => results.push('filter predicate called'))', 'source.filter' is undefined)
-FAIL filter(): Index is passed correctly to predicate source.filter is not a function. (In 'source.filter((value, index) => indices.push(index))', 'source.filter' is undefined)
+PASS filter(): Returned Observable filters out results based on predicate
+PASS filter(): Errors thrown in filter predicate are emitted to Observer error() handler
+PASS filter(): Passes complete() through from source Observable
+PASS filter(): Passes error() through from source Observable
+PASS filter(): Upon source completion, source Observable teardown sequence happens after downstream filter complete() is called
+PASS filter(): Index is passed correctly to predicate
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1129,6 +1129,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/PointerEvent.idl
     dom/PointerLockOptions.idl
     dom/PopStateEvent.idl
+    dom/PredicateCallback.idl
     dom/ProcessingInstruction.idl
     dom/ProgressEvent.idl
     dom/PromiseRejectionEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1440,6 +1440,7 @@ $(PROJECT_DIR)/dom/ParentNode.idl
 $(PROJECT_DIR)/dom/PointerEvent.idl
 $(PROJECT_DIR)/dom/PointerLockOptions.idl
 $(PROJECT_DIR)/dom/PopStateEvent.idl
+$(PROJECT_DIR)/dom/PredicateCallback.idl
 $(PROJECT_DIR)/dom/ProcessingInstruction.idl
 $(PROJECT_DIR)/dom/ProgressEvent.idl
 $(PROJECT_DIR)/dom/PromiseRejectionEvent.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2241,6 +2241,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPositionErrorCallback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPositionErrorCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPositionOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPositionOptions.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPredicateCallback.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPredicateCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPredefinedColorSpace.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPredefinedColorSpace.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSProcessingInstruction.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1136,6 +1136,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/PointerEvent.idl \
     $(WebCore)/dom/PointerLockOptions.idl \
     $(WebCore)/dom/PopStateEvent.idl \
+    $(WebCore)/dom/PredicateCallback.idl \
     $(WebCore)/dom/ProcessingInstruction.idl \
     $(WebCore)/dom/ProgressEvent.idl \
     $(WebCore)/dom/PromiseRejectionEvent.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1179,6 +1179,7 @@ dom/InlineStyleSheetOwner.cpp
 dom/InputEvent.cpp
 dom/InternalObserver.cpp
 dom/InternalObserverFromScript.cpp
+dom/InternalObserverFilter.cpp
 dom/InternalObserverTake.cpp
 dom/KeyboardEvent.cpp
 dom/LiveNodeList.cpp
@@ -4131,6 +4132,7 @@ JSPopStateEvent.cpp
 JSPositionCallback.cpp
 JSPositionErrorCallback.cpp
 JSPositionOptions.cpp
+JSPredicateCallback.cpp
 JSPredefinedColorSpace.cpp
 JSProcessingInstruction.cpp
 JSProgressEvent.cpp

--- a/Source/WebCore/dom/InternalObserver.h
+++ b/Source/WebCore/dom/InternalObserver.h
@@ -28,6 +28,12 @@
 #include "ActiveDOMObject.h"
 #include <wtf/RefCounted.h>
 
+namespace JSC {
+class AbstractSlotVisitor;
+class JSValue;
+class SlotVisitor;
+} // namespace JSC
+
 namespace WebCore {
 
 class InternalObserver : public ActiveDOMObject, public RefCounted<InternalObserver> {

--- a/Source/WebCore/dom/InternalObserverFilter.cpp
+++ b/Source/WebCore/dom/InternalObserverFilter.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InternalObserverFilter.h"
+
+#include "InternalObserver.h"
+#include "Observable.h"
+#include "PredicateCallback.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include "Subscriber.h"
+#include "SubscriberCallback.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+
+namespace WebCore {
+
+class InternalObserverFilter final : public InternalObserver {
+public:
+    static Ref<InternalObserverFilter> create(ScriptExecutionContext& context, Ref<Subscriber> subscriber, Ref<PredicateCallback> predicate)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverFilter(context, subscriber, predicate));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+    class SubscriberCallbackFilter final : public SubscriberCallback {
+    public:
+        static Ref<SubscriberCallbackFilter> create(ScriptExecutionContext& context, Ref<Observable> source, Ref<PredicateCallback> predicate)
+        {
+            return adoptRef(*new InternalObserverFilter::SubscriberCallbackFilter(context, source, predicate));
+        }
+
+        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        {
+            auto context = scriptExecutionContext();
+
+            if (!context) {
+                subscriber.complete();
+                return { };
+            }
+
+            SubscribeOptions options;
+            options.signal = &subscriber.signal();
+            m_sourceObservable->subscribeInternal(*context, InternalObserverFilter::create(*context, subscriber, m_predicate), options);
+
+            return { };
+        }
+
+    private:
+        Ref<Observable> m_sourceObservable;
+        Ref<PredicateCallback> m_predicate;
+
+        SubscriberCallbackFilter(ScriptExecutionContext& context, Ref<Observable> source, Ref<PredicateCallback> predicate)
+            : SubscriberCallback(&context)
+            , m_sourceObservable(source)
+            , m_predicate(predicate)
+        { }
+
+        bool hasCallback() const final { return true; }
+    };
+
+private:
+    Ref<Subscriber> m_subscriber;
+    Ref<PredicateCallback> m_predicate;
+    uint64_t m_idx { 0 };
+
+    void next(JSC::JSValue value) final
+    {
+        auto context = scriptExecutionContext();
+        if (!context)
+            return;
+
+        Ref vm = context->globalObject()->vm();
+        JSC::JSLockHolder lock(vm);
+
+        auto matches = false;
+
+        // The exception is not reported, instead it is forwarded to the
+        // error handler. As such, PredicateCallback `[RethrowsException]`
+        // and here a catch scope is declared so the error can be passed
+        // to the subscription error handler.
+        JSC::Exception* previousException = nullptr;
+        {
+            auto catchScope = DECLARE_CATCH_SCOPE(vm);
+            auto result = m_predicate->handleEvent(value, m_idx);
+            previousException = catchScope.exception();
+            if (previousException) {
+                catchScope.clearException();
+                m_subscriber->error(previousException->value());
+                return;
+            }
+
+            if (result.type() == CallbackResultType::Success)
+                matches = result.releaseReturnValue();
+        }
+
+        m_idx += 1;
+
+        if (matches)
+            m_subscriber->next(value);
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        m_subscriber->error(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+        m_subscriber->complete();
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    {
+        m_subscriber->visitAdditionalChildren(visitor);
+        m_predicate->visitJSFunction(visitor);
+    }
+
+    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
+    {
+        m_subscriber->visitAdditionalChildren(visitor);
+        m_predicate->visitJSFunction(visitor);
+    }
+
+    InternalObserverFilter(ScriptExecutionContext& context, Ref<Subscriber> subscriber, Ref<PredicateCallback> predicate)
+        : InternalObserver(context)
+        , m_subscriber(subscriber)
+        , m_predicate(predicate)
+    { }
+
+};
+
+Ref<SubscriberCallback> createSubscriberCallbackFilter(ScriptExecutionContext& context, Ref<Observable> observable, Ref<PredicateCallback> predicate)
+{
+    return InternalObserverFilter::SubscriberCallbackFilter::create(context, observable, predicate);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverFilter.h
+++ b/Source/WebCore/dom/InternalObserverFilter.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class Observable;
+class PredicateCallback;
+class ScriptExecutionContext;
+class SubscriberCallback;
+
+Ref<SubscriberCallback> createSubscriberCallbackFilter(ScriptExecutionContext&, Ref<Observable>, Ref<PredicateCallback>);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverTake.cpp
+++ b/Source/WebCore/dom/InternalObserverTake.cpp
@@ -32,6 +32,7 @@
 #include "SubscribeOptions.h"
 #include "Subscriber.h"
 #include "SubscriberCallback.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -30,9 +30,11 @@
 #include "Document.h"
 #include "Exception.h"
 #include "ExceptionCode.h"
+#include "InternalObserverFilter.h"
 #include "InternalObserverFromScript.h"
 #include "InternalObserverTake.h"
 #include "JSSubscriptionObserverCallback.h"
+#include "PredicateCallback.h"
 #include "SubscribeOptions.h"
 #include "Subscriber.h"
 #include "SubscriberCallback.h"
@@ -93,6 +95,12 @@ void Observable::subscribeInternal(ScriptExecutionContext& context, Ref<Internal
         }
     }
 }
+
+Ref<Observable> Observable::filter(ScriptExecutionContext& context, PredicateCallback& predicate)
+{
+    return create(createSubscriberCallbackFilter(context, *this, predicate));
+}
+
 
 Ref<Observable> Observable::take(ScriptExecutionContext& context, uint64_t amount)
 {

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -36,6 +36,7 @@ namespace WebCore {
 class InternalObserver;
 class ScriptExecutionContext;
 class JSSubscriptionObserverCallback;
+class PredicateCallback;
 struct SubscriptionObserver;
 struct SubscribeOptions;
 
@@ -51,6 +52,8 @@ public:
 
     void subscribe(ScriptExecutionContext&, std::optional<ObserverUnion>, SubscribeOptions);
     void subscribeInternal(ScriptExecutionContext&, Ref<InternalObserver>, SubscribeOptions);
+
+    Ref<Observable> filter(ScriptExecutionContext&, PredicateCallback&);
 
     Ref<Observable> take(ScriptExecutionContext&, uint64_t);
 

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -33,5 +33,7 @@ interface Observable {
   constructor(SubscriberCallback callback);
   [CallWith=CurrentScriptExecutionContext, RaisesException] undefined subscribe(optional ObserverUnion observer = {}, optional SubscribeOptions options = {});
 
+  [CallWith=CurrentScriptExecutionContext] Observable filter(PredicateCallback predicate);
+
   [CallWith=CurrentScriptExecutionContext] Observable take(unsigned long long amount);
 };

--- a/Source/WebCore/dom/PredicateCallback.h
+++ b/Source/WebCore/dom/PredicateCallback.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ActiveDOMCallback.h"
+#include "CallbackResult.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class PredicateCallback : public RefCounted<PredicateCallback>, public ActiveDOMCallback {
+public:
+    using ActiveDOMCallback::ActiveDOMCallback;
+
+    virtual CallbackResult<bool> handleEvent(JSC::JSValue, uint64_t) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/PredicateCallback.idl
+++ b/Source/WebCore/dom/PredicateCallback.idl
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[ RethrowException ] callback PredicateCallback = boolean (any value, unsigned long long index);
+

--- a/Source/WebCore/dom/Subscriber.cpp
+++ b/Source/WebCore/dom/Subscriber.cpp
@@ -69,7 +69,7 @@ void Subscriber::error(JSC::JSValue error)
     if (isInactiveDocument())
         return;
 
-    close(JSC::jsUndefined());
+    close(error);
 
     m_observer->error(error);
 }


### PR DESCRIPTION
#### f76bfc9138c07f28bc8ed9186ee95ffc899d9da7
<pre>
Implement Observable#filter
<a href="https://bugs.webkit.org/show_bug.cgi?id=277221">https://bugs.webkit.org/show_bug.cgi?id=277221</a>

Reviewed by Darin Adler.

This adds the InternalObserverFilter/SubscriberCallbackFilter, and the
required PredicateCallback IDL type, to support Observable#filter.

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-filter.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-filter.any.js:
(test):
  This test had a typo in it, where it called map rather than filter.
  I&apos;ve synced the changes in a PR to WPT here:
  <a href="https://github.com/web-platform-tests/wpt/pull/47324.">https://github.com/web-platform-tests/wpt/pull/47324.</a>
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-filter.any.worker-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/InternalObserver.h:
* Source/WebCore/dom/InternalObserverFilter.cpp:
(WebCore::createSubscriberCallbackFilter):
  Added the new Filter specialisations.
* Source/WebCore/dom/InternalObserverFilter.h:
* Source/WebCore/dom/InternalObserverTake.cpp:
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::filter):
  Added the filter function, which creates an Observable with the
  SubscriberCallbackFilter specialisation.
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.idl:
* Source/WebCore/dom/PredicateCallback.h: Copied from Source/WebCore/dom/Observable.idl.
* Source/WebCore/dom/PredicateCallback.idl: Copied from Source/WebCore/dom/Observable.idl.
* Source/WebCore/dom/Subscriber.cpp:
(WebCore::Subscriber::error):
  This method had an issue where close() was being called with
  JSC::JSUndefined() but actually needs to pass the error object, so the
  abort signal has an appropriate reason. This change also fixed one of
  the failing tests in constructor-any-expected.txt.

Canonical link: <a href="https://commits.webkit.org/281472@main">https://commits.webkit.org/281472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82b5952d625e89b9cc3f6ee5ea911e1b3fd2d19a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63948 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48638 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7371 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33422 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9229 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9480 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55337 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65680 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55992 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3978 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56141 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13305 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3287 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35191 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36273 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->