### PR TITLE
[web-animations] appearance should support discrete animation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
@@ -9,6 +9,9 @@ PASS align-items: "flex-start" onto "flex-end"
 PASS align-self (type: discrete) has testAccumulation function
 PASS align-self: "flex-end" onto "flex-start"
 PASS align-self: "flex-start" onto "flex-end"
+PASS appearance (type: discrete) has testAccumulation function
+PASS appearance: "none" onto "auto"
+PASS appearance: "auto" onto "none"
 PASS backface-visibility (type: discrete) has testAccumulation function
 PASS backface-visibility: "hidden" onto "visible"
 PASS backface-visibility: "visible" onto "hidden"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
@@ -9,6 +9,9 @@ PASS align-items: "flex-start" onto "flex-end"
 PASS align-self (type: discrete) has testAddition function
 PASS align-self: "flex-end" onto "flex-start"
 PASS align-self: "flex-start" onto "flex-end"
+PASS appearance (type: discrete) has testAddition function
+PASS appearance: "none" onto "auto"
+PASS appearance: "auto" onto "none"
 PASS backface-visibility (type: discrete) has testAddition function
 PASS backface-visibility: "hidden" onto "visible"
 PASS backface-visibility: "visible" onto "hidden"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
@@ -12,6 +12,10 @@ PASS align-self (type: discrete) has testInterpolation function
 PASS align-self uses discrete animation when animating between "flex-start" and "flex-end" with linear easing
 PASS align-self uses discrete animation when animating between "flex-start" and "flex-end" with effect easing
 PASS align-self uses discrete animation when animating between "flex-start" and "flex-end" with keyframe easing
+PASS appearance (type: discrete) has testInterpolation function
+PASS appearance uses discrete animation when animating between "auto" and "none" with linear easing
+PASS appearance uses discrete animation when animating between "auto" and "none" with effect easing
+PASS appearance uses discrete animation when animating between "auto" and "none" with keyframe easing
 PASS backface-visibility (type: discrete) has testInterpolation function
 PASS backface-visibility uses discrete animation when animating between "visible" and "hidden" with linear easing
 PASS backface-visibility uses discrete animation when animating between "visible" and "hidden" with effect easing

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -19,6 +19,12 @@ const gCSSProperties1 = {
       { type: 'discrete', options: [ [ 'flex-start', 'flex-end' ] ] }
     ]
   },
+  'appearance': {
+    // https://drafts.csswg.org/css-ui/#appearance-switching
+    types: [
+      { type: 'discrete' , options: [ [ 'auto', 'none' ] ] }
+    ]
+  },
   'backface-visibility': {
     // https://drafts.csswg.org/css-transforms/#propdef-backface-visibility
     types: [

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3986,6 +3986,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<Isolation>(CSSPropertyIsolation, &RenderStyle::isolation, &RenderStyle::setIsolation),
         new DiscretePropertyWrapper<BlendMode>(CSSPropertyMixBlendMode, &RenderStyle::blendMode, &RenderStyle::setBlendMode),
         new DiscretePropertyWrapper<BlendMode>(CSSPropertyBackgroundBlendMode, &RenderStyle::backgroundBlendMode, &RenderStyle::setBackgroundBlendMode),
+        new DiscretePropertyWrapper<StyleAppearance>(CSSPropertyAppearance, &RenderStyle::appearance, &RenderStyle::setAppearance),
 #if ENABLE(DARK_MODE_CSS)
         new DiscretePropertyWrapper<StyleColorScheme>(CSSPropertyColorScheme, &RenderStyle::colorScheme, &RenderStyle::setColorScheme),
 #endif
@@ -4145,7 +4146,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
 
         // To be fixed / untriaged:
         case CSSPropertyAlignmentBaseline:
-        case CSSPropertyAppearance:
         case CSSPropertyBlockStepInsert:
         case CSSPropertyBlockStepSize:
         case CSSPropertyBorderBlock: // logical shorthand

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1788,6 +1788,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyResize);
         if (first.objectFit != second.objectFit)
             changingProperties.m_properties.set(CSSPropertyObjectFit);
+        if (first.appearance != second.appearance)
+            changingProperties.m_properties.set(CSSPropertyAppearance);
 
         if (first.transform.ptr() != second.transform.ptr())
             conservativelyCollectChangedAnimatablePropertiesViaTransformData(*first.transform, *second.transform);
@@ -1798,7 +1800,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // hasExplicitlySetColorScheme
         // hasExplicitlySetDirection
         // hasExplicitlySetWritingMode
-        // appearance
         // usedAppearance
         // userDrag
     };


### PR DESCRIPTION
#### e1d34a4d3439082c790c973016017e354293a7ff
<pre>
[web-animations] appearance should support discrete animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=241171">https://bugs.webkit.org/show_bug.cgi?id=241171</a>
<a href="https://rdar.apple.com/96082999">rdar://96082999</a>

Reviewed by Darin Adler.

As per: <a href="https://drafts.csswg.org/css-ui-4/#propdef-appearance">https://drafts.csswg.org/css-ui-4/#propdef-appearance</a>

* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):

Canonical link: <a href="https://commits.webkit.org/281568@main">https://commits.webkit.org/281568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6f43fe42a552df8541608d0218fa13dc497d512

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64229 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10841 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48828 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7544 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52242 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29674 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9470 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9758 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65961 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56189 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56356 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13402 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3532 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35471 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36552 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37642 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->