### PR TITLE
[Pointer Events] Implement getPredictedEvents API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/idlharness.https.window-expected.txt
@@ -60,7 +60,7 @@ FAIL PointerEvent interface: attribute azimuthAngle assert_true: The prototype o
 PASS PointerEvent interface: attribute pointerType
 PASS PointerEvent interface: attribute isPrimary
 PASS PointerEvent interface: operation getCoalescedEvents()
-FAIL PointerEvent interface: operation getPredictedEvents() assert_own_property: interface prototype object missing non-static operation expected property "getPredictedEvents" missing
+PASS PointerEvent interface: operation getPredictedEvents()
 PASS PointerEvent must be primary interface of new PointerEvent("type")
 PASS Stringification of new PointerEvent("type")
 PASS PointerEvent interface: new PointerEvent("type") must inherit property "pointerId" with the proper type
@@ -76,7 +76,7 @@ FAIL PointerEvent interface: new PointerEvent("type") must inherit property "azi
 PASS PointerEvent interface: new PointerEvent("type") must inherit property "pointerType" with the proper type
 PASS PointerEvent interface: new PointerEvent("type") must inherit property "isPrimary" with the proper type
 PASS PointerEvent interface: new PointerEvent("type") must inherit property "getCoalescedEvents()" with the proper type
-FAIL PointerEvent interface: new PointerEvent("type") must inherit property "getPredictedEvents()" with the proper type assert_inherits: property "getPredictedEvents" not found in prototype chain
+PASS PointerEvent interface: new PointerEvent("type") must inherit property "getPredictedEvents()" with the proper type
 PASS HTMLElement interface: attribute ongotpointercapture
 PASS HTMLElement interface: attribute onlostpointercapture
 PASS HTMLElement interface: attribute onpointerdown

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_constructor-expected.txt
@@ -3,5 +3,39 @@ PointerEvent: Dispatch custom event
 Test Description: This test checks if PointerEvent constructor works properly.
 
 
-FAIL PointerEvent: Constructor test event.getPredictedEvents is not a function. (In 'event.getPredictedEvents()', 'event.getPredictedEvents' is undefined)
+PASS PointerEvent: Constructor test
+FAIL getCoalescedEvents in event assert_equals: expected false but got true
+PASS getPredictedEvents().length
+PASS event.target
+PASS event.currentTarget
+PASS event.eventPhase
+PASS event.clientX
+PASS event.pointerType
+PASS getPredictedEvents()[0].clientX
+PASS getPredictedEvents()[1].clientX
+PASS getPredictedEvents()[0].pointerId
+PASS getPredictedEvents()[0].pointerType
+PASS getPredictedEvents()[0].isPrimary
+PASS getPredictedEvents()[0].getPredictedEvents().length
+PASS getPredictedEvents()[0].target
+PASS getPredictedEvents()[0].currentTarget
+PASS getPredictedEvents()[0].eventPhase
+PASS getPredictedEvents()[0].cancelable
+PASS getPredictedEvents()[0].bubbles
+PASS getPredictedEvents()[0].offsetX
+PASS getPredictedEvents()[0].offsetY
+PASS getPredictedEvents()[1].pointerId
+PASS getPredictedEvents()[1].pointerType
+PASS getPredictedEvents()[1].isPrimary
+PASS getPredictedEvents()[1].getPredictedEvents().length
+PASS getPredictedEvents()[1].target
+PASS getPredictedEvents()[1].currentTarget
+PASS getPredictedEvents()[1].eventPhase
+PASS getPredictedEvents()[1].cancelable
+PASS getPredictedEvents()[1].bubbles
+PASS getPredictedEvents()[1].offsetX
+PASS getPredictedEvents()[1].offsetY
+PASS default event.pointerType
+PASS default getPredictedEvents().length
+PASS type event.pointerType
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/predicted_events_attributes_mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/predicted_events_attributes_mouse-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Predicted list in boundary events assert_equals: pointerover.getPredictedEvents is a function expected "function" but got "undefined"
-FAIL Predicted list in pointer-capture events assert_equals: gotpointercapture.getPredictedEvents is a function expected "function" but got "undefined"
-FAIL Predicted list in pointerdown/move/up events assert_equals: pointerdown.getPredictedEvents is a function expected "function" but got "undefined"
+PASS Predicted list in boundary events
+PASS Predicted list in pointer-capture events
+PASS Predicted list in pointerdown/move/up events
 PASS Predicted list in pointercancel event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/predicted_events_attributes_pen-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/predicted_events_attributes_pen-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Predicted list in boundary events assert_equals: pointerover.getPredictedEvents is a function expected "function" but got "undefined"
-FAIL Predicted list in pointer-capture events assert_equals: gotpointercapture.getPredictedEvents is a function expected "function" but got "undefined"
-FAIL Predicted list in pointerdown/move/up events assert_equals: pointerdown.getPredictedEvents is a function expected "function" but got "undefined"
+PASS Predicted list in boundary events
+PASS Predicted list in pointer-capture events
+PASS Predicted list in pointerdown/move/up events
 PASS Predicted list in pointercancel event
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/pointerevents/pointerevent_constructor-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/pointerevents/pointerevent_constructor-expected.txt
@@ -4,45 +4,18 @@ Test Description: This test checks if PointerEvent constructor works properly.
 
 
 PASS PointerEvent: Constructor test
-PASS getCoalescedEvents().length
+PASS getCoalescedEvents in event
 PASS getPredictedEvents().length
 PASS event.target
 PASS event.currentTarget
 PASS event.eventPhase
 PASS event.clientX
 PASS event.pointerType
-PASS getCoalescedEvents()[0].clientX
-PASS getCoalescedEvents()[1].clientX
 PASS getPredictedEvents()[0].clientX
 PASS getPredictedEvents()[1].clientX
-PASS getCoalescedEvents()[0].pointerId
-PASS getCoalescedEvents()[0].pointerType
-PASS getCoalescedEvents()[0].isPrimary
-PASS getCoalescedEvents()[0].getCoalescedEvents().length
-PASS getCoalescedEvents()[0].getPredictedEvents().length
-PASS getCoalescedEvents()[0].target
-PASS getCoalescedEvents()[0].currentTarget
-PASS getCoalescedEvents()[0].eventPhase
-PASS getCoalescedEvents()[0].cancelable
-PASS getCoalescedEvents()[0].bubbles
-PASS getCoalescedEvents()[0].offsetX
-PASS getCoalescedEvents()[0].offsetY
-PASS getCoalescedEvents()[1].pointerId
-PASS getCoalescedEvents()[1].pointerType
-PASS getCoalescedEvents()[1].isPrimary
-PASS getCoalescedEvents()[1].getCoalescedEvents().length
-PASS getCoalescedEvents()[1].getPredictedEvents().length
-PASS getCoalescedEvents()[1].target
-PASS getCoalescedEvents()[1].currentTarget
-PASS getCoalescedEvents()[1].eventPhase
-PASS getCoalescedEvents()[1].cancelable
-PASS getCoalescedEvents()[1].bubbles
-PASS getCoalescedEvents()[1].offsetX
-PASS getCoalescedEvents()[1].offsetY
 PASS getPredictedEvents()[0].pointerId
 PASS getPredictedEvents()[0].pointerType
 PASS getPredictedEvents()[0].isPrimary
-PASS getPredictedEvents()[0].getCoalescedEvents().length
 PASS getPredictedEvents()[0].getPredictedEvents().length
 PASS getPredictedEvents()[0].target
 PASS getPredictedEvents()[0].currentTarget
@@ -54,7 +27,6 @@ PASS getPredictedEvents()[0].offsetY
 PASS getPredictedEvents()[1].pointerId
 PASS getPredictedEvents()[1].pointerType
 PASS getPredictedEvents()[1].isPrimary
-PASS getPredictedEvents()[1].getCoalescedEvents().length
 PASS getPredictedEvents()[1].getPredictedEvents().length
 PASS getPredictedEvents()[1].target
 PASS getPredictedEvents()[1].currentTarget
@@ -64,7 +36,6 @@ PASS getPredictedEvents()[1].bubbles
 PASS getPredictedEvents()[1].offsetX
 PASS getPredictedEvents()[1].offsetY
 PASS default event.pointerType
