### PR TITLE
[web-animations] scroll-snap-* properties should support discrete animation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -166,6 +166,15 @@ PASS ruby-align: "start" onto "center"
 PASS scroll-behavior (type: discrete) has testAccumulation function
 PASS scroll-behavior: "smooth" onto "auto"
 PASS scroll-behavior: "auto" onto "smooth"
+PASS scroll-snap-align (type: discrete) has testAccumulation function
+PASS scroll-snap-align: "start" onto "none"
+PASS scroll-snap-align: "none" onto "start"
+PASS scroll-snap-stop (type: discrete) has testAccumulation function
+PASS scroll-snap-stop: "always" onto "normal"
+PASS scroll-snap-stop: "normal" onto "always"
+PASS scroll-snap-type (type: discrete) has testAccumulation function
+PASS scroll-snap-type: "x mandatory" onto "none"
+PASS scroll-snap-type: "none" onto "x mandatory"
 PASS scrollbar-color (type: colorPair) has testAccumulation function
 PASS scrollbar-color supports animating as color pair of rgb() with overflowed  from and to values
 PASS scrollbar-color supports animating as color pair of #RGB

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -166,6 +166,15 @@ PASS ruby-align: "start" onto "center"
 PASS scroll-behavior (type: discrete) has testAddition function
 PASS scroll-behavior: "smooth" onto "auto"
 PASS scroll-behavior: "auto" onto "smooth"
+PASS scroll-snap-align (type: discrete) has testAddition function
+PASS scroll-snap-align: "start" onto "none"
+PASS scroll-snap-align: "none" onto "start"
+PASS scroll-snap-stop (type: discrete) has testAddition function
+PASS scroll-snap-stop: "always" onto "normal"
+PASS scroll-snap-stop: "normal" onto "always"
+PASS scroll-snap-type (type: discrete) has testAddition function
+PASS scroll-snap-type: "x mandatory" onto "none"
+PASS scroll-snap-type: "none" onto "x mandatory"
 PASS scrollbar-color (type: colorPair) has testAddition function
 PASS scrollbar-color supports animating as color pair of rgb() with overflowed  from and to values
 PASS scrollbar-color supports animating as color pair of #RGB

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -204,6 +204,18 @@ PASS scroll-behavior (type: discrete) has testInterpolation function
 PASS scroll-behavior uses discrete animation when animating between "auto" and "smooth" with linear easing
 PASS scroll-behavior uses discrete animation when animating between "auto" and "smooth" with effect easing
 PASS scroll-behavior uses discrete animation when animating between "auto" and "smooth" with keyframe easing
+PASS scroll-snap-align (type: discrete) has testInterpolation function
+PASS scroll-snap-align uses discrete animation when animating between "none" and "start" with linear easing
+PASS scroll-snap-align uses discrete animation when animating between "none" and "start" with effect easing
+PASS scroll-snap-align uses discrete animation when animating between "none" and "start" with keyframe easing
+PASS scroll-snap-stop (type: discrete) has testInterpolation function
+PASS scroll-snap-stop uses discrete animation when animating between "normal" and "always" with linear easing
+PASS scroll-snap-stop uses discrete animation when animating between "normal" and "always" with effect easing
+PASS scroll-snap-stop uses discrete animation when animating between "normal" and "always" with keyframe easing
+PASS scroll-snap-type (type: discrete) has testInterpolation function
+PASS scroll-snap-type uses discrete animation when animating between "none" and "x mandatory" with linear easing
+PASS scroll-snap-type uses discrete animation when animating between "none" and "x mandatory" with effect easing
+PASS scroll-snap-type uses discrete animation when animating between "none" and "x mandatory" with keyframe easing
 PASS scrollbar-color (type: colorPair) has testInterpolation function
 PASS scrollbar-color supports animating as color pair of rgb()
 PASS scrollbar-color supports animating as color pair of #RGB

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -1255,6 +1255,24 @@ const gCSSProperties2 = {
       { type: 'discrete', options: [ [ 'auto', 'smooth' ] ] }
     ]
   },
