### PR TITLE
Crash with multiple video tags that contains webm source

### DIFF
--- a/LayoutTests/media/media-vp8-webm-with-preload-expected.txt
+++ b/LayoutTests/media/media-vp8-webm-with-preload-expected.txt
@@ -1,0 +1,7 @@
+
+EXPECTED (video.readyState <= '1') OK
+EXPECTED (video.readyState == '1') OK
+RUN(video.play())
+EVENT(playing)
+RUN(video.currentTime = video.duration - 0.02)
+

--- a/LayoutTests/media/media-vp8-webm-with-preload.html
+++ b/LayoutTests/media/media-vp8-webm-with-preload.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+<title>webm file with vp8 preload=metadata</title>
+<script src="../resources/testharness.js"></script>
+<script src="video-test.js"></script>
+<script>
+    async function init()
+    {
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        findMediaElement();
+        testExpected('video.readyState', video.HAVE_METADATA, '<=');
+        if (video.readyState != video.HAVE_METADATA)
+            await waitFor(video, 'loadedmetadata', true);
+        // wait a little bit, readyState shouldn't move from HAVE_METADATA
+        await sleepFor(500);
+        testExpected('video.readyState', video.HAVE_METADATA);
+        run('video.play()');
+        await waitFor(video, 'playing');
+        run('video.currentTime = video.duration - 0.02');
+        await Promise.all([ waitFor(video, 'seeked', true), waitFor(video, 'ended', true) ]);
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+</script>
+</head>
+<body onload="init();">
+    <video src="content/test-vp8.webm" preload="metadata" poster="content/test-vp8.webm.png" />
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1161,6 +1161,7 @@ webkit.org/b/146720 media/accessibility-describes-video.html [ Failure ]
 
 webkit.org/b/227934 media/media-source/media-webm-vorbis-partial.html [ Failure ]
 webkit.org/b/265016 media/media-webm-opus-error.html [ Timeout Failure ]
+webkit.org/b/277327 media/media-vp8-webm-with-preload.html [ Skip ]
 
 webkit.org/b/229973 media/track/in-band/track-in-band-srt-mkv-cues-added-once.html [ Failure Pass ]
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1073,7 +1073,9 @@ media/media-vp8-webm-error.html [ Failure ]
 media/media-vp8-webm.html [ Skip ]
 media/media-vp8-webm-seek-to-start.html [ Skip ]
 media/media-vp8-webm-with-poster.html [ Skip ]
+media/media-vp8-webm-with-preload.html [ Skip ]
 media/video-src-webm-blob.html [ Failure ]
+
 media/track/media-audio-track.html [ Failure ]
 media/media-sources-selection.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/platform/graphics/WebMResourceClient.cpp
+++ b/Source/WebCore/platform/graphics/WebMResourceClient.cpp
@@ -60,6 +60,14 @@ void WebMResourceClient::stop()
     resource->shutdown();
 }
 
+void WebMResourceClient::responseReceived(PlatformMediaResource&, const ResourceResponse& response, CompletionHandler<void(ShouldContinuePolicyCheck)>&& completionHandler)
+{
+    RefPtr parent = m_parent.get();
+    if (parent)
+        parent->dataLengthReceived(response.expectedContentLength());
+    completionHandler(parent ? ShouldContinuePolicyCheck::Yes : ShouldContinuePolicyCheck::No);
+}
+
 void WebMResourceClient::dataReceived(PlatformMediaResource&, const SharedBuffer& buffer)
 {
     if (RefPtr parent = m_parent.get())

--- a/Source/WebCore/platform/graphics/WebMResourceClient.h
+++ b/Source/WebCore/platform/graphics/WebMResourceClient.h
@@ -40,6 +40,7 @@ public:
     virtual void dataReceived(const SharedBuffer&) = 0;
     virtual void loadFailed(const ResourceError&) = 0;
     virtual void loadFinished() = 0;
+    virtual void dataLengthReceived(size_t) = 0;
 };
 
 class WebMResourceClient final
@@ -54,6 +55,7 @@ public:
 private:
     WebMResourceClient(WebMResourceClientParent&, Ref<PlatformMediaResource>&&);
 
