### PR TITLE
Implement Observable#map

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-map.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-map.any-expected.txt
@@ -1,22 +1,8 @@
 
-FAIL map(): Maps values correctly source.map is not a function. (In 'source.map((value, i) => {
-    indices.push(i);
-    return value * 2;
-  })', 'source.map' is undefined)
-FAIL map(): Mapper errors are emitted to Observer error() handler source.map is not a function. (In 'source.map((value) => {
-    if (value === 2) {
-      throw error;
-    }
-    return value * 2;
-  })', 'source.map' is undefined)
-FAIL map(): Passes complete() through from source Observable source.map is not a function. (In 'source.map(v => {
-    mapperCalls++;
-    return v * 2;
-  })', 'source.map' is undefined)
-FAIL map(): Passes error() through from source Observable source.map is not a function. (In 'source.map(v => {
-    mapperCalls++;
-    return v * 2;
-  })', 'source.map' is undefined)
-FAIL map(): Upon source completion, source Observable teardown sequence happens before downstream mapper complete() is called source.map is not a function. (In 'source.map(() => results.push('mapper called'))', 'source.map' is undefined)
-FAIL map(): Map observable unsubscription causes source Observable unsubscription. Mapper Observer's complete()/error() are not called source.map is not a function. (In 'source.map(v => v * 2)', 'source.map' is undefined)
+PASS map(): Maps values correctly
+PASS map(): Mapper errors are emitted to Observer error() handler
+PASS map(): Passes complete() through from source Observable
+PASS map(): Passes error() through from source Observable
+PASS map(): Upon source completion, source Observable teardown sequence happens before downstream mapper complete() is called
+PASS map(): Map observable unsubscription causes source Observable unsubscription. Mapper Observer's complete()/error() are not called
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-map.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-map.any.worker-expected.txt
@@ -1,22 +1,8 @@
 
-FAIL map(): Maps values correctly source.map is not a function. (In 'source.map((value, i) => {
-    indices.push(i);
-    return value * 2;
-  })', 'source.map' is undefined)
-FAIL map(): Mapper errors are emitted to Observer error() handler source.map is not a function. (In 'source.map((value) => {
-    if (value === 2) {
-      throw error;
-    }
-    return value * 2;
-  })', 'source.map' is undefined)
-FAIL map(): Passes complete() through from source Observable source.map is not a function. (In 'source.map(v => {
-    mapperCalls++;
-    return v * 2;
-  })', 'source.map' is undefined)
-FAIL map(): Passes error() through from source Observable source.map is not a function. (In 'source.map(v => {
-    mapperCalls++;
-    return v * 2;
-  })', 'source.map' is undefined)
-FAIL map(): Upon source completion, source Observable teardown sequence happens before downstream mapper complete() is called source.map is not a function. (In 'source.map(() => results.push('mapper called'))', 'source.map' is undefined)
-FAIL map(): Map observable unsubscription causes source Observable unsubscription. Mapper Observer's complete()/error() are not called source.map is not a function. (In 'source.map(v => v * 2)', 'source.map' is undefined)
+PASS map(): Maps values correctly
+PASS map(): Mapper errors are emitted to Observer error() handler
+PASS map(): Passes complete() through from source Observable
+PASS map(): Passes error() through from source Observable
+PASS map(): Upon source completion, source Observable teardown sequence happens before downstream mapper complete() is called
+PASS map(): Map observable unsubscription causes source Observable unsubscription. Mapper Observer's complete()/error() are not called
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-map.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-map.window-expected.txt
@@ -1,5 +1,3 @@
 
-FAIL map()'s internal observer's next steps do not crash in a detached document promise_test: Unhandled rejection with value: object "TypeError: source.map is not a function. (In 'source.map(value => {
-      parentResults.push(value);
-    })', 'source.map' is undefined)"
+PASS map()'s internal observer's next steps do not crash in a detached document
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1105,6 +1105,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/InnerHTML.idl
     dom/InputEvent.idl
     dom/KeyboardEvent.idl