+  'scroll-snap-align': {
+    // https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-snap-align
+    types: [
+      { type: 'discrete', options: [ [ 'none', 'start' ]] }
+    ]
+  },
+  'scroll-snap-stop': {
+    // https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-snap-stop
+    types: [
+      { type: 'discrete', options: [ [ 'normal', 'always' ]] }
+    ]
+  },
+  'scroll-snap-type': {
+    // https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-snap-type
+    types: [
+      { type: 'discrete', options: [ [ 'none', 'x mandatory' ]] }
+    ]
+  },
   'scrollbar-color': {
     // https://drafts.csswg.org/css-scrollbars/#propdef-scrollbar-color
     types: [ 'colorPair' ]

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -163,6 +163,15 @@ PASS resize: "both" onto "horizontal"
 PASS ruby-align (type: discrete) has testAccumulation function
 PASS ruby-align: "center" onto "start"
 PASS ruby-align: "start" onto "center"
+PASS scroll-snap-align (type: discrete) has testAccumulation function
+PASS scroll-snap-align: "start" onto "none"
+PASS scroll-snap-align: "none" onto "start"
+PASS scroll-snap-stop (type: discrete) has testAccumulation function
+PASS scroll-snap-stop: "always" onto "normal"
+PASS scroll-snap-stop: "normal" onto "always"
+PASS scroll-snap-type (type: discrete) has testAccumulation function
+PASS scroll-snap-type: "x mandatory" onto "none"
+PASS scroll-snap-type: "none" onto "x mandatory"
 PASS scrollbar-color (type: colorPair) has testAccumulation function
 PASS scrollbar-color supports animating as color pair of rgb() with overflowed  from and to values
 PASS scrollbar-color supports animating as color pair of #RGB

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -163,6 +163,15 @@ PASS resize: "both" onto "horizontal"
 PASS ruby-align (type: discrete) has testAddition function
 PASS ruby-align: "center" onto "start"
 PASS ruby-align: "start" onto "center"
+PASS scroll-snap-align (type: discrete) has testAddition function
+PASS scroll-snap-align: "start" onto "none"
+PASS scroll-snap-align: "none" onto "start"
+PASS scroll-snap-stop (type: discrete) has testAddition function
+PASS scroll-snap-stop: "always" onto "normal"
+PASS scroll-snap-stop: "normal" onto "always"
+PASS scroll-snap-type (type: discrete) has testAddition function
+PASS scroll-snap-type: "x mandatory" onto "none"
+PASS scroll-snap-type: "none" onto "x mandatory"
 PASS scrollbar-color (type: colorPair) has testAddition function
 PASS scrollbar-color supports animating as color pair of rgb() with overflowed  from and to values
 PASS scrollbar-color supports animating as color pair of #RGB

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -200,6 +200,18 @@ PASS ruby-align (type: discrete) has testInterpolation function
 PASS ruby-align uses discrete animation when animating between "start" and "center" with linear easing
 PASS ruby-align uses discrete animation when animating between "start" and "center" with effect easing
 PASS ruby-align uses discrete animation when animating between "start" and "center" with keyframe easing
+PASS scroll-snap-align (type: discrete) has testInterpolation function
+PASS scroll-snap-align uses discrete animation when animating between "none" and "start" with linear easing
+PASS scroll-snap-align uses discrete animation when animating between "none" and "start" with effect easing
+PASS scroll-snap-align uses discrete animation when animating between "none" and "start" with keyframe easing
+PASS scroll-snap-stop (type: discrete) has testInterpolation function
+PASS scroll-snap-stop uses discrete animation when animating between "normal" and "always" with linear easing
+PASS scroll-snap-stop uses discrete animation when animating between "normal" and "always" with effect easing
+PASS scroll-snap-stop uses discrete animation when animating between "normal" and "always" with keyframe easing
+PASS scroll-snap-type (type: discrete) has testInterpolation function
+PASS scroll-snap-type uses discrete animation when animating between "none" and "x mandatory" with linear easing
+PASS scroll-snap-type uses discrete animation when animating between "none" and "x mandatory" with effect easing
+PASS scroll-snap-type uses discrete animation when animating between "none" and "x mandatory" with keyframe easing
 PASS scrollbar-color (type: colorPair) has testInterpolation function
 PASS scrollbar-color supports animating as color pair of rgb()
 PASS scrollbar-color supports animating as color pair of #RGB

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2847,6 +2847,7 @@ rendering/style/StyleNonInheritedData.cpp
 rendering/style/StylePaintImage.cpp
 rendering/style/StyleRareInheritedData.cpp
 rendering/style/StyleRareNonInheritedData.cpp
+rendering/style/StyleScrollSnapPoints.cpp
 rendering/style/StyleSelfAlignmentData.cpp
 rendering/style/StyleSurroundData.cpp
 rendering/style/StyleTextBoxEdge.cpp

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -4047,8 +4047,11 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscreteSVGPropertyWrapper<const String&>(CSSPropertyMarkerEnd, &SVGRenderStyle::markerEndResource, &SVGRenderStyle::setMarkerEndResource),
         new DiscreteSVGPropertyWrapper<const String&>(CSSPropertyMarkerMid, &SVGRenderStyle::markerMidResource, &SVGRenderStyle::setMarkerMidResource),
         new DiscreteSVGPropertyWrapper<const String&>(CSSPropertyMarkerStart, &SVGRenderStyle::markerStartResource, &SVGRenderStyle::setMarkerStartResource),
-        new DiscretePropertyWrapper<const ScrollbarGutter>(CSSPropertyScrollbarGutter, &RenderStyle::scrollbarGutter, &RenderStyle::setScrollbarGutter),
+        new DiscretePropertyWrapper<ScrollbarGutter>(CSSPropertyScrollbarGutter, &RenderStyle::scrollbarGutter, &RenderStyle::setScrollbarGutter),
         new DiscretePropertyWrapper<ScrollbarWidth>(CSSPropertyScrollbarWidth, &RenderStyle::scrollbarWidth, &RenderStyle::setScrollbarWidth),
+        new DiscretePropertyWrapper<const ScrollSnapAlign&>(CSSPropertyScrollSnapAlign, &RenderStyle::scrollSnapAlign, &RenderStyle::setScrollSnapAlign),
+        new DiscretePropertyWrapper<ScrollSnapStop>(CSSPropertyScrollSnapStop, &RenderStyle::scrollSnapStop, &RenderStyle::setScrollSnapStop),
+        new DiscretePropertyWrapper<ScrollSnapType>(CSSPropertyScrollSnapType, &RenderStyle::scrollSnapType, &RenderStyle::setScrollSnapType),
         new DiscretePropertyWrapper<std::optional<Style::ScopedName>>(CSSPropertyViewTransitionName, &RenderStyle::viewTransitionName, &RenderStyle::setViewTransitionName),
         new DiscretePropertyWrapper<FieldSizing>(CSSPropertyFieldSizing, &RenderStyle::fieldSizing, &RenderStyle::setFieldSizing),
         new DiscretePropertyWrapper<const Vector<AtomString>&>(CSSPropertyAnchorName, &RenderStyle::anchorNames, &RenderStyle::setAnchorNames),
@@ -4210,9 +4213,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyScrollPaddingLeft:
         case CSSPropertyScrollPaddingRight:
         case CSSPropertyScrollPaddingTop:
-        case CSSPropertyScrollSnapAlign:
-        case CSSPropertyScrollSnapStop:
-        case CSSPropertyScrollSnapType:
 #if ENABLE(TEXT_AUTOSIZING)
         case CSSPropertyWebkitTextSizeAdjust:
 #endif

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1922,6 +1922,12 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyAnchorName);
         if (first.positionAnchor != second.positionAnchor)
             changingProperties.m_properties.set(CSSPropertyPositionAnchor);
