### PR TITLE
Expose altitudeAngle and azimuthAngle to PointerEvent

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/idlharness.https.window-expected.txt
@@ -55,8 +55,8 @@ PASS PointerEvent interface: attribute tangentialPressure
 PASS PointerEvent interface: attribute tiltX
 PASS PointerEvent interface: attribute tiltY
 PASS PointerEvent interface: attribute twist
-FAIL PointerEvent interface: attribute altitudeAngle assert_true: The prototype object must have a property "altitudeAngle" expected true got false
-FAIL PointerEvent interface: attribute azimuthAngle assert_true: The prototype object must have a property "azimuthAngle" expected true got false
+PASS PointerEvent interface: attribute altitudeAngle
+PASS PointerEvent interface: attribute azimuthAngle
 PASS PointerEvent interface: attribute pointerType
 PASS PointerEvent interface: attribute isPrimary
 PASS PointerEvent interface: operation getCoalescedEvents()
@@ -71,8 +71,8 @@ PASS PointerEvent interface: new PointerEvent("type") must inherit property "tan
 PASS PointerEvent interface: new PointerEvent("type") must inherit property "tiltX" with the proper type
 PASS PointerEvent interface: new PointerEvent("type") must inherit property "tiltY" with the proper type
 PASS PointerEvent interface: new PointerEvent("type") must inherit property "twist" with the proper type
-FAIL PointerEvent interface: new PointerEvent("type") must inherit property "altitudeAngle" with the proper type assert_inherits: property "altitudeAngle" not found in prototype chain
-FAIL PointerEvent interface: new PointerEvent("type") must inherit property "azimuthAngle" with the proper type assert_inherits: property "azimuthAngle" not found in prototype chain
+PASS PointerEvent interface: new PointerEvent("type") must inherit property "altitudeAngle" with the proper type
+PASS PointerEvent interface: new PointerEvent("type") must inherit property "azimuthAngle" with the proper type
 PASS PointerEvent interface: new PointerEvent("type") must inherit property "pointerType" with the proper type
 PASS PointerEvent interface: new PointerEvent("type") must inherit property "isPrimary" with the proper type
 PASS PointerEvent interface: new PointerEvent("type") must inherit property "getCoalescedEvents()" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_tiltX_tiltY_to_azimuth_altitude-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_tiltX_tiltY_to_azimuth_altitude-expected.txt
@@ -1,27 +1,27 @@
 
