### PR TITLE
[web-animations] hyphenate-character should support discrete animation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/animations/hyphen-no-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/animations/hyphen-no-interpolation-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (-0.3) should be [initial] assert_equals: expected "auto " but got "\" e \" "
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (0) should be [initial] assert_equals: expected "auto " but got "\" e \" "
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (0.3) should be [initial] assert_equals: expected "auto " but got "\" e \" "
+PASS CSS Transitions with transition-behavior:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (-0.3) should be [initial]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (0) should be [initial]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (0.3) should be [initial]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (0.5) should be ["e"]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (0.6) should be ["e"]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (1) should be ["e"]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (1.5) should be ["e"]
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (-0.3) should be [initial] assert_equals: expected "auto " but got "\" e \" "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (0) should be [initial] assert_equals: expected "auto " but got "\" e \" "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (0.3) should be [initial] assert_equals: expected "auto " but got "\" e \" "
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (-0.3) should be [initial]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (0) should be [initial]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (0.3) should be [initial]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (0.5) should be ["e"]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (0.6) should be ["e"]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <hyphenate-character> from [initial] to ["e"] at (1) should be ["e"]
@@ -30,17 +30,17 @@ PASS CSS Transitions with transition: all: property <hyphenate-character> from [
 PASS CSS Animations: property <hyphenate-character> from [initial] to ["e"] at (-0.3) should be [initial]
 PASS CSS Animations: property <hyphenate-character> from [initial] to ["e"] at (0) should be [initial]
 PASS CSS Animations: property <hyphenate-character> from [initial] to ["e"] at (0.3) should be [initial]
-FAIL CSS Animations: property <hyphenate-character> from [initial] to ["e"] at (0.5) should be ["e"] assert_equals: expected "\" e \" " but got "auto "
-FAIL CSS Animations: property <hyphenate-character> from [initial] to ["e"] at (0.6) should be ["e"] assert_equals: expected "\" e \" " but got "auto "
-FAIL CSS Animations: property <hyphenate-character> from [initial] to ["e"] at (1) should be ["e"] assert_equals: expected "\" e \" " but got "auto "
-FAIL CSS Animations: property <hyphenate-character> from [initial] to ["e"] at (1.5) should be ["e"] assert_equals: expected "\" e \" " but got "auto "
+PASS CSS Animations: property <hyphenate-character> from [initial] to ["e"] at (0.5) should be ["e"]
+PASS CSS Animations: property <hyphenate-character> from [initial] to ["e"] at (0.6) should be ["e"]
+PASS CSS Animations: property <hyphenate-character> from [initial] to ["e"] at (1) should be ["e"]
+PASS CSS Animations: property <hyphenate-character> from [initial] to ["e"] at (1.5) should be ["e"]
 PASS Web Animations: property <hyphenate-character> from [initial] to ["e"] at (-0.3) should be [initial]
 PASS Web Animations: property <hyphenate-character> from [initial] to ["e"] at (0) should be [initial]
 PASS Web Animations: property <hyphenate-character> from [initial] to ["e"] at (0.3) should be [initial]
-FAIL Web Animations: property <hyphenate-character> from [initial] to ["e"] at (0.5) should be ["e"] assert_equals: expected "\" e \" " but got "auto "
-FAIL Web Animations: property <hyphenate-character> from [initial] to ["e"] at (0.6) should be ["e"] assert_equals: expected "\" e \" " but got "auto "
-FAIL Web Animations: property <hyphenate-character> from [initial] to ["e"] at (1) should be ["e"] assert_equals: expected "\" e \" " but got "auto "
-FAIL Web Animations: property <hyphenate-character> from [initial] to ["e"] at (1.5) should be ["e"] assert_equals: expected "\" e \" " but got "auto "
+PASS Web Animations: property <hyphenate-character> from [initial] to ["e"] at (0.5) should be ["e"]
+PASS Web Animations: property <hyphenate-character> from [initial] to ["e"] at (0.6) should be ["e"]
+PASS Web Animations: property <hyphenate-character> from [initial] to ["e"] at (1) should be ["e"]
+PASS Web Animations: property <hyphenate-character> from [initial] to ["e"] at (1.5) should be ["e"]
 FAIL CSS Transitions with transition-behavior:allow-discrete: property <hyphenate-limit-chars> from [initial] to [10] at (-0.3) should be [initial] assert_true: 'from' value should be supported expected true got false
 FAIL CSS Transitions with transition-behavior:allow-discrete: property <hyphenate-limit-chars> from [initial] to [10] at (0) should be [initial] assert_true: 'from' value should be supported expected true got false
 FAIL CSS Transitions with transition-behavior:allow-discrete: property <hyphenate-limit-chars> from [initial] to [10] at (0.3) should be [initial] assert_true: 'from' value should be supported expected true got false

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3942,6 +3942,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<const GridPosition&>(CSSPropertyGridRowEnd, &RenderStyle::gridItemRowEnd, &RenderStyle::setGridItemRowEnd),
         new DiscretePropertyWrapper<const GridPosition&>(CSSPropertyGridRowStart, &RenderStyle::gridItemRowStart, &RenderStyle::setGridItemRowStart),
         new DiscretePropertyWrapper<Hyphens>(CSSPropertyHyphens, &RenderStyle::hyphens, &RenderStyle::setHyphens),
+        new DiscretePropertyWrapper<const AtomString&>(CSSPropertyHyphenateCharacter, &RenderStyle::hyphenationString, &RenderStyle::setHyphenationString),
         new DiscretePropertyWrapper<ImageOrientation>(CSSPropertyImageOrientation, &RenderStyle::imageOrientation, &RenderStyle::setImageOrientation),
         new DiscretePropertyWrapper<const IntSize&>(CSSPropertyWebkitInitialLetter, &RenderStyle::initialLetter, &RenderStyle::setInitialLetter),
         new DiscretePropertyWrapper<const StyleContentAlignmentData&>(CSSPropertyJustifyContent, &RenderStyle::justifyContent, &RenderStyle::setJustifyContent),
@@ -4289,7 +4290,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyWebkitCursorVisibility:
 #endif
         case CSSPropertyWebkitFontSizeDelta:
-        case CSSPropertyHyphenateCharacter:
         case CSSPropertyWebkitHyphenateLimitAfter:
         case CSSPropertyWebkitHyphenateLimitBefore:
         case CSSPropertyWebkitHyphenateLimitLines:

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2074,6 +2074,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyScrollbarColor);
         if (first.listStyleType != second.listStyleType)
             changingProperties.m_properties.set(CSSPropertyListStyleType);
