### PR TITLE
[Navigation] Implement NavigationActivation.finished handling

### DIFF
--- a/Source/WebCore/page/NavigationTransition.cpp
+++ b/Source/WebCore/page/NavigationTransition.cpp
@@ -32,9 +32,10 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(NavigationTransition);
 
-NavigationTransition::NavigationTransition(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry)
+NavigationTransition::NavigationTransition(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DOMPromise>&& finished)
     : m_navigationType(type)
     , m_from(WTFMove(fromEntry))
+    , m_finished(WTFMove(finished))
 {
 }
 

--- a/Source/WebCore/page/NavigationTransition.h
+++ b/Source/WebCore/page/NavigationTransition.h
@@ -37,18 +37,18 @@ class DOMPromise;
 class NavigationTransition final : public RefCounted<NavigationTransition>, public ScriptWrappable {
     WTF_MAKE_ISO_ALLOCATED(NavigationTransition);
 public:
-    static Ref<NavigationTransition> create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry) { return adoptRef(*new NavigationTransition(type, WTFMove(fromEntry))); };
+    static Ref<NavigationTransition> create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DOMPromise>&& finished) { return adoptRef(*new NavigationTransition(type, WTFMove(fromEntry), WTFMove(finished))); };
 
     NavigationNavigationType navigationType() { return m_navigationType; };
     NavigationHistoryEntry& from() { return m_from; };
-    DOMPromise* finished() { return m_finished.get(); };
+    DOMPromise& finished() { return m_finished; };
 
 private:
-    explicit NavigationTransition(NavigationNavigationType, Ref<NavigationHistoryEntry>&& fromEntry);
+    explicit NavigationTransition(NavigationNavigationType, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DOMPromise>&& finished);
 
     NavigationNavigationType m_navigationType;
     Ref<NavigationHistoryEntry> m_from;
-    RefPtr<DOMPromise> m_finished;
+    Ref<DOMPromise> m_finished;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 7a37f70fe38d35647ef34c69d1c228b2592d9c93
<pre>
[Navigation] Implement NavigationActivation.finished handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=277264">https://bugs.webkit.org/show_bug.cgi?id=277264</a>

Reviewed by NOBODY (OOPS!).

[Navigation] Implement NavigationActivation.finished handling as specified in the inner navigate event firing algorithm [1].

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm">https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm</a> (Steps 32.4, 38.4.7)

* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):
* Source/WebCore/page/NavigationTransition.cpp:
(WebCore::NavigationTransition::NavigationTransition):
* Source/WebCore/page/NavigationTransition.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a37f70fe38d35647ef34c69d1c228b2592d9c93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64079 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10691 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48734 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7461 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52118 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29576 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9349 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9611 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65811 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9510 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56085 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56240 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3404 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35322 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36404 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37492 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->