### PR TITLE
Enable CryptoKit for Auth use cases.

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
@@ -173,7 +173,7 @@ RefPtr<ArrayBuffer> AuthenticatorAttestationResponse::getPublicKey() const
 
         if (!peerKey)
             return nullptr;
-        auto keySpki = peerKey->exportSpki(UseCryptoKit::No).releaseReturnValue();
+        auto keySpki = peerKey->exportSpki(UseCryptoKit::Yes).releaseReturnValue();
         return ArrayBuffer::tryCreate(keySpki);
     }
     default:

--- a/Source/WebCore/Modules/webauthn/fido/Pin.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.cpp
@@ -68,8 +68,7 @@ static bool hasAtLeastFourCodepoints(const String& pin)
 // makePinAuth returns `LEFT(HMAC-SHA-256(secret, data), 16)`.
 static Vector<uint8_t> makePinAuth(const CryptoKeyHMAC& key, const Vector<uint8_t>& data)
 {
-    // FIXME: enable cryptoKit when it's enabled for SubtleCryptoAPI rdar://126352502
-    auto result = CryptoAlgorithmHMAC::platformSign(key, data, UseCryptoKit::No);
+    auto result = CryptoAlgorithmHMAC::platformSign(key, data, useCryptoKit);
     ASSERT(!result.hasException());
     auto pinAuth = result.releaseReturnValue();
     pinAuth.shrink(16);
@@ -345,8 +344,7 @@ std::optional<SetPinRequest> SetPinRequest::tryCreate(const String& inputPin, co
     auto newPinEnc = CryptoAlgorithmAESCBC::platformEncrypt({ }, *sharedKey, paddedPin, CryptoAlgorithmAESCBC::Padding::No);
     ASSERT(!newPinEnc.hasException());
 
-    // FIXME: enable cryptoKit when it's enabled for SubtleCryptoAPI rdar://126352502
-    auto pinUvAuthParam = CryptoAlgorithmHMAC::platformSign(*hmacKey, newPinEnc.returnValue(), UseCryptoKit::No);
+    auto pinUvAuthParam = CryptoAlgorithmHMAC::platformSign(*hmacKey, newPinEnc.returnValue(), useCryptoKit);
     ASSERT(!pinUvAuthParam.hasException());
 
     return SetPinRequest(sharedKey.releaseNonNull(), WTFMove(coseKey), newPinEnc.releaseReturnValue(), pinUvAuthParam.releaseReturnValue());


### PR DESCRIPTION
#### bbd59e8261407720117c25027d49f46c59097b3f
<pre>
Enable CryptoKit for Auth use cases.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277180">https://bugs.webkit.org/show_bug.cgi?id=277180</a>
<a href="https://rdar.apple.com/132602817">rdar://132602817</a>

Reviewed by Pascoe.

public-key-credential-create-success-local.https.html was failing as we were trying to use a non CryptoKit
key getter with a CryptoKit key.
With this PR we fix that by enabling CryptoKit for this specific instance also.
This was missed in (281139@main) when we enabled CryptoKit.

* Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp:
(WebCore::AuthenticatorAttestationResponse::getPublicKey const):
* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
(fido::pin::makePinAuth):
(fido::pin::SetPinRequest::tryCreate):

Canonical link: <a href="https://commits.webkit.org/281548@main">https://commits.webkit.org/281548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0900e87689dbec0914e4a5b301ec0a58cf857705

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64112 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10723 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48747 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7473 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29589 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33561 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9371 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9643 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65843 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56103 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56258 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13376 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3432 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35354 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->