+    void responseReceived(PlatformMediaResource&, const ResourceResponse&, CompletionHandler<void(ShouldContinuePolicyCheck)>&&) final;
     void dataReceived(PlatformMediaResource&, const SharedBuffer&) final;
     void loadFailed(PlatformMediaResource&, const ResourceError&) final;
     void loadFinished(PlatformMediaResource&, const NetworkLoadMetrics&) final;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -198,9 +198,20 @@ MediaPlayer::SupportsType MediaPlayerPrivateWebM::supportsType(const MediaEngine
     return SourceBufferParserWebM::isContentTypeSupported(parameters.type);
 }
 
-void MediaPlayerPrivateWebM::load(const String& url)
+void MediaPlayerPrivateWebM::setPreload(MediaPlayer::Preload preload)
 {
-    ALWAYS_LOG(LOGIDENTIFIER);
+    ALWAYS_LOG(LOGIDENTIFIER, " - ", static_cast<int>(preload));
+    if (preload == std::exchange(m_preload, preload))
+        return;
+    doPreload();
+}
+
+void MediaPlayerPrivateWebM::doPreload()
+{
+    if (m_assetURL.isEmpty() || m_networkState >= MediaPlayerNetworkState::FormatError) {
+        INFO_LOG(LOGIDENTIFIER, " - hasURL = ", static_cast<int>(m_assetURL.isEmpty()), " networkState = ", static_cast<int>(m_networkState));
+        return;
+    }
 
     auto player = m_player.get();
     if (!player)
@@ -213,18 +224,51 @@ void MediaPlayerPrivateWebM::load(const String& url)
         return;
     }
 
-    ResourceRequest request(url);
+    if (m_preload >= MediaPlayer::Preload::MetaData && !m_resourceClient) {
+        if (!createResourceClient()) {
+            ERROR_LOG(LOGIDENTIFIER, "could not create resource client");
+            setNetworkState(MediaPlayer::NetworkState::NetworkError);
+            setReadyState(MediaPlayer::ReadyState::HaveNothing);
+        } else
+            setNetworkState(MediaPlayer::NetworkState::Loading);
+    }
+
+    if (m_preload > MediaPlayer::Preload::MetaData) {
+        for (auto it = m_readyForMoreSamplesMap.begin(); it != m_readyForMoreSamplesMap.end(); ++it)
+            notifyClientWhenReadyForMoreSamples(it->first);
+    }
+}
+
+void MediaPlayerPrivateWebM::load(const String& url)
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+
+    setReadyState(MediaPlayer::ReadyState::HaveNothing);
+
+    m_assetURL = URL({ }, url);
+
+    doPreload();
+}
+
+bool MediaPlayerPrivateWebM::createResourceClient()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    RefPtr player = m_player.get();
+    if (!player)
+        return false;
+
+    ResourceRequest request(m_assetURL);
     request.setAllowCookies(true);
+    if (m_contentReceived) {
+        if (m_contentLength <= m_contentReceived)
+            return false;
+        request.addHTTPHeaderField(HTTPHeaderName::Range, makeString("bytes="_s, m_contentReceived, '-', m_contentLength));
+    }
 
     auto loader = player->createResourceLoader();
     m_resourceClient = WebMResourceClient::create(*this, *loader, WTFMove(request));
-    
-    if (!m_resourceClient) {
-        ERROR_LOG(LOGIDENTIFIER, "could not create resource client");
-        setNetworkState(MediaPlayer::NetworkState::NetworkError);
-        setReadyState(MediaPlayer::ReadyState::HaveNothing);
-        return;
-    }
+
+    return !!m_resourceClient;
 }
 
 #if ENABLE(MEDIA_SOURCE)
@@ -245,13 +289,21 @@ void MediaPlayerPrivateWebM::load(MediaStreamPrivate&)
 }
 #endif
 