+    dom/MapperCallback.idl
     dom/MessageChannel.idl
     dom/MessageEvent.idl
     dom/MessagePort.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1416,6 +1416,7 @@ $(PROJECT_DIR)/dom/IdleRequestOptions.idl
 $(PROJECT_DIR)/dom/InnerHTML.idl
 $(PROJECT_DIR)/dom/InputEvent.idl
 $(PROJECT_DIR)/dom/KeyboardEvent.idl
+$(PROJECT_DIR)/dom/MapperCallback.idl
 $(PROJECT_DIR)/dom/MessageChannel.idl
 $(PROJECT_DIR)/dom/MessageEvent.idl
 $(PROJECT_DIR)/dom/MessagePort.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1755,6 +1755,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSManagedMediaSource.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSManagedMediaSource.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSManagedSourceBuffer.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSManagedSourceBuffer.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMapperCallback.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMapperCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMathMLElement.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMathMLElement.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMathMLElementWrapperFactory.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1112,6 +1112,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/InnerHTML.idl \
     $(WebCore)/dom/InputEvent.idl \
     $(WebCore)/dom/KeyboardEvent.idl \
+    $(WebCore)/dom/MapperCallback.idl \
     $(WebCore)/dom/MessageChannel.idl \
     $(WebCore)/dom/MessageEvent.idl \
     $(WebCore)/dom/MessagePort.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1180,6 +1180,7 @@ dom/InputEvent.cpp
 dom/InternalObserver.cpp
 dom/InternalObserverFromScript.cpp
 dom/InternalObserverFilter.cpp
+dom/InternalObserverMap.cpp
 dom/InternalObserverTake.cpp
 dom/KeyboardEvent.cpp
 dom/LiveNodeList.cpp
@@ -3939,6 +3940,7 @@ JSLandmarkType.cpp
 JSLatencyMode.cpp
 JSLocation.cpp
 JSLongRange.cpp
+JSMapperCallback.cpp
 JSMathMLElement.cpp
 JSMathMLMathElement.cpp
 JSManagedMediaSource.cpp

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -69,6 +69,9 @@ struct IDLType {
     using ParameterType = T;
     using NullableParameterType = std::optional<ImplementationType>;
 
+    using CallbackReturnType = T;
+    using NullableCallbackReturnType = std::optional<ImplementationType>;
+
     using InnerParameterType = T;
     using NullableInnerParameterType = std::optional<ImplementationType>;
 
@@ -96,6 +99,9 @@ struct IDLAny : IDLType<JSC::Strong<JSC::Unknown>> {
     using SequenceStorageType = JSC::JSValue;
     using ParameterType = JSC::JSValue;
     using NullableParameterType = JSC::JSValue;
+
+    using CallbackReturnType = JSC::JSValue;
+    using NullableCallbackReturnType = JSC::JSValue;
 
     using ConversionResultType = JSC::JSValue;
     using NullableConversionResultType = JSC::JSValue;

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -6755,7 +6755,7 @@ sub GenerateCallbackHeaderContent
                 }
             }
 
-            my $nativeReturnType = "CallbackResult<typename " . GetIDLType($interfaceOrCallback, $operation->type) . "::ImplementationType>";
+            my $nativeReturnType = "CallbackResult<typename " . GetIDLType($interfaceOrCallback, $operation->type) . "::CallbackReturnType>";
             
             # FIXME: Change the default name (used for callback functions) to something other than handleEvent. It makes little sense.
             my $functionName = $operation->extendedAttributes->{ImplementedAs} || $operation->name || "handleEvent";
@@ -6879,7 +6879,7 @@ sub GenerateCallbackImplementationContent
         
             AddToIncludesForIDLType($operation->type, $includesRef);
 
