### PR TITLE
Fix the position of `;` after here-docs in make_names.pl

### DIFF
--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -499,12 +499,11 @@ sub printConstructorInterior
     # FIXME: Could we instead do this entirely in the wrapper, and use custom wrappers
     # instead of having all the support for this here in this script?
     if ($allElements{$elementKey}{wrapperOnlyIfMediaIsAvailable}) {
-        print F <<END
+        print F <<END;
     if (!document.settings().mediaEnabled())
         return $parameters{fallbackInterfaceName}::create($constructorTagName, document);
 
 END
-;
     }
 
     my $runtimeCondition;
@@ -517,11 +516,10 @@ END
     }
 
     if ($runtimeCondition) {
-        print F <<END
+        print F <<END;
     if (!$runtimeCondition)
         return $parameters{fallbackInterfaceName}::create($constructorTagName, document);
 END
-;
     }
 
     # Call the constructor with the right parameters.
@@ -651,7 +649,7 @@ sub printHeaderHead
 {
     my ($F, $prefix, $namespace, $includes, $definitions) = @_;
 
-    print F<<END
+    print F<<END;
 #pragma once
 
 $includes
@@ -661,7 +659,6 @@ namespace WebCore {
 ${definitions}namespace ${namespace}Names {
 
 END
-    ;
 }
 
 sub printCppHead
@@ -755,7 +752,7 @@ sub printTypeHelpers
         my $elementCount = scalar @{$classToKeys{$class}};
         next if $elementCount > 1;
 
-        print F <<END
+        print F <<END;
 namespace WebCore {
 class $class;
 }
@@ -765,9 +762,8 @@ public:
     static bool isOfType(ArgType& node) { return checkTagName(node); }
 private:
 END
-       ;
        if ($parameters{namespace} eq "HTML" && ($allElements{$elementKey}{wrapperOnlyIfMediaIsAvailable} || $allElements{$elementKey}{settingsConditional} || $allElements{$elementKey}{deprecatedGlobalSettingsConditional})) {
-           print F <<END
+           print F <<END;
     static bool checkTagName(const WebCore::HTMLElement& element) { return !element.isHTMLUnknownElement() && element.hasTagName(WebCore::$parameters{namespace}Names::$allElements{$elementKey}{identifier}Tag); }
     static bool checkTagName(const WebCore::Node& node)
     {
@@ -775,15 +771,13 @@ END
         return element && checkTagName(*element);
     }
 END
-           ;
        } else {
-           print F <<END
+           print F <<END;
     static bool checkTagName(const WebCore::$parameters{namespace}Element& element) { return element.hasTagName(WebCore::$parameters{namespace}Names::$allElements{$elementKey}{identifier}Tag); }
     static bool checkTagName(const WebCore::Node& node) { return node.hasTagName(WebCore::$parameters{namespace}Names::$allElements{$elementKey}{identifier}Tag); }
 END
-           ;
        }
-       print F <<END
+       print F <<END;
     static bool checkTagName(const WebCore::EventTarget& target)
     {
         auto* node = dynamicDowncast<WebCore::Node>(target);
@@ -792,7 +786,6 @@ END
 };
 }
 END
-       ;
        print F "\n";
     }
 }
@@ -1699,25 +1692,23 @@ sub printFactoryCppFile
 
     printLicenseHeader($F);
 
-    print F <<END
+    print F <<END;
 #include "config.h"
 END
-    ;
 
     print F "\n#if $parameters{guardFactoryWith}\n\n" if $parameters{guardFactoryWith};
 
-    print F <<END
+    print F <<END;
 #include "$parameters{namespace}ElementFactory.h"
 
 #include "$parameters{namespace}Names.h"
 
 END
-    ;
 
     printElementIncludes($F);
     printConditionalElementIncludes($F, 0);
 
-    print F <<END
+    print F <<END;
 
 #include "DeprecatedGlobalSettings.h"
 #include "Document.h"