+void MediaPlayerPrivateWebM::dataLengthReceived(size_t length)
+{
+    callOnMainThread([protectedThis = Ref { *this }, length] {
+        protectedThis->m_contentLength = length;
+    });
+}
+
 void MediaPlayerPrivateWebM::dataReceived(const SharedBuffer& buffer)
 {
     ALWAYS_LOG(LOGIDENTIFIER, "data length = ", buffer.size());
 
-    callOnMainThread([protectedThis = Ref { *this }, this] {
+    callOnMainThread([protectedThis = Ref { *this }, this, size = buffer.size()] {
         setNetworkState(MediaPlayer::NetworkState::Loading);
         m_pendingAppends++;
+        m_contentReceived += size;
     });
 
     // FIXME: Remove const_cast once https://bugs.webkit.org/show_bug.cgi?id=243370 is fixed.
@@ -287,6 +339,7 @@ void MediaPlayerPrivateWebM::cancelLoad()
         m_resourceClient->stop();
         m_resourceClient = nullptr;
     }
+    setNetworkState(MediaPlayer::NetworkState::Idle);
 }
 
 PlatformLayer* MediaPlayerPrivateWebM::platformLayer() const
@@ -294,6 +347,12 @@ PlatformLayer* MediaPlayerPrivateWebM::platformLayer() const
     if (!m_videoRenderer)
         return nullptr;
     return m_videoLayerManager->videoInlineLayer();
+}
+
+void MediaPlayerPrivateWebM::prepareToPlay()
+{
+    ALWAYS_LOG(LOGIDENTIFIER);
+    setPreload(MediaPlayer::Preload::Auto);
 }
 
 void MediaPlayerPrivateWebM::play()
@@ -673,12 +732,6 @@ void MediaPlayerPrivateWebM::setNaturalSize(FloatSize size)
         if (auto player = m_player.get())
             player->sizeChanged();
     }
-
-    if (m_readyState < MediaPlayer::ReadyState::HaveMetadata)
-        setReadyState(MediaPlayer::ReadyState::HaveMetadata);
-
-    if (m_delayedIdle)
-        setNetworkState(MediaPlayer::NetworkState::Idle);
 }
 
 void MediaPlayerPrivateWebM::setHasAudio(bool hasAudio)
@@ -758,8 +811,6 @@ void MediaPlayerPrivateWebM::setDuration(MediaTime duration)
 
 void MediaPlayerPrivateWebM::setNetworkState(MediaPlayer::NetworkState state)
 {
-    if (state == MediaPlayer::NetworkState::Idle)
-        m_delayedIdle = false;
     if (state == m_networkState)
         return;
 
@@ -1094,10 +1145,7 @@ void MediaPlayerPrivateWebM::maybeFinishLoading()
             setNetworkState(m_readyState >= MediaPlayer::ReadyState::HaveMetadata ? MediaPlayer::NetworkState::DecodeError : MediaPlayer::NetworkState::FormatError);
             return;
         }
-        if (m_readyState >= MediaPlayer::ReadyState::HaveMetadata)
-            setNetworkState(MediaPlayer::NetworkState::Idle);
-        else
-            m_delayedIdle = true;
+        setNetworkState(MediaPlayer::NetworkState::Idle);
 
         updateDurationFromTrackBuffers();
     }
@@ -1170,18 +1218,14 @@ void MediaPlayerPrivateWebM::trackDidChangeSelected(VideoTrackPrivate& track, bo
     if (selected) {
         m_enabledVideoTrackID = trackId;
         updateDisplayLayerAndDecompressionSession();
-        if (m_decompressionSession) {
-            m_decompressionSession->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }, this, trackId] {
-                if (RefPtr protectedThis = weakThis.get())
-                    didBecomeReadyForMoreSamples(trackId);
-            });
-        }
-        reenqueSamples(trackId);
         return;
     }
     
     if (isEnabledVideoTrackID(trackId)) {
         m_enabledVideoTrackID.reset();
+        m_readyForMoreSamplesMap.erase(trackId);
+        if (m_videoRenderer)
+            m_videoRenderer->stopRequestingMediaData();
         if (m_decompressionSession)
             m_decompressionSession->stopRequestingMediaData();
     }
