### PR TITLE
[ews] Remove unneeded logs

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5251,7 +5251,6 @@ class GenerateS3URL(master.MasterShellCommandNewStyle):
         build_url = f'{self.master.config.buildbotURL}#/builders/{self.build._builderid}/builds/{self.build.number}'
         if match:
             self.build.s3url = match.group('url')
-            print(f'build: {build_url}, url for GenerateS3URL: {self.build.s3url}')
             self.build.s3_archives.append(S3URL + f"{S3_BUCKET}/{self.identifier}/{self.getProperty('change_id')}.{self.extension}")
             defer.returnValue(rc)
         else:


### PR DESCRIPTION
#### 16953f9b1ed0974eb20fdce7cd940eccc57bffb0
<pre>
[ews] Remove unneeded logs
<a href="https://bugs.webkit.org/show_bug.cgi?id=277260">https://bugs.webkit.org/show_bug.cgi?id=277260</a>

Reviewed by Jonathan Bedard.

Remove unneeded logs for the GenerateS3URL step for the success case.
We added it earlier when the step was having issues, but we don&apos;t need it anymore.

* Tools/CISupport/ews-build/steps.py:
(GenerateS3URL.run):

Canonical link: <a href="https://commits.webkit.org/281503@main">https://commits.webkit.org/281503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cec3b1c036ca8b5cf6700f3baa1e6b72e39910f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60127 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/39475 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/12679 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64045 "Build was cancelled. Recent messages:Printed configuration") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/10657 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62257 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/47147 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/10886 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/64045 "Build was cancelled. Recent messages:Printed configuration") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/10657 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62158 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/47147 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/12679 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64045 "Build was cancelled. Recent messages:Printed configuration") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/47147 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/12679 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9577 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/47147 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/12679 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/65777 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4057 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/10886 "Build was cancelled. Recent messages:OS: Sonoma (14.5), Xcode: 15.4") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/65777 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/59817 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4075 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/12679 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/65777 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3374 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9003 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35288 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36370 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37458 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->