### PR TITLE
Account for zoom when computing SVG font size

### DIFF
--- a/LayoutTests/imported/blink/svg/zoom/text/zoom-text-and-geometry-expected.html
+++ b/LayoutTests/imported/blink/svg/zoom/text/zoom-text-and-geometry-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    font-size : 16px;
+    font-family : "Times New Roman";
+    zoom: 2;
+}
+rect {
+    fill : green;
+    stroke: green;
+}
+</style>
+</head>
+<body>
+    Text should zoom like geometry.<br/>
+    This test passes if there is no red.<br/>
+    <svg version="1.1" width="32px" height="32px">
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em">
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em" viewbox="0 0 32 32">
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="32px" height="32px">
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em">
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em" viewbox="0 0 32 32">
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/imported/blink/svg/zoom/text/zoom-text-and-geometry.html
+++ b/LayoutTests/imported/blink/svg/zoom/text/zoom-text-and-geometry.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    font-size : 16px;
+    font-family : "Times New Roman";
+    zoom: 2;
+}
+rect {
+    fill : green;
+    stroke: green;
+}
+text {
+    fill : red;
+}
+.geometricPrecision {
+    text-rendering: geometricPrecision;
+}
+</style>
+</head>
+<body>
+    Text should zoom like geometry.<br/>
+    This test passes if there is no red.<br/>
+    <svg version="1.1" width="32px" height="32px">
+        <text x="10" y="22">F</text>
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em">
+        <text x="10" y="22">A</text>
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em" viewbox="0 0 32 32">
+        <text x="10" y="22">I</text>
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="32px" height="32px">
+        <text class="geometricPrecision" x="10" y="22">L</text>
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em">
+        <text class="geometricPrecision" x="10" y="22">F</text>
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+    <svg version="1.1" width="2em" height="2em" viewbox="0 0 32 32">
+        <text class="geometricPrecision" x="10" y="22">F</text>
+        <rect x="10" y="10" width="12" height="12"/>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/import/interact-pevents-03-b-manual-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/import/interact-pevents-03-b-manual-expected.txt
@@ -14,9 +14,9 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (195,93) size 410x72
               RenderSVGText {text} at (117,66) size 246x43 contains 1 chunk(s)
                 RenderSVGInlineText {#text} at (0,0) size 245x43
-                  chunk 1 (middle anchor) text run 1 at (117.61,100.00) startOffset 0 endOffset 1 width 27.93: "@"
-                  chunk 1 (middle anchor) text run 2 at (155.54,100.00) startOffset 1 endOffset 2 width 15.00: " "
-                  chunk 1 (middle anchor) text run 3 at (180.54,100.00) startOffset 2 endOffset 3 width 21.93: "A"
+                  chunk 1 (middle anchor) text run 1 at (117.60,100.00) startOffset 0 endOffset 1 width 27.93: "@"
+                  chunk 1 (middle anchor) text run 2 at (155.53,100.00) startOffset 1 endOffset 2 width 15.00: " "
+                  chunk 1 (middle anchor) text run 3 at (180.53,100.00) startOffset 2 endOffset 3 width 21.93: "A"
                   chunk 1 (middle anchor) text run 4 at (212.46,100.00) startOffset 3 endOffset 4 width 15.00: " "
                   chunk 1 (middle anchor) text run 5 at (237.46,100.00) startOffset 4 endOffset 5 width 15.60: "y"
                   chunk 1 (middle anchor) text run 6 at (263.07,100.00) startOffset 5 endOffset 6 width 15.00: " "
@@ -26,9 +26,9 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (195,176) size 410x73 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,50.00)}]
               RenderSVGText {text} at (117,66) size 246x43 contains 1 chunk(s)
                 RenderSVGInlineText {#text} at (0,0) size 245x43
-                  chunk 1 (middle anchor) text run 1 at (117.61,100.00) startOffset 0 endOffset 1 width 27.93: "@"
-                  chunk 1 (middle anchor) text run 2 at (155.54,100.00) startOffset 1 endOffset 2 width 15.00: " "
-                  chunk 1 (middle anchor) text run 3 at (180.54,100.00) startOffset 2 endOffset 3 width 21.93: "A"
+                  chunk 1 (middle anchor) text run 1 at (117.60,100.00) startOffset 0 endOffset 1 width 27.93: "@"
+                  chunk 1 (middle anchor) text run 2 at (155.53,100.00) startOffset 1 endOffset 2 width 15.00: " "
+                  chunk 1 (middle anchor) text run 3 at (180.53,100.00) startOffset 2 endOffset 3 width 21.93: "A"
                   chunk 1 (middle anchor) text run 4 at (212.46,100.00) startOffset 3 endOffset 4 width 15.00: " "
                   chunk 1 (middle anchor) text run 5 at (237.46,100.00) startOffset 4 endOffset 5 width 15.60: "y"
                   chunk 1 (middle anchor) text run 6 at (263.07,100.00) startOffset 5 endOffset 6 width 15.00: " "
@@ -38,8 +38,8 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (212,260) size 376x72 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,100.00)}]
               RenderSVGText {text} at (127,66) size 226x43 contains 1 chunk(s)
                 RenderSVGInlineText {#text} at (0,0) size 225x43
-                  chunk 1 (middle anchor) text run 1 at (127.61,100.00) startOffset 0 endOffset 1 width 27.93: "@"
-                  chunk 1 (middle anchor) text run 2 at (185.54,100.00) startOffset 1 endOffset 2 width 21.93: "A"
+                  chunk 1 (middle anchor) text run 1 at (127.60,100.00) startOffset 0 endOffset 1 width 27.93: "@"
+                  chunk 1 (middle anchor) text run 2 at (185.53,100.00) startOffset 1 endOffset 2 width 21.93: "A"
                   chunk 1 (middle anchor) text run 3 at (237.46,100.00) startOffset 2 endOffset 3 width 15.60: "y"
                   chunk 1 (middle anchor) text run 4 at (283.07,100.00) startOffset 3 endOffset 4 width 23.94: "\x{D6}"
                   chunk 1 (middle anchor) text run 5 at (337.01,100.00) startOffset 4 endOffset 5 width 15.39: "\x{E7}"

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/interact-pevents-03-b-manual-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/interact-pevents-03-b-manual-expected.txt
@@ -14,9 +14,9 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (195,94) size 410x71
               RenderSVGText {text} at (117,66) size 246x43 contains 1 chunk(s)
                 RenderSVGInlineText {#text} at (0,0) size 245x42
-                  chunk 1 (middle anchor) text run 1 at (117.61,100.00) startOffset 0 endOffset 1 width 27.93: "@"
-                  chunk 1 (middle anchor) text run 2 at (155.54,100.00) startOffset 1 endOffset 2 width 15.00: " "
-                  chunk 1 (middle anchor) text run 3 at (180.54,100.00) startOffset 2 endOffset 3 width 21.93: "A"
+                  chunk 1 (middle anchor) text run 1 at (117.60,100.00) startOffset 0 endOffset 1 width 27.93: "@"
+                  chunk 1 (middle anchor) text run 2 at (155.53,100.00) startOffset 1 endOffset 2 width 15.00: " "
+                  chunk 1 (middle anchor) text run 3 at (180.53,100.00) startOffset 2 endOffset 3 width 21.93: "A"
                   chunk 1 (middle anchor) text run 4 at (212.46,100.00) startOffset 3 endOffset 4 width 15.00: " "
                   chunk 1 (middle anchor) text run 5 at (237.46,100.00) startOffset 4 endOffset 5 width 15.60: "y"
                   chunk 1 (middle anchor) text run 6 at (263.07,100.00) startOffset 5 endOffset 6 width 15.00: " "
@@ -26,9 +26,9 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (195,178) size 410x70 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,50.00)}]
               RenderSVGText {text} at (117,66) size 246x43 contains 1 chunk(s)
                 RenderSVGInlineText {#text} at (0,0) size 245x42
-                  chunk 1 (middle anchor) text run 1 at (117.61,100.00) startOffset 0 endOffset 1 width 27.93: "@"
-                  chunk 1 (middle anchor) text run 2 at (155.54,100.00) startOffset 1 endOffset 2 width 15.00: " "
-                  chunk 1 (middle anchor) text run 3 at (180.54,100.00) startOffset 2 endOffset 3 width 21.93: "A"
+                  chunk 1 (middle anchor) text run 1 at (117.60,100.00) startOffset 0 endOffset 1 width 27.93: "@"
+                  chunk 1 (middle anchor) text run 2 at (155.53,100.00) startOffset 1 endOffset 2 width 15.00: " "
+                  chunk 1 (middle anchor) text run 3 at (180.53,100.00) startOffset 2 endOffset 3 width 21.93: "A"
                   chunk 1 (middle anchor) text run 4 at (212.46,100.00) startOffset 3 endOffset 4 width 15.00: " "
                   chunk 1 (middle anchor) text run 5 at (237.46,100.00) startOffset 4 endOffset 5 width 15.60: "y"
                   chunk 1 (middle anchor) text run 6 at (263.07,100.00) startOffset 5 endOffset 6 width 15.00: " "
@@ -38,8 +38,8 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (212,261) size 376x71 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,100.00)}]
               RenderSVGText {text} at (127,66) size 226x43 contains 1 chunk(s)
                 RenderSVGInlineText {#text} at (0,0) size 225x42
-                  chunk 1 (middle anchor) text run 1 at (127.61,100.00) startOffset 0 endOffset 1 width 27.93: "@"
-                  chunk 1 (middle anchor) text run 2 at (185.54,100.00) startOffset 1 endOffset 2 width 21.93: "A"
+                  chunk 1 (middle anchor) text run 1 at (127.60,100.00) startOffset 0 endOffset 1 width 27.93: "@"
+                  chunk 1 (middle anchor) text run 2 at (185.53,100.00) startOffset 1 endOffset 2 width 21.93: "A"
                   chunk 1 (middle anchor) text run 3 at (237.46,100.00) startOffset 2 endOffset 3 width 15.60: "y"
                   chunk 1 (middle anchor) text run 4 at (283.07,100.00) startOffset 3 endOffset 4 width 23.94: "\x{D6}"
                   chunk 1 (middle anchor) text run 5 at (337.01,100.00) startOffset 4 endOffset 5 width 15.39: "\x{E7}"

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -225,16 +225,19 @@ bool RenderSVGInlineText::computeNewScaledFontForStyle(const RenderObject& rende
 {
     // Alter font-size to the right on-screen value to avoid scaling the glyphs themselves, except when GeometricPrecision is specified
     scalingFactor = computeScalingFactorForRenderer(renderer);
-    if (!scalingFactor || style.fontDescription().textRenderingMode() == TextRenderingMode::GeometricPrecision) {
+    if (!scalingFactor) {
         scalingFactor = 1;
         scaledFont = style.fontCascade();
         return false;
     }
 
+    if (style.fontDescription().textRenderingMode() == TextRenderingMode::GeometricPrecision)
+        scalingFactor = 1;
+
     auto fontDescription = style.fontDescription();
 
     // FIXME: We need to better handle the case when we compute very small fonts below (below 1pt).
-    fontDescription.setComputedSize(Style::computedFontSizeFromSpecifiedSizeForSVGInlineText(fontDescription.computedSize(), fontDescription.isAbsoluteSize(), scalingFactor, renderer.protectedDocument()));
+    fontDescription.setComputedSize(Style::computedFontSizeFromSpecifiedSizeForSVGInlineText(fontDescription.specifiedSize(), fontDescription.isAbsoluteSize(), scalingFactor, renderer.protectedDocument()));
 
     // SVG controls its own glyph orientation, so don't allow writing-mode
     // to affect it.


### PR DESCRIPTION
#### 6639b68a68a6ced93a7da7266f8fc003418ca0c1
<pre>
Account for zoom when computing SVG font size
<a href="https://bugs.webkit.org/show_bug.cgi?id=118818">https://bugs.webkit.org/show_bug.cgi?id=118818</a>

Reviewed by Nikolas Zimmermann.

Merge the following three Blink patches.

  Account for zoom when computing SVG font size.
  <a href="https://codereview.chromium.org/18190003">https://codereview.chromium.org/18190003</a>
  <a href="https://chromium.googlesource.com/chromium/src/+/54d75e71090b6cae2c4c5c29aeaf12c5096d40ec">https://chromium.googlesource.com/chromium/src/+/54d75e71090b6cae2c4c5c29aeaf12c5096d40ec</a>

  Properly recompute SVG font size under zoom
  <a href="https://codereview.chromium.org/508823002">https://codereview.chromium.org/508823002</a>
  <a href="https://chromium.googlesource.com/chromium/src/+/a72213bbae36fef99982aae9d734f9e75bbb7ad8">https://chromium.googlesource.com/chromium/src/+/a72213bbae36fef99982aae9d734f9e75bbb7ad8</a>

  Resolve em units against the specified font size in SVG
  <a href="https://codereview.chromium.org/18421006">https://codereview.chromium.org/18421006</a>
  <a href="https://chromium.googlesource.com/chromium/src/+/379adaff378d4fd06ad7bf69757db95085a7da8d">https://chromium.googlesource.com/chromium/src/+/379adaff378d4fd06ad7bf69757db95085a7da8d</a>

* LayoutTests/imported/blink/svg/zoom/text/zoom-text-and-geometry-expected.html: Added.
* LayoutTests/imported/blink/svg/zoom/text/zoom-text-and-geometry.html: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/import/interact-pevents-03-b-manual-expected.txt:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/import/interact-pevents-03-b-manual-expected.txt:
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::computeNewScaledFontForStyle):

Canonical link: <a href="https://commits.webkit.org/281919@main">https://commits.webkit.org/281919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96caffce0176a5713ee2a82e3ec7391f69342f72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65092 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11691 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11966 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49435 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8135 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30265 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10199 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10603 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56181 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66823 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56807 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5111 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57001 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4215 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9242 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36307 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37390 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38484 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->