@@ -1198,16 +1242,20 @@ void MediaPlayerPrivateWebM::trackDidChangeEnabled(AudioTrackPrivate& track, boo
 
     if (enabled) {
         addAudioRenderer(trackId);
-        reenqueSamples(trackId);
+        m_readyForMoreSamplesMap[trackId] = true;
         return;
     }
-    
+
+    m_readyForMoreSamplesMap.erase(trackId);
     removeAudioRenderer(trackId);
 }
 
 void MediaPlayerPrivateWebM::didParseInitializationData(InitializationSegment&& segment)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
+
+    if (m_preload == MediaPlayer::Preload::MetaData)
+        cancelLoad();
 
     clearTracks();
 
@@ -1244,8 +1292,10 @@ void MediaPlayerPrivateWebM::didParseInitializationData(InitializationSegment&& 
                 }
             });
 
-            if (m_videoTracks.isEmpty())
+            if (m_videoTracks.isEmpty()) {
+                setNaturalSize({ float(track->width()), float(track->height()) });
                 track->setSelected(true);
+            }
 
             m_videoTracks.append(track);
             if (player)
@@ -1283,8 +1333,7 @@ void MediaPlayerPrivateWebM::didParseInitializationData(InitializationSegment&& 
         }
     }
 
-    if (m_hasAudio && !m_hasVideo)
-        setReadyState(MediaPlayer::ReadyState::HaveMetadata);
+    setReadyState(MediaPlayer::ReadyState::HaveMetadata);
 }
 
 void MediaPlayerPrivateWebM::didProvideMediaDataForTrackId(Ref<MediaSampleAVFObjC>&& originalSample, TrackID trackId, const String& mediaType)
@@ -1327,6 +1376,10 @@ void MediaPlayerPrivateWebM::didProvideMediaDataForTrackId(Ref<MediaSampleAVFObj
 
     trackBuffer.addBufferedRange(presentationTimestamp, presentationEndTime);
 
+    if (m_preload <= MediaPlayer::Preload::MetaData) {
+        m_readyForMoreSamplesMap[trackId] = true;
+        return;
+    }
     notifyClientWhenReadyForMoreSamples(trackId);
 }
 
@@ -1444,15 +1497,8 @@ void MediaPlayerPrivateWebM::ensureDecompressionSession()
     m_decompressionSession->setTimebase([m_synchronizer timebase]);
     m_decompressionSession->setResourceOwner(m_resourceOwner);
 
-    m_decompressionSession->requestMediaDataWhenReady([weakThis = WeakPtr { *this }, this] {
-        if (weakThis && m_enabledVideoTrackID)
-            didBecomeReadyForMoreSamples(*m_enabledVideoTrackID);
-    });
     registerNotifyWhenHasAvailableVideoFrame();
     
-    if (m_enabledVideoTrackID)
-        reenqueSamples(*m_enabledVideoTrackID);
-
     if (auto player = m_player.get())
         player->renderingModeChanged();
 }
@@ -1501,12 +1547,6 @@ void MediaPlayerPrivateWebM::addAudioRenderer(TrackID trackId)
     }
 
     characteristicsChanged();
-
-    WeakPtr weakThis { *this };
-    [renderer requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
-        if (weakThis)
-            didBecomeReadyForMoreSamples(trackId);
-    }];
 
     m_audioRenderers.try_emplace(trackId, renderer);
     m_listener->beginObservingAudioRenderer(renderer.get());
@@ -1963,10 +2003,6 @@ void MediaPlayerPrivateWebM::configureLayerOrVideoRenderer(WebSampleBufferVideoR
 void MediaPlayerPrivateWebM::configureVideoRenderer(VideoMediaSampleRenderer& videoRenderer)
 {
     videoRenderer.setResourceOwner(m_resourceOwner);
-    videoRenderer.requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }] {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_enabledVideoTrackID)
-            protectedThis->didBecomeReadyForMoreSamples(*protectedThis->m_enabledVideoTrackID);
-    });
     m_listener->beginObservingVideoRenderer(videoRenderer.renderer());
 }
 
