### PR TITLE
Add conditions for sidebarAction / sidePanel to WebExtensionAPINamespace::isPropertyAllowed.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.mm
@@ -42,6 +42,7 @@ _WKWebExtensionPermission const _WKWebExtensionPermissionMenus = @"menus";
 _WKWebExtensionPermission const _WKWebExtensionPermissionNativeMessaging = @"nativeMessaging";
 _WKWebExtensionPermission const _WKWebExtensionPermissionNotifications = @"notifications";
 _WKWebExtensionPermission const _WKWebExtensionPermissionScripting = @"scripting";
+_WKWebExtensionPermission const _WKWebExtensionPermissionSidePanel = @"sidePanel";
 _WKWebExtensionPermission const _WKWebExtensionPermissionStorage = @"storage";
 _WKWebExtensionPermission const _WKWebExtensionPermissionTabs = @"tabs";
 _WKWebExtensionPermission const _WKWebExtensionPermissionUnlimitedStorage = @"unlimitedStorage";

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermissionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermissionPrivate.h
@@ -28,3 +28,7 @@
 /*! @abstract The `notifications` permission requests access to the `browser.notifications` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionNotifications;
+
+/*! @abstract The `sidePanel` permission requests access to the `browser.sidePanel` APIs. */
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionSidePanel;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -2103,7 +2103,11 @@ const WebExtension::PermissionsSet& WebExtension::supportedPermissions()
     static MainThreadNeverDestroyed<PermissionsSet> permissions = std::initializer_list<String> { _WKWebExtensionPermissionActiveTab, _WKWebExtensionPermissionAlarms, _WKWebExtensionPermissionClipboardWrite,
         _WKWebExtensionPermissionContextMenus, _WKWebExtensionPermissionCookies, _WKWebExtensionPermissionDeclarativeNetRequest, _WKWebExtensionPermissionDeclarativeNetRequestFeedback,
         _WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess, _WKWebExtensionPermissionMenus, _WKWebExtensionPermissionNativeMessaging, _WKWebExtensionPermissionNotifications, _WKWebExtensionPermissionScripting,
-        _WKWebExtensionPermissionStorage, _WKWebExtensionPermissionTabs, _WKWebExtensionPermissionUnlimitedStorage, _WKWebExtensionPermissionWebNavigation, _WKWebExtensionPermissionWebRequest };
+        _WKWebExtensionPermissionStorage, _WKWebExtensionPermissionTabs, _WKWebExtensionPermissionUnlimitedStorage, _WKWebExtensionPermissionWebNavigation, _WKWebExtensionPermissionWebRequest,
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+        _WKWebExtensionPermissionSidePanel,
+#endif
+    };
     return permissions;
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -75,14 +75,14 @@ bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPa
         return !extensionContext().supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext().manifest(), @"page_action", false);
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
-    // FIXME: <https://webkit.org/b/276833> Check if the sidebar feature flag is enabled and if we have the sidePanel permission to determine if this property should be visible
+    // If the extension requests both sidePanel and sidebarAction, we will give them sidebarAction --
+    // we check in sidePanel that there is no sidebar_action key, but we do not check in sidebarAction
+    // that there is no sidePanel permission
     if (name == "sidePanel"_s)
-        return false;
-
-    // FIXME: <https://webkit.org/b/276833> Check if the sidebar feature flag is enabled and if we have a sidebarAction key in the manifest to determine if this property should be visible
+        return page->corePage()->settings().webExtensionSidebarEnabled() && extensionContext().hasPermission("sidePanel"_s) && !objectForKey<NSDictionary>(extensionContext().manifest(), @"sidebar_action", true);
     if (name == "sidebarAction"_s)
-        return false;
-#endif
+        return page->corePage()->settings().webExtensionSidebarEnabled() && objectForKey<NSDictionary>(extensionContext().manifest(), @"sidebar_action", true);
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
     if (name == "storage"_s)
         return extensionContext().hasPermission(name) || extensionContext().hasPermission("unlimitedStorage"_s);

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -314,6 +314,7 @@ Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
 Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
 Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
 Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
 Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
 Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
 Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2052,6 +2052,7 @@
 		021CCE262B7F2E30002C26EF /* WKWebViewFindStringFindDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKWebViewFindStringFindDelegate.h; sourceTree = "<group>"; };
 		021CCE332B7F31AB002C26EF /* WKWebViewFindStringFindDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewFindStringFindDelegate.mm; sourceTree = "<group>"; };
 		02238A3D2B2FB47C00442B86 /* VerifyUserGestureFromUIProcess.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VerifyUserGestureFromUIProcess.mm; sourceTree = "<group>"; };
+		02ABB97C2C46EE2100696FE3 /* WKWebExtensionAPISidebar.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPISidebar.mm; sourceTree = "<group>"; };
 		041A1E33216FFDBC00789E0A /* PublicSuffix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PublicSuffix.cpp; sourceTree = "<group>"; };
 		0451A5A6235E438E009DF945 /* BumpPointerAllocator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BumpPointerAllocator.cpp; sourceTree = "<group>"; };
 		0711DF51226A95FB003DD2F7 /* AVFoundationSoftLinkTest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AVFoundationSoftLinkTest.mm; sourceTree = "<group>"; };
@@ -4388,6 +4389,7 @@
 				B61EB1642994734A0048DFC0 /* WKWebExtensionAPIPermissions.mm */,
 				1C1549852926F4CA001B9E5B /* WKWebExtensionAPIRuntime.mm */,
 				B67543F12ABA3F21005E4184 /* WKWebExtensionAPIScripting.mm */,