-PASS default getCoalescedEvents().length
 PASS default getPredictedEvents().length
 PASS type event.pointerType
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2911,6 +2911,20 @@ GetCoalescedEventsEnabled:
     WebCore:
       default: true
 
+GetPredictedEventsEnabled:
+  type: bool
+  status: stable
+  category: dom
+  humanReadableName: "Pointer Events getPredictedEvents API"
+  humanReadableDescription: "Enable the `getPredictedEvents` function of the Pointer Events API"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 GetUserMediaRequiresFocus:
   type: bool
   status: internal

--- a/Source/WebCore/dom/DragEvent.cpp
+++ b/Source/WebCore/dom/DragEvent.cpp
@@ -62,7 +62,7 @@ DragEvent::DragEvent(const AtomString& eventType, CanBubble canBubble, IsCancela
     MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
     const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
     EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, DataTransfer* dataTransfer, IsSimulated isSimulated, IsTrusted isTrusted)
-    : MouseEvent(EventInterfaceType::DragEvent, eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation, movementX, movementY, modifiers, button, buttons, relatedTarget, force, syntheticClickType, { }, isSimulated, isTrusted)
+    : MouseEvent(EventInterfaceType::DragEvent, eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation, movementX, movementY, modifiers, button, buttons, relatedTarget, force, syntheticClickType, { }, { }, isSimulated, isTrusted)
     , m_dataTransfer(dataTransfer)
 {
 }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -489,11 +489,17 @@ Element::DispatchMouseEventResult Element::dispatchMouseEvent(const PlatformMous
 
     Vector<Ref<MouseEvent>> childMouseEvents;
     for (const auto& childPlatformEvent : platformEvent.coalescedEvents()) {
-        Ref childMouseEvent = MouseEvent::create(eventType, document().windowProxy(), childPlatformEvent, { }, detail, relatedTarget);
+        Ref childMouseEvent = MouseEvent::create(eventType, document().windowProxy(), childPlatformEvent, { }, { }, detail, relatedTarget);
         childMouseEvents.append(WTFMove(childMouseEvent));
     }
 
-    Ref mouseEvent = MouseEvent::create(eventType, document().windowProxy(), platformEvent, childMouseEvents, detail, relatedTarget);
+    Vector<Ref<MouseEvent>> predictedEvents;
+    for (const auto& childPlatformEvent : platformEvent.predictedEvents()) {
+        Ref childMouseEvent = MouseEvent::create(eventType, document().windowProxy(), childPlatformEvent, { }, { }, detail, relatedTarget);
+        predictedEvents.append(WTFMove(childMouseEvent));
+    }
+
+    Ref mouseEvent = MouseEvent::create(eventType, document().windowProxy(), platformEvent, childMouseEvents, predictedEvents, detail, relatedTarget);
 
     if (mouseEvent->type().isEmpty())
         return { Element::EventIsDispatched::Yes, eventIsDefaultPrevented }; // Shouldn't happen.
@@ -3898,7 +3904,7 @@ bool Element::dispatchMouseForceWillBegin()
         return false;
 
     PlatformMouseEvent platformMouseEvent { frame->eventHandler().lastKnownMousePosition(), frame->eventHandler().lastKnownMouseGlobalPosition(), MouseButton::None, PlatformEvent::Type::NoType, 1, { }, WallTime::now(), ForceAtClick, SyntheticClickType::NoTap };
-    auto mouseForceWillBeginEvent = MouseEvent::create(eventNames().webkitmouseforcewillbeginEvent, document().windowProxy(), platformMouseEvent, { }, 0, nullptr);
+    auto mouseForceWillBeginEvent = MouseEvent::create(eventNames().webkitmouseforcewillbeginEvent, document().windowProxy(), platformMouseEvent, { }, { }, 0, nullptr);
     mouseForceWillBeginEvent->setTarget(Ref { *this });
     dispatchEvent(mouseForceWillBeginEvent);
 

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -56,7 +56,7 @@ Ref<MouseEvent> MouseEvent::create(const AtomString& type, const MouseEventInit&
     return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, type, initializer));
 }
 
-Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, RefPtr<WindowProxy>&& view, const PlatformMouseEvent& event, const Vector<Ref<MouseEvent>>& coalescedEvents, int detail, Node* relatedTarget)
+Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, RefPtr<WindowProxy>&& view, const PlatformMouseEvent& event, const Vector<Ref<MouseEvent>>& coalescedEvents, const Vector<Ref<MouseEvent>>& predictedEvents, int detail, Node* relatedTarget)
 {
     auto& eventNames = WebCore::eventNames();
     bool isMouseEnterOrLeave = eventType == eventNames.mouseenterEvent || eventType == eventNames.mouseleaveEvent;
@@ -66,15 +66,15 @@ Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, RefPtr<WindowPro
 
     return MouseEvent::create(eventType, canBubble, isCancelable, isComposed, event.timestamp().approximateMonotonicTime(), WTFMove(view), detail,
         event.globalPosition(), event.position(), event.movementDelta().x(), event.movementDelta().y(),
-        event.modifiers(), event.button(), event.buttons(), relatedTarget, event.force(), event.syntheticClickType(), coalescedEvents);
+        event.modifiers(), event.button(), event.buttons(), relatedTarget, event.force(), event.syntheticClickType(), coalescedEvents, predictedEvents);
 }
 
 Ref<MouseEvent> MouseEvent::create(const AtomString& type, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
     const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
-    EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, const Vector<Ref<MouseEvent>>& coalescedEvents, IsSimulated isSimulated, IsTrusted isTrusted)
+    EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, const Vector<Ref<MouseEvent>>& coalescedEvents, const Vector<Ref<MouseEvent>>& predictedEvents, IsSimulated isSimulated, IsTrusted isTrusted)
 {
     return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, type, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail,
-        screenLocation, windowLocation, movementX, movementY, modifiers, button, buttons, relatedTarget, force, syntheticClickType, coalescedEvents, isSimulated, isTrusted));
+        screenLocation, windowLocation, movementX, movementY, modifiers, button, buttons, relatedTarget, force, syntheticClickType, coalescedEvents, predictedEvents, isSimulated, isTrusted));
 }
 
 Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
@@ -98,7 +98,7 @@ MouseEvent::MouseEvent(enum EventInterfaceType eventInterface)
 MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed,
     MonotonicTime timestamp, RefPtr<WindowProxy>&& view, int detail,
     const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers, MouseButton button, unsigned short buttons,
-    EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, const Vector<Ref<MouseEvent>>& coalescedEvents, IsSimulated isSimulated, IsTrusted isTrusted)
+    EventTarget* relatedTarget, double force, SyntheticClickType syntheticClickType, const Vector<Ref<MouseEvent>>& coalescedEvents, const Vector<Ref<MouseEvent>>& predictedEvents, IsSimulated isSimulated, IsTrusted isTrusted)
     : MouseRelatedEvent(eventInterface, eventType, canBubble, isCancelable, isComposed, timestamp, WTFMove(view), detail, screenLocation, windowLocation, movementX, movementY, modifiers, isSimulated, isTrusted)
     , m_button(enumToUnderlyingType(button == MouseButton::None ? MouseButton::Left : button))
     , m_buttons(buttons)
