### PR TITLE
[GTK3][Cairo] Wrong documentLoder for fragmentNavigation with ongoing navigation

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4814,7 +4814,7 @@ RefPtr<DocumentLoader> FrameLoader::loaderForWebsitePolicies(CanIncludeCurrentDo
     RefPtr loader = policyDocumentLoader();
     if (!loader)
         loader = provisionalDocumentLoader();
-    if (!loader && canIncludeCurrentDocumentLoader == CanIncludeCurrentDocumentLoader::Yes)
+    if ((!loader && canIncludeCurrentDocumentLoader == CanIncludeCurrentDocumentLoader::Yes) || (canIncludeCurrentDocumentLoader == CanIncludeCurrentDocumentLoader::Always))
         loader = documentLoader();
     return loader;
 }

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -184,7 +184,7 @@ public:
     RefPtr<DocumentLoader> protectedProvisionalDocumentLoader() const;
     FrameState state() const { return m_state; }
 
-    enum class CanIncludeCurrentDocumentLoader : bool { No, Yes };
+    enum class CanIncludeCurrentDocumentLoader : uint8_t { No, Yes, Always };
     WEBCORE_EXPORT RefPtr<DocumentLoader> loaderForWebsitePolicies(CanIncludeCurrentDocumentLoader = CanIncludeCurrentDocumentLoader::Yes) const;
 
     bool shouldReportResourceTimingToParentFrame() const { return m_shouldReportResourceTimingToParentFrame; };

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -284,7 +284,10 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
         return;
     }
 
-    auto documentLoader = frameLoader->loaderForWebsitePolicies();
+    // PolicyDecisionMode::Synchronous means that it is a FragmentNavigation and in that case we should use documentLoader,
+    // because there can be ongoing (in policy or provisional state) navigation.
+    const auto canIncludeCurrentDocumentLoader = policyDecisionMode == PolicyDecisionMode::Synchronous ? FrameLoader::CanIncludeCurrentDocumentLoader::Always:FrameLoader::CanIncludeCurrentDocumentLoader::Yes;
+    auto documentLoader = frameLoader->loaderForWebsitePolicies(canIncludeCurrentDocumentLoader);
     auto clientRedirectSourceForHistory = documentLoader ? documentLoader->clientRedirectSourceForHistory() : String();
     auto navigationID = documentLoader ? documentLoader->navigationID() : 0;
     bool hasOpener = !!frame->opener();

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -310,7 +310,6 @@ public:
     void didAccessWindowProxyPropertyViaOpener(WindowProxyProperty);
 #endif
 
-    WEBCORE_EXPORT RefPtr<DocumentLoader> loaderForWebsitePolicies() const;
     void storageAccessExceptionReceivedForDomain(const RegistrableDomain&);
     bool requestSkipUserActivationCheckForStorageAccess(const RegistrableDomain&);
 


### PR DESCRIPTION
#### 28ff1d1fe2bf23ba0fb84c225cf49b8faae1252e
<pre>
[GTK3][Cairo] Wrong documentLoder for fragmentNavigation with ongoing navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=277332">https://bugs.webkit.org/show_bug.cgi?id=277332</a>

Reviewed by NOBODY (OOPS!).

In some specific situation the loaderDocument can be wrong and the consequence is that
navigationID passed from WebProcess to UIProcess is incorrect.
It can happen with PSON disabled and fragment navigation (sync navigation) with ongoing
navigation (async navigation in provisional state).

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loaderForWebsitePolicies const):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):

* Source/WebCore/page/LocalFrame.h:
remove dead declaration of loaderForWebsitePolicies
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81f350dbe6a8219ac27280bc085ea4365aeb7545

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11095 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48985 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7710 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29818 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9683 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10008 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55731 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66209 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56349 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56524 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3725 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35715 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36797 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36542 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->