+        if (first.scrollSnapAlign != second.scrollSnapAlign)
+            changingProperties.m_properties.set(CSSPropertyScrollSnapAlign);
+        if (first.scrollSnapStop != second.scrollSnapStop)
+            changingProperties.m_properties.set(CSSPropertyScrollSnapStop);
+        if (first.scrollSnapType != second.scrollSnapType)
+            changingProperties.m_properties.set(CSSPropertyScrollSnapType);
 
         // Non animated styles are followings.
         // customProperties
@@ -1937,9 +1943,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // boxReflect
         // pageSize
         // pageSizeType
-        // scrollSnapType
-        // scrollSnapAlign
-        // scrollSnapStop
         // blockStepSize
         // blockStepInsert
         // overscrollBehaviorX
@@ -3689,7 +3692,7 @@ ScrollbarWidth RenderStyle::initialScrollbarWidth()
     return ScrollbarWidth::Auto;
 }
 
-const ScrollSnapType RenderStyle::scrollSnapType() const
+ScrollSnapType RenderStyle::scrollSnapType() const
 {
     return m_nonInheritedData->rareData->scrollSnapType;
 }
@@ -3704,7 +3707,7 @@ ScrollSnapStop RenderStyle::scrollSnapStop() const
     return m_nonInheritedData->rareData->scrollSnapStop;
 }
 
-const ScrollbarGutter RenderStyle::scrollbarGutter() const
+ScrollbarGutter RenderStyle::scrollbarGutter() const
 {
     return m_nonInheritedData->rareData->scrollbarGutter;
 }
@@ -3714,7 +3717,7 @@ ScrollbarWidth RenderStyle::scrollbarWidth() const
     return m_nonInheritedData->rareData->scrollbarWidth;
 }
 
-void RenderStyle::setScrollSnapType(const ScrollSnapType type)
+void RenderStyle::setScrollSnapType(ScrollSnapType type)
 {
     SET_NESTED_VAR(m_nonInheritedData, rareData, scrollSnapType, type);
 }
@@ -3724,7 +3727,7 @@ void RenderStyle::setScrollSnapAlign(const ScrollSnapAlign& alignment)
     SET_NESTED_VAR(m_nonInheritedData, rareData, scrollSnapAlign, alignment);
 }
 
