### PR TITLE
Crash in RenderStyle::fontCascade

### DIFF
--- a/LayoutTests/fast/canvas/canvas-filter-font-relative-unit-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-filter-font-relative-unit-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash

--- a/LayoutTests/fast/canvas/canvas-filter-font-relative-unit.html
+++ b/LayoutTests/fast/canvas/canvas-filter-font-relative-unit.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <canvas id="canvas"></canvas>
+    <p>This test passes if it does not crash</p>
+
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        const canvas = document.getElementById('canvas');
+        const context = canvas.getContext('2d');
+        context.filter = 'drop-shadow(0em 1em green)';
+    </script>
+</body>
+</html>
+

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -92,7 +92,9 @@ std::optional<FilterOperations> CSSPropertyParserWorkerSafe::parseFilterString(c
     if (!parsedValue)
         return std::nullopt;
 
-    return Style::createFilterOperations(document, style, CSSToLengthConversionData(), *parsedValue);
+    CSSToLengthConversionData conversionData { style, nullptr, nullptr, nullptr };
+
+    return Style::createFilterOperations(document, style, conversionData, *parsedValue);
 }
 
 static CSSParserMode parserMode(ScriptExecutionContext& context)


### PR DESCRIPTION
#### 4297065d4e78029ce0a054923693c2fced491cd5
<pre>
Crash in RenderStyle::fontCascade
<a href="https://rdar.apple.com/132430589">rdar://132430589</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=277029">https://bugs.webkit.org/show_bug.cgi?id=277029</a>

Reviewed by Said Abou-Hallawa.

278000@main introduced support for CanvasRenderingContext2D.filter. The filter string
is parsed by CSSPropertyParserWorkerSafe::parseFilterString, which calls
Style::createFilterOperations to build a filter object from the filter
string. Style::createFilterOperations takes a CSSToLengthConversionData to help
convert CSS lengths in the filter string. If the length is a relative length
e.g &quot;drop-shadow(10em)&quot;, CSSToLengthConversionData consults the element style to
figure out the length of an em. However, we didn&apos;t pass the current element style
to CSSToLengthConversionData, hence the style pointer it holds is null, and
trying to resolve a relative length crashes with a null pointer dereference.

Test: LayoutTests/fast/canvas/canvas-filter-font-relative-unit.html

* LayoutTests/fast/canvas/canvas-filter-font-relative-unit-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-filter-font-relative-unit.html: Added.
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserWorkerSafe::parseFilterString): Pass the current element style
to CSSToLengthConversionData.

Canonical link: <a href="https://commits.webkit.org/281546@main">https://commits.webkit.org/281546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b4c6ed41a39149525ce1c415d9df0ee9c9f7350

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64173 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11018 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48792 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7507 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29631 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33621 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9427 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9704 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65904 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4189 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56151 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4211 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56308 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13374 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3488 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->