### PR TITLE
Faster color resolving access

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -43,6 +43,7 @@
 #include "HTMLTableSectionElement.h"
 #include "NodeRenderStyle.h"
 #include "RenderObject.h"
+#include "RenderStyleResolveColor.h"
 #include "RenderTable.h"
 #include "RenderTableCell.h"
 #include <wtf/Scope.h>
@@ -196,7 +197,7 @@ bool AccessibilityTable::isDataTable() const
 
     // Store the background color of the table to check against cell's background colors.
     const auto* tableStyle = this->style();
-    Color tableBackgroundColor = tableStyle ? tableStyle->visitedDependentColor(CSSPropertyBackgroundColor) : Color::white;
+    Color tableBackgroundColor = tableStyle ? tableStyle->visitedDependentColor<CSSPropertyBackgroundColor>() : Color::white;
     unsigned tableHorizontalBorderSpacing = tableStyle ? tableStyle->horizontalBorderSpacing() : 0;
     unsigned tableVerticalBorderSpacing = tableStyle ? tableStyle->verticalBorderSpacing() : 0;
 
@@ -255,7 +256,7 @@ bool AccessibilityTable::isDataTable() const
                 // For the first 5 rows, cache the background color so we can check if this table has zebra-striped rows.
                 if (alternatingRowColorCount < 5) {
                     if (const auto* rowStyle = styleFrom(*tableRow)) {
-                        alternatingRowColors[alternatingRowColorCount] = rowStyle->visitedDependentColor(CSSPropertyBackgroundColor);
+                        alternatingRowColors[alternatingRowColorCount] = rowStyle->visitedDependentColor<CSSPropertyBackgroundColor>();
                         alternatingRowColorCount++;
                     }
                 }
@@ -321,7 +322,7 @@ bool AccessibilityTable::isDataTable() const
 
                 // If the cell has a different color from the table and there is cell spacing,
                 // then it is probably a data table cell (spacing and colors take the place of borders).
-                Color cellColor = cellStyle ? cellStyle->visitedDependentColor(CSSPropertyBackgroundColor) : Color::white;
+                Color cellColor = cellStyle ? cellStyle->visitedDependentColor<CSSPropertyBackgroundColor>() : Color::white;
                 if (tableHorizontalBorderSpacing > 0 && tableVerticalBorderSpacing > 0 && tableBackgroundColor != cellColor && !cellColor.isOpaque())
                     backgroundDifferenceCellCount++;
 

--- a/Source/WebCore/css/color/StyleColor.cpp
+++ b/Source/WebCore/css/color/StyleColor.cpp
@@ -211,9 +211,10 @@ decltype(auto) StyleColor::visit(const StyleColor::ColorKind& color, F&&... f)
     );
 }
 
-StyleColor StyleColor::currentColor()
+const StyleColor& StyleColor::currentColor()
 {
-    return StyleColor { StyleCurrentColor { } };
+    static NeverDestroyed<StyleColor> currentColor = StyleColor { StyleCurrentColor { } };
+    return currentColor;
 }
 
 StyleColor::ColorKind StyleColor::copy(const StyleColor::ColorKind& other)

--- a/Source/WebCore/css/color/StyleColor.h
+++ b/Source/WebCore/css/color/StyleColor.h
@@ -66,7 +66,7 @@ public:
     StyleColor();
 
     // Convenience constructors that create StyleAbsoluteColor.
-    StyleColor(Color);
+    WEBCORE_EXPORT StyleColor(Color);
     StyleColor(SRGBA<uint8_t>);
 
     StyleColor(StyleAbsoluteColor&&);
@@ -98,7 +98,7 @@ public:
 
     WEBCORE_EXPORT ~StyleColor();
 
-    static StyleColor currentColor();
+    static const StyleColor& currentColor();
 
     static Color colorFromKeyword(CSSValueID, OptionSet<StyleColorOptions>);
     static Color colorFromAbsoluteKeyword(CSSValueID);

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4528,7 +4528,7 @@ Color LocalFrameView::documentBackgroundColor() const
     Color htmlBackgroundColor;
     Color bodyBackgroundColor;
     if (htmlElement && htmlElement->renderer())
