### PR TITLE
[WebDriver][WPE] Allow reconnections while keeping the view open

### DIFF
--- a/Source/WebDriver/SessionHost.cpp
+++ b/Source/WebDriver/SessionHost.cpp
@@ -88,4 +88,11 @@ void SessionHost::dispatchMessage(const String& message)
     responseHandler(WTFMove(response));
 }
 
+#if !USE(GLIB)
+bool SessionHost::isRemoteBrowser() const
+{
+    return false;
+}
+#endif
+
 } // namespace WebDriver

--- a/Source/WebDriver/SessionHost.h
+++ b/Source/WebDriver/SessionHost.h
@@ -65,6 +65,8 @@ public:
     void connectToBrowser(Function<void (std::optional<String> error)>&&);
     void startAutomationSession(Function<void (bool, std::optional<String>)>&&);
 
+    bool isRemoteBrowser() const;
+
     struct CommandResponse {
         RefPtr<JSON::Object> responseObject;
         bool isError { false };

--- a/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
@@ -62,6 +62,7 @@ enum {
 
 enum {
     CREATE_WEB_VIEW,
+    WILL_CLOSE,
 
     LAST_SIGNAL
 };
@@ -319,6 +320,26 @@ static void webkit_automation_session_class_init(WebKitAutomationSessionClass* s
         nullptr, nullptr,
         g_cclosure_marshal_generic,
         WEBKIT_TYPE_WEB_VIEW, 0,
+        G_TYPE_NONE);
+
+
+    /**
+     * WebKitAutomationSession::will-close:
+     * @session: a #WebKitAutomationSession
+     *
+     * This signal is emitted when the given automation session is about to finish.
+     * It allows clients to perform any cleanup tasks before the session is destroyed.
+     *
+     * Since: 2.46
+     */
+    signals[WILL_CLOSE] = g_signal_new(
+        "will-close",
+        G_TYPE_FROM_CLASS(gObjectClass),
+        G_SIGNAL_RUN_LAST,
+        0,
+        nullptr, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_NONE, 0,
         G_TYPE_NONE);
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -323,6 +323,7 @@ void WebKitAutomationClient::requestAutomationSession(const String& sessionIdent
 
 void webkitWebContextWillCloseAutomationSession(WebKitWebContext* webContext)
 {
+    g_signal_emit_by_name(webContext->priv->automationSession.get(), "will-close");
     webContext->priv->processPool->setAutomationSession(nullptr);
     webContext->priv->automationSession = nullptr;
 }

--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -428,6 +428,10 @@
             ]
         },
         {
+            "name": "deleteSession",
+            "description": "Closes the automation session. Deletion of browsing contexts is handled by separate previous closeBrowsingContext commands."
+        },
+        {
             "name": "switchToBrowsingContext",
             "description": "Activates the specified browsing context and optional frame, which gives them focus (causing the 'focus' DOM event to fire, and 'blur' DOM event to fire for the previous browsing context and frame).",
             "parameters": [

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -375,6 +375,15 @@ Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::closeBrowsingCont
     return { };
 }
 
+Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::deleteSession()
+{
+    if (!isPaired())
+        SYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
+
+    terminate();
+    return { };
+}
+
 void WebAutomationSession::switchToBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, Ref<SwitchToBrowsingContextCallback>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -174,6 +174,7 @@ public:
     void getBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<GetBrowsingContextCallback>&&);
     void createBrowsingContext(std::optional<Inspector::Protocol::Automation::BrowsingContextPresentation>&&, Ref<CreateBrowsingContextCallback>&&);
     Inspector::Protocol::ErrorStringOr<void> closeBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&);
+    Inspector::Protocol::ErrorStringOr<void> deleteSession();
     void switchToBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, Ref<SwitchToBrowsingContextCallback>&&);
     void setWindowFrameOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, RefPtr<JSON::Object>&& origin, RefPtr<JSON::Object>&& size, Ref<SetWindowFrameOfBrowsingContextCallback>&&);
     void maximizeWindowOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<MaximizeWindowOfBrowsingContextCallback>&&);


### PR DESCRIPTION
#### 79271e75c2fec165d6badfa191b6b9a6edeee611
<pre>
[WebDriver][WPE] Allow reconnections while keeping the view open
<a href="https://bugs.webkit.org/show_bug.cgi?id=277341">https://bugs.webkit.org/show_bug.cgi?id=277341</a>

Reviewed by Carlos Garcia Campos.

Currently, when we close a session, all open windows are unconditionally
closed, while the spec[1] says it&apos;s optional. Allowing the window to
remain open might be interesting when we connect to an already running
browser, another scenario covered by the WebDriver spec[2] and supported
by WPEWebKit.

For the record, while the usual practice is to let the WebDriver service
manage the browser lifetime, in some cases we might want to start the
browser in a more controlled way, for example, to enable
profiling/debugging, loading a heavy page beforehand, etc.

To allow deleting a session and keep the windows open, this commit adds
a new `Automation.json` command, &quot;deleteSession&quot;, which makes the
UIProcess terminate the automation session and thus the RemoteInspector
connection between the UIProcess and the WebDriver service. This command
also serves as a fallback if somehow the browser fails to close all
windows.

On the browser-level API, this commit also adds a new signal,
`WebKitAutomationSession::will-close` to notify the browser that the
WebDriver client disconnected, and the browser is free to either kill or
keep the view open for new sessions as required.

[1] <a href="https://w3c.github.io/webdriver/#dfn-close-the-session">https://w3c.github.io/webdriver/#dfn-close-the-session</a> (Step 3.5)
[2] <a href="https://w3c.github.io/webdriver/#new-session">https://w3c.github.io/webdriver/#new-session</a> (Step 8 note)

* Source/WebDriver/Session.cpp:
(WebDriver::Session::close): Only close windows for non-remote sessions
and issue the new &quot;deleteSession&quot; automation command.
* Source/WebDriver/SessionHost.cpp:
(WebDriver::SessionHost::isRemoteBrowser const): Added
* Source/WebDriver/SessionHost.h: Ditto
* Source/WebDriver/glib/SessionHostGlib.cpp:
(WebDriver::SessionHost::connectionDidClose): If we lost connection to a
non-remote (i.e. managed) browser, kill it.
(WebDriver::SessionHost::setTargetList): Check for empty target list.
(WebDriver::SessionHost::isRemoteBrowser const): Added
* Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp:
(webkit_automation_session_class_init): Add new &quot;will-close&quot; signal
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
(webkitWebContextWillCloseAutomationSession): Emit the new signal
* Source/WebKit/UIProcess/Automation/Automation.json: Added
  &quot;deleteSession&quot; command.
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::deleteSession): Implemented by requesting
to terminate the connection between the WebDriver service and the
browser.
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h: Ditto.

Canonical link: <a href="https://commits.webkit.org/282489@main">https://commits.webkit.org/282489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c069b4b2ff1611fd4d682ac52438ba0c5ab9e650

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/42673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/15914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67338 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/13925 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14205 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/51008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9622 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/54829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/31690 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36303 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12178 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/12797 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/57842 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12506 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69034 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12110 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7295 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/54899 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14020 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6054 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38494 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/39573 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/40685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39316 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->