### PR TITLE
Add WebXR Enabled features

### DIFF
--- a/LayoutTests/http/wpt/webxr/resources/webxr_test_constants_single_view.js
+++ b/LayoutTests/http/wpt/webxr/resources/webxr_test_constants_single_view.js
@@ -300,3 +300,15 @@ const SCREEN_CONTROLLER = {
     pointerOrigin: VALID_POINTER_TRANSFORM,
     profiles: []
 };
+
+const FIRST_PERSON_OFFSET = {
+  position: [0, 0.1, 0],
+  orientation: [0, 0, 0, 1]
+};
+
+// From: https://immersive-web.github.io/webxr/#default-features
+const DEFAULT_FEATURES = {
+  "inline": ["viewer"],
+  "immersive-vr": ["viewer", "local"],
+  "immersive-ar": ["viewer", "local"],
+};

--- a/LayoutTests/http/wpt/webxr/xrSession_enabledFeatures-expected.txt
+++ b/LayoutTests/http/wpt/webxr/xrSession_enabledFeatures-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Validate enabledFeatures on XRSession - webgl
+PASS Validate enabledFeatures on XRSession - webgl2
+

--- a/LayoutTests/http/wpt/webxr/xrSession_enabledFeatures.html
+++ b/LayoutTests/http/wpt/webxr/xrSession_enabledFeatures.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<body>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="resources/webxr_util.js"></script>
+<script src="resources/webxr_test_constants_single_view.js"></script>
+<canvas></canvas>
+<script>
+
+  const testName = "Validate enabledFeatures on XRSession";
+
+  const supportedFeatureList = [
+    'viewer',
+    'local',
+    'local-floor',
+    'anchors',
+    'hit-test',
+    'dom-overlay',
+    'hand-tracking',
+  ];
+
+  const fakeDeviceInitParams = {
+    supportsImmersive: true,
+    supportedModes: ["inline", "immersive-vr"],
+    views: VALID_VIEWS,
+    viewerOrigin: IDENTITY_TRANSFORM,
+    supportedFeatures: supportedFeatureList
+  };
+
+  // NOTE: We explicit don't ask for the 'default' features of viewer/local to
+  // verify that they are being added here.
+  const requestFeatures = [
+    'local-floor',
+    // 'anchors', Anchors is currently not supported in WebKit
+    'secondary-views',
+    'camera-access'
+  ];
+
+const testFunction = function(session, fakeDeviceController, t) {
+  return new Promise((resolve,reject) => {
+    const unsupportedRequestedFeatures = [];
+
+    for (const feature of requestFeatures) {
+      if (!supportedFeatureList.includes(feature)) {
+        unsupportedRequestedFeatures.push(feature);
+      } 
+    }
+
+    const enabledFeatures = session.enabledFeatures;
+    const modeDefaultFeatures = DEFAULT_FEATURES[session.mode];
+
+    t.step(() => {
+      // Whether they were requested or not, all Default features should be
+      // enabled.
+      for (const feature of modeDefaultFeatures) {
+        assert_true(enabledFeatures.includes(feature),
+          "Did not support default feature: " + feature);
+      }
+
+      // Assert that we asked for everything that was included apart from the
+      // default features
+      for (const feature of enabledFeatures) {
+        assert_true(requestFeatures.includes(feature) ||
+                    modeDefaultFeatures.includes(feature),
+                    "Enabled unrequested feature: " + feature);
+      }
+
+      // Assert that all of the features we asked are either excluded because
+      // they were unsupported, or included because they were supported.
+      for (const feature of requestFeatures) {
+        if (unsupportedRequestedFeatures.includes(feature)) {
+          assert_false(enabledFeatures.includes(feature),
+            "Enabled supposedly unsupported feature: " + feature);
+        } else {
+          assert_true(enabledFeatures.includes(feature),
+            "Did not enable supposedly supported feature: " + feature);
+        }
+      }
+    });
+
+    resolve();
+  });
+};
+
+xr_session_promise_test(testName, testFunction,
+  fakeDeviceInitParams, 'immersive-vr', { optionalFeatures: requestFeatures });
+
+</script>
+</body>

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -34,6 +34,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSWebXRReferenceSpace.h"
 #include "Page.h"
+#include "PlatformXR.h"
 #include "SecurityOrigin.h"
 #include "WebCoreOpaqueRoot.h"
 #include "WebXRBoundedReferenceSpace.h"
@@ -108,6 +109,22 @@ const WebXRRenderState& WebXRSession::renderState() const
 const WebXRInputSourceArray& WebXRSession::inputSources() const
 {
     return m_inputSources;
+}
+
+// https://www.w3.org/TR/webxr/#dom-xrsession-enabledfeatures
+const Vector<String> WebXRSession::enabledFeatures() const
+{
+    Vector<String> enabledFeatureArray;
+    unsigned i = 0;
+    for (PlatformXR::SessionFeature feature : m_requestedFeatures) {
+        String sessionFeature = PlatformXR::sessionFeatureDescriptor(feature);
+        if (sessionFeature != ""_s) {
+            enabledFeatureArray.insert(i, sessionFeature);
+            i++;
+        }
+    }
+
+    return enabledFeatureArray;
 }
 
 // https://immersive-web.github.io/webxr/#dom-xrsession-updaterenderstate

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -79,6 +79,8 @@ public:
     const WebXRInputSourceArray& inputSources() const;
     RefPtr<PlatformXR::Device> device() const { return m_device.get(); }
 
+    const Vector<String> enabledFeatures() const;
+
     ExceptionOr<void> updateRenderState(const XRRenderStateInit&);
     void requestReferenceSpace(XRReferenceSpaceType, RequestReferenceSpacePromise&&);
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.idl
+++ b/Source/WebCore/Modules/webxr/WebXRSession.idl
@@ -37,6 +37,7 @@
     readonly attribute XRVisibilityState visibilityState;
     [SameObject] readonly attribute WebXRRenderState renderState;
     [SameObject] readonly attribute WebXRInputSourceArray inputSources;
+    [SameObject] readonly attribute sequence<DOMString> enabledFeatures;
 
     // Methods
     undefined updateRenderState(optional XRRenderStateInit stateInit);


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=277155

Reviewed by NOBODY (OOPS!).

Add the `enabledFeatures` property to WebXR Sessions.

* Source/WebCore/Modules/webxr/WebXRSession.cpp: Modified to add EnabledFeatures Property
* Source/WebCore/Modules/webxr/WebXRSession.h: Modified to add EnabledFeatures Property
* Source/WebCore/Modules/webxr/WebXRSession.idl: Modified to add EnabledFeatures Property
* LayoutTests/http/wpt/webxr/xrSession_enabledFeatures.html: Added, Imported from WPT. Modified to not test for anchor support which is unsupported in WebKit.
* LayoutTests/http/wpt/webxr/xrSession_enabledFeatures-expected.txt: Added, Imported from WPT.
* LayoutTests/http/wpt/webxr/resources/webxr_test_constants_single_view.js: Modified, Updated by importing from WPT.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3229e1ef6d7082842d25fb7a56e1838000cdfe1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/60221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/39569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/12773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/10751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/62351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/47241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/10985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/64140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/10751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/62252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/47241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/12773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/47241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/12773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/9671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/47241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/12773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/65871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/4151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/10985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/65871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/4170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/12773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/65871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->