### PR TITLE
[macOS] Dictation UI no longer shows up when beginning dictation after focusing an empty text field

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7020,7 +7020,10 @@ void WebPage::firstRectForCharacterRangeAsync(const EditingRange& editingRange, 
         return completionHandler({ }, editingRange);
 
     auto rect = RefPtr(frame->view())->contentsToWindow(frame->editor().firstRectForRange(*range));
-    auto lineEndPosition = endOfLine(makeContainerOffsetPosition(range->start));
+    auto startPosition = makeContainerOffsetPosition(range->start);
+    auto lineEndPosition = endOfLine(startPosition);
+    if (lineEndPosition.isNull())
+        lineEndPosition = startPosition;
     auto lineEndBoundary = makeBoundaryPoint(lineEndPosition);
     if (!lineEndBoundary)
         return completionHandler({ }, editingRange);


### PR DESCRIPTION
#### 72212a28c6b2c3b605bebb33a5c9e14196952586
<pre>
[macOS] Dictation UI no longer shows up when beginning dictation after focusing an empty text field
<a href="https://bugs.webkit.org/show_bug.cgi?id=277236">https://bugs.webkit.org/show_bug.cgi?id=277236</a>
<a href="https://rdar.apple.com/131534054">rdar://131534054</a>

Reviewed by Richard Robinson.

After the changes in 279576@main, `-firstRectForCharacterRange:completionHandler:` returns an empty
rect in the case where the selection is a caret in a focused, empty `textarea` or text field. This
happens because the selected range is the first position inside of an empty block-level container
underneath the text form control&apos;s shadow root, which causes `endOfLine` to return the null position
and subsequently means `lineEndBoundary` is null, so we bail early.

Avoid this by falling back to the selection start in the case where `endOfLine` returns a null
position.

Test: WKWebViewMacEditingTests.FirstRectForCharacterRangeInTextArea

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::firstRectForCharacterRangeAsync):

See above for more details.

* Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm:
(-[WKWebView _firstRectForCharacterRange:]):
(TEST(WKWebViewMacEditingTests, FirstRectForCharacterRange)):
(TEST(WKWebViewMacEditingTests, FirstRectForCharacterRangeInTextArea)):

Add a new API test to exercise the change; clean up some of these existing tests as well, by
factoring out some of the common logic to asynchronously request the first rect for a
character range into a new category helper method that returns a `std::pair`.

Canonical link: <a href="https://commits.webkit.org/281474@main">https://commits.webkit.org/281474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26303e55d7a3aee3ee7ec171a637d32af82f5f5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63960 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10572 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10784 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7379 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29488 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33434 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9242 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9492 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55350 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65692 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9388 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56000 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56151 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13308 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3299 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35203 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36285 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->