@@ -1728,7 +1719,6 @@ END
 namespace WebCore {
 
 END
-    ;
 
     my %tagConstructorMap = buildConstructorMap();
     my $argumentList;
@@ -1749,17 +1739,16 @@ END
         last;
     }
 
-    print F <<END
+    print F <<END;
 
 RefPtr<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createKnownElement(TagName tagName, Document& document$formElementArgumentForDefinition, bool createdByParser)
 {
     switch (tagName) {
 END
-    ;
 
     printTagNameCases($F, \%tagConstructorMap, 0);
 
-    print F <<END
+    print F <<END;
     default:
         return nullptr;
     }
@@ -1769,11 +1758,10 @@ RefPtr<$parameters{namespace}Element> $parameters{namespace}ElementFactory::crea
 {
     switch (tagName) {
 END
-    ;
 
     printTagNameCases($F, \%tagConstructorMap, 1);
 
-    print F <<END
+    print F <<END;
     default:
         return nullptr;
     }
@@ -1810,7 +1798,6 @@ Ref<$parameters{namespace}Element> $parameters{namespace}ElementFactory::createE
 } // namespace WebCore
 
 END
-    ;
 
     print F "#endif\n" if $parameters{guardFactoryWith};
 
@@ -1825,7 +1812,7 @@ sub printFactoryHeaderFile
 
     printLicenseHeader($F);
 
-    print F<<END
+    print F<<END;
 #pragma once
 
 #include <wtf/Forward.h>
@@ -1843,7 +1830,6 @@ enum class TagName : uint16_t;
 class $parameters{namespace}ElementFactory {
 public:
 END
-;
 
 print F "    static RefPtr<$parameters{namespace}Element> createKnownElement(const AtomString&, Document&";
 print F ", HTMLFormElement* = nullptr" if $parameters{namespace} eq "HTML";
@@ -1869,13 +1855,12 @@ print F "    static Ref<$parameters{namespace}Element> createElement(const Quali
 print F ", HTMLFormElement* = nullptr" if $parameters{namespace} eq "HTML";
 print F ", bool createdByParser = false);\n";
 
-printf F <<END
+printf F <<END;
 };
 
 }
 
 END
-;
 
     close F;
 }
