### PR TITLE
Trigger toggle capture actions in case page muted state changes

### DIFF
--- a/LayoutTests/http/wpt/mediasession/resources/toggleCapture-iframe.html
+++ b/LayoutTests/http/wpt/mediasession/resources/toggleCapture-iframe.html
@@ -1,0 +1,54 @@
+<script>
+var stream;
+async function startCapture(audio, video)
+{
+    stream = await navigator.mediaDevices.getUserMedia({ audio, video });
+}
+
+function stopCapture()
+{
+   stream.getTracks().forEach(t => t.stop());
+}
+
+function isCameraMuted()
+{
+    if (!stream)
+        return false;
+    const tracks = stream.getVideoTracks();
+    if (!tracks.length)
+        return false;
+    return tracks()[0].muted;
+}
+
+function isMicrophoneMuted()
+{
+    if (!stream)
+        return false;
+    const tracks = stream.getAudioTracks();
+    if (!tracks.length)
+        return false;
+    return tracks()[0].muted;
+}
+
+function waitForNoToggleAction(action)
+{
+    let rejectCallback;
+    const promise = new Promise((resolve, reject) => {
+        rejectCallback = reject;
+        setTimeout(() => resolve(null), 50);
+    });
+    navigator.mediaSession.setActionHandler(action, details => rejectCallback(details.isActivating));
+    return promise;
+}
+
+function waitForToggleAction(action)
+{
+    let resolveCallback;
+    const promise = new Promise((resolve, reject) => {
+        resolveCallback = resolve;
+        setTimeout(() => reject("waitForToggleAction " + action + " timed out"), 5000);
+    });
+    navigator.mediaSession.setActionHandler(action, details => resolveCallback(details.isActivating));
+    return promise;
+}
+</script>

--- a/LayoutTests/http/wpt/mediasession/toggleCapture-expected.txt
+++ b/LayoutTests/http/wpt/mediasession/toggleCapture-expected.txt
@@ -1,0 +1,8 @@
+
+
+PASS Setup tests
+PASS togglecamera and togglemicrophone on various iframes
+PASS togglecamera and mute/unmute events order
+PASS togglemicrophone and mute/unmute events order
+PASS togglescreenshare and mute/unmute events order
+

