### PR TITLE
Strip prefix from Trusted Type Function samples

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https-expected.txt
@@ -1,9 +1,9 @@
 
 PASS Unsafe eval violation sample is clipped to 40 characters.
 PASS Unsafe indirect eval violation sample is clipped to 40 characters.
-FAIL Function constructor - the other kind of eval - is clipped. assert_equals: expected "Function|(a,b\n) {\nreturn '12345678901234567890123" but got "Function|function anonymous(a,b\n) {\nreturn '12345"
-FAIL Async Function constructor is also clipped. assert_equals: expected "Function|(a,b\n) {\nreturn '12345678901234567890123" but got "Function|async function anonymous(a,b\n) {\nreturn "
-FAIL Generator Function constructor is also clipped. assert_equals: expected "Function|(a,b\n) {\nreturn '12345678901234567890123" but got "Function|function* anonymous(a,b\n) {\nreturn '1234"
-FAIL AsyncGenerator Function constructor is also clipped. assert_equals: expected "Function|(a,b\n) {\nreturn '12345678901234567890123" but got "Function|async function* anonymous(a,b\n) {\nreturn"
+PASS Function constructor - the other kind of eval - is clipped.
+PASS Async Function constructor is also clipped.
+PASS Generator Function constructor is also clipped.
+PASS AsyncGenerator Function constructor is also clipped.
 PASS Trusted Types violation sample is clipped to 40 characters excluded the sink name.
 


### PR DESCRIPTION
#### 6dd9fa30a220a37e4edc257c79c3512403f25c17
<pre>
Strip prefix from Trusted Type Function samples
<a href="https://bugs.webkit.org/show_bug.cgi?id=277258">https://bugs.webkit.org/show_bug.cgi?id=277258</a>

Reviewed by Tim Nguyen.

This strips &quot;function anonymous&quot; and similar prefixes for the function variants from the
CSP violation report sample produced by trusted types.

This aligns with Chromium&apos;s existing behaviour and the latest spec consensus.

Spec: <a href="https://w3c.github.io/trusted-types/dist/spec/#should-block-sink-type-mismatch">https://w3c.github.io/trusted-types/dist/spec/#should-block-sink-type-mismatch</a>

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https-expected.txt:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::allowMissingTrustedTypesForSinkGroup const):

Canonical link: <a href="https://commits.webkit.org/287999@main">https://commits.webkit.org/287999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98a7884cffe3e32ceca02162cf2d0e16f0c2aaff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32500 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63615 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21353 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43906 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28351 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30953 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72087 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87474 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8739 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71940 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71173 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17739 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15238 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14149 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8699 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14227 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->