-void RenderStyle::setScrollSnapStop(const ScrollSnapStop stop)
+void RenderStyle::setScrollSnapStop(ScrollSnapStop stop)
 {
     SET_NESTED_VAR(m_nonInheritedData, rareData, scrollSnapStop, stop);
 }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1034,7 +1034,7 @@ public:
     const Length& scrollPaddingRight() const;
 
     bool hasSnapPosition() const;
-    const ScrollSnapType scrollSnapType() const;
+    ScrollSnapType scrollSnapType() const;
     const ScrollSnapAlign& scrollSnapAlign() const;
     ScrollSnapStop scrollSnapStop() const;
 
@@ -1043,7 +1043,7 @@ public:
     inline std::optional<ScrollbarColor> scrollbarColor() const;
     inline const StyleColor& scrollbarThumbColor() const;
     inline const StyleColor& scrollbarTrackColor() const;
-    WEBCORE_EXPORT const ScrollbarGutter scrollbarGutter() const;
+    WEBCORE_EXPORT ScrollbarGutter scrollbarGutter() const;
     WEBCORE_EXPORT ScrollbarWidth scrollbarWidth() const;
 
 #if ENABLE(TOUCH_EVENTS)

--- a/Source/WebCore/rendering/style/StyleScrollSnapPoints.cpp
+++ b/Source/WebCore/rendering/style/StyleScrollSnapPoints.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleScrollSnapPoints.h"
+
+namespace WebCore {
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, ScrollSnapAlign align)
+{
+    auto populateTextStreamForAlignType = [&](ScrollSnapAxisAlignType type) {
+        switch (type) {
+        case ScrollSnapAxisAlignType::None: ts << "none"; break;
+        case ScrollSnapAxisAlignType::Start: ts << "start"; break;
+        case ScrollSnapAxisAlignType::Center: ts << "center"; break;
+        case ScrollSnapAxisAlignType::End: ts << "end"; break;
+        }
+    };
+    populateTextStreamForAlignType(align.blockAlign);
+    if (align.blockAlign != align.inlineAlign) {
+        ts << ' ';
+        populateTextStreamForAlignType(align.inlineAlign);
+    }
+    return ts;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, ScrollSnapType type)
+{
+    if (type.strictness != ScrollSnapStrictness::None) {
+        switch (type.axis) {
+        case ScrollSnapAxis::XAxis: ts << "x"; break;
+        case ScrollSnapAxis::YAxis: ts << "y"; break;
+        case ScrollSnapAxis::Block: ts << "block"; break;
+        case ScrollSnapAxis::Inline: ts << "inline"; break;
+        case ScrollSnapAxis::Both: ts << "both"; break;
+        }
+        ts << ' ';
+    }
+    switch (type.strictness) {
+    case ScrollSnapStrictness::None: ts << "none"; break;
+    case ScrollSnapStrictness::Proximity: ts << "proximity"; break;
+    case ScrollSnapStrictness::Mandatory: ts << "mandatory"; break;
+    }
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleScrollSnapPoints.h
+++ b/Source/WebCore/rendering/style/StyleScrollSnapPoints.h
@@ -47,4 +47,7 @@ struct ScrollSnapAlign {
     friend bool operator==(const ScrollSnapAlign&, const ScrollSnapAlign&) = default;
 };
 
+TextStream& operator<<(TextStream&, ScrollSnapType);
+TextStream& operator<<(TextStream&, ScrollSnapAlign);
+
 } // namespace WebCore


### PR DESCRIPTION
#### dbe541d8ae395340e1bf694d069456874e8c02a4
<pre>
[web-animations] scroll-snap-* properties should support discrete animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=241176">https://bugs.webkit.org/show_bug.cgi?id=241176</a>
<a href="https://rdar.apple.com/94614257">rdar://94614257</a>

Reviewed by Darin Adler.

As per: <a href="https://drafts.csswg.org/css-scroll-snap/#scroll-snap-type">https://drafts.csswg.org/css-scroll-snap/#scroll-snap-type</a>

* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
(WebCore::RenderStyle::scrollSnapType const):
(WebCore::RenderStyle::scrollbarGutter const):
(WebCore::RenderStyle::setScrollSnapType):
(WebCore::RenderStyle::setScrollSnapStop):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/StyleScrollSnapPoints.cpp: Added.
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/StyleScrollSnapPoints.h:

Canonical link: <a href="https://commits.webkit.org/281572@main">https://commits.webkit.org/281572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42094d7e5a711d837405875b6fa260840b09f8b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60372 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/39723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12930 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/10903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62502 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/47395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11136 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/64291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/10903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62403 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/47395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/52304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/47395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/9529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/9820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/47395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/9818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/4305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/66023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/4324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/52277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9054 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->