### PR TITLE
REGRESSION (281060@main): [iOS] Crash when entering Japanese text into a text box

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -6307,6 +6307,9 @@ static Vector<WebCore::CompositionHighlight> compositionHighlights(NSAttributedS
 - (void)setAttributedMarkedText:(NSAttributedString *)markedText selectedRange:(NSRange)selectedRange
 {
     BOOL hasTextCompletion = ^{
+        if (!markedText.length)
+            return NO;
+
         // UIKit doesn't include the `NSTextCompletionAttributeName`, so the next best way to detect if this method
         // is being used for a text completion is to check if the attributes match these hard-coded ones.
         RetainPtr textCompletionAttributes = @{

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -1088,6 +1088,34 @@ TEST(KeyboardInputTests, NoCrashWhenDiscardingMarkedText)
     Util::runFor(100_ms);
 }
 
+TEST(KeyboardInputTests, NoCrashWithEmptyAttributedMarkedText)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView _setEditable:YES];
+    [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width'><meta charset='utf-8'><body></body>"];
+    [webView selectAll:nil];
+
+    RetainPtr attributes = @{
+        NSMarkedClauseSegmentAttributeName: @(0),
+        NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle),
+        NSUnderlineColorAttributeName: UIColor.tintColor
+    };
+
+    RetainPtr composition = adoptNS([[NSAttributedString alloc] initWithString:@"あ" attributes:attributes.get()]);
+    [[webView textInputContentView] setAttributedMarkedText:composition.get() selectedRange:NSMakeRange(0, 1)];
+
+    RetainPtr finalComposition = adoptNS([[NSMutableAttributedString alloc] initWithString:@"あs" attributes:attributes.get()]);
+    [[webView textInputContentView] setAttributedMarkedText:finalComposition.get() selectedRange:NSMakeRange(0, 2)];
+
+    [finalComposition setAttributes:nil range:NSMakeRange(0, 2)];
+    [finalComposition replaceCharactersInRange:NSMakeRange(0, 2) withString:@"明日"];
+
+    [[webView textInputContentView] setAttributedMarkedText:finalComposition.get() selectedRange:NSMakeRange(0, 2)];
+
+    [finalComposition deleteCharactersInRange:NSMakeRange(0, 2)];
+    [[webView textInputContentView] setAttributedMarkedText:finalComposition.get() selectedRange:NSMakeRange(0, 0)];
+}
+
 TEST(KeyboardInputTests, CharactersAroundCaretSelection)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);


### PR DESCRIPTION
#### 1b25554251447179a862eb544b6323a473b9afc6
<pre>
REGRESSION (281060@main): [iOS] Crash when entering Japanese text into a text box
<a href="https://bugs.webkit.org/show_bug.cgi?id=277251">https://bugs.webkit.org/show_bug.cgi?id=277251</a>
<a href="https://rdar.apple.com/132702363">rdar://132702363</a>

Reviewed by Wenson Hsieh.

281060@main introduced an unconditional call to
`-[NSAttributedString attributesAtIndex:effectiveRange:]` in the marked text
codepath, which is used for both IME and inline text predictions.

This is unsafe, as an empty string is inserted when accepting an IME composition.
Fix by eliding the call to `-[NSAttributedString attributesAtIndex:effectiveRange:]`
when the text is empty.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setAttributedMarkedText:selectedRange:]):
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::TEST(KeyboardInputTests, NoCrashWithEmptyAttributedMarkedText)):

Reproducing the issue in a test requires the use of `NSMutableAttributedString`.
Specifically, the crash is in the run-length encoded array used to keep track
of attributes. The issue only reproduces when that array is modified. Simply
creating an empty attributed string is insufficient to reproduce the crash.

Canonical link: <a href="https://commits.webkit.org/281501@main">https://commits.webkit.org/281501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08b254c2b3c0a691a496be937002f333beb92ca6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10624 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48686 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7419 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29528 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9294 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9544 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65744 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56041 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52038 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56193 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3347 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9001 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35255 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36337 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->