@@ -107,6 +107,7 @@ MouseEvent::MouseEvent(enum EventInterfaceType eventInterface, const AtomString&
     , m_relatedTarget(relatedTarget)
     , m_force(force)
     , m_coalescedEvents(coalescedEvents)
+    , m_predictedEvents(predictedEvents)
 {
 }
 

--- a/Source/WebCore/dom/MouseEvent.h
+++ b/Source/WebCore/dom/MouseEvent.h
@@ -53,9 +53,9 @@ class MouseEvent : public MouseRelatedEvent {
 public:
     WEBCORE_EXPORT static Ref<MouseEvent> create(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
         const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
-        EventTarget* relatedTarget, double force, SyntheticClickType, const Vector<Ref<MouseEvent>>& coalescedEvents, IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
+        EventTarget* relatedTarget, double force, SyntheticClickType, const Vector<Ref<MouseEvent>>& coalescedEvents, const Vector<Ref<MouseEvent>>& predictedEvents, IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
 
-    WEBCORE_EXPORT static Ref<MouseEvent> create(const AtomString& eventType, RefPtr<WindowProxy>&&, const PlatformMouseEvent&, const Vector<Ref<MouseEvent>>& coalescedEvents, int detail, Node* relatedTarget);
+    WEBCORE_EXPORT static Ref<MouseEvent> create(const AtomString& eventType, RefPtr<WindowProxy>&&, const PlatformMouseEvent&, const Vector<Ref<MouseEvent>>& coalescedEvents, const Vector<Ref<MouseEvent>>& predictedEvents, int detail, Node* relatedTarget);
 
     static Ref<MouseEvent> create(const AtomString& eventType, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
         int screenX, int screenY, int clientX, int clientY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
@@ -93,10 +93,12 @@ public:
 
     Vector<Ref<MouseEvent>> coalescedEvents() const { return m_coalescedEvents; }
 
+    Vector<Ref<MouseEvent>> predictedEvents() const { return m_predictedEvents; }
+
 protected:
     MouseEvent(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
         const IntPoint& screenLocation, const IntPoint& windowLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
-        EventTarget* relatedTarget, double force, SyntheticClickType, const Vector<Ref<MouseEvent>>& coalescedEvents, IsSimulated, IsTrusted);
+        EventTarget* relatedTarget, double force, SyntheticClickType, const Vector<Ref<MouseEvent>>& coalescedEvents, const Vector<Ref<MouseEvent>>& predictedEvents, IsSimulated, IsTrusted);
 
     MouseEvent(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,
         const IntPoint& screenLocation, const IntPoint& clientLocation, double movementX, double movementY, OptionSet<Modifier>, MouseButton, unsigned short buttons,
@@ -118,6 +120,7 @@ private:
     RefPtr<EventTarget> m_relatedTarget;
     double m_force { 0 };
     Vector<Ref<MouseEvent>> m_coalescedEvents;
+    Vector<Ref<MouseEvent>> m_predictedEvents;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -99,6 +99,7 @@ PointerEvent::PointerEvent(const AtomString& type, Init&& initializer)
     , m_pointerType(initializer.pointerType)
     , m_isPrimary(initializer.isPrimary)
     , m_coalescedEvents(initializer.coalescedEvents)
+    , m_predictedEvents(initializer.predictedEvents)
 {
 }
 
@@ -118,6 +119,22 @@ static Vector<Ref<PointerEvent>> createCoalescedPointerEvents(const AtomString& 
     return result;
 }
 
+static Vector<Ref<PointerEvent>> createPredictedPointerEvents(const AtomString& type, MouseButton button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
+{
+    if (type != eventNames().pointermoveEvent)
+        return { };
+
+    // Populated in accordance with the https://www.w3.org/TR/pointerevents3/#populating-and-maintaining-the-coalesced-and-predicted-events-lists spec.
+
+    Vector<Ref<PointerEvent>> result;
+    for (Ref predictedMouseEvent : mouseEvent.predictedEvents()) {
+        Ref pointerEvent = PointerEvent::create(type, button, predictedMouseEvent.get(), pointerId, pointerType, Event::CanBubble::No, Event::IsCancelable::No);
+        result.append(WTFMove(pointerEvent));
+    }
+
+    return result;
+}
+
 PointerEvent::PointerEvent(const AtomString& type, MouseButton button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType, CanBubble canBubble, IsCancelable isCancelable)
     : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), mouseEvent.timeStamp(), mouseEvent.view(), mouseEvent.detail(), mouseEvent.screenLocation(),
         { mouseEvent.clientX(), mouseEvent.clientY() }, mouseEvent.movementX(), mouseEvent.movementY(), mouseEvent.modifierKeys(), button, mouseEvent.buttons(),
@@ -129,6 +146,7 @@ PointerEvent::PointerEvent(const AtomString& type, MouseButton button, const Mou
     , m_pointerType(pointerType)
     , m_isPrimary(true)
     , m_coalescedEvents(createCoalescedPointerEvents(type, button, mouseEvent, pointerId, pointerType))
+    , m_predictedEvents(createPredictedPointerEvents(type, button, mouseEvent, pointerId, pointerType))
 {
 }
 
@@ -151,33 +169,67 @@ Vector<Ref<PointerEvent>> PointerEvent::getCoalescedEvents() const
     if (isTrusted()) {
         auto& names = eventNames();
         if (type() == names.pointermoveEvent)
-            ASSERT(m_coalescedEvents.size() >= 1, "Trusted pointermove events must have more than zero coalesced events.");
+            ASSERT(!m_coalescedEvents.isEmpty(), "Trusted pointermove events must have more than zero coalesced events.");
         else
-            ASSERT(m_coalescedEvents.size() == 0, "Trusted non-pointermove events must have zero coalesced events.");
+            ASSERT(m_coalescedEvents.isEmpty(), "Trusted non-pointermove events must have zero coalesced events.");
+
+        auto timestampsAreMonotonicallyIncreasing = std::ranges::is_sorted(m_coalescedEvents, [](const auto& previousEvent, const auto& newEvent) {
+            return previousEvent->timeStamp() <= newEvent->timeStamp();
+        });
+
+        ASSERT(timestampsAreMonotonicallyIncreasing, "Coalesced event timestamps are not monotonically increasing.");
+
+        auto canBubbleOrIsCancelable = std::ranges::any_of(m_coalescedEvents, [](const auto& event) {
+            return event->bubbles() || event->cancelable();
+        });
+
+        ASSERT(!canBubbleOrIsCancelable, "Coalesced events must not bubble and must not be cancelable.");
     }
-
-    auto timestampsAreMonotonicallyIncreasing = std::ranges::is_sorted(m_coalescedEvents, [](const auto& previousEvent, const auto& newEvent) {
-        return previousEvent->timeStamp() <= newEvent->timeStamp();
-    });
-
-    ASSERT(timestampsAreMonotonicallyIncreasing, "Coalesced event timestamps are not monotonically increasing.");
-
-    auto canBubbleOrIsCancelable = std::ranges::any_of(m_coalescedEvents, [](const auto& event) {
-        return event->bubbles() || event->cancelable();
-    });
-
-    ASSERT(!canBubbleOrIsCancelable, "Coalesced events must not bubble and must not be cancelable.");
 #endif
 
     return m_coalescedEvents;
+}
+
+Vector<Ref<PointerEvent>> PointerEvent::getPredictedEvents() const
+{
+#if ASSERT_ENABLED
+    if (isTrusted()) {
+        auto& names = eventNames();
+        if (type() != names.pointermoveEvent)
+            ASSERT(m_predictedEvents.isEmpty(), "Trusted non-pointermove events must have zero predicted events.");
+
+        auto timestampsAreMonotonicallyIncreasing = std::ranges::is_sorted(m_predictedEvents, [](const auto& previousEvent, const auto& newEvent) {
+            return previousEvent->timeStamp() <= newEvent->timeStamp();
+        });
+
+        ASSERT(timestampsAreMonotonicallyIncreasing, "Predicted event timestamps are not monotonically increasing.");
+
+        if (!m_predictedEvents.isEmpty())
+            ASSERT(m_predictedEvents.first()->timeStamp() >= this->timeStamp(), "Predicted events must have a timestamp greater than or equal to the dispatched event.");
+
+        auto canBubbleOrIsCancelable = std::ranges::any_of(m_predictedEvents, [](const auto& event) {
+            return event->bubbles() || event->cancelable();
+        });
+
+        ASSERT(!canBubbleOrIsCancelable, "Predicted events must not bubble and must not be cancelable.");
+    }
+#endif
+
+    return m_predictedEvents;
 }
 
 void PointerEvent::receivedTarget()
 {
     MouseRelatedEvent::receivedTarget();
 
+    if (!isTrusted())
+        return;
+
     for (Ref coalescedEvent : m_coalescedEvents)
         coalescedEvent->setTarget(this->target());
+
+    for (Ref predictedEvent : m_predictedEvents)
+        predictedEvent->setTarget(this->target());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -59,6 +59,7 @@ public:
         String pointerType { mousePointerEventType() };
         bool isPrimary { false };
         Vector<Ref<PointerEvent>> coalescedEvents;
+        Vector<Ref<PointerEvent>> predictedEvents;
     };
 
     enum class IsPrimary : bool { No, Yes };
@@ -89,9 +90,9 @@ public:
     static Ref<PointerEvent> create(const AtomString& type, PointerID, const String& pointerType, IsPrimary = IsPrimary::No);
 
 #if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
-    static Ref<PointerEvent> create(const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
-    static Ref<PointerEvent> create(const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, CanBubble, IsCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta = { });
-    static Ref<PointerEvent> create(const AtomString& type, const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
+    static Ref<PointerEvent> create(const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
+    static Ref<PointerEvent> create(const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble, IsCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta = { });
+    static Ref<PointerEvent> create(const AtomString& type, const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
 #endif
 
     virtual ~PointerEvent();
@@ -108,6 +109,8 @@ public:
     bool isPrimary() const { return m_isPrimary; }
 
     Vector<Ref<PointerEvent>> getCoalescedEvents() const;
+
+    Vector<Ref<PointerEvent>> getPredictedEvents() const;
 
     void receivedTarget() final;
 
@@ -148,7 +151,7 @@ private:
     PointerEvent(const AtomString& type, MouseButton, const MouseEvent&, PointerID, const String& pointerType, CanBubble, IsCancelable);
     PointerEvent(const AtomString& type, PointerID, const String& pointerType, IsPrimary);
 #if ENABLE(TOUCH_EVENTS) && (PLATFORM(IOS_FAMILY) || PLATFORM(WPE))
-    PointerEvent(const AtomString& type, const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
+    PointerEvent(const AtomString& type, const PlatformTouchEvent&, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned touchIndex, bool isPrimary, Ref<WindowProxy>&&, const IntPoint& touchDelta = { });
 #endif
 
     PointerID m_pointerId { mousePointerID };
@@ -162,6 +165,7 @@ private:
     String m_pointerType { mousePointerEventType() };
     bool m_isPrimary { false };
     Vector<Ref<PointerEvent>> m_coalescedEvents;
+    Vector<Ref<PointerEvent>> m_predictedEvents;
 };
 
 inline bool PointerEvent::typeIsEnterOrLeave(const AtomString& type)

--- a/Source/WebCore/dom/PointerEvent.idl
+++ b/Source/WebCore/dom/PointerEvent.idl
@@ -34,7 +34,8 @@ dictionary PointerEventInit : MouseEventInit {
     long twist = 0;
     DOMString pointerType = "";
     boolean isPrimary = false;
-    sequence<PointerEvent> coalescedEvents = [];
+    [EnabledBySetting=GetCoalescedEventsEnabled] sequence<PointerEvent> coalescedEvents = [];
+    [EnabledBySetting=GetPredictedEventsEnabled] sequence<PointerEvent> predictedEvents = [];
 };
 
 [
@@ -57,5 +58,6 @@ dictionary PointerEventInit : MouseEventInit {
     readonly attribute boolean isPrimary;
 
     [SecureContext, EnabledBySetting=GetCoalescedEventsEnabled] sequence<PointerEvent> getCoalescedEvents();
+    [EnabledBySetting=GetPredictedEventsEnabled] sequence<PointerEvent> getPredictedEvents();
 };
 

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -50,7 +50,7 @@ private:
     SimulatedMouseEvent(const AtomString& eventType, RefPtr<WindowProxy>&& view, RefPtr<Event>&& underlyingEvent, Element& target, SimulatedClickSource source)
         : MouseEvent(EventInterfaceType::MouseEvent, eventType, CanBubble::Yes, IsCancelable::Yes, IsComposed::Yes,
             underlyingEvent ? underlyingEvent->timeStamp() : MonotonicTime::now(), WTFMove(view), /* detail */ 0,
-            { }, { }, 0, 0, modifiersFromUnderlyingEvent(underlyingEvent), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, { }, IsSimulated::Yes,
+            { }, { }, 0, 0, modifiersFromUnderlyingEvent(underlyingEvent), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::Yes,
             source == SimulatedClickSource::UserAgent ? IsTrusted::Yes : IsTrusted::No)
     {
         setUnderlyingEvent(underlyingEvent.get());

--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -65,7 +65,7 @@ inline WheelEvent::WheelEvent(const AtomString& type, const Init& initializer)
 
 inline WheelEvent::WheelEvent(const PlatformWheelEvent& event, RefPtr<WindowProxy>&& view, IsCancelable isCancelable)
     : MouseEvent(EventInterfaceType::WheelEvent, eventNames().wheelEvent, CanBubble::Yes, isCancelable, IsComposed::Yes, event.timestamp().approximateMonotonicTime(), WTFMove(view), 0,
-        event.globalPosition(), event.position() , 0, 0, event.modifiers(), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, { }, IsSimulated::No, IsTrusted::Yes)
+        event.globalPosition(), event.position() , 0, 0, event.modifiers(), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes)
     , m_wheelDelta(event.wheelTicksX() * TickMultiplier, event.wheelTicksY() * TickMultiplier)
     , m_deltaX(-event.deltaX())
     , m_deltaY(-event.deltaY())

--- a/Source/WebCore/dom/ios/MouseEventIOS.cpp
+++ b/Source/WebCore/dom/ios/MouseEventIOS.cpp
@@ -53,7 +53,7 @@ Ref<MouseEvent> MouseEvent::create(const PlatformTouchEvent& event, unsigned ind
 {
     return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, mouseEventType(event.touchPhaseAtIndex(index)), CanBubble::Yes, cancelable, IsComposed::Yes,
         event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), 0, 0,
-        event.modifiers(), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, { }, IsSimulated::No, IsTrusted::Yes));
+        event.modifiers(), MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ios/PointerEventIOS.cpp
+++ b/Source/WebCore/dom/ios/PointerEventIOS.cpp
@@ -51,28 +51,28 @@ static const AtomString& pointerEventType(PlatformTouchPoint::TouchPhaseType pha
     return nullAtom();
 }
 
-Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
 {
     const auto& type = pointerEventType(event.touchPhaseAtIndex(index));
 
-    return adoptRef(*new PointerEvent(type, event, coalescedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
+    return adoptRef(*new PointerEvent(type, event, coalescedEvents, predictedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
 }
 
-Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
 {
     const auto& type = pointerEventType(event.touchPhaseAtIndex(index));
 
-    return adoptRef(*new PointerEvent(type, event, coalescedEvents, canBubble, isCancelable, index, isPrimary, WTFMove(view), touchDelta));
+    return adoptRef(*new PointerEvent(type, event, coalescedEvents, predictedEvents, canBubble, isCancelable, index, isPrimary, WTFMove(view), touchDelta));
 }
 
-Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
 {
-    return adoptRef(*new PointerEvent(type, event, coalescedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
+    return adoptRef(*new PointerEvent(type, event, coalescedEvents, predictedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
 }
 
-PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
     : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0,
-        event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, IsSimulated::No, IsTrusted::Yes)
+        event.touchLocationAtIndex(index), event.touchLocationAtIndex(index), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes)
     , m_pointerId(event.touchIdentifierAtIndex(index))
     , m_width(2 * event.radiusXAtIndex(index))
     , m_height(2 * event.radiusYAtIndex(index))
@@ -80,6 +80,7 @@ PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& eve
     , m_pointerType(event.touchTypeAtIndex(index) == PlatformTouchPoint::TouchType::Stylus ? penPointerEventType() : touchPointerEventType())
     , m_isPrimary(isPrimary)
     , m_coalescedEvents(coalescedEvents)
+    , m_predictedEvents(predictedEvents)
 {
     // See https://github.com/w3c/pointerevents/issues/274. We might expose the azimuth and altitude
     // directly as well as the tilt.

--- a/Source/WebCore/dom/wpe/PointerEventWPE.cpp
+++ b/Source/WebCore/dom/wpe/PointerEventWPE.cpp
@@ -54,25 +54,25 @@ static const AtomString& pointerEventType(PlatformTouchPoint::State state)
     return nullAtom();
 }
 
-Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
 {
     const auto& type = pointerEventType(event.touchPoints().at(index).state());
-    return adoptRef(*new PointerEvent(type, event, coalescedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
+    return adoptRef(*new PointerEvent(type, event, coalescedEvents, predictedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
 }
 
-Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
 {
     const auto& type = pointerEventType(event.touchPoints().at(index).state());
-    return adoptRef(*new PointerEvent(type, event, coalescedEvents, canBubble, isCancelable, index, isPrimary, WTFMove(view), touchDelta));
+    return adoptRef(*new PointerEvent(type, event, coalescedEvents, predictedEvents, canBubble, isCancelable, index, isPrimary, WTFMove(view), touchDelta));
 }
 
-Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+Ref<PointerEvent> PointerEvent::create(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
 {
-    return adoptRef(*new PointerEvent(type, event, coalescedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
+    return adoptRef(*new PointerEvent(type, event, coalescedEvents, predictedEvents, typeCanBubble(type), typeIsCancelable(type), index, isPrimary, WTFMove(view), touchDelta));
 }
 
-PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
-    : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchPoints().at(index).pos(), event.touchPoints().at(index).pos(), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, IsSimulated::No, IsTrusted::Yes)
+PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& event, const Vector<Ref<PointerEvent>>& coalescedEvents, const Vector<Ref<PointerEvent>>& predictedEvents, CanBubble canBubble, IsCancelable isCancelable, unsigned index, bool isPrimary, Ref<WindowProxy>&& view, const IntPoint& touchDelta)
+    : MouseEvent(EventInterfaceType::PointerEvent, type, canBubble, isCancelable, typeIsComposed(type), event.timestamp().approximateMonotonicTime(), WTFMove(view), 0, event.touchPoints().at(index).pos(), event.touchPoints().at(index).pos(), touchDelta.x(), touchDelta.y(), event.modifiers(), buttonForType(type), buttonsForType(type), nullptr, 0, SyntheticClickType::NoTap, { }, { }, IsSimulated::No, IsTrusted::Yes)
     , m_pointerId(event.touchPoints().at(index).id())
     , m_width(2 * event.touchPoints().at(index).radiusX())
     , m_height(2 * event.touchPoints().at(index).radiusY())
@@ -80,6 +80,7 @@ PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& eve
     , m_pointerType(touchPointerEventType())
     , m_isPrimary(isPrimary)
     , m_coalescedEvents(coalescedEvents)
+    , m_predictedEvents(predictedEvents)
 {
 }
 

--- a/Source/WebCore/platform/PlatformMouseEvent.h
+++ b/Source/WebCore/platform/PlatformMouseEvent.h
@@ -82,6 +82,7 @@ public:
     const String& pointerType() const { return m_pointerType; }
 
     Vector<PlatformMouseEvent> coalescedEvents() const { return m_coalescedEvents; }
+    Vector<PlatformMouseEvent> predictedEvents() const { return m_predictedEvents; }
 
 #if PLATFORM(MAC)
     int eventNumber() const { return m_eventNumber; }
@@ -115,6 +116,7 @@ protected:
     unsigned m_modifierFlags { 0 };
     unsigned short m_buttons { 0 };
     Vector<PlatformMouseEvent> m_coalescedEvents;
+    Vector<PlatformMouseEvent> m_predictedEvents;
 #if PLATFORM(MAC)
     int m_eventNumber { 0 };
     int m_menuTypeForEvent { 0 };

--- a/Source/WebCore/platform/PlatformTouchEvent.h
+++ b/Source/WebCore/platform/PlatformTouchEvent.h
@@ -40,6 +40,8 @@ public:
 
     const Vector<PlatformTouchEvent>& coalescedEvents() const { return m_coalescedEvents; }
 
+    const Vector<PlatformTouchEvent>& predictedEvents() const { return m_predictedEvents; }
+
 #if PLATFORM(WPE)
     // FIXME: since WPE currently does not send touch stationary events, we need to be able to set
     // TouchCancelled touchPoints subsequently
@@ -49,6 +51,7 @@ public:
 protected:
     Vector<PlatformTouchPoint> m_touchPoints;
     Vector<PlatformTouchEvent> m_coalescedEvents;
+    Vector<PlatformTouchEvent> m_predictedEvents;
 };
 
 }

--- a/Source/WebKit/Shared/NativeWebTouchEvent.h
+++ b/Source/WebKit/Shared/NativeWebTouchEvent.h
@@ -78,6 +78,7 @@ private:
 #if PLATFORM(IOS_FAMILY) && defined(__OBJC__)
     Vector<WebPlatformTouchPoint> extractWebTouchPoints(const WKTouchEvent&);
     Vector<WebTouchEvent> extractCoalescedWebTouchEvents(const WKTouchEvent&, UIKeyModifierFlags);
+    Vector<WebTouchEvent> extractPredictedWebTouchEvents(const WKTouchEvent&, UIKeyModifierFlags);
 #endif
 
 #if PLATFORM(GTK) && USE(GTK4)

--- a/Source/WebKit/Shared/WebEvent.serialization.in
+++ b/Source/WebKit/Shared/WebEvent.serialization.in
@@ -101,6 +101,7 @@ class WebKit::WebKeyboardEvent : WebKit::WebEvent {
 class WebKit::WebTouchEvent : WebKit::WebEvent {
     Vector<WebKit::WebPlatformTouchPoint> touchPoints();
     Vector<WebKit::WebTouchEvent> coalescedEvents();
+    Vector<WebKit::WebTouchEvent> predictedEvents();
 #if PLATFORM(IOS_FAMILY)
     WebCore::IntPoint position();
     bool isPotentialTap();

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -120,6 +120,9 @@ public:
         m_coalescedEvents = WTF::map(webEvent.coalescedEvents(), [&](const auto& event) {
             return platform(event);
         });
+        m_predictedEvents = WTF::map(webEvent.predictedEvents(), [&](const auto& event) {
+            return platform(event);
+        });
 #if PLATFORM(MAC)
         m_eventNumber = webEvent.eventNumber();
         m_menuTypeForEvent = webEvent.menuTypeForEvent();
@@ -360,6 +363,10 @@ public:
         });
 
         m_coalescedEvents = WTF::map(webEvent.coalescedEvents(), [&](auto& event) {
+            return platform(event);
+        });
+
+        m_predictedEvents = WTF::map(webEvent.predictedEvents(), [&](auto& event) {
             return platform(event);
         });
 

--- a/Source/WebKit/Shared/WebMouseEvent.cpp
+++ b/Source/WebKit/Shared/WebMouseEvent.cpp
@@ -33,11 +33,11 @@ namespace WebKit {
 using namespace WebCore;
 
 #if PLATFORM(MAC)
-WebMouseEvent::WebMouseEvent(WebEvent&& event, WebMouseEventButton button, unsigned short buttons, const IntPoint& positionInView, const IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, double force, WebMouseEventSyntheticClickType syntheticClickType, int eventNumber, int menuType, GestureWasCancelled gestureWasCancelled, const IntPoint& unadjustedMovementDelta, const Vector<WebMouseEvent>& coalescedEvents)
+WebMouseEvent::WebMouseEvent(WebEvent&& event, WebMouseEventButton button, unsigned short buttons, const IntPoint& positionInView, const IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, double force, WebMouseEventSyntheticClickType syntheticClickType, int eventNumber, int menuType, GestureWasCancelled gestureWasCancelled, const IntPoint& unadjustedMovementDelta, const Vector<WebMouseEvent>& coalescedEvents, const Vector<WebMouseEvent>& predictedEvents)
 #elif PLATFORM(GTK)
-WebMouseEvent::WebMouseEvent(WebEvent&& event, WebMouseEventButton button, unsigned short buttons, const IntPoint& positionInView, const IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, double force, WebMouseEventSyntheticClickType syntheticClickType, PlatformMouseEvent::IsTouch isTouchEvent, WebCore::PointerID pointerId, const String& pointerType, GestureWasCancelled gestureWasCancelled, const IntPoint& unadjustedMovementDelta, const Vector<WebMouseEvent>& coalescedEvents)
+WebMouseEvent::WebMouseEvent(WebEvent&& event, WebMouseEventButton button, unsigned short buttons, const IntPoint& positionInView, const IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, double force, WebMouseEventSyntheticClickType syntheticClickType, PlatformMouseEvent::IsTouch isTouchEvent, WebCore::PointerID pointerId, const String& pointerType, GestureWasCancelled gestureWasCancelled, const IntPoint& unadjustedMovementDelta, const Vector<WebMouseEvent>& coalescedEvents, const Vector<WebMouseEvent>& predictedEvents)
 #else
-WebMouseEvent::WebMouseEvent(WebEvent&& event, WebMouseEventButton button, unsigned short buttons, const IntPoint& positionInView, const IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, double force, WebMouseEventSyntheticClickType syntheticClickType, WebCore::PointerID pointerId, const String& pointerType, GestureWasCancelled gestureWasCancelled, const IntPoint& unadjustedMovementDelta, const Vector<WebMouseEvent>& coalescedEvents)
+WebMouseEvent::WebMouseEvent(WebEvent&& event, WebMouseEventButton button, unsigned short buttons, const IntPoint& positionInView, const IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, double force, WebMouseEventSyntheticClickType syntheticClickType, WebCore::PointerID pointerId, const String& pointerType, GestureWasCancelled gestureWasCancelled, const IntPoint& unadjustedMovementDelta, const Vector<WebMouseEvent>& coalescedEvents, const Vector<WebMouseEvent>& predictedEvents)
 #endif
     : WebEvent(WTFMove(event))
     , m_button(button)
@@ -63,6 +63,7 @@ WebMouseEvent::WebMouseEvent(WebEvent&& event, WebMouseEventButton button, unsig
 #endif
     , m_gestureWasCancelled(gestureWasCancelled)
     , m_coalescedEvents(coalescedEvents)
+    , m_predictedEvents(predictedEvents)
 {
     ASSERT(isMouseEventType(type()));
 }

--- a/Source/WebKit/Shared/WebMouseEvent.h
+++ b/Source/WebKit/Shared/WebMouseEvent.h
@@ -61,11 +61,11 @@ WebMouseEventSyntheticClickType syntheticClickType(const WebCore::NavigationActi
 class WebMouseEvent : public WebEvent {
 public:
 #if PLATFORM(MAC)
-    WebMouseEvent(WebEvent&&, WebMouseEventButton, unsigned short buttons, const WebCore::IntPoint& positionInView, const WebCore::IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, double force, WebMouseEventSyntheticClickType = WebMouseEventSyntheticClickType::NoTap, int eventNumber = -1, int menuType = 0, GestureWasCancelled = GestureWasCancelled::No, const WebCore::IntPoint& unadjustedMovementDelta = { }, const Vector<WebMouseEvent>& coalescedEvents = { });
+    WebMouseEvent(WebEvent&&, WebMouseEventButton, unsigned short buttons, const WebCore::IntPoint& positionInView, const WebCore::IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, double force, WebMouseEventSyntheticClickType = WebMouseEventSyntheticClickType::NoTap, int eventNumber = -1, int menuType = 0, GestureWasCancelled = GestureWasCancelled::No, const WebCore::IntPoint& unadjustedMovementDelta = { }, const Vector<WebMouseEvent>& coalescedEvents = { }, const Vector<WebMouseEvent>& predictedEvents = { });
 #elif PLATFORM(GTK)
-    WebMouseEvent(WebEvent&&, WebMouseEventButton, unsigned short buttons, const WebCore::IntPoint& positionInView, const WebCore::IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, double force = 0, WebMouseEventSyntheticClickType = WebMouseEventSyntheticClickType::NoTap, WebCore::PlatformMouseEvent::IsTouch m_isTouchEvent = WebCore::PlatformMouseEvent::IsTouch::No, WebCore::PointerID = WebCore::mousePointerID, const String& pointerType = WebCore::mousePointerEventType(), GestureWasCancelled = GestureWasCancelled::No, const WebCore::IntPoint& unadjustedMovementDelta = { }, const Vector<WebMouseEvent>& coalescedEvents = { });
+    WebMouseEvent(WebEvent&&, WebMouseEventButton, unsigned short buttons, const WebCore::IntPoint& positionInView, const WebCore::IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, double force = 0, WebMouseEventSyntheticClickType = WebMouseEventSyntheticClickType::NoTap, WebCore::PlatformMouseEvent::IsTouch m_isTouchEvent = WebCore::PlatformMouseEvent::IsTouch::No, WebCore::PointerID = WebCore::mousePointerID, const String& pointerType = WebCore::mousePointerEventType(), GestureWasCancelled = GestureWasCancelled::No, const WebCore::IntPoint& unadjustedMovementDelta = { }, const Vector<WebMouseEvent>& coalescedEvents = { }, const Vector<WebMouseEvent>& predictedEvents = { });
 #else
-    WebMouseEvent(WebEvent&&, WebMouseEventButton, unsigned short buttons, const WebCore::IntPoint& positionInView, const WebCore::IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, double force = 0, WebMouseEventSyntheticClickType = WebMouseEventSyntheticClickType::NoTap, WebCore::PointerID = WebCore::mousePointerID, const String& pointerType = WebCore::mousePointerEventType(), GestureWasCancelled = GestureWasCancelled::No, const WebCore::IntPoint& unadjustedMovementDelta = { }, const Vector<WebMouseEvent>& coalescedEvents = { });
+    WebMouseEvent(WebEvent&&, WebMouseEventButton, unsigned short buttons, const WebCore::IntPoint& positionInView, const WebCore::IntPoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, double force = 0, WebMouseEventSyntheticClickType = WebMouseEventSyntheticClickType::NoTap, WebCore::PointerID = WebCore::mousePointerID, const String& pointerType = WebCore::mousePointerEventType(), GestureWasCancelled = GestureWasCancelled::No, const WebCore::IntPoint& unadjustedMovementDelta = { }, const Vector<WebMouseEvent>& coalescedEvents = { }, const Vector<WebMouseEvent>& predictedEvents = { });
 #endif
 
     WebMouseEventButton button() const { return m_button; }
@@ -94,6 +94,9 @@ public:
     void setCoalescedEvents(const Vector<WebMouseEvent>& coalescedEvents) { m_coalescedEvents = coalescedEvents; }
     Vector<WebMouseEvent> coalescedEvents() const { return m_coalescedEvents; }
 
+    void setPredictedEvents(const Vector<WebMouseEvent>& predictedEvents) { m_predictedEvents = predictedEvents; }
+    Vector<WebMouseEvent> predictedEvents() const { return m_predictedEvents; }
+
 private:
     static bool isMouseEventType(WebEventType);
 
@@ -118,6 +121,7 @@ private:
     String m_pointerType { WebCore::mousePointerEventType() };
     GestureWasCancelled m_gestureWasCancelled { GestureWasCancelled::No };
     Vector<WebMouseEvent> m_coalescedEvents;
+    Vector<WebMouseEvent> m_predictedEvents;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebTouchEvent.cpp
+++ b/Source/WebKit/Shared/WebTouchEvent.cpp
@@ -34,10 +34,11 @@ namespace WebKit {
 
 #if !PLATFORM(IOS_FAMILY)
 
-WebTouchEvent::WebTouchEvent(WebEvent&& event, Vector<WebPlatformTouchPoint>&& touchPoints, Vector<WebTouchEvent>&& coalescedEvents)
+WebTouchEvent::WebTouchEvent(WebEvent&& event, Vector<WebPlatformTouchPoint>&& touchPoints, Vector<WebTouchEvent>&& coalescedEvents, Vector<WebTouchEvent>&& predictedEvents)
     : WebEvent(WTFMove(event))
     , m_touchPoints(WTFMove(touchPoints))
     , m_coalescedEvents(WTFMove(coalescedEvents))
+    , m_predictedEvents(WTFMove(predictedEvents))
 {
     ASSERT(isTouchEventType(type()));
 }

--- a/Source/WebKit/Shared/WebTouchEvent.h
+++ b/Source/WebKit/Shared/WebTouchEvent.h
@@ -114,10 +114,11 @@ private:
 
 class WebTouchEvent : public WebEvent {
 public:
-    WebTouchEvent(WebEvent&& event, const Vector<WebPlatformTouchPoint>& touchPoints, const Vector<WebTouchEvent>& coalescedEvents, WebCore::IntPoint position, bool isPotentialTap, bool isGesture, float gestureScale, float gestureRotation, bool canPreventNativeGestures = true)
+    WebTouchEvent(WebEvent&& event, const Vector<WebPlatformTouchPoint>& touchPoints, const Vector<WebTouchEvent>& coalescedEvents, const Vector<WebTouchEvent>& predictedEvents, WebCore::IntPoint position, bool isPotentialTap, bool isGesture, float gestureScale, float gestureRotation, bool canPreventNativeGestures = true)
         : WebEvent(WTFMove(event))
         , m_touchPoints(touchPoints)
         , m_coalescedEvents(coalescedEvents)
+        , m_predictedEvents(predictedEvents)
         , m_position(position)
         , m_canPreventNativeGestures(canPreventNativeGestures)
         , m_isPotentialTap(isPotentialTap)
@@ -132,6 +133,9 @@ public:
 
     const Vector<WebTouchEvent>& coalescedEvents() const { return m_coalescedEvents; }
     void setCoalescedEvents(const Vector<WebTouchEvent>& coalescedEvents) { m_coalescedEvents = coalescedEvents; }
+
+    const Vector<WebTouchEvent>& predictedEvents() const { return m_predictedEvents; }
+    void setPredictedEvents(const Vector<WebTouchEvent>& predictedEvents) { m_predictedEvents = predictedEvents; }
 
     WebCore::IntPoint position() const { return m_position; }
     void setPosition(WebCore::IntPoint position) { m_position = position; }
@@ -150,6 +154,7 @@ public:
 private:
     Vector<WebPlatformTouchPoint> m_touchPoints;
     Vector<WebTouchEvent> m_coalescedEvents;
+    Vector<WebTouchEvent> m_predictedEvents;
 
     WebCore::IntPoint m_position;
     bool m_canPreventNativeGestures { false };
@@ -201,11 +206,13 @@ private:
 
 class WebTouchEvent : public WebEvent {
 public:
-    WebTouchEvent(WebEvent&&, Vector<WebPlatformTouchPoint>&&, Vector<WebTouchEvent>&&);
+    WebTouchEvent(WebEvent&&, Vector<WebPlatformTouchPoint>&&, Vector<WebTouchEvent>&&, Vector<WebTouchEvent>&&);
 
     const Vector<WebPlatformTouchPoint>& touchPoints() const { return m_touchPoints; }
 
     const Vector<WebTouchEvent>& coalescedEvents() const { return m_coalescedEvents; }
+
+    const Vector<WebTouchEvent>& predictedEvents() const { return m_predictedEvents; }
 
     bool allTouchPointsAreReleased() const;
 
@@ -214,6 +221,7 @@ private:
 
     Vector<WebPlatformTouchPoint> m_touchPoints;
     Vector<WebTouchEvent> m_coalescedEvents;
+    Vector<WebTouchEvent> m_predictedEvents;
 };
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/gtk/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/gtk/WebEventFactory.cpp
@@ -289,7 +289,7 @@ WebTouchEvent WebEventFactory::createWebTouchEvent(const GdkEvent* event, Vector
         ASSERT_NOT_REACHED();
     }
 
-    return WebTouchEvent({ type, modifiersForEvent(event), wallTimeForEvent(event) }, WTFMove(touchPoints), { });
+    return WebTouchEvent({ type, modifiersForEvent(event), wallTimeForEvent(event) }, WTFMove(touchPoints), { }, { });
 }
 #endif
 

--- a/Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm
+++ b/Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm
@@ -125,11 +125,19 @@ Vector<WebTouchEvent> NativeWebTouchEvent::extractCoalescedWebTouchEvents(const 
     });
 }
 
+Vector<WebTouchEvent> NativeWebTouchEvent::extractPredictedWebTouchEvents(const WKTouchEvent& event, UIKeyModifierFlags flags)
+{
+    return event.predictedEvents.map([&](auto& event) -> WebTouchEvent {
+        return NativeWebTouchEvent { event, flags };
+    });
+}
+
 NativeWebTouchEvent::NativeWebTouchEvent(const WKTouchEvent& event, UIKeyModifierFlags flags)
     : WebTouchEvent(
         { webEventTypeForWKTouchEventType(event.type), webEventModifierFlags(flags), WallTime::fromRawSeconds(event.timestamp) },
         extractWebTouchPoints(event),
         extractCoalescedWebTouchEvents(event, flags),
+        extractPredictedWebTouchEvents(event, flags),
         positionForCGPoint(event.locationInDocumentCoordinates),
         event.isPotentialTap,
         event.inJavaScriptGesture,

--- a/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
@@ -347,7 +347,7 @@ WebTouchEvent WebEventFactory::createWebTouchEvent(struct wpe_input_touch_event*
                 pointCoordinates, pointCoordinates));
     }
 
-    return WebTouchEvent({ type, OptionSet<WebEventModifier> { }, wallTimeForEventTime(event->time) }, WTFMove(touchPoints), { });
+    return WebTouchEvent({ type, OptionSet<WebEventModifier> { }, wallTimeForEventTime(event->time) }, WTFMove(touchPoints), { }, { });
 }
 #endif // ENABLE(TOUCH_EVENTS)
 

--- a/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
+++ b/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
@@ -231,7 +231,7 @@ WebTouchEvent WebEventFactory::createWebTouchEvent(WPEEvent* event, Vector<WebPl
         RELEASE_ASSERT_NOT_REACHED();
     }
 
-    return WebTouchEvent({ type.value(), modifiersFromWPEModifiers(wpe_event_get_modifiers(event)), wallTimeForEvent(event) }, WTFMove(touchPoints), { });
+    return WebTouchEvent({ type.value(), modifiersFromWPEModifiers(wpe_event_get_modifiers(event)), wallTimeForEvent(event) }, WTFMove(touchPoints), { }, { });
 }
 #endif // ENABLE(TOUCH_EVENTS)
 

--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h
@@ -57,6 +57,7 @@ struct WKTouchEvent {
 
     Vector<WKTouchPoint> touchPoints;
     Vector<WKTouchEvent> coalescedEvents;
+    Vector<WKTouchEvent> predictedEvents;
     bool isPotentialTap { false };
 };
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1196,7 +1196,7 @@ void PDFPluginBase::navigateToURL(const URL& url)
 
     RefPtr<Event> coreEvent;
     if (m_lastMouseEvent)
-        coreEvent = MouseEvent::create(eventNames().clickEvent, &frame->windowProxy(), platform(*m_lastMouseEvent), { }, 0, 0);
+        coreEvent = MouseEvent::create(eventNames().clickEvent, &frame->windowProxy(), platform(*m_lastMouseEvent), { }, { }, 0, 0);
 
     frame->loader().changeLocation(url, emptyAtom(), coreEvent.get(), ReferrerPolicy::NoReferrer, ShouldOpenExternalURLsPolicy::ShouldAllow);
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2187,7 +2187,7 @@ void WebPage::navigateToPDFLinkWithSimulatedClick(const String& url, IntPoint do
     // FIXME: Set modifier keys.
     // FIXME: This should probably set IsSimulated::Yes.
     auto mouseEvent = MouseEvent::create(eventNames().clickEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes, Event::IsComposed::Yes,
-        MonotonicTime::now(), nullptr, singleClick, screenPoint, documentPoint, 0, 0, { }, MouseButton::Left, 0, nullptr, 0, WebCore::SyntheticClickType::NoTap, { });
+        MonotonicTime::now(), nullptr, singleClick, screenPoint, documentPoint, 0, 0, { }, MouseButton::Left, 0, nullptr, 0, WebCore::SyntheticClickType::NoTap, { }, { });
 
     mainFrame->loader().changeLocation(mainFrameDocument->completeURL(url), emptyAtom(), mouseEvent.ptr(), ReferrerPolicy::NoReferrer, ShouldOpenExternalURLsPolicy::ShouldAllow);
 }

--- a/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
+++ b/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
@@ -464,12 +464,12 @@ static const float PAGE_HEIGHT_INSET = 4.0f * 2.0f;
         return;
 
     auto event = MouseEvent::create(eventNames().clickEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes, Event::IsComposed::Yes,
-        MonotonicTime::now(), nullptr, 1, { }, { }, 0, 0, { }, MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, { }, MouseEvent::IsSimulated::Yes);
+        MonotonicTime::now(), nullptr, 1, { }, { }, 0, 0, { }, MouseButton::Left, 0, nullptr, 0, SyntheticClickType::NoTap, { }, { }, MouseEvent::IsSimulated::Yes);
 
     // Call to the frame loader because this is where our security checks are made.
     auto* frame = core([_dataSource webFrame]);
     FrameLoadRequest frameLoadRequest { *frame->document(), frame->document()->securityOrigin(), { URL }, { }, InitiatedByMainFrame::Unknown };
-frameLoadRequest.setReferrerPolicy(ReferrerPolicy::NoReferrer);
+    frameLoadRequest.setReferrerPolicy(ReferrerPolicy::NoReferrer);
     frame->loader().loadFrameRequest(WTFMove(frameLoadRequest), event.ptr(), nullptr);
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
@@ -961,7 +961,7 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
         // FIXME: Use createPlatformMouseEvent instead.
         event = WebCore::MouseEvent::create(WebCore::eventNames().clickEvent, WebCore::Event::CanBubble::Yes, WebCore::Event::IsCancelable::Yes, WebCore::Event::IsComposed::Yes,
             MonotonicTime::now(), nullptr, [nsEvent clickCount], { }, { }, 0, 0, WebCore::modifiersForEvent(nsEvent),
-            button, [NSEvent pressedMouseButtons], nullptr, WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap, { }, WebCore::MouseEvent::IsSimulated::Yes);
+            button, [NSEvent pressedMouseButtons], nullptr, WebCore::ForceAtClick, WebCore::SyntheticClickType::NoTap, { }, { }, WebCore::MouseEvent::IsSimulated::Yes);
     }
 
     // Call to the frame loader because this is where our security checks are made.

--- a/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm
@@ -90,7 +90,7 @@ static Class touchEventsGestureRecognizerClass()
 namespace TestWebKitAPI {
 
 static WebKit::WKTouchPoint globalTouchPoint { CGPointZero, CGPointZero, 100, UITouchPhaseBegan, 1, 0, 0, 0, WebKit::WKTouchPointType::Direct };
-static WebKit::WKTouchEvent globalTouchEvent { WebKit::WKTouchEventType::Begin, CACurrentMediaTime(), CGPointZero, CGPointZero, 1, 0, false, { globalTouchPoint }, { }, true };
+static WebKit::WKTouchEvent globalTouchEvent { WebKit::WKTouchEventType::Begin, CACurrentMediaTime(), CGPointZero, CGPointZero, 1, 0, false, { globalTouchPoint }, { }, { }, true };
 static void updateSimulatedTouchEvent(CGPoint location, UITouchPhase phase)
 {
     globalTouchPoint.locationInScreenCoordinates = location;


### PR DESCRIPTION
#### c61ac73a566f8da79f55c6e83b00952202edf3bf
<pre>
[Pointer Events] Implement getPredictedEvents API
<a href="https://bugs.webkit.org/show_bug.cgi?id=264002">https://bugs.webkit.org/show_bug.cgi?id=264002</a>
<a href="https://rdar.apple.com/117767174">rdar://117767174</a>

Reviewed by Abrar Rahman Protyasha.

Implement the `getPredictedEvents` function of the `PointerEvent` interface, as per the corresponding
UI events specification (<a href="https://w3c.github.io/pointerevents/#dom-pointerevent-getpredictedevents).">https://w3c.github.io/pointerevents/#dom-pointerevent-getpredictedevents).</a>

On non-iOS platforms, this will return an empty array. On iOS, the predicted events are generated via
UIKit&apos;s `predictedTouchesForTouch` method.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/DragEvent.cpp:
(WebCore::DragEvent::DragEvent):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::dispatchMouseEvent):
(WebCore::Element::dispatchMouseForceWillBegin):
* Source/WebCore/dom/MouseEvent.cpp:
(WebCore::MouseEvent::create):
(WebCore::MouseEvent::MouseEvent):
* Source/WebCore/dom/MouseEvent.h:
(WebCore::MouseEvent::predictedEvents const):
* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::PointerEvent):
(WebCore::createPredictedPointerEvents):
(WebCore::m_predictedEvents):
(WebCore::PointerEvent::getCoalescedEvents const):
(WebCore::PointerEvent::getPredictedEvents const):
(WebCore::PointerEvent::receivedTarget):
(WebCore::m_coalescedEvents): Deleted.
* Source/WebCore/dom/PointerEvent.h:
* Source/WebCore/dom/PointerEvent.idl:
* Source/WebCore/dom/SimulatedClick.cpp:
* Source/WebCore/dom/WheelEvent.cpp:
(WebCore::WheelEvent::WheelEvent):
* Source/WebCore/dom/ios/MouseEventIOS.cpp:
(WebCore::MouseEvent::create):
* Source/WebCore/dom/ios/PointerEventIOS.cpp:
(WebCore::PointerEvent::create):
(WebCore::PointerEvent::PointerEvent):
(WebCore::m_predictedEvents):
(WebCore::m_coalescedEvents): Deleted.
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::dispatchEventForTouchAtIndex):
* Source/WebCore/platform/PlatformMouseEvent.h:
(WebCore::PlatformMouseEvent::predictedEvents const):
* Source/WebCore/platform/PlatformTouchEvent.h:
(WebCore::PlatformTouchEvent::predictedEvents const):
* Source/WebKit/Shared/NativeWebTouchEvent.h:
* Source/WebKit/Shared/WebEvent.serialization.in:
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformMouseEvent::WebKit2PlatformMouseEvent):
(WebKit::WebKit2PlatformTouchEvent::WebKit2PlatformTouchEvent):
* Source/WebKit/Shared/WebMouseEvent.cpp:
(WebKit::WebMouseEvent::WebMouseEvent):
* Source/WebKit/Shared/WebMouseEvent.h:
(WebKit::WebMouseEvent::WebMouseEvent):
(WebKit::WebMouseEvent::setPredictedEvents):
(WebKit::WebMouseEvent::predictedEvents const):
* Source/WebKit/Shared/WebTouchEvent.h:
(WebKit::WebTouchEvent::WebTouchEvent):
(WebKit::WebTouchEvent::predictedEvents const):
(WebKit::WebTouchEvent::setPredictedEvents):
* Source/WebKit/Shared/ios/NativeWebTouchEventIOS.mm:
(WebKit::NativeWebTouchEvent::extractPredictedWebTouchEvents):
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.h:
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm:
(-[WKTouchEventsGestureRecognizer reset]):
(-[WKTouchEventsGestureRecognizer _recordTouches:type:coalescedTouches:predictedTouches:]):
(-[WKTouchEventsGestureRecognizer _processTouches:withEvent:type:]):
(-[WKTouchEventsGestureRecognizer _recordTouches:type:coalescedTouches:]): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::navigateToURL):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::navigateToPDFLinkWithSimulatedClick):
* Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm:
(-[WebPDFViewPlaceholder simulateClickOnLinkToURL:]):
* Source/WebKitLegacy/mac/WebView/WebPDFView.mm:
(-[WebPDFView PDFViewWillClickOnLink:withURL:]):
* Tools/TestWebKitAPI/Tests/ios/TouchEventTests.mm:

Canonical link: <a href="https://commits.webkit.org/281756@main">https://commits.webkit.org/281756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25ff6491fbd6378611a4cde08644c530634b08eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60856 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64787 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11403 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62986 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49204 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7912 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37447 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52729 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30031 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34134 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9953 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10316 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/53958 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55958 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66516 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60103 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4800 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56571 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56756 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3982 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81858 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9163 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36020 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14257 "Found 1 new JSC stress test failure: wasm.yaml/wasm/fuzz/memory.js.wasm-bbq (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37102 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38195 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->