@@ -1997,8 +2033,6 @@ void MediaPlayerPrivateWebM::setVideoRenderer(WebSampleBufferVideoRendering *ren
 
     m_videoRenderer = VideoMediaSampleRenderer::create(renderer);
     configureVideoRenderer(*m_videoRenderer);
-    if (m_enabledVideoTrackID)
-        reenqueSamples(*m_enabledVideoTrackID);
 }
 
 void MediaPlayerPrivateWebM::stageVideoRenderer(WebSampleBufferVideoRendering *renderer)

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h
@@ -44,6 +44,8 @@ public:
     AtomString language() const final;
     int trackIndex() const final;
     std::optional<bool> defaultEnabled() const final;
+    uint32_t width() const;
+    uint32_t height() const;
 
 private:
     VideoTrackPrivateWebM(webm::TrackEntry&&);
@@ -51,8 +53,6 @@ private:
     void setFormatDescription(Ref<VideoInfo>&&);
 
     String codec() const;
-    uint32_t width() const;
-    uint32_t height() const;
     double framerate() const;
     PlatformVideoColorSpace colorSpace() const;
     void updateConfiguration();


### PR DESCRIPTION
#### 75467caf79bb0cbbc7441ecbe4a239829779eac3
<pre>
Crash with multiple video tags that contains webm source
<a href="https://bugs.webkit.org/show_bug.cgi?id=276717">https://bugs.webkit.org/show_bug.cgi?id=276717</a>
<a href="https://rdar.apple.com/132405520">rdar://132405520</a>

Reviewed by Youenn Fablet.

The WebM MediaPlayer ignored the preload attribute and would read the webm video
in its entirety all the time. This could lead to great memory usage and eventually the
page being jetsammed.
We now stops loading the video if preload is set to &lt;= metadata and will continue
from where we stopped when play() is called.
The `requestMediaDataWhenReady` callback was set whenever we demuxed a
single sample or when a new audio or video renderer was created, flushed etc.
It only needed to be set once.
The dimensions of the video were determined after enqueuing the first video sample.
We now read it from the container instead as it allows to reduce how much of the
media we have to download to obtain the information and move the readyState to
HAVE_METADATA.

Added test.

* LayoutTests/media/media-vp8-webm-withp-reload-expected.txt: Added.
* LayoutTests/media/media-vp8-webm-with-preload.html: Added.
* LayoutTests/platform/glib/TestExpectations: see webkit.org/b/277327
* LayoutTests/platform/mac-wk1/TestExpectations: webm not supported in wk1.
* Source/WebCore/platform/graphics/WebMResourceClient.cpp:
(WebCore::WebMResourceClient::responseReceived):
* Source/WebCore/platform/graphics/WebMResourceClient.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::setPreload):
(WebCore::MediaPlayerPrivateWebM::doPreload):
(WebCore::MediaPlayerPrivateWebM::load):
(WebCore::MediaPlayerPrivateWebM::createResourceClient):
(WebCore::MediaPlayerPrivateWebM::dataLengthReceived):
(WebCore::MediaPlayerPrivateWebM::dataReceived):
(WebCore::MediaPlayerPrivateWebM::cancelLoad):
(WebCore::MediaPlayerPrivateWebM::prepareToPlay):
(WebCore::MediaPlayerPrivateWebM::setNaturalSize):
(WebCore::MediaPlayerPrivateWebM::setNetworkState):
(WebCore::MediaPlayerPrivateWebM::maybeFinishLoading):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeSelected):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeEnabled):
(WebCore::MediaPlayerPrivateWebM::didParseInitializationData):
(WebCore::MediaPlayerPrivateWebM::didProvideMediaDataForTrackId):
(WebCore::MediaPlayerPrivateWebM::ensureDecompressionSession):
(WebCore::MediaPlayerPrivateWebM::addAudioRenderer):
(WebCore::MediaPlayerPrivateWebM::configureVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::setVideoRenderer):
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.h: We were relying on the first video frame
being enqueued to determine the dimensions of the video. We&apos;ll now instead rely on the container&apos;s track data.
So we make public the width and height function.

Canonical link: <a href="https://commits.webkit.org/281554@main">https://commits.webkit.org/281554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0de67b14ea26bfe31283e8be8f9b4126394b91d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64231 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10843 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11076 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48832 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7548 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29678 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33669 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/9479 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9760 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65963 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4245 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56193 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56360 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13382 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3536 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->