### PR TITLE
prepare-ChangeLog fails to extract function names from changed files with Windows Perl

### DIFF
--- a/Tools/Scripts/prepare-ChangeLog
+++ b/Tools/Scripts/prepare-ChangeLog
@@ -251,20 +251,20 @@ sub originalFile($$$$)
 {
     my ($file, $gitCommit, $gitIndex, $mergeBase) = @_;
 
-    my $command;
+    my @command;
     if (isGit()) {
-        $command = GIT . " show ";
+        @command = (GIT, "show");
+        $file = unixPath($file);
         if ($gitCommit) {
-            $command .= "$gitCommit^";
+            push(@command, "$gitCommit^:$file");
         } elsif ($mergeBase) {
-            $command .= "$mergeBase";
+            push(@command, "$mergeBase:$file");
         } else {
-            $command .= "HEAD";
+            push(@command, "HEAD:$file");
         }
-        $command .= ":'$file'";
     }
 
-    return $command;
+    return @command;
 }
 
 sub generateFunctionLists($$$$$)
@@ -279,8 +279,9 @@ sub generateFunctionLists($$$$$)
         openFile => sub ($) {
             my ($file) = @_;
             if (isGit() && $gitCommit && !$gitIndex) {
-                my $command = GIT . " show " . "$gitCommit" . ":'$file'";
-                return unless open(SOURCE, "-|", $command);
+                $file = unixPath($file);
+                my @command = (GIT, "show", "$gitCommit:$file");
+                return unless open(SOURCE, "-|", @command);
             } else {
                 return unless open(SOURCE, "<", $file);
             }
@@ -688,8 +689,7 @@ sub printDiff($$$$)
 
     print STDERR "  Running diff to help you write the ChangeLog entries.\n";
     local $/ = undef; # local slurp mode
-    my $changedFilesString = "'" . join("' '", @$changedFiles) . "'";
-    open DIFF, "-|", createPatchCommand($changedFilesString, $gitCommit, $gitIndex, $mergeBase) or die "The diff failed: $!.\n";
+    open DIFF, "-|", createPatchCommand($changedFiles, $gitCommit, $gitIndex, $mergeBase) or die "The diff failed: $!.\n";
     print <DIFF>;
     close DIFF;
 }
@@ -2040,8 +2040,8 @@ sub diffFromToString($$$)
     my ($gitCommit, $gitIndex, $mergeBase) = @_;
 
     return $gitCommit if $gitCommit =~ m/.+\.\..+/;
-    return "--cached \"$gitCommit^\"" if $gitCommit && $gitIndex;
-    return "\"$gitCommit^\" \"$gitCommit\"" if $gitCommit;
+    return ("--cached", "$gitCommit^") if $gitCommit && $gitIndex;
+    return ("$gitCommit^", $gitCommit) if $gitCommit;
     return "--cached" if $gitIndex;
     return $mergeBase if $mergeBase;
     return "HEAD" if isGit();
@@ -2053,28 +2053,26 @@ sub diffCommand($$$$)
 
     # The function overlap detection logic in computeModifiedFunctions() assumes that its line
     # ranges were from a unified diff without any context lines.
-    my $command;
+    my @command;
     if (isGit()) {
-        my $pathsString = "'" . join("' '", @$paths) . "'"; 
-        $command = GIT . " diff --no-ext-diff -U0 " . diffFromToString($gitCommit, $gitIndex, $mergeBase);
-        $command .= " -- $pathsString" unless $gitCommit or $mergeBase;
+        push(@command, GIT, "diff", "--no-ext-diff", "-U0", diffFromToString($gitCommit, $gitIndex, $mergeBase));
+        push(@command, "--", @$paths) unless $gitCommit or $mergeBase;
     }
 
-    return $command;
+    return @command;
 }
 
 sub statusCommand($$$$)
 {
     my ($paths, $gitCommit, $gitIndex, $mergeBase) = @_;
 
-    my $command;
+    my @command;
     if (isGit()) {
-        my $filesString = '"' . join('" "', keys %$paths) . '"';
-        $command = GIT . " diff -r --name-status -M -C " . diffFromToString($gitCommit, $gitIndex, $mergeBase);
-        $command .= " -- $filesString" unless $gitCommit;
+        push(@command, GIT, "diff", "-r", "--name-status", "-M", "-C", diffFromToString($gitCommit, $gitIndex, $mergeBase));
+        push(@command, "--", keys %$paths) unless $gitCommit;
     }
 
-    return "$command 2>&1";
+    return @command;
 }
 
 sub attributeCommand($$$)
@@ -2095,15 +2093,15 @@ sub attributeCommand($$$)
 
 sub createPatchCommand($$$$)
 {
-    my ($changedFilesString, $gitCommit, $gitIndex, $mergeBase) = @_;
+    my ($changedFiles, $gitCommit, $gitIndex, $mergeBase) = @_;
 
-    my $command;
+    my @command;
     if (isGit()) {
-        $command = GIT . " diff -M -C " . diffFromToString($gitCommit, $gitIndex, $mergeBase);
-        $command .= " -- $changedFilesString" unless $gitCommit;
+        push(@command, GIT, "diff", "-M", "-C", diffFromToString($gitCommit, $gitIndex, $mergeBase));
+        push(@command, "--", @$changedFiles) unless $gitCommit;
     }
 
-    return $command;
+    return @command;
 }
 
 sub pluralizeAndList($$@)


### PR DESCRIPTION
#### feb8501f9c7bf1255c34f539a92bc1573ea01acb
<pre>
prepare-ChangeLog fails to extract function names from changed files with Windows Perl
<a href="https://bugs.webkit.org/show_bug.cgi?id=277243">https://bugs.webkit.org/show_bug.cgi?id=277243</a>

Reviewed by Jonathan Bedard.

There were two problems.

1. &quot;git show HEAD:path&quot; doesn&apos;t take a Windows style backslash delimited file path.
Use a Unix style slash delimited path.

2. open FH, &quot;-| git show HEAD:&apos;$path&apos;&quot; doesn&apos;t quote $path as expected.
Use a command array instead of a command string.
&gt; open FH, &quot;-|&quot;, &quot;git&quot;, &quot;show&quot;, &quot;HEAD:$path&quot;;

* Tools/Scripts/prepare-ChangeLog:

Canonical link: <a href="https://commits.webkit.org/281589@main">https://commits.webkit.org/281589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3410f39e1686a7f40bc6781fd3526f58ddf83a96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63987 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10599 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48666 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7399 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29508 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33460 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9269 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9519 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65719 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9419 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56020 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56172 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3325 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9071 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35230 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36312 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37400 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36056 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->