### PR TITLE
REGRESSION (276531@main): State dropdown is invisible, unable to send feedback via Bunnings.com.au

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative-expected.txt
@@ -1,4 +1,5 @@
-hello hello
+hello
+hello
 
 PASS display:none animating to display:inline should be inline for the whole animation.
 PASS A CSS variable of display:none animating to display:inline should be inline for the whole animation.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative.html
@@ -17,7 +17,9 @@
 }
 </style>
 <script>
-promise_test(async () => {
+promise_test(async (t) => {
+  t.add_cleanup(() => target1.classList.remove('animate1'));
+
   let numAnimationstartFired = 0;
   target1.addEventListener('animationstart', () => numAnimationstartFired++);
 
@@ -46,7 +48,9 @@ promise_test(async () => {
 }
 </style>
 <script>
-promise_test(async () => {
+promise_test(async (t) => {
+  t.add_cleanup(() => target2.classList.remove('animate2'));
+
   let numAnimationstartFired = 0;
   target2.addEventListener('animationstart', () => numAnimationstartFired++);
 
@@ -72,7 +76,9 @@ promise_test(async () => {
 }
 </style>
 <script>
-promise_test(async () => {
+promise_test(async (t) => {
+  t.add_cleanup(() => target3.classList.remove('animate3'));
+
   let numAnimationstartFired = 0;
   target3.addEventListener('animationstart', () => numAnimationstartFired++);
 
@@ -101,7 +107,9 @@ promise_test(async () => {
 }
 </style>
 <script>
-promise_test(async () => {
+promise_test(async (t) => {
+  t.add_cleanup(() => target4.classList.remove('animate4'));
+
   let numAnimationstartFired = 0;
   target4.addEventListener('animationstart', () => numAnimationstartFired++);
 
@@ -130,7 +138,9 @@ promise_test(async () => {
 }
 </style>
 <script>
-promise_test(async () => {
+promise_test(async (t) => {
+  t.add_cleanup(() => target5.classList.remove('animate5'));
+
   let numAnimationstartFired = 0;
   target5.addEventListener('animationstart', () => numAnimationstartFired++);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-to-display-block-dont-cancel.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-to-display-block-dont-cancel.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS display:none animating to display:block should be block for the whole animation.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-to-display-block-dont-cancel.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-to-display-block-dont-cancel.tentative.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-display-4/#display-animation">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/6429">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/css-animations/support/testcommon.js"></script>
+
+<div id="target">hello</div>
+<style>
+@keyframes display-animation {
+  0% { display: none; }
+  100% { display: block; }
+}
+#target {
+  display: none;
+}
+#target.animate {
+  animation: display-animation 1s;
+  display: block;
+}
+</style>
+<script>
+promise_test(async (t) => {
+  t.add_cleanup(() => target.classList.remove('animate'));
+  let numAnimationstartFired = 0;
+  target.addEventListener('animationstart', () => numAnimationstartFired++);
+
+  assert_equals(getComputedStyle(target).display, 'none',
+  'The display should be none before the animation.');
+
+  await waitForAnimationFrames(1);
+  target.classList.add('animate');
+  await waitForAnimationFrames(2);
+
+  assert_equals(getComputedStyle(target).display, 'block',
+    'The display should be block during the animation.');
+  assert_equals(numAnimationstartFired, 1,
+    'Only one animation should start.');
+}, 'display:none animating to display:block should be block for the whole animation.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-to-display-block-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-to-display-block-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-to-display-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-to-display-block.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-display-4/#display-animation">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/6429">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+<style>
+@keyframes display-animation {
+  0% { display: none; }
+  100% { display: block; }
+}
+#target {
+  display: none;
+  width: 100px;
+  height: 100px;
+  background-color: green;
+}
+#target.animate {
+  animation: display-animation 1s;
+  display: block;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="target"></div>
+<script src="/css/css-animations/support/testcommon.js"></script>
+<script>
+onload = async () => {
+  await waitForAnimationFrames(1);
+  target.classList.add("animate");
+  await waitForAnimationFrames(2);
+  document.documentElement.classList.remove("reftest-wait");
+};
+</script>
+</html>

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -740,13 +740,12 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
         return keyframeEffectStack->containsProperty(CSSPropertyDisplay);
     }();
 
-    if (!affectsRenderedSubtree(styleable.element, *newStyle)) {
+    if (!affectsRenderedSubtree(styleable.element, *newStyle) && !animationsAffectedDisplay) {
         // If after updating animations we end up not rendering this element or its subtree
         // and the update did not change the "display" value then we should cancel all
         // style-originated animations while ensuring that the new ones are canceled silently,
         // as if they hadn't been created.
-        if (!animationsAffectedDisplay)
-            styleable.cancelStyleOriginatedAnimations(newStyleOriginatedAnimations);
+        styleable.cancelStyleOriginatedAnimations(newStyleOriginatedAnimations);
     } else if (!newStyleOriginatedAnimations.isEmpty()) {
         // If style-originated animations were not canceled, then we should make sure that
         // the creation of new style-originated animations during this update is known to the


### PR DESCRIPTION
#### 72ac253c4d48099635aa14a321e0c7e1ca267cb2
<pre>
REGRESSION (276531@main): State dropdown is invisible, unable to send feedback via Bunnings.com.au
<a href="https://bugs.webkit.org/show_bug.cgi?id=277303">https://bugs.webkit.org/show_bug.cgi?id=277303</a>
<a href="https://rdar.apple.com/130520487">rdar://130520487</a>

Reviewed by Cameron McCormack.

We should not be cancelling animations in the case where we&apos;re starting in a hidden subtree, then animating with a keyframe that changes
the display value away from none. Make sure we notify about the newly created keyframe instead.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-to-display-block-dont-cancel.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-to-display-block-dont-cancel.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-to-display-block-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-to-display-block.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

Canonical link: <a href="https://commits.webkit.org/281544@main">https://commits.webkit.org/281544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2229a7b7b5b1c49e3c84391381cb61749ae000a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64190 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11035 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7515 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29645 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9437 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9719 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65922 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4204 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56159 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56320 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13367 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3494 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->