### PR TITLE
Fix the internal tvOS build after 281437@main

### DIFF
--- a/Source/WebCore/platform/text/cocoa/LocalizedDateCache.mm
+++ b/Source/WebCore/platform/text/cocoa/LocalizedDateCache.mm
@@ -120,7 +120,7 @@ RetainPtr<NSDateFormatter> LocalizedDateCache::createFormatterForType(DateCompon
         [dateFormatter setDateStyle:NSDateFormatterNoStyle];
         break;
     case DateComponentsType::Week:
-#if HAVE(UI_CALENDAR_SELECTION_WEEK_OF_YEAR)
+#if ENABLE(INPUT_TYPE_WEEK_PICKER)
         [dateFormatter setDateFormat:[NSString stringWithFormat:@"'%@' w',' yyyy", (NSString *)inputWeekLabel()]];
 #else
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
@@ -47,8 +47,8 @@ const CGFloat toolbarBottomMarginSmall = 2;
 @implementation WKDatePickerPopoverView {
     RetainPtr<UIVisualEffectView> _backgroundView;
     __weak UIDatePicker *_datePicker;
-    __weak UICalendarView *_calendarView;
 #if HAVE(UI_CALENDAR_SELECTION_WEEK_OF_YEAR)
+    __weak UICalendarView *_calendarView;
     RetainPtr<UICalendarSelectionWeekOfYear> _selectionWeekOfYear;
 #endif
     RetainPtr<UIToolbar> _accessoryView;
@@ -142,10 +142,14 @@ const CGFloat toolbarBottomMarginSmall = 2;
     return _datePicker;
 }
 
+#if HAVE(UI_CALENDAR_SELECTION_WEEK_OF_YEAR)
+
 - (UICalendarView *)calendarView
 {
     return _calendarView;
 }
+
+#endif
 
 - (UIToolbar *)accessoryView
 {

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -53,8 +53,8 @@
     WKContentView *_view;
     CGPoint _interactionPoint;
     RetainPtr<UIDatePicker> _datePicker;
-    RetainPtr<UICalendarView> _calendarView;
 #if HAVE(UI_CALENDAR_SELECTION_WEEK_OF_YEAR)
+    RetainPtr<UICalendarView> _calendarView;
     RetainPtr<UICalendarSelectionWeekOfYear> _selectionWeekOfYear;
 #endif
     BOOL _isDismissingDatePicker;


### PR DESCRIPTION
#### eec25f445cc155a2ba4521a3fd07705d0e794fb4
<pre>
Fix the internal tvOS build after 281437@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=277242">https://bugs.webkit.org/show_bug.cgi?id=277242</a>
<a href="https://rdar.apple.com/132691264">rdar://132691264</a>

Unreviewed, fix the build.

* Source/WebCore/platform/text/cocoa/LocalizedDateCache.mm:
(WebCore::LocalizedDateCache::createFormatterForType):

Drive-by fix. Uncouple from UI flag.

* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm:
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:

`UICalendarView` is unavailable on tvOS. Guard the variable behind
`HAVE(UI_CALENDAR_SELECTION_WEEK_OF_YEAR)`, as its allocation already is.

Canonical link: <a href="https://commits.webkit.org/281477@main">https://commits.webkit.org/281477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b312af24f97fecc6763a7b268042096abf027ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10593 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10807 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7392 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62094 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/36750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29502 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9262 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9513 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65713 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3993 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9410 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56014 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4011 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56165 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3318 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8991 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35224 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36306 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37394 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->