### PR TITLE
Rewrite Document abandonment LayoutTests to be more robust against flakiness

### DIFF
--- a/LayoutTests/fast/reporting/reporting-observer-callback-does-not-leak-expected.txt
+++ b/LayoutTests/fast/reporting/reporting-observer-callback-does-not-leak-expected.txt
@@ -3,7 +3,7 @@ Tests that ReportingObserver callbacks do not leak documents.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS The iframe document didn't leak
+PASS The iframe document didn't leak.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/reporting/reporting-observer-callback-does-not-leak.html
+++ b/LayoutTests/fast/reporting/reporting-observer-callback-does-not-leak.html
@@ -2,67 +2,10 @@
 <html>
 <body>
 <script src="../../resources/js-test.js"></script>
+<script src="../../resources/document-leak-test.js"></script>
 <script>
 description("Tests that ReportingObserver callbacks do not leak documents.");
-
-jsTestIsAsync = true;
-var framesToCreate = 20;
-var allFrames = new Array(framesToCreate);
-
-for (let i = 0; i < framesToCreate; ++i) {
-    let iframe = document.createElement("iframe");
-    document.body.appendChild(iframe);
-    allFrames[i] = iframe;
-}
-
-function iframeForMessage(message)
-{
-    return allFrames.find(frame => frame.contentWindow === message.source);
-}
-
-var failCount = 0;
-function iframeLeaked()
-{
-    if (++failCount >= framesToCreate) {
-        testFailed("All iframe documents leaked.");
-        finishJSTest();
-    }
-}
-
-function iframeLoaded(iframe)
-{
-    let frameDocumentID = internals.documentIdentifier(iframe.contentWindow.document);
-    let checkCount = 0;
-
-    iframe.addEventListener("load", () => {
-        let handle = setInterval(() => {
-            gc();
-            if (!internals.isDocumentAlive(frameDocumentID)) {
-                clearInterval(handle);
-                testPassed("The iframe document didn't leak");
-                finishJSTest();
-            }
-            if (++checkCount > 5) {
-                clearInterval(handle);
-                iframeLeaked();
-            }
-        }, 10);
-    });
-
-    iframe.src = "about:blank";
-}
-
-onload = () => {
-    if (!(window.internals && window.testRunner)) {
-        testFailed("Test requires internals and testRunner.");
-        finishJSTest();
-    }
-
-    window.addEventListener("message", message => iframeLoaded(iframeForMessage(message)));
-
-    allFrames.forEach(iframe => iframe.src = "./resources/reporting-observer-with-callback.html");
-};
-
+onload = () => runDocumentLeakTest({ frameURL: "./resources/reporting-observer-with-callback.html", framesToCreate: 20 });
 </script>
 </body>
 </html>

--- a/LayoutTests/http/tests/geolocation/geolocation-watch-position-does-not-leak.https.html
+++ b/LayoutTests/http/tests/geolocation/geolocation-watch-position-does-not-leak.https.html
@@ -2,66 +2,12 @@
 <html>
 <head>
 <script src="../resources/js-test-pre.js"></script>
+<script src="../resources/document-leak-test.js"></script>
 </head>
 <body>
 <script>
 description("Tests that navigator.geolocation.watchPosition() does not leak the document object.");
-jsTestIsAsync = true;
-
-var framesToCreate = 20;
-var allFrames = new Array(framesToCreate);
-
-for (let i = 0; i < framesToCreate; ++i) {
-    let iframe = document.createElement("iframe");
-    document.body.appendChild(iframe);
-    allFrames[i] = iframe;
-}
-
-function iframeForMessage(message)
-{
-    return allFrames.find(frame => frame.contentWindow === message.source);
-}
-
-var failCount = 0;
-function iFrameLeaked()
-{
-    if (++failCount >= framesToCreate) {
-        testFailed("All iframe documents leaked.");
-        finishJSTest();
-    }
-}
-
-function iframeLoaded(iframe)
-{
-    let frameDocumentID = internals.documentIdentifier(iframe.contentWindow.document);
-    let checkCount = 0;
-    iframe.addEventListener("load", () => {
-        let handle = setInterval(() => {
-            gc();
-            if (!internals.isDocumentAlive(frameDocumentID)) {
-                clearInterval(handle);
-                testPassed("The iframe document didn't leak.");
-                finishJSTest();
-            }
-            if (++checkCount > 5) {
-                clearInterval(handle);
-                iframeLeaked();
-            }
-        }, 10);
-    });
-
-    iframe.src = "about:blank";
-}
-
-onload = () => {
-    if (!(window.internals && window.testRunner)) {
-        testFailed("Test requires internals and testRunner.");
-        finishJSTest();
-    }
-
-    window.addEventListener("message", message => iframeLoaded(iframeForMessage(message)));
-    allFrames.forEach(frame => frame.src = "https://127.0.0.1:8443/geolocation/resources/geolocation-watch-position-callback.html");
-};
+onload = () => runDocumentLeakTest({ frameURL: "https://127.0.0.1:8443/geolocation/resources/geolocation-watch-position-callback.html", framesToCreate: 20 });
 </script>
 <script src="../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/media/media-session/actionHandler-no-document-leak-expected.txt
