### PR TITLE
Add the `enabledFeatures` property to WebXR Sessions.

### DIFF
--- a/LayoutTests/http/wpt/webxr/resources/webxr_test_constants_single_view.js
+++ b/LayoutTests/http/wpt/webxr/resources/webxr_test_constants_single_view.js
@@ -300,3 +300,15 @@ const SCREEN_CONTROLLER = {
     pointerOrigin: VALID_POINTER_TRANSFORM,
     profiles: []
 };
+
+const FIRST_PERSON_OFFSET = {
+  position: [0, 0.1, 0],
+  orientation: [0, 0, 0, 1]
+};
+
+// From: https://immersive-web.github.io/webxr/#default-features
+const DEFAULT_FEATURES = {
+  "inline": ["viewer"],
+  "immersive-vr": ["viewer", "local"],
+  "immersive-ar": ["viewer", "local"],
+};

--- a/LayoutTests/http/wpt/webxr/xrSession_enabledFeatures-expected.txt
+++ b/LayoutTests/http/wpt/webxr/xrSession_enabledFeatures-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Validate enabledFeatures on XRSession - webgl
+PASS Validate enabledFeatures on XRSession - webgl2
+

--- a/LayoutTests/http/wpt/webxr/xrSession_enabledFeatures.html
+++ b/LayoutTests/http/wpt/webxr/xrSession_enabledFeatures.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<body>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="resources/webxr_util.js"></script>
+<script src="resources/webxr_test_constants_single_view.js"></script>
+<canvas></canvas>
+<script>
+
+  const testName = "Validate enabledFeatures on XRSession";
+
+  const supportedFeatureList = [
+    'viewer',
+    'local',
+    'local-floor',
+    'anchors',
+    'hit-test',
+    'dom-overlay',
+    'hand-tracking',
+  ];
+
+  const fakeDeviceInitParams = {
+    supportsImmersive: true,
+    supportedModes: ["inline", "immersive-vr"],
+    views: VALID_VIEWS,
+    viewerOrigin: IDENTITY_TRANSFORM,
+    supportedFeatures: supportedFeatureList
+  };
+
+  // NOTE: We explicit don't ask for the 'default' features of viewer/local to
+  // verify that they are being added here.
+  const requestFeatures = [
+    'local-floor',
+    // 'anchors', Anchors is currently not supported in WebKit
+    'secondary-views',
+    'camera-access'
+  ];
+
+const testFunction = function(session, fakeDeviceController, t) {
+  return new Promise((resolve,reject) => {
+    const unsupportedRequestedFeatures = [];
+
+    for (const feature of requestFeatures) {
+      if (!supportedFeatureList.includes(feature)) {
+        unsupportedRequestedFeatures.push(feature);
+      } 
+    }
+
+    const enabledFeatures = session.enabledFeatures;
+    const modeDefaultFeatures = DEFAULT_FEATURES[session.mode];
+
+    t.step(() => {
+      // Whether they were requested or not, all Default features should be
+      // enabled.
+      for (const feature of modeDefaultFeatures) {
+        assert_true(enabledFeatures.includes(feature),
+          "Did not support default feature: " + feature);
+      }
+
+      // Assert that we asked for everything that was included apart from the
+      // default features
+      for (const feature of enabledFeatures) {
+        assert_true(requestFeatures.includes(feature) ||
+                    modeDefaultFeatures.includes(feature),
+                    "Enabled unrequested feature: " + feature);
+      }
+
+      // Assert that all of the features we asked are either excluded because
+      // they were unsupported, or included because they were supported.
+      for (const feature of requestFeatures) {
+        if (unsupportedRequestedFeatures.includes(feature)) {
+          assert_false(enabledFeatures.includes(feature),
+            "Enabled supposedly unsupported feature: " + feature);
+        } else {
+          assert_true(enabledFeatures.includes(feature),
+            "Did not enable supposedly supported feature: " + feature);
+        }
+      }
+    });
+
+    resolve();
+  });
+};
+
+xr_session_promise_test(testName, testFunction,
+  fakeDeviceInitParams, 'immersive-vr', { optionalFeatures: requestFeatures });
+
+</script>
+</body>

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -34,6 +34,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSWebXRReferenceSpace.h"
 #include "Page.h"
+#include "PlatformXR.h"
 #include "SecurityOrigin.h"
 #include "WebCoreOpaqueRoot.h"
 #include "WebXRBoundedReferenceSpace.h"
@@ -108,6 +109,19 @@ const WebXRRenderState& WebXRSession::renderState() const
 const WebXRInputSourceArray& WebXRSession::inputSources() const
 {
     return m_inputSources;
+}
+
+// https://www.w3.org/TR/webxr/#dom-xrsession-enabledfeatures
+const Vector<String> WebXRSession::enabledFeatures() const
+{
+    Vector<String> enabledFeatureArray;
+    for (const auto& feature : m_requestedFeatures) {
+        String sessionFeature = PlatformXR::sessionFeatureDescriptor(feature);
+        if (sessionFeature != ""_s)
+            enabledFeatureArray.append(WTFMove(sessionFeature));
+    }
+
+    return enabledFeatureArray;
 }
 
 // https://immersive-web.github.io/webxr/#dom-xrsession-updaterenderstate

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -79,6 +79,8 @@ public:
     const WebXRInputSourceArray& inputSources() const;
     RefPtr<PlatformXR::Device> device() const { return m_device.get(); }
 
+    const Vector<String> enabledFeatures() const;
+
     ExceptionOr<void> updateRenderState(const XRRenderStateInit&);
     void requestReferenceSpace(XRReferenceSpaceType, RequestReferenceSpacePromise&&);
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.idl
+++ b/Source/WebCore/Modules/webxr/WebXRSession.idl
@@ -37,6 +37,7 @@
     readonly attribute XRVisibilityState visibilityState;
     [SameObject] readonly attribute WebXRRenderState renderState;
     [SameObject] readonly attribute WebXRInputSourceArray inputSources;
+    [SameObject] readonly attribute sequence<DOMString> enabledFeatures;
 
     // Methods
     undefined updateRenderState(optional XRRenderStateInit stateInit);


### PR DESCRIPTION
#### 2b89d244a43e806e1d15711b74b51e0cc4452537
<pre>
Add the `enabledFeatures` property to WebXR Sessions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277155">https://bugs.webkit.org/show_bug.cgi?id=277155</a>

Reviewed by Mike Wyrzykowski.

Add the `enabledFeatures` property to WebXR Sessions.

* Source/WebCore/Modules/webxr/WebXRSession.cpp: Modified to add EnabledFeatures Property
* Source/WebCore/Modules/webxr/WebXRSession.h: Modified to add EnabledFeatures Property
* Source/WebCore/Modules/webxr/WebXRSession.idl: Modified to add EnabledFeatures Property
* LayoutTests/http/wpt/webxr/xrSession_enabledFeatures.html: Added, Imported from WPT. Modified to not test for anchor support which is unsupported in WebKit.
* LayoutTests/http/wpt/webxr/xrSession_enabledFeatures-expected.txt: Added, Imported from WPT.
* LayoutTests/http/wpt/webxr/resources/webxr_test_constants_single_view.js: Modified, Updated by importing from WPT.

Canonical link: <a href="https://commits.webkit.org/281643@main">https://commits.webkit.org/281643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31530d3a2ab1852c59c3781d4913cf92ba98e16b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64417 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11031 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48949 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7674 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29781 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9644 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9946 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9925 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66148 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9752 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56316 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56494 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/13471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3676 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35657 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36739 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->