-            my $nativeReturnType = "CallbackResult<typename " . GetIDLType($interfaceOrCallback, $operation->type) . "::ImplementationType>";
+            my $nativeReturnType = "CallbackResult<typename " . GetIDLType($interfaceOrCallback, $operation->type) . "::CallbackReturnType>";
             
             # FIXME: Change the default name (used for callback functions) to something other than handleEvent. It makes little sense.
             my $functionName = $operation->name || "handleEvent";

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
@@ -51,7 +51,7 @@ JSTestCallbackFunction::~JSTestCallbackFunction()
 #endif
 }
 
-CallbackResult<typename IDLDOMString::ImplementationType> JSTestCallbackFunction::handleEvent(typename IDLLong::ParameterType argument)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction::handleEvent(typename IDLLong::ParameterType argument)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
@@ -40,7 +40,7 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLDOMString::ImplementationType> handleEvent(typename IDLLong::ParameterType argument) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> handleEvent(typename IDLLong::ParameterType argument) override;
 
 private:
     JSTestCallbackFunction(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
@@ -51,7 +51,7 @@ JSTestCallbackFunctionGenerateIsReachable::~JSTestCallbackFunctionGenerateIsReac
 #endif
 }
 
-CallbackResult<typename IDLDOMString::ImplementationType> JSTestCallbackFunctionGenerateIsReachable::handleEvent(typename IDLLong::ParameterType argument)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunctionGenerateIsReachable::handleEvent(typename IDLLong::ParameterType argument)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
@@ -41,7 +41,7 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLDOMString::ImplementationType> handleEvent(typename IDLLong::ParameterType argument) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> handleEvent(typename IDLLong::ParameterType argument) override;
 
 private:
     JSTestCallbackFunctionGenerateIsReachable(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.cpp
@@ -54,7 +54,7 @@ JSTestCallbackFunctionRethrow::~JSTestCallbackFunctionRethrow()
 #endif
 }
 
-CallbackResult<typename IDLDOMString::ImplementationType> JSTestCallbackFunctionRethrow::handleEvent(typename IDLSequence<IDLLong>::ParameterType argument)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunctionRethrow::handleEvent(typename IDLSequence<IDLLong>::ParameterType argument)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.h
@@ -40,7 +40,7 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLDOMString::ImplementationType> handleEvent(typename IDLSequence<IDLLong>::ParameterType argument) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> handleEvent(typename IDLSequence<IDLLong>::ParameterType argument) override;
 
 private:
     JSTestCallbackFunctionRethrow(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
@@ -55,7 +55,7 @@ JSTestCallbackFunctionWithThisObject::~JSTestCallbackFunctionWithThisObject()
 #endif
 }
 
-CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackFunctionWithThisObject::handleEvent(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLSequence<IDLInterface<TestNode>>::ParameterType parameter)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunctionWithThisObject::handleEvent(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLSequence<IDLInterface<TestNode>>::ParameterType parameter)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
@@ -40,7 +40,7 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLUndefined::ImplementationType> handleEvent(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLSequence<IDLInterface<TestNode>>::ParameterType parameter) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> handleEvent(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLSequence<IDLInterface<TestNode>>::ParameterType parameter) override;
 
 private:
     JSTestCallbackFunctionWithThisObject(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
@@ -55,7 +55,7 @@ JSTestCallbackFunctionWithTypedefs::~JSTestCallbackFunctionWithTypedefs()
 #endif
 }
 
-CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackFunctionWithTypedefs::handleEvent(typename IDLSequence<IDLNullable<IDLLong>>::ParameterType sequenceArg, typename IDLLong::ParameterType longArg)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunctionWithTypedefs::handleEvent(typename IDLSequence<IDLNullable<IDLLong>>::ParameterType sequenceArg, typename IDLLong::ParameterType longArg)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
@@ -40,7 +40,7 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLUndefined::ImplementationType> handleEvent(typename IDLSequence<IDLNullable<IDLLong>>::ParameterType sequenceArg, typename IDLLong::ParameterType longArg) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> handleEvent(typename IDLSequence<IDLNullable<IDLLong>>::ParameterType sequenceArg, typename IDLLong::ParameterType longArg) override;
 
 private:
     JSTestCallbackFunctionWithTypedefs(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
@@ -50,7 +50,7 @@ JSTestCallbackFunctionWithVariadic::~JSTestCallbackFunctionWithVariadic()
 #endif
 }
 