+				02ABB97C2C46EE2100696FE3 /* WKWebExtensionAPISidebar.mm */,
 				B626B7C42B4F4DEE008E8DD1 /* WKWebExtensionAPIStorage.mm */,
 				1CF7FFA72AA7C302003609F0 /* WKWebExtensionAPITabs.mm */,
 				3378222C2947C095002106BB /* WKWebExtensionAPIWebNavigation.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WebExtensionUtilities.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
+
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/_WKFeature.h>
+
+namespace TestWebKitAPI {
+
+static constexpr auto *sidebarActionManifest = @{
+    @"manifest_version": @3,
+    @"name": @"SidebarAction Test",
+    @"description": @"SidebarAction Test",
+    @"version": @"1",
+
+    @"permissions": @[],
+    @"background": @{
+        @"scripts": @[ @"background.js", ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+
+    @"sidebar_action": @{
+        @"default_title": @"Test Sidebar",
+        @"default_panel": @"sidebar.html",
+        @"default_icon": @{
+            @"16": @"sidebar-16.png",
+            @"32": @"sidebar-32.png",
+        },
+        @"open_at_install": @NO,
+    },
+};
+
+
+static auto *sidePanelManifest = @{
+    @"manifest_version": @3,
+
+    @"name": @"SidePanel Test",
+    @"description": @"SidePanel Test",
+    @"version": @"1",
+
+    @"permissions": @[ @"sidePanel" ],
+    @"background": @{
+        @"scripts": @[ @"background.js" ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+};
+
+static auto *sidebarActionAndPanelManifest = @{
+    @"manifest_version": @3,
+
+    @"name": @"Sidebar Test (both)",
+    @"description": @"Sidebar Test (both)",
+    @"version": @"1",
+
+    @"permissions": @[ @"sidePanel" ],
+
+    @"background": @{
+        @"scripts": @[ @"background.js" ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+
+    @"sidebar_action": @{
+        @"default_title": @"Test Sidebar",
+        @"default_panel": @"sidebar.html",
+        @"default_icon": @{
+            @"16": @"sidebar-16.png",
+            @"32": @"sidebar-32.png",
+        },
+        @"open_at_install": @NO,
+    },
+};
+
+static auto *neitherSidebarActionNorPanelManifest = @{
+    @"manifest_version": @3,
+    @"name": @"Sidebar Test (neither)",
+    @"description": @"Sidebar Test (neither)",
+    @"version": @"1",
+
+    @"permissions": @[],
+    @"background": @{
+        @"scripts": @[ @"background.js", ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+};
+
+// This test fixture allows us to use sidebarConfig (which enables the sidebar feature flag) without manually constructing one on each run
+class WKWebExtensionAPISidebar : public testing::Test {
+protected:
+    WKWebExtensionAPISidebar()
+    {
+        sidebarConfig = _WKWebExtensionControllerConfiguration.defaultConfiguration;
+        if (!sidebarConfig.webViewConfiguration)
+            sidebarConfig.webViewConfiguration = [[WKWebViewConfiguration alloc] init];
+
+        for (_WKFeature *feature in [WKPreferences _features]) {
+            if ([feature.key isEqualToString:@"WebExtensionSidebarEnabled"])
+                [sidebarConfig.webViewConfiguration.preferences _setEnabled:YES forFeature:feature];
+        }
+    }
+
+    _WKWebExtensionControllerConfiguration *sidebarConfig;
+};
+
+TEST_F(WKWebExtensionAPISidebar, APISUnavailableWhenManifestDoesNotRequest)
+{
+    auto *script = @[
+        @"browser.test.assertDeepEq(browser.sidebarAction, undefined)",
+        @"browser.test.assertDeepEq(browser.sidePanel, undefined)",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(neitherSidebarActionNorPanelManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionAPIAvailableWhenManifestRequests)
+{
+    auto *script = @[
+        @"browser.test.assertFalse(browser.sidebarAction === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.close === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.getPanel === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.getTitle === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.isOpen === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.open === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.setIcon === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.setPanel === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.setTitle === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.toggle === undefined)",
+
+        @"browser.test.assertDeepEq(browser.sidePanel, undefined)",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(sidebarActionManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidePanelAPIAvailableWhenManifestRequests)
+{
+    auto *script = @[
+        @"browser.test.assertFalse(browser.sidePanel === undefined)",
+        @"browser.test.assertFalse(browser.sidePanel?.open === undefined)",
+        @"browser.test.assertFalse(browser.sidePanel?.getOptions === undefined)",
+        @"browser.test.assertFalse(browser.sidePanel?.setOptions === undefined)",
+        @"browser.test.assertFalse(browser.sidePanel?.getPanelBehavior === undefined)",
+        @"browser.test.assertFalse(browser.sidePanel?.setPanelBehavior === undefined)",
+
+        @"browser.test.assertDeepEq(browser.sidebarAction, undefined)",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(sidePanelManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionAPIAvailableWhenManifestRequestsBoth)
+{
+    auto *script = @[
+        @"browser.test.assertFalse(browser.sidebarAction === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.close === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.getPanel === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.getTitle === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.isOpen === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.open === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.setIcon === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.setPanel === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.setTitle === undefined)",
+        @"browser.test.assertFalse(browser.sidebarAction.toggle === undefined)",
+
+        @"browser.test.assertDeepEq(browser.sidePanel, undefined)",
+
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(sidebarActionAndPanelManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidebarActionAPIDisallowsMissingArguments)
+{
+    auto *script = @[
+        @"browser.test.assertThrows(() => browser.sidebarAction.getTitle())",
+        @"browser.test.assertThrows(() => browser.sidebarAction.setTitle())",
+        @"browser.test.assertThrows(() => browser.sidebarAction.getPanel())",
+        @"browser.test.assertThrows(() => browser.sidebarAction.setPanel())",
+        @"browser.test.assertThrows(() => browser.sidebarAction.isOpen())",
+        @"browser.test.assertThrows(() => browser.sidebarAction.setIcon())",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(sidebarActionManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
+}
+
+TEST_F(WKWebExtensionAPISidebar, SidePanelAPIDisallowsMissingArguments)
+{
+    auto *script = @[
+        @"browser.test.assertThrows(() => browser.sidePanel.getOptions())",
+        @"browser.test.assertThrows(() => browser.sidePanel.setOptions())",
+        @"browser.test.assertThrows(() => browser.sidePanel.setPanelBehavior())",
+        @"browser.test.assertThrows(() => browser.sidePanel.open())",
+        @"browser.test.notifyPass()",
+    ];
+
+    Util::loadAndRunExtension(sidePanelManifest, @{ @"background.js": Util::constructScript(script) }, sidebarConfig);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)


### PR DESCRIPTION
#### a0ee10281281011863adade244a37ff6dc0da272
<pre>
Add conditions for sidebarAction / sidePanel to WebExtensionAPINamespace::isPropertyAllowed.
<a href="https://webkit.org/b/277298">https://webkit.org/b/277298</a>
<a href="https://rdar.apple.com/132763372">rdar://132763372</a>

Reviewed by Timothy Hatcher and Brian Weinstein.

This patch adds the correct conditions for sidebarAction and sidePanel
to WebExtensionAPINamespace::isPropertyAllowed. It also adds the
sidePanel permission to the list of recognized valid permissions, so
that we can correctly parse it from the manifest. Finally, it also adds
a set of unit tests that exercise the added conditions for property
visibility.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.h: Declare
  _WKWebExtensionPermissionSidePanel
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.mm: Define
  _WKWebExtensionPermissionSidePanel
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::supportedPermissions): Add
_WKWebExtensionPermissionSidePanel to the list of supported permissions.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed): Add correct
conditions for sidePanel / sidebarAction properties
* Tools/TestWebKitAPI/SourcesCocoa.txt: Add WKWebExtensionAPISidebar.mm
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj: Add
  WKWebExtensionAPISidebar.mm
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm: Added.
(TestWebKitAPI::WKWebExtensionAPISidebarTest::WKWebExtensionAPISidebarTest): Add test fixture for sidebar tests
(TestWebKitAPI::TEST_F): Add various tests exercising property
conditions / argument count validation.

Canonical link: <a href="https://commits.webkit.org/281585@main">https://commits.webkit.org/281585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f5865c656d32fe7b950e71699b6744269950154

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12967 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/10940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11173 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/64328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/10940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37042 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/52335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/33740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/9560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/9857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/9848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4342 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/66060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52309 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/3612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9068 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->