### PR TITLE
Remove 32-bit git on 64-bit macOS warning

### DIFF
--- a/Tools/Scripts/webkitpy/common/checkout/scm/git.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/git.py
@@ -63,44 +63,12 @@ class Git(SCM):
 
     def __init__(self, cwd, patch_directories, **kwargs):
         SCM.__init__(self, cwd, **kwargs)
-        self._check_git_architecture()
         if patch_directories == []:
             raise Exception(message='Empty list of patch directories passed to SCM.__init__')
         elif patch_directories == None:
             self._patch_directories = [self._filesystem.relpath(cwd, self.checkout_root)]
         else:
             self._patch_directories = patch_directories
-
-    def _machine_is_64bit(self):
-        import platform
-        # This only is tested on Mac.
-        if not platform.mac_ver()[0]:
-            return False
-
-        # platform.architecture()[0] can be '64bit' even if the machine is 32bit:
-        # http://mail.python.org/pipermail/pythonmac-sig/2009-September/021648.html
-        # Use the sysctl command to find out what the processor actually supports.
-        return self.run(['sysctl', '-n', 'hw.cpu64bit_capable']).rstrip() == '1'
-
-    def _executable_is_64bit(self, path):
-        # Again, platform.architecture() fails us.  On my machine
-        # git_bits = platform.architecture(executable=git_path, bits='default')[0]
-        # git_bits is just 'default', meaning the call failed.
-        file_output = self.run(['file', path])
-        return re.search('64', file_output)
-
-    def _check_git_architecture(self):
-        if not self._machine_is_64bit():
-            return
-
-        # We could path-search entirely in python or with
-        # which.py (http://code.google.com/p/which), but this is easier:
-        git_path = self.run(['which', self.executable_name]).rstrip()
-        if self._executable_is_64bit(git_path):
-            return
-
-        webkit_dev_thread_url = "https://lists.webkit.org/pipermail/webkit-dev/2010-December/015287.html"
-        _log.warning("This machine is 64-bit, but the git binary (%s) does not support 64-bit.\nInstall a 64-bit git for better performance, see:\n%s\n" % (git_path, webkit_dev_thread_url))
 
     def _run_git(self, command_args, **kwargs):
         full_command_args = [self.executable_name] + command_args


### PR DESCRIPTION
#### ce6bf38fc7efd7e9e3e1528bf582c88704e9417b
<pre>
Remove 32-bit git on 64-bit macOS warning
<a href="https://bugs.webkit.org/show_bug.cgi?id=277307">https://bugs.webkit.org/show_bug.cgi?id=277307</a>

Reviewed by Alexey Proskuryakov.

With 32-bit support having been gone for years, this is all needless.

* Tools/Scripts/webkitpy/common/checkout/scm/git.py:
(Git.__init__):
(Git._machine_is_64bit): Deleted.
(Git._executable_is_64bit): Deleted.
(Git._check_git_architecture): Deleted.

Canonical link: <a href="https://commits.webkit.org/281587@main">https://commits.webkit.org/281587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23b2cab1831abd17380fa3db3d68d4e006d47e9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64179 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10793 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48796 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7509 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29637 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/59787 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9436 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9710 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65910 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56154 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4213 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56312 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3489 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9069 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35423 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36504 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37594 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->