-CallbackResult<typename IDLDOMString::ImplementationType> JSTestCallbackFunctionWithVariadic::handleEvent(VariadicArguments<IDLAny>&& arguments)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunctionWithVariadic::handleEvent(VariadicArguments<IDLAny>&& arguments)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
@@ -42,7 +42,7 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLDOMString::ImplementationType> handleEvent(VariadicArguments<IDLAny>&& arguments) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> handleEvent(VariadicArguments<IDLAny>&& arguments) override;
 
 private:
     JSTestCallbackFunctionWithVariadic(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -189,7 +189,7 @@ JSValue JSTestCallbackInterface::getConstructor(VM& vm, const JSGlobalObject* gl
     return getDOMConstructor<JSTestCallbackInterfaceDOMConstructor, DOMConstructorID::TestCallbackInterface>(vm, *jsCast<const JSDOMGlobalObject*>(globalObject));
 }
 
-CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackInterface::callbackWithNoParam()
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackInterface::callbackWithNoParam()
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -216,7 +216,7 @@ CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackInterfac
     return { };
 }
 
-CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackInterface::callbackWithArrayParam(typename IDLFloat32Array::ParameterType arrayParam)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackInterface::callbackWithArrayParam(typename IDLFloat32Array::ParameterType arrayParam)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -244,7 +244,7 @@ CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackInterfac
     return { };
 }
 
-CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackInterface::callbackWithSerializedScriptValueParam(typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strParam)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackInterface::callbackWithSerializedScriptValueParam(typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strParam)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -273,7 +273,7 @@ CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackInterfac
     return { };
 }
 
-CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackInterface::callbackWithStringList(typename IDLInterface<DOMStringList>::ParameterType listParam)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackInterface::callbackWithStringList(typename IDLInterface<DOMStringList>::ParameterType listParam)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -301,7 +301,7 @@ CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackInterfac
     return { };
 }
 
-CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackInterface::callbackWithBoolean(typename IDLBoolean::ParameterType boolParam)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackInterface::callbackWithBoolean(typename IDLBoolean::ParameterType boolParam)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -329,7 +329,7 @@ CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackInterfac
     return { };
 }
 
-CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackInterface::callbackRequiresThisToPass(typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackInterface::callbackRequiresThisToPass(typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -358,7 +358,7 @@ CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackInterfac
     return { };
 }
 
-CallbackResult<typename IDLDOMString::ImplementationType> JSTestCallbackInterface::callbackWithAReturnValue()
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackInterface::callbackWithAReturnValue()
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -389,7 +389,7 @@ CallbackResult<typename IDLDOMString::ImplementationType> JSTestCallbackInterfac
     return { returnValue.releaseReturnValue() };
 }
 
-CallbackResult<typename IDLDOMString::ImplementationType> JSTestCallbackInterface::callbackThatRethrowsExceptions(typename IDLEnumeration<TestCallbackInterface::Enum>::ParameterType enumParam)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackInterface::callbackThatRethrowsExceptions(typename IDLEnumeration<TestCallbackInterface::Enum>::ParameterType enumParam)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;
@@ -421,7 +421,7 @@ CallbackResult<typename IDLDOMString::ImplementationType> JSTestCallbackInterfac
     return { returnValue.releaseReturnValue() };
 }
 
-CallbackResult<typename IDLDOMString::ImplementationType> JSTestCallbackInterface::callbackWithThisObject(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLInterface<TestObj>::ParameterType testObjParam)
+CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackInterface::callbackWithThisObject(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLInterface<TestObj>::ParameterType testObjParam)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
@@ -45,16 +45,16 @@ public:
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
 
     // Functions
