### PR TITLE
[web-animations] font-optical-sizing should support discrete animation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/discrete-no-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/discrete-no-interpolation-expected.txt
@@ -83,16 +83,16 @@ PASS Web Animations: property <font-kerning> from [initial] to [none] at (0.5) s
 PASS Web Animations: property <font-kerning> from [initial] to [none] at (0.6) should be [none]
 PASS Web Animations: property <font-kerning> from [initial] to [none] at (1) should be [none]
 PASS Web Animations: property <font-kerning> from [initial] to [none] at (1.5) should be [none]
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (-0.3) should be [initial] assert_equals: expected "auto " but got "none "
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (0) should be [initial] assert_equals: expected "auto " but got "none "
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (0.3) should be [initial] assert_equals: expected "auto " but got "none "
+PASS CSS Transitions with transition-behavior:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (-0.3) should be [initial]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (0) should be [initial]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (0.3) should be [initial]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (0.5) should be [none]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (0.6) should be [none]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (1) should be [none]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (1.5) should be [none]
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (-0.3) should be [initial] assert_equals: expected "auto " but got "none "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (0) should be [initial] assert_equals: expected "auto " but got "none "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (0.3) should be [initial] assert_equals: expected "auto " but got "none "
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (-0.3) should be [initial]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (0) should be [initial]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (0.3) should be [initial]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (0.5) should be [none]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (0.6) should be [none]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <font-optical-sizing> from [initial] to [none] at (1) should be [none]
@@ -114,17 +114,17 @@ PASS CSS Transitions with transition: all: property <font-optical-sizing> from [
 PASS CSS Animations: property <font-optical-sizing> from [initial] to [none] at (-0.3) should be [initial]
 PASS CSS Animations: property <font-optical-sizing> from [initial] to [none] at (0) should be [initial]
 PASS CSS Animations: property <font-optical-sizing> from [initial] to [none] at (0.3) should be [initial]
-FAIL CSS Animations: property <font-optical-sizing> from [initial] to [none] at (0.5) should be [none] assert_equals: expected "none " but got "auto "
-FAIL CSS Animations: property <font-optical-sizing> from [initial] to [none] at (0.6) should be [none] assert_equals: expected "none " but got "auto "
-FAIL CSS Animations: property <font-optical-sizing> from [initial] to [none] at (1) should be [none] assert_equals: expected "none " but got "auto "
-FAIL CSS Animations: property <font-optical-sizing> from [initial] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "auto "
+PASS CSS Animations: property <font-optical-sizing> from [initial] to [none] at (0.5) should be [none]
+PASS CSS Animations: property <font-optical-sizing> from [initial] to [none] at (0.6) should be [none]
+PASS CSS Animations: property <font-optical-sizing> from [initial] to [none] at (1) should be [none]
+PASS CSS Animations: property <font-optical-sizing> from [initial] to [none] at (1.5) should be [none]
 PASS Web Animations: property <font-optical-sizing> from [initial] to [none] at (-0.3) should be [initial]
 PASS Web Animations: property <font-optical-sizing> from [initial] to [none] at (0) should be [initial]
 PASS Web Animations: property <font-optical-sizing> from [initial] to [none] at (0.3) should be [initial]
-FAIL Web Animations: property <font-optical-sizing> from [initial] to [none] at (0.5) should be [none] assert_equals: expected "none " but got "auto "
-FAIL Web Animations: property <font-optical-sizing> from [initial] to [none] at (0.6) should be [none] assert_equals: expected "none " but got "auto "
-FAIL Web Animations: property <font-optical-sizing> from [initial] to [none] at (1) should be [none] assert_equals: expected "none " but got "auto "
-FAIL Web Animations: property <font-optical-sizing> from [initial] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "auto "
+PASS Web Animations: property <font-optical-sizing> from [initial] to [none] at (0.5) should be [none]
+PASS Web Animations: property <font-optical-sizing> from [initial] to [none] at (0.6) should be [none]
+PASS Web Animations: property <font-optical-sizing> from [initial] to [none] at (1) should be [none]
+PASS Web Animations: property <font-optical-sizing> from [initial] to [none] at (1.5) should be [none]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <font-palette> from [initial] to [dark] at (-0.3) should be [initial]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <font-palette> from [initial] to [dark] at (0) should be [initial]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <font-palette> from [initial] to [dark] at (0.3) should be [initial]

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3874,6 +3874,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new PropertyWrapperBaselineShift,
         new PropertyWrapper<SVGLengthValue>(CSSPropertyKerning, &RenderStyle::kerning, &RenderStyle::setKerning),
 #if ENABLE(VARIATION_FONTS)
+        new DiscretePropertyWrapper<FontOpticalSizing>(CSSPropertyFontOpticalSizing, &RenderStyle::fontOpticalSizing, &RenderStyle::setFontOpticalSizing),
         new PropertyWrapperFontVariationSettings,
 #endif
         new PropertyWrapperFontSizeAdjust,
@@ -4132,9 +4133,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         // or provide a wrapper for it above. If you are adding to this list but the
         // property should be animatable, make sure to file a bug.
         case CSSPropertyDirection:
-#if ENABLE(VARIATION_FONTS)
-        case CSSPropertyFontOpticalSizing:
-#endif
         case CSSPropertyTextOrientation:
         case CSSPropertyWritingMode:
         case CSSPropertyWebkitFontSmoothing:

--- a/Source/WebCore/platform/text/TextFlags.cpp
+++ b/Source/WebCore/platform/text/TextFlags.cpp
@@ -74,6 +74,15 @@ WTF::TextStream& operator<<(TextStream& ts, Kerning kerning)
     return ts;
 }
 
