### PR TITLE
[web-animations] stroke-color should be animatable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -203,6 +203,13 @@ PASS stop-color supports animating as color of hsla()
 PASS stop-opacity (type: opacity) has testAccumulation function
 PASS stop-opacity: [0, 1] number
 PASS stop-opacity: [0, 1] number (clamped)
+PASS stroke-color (type: color) has testAccumulation function
+PASS stroke-color supports animating as color of rgb() with overflowed  from and to values
+PASS stroke-color supports animating as color of #RGB
+PASS stroke-color supports animating as color of hsl()
+PASS stroke-color supports animating as color of #RGBa
+PASS stroke-color supports animating as color of rgba()
+PASS stroke-color supports animating as color of hsla()
 PASS stroke-dasharray (type: dasharray) has testAccumulation function
 PASS stroke-dasharray: dasharray
 PASS stroke-dasharray (type: discrete) has testAccumulation function

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -203,6 +203,13 @@ PASS stop-color supports animating as color of hsla()
 PASS stop-opacity (type: opacity) has testAddition function
 PASS stop-opacity: [0, 1] number
 PASS stop-opacity: [0, 1] number (clamped)
+PASS stroke-color (type: color) has testAddition function
+PASS stroke-color supports animating as color of rgb() with overflowed  from and to values
+PASS stroke-color supports animating as color of #RGB
+PASS stroke-color supports animating as color of hsl()
+PASS stroke-color supports animating as color of #RGBa
+PASS stroke-color supports animating as color of rgba()
+PASS stroke-color supports animating as color of hsla()
 PASS stroke-dasharray (type: dasharray) has testAddition function
 PASS stroke-dasharray: dasharray
 PASS stroke-dasharray (type: discrete) has testAddition function

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -248,6 +248,13 @@ PASS stop-color supports animating as color of rgba()
 PASS stop-color supports animating as color of hsla()
 PASS stop-opacity (type: opacity) has testInterpolation function
 PASS stop-opacity supports animating as a [0, 1] number
+PASS stroke-color (type: color) has testInterpolation function
+PASS stroke-color supports animating as color of rgb()
+PASS stroke-color supports animating as color of #RGB
+PASS stroke-color supports animating as color of hsl()
+PASS stroke-color supports animating as color of #RGBa
+PASS stroke-color supports animating as color of rgba()
+PASS stroke-color supports animating as color of hsla()
 PASS stroke-dasharray (type: dasharray) has testInterpolation function
 PASS stroke-dasharray supports animating as a percentage
 PASS stroke-dasharray supports animating as a positive number

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -1298,6 +1298,10 @@ const gCSSProperties2 = {
     types: [
     ]
   },
