### PR TITLE
Adding Glyph display list COLRv0 shared test

### DIFF
--- a/LayoutTests/fast/text/glyph-display-lists/glyph-display-list-colr-shared-expected.txt
+++ b/LayoutTests/fast/text/glyph-display-lists/glyph-display-list-colr-shared-expected.txt
@@ -1,0 +1,2 @@
+PASS: Display lists match.
+

--- a/LayoutTests/fast/text/glyph-display-lists/glyph-display-list-colr-shared.html
+++ b/LayoutTests/fast/text/glyph-display-lists/glyph-display-list-colr-shared.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+if (window.internals)
+    internals.setForceUseGlyphDisplayListForTesting(true);
+</script>
+<body onload="run()">
+<style>
+@font-face {
+    font-family: "Ahem COLR";
+    src: url("../resources/Ahem-COLR.ttf") format("truetype");
+}
+span { font: 48px Ahem COLR; }
+</style>
+<div id=container>
+    <span id=first>A</span>
+    <span id=second>A</span>
+</div>
+<pre id=log></pre>
+<script>
+function run() {
+    requestAnimationFrame(function() {
+        requestAnimationFrame(function() {
+            if (window.internals) {
+                let firstDisplayListWithResourceIDs = internals.cachedGlyphDisplayListsForTextNode(first.firstChild, internals.DISPLAY_LIST_INCLUDE_RESOURCE_IDENTIFIERS);
+                let secondDisplayListWithResourceIDs = internals.cachedGlyphDisplayListsForTextNode(second.firstChild, internals.DISPLAY_LIST_INCLUDE_RESOURCE_IDENTIFIERS);
+                if (firstDisplayListWithResourceIDs == secondDisplayListWithResourceIDs)
+                    log.textContent = "PASS: Display lists match.\n";
+                else
+                    log.textContent = "FAIL: Display lists do not match." + internals.cachedGlyphDisplayListsForTextNode(first.firstChild);
+                internals.setForceUseGlyphDisplayListForTesting(false);
+                container.remove();
+            }
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    });
+}
+</script>


### PR DESCRIPTION
#### af007e7018ef838fd83c60ea5c96841420245278
<pre>
Adding Glyph display list COLRv0 shared test
<a href="https://bugs.webkit.org/show_bug.cgi?id=277288">https://bugs.webkit.org/show_bug.cgi?id=277288</a>
<a href="https://rdar.apple.com/117866670">rdar://117866670</a>

Reviewed by Cameron McCormack and Brent Fulgham.

LayoutTests/fast/text/glyph-display-lists/glyph-display-list-colr-unshared.html tests that glyph
display lists for COLRv0 glyphs are not cached.

However, after a CoreText update, WebKit had to introduce drawPath delegates for DrawGlyphsRecorderCoreText.cpp.
The glyphs that are drawn as a path, and not as a glyph, by CoreText, were failing this test, because they share same
display list, which is dictated by GlyphDisplayListCache::canShareDisplayList .

Since this test is covering the unshared behavior, we should have another test for shared behavior.
The glyph of the character &quot;A&quot; from Ahem-COLR font is a multi-coloured glyph, drawn as a path,
and therefore a Glyph display list containing only items representing this glyph can be shared.

* LayoutTests/fast/text/glyph-display-lists/glyph-display-list-colr-shared-expected.txt: Added.
* LayoutTests/fast/text/glyph-display-lists/glyph-display-list-colr-shared.html: Added.

Canonical link: <a href="https://commits.webkit.org/281533@main">https://commits.webkit.org/281533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9795f8fd64070ac9c2292f74808202e35380e9fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64146 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10757 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10991 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48772 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/7496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62258 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29615 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9399 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9677 "Hash 9795f8fd for PR 31414 does not build (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65877 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4157 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56129 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56286 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3457 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->