-FAIL tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=0 assert_equals: azimuth angle should be 0 expected (number) 0 but got (undefined) undefined
-FAIL tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=90 assert_equals: azimuth angle should be 1.5707963267948966 expected (number) 1.5707963267948966 but got (undefined) undefined
-FAIL tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=-90 assert_equals: azimuth angle should be 4.71238898038469 expected (number) 4.71238898038469 but got (undefined) undefined
-FAIL tiltX,tiltY to azimuth/altitude when tiltX=90 and tiltY=0 assert_equals: azimuth angle should be 0 expected (number) 0 but got (undefined) undefined
-FAIL tiltX,tiltY to azimuth/altitude when tiltX=90 and tiltY=90 assert_equals: azimuth angle should be 0 expected (number) 0 but got (undefined) undefined
-FAIL tiltX,tiltY to azimuth/altitude when tiltX=90 and tiltY=-90 assert_equals: azimuth angle should be 0 expected (number) 0 but got (undefined) undefined
-FAIL tiltX,tiltY to azimuth/altitude when tiltX=-90 and tiltY=0 assert_equals: azimuth angle should be 3.141592653589793 expected (number) 3.141592653589793 but got (undefined) undefined
-FAIL tiltX,tiltY to azimuth/altitude when tiltX=-90 and tiltY=90 assert_equals: azimuth angle should be 0 expected (number) 0 but got (undefined) undefined
-FAIL tiltX,tiltY to azimuth/altitude when tiltX=-90 and tiltY=-90 assert_equals: azimuth angle should be 0 expected (number) 0 but got (undefined) undefined
-FAIL tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=45 assert_equals: azimuth angle should be 1.5707963267948966 expected (number) 1.5707963267948966 but got (undefined) undefined
-FAIL tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=-45 assert_equals: azimuth angle should be 4.71238898038469 expected (number) 4.71238898038469 but got (undefined) undefined
-FAIL tiltX,tiltY to azimuth/altitude when tiltX=45 and tiltY=0 assert_equals: azimuth angle should be 0 expected (number) 0 but got (undefined) undefined
-FAIL tiltX,tiltY to azimuth/altitude when tiltX=-45 and tiltY=0 assert_equals: azimuth angle should be 3.141592653589793 expected (number) 3.141592653589793 but got (undefined) undefined
-FAIL tiltX/tiltY to azimuth/altitude when tiltX/tiltY are not populated assert_equals: azimuth angle should be 0 expected (number) 0 but got (undefined) undefined
-FAIL azimuth/altitude to tiltX/tiltY when azimuth=0 and altitude=0 assert_equals: tiltX angle should be 90 expected 90 but got 0
-FAIL azimuth/altitude to tiltX/tiltY when azimuth=0 and altitude=0.7853981633974483 assert_equals: tiltX angle should be 45 expected 45 but got 0
+PASS tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=0
+PASS tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=90
+PASS tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=-90
+PASS tiltX,tiltY to azimuth/altitude when tiltX=90 and tiltY=0
+PASS tiltX,tiltY to azimuth/altitude when tiltX=90 and tiltY=90
+PASS tiltX,tiltY to azimuth/altitude when tiltX=90 and tiltY=-90
+PASS tiltX,tiltY to azimuth/altitude when tiltX=-90 and tiltY=0
+PASS tiltX,tiltY to azimuth/altitude when tiltX=-90 and tiltY=90
+PASS tiltX,tiltY to azimuth/altitude when tiltX=-90 and tiltY=-90
+PASS tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=45
+PASS tiltX,tiltY to azimuth/altitude when tiltX=0 and tiltY=-45
+PASS tiltX,tiltY to azimuth/altitude when tiltX=45 and tiltY=0
+PASS tiltX,tiltY to azimuth/altitude when tiltX=-45 and tiltY=0
+PASS tiltX/tiltY to azimuth/altitude when tiltX/tiltY are not populated
+PASS azimuth/altitude to tiltX/tiltY when azimuth=0 and altitude=0
+PASS azimuth/altitude to tiltX/tiltY when azimuth=0 and altitude=0.7853981633974483
 PASS azimuth/altitude to tiltX/tiltY when azimuth=0 and altitude=1.5707963267948966
-FAIL azimuth/altitude to tiltX/tiltY when azimuth=1.5707963267948966 and altitude=0 assert_equals: tiltY angle should be 90 expected 90 but got 0
-FAIL azimuth/altitude to tiltX/tiltY when azimuth=1.5707963267948966 and altitude=0.7853981633974483 assert_equals: tiltY angle should be 45 expected 45 but got 0
-FAIL azimuth/altitude to tiltX/tiltY when azimuth=3.141592653589793 and altitude=0 assert_equals: tiltX angle should be -90 expected -90 but got 0
-FAIL azimuth/altitude to tiltX/tiltY when azimuth=3.141592653589793 and altitude=0.7853981633974483 assert_equals: tiltX angle should be -45 expected -45 but got 0
-FAIL azimuth/altitude to tiltX/tiltY when azimuth=4.71238898038469 and altitude=0 assert_equals: tiltY angle should be -90 expected -90 but got 0
-FAIL azimuth/altitude to tiltX/tiltY when azimuth=4.71238898038469 and altitude=0.7853981633974483 assert_equals: tiltY angle should be -45 expected -45 but got 0
-FAIL If only one of the values (tiltX, tiltY) or (azimuthAngle, altitudeAngle) is available the other one is set to the default value assert_equals: for (tiltX, tiltY) = (45, 0) azimuthAngle should be 0 expected (number) 0 but got (undefined) undefined
-FAIL If one of the values in both sets is provided, the other value in the set is initialized with the default value assert_equals: azimuthAngle should stay as initialized expected (number) 0.7853981633974483 but got (undefined) undefined
+PASS azimuth/altitude to tiltX/tiltY when azimuth=1.5707963267948966 and altitude=0
+PASS azimuth/altitude to tiltX/tiltY when azimuth=1.5707963267948966 and altitude=0.7853981633974483
+PASS azimuth/altitude to tiltX/tiltY when azimuth=3.141592653589793 and altitude=0
+PASS azimuth/altitude to tiltX/tiltY when azimuth=3.141592653589793 and altitude=0.7853981633974483
+PASS azimuth/altitude to tiltX/tiltY when azimuth=4.71238898038469 and altitude=0
+PASS azimuth/altitude to tiltX/tiltY when azimuth=4.71238898038469 and altitude=0.7853981633974483
+PASS If only one of the values (tiltX, tiltY) or (azimuthAngle, altitudeAngle) is available the other one is set to the default value
+PASS If one of the values in both sets is provided, the other value in the set is initialized with the default value
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -464,6 +464,22 @@ AlternateWebMPlayerEnabled:
       default: true
     WebCore:
       default: true