--- a/LayoutTests/http/wpt/mediasession/toggleCapture.html
+++ b/LayoutTests/http/wpt/mediasession/toggleCapture.html
@@ -1,0 +1,141 @@
+<html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<iframe src="resources/toggleCapture-iframe.html" id=frame1></iframe>
+<iframe src="resources/toggleCapture-iframe.html" id=frame2></iframe>
+<script>
+
+promise_test(async () => {
+    return Promise.all([
+        new Promise(resolve => frame1.onload = resolve),
+        new Promise(resolve => frame2.onload = resolve),
+    ]);
+}, "Setup tests");
+
+promise_test(async (test) => {
+    if (!window.internals)
+        return;
+
+    let actionCount = 0;
+    navigator.mediaSession.setActionHandler("togglecamera", () => actionCount++);
+    navigator.mediaSession.setActionHandler("togglemicrophone", () => actionCount++);
+    navigator.mediaSession.setActionHandler("togglescreenshare", () => actionCount++);
+
+    await Promise.all([
+        frame1.contentWindow.startCapture(true, true),
+        frame2.contentWindow.startCapture(true, false)
+    ]);
+
+    let resultsPromise = Promise.all([
+        frame1.contentWindow.waitForToggleAction("togglecamera"),
+        frame1.contentWindow.waitForToggleAction("togglemicrophone"),
+        frame2.contentWindow.waitForNoToggleAction("togglecamera"),
+        frame2.contentWindow.waitForToggleAction("togglemicrophone"),
+    ]);
+    internals.setPageMuted("capturedevices");
+    assert_array_equals(await resultsPromise, [false, false, null, false]);
+
+    assert_equals(actionCount, 0);
+
+    resultsPromise = Promise.all([
+        frame1.contentWindow.waitForToggleAction("togglecamera"),
+        frame1.contentWindow.waitForToggleAction("togglemicrophone"),
+        frame2.contentWindow.waitForNoToggleAction("togglecamera"),
+        frame2.contentWindow.waitForToggleAction("togglemicrophone"),
+    ]);
+    internals.setPageMuted("");
+    assert_array_equals(await resultsPromise, [true, true, null, true]);
+
+    assert_equals(actionCount, 0);
+
+   frame1.contentWindow.stopCapture();
+   frame2.contentWindow.stopCapture();
+}, "togglecamera and togglemicrophone on various iframes");
+
+async function testActionEventOrder(track, action)
+{
+    if (!window.internals)
+        return;
+
+    let isActionHandled = false;
+    let isMuteEventFired = false;
+    let promiseAction = new Promise((resolve, reject) => {
+        setTimeout(() => reject("promiseAction timed out"), 5000);
+        navigator.mediaSession.setActionHandler(action, details => {
+            isActionHandled = true;
+            assert_false(isMuteEventFired);
+            resolve(details.isActivating);
+        });
+    });
+
+    let promiseMuteEvent = new Promise((resolve, reject) => {
+        setTimeout(() => reject("promiseMuteEvent mute timed out"), 5000);
+        track.onmute = () => {
+            isMuteEventFired = true;
+            assert_true(isActionHandled);
+            resolve();
+        };
+    });
+
+    internals.setPageMuted(action === "togglescreenshare" ? "screencapture" : "capturedevices");
+    await Promise.all([promiseAction, promiseMuteEvent]);
+
+    isActionHandled = false;
+    isMuteEventFired = false;
+    promiseAction = new Promise((resolve, reject) => {
+        setTimeout(() => reject("promiseAction timed out"), 5000);
+        navigator.mediaSession.setActionHandler(action, details => {
+            isActionHandled = true;
+            assert_false(isMuteEventFired);
+            resolve(details.isActivating);
+        });
+    });
+
+    promiseMuteEvent = new Promise((resolve, reject) => {
+        setTimeout(() => reject("promiseMuteEvent unmmute timed out"), 5000);
+        track.onunmute = () => {
+            isMuteEventFired = true;
+            assert_true(isActionHandled);
+            resolve();
+        };
+    });
+
+    internals.setPageMuted("");
+    await Promise.all([promiseAction, promiseMuteEvent]);
+}
+
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    const track = stream.getTracks()[0];
+
+    await testActionEventOrder(track, "togglecamera");
+    track.stop();
+}, "togglecamera and mute/unmute events order");
+
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const track = stream.getTracks()[0];
+
+    await testActionEventOrder(track, "togglemicrophone");
+    track.stop();
+}, "togglemicrophone and mute/unmute events order");
+
+promise_test(async () => {
+    if (!window.internals)
+        return;
+
+    let promise;
+    internals.withUserGesture(() => {
+        promise = navigator.mediaDevices.getDisplayMedia({ video: true });
+    });
+    const stream = await promise;
+    const track = stream.getTracks()[0];
+
+    await testActionEventOrder(track, "togglescreenshare");
+    track.stop();
+}, "togglescreenshare and mute/unmute events order");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -60,6 +60,8 @@ css-dark-mode [ Skip ]
 
 media/audioSession [ Skip ]
 
+http/wpt/mediasession [ Skip ]
+
 # Media Stream API testing is not supported for WK1 yet.
 fast/mediastream
 http/wpt/mediastream

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -101,6 +101,8 @@ fast/dom/HTMLLinkElement/prefetch-too-many-clients.html [ Skip ]
 # MEDIA_CAPTURE is disabled
 fast/forms/file/file-input-capture.html [ Skip ]
 
+http/wpt/mediasession [ Skip ]
+
 # MEDIA_SOURCE is disabled
 webkit.org/b/64731 fast/history/page-cache-media-source-opened.html [ Skip ]
 webkit.org/b/64731 fast/history/page-cache-media-source-closed.html [ Skip ]

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -123,6 +123,10 @@ static std::optional<std::pair<PlatformMediaSession::RemoteControlCommandType, P
     case MediaSessionAction::Settrack:
         // Not supported at present.
         break;
+    case MediaSessionAction::Togglecamera:
+    case MediaSessionAction::Togglemicrophone:
+    case MediaSessionAction::Togglescreenshare:
+        break;
     }
     if (command == PlatformMediaSession::RemoteControlCommandType::NoCommand)
         return { };
@@ -286,6 +290,7 @@ bool MediaSession::callActionHandler(const MediaSessionActionDetails& actionDeta
         Locker lock { m_actionHandlersLock };
         handler = m_actionHandlers.get(actionDetails.action);
     }
