### PR TITLE
http/tests/xmlhttprequest/gzip-content-type-no-content-encoding.html is failing on next major OSes

### DIFF
--- a/LayoutTests/http/conf/apache2.4-darwin-httpd.conf
+++ b/LayoutTests/http/conf/apache2.4-darwin-httpd.conf
@@ -42,7 +42,7 @@ LoadModule setenvif_module libexec/apache2/mod_setenvif.so
 ServerName 127.0.0.1
 
 # Allow python CGI scripts to set the `Content-Length` header.
-SetEnvIf Request_URI "\.py$" ap_trust_cgilike_cl
+SetEnvIf Request_URI "\.py" ap_trust_cgilike_cl
 
 <Directory />
     Options Indexes FollowSymLinks MultiViews ExecCGI Includes

--- a/LayoutTests/platform/ios-17/TestExpectations
+++ b/LayoutTests/platform/ios-17/TestExpectations
@@ -80,9 +80,8 @@ imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.
 
 webkit.org/b/277067 http/tests/misc/authentication-redirect-3/authentication-sent-to-redirect-same-origin-with-location-credentials.html [ Pass ]
 
-# webkit.org/b/277198 (REGRESSION (iOS 18): 2 http/tests/xmlhttprequests layout tests are constantly failing.)
+# webkit.org/b/277198 (REGRESSION (iOS 18): chunked-progress-event-expectedLength.html is constantly failing.)
 http/tests/xmlhttprequest/chunked-progress-event-expectedLength.html [ Pass ]
-http/tests/xmlhttprequest/gzip-content-type-no-content-encoding.html [ Pass ]
 
 ###
 ### NOTICE: Unless you know that the issue for which you're setting expectations specifically only occurs on iOS 17, 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3123,8 +3123,7 @@ editing/selection/character-granularity-rect.html [ Pass ]
 webkit.org/b/184783 compositing/ios/overflow-scroll-touch-tiles.html [ Pass Failure ]
 
 # Disabled globally.
-#http/tests/xmlhttprequest/gzip-content-type-no-content-encoding.html [ Pass ]
-# FIXME: Uncomment above after webkit.org/b/277198 is resolved (new expectation set below).
+http/tests/xmlhttprequest/gzip-content-type-no-content-encoding.html [ Pass ]
 
 webkit.org/b/173041 http/tests/websocket/tests/hybi/handshake-ok-with-legacy-sec-websocket-response-headers.html [ Pass Failure ]
 
@@ -7414,7 +7413,6 @@ webkit.org/b/277195 imported/w3c/web-platform-tests/html/semantics/interactive-e
 imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-dialog-behavior.tentative.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-on-popover-behavior.tentative.html [ Failure ]
 
-# webkit.org/b/277198 (REGRESSION (iOS 18): 2 http/tests/xmlhttprequests layout tests are constantly failing.)
+# webkit.org/b/277198 (REGRESSION (iOS 18): chunked-progress-event-expectedLength.html is constantly failing.)
 # FIXME: Uncomment explicit pass expectation above when this is resolved (search for bug link)
 http/tests/xmlhttprequest/chunked-progress-event-expectedLength.html [ Failure ]
-http/tests/xmlhttprequest/gzip-content-type-no-content-encoding.html [ Failure ]


### PR DESCRIPTION
#### dd1aeb2913208ab25378408f55e87169e0b32c90
<pre>
http/tests/xmlhttprequest/gzip-content-type-no-content-encoding.html is failing on next major OSes
<a href="https://bugs.webkit.org/show_bug.cgi?id=277269">https://bugs.webkit.org/show_bug.cgi?id=277269</a>
<a href="https://rdar.apple.com/132739988">rdar://132739988</a>

Reviewed by Aakash Jain.

In 280834@main, I had landed a fix that was required to maintain pre-existing behavior after an
Apache update. Without this fix, our python scripts were no longer able to set the `Content-Length`
header. The fix unfortunately didn&apos;t cover gzip-content-type-no-content-encoding.html which the
script name ends with `.py.gz` instead of `.py`. This patch fixes the regex to cover this case
as well.

* LayoutTests/http/conf/apache2.4-darwin-httpd.conf:
* LayoutTests/platform/ios-17/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/281518@main">https://commits.webkit.org/281518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab7e2cfaa80736707d11f8d451f5c57cfe921a09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64082 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10694 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10928 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48732 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7463 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62195 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52119 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29574 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33541 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9350 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9614 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65814 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4094 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56087 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56242 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3409 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9015 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->