+WTF::TextStream& operator<<(TextStream& ts, FontOpticalSizing opticalSizing)
+{
+    switch (opticalSizing) {
+    case FontOpticalSizing::Enabled: ts << "auto"; break;
+    case FontOpticalSizing::Disabled: ts << "none"; break;
+    }
+    return ts;
+}
+
 WTF::TextStream& operator<<(TextStream& ts, const FontVariantAlternates& alternates)
 {
     if (alternates.isNormal())

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -448,10 +448,12 @@ enum class Kerning : uint8_t {
 
 WTF::TextStream& operator<<(WTF::TextStream&, Kerning);
 
-enum class FontOpticalSizing : uint8_t {
+enum class FontOpticalSizing : bool {
     Enabled,
     Disabled
 };
+
+WTF::TextStream& operator<<(WTF::TextStream&, FontOpticalSizing);
 
 // https://www.microsoft.com/typography/otspec/fvar.htm#VAT
 enum class FontStyleAxis : uint8_t {

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1965,6 +1965,7 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyTextAutospace);
             changingProperties.m_properties.set(CSSPropertyFontStyle);
 #if ENABLE(VARIATION_FONTS)
+            changingProperties.m_properties.set(CSSPropertyFontOpticalSizing);
             changingProperties.m_properties.set(CSSPropertyFontVariationSettings);
 #endif
             changingProperties.m_properties.set(CSSPropertyFontWeight);
@@ -2887,6 +2888,16 @@ void RenderStyle::setFontSizeAdjust(FontSizeAdjust sizeAdjust)
     auto selector = fontCascade().fontSelector();
     auto description = fontDescription();
     description.setFontSizeAdjust(sizeAdjust);
+
+    setFontDescription(WTFMove(description));
+    fontCascade().update(selector);
+}
+
+void RenderStyle::setFontOpticalSizing(FontOpticalSizing opticalSizing)
+{
+    auto selector = fontCascade().fontSelector();
+    auto description = fontDescription();
+    description.setOpticalSizing(opticalSizing);
 
     setFontDescription(WTFMove(description));
     fontCascade().update(selector);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -150,6 +150,7 @@ enum class FlexDirection : uint8_t;
 enum class FlexWrap : uint8_t;
 enum class Float : uint8_t;
 enum class FontOrientation : bool;
+enum class FontOpticalSizing : bool;
 enum class GridTrackSizingDirection : uint8_t;
 enum class HangingPunctuation : uint8_t;
 enum class Hyphens : uint8_t;
@@ -553,6 +554,7 @@ public:
     float computedFontSize() const;
     std::pair<FontOrientation, NonCJKGlyphOrientation> fontAndGlyphOrientation();
 
+    inline FontOpticalSizing fontOpticalSizing() const;
     inline FontVariationSettings fontVariationSettings() const;
     inline FontSelectionValue fontWeight() const;
     inline FontSelectionValue fontStretch() const;
@@ -1244,6 +1246,7 @@ public:
     void setFontSize(float);
     void setFontSizeAdjust(FontSizeAdjust);
 
+    void setFontOpticalSizing(FontOpticalSizing);
     void setFontVariationSettings(FontVariationSettings);
     void setFontWeight(FontSelectionValue);
     void setFontStretch(FontSelectionValue);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -218,6 +218,7 @@ inline std::optional<FontSelectionValue> RenderStyle::fontItalic() const { retur
 inline const FontPalette& RenderStyle::fontPalette() const { return fontDescription().fontPalette(); }
 inline FontSizeAdjust RenderStyle::fontSizeAdjust() const { return fontDescription().fontSizeAdjust(); }
 inline FontSelectionValue RenderStyle::fontStretch() const { return fontDescription().stretch(); }
+inline FontOpticalSizing RenderStyle::fontOpticalSizing() const { return fontDescription().opticalSizing(); }
 inline FontVariationSettings RenderStyle::fontVariationSettings() const { return fontDescription().variationSettings(); }
 inline FontSelectionValue RenderStyle::fontWeight() const { return fontDescription().weight(); }
 inline void RenderStyle::getBoxShadowBlockDirectionExtent(LayoutUnit& logicalTop, LayoutUnit& logicalBottom) const { getShadowBlockDirectionExtent(boxShadow(), logicalTop, logicalBottom); }

--- a/Source/WebKit/Shared/TextFlags.serialization.in
+++ b/Source/WebKit/Shared/TextFlags.serialization.in
@@ -33,10 +33,7 @@ enum class WebCore::Kerning : uint8_t {
     NoShift
 };
 
-enum class WebCore::FontOpticalSizing : uint8_t {
-    Enabled,
-    Disabled
-};
+enum class WebCore::FontOpticalSizing : bool;
 
 enum class WebCore::FontStyleAxis : uint8_t {
     slnt,


### PR DESCRIPTION
#### 5d6902acf26c13d243421060ef36cf435728eb7c
<pre>
[web-animations] font-optical-sizing should support discrete animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=277246">https://bugs.webkit.org/show_bug.cgi?id=277246</a>
<a href="https://rdar.apple.com/132699150">rdar://132699150</a>

Reviewed by Cameron McCormack.

As per: <a href="https://drafts.csswg.org/css-fonts/#font-optical-sizing-def">https://drafts.csswg.org/css-fonts/#font-optical-sizing-def</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/discrete-no-interpolation-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/platform/text/TextFlags.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/text/TextFlags.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
(WebCore::RenderStyle::setFontOpticalSizing):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::fontOpticalSizing const):
* Source/WebKit/Shared/TextFlags.serialization.in:

Canonical link: <a href="https://commits.webkit.org/281489@main">https://commits.webkit.org/281489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0245eab88d3bd132d1acccaaeccbeaccd7f2ebbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63995 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10607 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10825 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48675 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7405 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29517 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9277 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9527 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65727 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9427 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56181 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3335 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8994 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35238 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36320 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->