+
     if (handler) {
         std::optional<UserGestureIndicator> maybeGestureIndicator;
         if (triggerGestureIndicator == TriggerGestureIndicator::Yes)

--- a/Source/WebCore/Modules/mediasession/MediaSessionAction.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionAction.h
@@ -39,6 +39,9 @@ enum class MediaSessionAction : uint8_t {
     Skipad,
     Stop,
     Seekto,
+    Togglemicrophone,
+    Togglecamera,
+    Togglescreenshare,
     Settrack,
 };
 

--- a/Source/WebCore/Modules/mediasession/MediaSessionAction.idl
+++ b/Source/WebCore/Modules/mediasession/MediaSessionAction.idl
@@ -34,7 +34,10 @@
     "nexttrack",
     "skipad",
     "stop",
-    "seekto"
+    "seekto",
+    "togglemicrophone",
+    "togglecamera",
+    "togglescreenshare"
 #if defined(ENABLE_MEDIA_SESSION_PLAYLIST) && ENABLE_MEDIA_SESSION_PLAYLIST
     , "settrack"
 #endif

--- a/Source/WebCore/Modules/mediasession/MediaSessionActionDetails.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionActionDetails.h
@@ -36,6 +36,7 @@ struct MediaSessionActionDetails {
     std::optional<double> seekOffset;
     std::optional<double> seekTime;
     std::optional<bool> fastSeek;
+    std::optional<bool> isActivating;
 #if ENABLE(MEDIA_SESSION_PLAYLIST)
     String trackIdentifier;
 #endif

--- a/Source/WebCore/Modules/mediasession/MediaSessionActionDetails.idl
+++ b/Source/WebCore/Modules/mediasession/MediaSessionActionDetails.idl
@@ -33,6 +33,7 @@
     double? seekOffset;
     double? seekTime;
     boolean? fastSeek;
+    boolean? isActivating;
 
     [Conditional=MEDIA_SESSION_PLAYLIST, EnabledBySetting=MediaSessionPlaylistEnabled] DOMString? trackIdentifier;
 };

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -323,6 +323,10 @@ enum class VisibilityState : bool;
 enum class EventTrackingRegionsEventType : uint8_t;
 #endif
 
+#if ENABLE(MEDIA_SESSION)
+enum class MediaSessionAction : uint8_t;
+#endif
+
 using MediaProducerMediaStateFlags = OptionSet<MediaProducerMediaState>;
 using MediaProducerMutedStateFlags = OptionSet<MediaProducerMutedState>;
 using PlatformDisplayID = uint32_t;
@@ -1636,6 +1640,13 @@ public:
     void noteUserInteractionWithMediaElement();
     inline bool isCapturing() const;
     WEBCORE_EXPORT void updateIsPlayingMedia();
+
+#if ENABLE(MEDIA_STREAM) && ENABLE(MEDIA_SESSION)
+    void processCaptureStateDidChange(Function<bool(const Page&)>&&, Function<bool(const RealtimeMediaSource&)>&&, MediaSessionAction);
+    void cameraCaptureStateDidChange();
+    void microphoneCaptureStateDidChange();
+    void screenshareCaptureStateDidChange();
+#endif
     void pageMutedStateDidChange();
     void visibilityAdjustmentStateDidChange();
 


### PR DESCRIPTION
#### 6b9d0d0c4172149e7d2fc204a083ca16c27e3b16
<pre>
Trigger toggle capture actions in case page muted state changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=277261">https://bugs.webkit.org/show_bug.cgi?id=277261</a>
<a href="https://rdar.apple.com/132725520">rdar://132725520</a>

Reviewed by Jean-Yves Avenard.

When user is toggling capture mute/unmute buttons, this triggers a call to Page::setMuted.
We pipe this information to MediaSession.
We make sure to call the MediaSession action handlers:
- for documents that have live capture tracks
- before live capture tracks fire the corresponding mute/unmute event.

* LayoutTests/http/wpt/mediasession/resources/toggleCapture-iframe.html: Added.
* LayoutTests/http/wpt/mediasession/toggleCapture-expected.txt: Added.
* LayoutTests/http/wpt/mediasession/toggleCapture.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::platformCommandForMediaSessionAction):
(WebCore::MediaSession::callActionHandler):
* Source/WebCore/Modules/mediasession/MediaSessionAction.h:
* Source/WebCore/Modules/mediasession/MediaSessionAction.idl:
* Source/WebCore/Modules/mediasession/MediaSessionActionDetails.h:
* Source/WebCore/Modules/mediasession/MediaSessionActionDetails.idl:
* Source/WebCore/dom/Document.cpp:
(WebCore::hasRealtimeMediaSource):
(WebCore::Document::processCaptureStateDidChange):
(WebCore::Document::cameraCaptureStateDidChange):
(WebCore::Document::microphoneCaptureStateDidChange):
(WebCore::Document::screenshareCaptureStateDidChange):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setMuted):

Canonical link: <a href="https://commits.webkit.org/281596@main">https://commits.webkit.org/281596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1409c7ae9ae1ccfaba3dff755c4c952b88acb7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64283 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10895 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48870 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7588 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29717 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33710 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9525 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9812 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66015 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9649 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56228 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56397 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13423 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3581 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35525 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37696 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->