+  'stroke-color': {
+    // https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-color
+    types: [ 'color' ]
+  },
   'stroke-dasharray': {
     // https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty
     types: [

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -200,6 +200,13 @@ PASS stop-color supports animating as color of hsla()
 PASS stop-opacity (type: opacity) has testAccumulation function
 PASS stop-opacity: [0, 1] number
 PASS stop-opacity: [0, 1] number (clamped)
+PASS stroke-color (type: color) has testAccumulation function
+PASS stroke-color supports animating as color of rgb() with overflowed  from and to values
+PASS stroke-color supports animating as color of #RGB
+PASS stroke-color supports animating as color of hsl()
+PASS stroke-color supports animating as color of #RGBa
+PASS stroke-color supports animating as color of rgba()
+PASS stroke-color supports animating as color of hsla()
 PASS stroke-dasharray (type: dasharray) has testAccumulation function
 PASS stroke-dasharray: dasharray
 PASS stroke-dasharray (type: discrete) has testAccumulation function

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -200,6 +200,13 @@ PASS stop-color supports animating as color of hsla()
 PASS stop-opacity (type: opacity) has testAddition function
 PASS stop-opacity: [0, 1] number
 PASS stop-opacity: [0, 1] number (clamped)
+PASS stroke-color (type: color) has testAddition function
+PASS stroke-color supports animating as color of rgb() with overflowed  from and to values
+PASS stroke-color supports animating as color of #RGB
+PASS stroke-color supports animating as color of hsl()
+PASS stroke-color supports animating as color of #RGBa
+PASS stroke-color supports animating as color of rgba()
+PASS stroke-color supports animating as color of hsla()
 PASS stroke-dasharray (type: dasharray) has testAddition function
 PASS stroke-dasharray: dasharray
 PASS stroke-dasharray (type: discrete) has testAddition function

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -244,6 +244,13 @@ PASS stop-color supports animating as color of rgba()
 PASS stop-color supports animating as color of hsla()
 PASS stop-opacity (type: opacity) has testInterpolation function
 PASS stop-opacity supports animating as a [0, 1] number
+PASS stroke-color (type: color) has testInterpolation function
+PASS stroke-color supports animating as color of rgb()
+PASS stroke-color supports animating as color of #RGB
+PASS stroke-color supports animating as color of hsl()
+PASS stroke-color supports animating as color of #RGBa
+PASS stroke-color supports animating as color of rgba()
+PASS stroke-color supports animating as color of hsla()
 PASS stroke-dasharray (type: dasharray) has testInterpolation function
 PASS stroke-dasharray supports animating as a percentage
 PASS stroke-dasharray supports animating as a positive number

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3882,6 +3882,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new PropertyWrapperStyleColor(CSSPropertyStopColor, &RenderStyle::stopColor, &RenderStyle::setStopColor),
 
         new PropertyWrapperStyleColor(CSSPropertyLightingColor, &RenderStyle::lightingColor, &RenderStyle::setLightingColor),
+        new PropertyWrapperStyleColor(CSSPropertyStrokeColor, &RenderStyle::strokeColor, &RenderStyle::setStrokeColor),
 
         new PropertyWrapperBaselineShift,
         new PropertyWrapper<SVGLengthValue>(CSSPropertyKerning, &RenderStyle::kerning, &RenderStyle::setKerning),
@@ -4212,7 +4213,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyScrollSnapAlign:
         case CSSPropertyScrollSnapStop:
         case CSSPropertyScrollSnapType:
-        case CSSPropertyStrokeColor:
 #if ENABLE(TEXT_AUTOSIZING)
         case CSSPropertyWebkitTextSizeAdjust:
 #endif

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1652,7 +1652,7 @@ public:
     inline bool hasExplicitlySetStrokeWidth() const;
     bool hasPositiveStrokeWidth() const;
     
-    inline StyleColor strokeColor() const;
+    inline const StyleColor& strokeColor() const;
     inline void setStrokeColor(const StyleColor&);
     inline void setVisitedLinkStrokeColor(const StyleColor&);
     inline const StyleColor& visitedLinkStrokeColor() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -681,7 +681,7 @@ inline const AtomString& RenderStyle::specifiedLocale() const { return fontDescr
 inline int RenderStyle::specifiedZIndex() const { return m_nonInheritedData->boxData->specifiedZIndex(); }
 inline bool RenderStyle::specifiesColumns() const { return !hasAutoColumnCount() || !hasAutoColumnWidth() || !hasInlineColumnAxis(); }
 constexpr OptionSet<Containment> RenderStyle::strictContainment() { return { Containment::Size, Containment::Layout, Containment::Paint, Containment::Style }; }
-inline StyleColor RenderStyle::strokeColor() const { return m_rareInheritedData->strokeColor; }
+inline const StyleColor& RenderStyle::strokeColor() const { return m_rareInheritedData->strokeColor; }
 inline float RenderStyle::strokeMiterLimit() const { return m_rareInheritedData->miterLimit; }
 inline const AtomString& RenderStyle::pseudoElementNameArgument() const { return m_nonInheritedData->rareData->pseudoElementNameArgument; }
 inline const TabSize& RenderStyle::tabSize() const { return m_rareInheritedData->tabSize; }


### PR DESCRIPTION
#### 858d667ffa59f71d85a502fe31d5edba5b6623f0
<pre>
[web-animations] stroke-color should be animatable
<a href="https://bugs.webkit.org/show_bug.cgi?id=277317">https://bugs.webkit.org/show_bug.cgi?id=277317</a>
<a href="https://rdar.apple.com/132784589">rdar://132784589</a>

Reviewed by Darin Adler.

As per: <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-color">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-color</a>

* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::strokeColor const):

Canonical link: <a href="https://commits.webkit.org/281570@main">https://commits.webkit.org/281570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3d4ad2d2b84cf7115841021e42a254fa2d62643

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64228 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10840 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48831 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7546 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29677 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33663 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9475 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9757 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65960 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56190 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56357 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13401 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3530 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35470 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36551 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37641 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->