+      
+AltitudeAngleEnabled:
+  type: bool
+  status: stable
+  category: dom
+  humanReadableName: "altitudeAngle PointerEvent Property"
+  humanReadableDescription: "Enable the `altitudeAngle` property of the PointerEvents API"
+  defaultValue:
+    WebKitLegacy:
+     default: false
+    WebKit:
+      "PLATFORM(COCOA)": true
+      default: false
+    WebCore:
+      "PLATFORM(COCOA)": true
+      default: false
 
 AlwaysAllowLocalWebarchive:
   type: bool
@@ -747,6 +763,22 @@ AuxclickEventEnabled:
       default: true
     WebCore:
       default: true
+
+AzimuthAngleEnabled:
+  type: bool
+  status: stable
+  category: dom
+  humanReadableName: "azimuthAngle PointerEvent Property"
+  humanReadableDescription: "Enable the `azimuthAngle` property of the PointerEvents API"
+  defaultValue:
+    WebKitLegacy:
+     default: false
+    WebKit:
+      "PLATFORM(COCOA)": true
+      default: false
+    WebCore:
+      "PLATFORM(COCOA)": true
+      default: false
 
 BackgroundFetchAPIEnabled:
   type: bool

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -36,6 +36,16 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(PointerEvent);
 
+typedef struct PointerEventTilt {
+    long tiltX;
+    long tiltY;
+} PointerEventTilt;
+
+typedef struct PointerEventAngle {
+    double altitudeAngle;
+    double azimuthAngle;
+} PointerEventAngle;
+
 static AtomString pointerEventType(const AtomString& mouseEventType)
 {
     auto& names = eventNames();
@@ -86,6 +96,47 @@ PointerEvent::PointerEvent()
 {
 }
 
+// Calculated in accordance with https://w3c.github.io/pointerevents/#converting-between-tiltx-tilty-and-altitudeangle-azimuthangle.
+static PointerEventAngle angleFromTilt(long tiltX, long tiltY)
+{
+    const double tiltXRadians = tiltX * radiansPerDegreeDouble;
+    const double tiltYRadians = tiltY * radiansPerDegreeDouble;
+    double azimuthAngle = 0;
+
+    if (!tiltX && tiltY)
+        azimuthAngle = tiltY > 0 ? piOverTwoDouble : 3 * piOverTwoDouble;
+    else if (tiltX && !tiltY)
+        azimuthAngle = tiltX < 0 ? piDouble : azimuthAngle;
+    else if (abs(tiltX) == 90 || abs(tiltY) == 90)
+        azimuthAngle = 0;
+    else {
+        azimuthAngle = atan2(tan(tiltYRadians), tan(tiltXRadians));
+        azimuthAngle = azimuthAngle < 0 ? azimuthAngle + radiansPerTurnDouble : azimuthAngle;
+    }
+
+    double altitudeAngle = 0;
+
+    if (abs(tiltX) == 90 || abs(tiltY) == 90)
+        altitudeAngle = 0;
+    else if (!tiltX)
+        altitudeAngle = piOverTwoDouble - abs(tiltYRadians);
+    else if (!tiltY)
+        altitudeAngle = piOverTwoDouble - abs(tiltXRadians);
+    else
+        altitudeAngle =  atan(1.0 / sqrt(pow(tan(tiltXRadians), 2) + pow(tan(tiltYRadians), 2)));
+
+    return { altitudeAngle, azimuthAngle };
+}
+
+// This algorithm is equivalent to the one provided in https://w3c.github.io/pointerevents/#converting-between-tiltx-tilty-and-altitudeangle-azimuthangle.
+static PointerEventTilt tiltFromAngle(double altitudeAngle, double azimuthAngle)
+{
+    double tiltXRadians = WTF::areEssentiallyEqual(altitudeAngle, 0.0) ? cos(azimuthAngle) * piOverTwoDouble : atan(cos(azimuthAngle) / tan(altitudeAngle));
+    double tiltYRadians = WTF::areEssentiallyEqual(altitudeAngle, 0.0) ? sin(azimuthAngle) * piOverTwoDouble : atan(sin(azimuthAngle) / tan(altitudeAngle));
+
+    return { static_cast<long>(round(tiltXRadians * degreesPerRadianDouble)), static_cast<long>(round(tiltYRadians * degreesPerRadianDouble)) };
+}
+
 PointerEvent::PointerEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
     : MouseEvent(EventInterfaceType::PointerEvent, type, initializer, isTrusted)
     , m_pointerId(initializer.pointerId)
@@ -96,11 +147,24 @@ PointerEvent::PointerEvent(const AtomString& type, Init&& initializer, IsTrusted
     , m_tiltX(initializer.tiltX)
     , m_tiltY(initializer.tiltY)
     , m_twist(initializer.twist)
+    , m_altitudeAngle(initializer.altitudeAngle)
+    , m_azimuthAngle(initializer.azimuthAngle)
     , m_pointerType(initializer.pointerType)
     , m_isPrimary(initializer.isPrimary)
     , m_coalescedEvents(initializer.coalescedEvents)
     , m_predictedEvents(initializer.predictedEvents)
 {
+    // A pair of components is complete when both or no values have been initialized to non-default values.
+    bool tiltComponentsComplete = !initializer.tiltX == !initializer.tiltY;
+    bool angleComponentsComplete = !initializer.azimuthAngle == (initializer.altitudeAngle == piOverTwoDouble);
+
+    PointerEventAngle angle = angleFromTilt(m_tiltX, m_tiltY);
+    PointerEventTilt tilt = tiltFromAngle(m_altitudeAngle, m_azimuthAngle);
+
+    m_altitudeAngle = angleComponentsComplete ? angle.altitudeAngle : m_altitudeAngle;
+    m_azimuthAngle = angleComponentsComplete ? angle.azimuthAngle : m_azimuthAngle;
+    m_tiltX = tiltComponentsComplete ? tilt.tiltX : m_tiltX;
+    m_tiltY = tiltComponentsComplete ? tilt.tiltY : m_tiltY;
 }
 
 static Vector<Ref<PointerEvent>> createCoalescedPointerEvents(const AtomString& type, MouseButton button, const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -56,6 +56,8 @@ public:
         long tiltX { 0 };
         long tiltY { 0 };
         long twist { 0 };
+        double altitudeAngle { piOverTwoDouble };
+        double azimuthAngle { 0 };
         String pointerType { mousePointerEventType() };
         bool isPrimary { false };
         Vector<Ref<PointerEvent>> coalescedEvents;
@@ -106,6 +108,8 @@ public:
     long tiltX() const { return m_tiltX; }
     long tiltY() const { return m_tiltY; }
     long twist() const { return m_twist; }
+    double altitudeAngle() const { return m_altitudeAngle; }
+    double azimuthAngle() const { return m_azimuthAngle; }
     String pointerType() const { return m_pointerType; }
     bool isPrimary() const { return m_isPrimary; }
 
@@ -163,6 +167,8 @@ private:
     long m_tiltX { 0 };
     long m_tiltY { 0 };
     long m_twist { 0 };
+    double m_altitudeAngle { piOverTwoDouble };
+    double m_azimuthAngle { 0 };
     String m_pointerType { mousePointerEventType() };
     bool m_isPrimary { false };
     Vector<Ref<PointerEvent>> m_coalescedEvents;

--- a/Source/WebCore/dom/PointerEvent.idl
+++ b/Source/WebCore/dom/PointerEvent.idl
@@ -32,6 +32,8 @@ dictionary PointerEventInit : MouseEventInit {
     long tiltX = 0;
     long tiltY = 0;
     long twist = 0;
+    [EnabledBySetting=AltitudeAngleEnabled] double altitudeAngle;
+    [EnabledBySetting=AzimuthAngleEnabled] double azimuthAngle;
     DOMString pointerType = "";
     boolean isPrimary = false;
     [EnabledBySetting=GetCoalescedEventsEnabled] sequence<PointerEvent> coalescedEvents = [];
@@ -54,6 +56,8 @@ dictionary PointerEventInit : MouseEventInit {
     readonly attribute long tiltX;
     readonly attribute long tiltY;
     readonly attribute long twist;
+    [EnabledBySetting=AltitudeAngleEnabled] readonly attribute double altitudeAngle;
+    [EnabledBySetting=AzimuthAngleEnabled] readonly attribute double azimuthAngle;
     readonly attribute DOMString pointerType;
     readonly attribute boolean isPrimary;
 

--- a/Source/WebCore/dom/ios/PointerEventIOS.cpp
+++ b/Source/WebCore/dom/ios/PointerEventIOS.cpp
@@ -82,13 +82,10 @@ PointerEvent::PointerEvent(const AtomString& type, const PlatformTouchEvent& eve
     , m_coalescedEvents(coalescedEvents)
     , m_predictedEvents(predictedEvents)
 {
-    // See https://github.com/w3c/pointerevents/issues/274. We might expose the azimuth and altitude
-    // directly as well as the tilt.
-    double azimuthAngle = event.azimuthAngleAtIndex(index);
-    double altitudeAngle = event.altitudeAngleAtIndex(index);
-
-    m_tiltX = round(cos(azimuthAngle) * cos(altitudeAngle) * 90);
-    m_tiltY = round(sin(azimuthAngle) * cos(altitudeAngle) * 90);
+    m_azimuthAngle = event.azimuthAngleAtIndex(index);
+    m_altitudeAngle = event.altitudeAngleAtIndex(index);
+    m_tiltX = round(cos(m_azimuthAngle) * cos(m_altitudeAngle) * 90);
+    m_tiltY = round(sin(m_azimuthAngle) * cos(m_altitudeAngle) * 90);
 }
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
@@ -339,7 +339,7 @@ static unsigned nextTouchIdentifier()
             touchPoint.azimuthAngle = [touch azimuthAngleInView:self.view.window];
         } else {
             touchPoint.touchType = WebKit::WKTouchPointType::Direct;
-            touchPoint.altitudeAngle = 0;
+            touchPoint.altitudeAngle = piOverTwoDouble;
             touchPoint.azimuthAngle = 0;
         }
 


### PR DESCRIPTION
#### 1b6a1bb6dfcbbc09d6e224de75eb932a2e97c64d
<pre>
Expose altitudeAngle and azimuthAngle to PointerEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=276755">https://bugs.webkit.org/show_bug.cgi?id=276755</a>
<a href="https://rdar.apple.com/131974392">rdar://131974392</a>

Reviewed by Abrar Rahman Protyasha.

These changes make the altitudeAngle and azimuthAngle attributes accessible as part of the PointerEvent interface.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::PointerEvent):
* Source/WebCore/dom/PointerEvent.h:
* Source/WebCore/dom/PointerEvent.idl:
* Source/WebCore/dom/ios/PointerEventIOS.cpp:
(WebCore::m_isPrimary):
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm:

Canonical link: <a href="https://commits.webkit.org/282017@main">https://commits.webkit.org/282017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c8f8d84386255549a6499ab73adb8cbe5c86480

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65609 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12180 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49727 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8453 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30560 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10618 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11111 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54730 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67337 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60876 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57103 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57323 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13743 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4588 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82637 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36789 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14446 "Found 1466 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-medium.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-small.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm.js.no-cjit-validate-phases, microbenchmarks/wasm-cc-int-to-int.js.default-wasm, stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37873 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38969 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->