### PR TITLE
[iOS 18] Build on the public SDK

### DIFF
--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SDKSettings.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CanonicalName</key>
+	<string>WebKitSDKAdditions_iphoneos</string>
+	<key>IsBaseSDK</key>
+	<string>NO</string>
+    <key>HeaderSearchPaths</key>
+    <array>
+        <!-- usr/local/include is a built-in search path of the base SDK -->
+        <string>usr/local/include</string>
+    </array>
+    <key>DefaultProperties</key>
+    <dict>
+        <key>SDK_DIR_macosx</key>
+        <string>$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk</string>
+        <key>WK_DERIVED_SDK_HEADERS_DIR</key>
+        <string>$(BUILT_PRODUCTS_DIR)/SDKAdditions</string>
+        <key>SYSTEM_FRAMEWORK_SEARCH_PATHS</key>
+        <string>$(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks</string>
+        <key>SYSTEM_HEADER_SEARCH_PATHS</key>
+        <string>$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include</string>
+    </dict>
+</dict>
+</plist>

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
@@ -1,0 +1,13 @@
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/libxslt
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/mach.h
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/mach_error.h
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/mach_types.defs
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/machine/machine_types.defs
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/std_types.defs
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/task.h
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/Protocol.h
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-class.h
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-runtime.h
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline/history.h
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline/readline.h

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SymlinkedHeaders.xcfilelist
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SymlinkedHeaders.xcfilelist
@@ -1,0 +1,13 @@
+$(SDK_DIR_macosx)/usr/include/readline
+$(SDK_DIR_macosx)/usr/include/libxslt
+$(SDK_DIR_macosx)/usr/include/mach/mach.h
+$(SDK_DIR_macosx)/usr/include/mach/mach_error.h
+$(SDK_DIR_macosx)/usr/include/mach/mach_types.defs
+$(SDK_DIR_macosx)/usr/include/mach/machine/machine_types.defs
+$(SDK_DIR_macosx)/usr/include/mach/std_types.defs
+$(SDK_DIR_macosx)/usr/include/mach/task.h
+$(SDK_DIR_macosx)/usr/include/objc/Protocol.h
+$(SDK_DIR_macosx)/usr/include/objc/objc-class.h
+$(SDK_DIR_macosx)/usr/include/objc/objc-runtime.h
+$(SDK_DIR_macosx)/usr/include/readline/history.h
+$(SDK_DIR_macosx)/usr/include/readline/readline.h

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/AppServerSupport.framework/AppServerSupport.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/AppServerSupport.framework/AppServerSupport.tbd
@@ -1,0 +1,9 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/AppServerSupport.framework/AppServerSupport
+current-version: 2866.0.13
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        objc-classes: [OSLaunchdJob]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/AppStoreDaemon.framework/AppStoreDaemon.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/AppStoreDaemon.framework/AppStoreDaemon.tbd
@@ -1,0 +1,9 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/AppStoreDaemon.framework/AppStoreDaemon
+swift-abi-version: 7
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        objc-classes: [ASDInstallWebAttributionParamsConfig, ASDInstallWebAttributionService]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport.tbd
@@ -1,0 +1,19 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/AppSupport.framework/AppSupport
+current-version: 29
+reexported-libraries:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        libraries: [/System/Library/PrivateFrameworks/CorePhoneNumbers.framework/CorePhoneNumbers]
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [_CPCopyBundleIdentifierAndTeamFromAuditToken]
+        objc-classes: [CPNetworkObserver]
+...
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/CorePhoneNumbers.framework/CorePhoneNumbers
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/ApplePushService.framework/ApplePushService.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/ApplePushService.framework/ApplePushService.tbd
@@ -1,0 +1,9 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/ApplePushService.framework/ApplePushService
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [_APSEnvironmentProduction]
+        objc-classes: [APSConnection, APSURLTokenInfo]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/AuthKit.framework/AuthKit.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/AuthKit.framework/AuthKit.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/AuthKit.framework/AuthKit
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        objc-classes: [AKAuthorizationController]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices.tbd
@@ -1,0 +1,18 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices
+reexported-libraries:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        libraries: [/System/Library/PrivateFrameworks/AssertionServices.framework/AssertionServices]
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        objc-classes: [BKSMousePointerService]
+...
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/AssertionServices.framework/AssertionServices
+current-version: 945
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/CoreAnalytics.framework/CoreAnalytics.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/CoreAnalytics.framework/CoreAnalytics.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/CoreAnalytics.framework/CoreAnalytics
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [_AnalyticsSendEventLazy]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/CorePrediction.framework/CorePrediction.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/CorePrediction.framework/CorePrediction.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/CorePrediction.framework/CorePrediction
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [_svm_load_model, _svm_predict_values]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -1,0 +1,9 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib
+swift-abi-version: 7
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices.tbd
@@ -1,0 +1,29 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices
+current-version: 0
+reexported-libraries:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        libraries: [/System/Library/PrivateFrameworks/BaseBoard.framework/BaseBoard, /System/Library/PrivateFrameworks/BoardServices.framework/BoardServices]
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [_FBSActivateForEventOptionTypeBackgroundContentFetching, _FBSOpenApplicationOptionKeyActivateForEvent, _FBSOpenApplicationOptionKeyLaunchIntent,
+                _FBSOpenApplicationOptionKeyPayloadOptions, _FBSOpenApplicationOptionKeyPayloadURL, _FBSOpenApplicationOptionKeyUnlockDevice,
+                _FBSSceneVisibilityEndowmentNamespace]
+        objc-classes: [FBSOpenApplicationOptions, FBSOpenApplicationService]
+...
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/BaseBoard.framework/BaseBoard
+current-version: 0
+exports: []
+...
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/BoardServices.framework/BoardServices
+current-version: 0
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -1,0 +1,11 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices
+current-version: 14
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSFontInitialize,
+                _GSFontPurgeFontCache, _GSInitialize, _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/IOSurfaceAccelerator.framework/IOSurfaceAccelerator.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/IOSurfaceAccelerator.framework/IOSurfaceAccelerator.tbd
@@ -1,0 +1,9 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/IOSurfaceAccelerator.framework/IOSurfaceAccelerator
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [_IOSurfaceAcceleratorCreate, _IOSurfaceAcceleratorGetRunLoopSource, _IOSurfaceAcceleratorTransformSurface,
+                _kIOSurfaceAcceleratorUnwireSurfaceKey]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/IconServices.framework/IconServices.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/IconServices.framework/IconServices.tbd
@@ -1,0 +1,19 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/IconServices.framework/IconServices
+current-version: 493
+reexported-libraries:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        libraries: [/System/Library/PrivateFrameworks/IconFoundation.framework/IconFoundation]
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        objc-classes: [ISIcon, ISImageDescriptor]
+...
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/IconFoundation.framework/IconFoundation
+current-version: 493
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/IdleTimerServices.framework/IdleTimerServices.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/IdleTimerServices.framework/IdleTimerServices.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/IdleTimerServices.framework/IdleTimerServices
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        objc-classes: [ITIdleTimerState]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/InstallCoordination.framework/InstallCoordination.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/InstallCoordination.framework/InstallCoordination.tbd
@@ -1,0 +1,6 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/InstallCoordination.framework/InstallCoordination
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/MobileKeyBag.framework/MobileKeyBag.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/MobileKeyBag.framework/MobileKeyBag.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/MobileKeyBag.framework/MobileKeyBag
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [_MKBDeviceUnlockedSinceBoot, _kMobileKeyBagLockStatusNotifyToken]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/PrototypeTools.framework/PrototypeTools.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/PrototypeTools.framework/PrototypeTools.tbd
@@ -1,0 +1,6 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/PrototypeTools.framework/PrototypeTools
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/RemotePairingDevice.framework/RemotePairingDevice.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/RemotePairingDevice.framework/RemotePairingDevice.tbd
@@ -1,0 +1,12 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/RemotePairingDevice.framework/RemotePairingDevice
+current-version: 199.0.4
+swift-abi-version: 7
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [_$s19RemotePairingDevice21AuxiliaryMetadataItemO7booleanyACSbcACmFWC, _$s19RemotePairingDevice21AuxiliaryMetadataItemOMa,
+                _$s19RemotePairingDevice21AuxiliaryMetadataItemOMn, _$s19RemotePairingDevice25AuxiliaryMetadataProviderC08registerE09forDomain8metadataySS_SDySSAA0dE4ItemOGtFTj,
+                _$s19RemotePairingDevice25AuxiliaryMetadataProviderC6sharedACvgZ, _$s19RemotePairingDevice25AuxiliaryMetadataProviderCMa]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/RunningBoardServices.framework/RunningBoardServices.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/RunningBoardServices.framework/RunningBoardServices.tbd
@@ -1,0 +1,11 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/RunningBoardServices.framework/RunningBoardServices
+current-version: 945
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [_RBSProcessTimeLimitationNone]
+        objc-classes: [RBSAssertion, RBSDomainAttribute, RBSProcessHandle, RBSProcessIdentifier, RBSProcessMonitor, RBSProcessPredicate,
+                RBSProcessStateDescriptor, RBSTarget]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/SafariSafeBrowsing.framework/SafariSafeBrowsing.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/SafariSafeBrowsing.framework/SafariSafeBrowsing.tbd
@@ -1,0 +1,10 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/SafariSafeBrowsing.framework/SafariSafeBrowsing
+current-version: 0
+compatibility-version: 0
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        objc-classes: [SSBLookupContext]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/SharedWebCredentials.framework/SharedWebCredentials.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/SharedWebCredentials.framework/SharedWebCredentials.tbd
@@ -1,0 +1,10 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/SharedWebCredentials.framework/SharedWebCredentials
+current-version: 1001
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [__SWCServiceTypeAppLinks]
+        objc-classes: [_SWCServiceSpecifier]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/UIIntelligenceSupport.framework/UIIntelligenceSupport.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/UIIntelligenceSupport.framework/UIIntelligenceSupport.tbd
@@ -1,0 +1,31 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/UIIntelligenceSupport.framework/UIIntelligenceSupport
+swift-abi-version: 7
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [_$s10Foundation22AttributeDynamicLookupO21UIIntelligenceSupportE13dynamicMemberxs7KeyPathCyAD19IntelligenceElementV4TextV10AttributesVxG_tcAA016AttributedStringI0Rzluig,
+                _$s10Foundation22AttributeDynamicLookupO21UIIntelligenceSupportE13dynamicMemberxs7KeyPathCyAD19IntelligenceElementV4TextV10AttributesVxG_tcAA016AttributedStringI0RzluipMV,
+                _$s21UIIntelligenceSupport0A16ElementCollectorC7collectyyAA012IntelligenceC0V7ContentOF, _$s21UIIntelligenceSupport0A16ElementCollectorC7contextAA29IntelligenceCollectionContext_pvg,
+                _$s21UIIntelligenceSupport19IntelligenceElementV11boundingBox7content11subelementsACSo6CGRectV_AC7ContentOSayACGtcfC,
+                _$s21UIIntelligenceSupport19IntelligenceElementV11subelementsSayACGvs, _$s21UIIntelligenceSupport19IntelligenceElementV4TextV010attributedE08editable11textOptionsAE10Foundation16AttributedStringV_AE8EditableVSgAA0C17CollectionRequestV0eI0VSgtcfC,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV16intelligenceLink10Foundation15AttributeScopesO0iF0V0hJ0Ovg,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV16intelligenceLink10Foundation15AttributeScopesO0iF0V0hJ0OvpMV,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV17SelectedAttributeV10Foundation19AttributedStringKeyAAMc,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV17SelectedAttributeVMa, _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV17SelectedAttributeVMn,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV20intelligenceSelectedAG0H9AttributeVvg,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV20intelligenceSelectedAG0H9AttributeVvpMV,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesVMa, _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesVMn,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV8EditableV5label6prompt11contentType8isSecure0K7FocusedAGSSSg_A2MS2btcfC,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV8EditableVMa, _$s21UIIntelligenceSupport19IntelligenceElementV4TextV8EditableVMn,
+                _$s21UIIntelligenceSupport19IntelligenceElementV5ImageV4name15textDescriptionAESSSg_AHtcfC, _$s21UIIntelligenceSupport19IntelligenceElementV7ContentO4baseyA2EmFWC,
+                _$s21UIIntelligenceSupport19IntelligenceElementV7ContentO4textyAeC4TextVcAEmFWC, _$s21UIIntelligenceSupport19IntelligenceElementV7ContentO5imageyAeC5ImageVcAEmFWC,
+                _$s21UIIntelligenceSupport19IntelligenceElementV7ContentO6remoteyAeA0C8FragmentV13RemoteContextVcAEmFWC, _$s21UIIntelligenceSupport19IntelligenceElementV7ContentOMa,
+                _$s21UIIntelligenceSupport19IntelligenceElementVMa, _$s21UIIntelligenceSupport29IntelligenceCollectionContextP012createRemoteE0AA0C8FragmentV0gE0VyFTj,
+                _$s21UIIntelligenceSupport29IntelligenceCollectionRequestV11TextOptionsVMa, _$s21UIIntelligenceSupport29IntelligenceCollectionRequestV11TextOptionsVMn,
+                _$s21UIIntelligenceSupport29IntelligenceFragmentCollectorC7collectyyAA0C7ElementVF, _$s21UIIntelligenceSupport29IntelligenceFragmentCollectorCMn,
+                _$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorC06finishD0yyAA0C17FragmentCollectorCF, _$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorC15createCollector20remoteContextWrapper10completionyAA0ad6RemoteiJ0C_yAA0c8FragmentG0CSg_s5Error_pSgtctF,
+                _$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorC6sharedACvgZ, _$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorCMa,
+                _$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorCMn]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/URLFormatting.framework/URLFormatting.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/URLFormatting.framework/URLFormatting.tbd
@@ -1,0 +1,7 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/URLFormatting.framework/URLFormatting
+current-version: 270
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/VisionKitCore.framework/VisionKitCore.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/VisionKitCore.framework/VisionKitCore.tbd
@@ -1,0 +1,6 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/VisionKitCore.framework/VisionKitCore
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/WritingTools.framework/WritingTools.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/WritingTools.framework/WritingTools.tbd
@@ -1,0 +1,9 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/WritingTools.framework/WritingTools
+exports:
+-       targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+        symbols: [_WTWritingToolsPreservedAttributeName]
+        objc-classes: [WTContext, WTSession, WTTextSuggestion]
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/WritingToolsUI.framework/WritingToolsUI.tbd
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/WritingToolsUI.framework/WritingToolsUI.tbd
@@ -1,0 +1,7 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
+install-name: /System/Library/PrivateFrameworks/WritingToolsUI.framework/WritingToolsUI
+swift-abi-version: 7
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */ 
+
+#pragma once
+
+// Handle __IOS_PROHIBITED and friends.
+#undef __OS_AVAILABILITY
+#define __OS_AVAILABILITY(...)
+
+// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
+#undef __API_AVAILABLE_GET_MACRO
+#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
+#undef SWIFT_AVAILABILITY
+#define SWIFT_AVAILABILITY __NULL_AVAILABILITY
+
+// Take care of {A,S}PI_DEPRECATED{,WITH_REPLACEMENT}{,_BEGIN,_END}
+#undef __API_DEPRECATED_MSG_GET_MACRO
+#define __API_DEPRECATED_MSG_GET_MACRO(...) __NULL_AVAILABILITY
+
+// Take care of API_UNAVAILABLE{,_BEGIN,_END}
+#undef __API_UNAVAILABLE_GET_MACRO
+#define __API_UNAVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
+#define __NULL_AVAILABILITY(...)

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/SDKSettings.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CanonicalName</key>
+	<string>WebKitSDKAdditions_iphonesimulator</string>
+	<key>IsBaseSDK</key>
+	<string>NO</string>
+    <key>HeaderSearchPaths</key>
+    <array>
+        <!-- usr/local/include is a built-in search path of the base SDK -->
+        <string>usr/local/include</string>
+    </array>
+    <key>DefaultProperties</key>
+    <dict>
+        <key>SDK_DIR_macosx</key>
+        <string>$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk</string>
+        <key>SDK_DIR_iphoneos</key>
+        <string>$(DEVELOPER_DIR)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk</string>
+        <key>WK_DERIVED_SDK_HEADERS_DIR</key>
+        <string>$(BUILT_PRODUCTS_DIR)/SDKAdditions</string>
+        <key>SYSTEM_FRAMEWORK_SEARCH_PATHS</key>
+        <string>$(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks</string>
+        <key>SYSTEM_HEADER_SEARCH_PATHS</key>
+        <string>$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include</string>
+    </dict>
+</dict>
+</plist>

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
@@ -1,0 +1,17 @@
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/libxslt
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/mach_types.defs
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/machine/machine_types.defs
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/mach/std_types.defs
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/Protocol.h
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-class.h
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-runtime.h
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline/history.h
+$(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline/readline.h
+$(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AVKit.framework
+$(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AudioToolbox.framework
+$(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/MediaAccessibility.framework
+$(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/Metal.framework
+$(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/OpenGLES.framework
+$(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/QuartzCore.framework
+$(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/UIKit.framework

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/SymlinkedHeaders.xcfilelist
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/SymlinkedHeaders.xcfilelist
@@ -1,0 +1,17 @@
+$(SDK_DIR_macosx)/usr/include/readline
+$(SDK_DIR_macosx)/usr/include/libxslt
+$(SDK_DIR_macosx)/usr/include/mach/mach_types.defs
+$(SDK_DIR_macosx)/usr/include/mach/machine/machine_types.defs
+$(SDK_DIR_macosx)/usr/include/mach/std_types.defs
+$(SDK_DIR_macosx)/usr/include/objc/Protocol.h
+$(SDK_DIR_macosx)/usr/include/objc/objc-class.h
+$(SDK_DIR_macosx)/usr/include/objc/objc-runtime.h
+$(SDK_DIR_macosx)/usr/include/readline/history.h
+$(SDK_DIR_macosx)/usr/include/readline/readline.h
+$(SDK_DIR_iphoneos)/System/Library/Frameworks/AVKit.framework
+$(SDK_DIR_iphoneos)/System/Library/Frameworks/AudioToolbox.framework
+$(SDK_DIR_iphoneos)/System/Library/Frameworks/MediaAccessibility.framework
+$(SDK_DIR_iphoneos)/System/Library/Frameworks/Metal.framework
+$(SDK_DIR_iphoneos)/System/Library/Frameworks/OpenGLES.framework
+$(SDK_DIR_iphoneos)/System/Library/Frameworks/QuartzCore.framework
+$(SDK_DIR_iphoneos)/System/Library/Frameworks/UIKit.framework

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/AppServerSupport.framework/AppServerSupport.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/AppServerSupport.framework/AppServerSupport.tbd
@@ -1,0 +1,9 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/AppServerSupport.framework/AppServerSupport
+current-version: 2866.0.13
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        objc-classes: [OSLaunchdJob]
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/AppStoreDaemon.framework/AppStoreDaemon.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/AppStoreDaemon.framework/AppStoreDaemon.tbd
@@ -1,0 +1,9 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/AppStoreDaemon.framework/AppStoreDaemon
+swift-abi-version: 7
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        objc-classes: [ASDInstallWebAttributionParamsConfig, ASDInstallWebAttributionService]
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport.tbd
@@ -1,0 +1,19 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/AppSupport.framework/AppSupport
+current-version: 29
+reexported-libraries:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        libraries: [/System/Library/PrivateFrameworks/CorePhoneNumbers.framework/CorePhoneNumbers]
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        symbols: [_CPCopyBundleIdentifierAndTeamFromAuditToken]
+        objc-classes: [CPNetworkObserver]
+...
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/CorePhoneNumbers.framework/CorePhoneNumbers
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/ApplePushService.framework/ApplePushService.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/ApplePushService.framework/ApplePushService.tbd
@@ -1,0 +1,9 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/ApplePushService.framework/ApplePushService
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        symbols: [_APSEnvironmentProduction]
+        objc-classes: [APSConnection, APSURLTokenInfo]
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/AuthKit.framework/AuthKit.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/AuthKit.framework/AuthKit.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/AuthKit.framework/AuthKit
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        objc-classes: [AKAuthorizationController]
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices.tbd
@@ -1,0 +1,18 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices
+reexported-libraries:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        libraries: [/System/Library/PrivateFrameworks/AssertionServices.framework/AssertionServices]
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        objc-classes: [BKSMousePointerService]
+...
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/AssertionServices.framework/AssertionServices
+current-version: 945
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/CoreAnalytics.framework/CoreAnalytics.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/CoreAnalytics.framework/CoreAnalytics.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/CoreAnalytics.framework/CoreAnalytics
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        symbols: [_AnalyticsSendEventLazy]
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/CorePrediction.framework/CorePrediction.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/CorePrediction.framework/CorePrediction.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/CorePrediction.framework/CorePrediction
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        symbols: [_svm_load_model, _svm_predict_values]
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd
@@ -1,0 +1,9 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib
+swift-abi-version: 7
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        symbols: [_FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData]
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices.tbd
@@ -1,0 +1,29 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices
+current-version: 0
+reexported-libraries:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        libraries: [/System/Library/PrivateFrameworks/BaseBoard.framework/BaseBoard, /System/Library/PrivateFrameworks/BoardServices.framework/BoardServices]
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        symbols: [_FBSActivateForEventOptionTypeBackgroundContentFetching, _FBSOpenApplicationOptionKeyActivateForEvent, _FBSOpenApplicationOptionKeyLaunchIntent,
+                _FBSOpenApplicationOptionKeyPayloadOptions, _FBSOpenApplicationOptionKeyPayloadURL, _FBSOpenApplicationOptionKeyUnlockDevice,
+                _FBSSceneVisibilityEndowmentNamespace]
+        objc-classes: [FBSOpenApplicationOptions, FBSOpenApplicationService]
+...
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/BaseBoard.framework/BaseBoard
+current-version: 0
+exports: []
+...
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/BoardServices.framework/BoardServices
+current-version: 0
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd
@@ -1,0 +1,11 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices
+current-version: 14
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        symbols: [_GSCurrentEventTimestamp, _GSEventGetHardwareKeyboardCountry, _GSEventGetHardwareKeyboardType, _GSEventIsHardwareKeyboardAttached,
+                _GSEventSetHardwareKeyboardAttached, _GSEventSetHardwareKeyboardAttachedWithCountryCodeAndType, _GSInitialize,
+                _GSKeyboardGetModifierState, _GSSystemRootDirectory, _kGSEventHardwareKeyboardAvailabilityChangedNotification]
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/IconServices.framework/IconServices.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/IconServices.framework/IconServices.tbd
@@ -1,0 +1,19 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/IconServices.framework/IconServices
+current-version: 493
+reexported-libraries:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        libraries: [/System/Library/PrivateFrameworks/IconFoundation.framework/IconFoundation]
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        objc-classes: [ISIcon, ISImageDescriptor]
+...
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/IconFoundation.framework/IconFoundation
+current-version: 493
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/IdleTimerServices.framework/IdleTimerServices.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/IdleTimerServices.framework/IdleTimerServices.tbd
@@ -1,0 +1,6 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/IdleTimerServices.framework/IdleTimerServices
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/InstallCoordination.framework/InstallCoordination.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/InstallCoordination.framework/InstallCoordination.tbd
@@ -1,0 +1,6 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/InstallCoordination.framework/InstallCoordination
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/PrototypeTools.framework/PrototypeTools.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/PrototypeTools.framework/PrototypeTools.tbd
@@ -1,0 +1,6 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/PrototypeTools.framework/PrototypeTools
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/RunningBoardServices.framework/RunningBoardServices.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/RunningBoardServices.framework/RunningBoardServices.tbd
@@ -1,0 +1,11 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/RunningBoardServices.framework/RunningBoardServices
+current-version: 945
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        symbols: [_RBSProcessTimeLimitationNone]
+        objc-classes: [RBSAssertion, RBSDomainAttribute, RBSProcessHandle, RBSProcessIdentifier, RBSProcessMonitor, RBSProcessPredicate,
+                RBSProcessStateDescriptor, RBSTarget]
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/SafariSafeBrowsing.framework/SafariSafeBrowsing.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/SafariSafeBrowsing.framework/SafariSafeBrowsing.tbd
@@ -1,0 +1,10 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/SafariSafeBrowsing.framework/SafariSafeBrowsing
+current-version: 0
+compatibility-version: 0
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        objc-classes: [SSBLookupContext]
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/SharedWebCredentials.framework/SharedWebCredentials.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/SharedWebCredentials.framework/SharedWebCredentials.tbd
@@ -1,0 +1,10 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/SharedWebCredentials.framework/SharedWebCredentials
+current-version: 1001
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        symbols: [__SWCServiceTypeAppLinks]
+        objc-classes: [_SWCServiceSpecifier]
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/UIIntelligenceSupport.framework/UIIntelligenceSupport.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/UIIntelligenceSupport.framework/UIIntelligenceSupport.tbd
@@ -1,0 +1,31 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/UIIntelligenceSupport.framework/UIIntelligenceSupport
+swift-abi-version: 7
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        symbols: [_$s10Foundation22AttributeDynamicLookupO21UIIntelligenceSupportE13dynamicMemberxs7KeyPathCyAD19IntelligenceElementV4TextV10AttributesVxG_tcAA016AttributedStringI0Rzluig,
+                _$s10Foundation22AttributeDynamicLookupO21UIIntelligenceSupportE13dynamicMemberxs7KeyPathCyAD19IntelligenceElementV4TextV10AttributesVxG_tcAA016AttributedStringI0RzluipMV,
+                _$s21UIIntelligenceSupport0A16ElementCollectorC7collectyyAA012IntelligenceC0V7ContentOF, _$s21UIIntelligenceSupport0A16ElementCollectorC7contextAA29IntelligenceCollectionContext_pvg,
+                _$s21UIIntelligenceSupport19IntelligenceElementV11boundingBox7content11subelementsACSo6CGRectV_AC7ContentOSayACGtcfC,
+                _$s21UIIntelligenceSupport19IntelligenceElementV11subelementsSayACGvs, _$s21UIIntelligenceSupport19IntelligenceElementV4TextV010attributedE08editable11textOptionsAE10Foundation16AttributedStringV_AE8EditableVSgAA0C17CollectionRequestV0eI0VSgtcfC,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV16intelligenceLink10Foundation15AttributeScopesO0iF0V0hJ0Ovg,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV16intelligenceLink10Foundation15AttributeScopesO0iF0V0hJ0OvpMV,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV17SelectedAttributeV10Foundation19AttributedStringKeyAAMc,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV17SelectedAttributeVMa, _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV17SelectedAttributeVMn,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV20intelligenceSelectedAG0H9AttributeVvg,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV20intelligenceSelectedAG0H9AttributeVvpMV,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesVMa, _$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesVMn,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV8EditableV5label6prompt11contentType8isSecure0K7FocusedAGSSSg_A2MS2btcfC,
+                _$s21UIIntelligenceSupport19IntelligenceElementV4TextV8EditableVMa, _$s21UIIntelligenceSupport19IntelligenceElementV4TextV8EditableVMn,
+                _$s21UIIntelligenceSupport19IntelligenceElementV5ImageV4name15textDescriptionAESSSg_AHtcfC, _$s21UIIntelligenceSupport19IntelligenceElementV7ContentO4baseyA2EmFWC,
+                _$s21UIIntelligenceSupport19IntelligenceElementV7ContentO4textyAeC4TextVcAEmFWC, _$s21UIIntelligenceSupport19IntelligenceElementV7ContentO5imageyAeC5ImageVcAEmFWC,
+                _$s21UIIntelligenceSupport19IntelligenceElementV7ContentO6remoteyAeA0C8FragmentV13RemoteContextVcAEmFWC, _$s21UIIntelligenceSupport19IntelligenceElementV7ContentOMa,
+                _$s21UIIntelligenceSupport19IntelligenceElementVMa, _$s21UIIntelligenceSupport29IntelligenceCollectionContextP012createRemoteE0AA0C8FragmentV0gE0VyFTj,
+                _$s21UIIntelligenceSupport29IntelligenceCollectionRequestV11TextOptionsVMa, _$s21UIIntelligenceSupport29IntelligenceCollectionRequestV11TextOptionsVMn,
+                _$s21UIIntelligenceSupport29IntelligenceFragmentCollectorC7collectyyAA0C7ElementVF, _$s21UIIntelligenceSupport29IntelligenceFragmentCollectorCMn,
+                _$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorC06finishD0yyAA0C17FragmentCollectorCF, _$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorC15createCollector20remoteContextWrapper10completionyAA0ad6RemoteiJ0C_yAA0c8FragmentG0CSg_s5Error_pSgtctF,
+                _$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorC6sharedACvgZ, _$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorCMa,
+                _$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorCMn]
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/URLFormatting.framework/URLFormatting.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/URLFormatting.framework/URLFormatting.tbd
@@ -1,0 +1,7 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/URLFormatting.framework/URLFormatting
+current-version: 270
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/VisionKitCore.framework/VisionKitCore.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/VisionKitCore.framework/VisionKitCore.tbd
@@ -1,0 +1,6 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/VisionKitCore.framework/VisionKitCore
+exports: []
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/WritingTools.framework/WritingTools.tbd
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/WritingTools.framework/WritingTools.tbd
@@ -1,0 +1,9 @@
+--- !tapi-tbd
+tbd-version: 4
+targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+install-name: /System/Library/PrivateFrameworks/WritingTools.framework/WritingTools
+exports:
+-       targets: [i386-ios-simulator, x86_64-ios-simulator, arm64-ios-simulator]
+        symbols: [_WTWritingToolsPreservedAttributeName]
+        objc-classes: [WTContext, WTSession, WTTextSuggestion]
+...

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */ 
+
+#pragma once
+
+// Handle __IOS_PROHIBITED and friends.
+#undef __OS_AVAILABILITY
+#define __OS_AVAILABILITY(...)
+
+// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
+#undef __API_AVAILABLE_GET_MACRO
+#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
+#undef SWIFT_AVAILABILITY
+#define SWIFT_AVAILABILITY __NULL_AVAILABILITY
+
+// Take care of {A,S}PI_DEPRECATED{,WITH_REPLACEMENT}{,_BEGIN,_END}
+#undef __API_DEPRECATED_MSG_GET_MACRO
+#define __API_DEPRECATED_MSG_GET_MACRO(...) __NULL_AVAILABILITY
+
+// Take care of API_UNAVAILABLE{,_BEGIN,_END}
+#undef __API_UNAVAILABLE_GET_MACRO
+#define __API_UNAVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
+#define __NULL_AVAILABILITY(...)


### PR DESCRIPTION
#### 0a4bddf5cc108feed39f67bef24c7e5bcf9132fc
<pre>
[iOS 18] Build on the public SDK
<a href="https://rdar.apple.com/132780457">rdar://132780457</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=277325">https://bugs.webkit.org/show_bug.cgi?id=277325</a>

Reviewed by Alexey Proskuryakov.

Add TBD stubs generated using extract-tbds-from-internal-sdk.

Copy over SDK settings and AvailabilityProhibitedInternal.h, and remove
some symlinked headers that no longer need to be modified.

* WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/InstallCoordination.framework/InstallCoordination.tbd: Removed.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SDKSettings.plist: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/SDKSettings.plist.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SymlinkedHeaders-output.xcfilelist: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/SymlinkedHeaders-output.xcfilelist.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/SymlinkedHeaders.xcfilelist: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/SymlinkedHeaders.xcfilelist.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/AppServerSupport.framework/AppServerSupport.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/AppServerSupport.framework/AppServerSupport.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/AppStoreDaemon.framework/AppStoreDaemon.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/AppStoreDaemon.framework/AppStoreDaemon.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/ApplePushService.framework/ApplePushService.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/ApplePushService.framework/ApplePushService.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/AuthKit.framework/AuthKit.tbd: Copied from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/AuthKit.framework/AuthKit.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/CoreAnalytics.framework/CoreAnalytics.tbd: Copied from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/AuthKit.framework/AuthKit.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/CorePrediction.framework/CorePrediction.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/CorePrediction.framework/CorePrediction.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/IOSurfaceAccelerator.framework/IOSurfaceAccelerator.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/IOSurfaceAccelerator.framework/IOSurfaceAccelerator.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/IconServices.framework/IconServices.tbd: Added.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/IdleTimerServices.framework/IdleTimerServices.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/AuthKit.framework/AuthKit.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/InstallCoordination.framework/InstallCoordination.tbd: Copied from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/VisionKitCore.framework/VisionKitCore.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/MobileKeyBag.framework/MobileKeyBag.tbd: Added.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/PrototypeTools.framework/PrototypeTools.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/PrototypeTools.framework/PrototypeTools.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/RemotePairingDevice.framework/RemotePairingDevice.tbd: Added.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/RunningBoardServices.framework/RunningBoardServices.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/RunningBoardServices.framework/RunningBoardServices.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/SafariSafeBrowsing.framework/SafariSafeBrowsing.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/SafariSafeBrowsing.framework/SafariSafeBrowsing.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/SharedWebCredentials.framework/SharedWebCredentials.tbd: Added.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/UIIntelligenceSupport.framework/UIIntelligenceSupport.tbd: Added.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/URLFormatting.framework/URLFormatting.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/URLFormatting.framework/URLFormatting.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/VisionKitCore.framework/VisionKitCore.tbd: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/System/Library/PrivateFrameworks/VisionKitCore.framework/VisionKitCore.tbd.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/WritingTools.framework/WritingTools.tbd: Added.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/System/Library/PrivateFrameworks/WritingToolsUI.framework/WritingToolsUI.tbd: Added.
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h: Copied from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h.
* WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/Frameworks/AudioToolbox.framework/AudioToolbox.tbd: Removed.
* WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/Frameworks/CFNetwork.framework/CFNetwork.tbd: Removed.
* WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/Frameworks/IOKit.framework/IOKit.tbd: Removed.
* WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit.tbd: Removed.
* WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/Frameworks/IOKit.framework/Versions/Current: Removed.
* WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/Frameworks/IOSurface.framework/IOSurface.tbd: Removed.
* WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/Frameworks/Metal.framework/Metal.tbd: Removed.
* WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/Frameworks/QuartzCore.framework/QuartzCore.tbd: Removed.
* WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/InstallCoordination.framework/InstallCoordination.tbd: Removed.
* WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/usr: Removed.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/SDKSettings.plist: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/SDKSettings.plist.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/SymlinkedHeaders-output.xcfilelist: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/SymlinkedHeaders-output.xcfilelist.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/SymlinkedHeaders.xcfilelist: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/SymlinkedHeaders.xcfilelist.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/AppServerSupport.framework/AppServerSupport.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/AppServerSupport.framework/AppServerSupport.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/AppStoreDaemon.framework/AppStoreDaemon.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/AppStoreDaemon.framework/AppStoreDaemon.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport.tbd: Copied from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/ApplePushService.framework/ApplePushService.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/ApplePushService.framework/ApplePushService.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/AuthKit.framework/AuthKit.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/AuthKit.framework/AuthKit.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/CoreAnalytics.framework/CoreAnalytics.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/Frameworks/OpenGLES.framework/OpenGLES.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/CorePrediction.framework/CorePrediction.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/CorePrediction.framework/CorePrediction.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/IconServices.framework/IconServices.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/IdleTimerServices.framework/IdleTimerServices.tbd: Copied from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/VisionKitCore.framework/VisionKitCore.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/InstallCoordination.framework/InstallCoordination.tbd: Copied from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/VisionKitCore.framework/VisionKitCore.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/PrototypeTools.framework/PrototypeTools.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/PrototypeTools.framework/PrototypeTools.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/RunningBoardServices.framework/RunningBoardServices.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/RunningBoardServices.framework/RunningBoardServices.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/SafariSafeBrowsing.framework/SafariSafeBrowsing.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/SafariSafeBrowsing.framework/SafariSafeBrowsing.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/SharedWebCredentials.framework/SharedWebCredentials.tbd: Added.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/UIIntelligenceSupport.framework/UIIntelligenceSupport.tbd: Added.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/URLFormatting.framework/URLFormatting.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/URLFormatting.framework/URLFormatting.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/VisionKitCore.framework/VisionKitCore.tbd: Renamed from WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/System/Library/PrivateFrameworks/VisionKitCore.framework/VisionKitCore.tbd.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/System/Library/PrivateFrameworks/WritingTools.framework/WritingTools.tbd: Added.
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h: Renamed from WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h.

Canonical link: <a href="https://commits.webkit.org/281605@main">https://commits.webkit.org/281605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a8710ca81a8fb9a55e72eba819de7c4bf929848

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13005 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/10978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11211 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/64370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/10978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37074 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/52356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/33783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9585 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/9899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9875 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4380 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/66098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52336 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13432 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3639 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->