+++ b/LayoutTests/media/media-session/actionHandler-no-document-leak-expected.txt
@@ -3,7 +3,6 @@ Tests that page installed actionHandlers do not leak documents.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS internals.isDocumentAlive(frameDocumentID) is true
 PASS The iframe document didn't leak.
 PASS successfullyParsed is true
 

--- a/LayoutTests/media/media-session/actionHandler-no-document-leak.html
+++ b/LayoutTests/media/media-session/actionHandler-no-document-leak.html
@@ -5,52 +5,10 @@
 <body>
 <iframe id="iframe"></iframe>
 <script src="../../resources/js-test.js"></script>
+<script src="../../resources/document-leak-test.js"></script>
 <script>
 description("Tests that page installed actionHandlers do not leak documents.");
-
-jsTestIsAsync = true;
-frameDocumentID = 0;
-checkCount = 0;
-
-function iframeLoaded(frameDocument) {
-    if (!window.internals) {
-        testFailed("Test requires internals.");
-        return;
-    }
-
-    frameDocumentID = internals.documentIdentifier(frameDocument);
-    shouldBeTrue("internals.isDocumentAlive(frameDocumentID)");
-
-    iframe.addEventListener("load", () => {
-        handle = setInterval(() => {
-            gc();
-            if (!internals.isDocumentAlive(frameDocumentID)) {
-                clearInterval(handle);
-                testPassed("The iframe document didn't leak.");
-                finishJSTest();
-            }
-            checkCount++;
-            if (checkCount > 500) {
-                clearInterval(handle);
-                testFailed("The iframe document leaked.");
-                finishJSTest();
-            }
-        }, 10);
-    });
-
-    iframe.src = "about:blank";
-}
-
-onload = () => {
-    iframe.src = "resources/media-session-action-handler-document-leak-frame.html";
-    document.body.appendChild(iframe);
-};
-
-onmessage = (message) => {
-    if (message.data === "frameLoaded")
-        iframeLoaded(iframe.contentWindow.document);
-};
-
+onload = () => runDocumentLeakTest({ frameURL: "./resources/media-session-action-handler-document-leak-frame.html", framesToCreate: 20 });
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### 3323735874527c9cdec27aa7e6e6dc9644578ea3
<pre>
Rewrite Document abandonment LayoutTests to be more robust against flakiness
<a href="https://bugs.webkit.org/show_bug.cgi?id=277263">https://bugs.webkit.org/show_bug.cgi?id=277263</a>
<a href="https://rdar.apple.com/132726649">rdar://132726649</a>

Reviewed by Sammy Gill.

document-leak-test.js was added to help write layout tests for Document
object abandonment. Tests which predate this helper are being changed to
use it instead to help guard against flaky pass/failure results.

* LayoutTests/fast/reporting/reporting-observer-callback-does-not-leak-expected.txt:
* LayoutTests/fast/reporting/reporting-observer-callback-does-not-leak.html:
* LayoutTests/http/tests/geolocation/geolocation-watch-position-does-not-leak.https.html:
* LayoutTests/media/media-session/actionHandler-no-document-leak-expected.txt:
* LayoutTests/media/media-session/actionHandler-no-document-leak.html:

Canonical link: <a href="https://commits.webkit.org/281524@main">https://commits.webkit.org/281524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8879eecdfcfd11da1536effd8591ed07f38a7635

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64053 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10665 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48715 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7450 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29557 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9327 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9585 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65785 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56069 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56223 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13344 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3384 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35296 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36378 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37466 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->