-    CallbackResult<typename IDLUndefined::ImplementationType> callbackWithNoParam() override;
-    CallbackResult<typename IDLUndefined::ImplementationType> callbackWithArrayParam(typename IDLFloat32Array::ParameterType arrayParam) override;
-    CallbackResult<typename IDLUndefined::ImplementationType> callbackWithSerializedScriptValueParam(typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strParam) override;
-    CallbackResult<typename IDLLong::ImplementationType> customCallback(typename IDLInterface<TestObj>::ParameterType testObjParam, typename IDLInterface<TestNode>::ParameterType testNodeParam) override;
-    CallbackResult<typename IDLUndefined::ImplementationType> callbackWithStringList(typename IDLInterface<DOMStringList>::ParameterType listParam) override;
-    CallbackResult<typename IDLUndefined::ImplementationType> callbackWithBoolean(typename IDLBoolean::ParameterType boolParam) override;
-    CallbackResult<typename IDLUndefined::ImplementationType> callbackRequiresThisToPass(typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam) override;
-    CallbackResult<typename IDLDOMString::ImplementationType> callbackWithAReturnValue() override;
-    CallbackResult<typename IDLDOMString::ImplementationType> callbackThatRethrowsExceptions(typename IDLEnumeration<TestCallbackInterface::Enum>::ParameterType enumParam) override;
-    CallbackResult<typename IDLDOMString::ImplementationType> callbackWithThisObject(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLInterface<TestObj>::ParameterType testObjParam) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> callbackWithNoParam() override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> callbackWithArrayParam(typename IDLFloat32Array::ParameterType arrayParam) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> callbackWithSerializedScriptValueParam(typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strParam) override;
+    CallbackResult<typename IDLLong::CallbackReturnType> customCallback(typename IDLInterface<TestObj>::ParameterType testObjParam, typename IDLInterface<TestNode>::ParameterType testNodeParam) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> callbackWithStringList(typename IDLInterface<DOMStringList>::ParameterType listParam) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> callbackWithBoolean(typename IDLBoolean::ParameterType boolParam) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> callbackRequiresThisToPass(typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> callbackWithAReturnValue() override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> callbackThatRethrowsExceptions(typename IDLEnumeration<TestCallbackInterface::Enum>::ParameterType enumParam) override;
+    CallbackResult<typename IDLDOMString::CallbackReturnType> callbackWithThisObject(typename IDLInterface<TestNode>::ParameterType thisObject, typename IDLInterface<TestObj>::ParameterType testObjParam) override;
 
 private:
     JSTestCallbackInterface(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
@@ -57,7 +57,7 @@ JSTestCallbackWithFunctionOrDict::~JSTestCallbackWithFunctionOrDict()
 #endif
 }
 
-CallbackResult<typename IDLUndefined::ImplementationType> JSTestCallbackWithFunctionOrDict::handleEvent(typename IDLUnion<IDLDictionary<TestDictionary>, IDLCallbackFunction<JSTestCallbackFunction>>::ParameterType callback)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackWithFunctionOrDict::handleEvent(typename IDLUnion<IDLDictionary<TestDictionary>, IDLCallbackFunction<JSTestCallbackFunction>>::ParameterType callback)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
@@ -40,7 +40,7 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLUndefined::ImplementationType> handleEvent(typename IDLUnion<IDLDictionary<TestDictionary>, IDLCallbackFunction<JSTestCallbackFunction>>::ParameterType callback) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> handleEvent(typename IDLUnion<IDLDictionary<TestDictionary>, IDLCallbackFunction<JSTestCallbackFunction>>::ParameterType callback) override;
 
 private:
     JSTestCallbackWithFunctionOrDict(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
@@ -63,7 +63,7 @@ JSTestVoidCallbackFunction::~JSTestVoidCallbackFunction()
 #endif
 }
 
-CallbackResult<typename IDLUndefined::ImplementationType> JSTestVoidCallbackFunction::handleEvent(typename IDLFloat32Array::ParameterType arrayParam, typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strArg, typename IDLBoolean::ParameterType boolParam, typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam)
+CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestVoidCallbackFunction::handleEvent(typename IDLFloat32Array::ParameterType arrayParam, typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strArg, typename IDLBoolean::ParameterType boolParam, typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam)
 {
     if (!canInvokeCallback())
         return CallbackResultType::UnableToExecute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
@@ -42,7 +42,7 @@ public:
     JSCallbackData* callbackData() { return m_data; }
 
     // Functions
-    CallbackResult<typename IDLUndefined::ImplementationType> handleEvent(typename IDLFloat32Array::ParameterType arrayParam, typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strArg, typename IDLBoolean::ParameterType boolParam, typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam) override;
+    CallbackResult<typename IDLUndefined::CallbackReturnType> handleEvent(typename IDLFloat32Array::ParameterType arrayParam, typename IDLSerializedScriptValue<SerializedScriptValue>::ParameterType srzParam, typename IDLDOMString::ParameterType strArg, typename IDLBoolean::ParameterType boolParam, typename IDLLong::ParameterType longParam, typename IDLInterface<TestNode>::ParameterType testNodeParam) override;
 
 private:
     JSTestVoidCallbackFunction(JSC::JSObject*, JSDOMGlobalObject*);

--- a/Source/WebCore/dom/InternalObserverMap.cpp
+++ b/Source/WebCore/dom/InternalObserverMap.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InternalObserverMap.h"
+
+#include "InternalObserver.h"
+#include "MapperCallback.h"
+#include "Observable.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include "Subscriber.h"
+#include "SubscriberCallback.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+
+namespace WebCore {
+
+class InternalObserverMap final : public InternalObserver {
+public:
+    static Ref<InternalObserverMap> create(ScriptExecutionContext& context, Ref<Subscriber> subscriber, Ref<MapperCallback> mapper)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverMap(context, subscriber, mapper));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+    class SubscriberCallbackMap final : public SubscriberCallback {
+    public:
+        static Ref<SubscriberCallbackMap> create(ScriptExecutionContext& context, Ref<Observable> source, Ref<MapperCallback> mapper)
+        {
+            return adoptRef(*new InternalObserverMap::SubscriberCallbackMap(context, source, mapper));
+        }
+
+        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        {
+            auto context = scriptExecutionContext();
+
+            if (!context) {
+                subscriber.complete();
+                return { };
+            }
+
+            SubscribeOptions options;
+            options.signal = &subscriber.signal();
+            m_sourceObservable->subscribeInternal(*context, InternalObserverMap::create(*context, subscriber, m_mapper), options);
+
+            return { };
+        }
+
+    private:
+        Ref<Observable> m_sourceObservable;
+        Ref<MapperCallback> m_mapper;
+
+        SubscriberCallbackMap(ScriptExecutionContext& context, Ref<Observable> source, Ref<MapperCallback> mapper)
+            : SubscriberCallback(&context)
+            , m_sourceObservable(source)
+            , m_mapper(mapper)
+        { }
+
+        bool hasCallback() const final { return true; }
+    };
+
+private:
+    Ref<Subscriber> m_subscriber;
+    Ref<MapperCallback> m_mapper;
+    uint64_t m_idx { 0 };
+
+    void next(JSC::JSValue value) final
+    {
+        auto context = scriptExecutionContext();
+        if (!context)
+            return;
+
+        Ref vm = context->globalObject()->vm();
+        JSC::JSLockHolder lock(vm);
+
+        // The exception is not reported, instead it is forwarded to the
+        // error handler. As such, MapperCallback `[RethrowsException]`
+        // and here a catch scope is declared so the error can be passed
+        // to the subscription error handler.
+        JSC::Exception* previousException = nullptr;
+        {
+            auto catchScope = DECLARE_CATCH_SCOPE(vm);
+            auto result = m_mapper->handleEvent(value, m_idx);
+            previousException = catchScope.exception();
+            if (previousException) {
+                catchScope.clearException();
+                m_subscriber->error(previousException->value());
+                return;
+            }
+
+            m_idx += 1;
+
+            if (result.type() == CallbackResultType::Success)
+                m_subscriber->next(result.releaseReturnValue());
+        }
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        m_subscriber->error(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+        m_subscriber->complete();
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    {
+        m_subscriber->visitAdditionalChildren(visitor);
+        m_mapper->visitJSFunction(visitor);
+    }
+
+    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
+    {
+        m_subscriber->visitAdditionalChildren(visitor);
+        m_mapper->visitJSFunction(visitor);
+    }
+
+    InternalObserverMap(ScriptExecutionContext& context, Ref<Subscriber> subscriber, Ref<MapperCallback> mapper)
+        : InternalObserver(context)
+        , m_subscriber(subscriber)
+        , m_mapper(mapper)
+    { }
+
+};
+
+Ref<SubscriberCallback> createSubscriberCallbackMap(ScriptExecutionContext& context, Ref<Observable> observable, Ref<MapperCallback> mapper)
+{
+    return InternalObserverMap::SubscriberCallbackMap::create(context, observable, mapper);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverMap.h
+++ b/Source/WebCore/dom/InternalObserverMap.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class Observable;
+class MapperCallback;
+class ScriptExecutionContext;
+class SubscriberCallback;
+
+Ref<SubscriberCallback> createSubscriberCallbackMap(ScriptExecutionContext&, Ref<Observable>, Ref<MapperCallback>);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/MapperCallback.h
+++ b/Source/WebCore/dom/MapperCallback.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ActiveDOMCallback.h"
+#include "CallbackResult.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class MapperCallback : public RefCounted<MapperCallback>, public ActiveDOMCallback {
+public:
+    using ActiveDOMCallback::ActiveDOMCallback;
+
+    virtual CallbackResult<JSC::JSValue> handleEvent(JSC::JSValue, uint64_t) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/MapperCallback.idl
+++ b/Source/WebCore/dom/MapperCallback.idl
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[ RethrowException ] callback MapperCallback = any (any value, unsigned long long index);
+

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -32,8 +32,10 @@
 #include "ExceptionCode.h"
 #include "InternalObserverFilter.h"
 #include "InternalObserverFromScript.h"
+#include "InternalObserverMap.h"
 #include "InternalObserverTake.h"
 #include "JSSubscriptionObserverCallback.h"
+#include "MapperCallback.h"
 #include "PredicateCallback.h"
 #include "SubscribeOptions.h"
 #include "Subscriber.h"
@@ -96,11 +98,15 @@ void Observable::subscribeInternal(ScriptExecutionContext& context, Ref<Internal
     }
 }
 
+Ref<Observable> Observable::map(ScriptExecutionContext& context, MapperCallback& mapper)
+{
+    return create(createSubscriberCallbackMap(context, *this, mapper));
+}
+
 Ref<Observable> Observable::filter(ScriptExecutionContext& context, PredicateCallback& predicate)
 {
     return create(createSubscriberCallbackFilter(context, *this, predicate));
 }
-
 
 Ref<Observable> Observable::take(ScriptExecutionContext& context, uint64_t amount)
 {

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -37,6 +37,7 @@ class InternalObserver;
 class ScriptExecutionContext;
 class JSSubscriptionObserverCallback;
 class PredicateCallback;
+class MapperCallback;
 struct SubscriptionObserver;
 struct SubscribeOptions;
 
@@ -52,6 +53,8 @@ public:
 
     void subscribe(ScriptExecutionContext&, std::optional<ObserverUnion>, SubscribeOptions);
     void subscribeInternal(ScriptExecutionContext&, Ref<InternalObserver>, SubscribeOptions);
+
+    Ref<Observable> map(ScriptExecutionContext&, MapperCallback&);
 
     Ref<Observable> filter(ScriptExecutionContext&, PredicateCallback&);
 

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -33,6 +33,8 @@ interface Observable {
   constructor(SubscriberCallback callback);
   [CallWith=CurrentScriptExecutionContext, RaisesException] undefined subscribe(optional ObserverUnion observer = {}, optional SubscribeOptions options = {});
 
+  [CallWith=CurrentScriptExecutionContext] Observable map(MapperCallback mapper);
+
   [CallWith=CurrentScriptExecutionContext] Observable filter(PredicateCallback predicate);
 
   [CallWith=CurrentScriptExecutionContext] Observable take(unsigned long long amount);


### PR DESCRIPTION
#### 2b4024b9e553db21230d1f620f7e33fa3f41241e
<pre>
Implement Observable#map
<a href="https://bugs.webkit.org/show_bug.cgi?id=277222">https://bugs.webkit.org/show_bug.cgi?id=277222</a>

Reviewed by Sam Weinig.

This adds the map operator to Observable, using the new
InternalObserverMap and SubscriberCallbackMap specialisations.

This also adds a new `MapperCallback` IDL which represents the mapping
function Observable#map takes. It&apos;s similar to `PredicateCallback` but
the return value is an `any` not `bool`.

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-map.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-map.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-map.window-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/IDLTypes.h:
  Added a new `CallbackReturnType` type which IDLAny assigns as
  JSC::JSValue. This enables safely changing CodeGeneratorJS to move
  callback returns from `ImplementationType` to `CallbackReturnType`,
  making the value of IDLAny propertly map to `JSC::JSValue` rather
  than `JSC::Strong&lt;JSC::Unknown&gt;` (the template type of IDLAny).
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
  Change GenerateCallbackHeaderContent and
  GenerateCallbackImplementationContent to use the new
  `CallbackReturnType` property for the return value (see above IDLTypes
  comment).
(GenerateCallbackHeaderContent):
(GenerateCallbackImplementationContent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp:
(WebCore::JSTestCallbackFunction::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp:
(WebCore::JSTestCallbackFunctionGenerateIsReachable::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.cpp:
(WebCore::JSTestCallbackFunctionRethrow::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionRethrow.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp:
(WebCore::JSTestCallbackFunctionWithThisObject::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp:
(WebCore::JSTestCallbackFunctionWithTypedefs::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp:
(WebCore::JSTestCallbackFunctionWithVariadic::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
(WebCore::JSTestCallbackInterface::callbackWithNoParam):
(WebCore::JSTestCallbackInterface::callbackWithArrayParam):
(WebCore::JSTestCallbackInterface::callbackWithSerializedScriptValueParam):
(WebCore::JSTestCallbackInterface::callbackWithStringList):
(WebCore::JSTestCallbackInterface::callbackWithBoolean):
(WebCore::JSTestCallbackInterface::callbackRequiresThisToPass):
(WebCore::JSTestCallbackInterface::callbackWithAReturnValue):
(WebCore::JSTestCallbackInterface::callbackThatRethrowsExceptions):
(WebCore::JSTestCallbackInterface::callbackWithThisObject):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp:
(WebCore::JSTestCallbackWithFunctionOrDict::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp:
(WebCore::JSTestVoidCallbackFunction::handleEvent):
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h:
* Source/WebCore/dom/InternalObserverMap.cpp: Added.
(WebCore::createSubscriberCallbackMap):
* Source/WebCore/dom/InternalObserverMap.h: Copied from Source/WebCore/dom/Observable.idl.
* Source/WebCore/dom/MapperCallback.h: Copied from Source/WebCore/dom/Observable.idl.
* Source/WebCore/dom/MapperCallback.idl: Copied from Source/WebCore/dom/Observable.idl.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::map):
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.idl:

Canonical link: <a href="https://commits.webkit.org/281591@main">https://commits.webkit.org/281591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03dcf81cf2a6eecceecad47138839a073b150acc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39386 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63956 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10568 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48643 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7377 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29485 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9238 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9488 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65688 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55997 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3986 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56148 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13419 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3295 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35199 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36281 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36025 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->