-        htmlBackgroundColor = htmlElement->renderer()->style().visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
+        htmlBackgroundColor = htmlElement->renderer()->style().visitedDependentColorWithColorFilter<CSSPropertyBackgroundColor>();
     if (bodyElement && bodyElement->renderer())
         bodyBackgroundColor = bodyElement->renderer()->style().visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
 

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -81,7 +81,7 @@ void BackgroundPainter::paintBackground(const LayoutRect& paintRect, BleedAvoida
     if (m_renderer.backgroundIsKnownToBeObscured(paintRect.location()) && !boxShadowShouldBeAppliedToBackground(m_renderer, paintRect.location(), bleedAvoidance, { }))
         return;
 
-    auto backgroundColor = m_renderer.style().visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
+    auto backgroundColor = m_renderer.style().template visitedDependentColorWithColorFilter<CSSPropertyBackgroundColor>();
     auto compositeOp = document().compositeOperatorForBackgroundColor(backgroundColor, m_renderer);
 
     paintFillLayers(backgroundColor, m_renderer.style().backgroundLayers(), paintRect, bleedAvoidance, compositeOp);
@@ -98,7 +98,7 @@ void BackgroundPainter::paintRootBoxFillLayers() const
         return;
 
     auto& style = rootBackgroundRenderer->style();
-    auto backgroundColor = style.visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
+    auto backgroundColor = style.visitedDependentColorWithColorFilter<CSSPropertyBackgroundColor>();
     auto compositeOp = document().compositeOperatorForBackgroundColor(backgroundColor, m_renderer);
 
     paintFillLayers(backgroundColor, style.backgroundLayers(), view().backgroundRect(), BleedAvoidance::None, compositeOp, rootBackgroundRenderer);
@@ -806,7 +806,7 @@ void BackgroundPainter::paintBoxShadow(const LayoutRect& paintRect, const Render
     bool hasBorderRadius = style.hasBorderRadius();
     float deviceScaleFactor = document().deviceScaleFactor();
 
-    bool hasOpaqueBackground = style.visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor).isOpaque();
+    bool hasOpaqueBackground = style.visitedDependentColorWithColorFilter<CSSPropertyBackgroundColor>().isOpaque();
     for (const ShadowData* shadow = style.boxShadow(); shadow; shadow = shadow->next()) {
         if (shadow->style() != shadowStyle)
             continue;
@@ -978,7 +978,7 @@ bool BackgroundPainter::boxShadowShouldBeAppliedToBackground(const RenderBoxMode
     if (!hasOneNormalBoxShadow)
         return false;
 
-    Color backgroundColor = style.visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
+    Color backgroundColor = style.visitedDependentColorWithColorFilter<CSSPropertyBackgroundColor>();
     if (!backgroundColor.isOpaque())
         return false;
 

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -417,7 +417,7 @@ void BorderPainter::paintOutline(const LayoutPoint& paintOffset, const Vector<La
     }
 
     auto& graphicsContext = m_paintInfo.context();
-    auto outlineColor = styleToUse.visitedDependentColorWithColorFilter(CSSPropertyOutlineColor);
+    auto outlineColor = styleToUse.template visitedDependentColorWithColorFilter<CSSPropertyOutlineColor>();
     auto useTransparencyLayer = !outlineColor.isOpaque();
     if (useTransparencyLayer) {
         graphicsContext.beginTransparencyLayer(outlineColor.alphaAsFloat());

--- a/Source/WebCore/rendering/InlineBoxPainter.cpp
+++ b/Source/WebCore/rendering/InlineBoxPainter.cpp
@@ -238,7 +238,7 @@ void InlineBoxPainter::paintDecorations()
     if (!BackgroundPainter::boxShadowShouldBeAppliedToBackground(renderer(), adjustedPaintoffset, BleedAvoidance::None, m_inlineBox))
         paintBoxShadow(ShadowStyle::Normal, paintRect);
 
-    auto color = style.visitedDependentColor(CSSPropertyBackgroundColor, m_paintInfo.paintBehavior);
+    auto color = style.visitedDependentColor<CSSPropertyBackgroundColor>(m_paintInfo.paintBehavior);
     auto compositeOp = renderer().document().compositeOperatorForBackgroundColor(color, renderer());
 
     color = style.colorByApplyingColorFilter(color);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1760,7 +1760,7 @@ bool RenderBox::getBackgroundPaintedExtent(const LayoutPoint& paintOffset, Layou
     ASSERT(hasBackground());
     LayoutRect backgroundRect = snappedIntRect(borderBoxRect());
 
-    Color backgroundColor = style().visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
+    Color backgroundColor = style().visitedDependentColorWithColorFilter<CSSPropertyBackgroundColor>();
     if (backgroundColor.isVisible()) {
         paintedExtent = backgroundRect;
         return true;
@@ -1782,7 +1782,7 @@ bool RenderBox::backgroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect) c
     if (!BackgroundPainter::paintsOwnBackground(*this))
         return false;
 
-    Color backgroundColor = style().visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
+    Color backgroundColor = style().visitedDependentColorWithColorFilter<CSSPropertyBackgroundColor>();
     if (!backgroundColor.isOpaque())
         return false;
 
@@ -1914,7 +1914,7 @@ bool RenderBox::backgroundHasOpaqueTopLayer() const
 
     // If there is only one layer and no image, check whether the background color is opaque.
     if (!fillLayer.next() && !fillLayer.hasImage()) {
-        Color bgColor = style().visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
+        Color bgColor = style().visitedDependentColorWithColorFilter<CSSPropertyBackgroundColor>();
         if (bgColor.isOpaque())
             return true;
     }

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -98,6 +98,7 @@
 #include "Styleable.h"
 #include "TextAutoSizing.h"
 #include "ViewTransition.h"
+#include "WebCore/CSSPropertyNames.h"
 #include <wtf/MathExtras.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -1754,7 +1755,7 @@ const RenderStyle* RenderElement::textSegmentPseudoStyle(PseudoId pseudoId) cons
     return nullptr;
 }
 
-Color RenderElement::selectionColor(CSSPropertyID colorProperty) const
+template <CSSPropertyID colorProperty> Color RenderElement::selectionColor() const
 {
     // If the element is unselectable, or we are only painting the selection,
     // don't override the foreground color with the selection foreground color.
@@ -1763,9 +1764,9 @@ Color RenderElement::selectionColor(CSSPropertyID colorProperty) const
         return Color();
 
     if (auto pseudoStyle = selectionPseudoStyle()) {
-        Color color = pseudoStyle->visitedDependentColorWithColorFilter(colorProperty);
+        Color color = pseudoStyle->visitedDependentColorWithColorFilter<colorProperty>();
         if (!color.isValid())
-            color = pseudoStyle->visitedDependentColorWithColorFilter(CSSPropertyColor);
+            color = pseudoStyle->template visitedDependentColorWithColorFilter<CSSPropertyColor>();
         return color;
     }
 
@@ -1794,12 +1795,12 @@ std::unique_ptr<RenderStyle> RenderElement::selectionPseudoStyle() const
 
 Color RenderElement::selectionForegroundColor() const
 {
-    return selectionColor(CSSPropertyWebkitTextFillColor);
+    return selectionColor<CSSPropertyWebkitTextFillColor>();
 }
 
 Color RenderElement::selectionEmphasisMarkColor() const
 {
-    return selectionColor(CSSPropertyTextEmphasisColor);
+    return selectionColor<CSSPropertyTextEmphasisColor>();
 }
 
 Color RenderElement::selectionBackgroundColor() const

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -113,7 +113,7 @@ public:
 
     bool hasEligibleContainmentForSizeQuery() const;
 
-    Color selectionColor(CSSPropertyID) const;
+    template <CSSPropertyID> Color selectionColor() const;
     std::unique_ptr<RenderStyle> selectionPseudoStyle() const;
 
     // Obtains the selection colors that should be used when painting a selection.

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2739,7 +2739,7 @@ static bool canDirectlyCompositeBackgroundBackgroundImage(const RenderElement& r
 
     // FIXME: Allow color+image compositing when it makes sense.
     // For now bailing out.
-    if (style.visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor).isVisible())
+    if (style.visitedDependentColorWithColorFilter<CSSPropertyBackgroundColor>().isVisible())
         return false;
 
     // FIXME: support gradients with isGeneratedImage.
@@ -2781,7 +2781,7 @@ Color RenderLayerBacking::rendererBackgroundColor() const
     if (!backgroundRenderer)
         backgroundRenderer = &renderer();
 
-    return backgroundRenderer->style().visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
+    return backgroundRenderer->style().visitedDependentColorWithColorFilter<CSSPropertyBackgroundColor>();
 }
 
 void RenderLayerBacking::updateDirectlyCompositedBackgroundColor(PaintedContentsInfo& contentsInfo, bool& didUpdateContentsRect)

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -63,7 +63,9 @@
 #include "RenderLayerInlines.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderObjectInlines.h"
+#include "RenderStyleConstants.h"
 #include "RenderStyleInlines.h"
+#include "RenderStyleResolveColor.h"
 #include "RenderVideo.h"
 #include "RenderView.h"
 #include "RenderViewTransitionCapture.h"
@@ -4624,9 +4626,9 @@ void RenderLayerCompositor::rootOrBodyStyleChanged(RenderElement& renderer, cons
 
     Color oldBackgroundColor;
     if (oldStyle)
-        oldBackgroundColor = oldStyle->visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor);
+        oldBackgroundColor = oldStyle->visitedDependentColorWithColorFilter<CSSPropertyBackgroundColor>();
 
-    if (oldBackgroundColor != renderer.style().visitedDependentColorWithColorFilter(CSSPropertyBackgroundColor))
+    if (oldBackgroundColor != renderer.style().visitedDependentColorWithColorFilter<CSSPropertyBackgroundColor>())
         rootBackgroundColorOrTransparencyChanged();
 
     bool hadFixedBackground = oldStyle && oldStyle->hasEntirelyFixedBackground();

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -192,7 +192,7 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
         context.fillRect(snappedIntRect(selRect), m_listItem->selectionBackgroundColor());
     }
 
-    auto color = style().visitedDependentColorWithColorFilter(CSSPropertyColor);
+    auto color = style().visitedDependentColorWithColorFilter<CSSPropertyColor>();
     context.setStrokeColor(color);
     context.setStrokeStyle(StrokeStyle::SolidStroke);
     context.setStrokeThickness(1.0f);

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -43,6 +43,7 @@
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderCombineText.h"
 #include "RenderElementInlines.h"
+#include "RenderStyleConstants.h"
 #include "RenderText.h"
 #include "RenderTheme.h"
 #include "RenderView.h"
@@ -859,7 +860,7 @@ void TextBoxPainter<TextBoxPath>::fillCompositionUnderline(float start, float wi
         width -= 2;
 
         auto& style = m_renderer.style();
-        auto underlineColor = underline.compositionUnderlineColor == CompositionUnderlineColor::TextColor ? style.visitedDependentColorWithColorFilter(CSSPropertyWebkitTextFillColor) : style.colorByApplyingColorFilter(underline.color);
+        auto underlineColor = underline.compositionUnderlineColor == CompositionUnderlineColor::TextColor ? style. template visitedDependentColorWithColorFilter<CSSPropertyWebkitTextFillColor>() : style.colorByApplyingColorFilter(underline.color);
 
         auto& context = m_paintInfo.context();
         context.setStrokeColor(underlineColor);

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -31,6 +31,7 @@
 #include "InlineTextBoxStyle.h"
 #include "RenderBlock.h"
 #include "RenderStyleInlines.h"
+#include "RenderStyleResolveColor.h"
 #include "RenderText.h"
 #include "ShadowData.h"
 #include "TextRun.h"
@@ -390,7 +391,7 @@ Color TextDecorationPainter::decorationColor(const RenderStyle& style, OptionSet
     if (paintBehavior.contains(PaintBehavior::ForceWhiteText))
         return Color::white;
 
-    return style.visitedDependentColorWithColorFilter(CSSPropertyTextDecorationColor, paintBehavior);
+    return style.visitedDependentColorWithColorFilter<CSSPropertyTextDecorationColor>(paintBehavior);
 }
 
 auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, OptionSet<TextDecorationLine> requestedDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId) -> Styles

--- a/Source/WebCore/rendering/TextPaintStyle.cpp
+++ b/Source/WebCore/rendering/TextPaintStyle.cpp
@@ -33,6 +33,7 @@
 #include "Page.h"
 #include "PaintInfo.h"
 #include "RenderStyleInlines.h"
+#include "RenderStyleResolveColor.h"
 #include "RenderText.h"
 #include "RenderTheme.h"
 #include "RenderView.h"
@@ -106,7 +107,7 @@ TextPaintStyle computeTextPaintStyle(const LocalFrame& frame, const RenderStyle&
         }
     }
 
-    paintStyle.fillColor = lineStyle.visitedDependentColorWithColorFilter(CSSPropertyWebkitTextFillColor, paintInfo.paintBehavior);
+    paintStyle.fillColor = lineStyle.visitedDependentColorWithColorFilter<CSSPropertyWebkitTextFillColor>(paintInfo.paintBehavior);
 
     bool forceBackgroundToWhite = false;
     if (frame.document() && frame.document()->printing()) {
@@ -126,7 +127,7 @@ TextPaintStyle computeTextPaintStyle(const LocalFrame& frame, const RenderStyle&
     if (forceBackgroundToWhite)
         paintStyle.strokeColor = adjustColorForVisibilityOnBackground(paintStyle.strokeColor, Color::white);
 
-    paintStyle.emphasisMarkColor = lineStyle.visitedDependentColorWithColorFilter(CSSPropertyTextEmphasisColor);
+    paintStyle.emphasisMarkColor = lineStyle.visitedDependentColorWithColorFilter<CSSPropertyTextEmphasisColor>();
 
     // Make the text stroke color legible against a white background
     if (forceBackgroundToWhite)

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3092,7 +3092,7 @@ Color RenderStyle::colorResolvingCurrentColor(const StyleColor& color, bool visi
 Color RenderStyle::visitedDependentColor(CSSPropertyID colorProperty, OptionSet<PaintBehavior> paintBehavior) const
 {
     Color unvisitedColor = colorResolvingCurrentColor(colorProperty, false);
-    if (insideLink() != InsideLink::InsideVisited)
+    if (LIKELY(insideLink() != InsideLink::InsideVisited))
         return unvisitedColor;
 
     if (paintBehavior.contains(PaintBehavior::DontShowVisitedLinks))

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1854,13 +1854,20 @@ public:
     bool lastChildState() const { return m_nonInheritedFlags.lastChildState; }
     void setLastChildState() { setUnique(); m_nonInheritedFlags.lastChildState = true; }
 
+    template <CSSPropertyID, bool> inline StyleColor unresolvedColorForProperty() const;
     StyleColor unresolvedColorForProperty(CSSPropertyID colorProperty, bool visitedLink = false) const;
+
+    template <CSSPropertyID, bool> inline Color colorResolvingCurrentColor() const;
     Color colorResolvingCurrentColor(CSSPropertyID colorProperty, bool visitedLink) const;
 
     // Resolves the currentColor keyword, but must not be used for the "color" property which has a different semantic.
+    template<bool> Color colorResolvingCurrentColor(const StyleColor&) const;
     WEBCORE_EXPORT Color colorResolvingCurrentColor(const StyleColor&, bool visitedLink = false) const;
 
+    template <CSSPropertyID> Color visitedDependentColor(OptionSet<PaintBehavior> paintBehavior = { }) const;
     WEBCORE_EXPORT Color visitedDependentColor(CSSPropertyID, OptionSet<PaintBehavior> paintBehavior = { }) const;
+
+    template <CSSPropertyID> Color visitedDependentColorWithColorFilter(OptionSet<PaintBehavior> paintBehavior = { }) const;
     WEBCORE_EXPORT Color visitedDependentColorWithColorFilter(CSSPropertyID, OptionSet<PaintBehavior> paintBehavior = { }) const;
 
     WEBCORE_EXPORT Color colorByApplyingColorFilter(const Color&) const;
@@ -2197,11 +2204,11 @@ public:
     inline const StyleColor& outlineColor() const;
     inline const StyleColor& textEmphasisColor() const;
     inline const StyleColor& textFillColor() const;
-    static inline StyleColor initialTextFillColor();
+    static inline const StyleColor& initialTextFillColor();
     inline const StyleColor& textStrokeColor() const;
     inline const StyleColor& caretColor() const;
     inline bool hasAutoCaretColor() const;
-    const Color& visitedLinkColor() const;
+    WEBCORE_EXPORT const Color& visitedLinkColor() const;
     inline const StyleColor& visitedLinkBackgroundColor() const;
     inline const StyleColor& visitedLinkBorderLeftColor() const;
     inline const StyleColor& visitedLinkBorderRightColor() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -33,6 +33,7 @@
 #include "HitTestRequest.h"
 #include "ImageOrientation.h"
 #include "RenderStyle.h"
+#include "RenderStyleResolveColor.h"
 #include "ScrollTypes.h"
 #include "ScrollbarColor.h"
 #include "ShadowData.h"
@@ -277,7 +278,7 @@ inline bool RenderStyle::hasAutoSpecifiedZIndex() const { return m_nonInheritedD
 inline bool RenderStyle::hasAutoTopAndBottom() const { return top().isAuto() && bottom().isAuto(); }
 inline bool RenderStyle::hasAutoUsedZIndex() const { return m_nonInheritedData->boxData->hasAutoUsedZIndex(); }
 inline bool RenderStyle::hasAutoWidows() const { return m_rareInheritedData->hasAutoWidows; }
-inline bool RenderStyle::hasBackground() const { return visitedDependentColor(CSSPropertyBackgroundColor).isVisible() || hasBackgroundImage(); }
+inline bool RenderStyle::hasBackground() const { return visitedDependentColor<CSSPropertyBackgroundColor>().isVisible() || hasBackgroundImage(); }
 inline bool RenderStyle::hasBackgroundImage() const { return backgroundLayers().hasImage(); }
 inline bool RenderStyle::hasBlendMode() const { return blendMode() != BlendMode::Normal; }
 inline bool RenderStyle::hasBorder() const { return border().hasBorder(); }
@@ -486,7 +487,7 @@ inline const AtomString& RenderStyle::initialTextEmphasisCustomMark() { return n
 constexpr TextEmphasisFill RenderStyle::initialTextEmphasisFill() { return TextEmphasisFill::Filled; }
 constexpr TextEmphasisMark RenderStyle::initialTextEmphasisMark() { return TextEmphasisMark::None; }
 constexpr OptionSet<TextEmphasisPosition> RenderStyle::initialTextEmphasisPosition() { return { TextEmphasisPosition::Over, TextEmphasisPosition::Right }; }
-inline StyleColor RenderStyle::initialTextFillColor() { return StyleColor::currentColor(); }
+inline const StyleColor& RenderStyle::initialTextFillColor() { return StyleColor::currentColor(); }
 inline bool RenderStyle::hasExplicitlySetColor() const { return m_inheritedFlags.hasExplicitlySetColor; }
 constexpr TextGroupAlign RenderStyle::initialTextGroupAlign() { return TextGroupAlign::None; }
 inline Length RenderStyle::initialTextIndent() { return zeroLength(); }

--- a/Source/WebCore/rendering/style/RenderStyleResolveColor.h
+++ b/Source/WebCore/rendering/style/RenderStyleResolveColor.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include "FilterOperations.h"
+#include "PaintPhase.h"
+#include "RenderStyle.h"
+#include "RenderStyleConstants.h"
+#include "RenderStyleInlines.h"
+#include "SVGRenderStyle.h"
+#include "StyleColor.h"
+
+namespace WebCore {
+
+template <CSSPropertyID colorProperty, bool visitedLink>
+StyleColor RenderStyle::unresolvedColorForProperty() const
+{
+    switch (colorProperty) {
+    case CSSPropertyAccentColor:
+        return accentColor();
+    case CSSPropertyColor:
+        return visitedLink ? visitedLinkColor() : color();
+    case CSSPropertyBackgroundColor:
+        return visitedLink ? visitedLinkBackgroundColor() : backgroundColor();
+    case CSSPropertyBorderBottomColor:
+        return visitedLink ? visitedLinkBorderBottomColor() : borderBottomColor();
+    case CSSPropertyBorderLeftColor:
+        return visitedLink ? visitedLinkBorderLeftColor() : borderLeftColor();
+    case CSSPropertyBorderRightColor:
+        return visitedLink ? visitedLinkBorderRightColor() : borderRightColor();
+    case CSSPropertyBorderTopColor:
+        return visitedLink ? visitedLinkBorderTopColor() : borderTopColor();
+    case CSSPropertyFill:
+        return fillPaintColor();
+    case CSSPropertyFloodColor:
+        return floodColor();
+    case CSSPropertyLightingColor:
+        return lightingColor();
+    case CSSPropertyOutlineColor:
+        return visitedLink ? visitedLinkOutlineColor() : outlineColor();
+    case CSSPropertyStopColor:
+        return stopColor();
+    case CSSPropertyStroke:
+        return strokePaintColor();
+    case CSSPropertyStrokeColor:
+        return visitedLink ? visitedLinkStrokeColor() : strokeColor();
+    case CSSPropertyBorderBlockEndColor:
+    case CSSPropertyBorderBlockStartColor:
+    case CSSPropertyBorderInlineEndColor:
+    case CSSPropertyBorderInlineStartColor:
+        return { }; // FIXME
+    case CSSPropertyColumnRuleColor:
+        return visitedLink ? visitedLinkColumnRuleColor() : columnRuleColor();
+    case CSSPropertyTextEmphasisColor:
+        return visitedLink ? visitedLinkTextEmphasisColor() : textEmphasisColor();
+    case CSSPropertyWebkitTextFillColor:
+        return visitedLink ? visitedLinkTextFillColor() : textFillColor();
+    case CSSPropertyWebkitTextStrokeColor:
+        return visitedLink ? visitedLinkTextStrokeColor() : textStrokeColor();
+    case CSSPropertyTextDecorationColor:
+        return visitedLink ? visitedLinkTextDecorationColor() : textDecorationColor();
+    case CSSPropertyCaretColor:
+        return visitedLink ? visitedLinkCaretColor() : caretColor();
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+
+    return { };
+}
+
+template <bool visitedLink>
+Color RenderStyle::colorResolvingCurrentColor(const StyleColor& color) const
+{
+    return color.resolveColor(visitedLink ? visitedLinkColor() : this->color());
+}
+
+template <CSSPropertyID colorProperty, bool visitedLink>
+Color RenderStyle::colorResolvingCurrentColor() const
+{
+    auto result = unresolvedColorForProperty<colorProperty, visitedLink>();
+
+    if constexpr (colorProperty == CSSPropertyTextDecorationColor) {
+        if (result.isCurrentColor()) {
+            if (hasPositiveStrokeWidth()) {
+                // Prefer stroke color if possible but not if it's fully transparent.
+                auto strokeColor = colorResolvingCurrentColor(usedStrokeColorProperty(), visitedLink);
+                if (strokeColor.isVisible())
+                    return strokeColor;
+            }
+            return colorResolvingCurrentColor<CSSPropertyWebkitTextFillColor, visitedLink>();
+        }
+    }
+
+    return colorResolvingCurrentColor(result, visitedLink);
+}
+
+template <CSSPropertyID colorProperty>
+Color RenderStyle::visitedDependentColor(OptionSet<PaintBehavior> paintBehavior) const
+{
+    Color unvisitedColor = colorResolvingCurrentColor<colorProperty, false>();
+    if (LIKELY(insideLink() != InsideLink::InsideVisited))
+        return unvisitedColor;
+
+    if (paintBehavior.contains(PaintBehavior::DontShowVisitedLinks))
+        return unvisitedColor;
+
+    if (isInSubtreeWithBlendMode())
+        return unvisitedColor;
+
+    Color visitedColor = colorResolvingCurrentColor<colorProperty, true>();
+
+    // FIXME: Technically someone could explicitly specify the color transparent, but for now we'll just
+    // assume that if the background color is transparent that it wasn't set. Note that it's weird that
+    // we're returning unvisited info for a visited link, but given our restriction that the alpha values
+    // have to match, it makes more sense to return the unvisited background color if specified than it
+    // does to return black. This behavior matches what Firefox 4 does as well.
+    if (colorProperty == CSSPropertyBackgroundColor && visitedColor == Color::transparentBlack)
+        return unvisitedColor;
+
+    // Take the alpha from the unvisited color, but get the RGB values from the visited color.
+    return visitedColor.colorWithAlpha(unvisitedColor.alphaAsFloat());
+}
+
+template <CSSPropertyID colorProperty>
+Color RenderStyle::visitedDependentColorWithColorFilter(OptionSet<PaintBehavior> paintBehavior) const
+{
+    if (!hasAppleColorFilter())
+        return visitedDependentColor<colorProperty>(paintBehavior);
+
+    return colorByApplyingColorFilter(visitedDependentColor<colorProperty>(paintBehavior));
+}
+
+}

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -46,6 +46,7 @@
 #include "PlatformStrategies.h"
 #include "Quirks.h"
 #include "RenderElement.h"
+#include "RenderStyleResolveColor.h"
 #include "RenderStyleSetters.h"
 #include "RenderView.h"
 #include "ResolvedStyle.h"
@@ -293,7 +294,7 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
     // This is needed for resolving color:-webkit-text for subsequent elements.
     // FIXME: We shouldn't mutate document when resolving style.
     if (&element == m_document->body())
-        m_document->setTextColor(update.style->visitedDependentColor(CSSPropertyColor));
+        m_document->setTextColor(update.style->visitedDependentColor<CSSPropertyColor>());
 
     // FIXME: These elements should not change renderer based on appearance property.
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(element); (input && input->isSearchField())

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
@@ -40,7 +40,7 @@ Color SVGAnimationColorFunction::colorFromString(SVGElement& targetElement, cons
         return SVGPropertyTraits<Color>::fromString(string);
 
     if (auto* renderer = targetElement.renderer())
-        return renderer->style().visitedDependentColor(CSSPropertyColor);
+        return renderer->style().visitedDependentColor<CSSPropertyColor>();
 
     return { };
 }


### PR DESCRIPTION
#### eae6e37a2c43977ff143a6f99c47c4c520cc4cd7
<pre>
Faster color resolving access
Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::isDataTable const):
* Source/WebCore/css/color/StyleColor.cpp:
(WebCore::StyleColor::currentColor):
* Source/WebCore/css/color/StyleColor.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::documentBackgroundColor const):
* Source/WebCore/rendering/InlineBoxPainter.cpp:
(WebCore::InlineBoxPainter::paintDecorations):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::rootOrBodyStyleChanged):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::fillCompositionUnderline const):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::TextDecorationPainter::decorationColor):
* Source/WebCore/rendering/TextPaintStyle.cpp:
(WebCore::computeTextPaintStyle):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::visitedDependentColor const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::hasBackground const):
(WebCore::RenderStyle::initialTextFillColor):
* Source/WebCore/rendering/style/RenderStyleResolveColor.h: Added.
(WebCore::RenderStyle::unresolvedColorForProperty const):
(WebCore::RenderStyle::colorResolvingCurrentColor const):
(WebCore::RenderStyle::visitedDependentColor const):
(WebCore::RenderStyle::visitedDependentColorWithColorFilter const):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):
* Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp:
(WebCore::SVGAnimationColorFunction::colorFromString):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _bodyBackgroundColor]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView updateTextTouchBar]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eae6e37a2c43977ff143a6f99c47c4c520cc4cd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51846 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25213 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76606 "Hash eae6e37a for PR 31361 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23634 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23456 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/76606 "Hash eae6e37a for PR 31361 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/23634 "Failed to compile WebKit") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62370 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/76606 "Hash eae6e37a for PR 31361 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19837 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21984 "Hash eae6e37a for PR 31361 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65473 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20195 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78273 "Hash eae6e37a for PR 31361 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19332 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/78273 "Hash eae6e37a for PR 31361 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62383 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/78273 "Hash eae6e37a for PR 31361 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13024 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6662 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47644 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2429 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->