### PR TITLE
[web-animations] image-rendering should support discrete animation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/animation/image-no-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/animation/image-no-interpolation-expected.txt
@@ -41,16 +41,16 @@ PASS Web Animations: property <image-orientation> from [initial] to [none] at (0
 PASS Web Animations: property <image-orientation> from [initial] to [none] at (0.6) should be [none]
 PASS Web Animations: property <image-orientation> from [initial] to [none] at (1) should be [none]
 PASS Web Animations: property <image-orientation> from [initial] to [none] at (1.5) should be [none]
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (-0.3) should be [initial] assert_equals: expected "auto " but got "pixelated "
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (0) should be [initial] assert_equals: expected "auto " but got "pixelated "
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (0.3) should be [initial] assert_equals: expected "auto " but got "pixelated "
+PASS CSS Transitions with transition-behavior:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (-0.3) should be [initial]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (0) should be [initial]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (0.3) should be [initial]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (0.5) should be [pixelated]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (0.6) should be [pixelated]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (1) should be [pixelated]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (1.5) should be [pixelated]
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (-0.3) should be [initial] assert_equals: expected "auto " but got "pixelated "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (0) should be [initial] assert_equals: expected "auto " but got "pixelated "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (0.3) should be [initial] assert_equals: expected "auto " but got "pixelated "
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (-0.3) should be [initial]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (0) should be [initial]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (0.3) should be [initial]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (0.5) should be [pixelated]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (0.6) should be [pixelated]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <image-rendering> from [initial] to [pixelated] at (1) should be [pixelated]
@@ -72,15 +72,15 @@ PASS CSS Transitions with transition: all: property <image-rendering> from [init
 PASS CSS Animations: property <image-rendering> from [initial] to [pixelated] at (-0.3) should be [initial]
 PASS CSS Animations: property <image-rendering> from [initial] to [pixelated] at (0) should be [initial]
 PASS CSS Animations: property <image-rendering> from [initial] to [pixelated] at (0.3) should be [initial]
-FAIL CSS Animations: property <image-rendering> from [initial] to [pixelated] at (0.5) should be [pixelated] assert_equals: expected "pixelated " but got "auto "
-FAIL CSS Animations: property <image-rendering> from [initial] to [pixelated] at (0.6) should be [pixelated] assert_equals: expected "pixelated " but got "auto "
-FAIL CSS Animations: property <image-rendering> from [initial] to [pixelated] at (1) should be [pixelated] assert_equals: expected "pixelated " but got "auto "
-FAIL CSS Animations: property <image-rendering> from [initial] to [pixelated] at (1.5) should be [pixelated] assert_equals: expected "pixelated " but got "auto "
+PASS CSS Animations: property <image-rendering> from [initial] to [pixelated] at (0.5) should be [pixelated]
+PASS CSS Animations: property <image-rendering> from [initial] to [pixelated] at (0.6) should be [pixelated]
+PASS CSS Animations: property <image-rendering> from [initial] to [pixelated] at (1) should be [pixelated]
+PASS CSS Animations: property <image-rendering> from [initial] to [pixelated] at (1.5) should be [pixelated]
 PASS Web Animations: property <image-rendering> from [initial] to [pixelated] at (-0.3) should be [initial]
 PASS Web Animations: property <image-rendering> from [initial] to [pixelated] at (0) should be [initial]
 PASS Web Animations: property <image-rendering> from [initial] to [pixelated] at (0.3) should be [initial]
-FAIL Web Animations: property <image-rendering> from [initial] to [pixelated] at (0.5) should be [pixelated] assert_equals: expected "pixelated " but got "auto "
-FAIL Web Animations: property <image-rendering> from [initial] to [pixelated] at (0.6) should be [pixelated] assert_equals: expected "pixelated " but got "auto "
-FAIL Web Animations: property <image-rendering> from [initial] to [pixelated] at (1) should be [pixelated] assert_equals: expected "pixelated " but got "auto "
-FAIL Web Animations: property <image-rendering> from [initial] to [pixelated] at (1.5) should be [pixelated] assert_equals: expected "pixelated " but got "auto "
+PASS Web Animations: property <image-rendering> from [initial] to [pixelated] at (0.5) should be [pixelated]
+PASS Web Animations: property <image-rendering> from [initial] to [pixelated] at (0.6) should be [pixelated]
+PASS Web Animations: property <image-rendering> from [initial] to [pixelated] at (1) should be [pixelated]
+PASS Web Animations: property <image-rendering> from [initial] to [pixelated] at (1.5) should be [pixelated]
 

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3946,6 +3946,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<Hyphens>(CSSPropertyHyphens, &RenderStyle::hyphens, &RenderStyle::setHyphens),
         new DiscretePropertyWrapper<const AtomString&>(CSSPropertyHyphenateCharacter, &RenderStyle::hyphenationString, &RenderStyle::setHyphenationString),
         new DiscretePropertyWrapper<ImageOrientation>(CSSPropertyImageOrientation, &RenderStyle::imageOrientation, &RenderStyle::setImageOrientation),
+        new DiscretePropertyWrapper<ImageRendering>(CSSPropertyImageRendering, &RenderStyle::imageRendering, &RenderStyle::setImageRendering),
         new DiscretePropertyWrapper<const IntSize&>(CSSPropertyWebkitInitialLetter, &RenderStyle::initialLetter, &RenderStyle::setInitialLetter),
         new DiscretePropertyWrapper<const StyleContentAlignmentData&>(CSSPropertyJustifyContent, &RenderStyle::justifyContent, &RenderStyle::setJustifyContent),
         new DiscretePropertyWrapper<const StyleSelfAlignmentData&>(CSSPropertyJustifyItems, &RenderStyle::justifyItems, &RenderStyle::setJustifyItems),
@@ -4185,7 +4186,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyGridRow:
         case CSSPropertyGridTemplate:
         case CSSPropertyHangingPunctuation:
-        case CSSPropertyImageRendering:
         case CSSPropertyInlineSize:
         case CSSPropertyInputSecurity:
         case CSSPropertyInset:

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2048,6 +2048,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyTabSize);
         if (first.imageOrientation != second.imageOrientation)
             changingProperties.m_properties.set(CSSPropertyImageOrientation);
+        if (first.imageRendering != second.imageRendering)
+            changingProperties.m_properties.set(CSSPropertyImageRendering);
         if (first.textAlignLast != second.textAlignLast)
             changingProperties.m_properties.set(CSSPropertyTextAlignLast);
         if (first.textBoxEdge != second.textBoxEdge)
@@ -2109,7 +2111,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // lineBoxContain
         // touchCalloutEnabled
         // lineGrid
-        // imageRendering
         // textZoom
         // lineSnap
         // lineAlign


### PR DESCRIPTION
#### c4a42c52ede3282feece760f804932e7931dc655
<pre>
[web-animations] image-rendering should support discrete animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=277250">https://bugs.webkit.org/show_bug.cgi?id=277250</a>
<a href="https://rdar.apple.com/132707652">rdar://132707652</a>

Reviewed by Darin Adler.

As per: <a href="https://drafts.csswg.org/css-images/#the-image-rendering">https://drafts.csswg.org/css-images/#the-image-rendering</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-images/animation/image-no-interpolation-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):

Canonical link: <a href="https://commits.webkit.org/281506@main">https://commits.webkit.org/281506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fecac3c347bac90a5d0a9a540d8cd923aadd15b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10623 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48685 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7418 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36775 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29527 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9291 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9543 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65743 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56040 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56192 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3345 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9006 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35254 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36336 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36080 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->