+        if (first.hyphenationString != second.hyphenationString)
+            changingProperties.m_properties.set(CSSPropertyHyphenateCharacter);
 
         // customProperties is handled separately.
         // Non animated styles are followings.
@@ -2083,7 +2085,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // hyphenationLimitBefore
         // hyphenationLimitAfter
         // hyphenationLimitLines
-        // hyphenationString
         // tapHighlightColor
         // nbspMode
         // useTouchOverflowScrolling


### PR DESCRIPTION
#### 57d356551670fd8b7fb2c5861c04242831da3ed6
<pre>
[web-animations] hyphenate-character should support discrete animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=277245">https://bugs.webkit.org/show_bug.cgi?id=277245</a>
<a href="https://rdar.apple.com/132698836">rdar://132698836</a>

Reviewed by Cameron McCormack.

As per <a href="https://drafts.csswg.org/css-text-4/#propdef-hyphenate-character">https://drafts.csswg.org/css-text-4/#propdef-hyphenate-character</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/animations/hyphen-no-interpolation-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):

Canonical link: <a href="https://commits.webkit.org/281484@main">https://commits.webkit.org/281484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd09f46b5dbb19311c19f6e08e8ce169d459f7d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63988 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10600 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48667 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7400 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29509 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33462 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9270 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9520 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65720 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56022 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56174 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13314 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3326 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35231 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36313 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37401 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->