@@ -1908,7 +1893,7 @@ sub printWrapperFunctions
         }
 
         if ($allElements{$elementKey}{wrapperOnlyIfMediaIsAvailable}) {
-            print F <<END
+            print F <<END;
 static JSDOMObject* create${JSInterfaceName}Wrapper(JSDOMGlobalObject* globalObject, Ref<$parameters{namespace}Element>&& element)
 {
     if (element->is$parameters{fallbackInterfaceName}())
@@ -1917,9 +1902,8 @@ static JSDOMObject* create${JSInterfaceName}Wrapper(JSDOMGlobalObject* globalObj
 }
 
 END
-            ;
         } elsif ($allElements{$elementKey}{settingsConditional}) {
-            print F <<END
+            print F <<END;
 static JSDOMObject* create$allElements{$elementKey}{interfaceName}Wrapper(JSDOMGlobalObject* globalObject, Ref<$parameters{namespace}Element>&& element)
 {
     if (element->is$parameters{fallbackInterfaceName}())
@@ -1928,10 +1912,9 @@ static JSDOMObject* create$allElements{$elementKey}{interfaceName}Wrapper(JSDOMG
 }
 
 END
-            ;
         } elsif ($allElements{$elementKey}{deprecatedGlobalSettingsConditional}) {
             my $deprecatedGlobalSettingsConditional = $allElements{$elementKey}{deprecatedGlobalSettingsConditional};
-            print F <<END
+            print F <<END;
 static JSDOMObject* create${JSInterfaceName}Wrapper(JSDOMGlobalObject* globalObject, Ref<$parameters{namespace}Element>&& element)
 {
     if (element->is$parameters{fallbackInterfaceName}())
@@ -1939,16 +1922,14 @@ static JSDOMObject* create${JSInterfaceName}Wrapper(JSDOMGlobalObject* globalObj
     return createWrapper<${JSInterfaceName}>(globalObject, WTFMove(element));
 }
 END
-    ;
         } else {
-            print F <<END
+            print F <<END;
 static JSDOMObject* create${JSInterfaceName}Wrapper(JSDOMGlobalObject* globalObject, Ref<$parameters{namespace}Element>&& element)
 {
     return createWrapper<${JSInterfaceName}>(globalObject, WTFMove(element));
 }
 
 END
-    ;
         }
 
         if ($conditional) {
@@ -1975,7 +1956,7 @@ sub printWrapperFactoryCppFile
     printElementIncludes($F);
 
     print F "\n#include \"$parameters{namespace}Names.h\"\n";
-    print F <<END
+    print F <<END;
 
 #include "DeprecatedGlobalSettings.h"
 #include "Document.h"
@@ -1984,18 +1965,16 @@ sub printWrapperFactoryCppFile
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 END
-;
 
     printConditionalElementIncludes($F, 1);
 
-    print F <<END
+    print F <<END;
 
 using namespace JSC;
 
 namespace WebCore {
 
 END
-;
 
     printWrapperFunctions($F);
 
@@ -2005,13 +1984,13 @@ END
         last;
     }
 
-print F <<END
+    print F <<END;
 
 JSDOMObject* createJS$parameters{namespace}Wrapper(JSDOMGlobalObject* globalObject, Ref<$parameters{namespace}Element>&& element)
 {
     switch (element->elementName()) {
 END
-;
+
     for my $elementKey (sort keys %allElements) {
         # Do not add the name to the map if it does not have a JS wrapper constructor or uses the default wrapper.
         next if usesDefaultJSWrapper($elementKey) && ($parameters{fallbackJSInterfaceName} eq $parameters{namespace} . "Element");
@@ -2036,27 +2015,24 @@ END
     print F "        break;\n";
     print F "    }\n";
     if ($parameters{customElementInterfaceName}) {
-        print F <<END
+        print F <<END;
     if (!element->isUnknownElement())
         return createWrapper<$parameters{customElementInterfaceName}>(globalObject, WTFMove(element));
 END
-;
     }
 
     if ("$parameters{namespace}Element" eq $parameters{fallbackJSInterfaceName}) {
-        print F <<END
+        print F <<END;
     ASSERT(element->is$parameters{fallbackJSInterfaceName}());
 END
-;
     }
 
-    print F <<END
+    print F <<END;
     return createWrapper<$parameters{fallbackJSInterfaceName}>(globalObject, WTFMove(element));
 }
 
 }
 END
-;
     print F "\n#endif\n" if $parameters{guardFactoryWith};
 
     close F;
@@ -2073,7 +2049,7 @@ sub printWrapperFactoryHeaderFile
 
     print F "#pragma once\n\n";
 
-    print F <<END
+    print F <<END;
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -2087,7 +2063,6 @@ namespace WebCore {
 }
 
 END
-    ;
 
     close F;
 }


### PR DESCRIPTION
#### a68a46391e95d53168ed6e952d6e8556d5aa0207
<pre>
Fix the position of `;` after here-docs in make_names.pl
<a href="https://bugs.webkit.org/show_bug.cgi?id=277241">https://bugs.webkit.org/show_bug.cgi?id=277241</a>

Reviewed by Darin Adler.

Some `;` were wrongly placed after the terminating strings of
here-docs. They should be placed at the end of sentence lines. The
Perl document about here-doc is &lt;<a href="https://perldoc.perl.org/perlop#EOF">https://perldoc.perl.org/perlop#EOF</a>&gt;.

* Source/WebCore/dom/make_names.pl:

Canonical link: <a href="https://commits.webkit.org/281590@main">https://commits.webkit.org/281590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c07d233b797c11cf9f3aa43666a5bbfba6dc627

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63980 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10592 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48659 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7393 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29501 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9263 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9512 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65712 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56013 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56164 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3319 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9072 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35223 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36305 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37393 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36049 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->