### PR TITLE
Adopt more smart pointers in our DOM iterator classes

### DIFF
--- a/Source/WebCore/dom/ElementAndTextDescendantIterator.h
+++ b/Source/WebCore/dom/ElementAndTextDescendantIterator.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class ElementAndTextDescendantIterator {
 public:
-    ElementAndTextDescendantIterator();
+    ElementAndTextDescendantIterator() = default;
     enum FirstChildTag { FirstChild };
     ElementAndTextDescendantIterator(const ContainerNode& root, FirstChildTag);
     ElementAndTextDescendantIterator(const ContainerNode& root, Node* current);
@@ -68,9 +68,9 @@ private:
 
     void popAncestorSiblingStack();
 
-    Node* m_current;
+    CheckedPtr<Node> m_current;
     struct AncestorSibling {
-        Node* node;
+        CheckedPtr<Node> node;
         unsigned depth;
     };
     Vector<AncestorSibling, 16> m_ancestorSiblingStack;
@@ -88,22 +88,17 @@ public:
     ElementAndTextDescendantIterator end() const;
 
 private:
-    const ContainerNode& m_root;
+    CheckedRef<const ContainerNode> m_root;
 };
 
 ElementAndTextDescendantRange elementAndTextDescendants(ContainerNode&);
 
 // ElementAndTextDescendantIterator
 
-inline ElementAndTextDescendantIterator::ElementAndTextDescendantIterator()
-    : m_current(nullptr)
-{
-}
-
 inline ElementAndTextDescendantIterator::ElementAndTextDescendantIterator(const ContainerNode& root, FirstChildTag)
     : m_current(firstChild(root))
 #if ASSERT_ENABLED
-    , m_assertions(m_current)
+    , m_assertions(m_current.get())
 #endif
 {
     if (!m_current)
@@ -115,7 +110,7 @@ inline ElementAndTextDescendantIterator::ElementAndTextDescendantIterator(const 
 inline ElementAndTextDescendantIterator::ElementAndTextDescendantIterator(const ContainerNode& root, Node* current)
     : m_current(current)
 #if ASSERT_ENABLED
-    , m_assertions(m_current)
+    , m_assertions(m_current.get())
 #endif
 {
     if (!m_current)
@@ -263,7 +258,7 @@ inline Node* ElementAndTextDescendantIterator::operator->()
     ASSERT(m_current);
     ASSERT(isElementOrText(*m_current));
     ASSERT(!m_assertions.domTreeHasMutated());
-    return m_current;
+    return m_current.get();
 }
 
 inline const Node& ElementAndTextDescendantIterator::operator*() const
@@ -279,7 +274,7 @@ inline const Node* ElementAndTextDescendantIterator::operator->() const
     ASSERT(m_current);
     ASSERT(isElementOrText(*m_current));
     ASSERT(!m_assertions.domTreeHasMutated());
-    return m_current;
+    return m_current.get();
 }
 
 inline bool ElementAndTextDescendantIterator::operator==(const ElementAndTextDescendantIterator& other) const
@@ -297,7 +292,7 @@ inline ElementAndTextDescendantRange::ElementAndTextDescendantRange(const Contai
 
 inline ElementAndTextDescendantIterator ElementAndTextDescendantRange::begin() const
 {
-    return ElementAndTextDescendantIterator(m_root, ElementAndTextDescendantIterator::FirstChild);
+    return ElementAndTextDescendantIterator(m_root.get(), ElementAndTextDescendantIterator::FirstChild);
 }
 
 inline ElementAndTextDescendantIterator ElementAndTextDescendantRange::end() const

--- a/Source/WebCore/dom/ElementChildIterator.h
+++ b/Source/WebCore/dom/ElementChildIterator.h
@@ -57,7 +57,7 @@ public:
     inline ElementType* last() const;
 
 private:
-    const ContainerNode& m_parent;
+    CheckedRef<const ContainerNode> m_parent;
 };
 
 // ElementChildIterator

--- a/Source/WebCore/dom/ElementChildIteratorInlines.h
+++ b/Source/WebCore/dom/ElementChildIteratorInlines.h
@@ -69,8 +69,8 @@ inline ElementType* ElementChildRange<ElementType>::last() const
 template <typename ElementType>
 inline ElementChildIterator<ElementType> ElementChildRange<ElementType>::beginAt(ElementType& child) const
 {
-    ASSERT(child.parentNode() == &m_parent);
-    return ElementChildIterator<ElementType>(m_parent, &child);
+    ASSERT(child.parentNode() == m_parent.ptr());
+    return ElementChildIterator<ElementType>(m_parent.get(), &child);
 }
 
 }

--- a/Source/WebCore/dom/ElementIterator.h
+++ b/Source/WebCore/dom/ElementIterator.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
+
 #if ASSERT_ENABLED
 #include "ElementIteratorAssertions.h"
 #endif
@@ -48,7 +50,7 @@ public:
     inline ElementType& operator*() const;
     inline ElementType* operator->() const;
 
-    constexpr operator bool() const { return m_current; }
+    constexpr operator bool() const { return m_current.get(); }
     constexpr bool operator!() const { return !m_current; }
     constexpr bool operator==(std::nullptr_t) const { return !m_current; }
     constexpr bool operator==(const ElementIterator&) const;
@@ -66,8 +68,8 @@ protected:
     ElementIterator(const ContainerNode* root, ElementType* current);
 
 private:
-    const ContainerNode* m_root { nullptr };
-    ElementType* m_current { nullptr };
+    CheckedPtr<const ContainerNode> m_root;
+    CheckedPtr<ElementType> m_current;
 
 #if ASSERT_ENABLED
     ElementIteratorAssertions m_assertions;
@@ -108,7 +110,7 @@ inline ElementType* ElementIterator<ElementType>::operator->() const
 {
     ASSERT(m_current);
     ASSERT(!m_assertions.domTreeHasMutated());
-    return m_current;
+    return m_current.get();
 }
 
 template <typename ElementType>

--- a/Source/WebCore/dom/ElementIteratorInlines.h
+++ b/Source/WebCore/dom/ElementIteratorInlines.h
@@ -36,7 +36,7 @@ inline ElementIterator<ElementType>& ElementIterator<ElementType>::traverseNext(
 {
     ASSERT(m_current);
     ASSERT(!m_assertions.domTreeHasMutated());
-    m_current = Traversal<ElementType>::next(*m_current, m_root);
+    m_current = Traversal<ElementType>::next(*m_current, m_root.get());
 #if ASSERT_ENABLED
     // Drop the assertion when the iterator reaches the end.
     if (!m_current)
@@ -50,7 +50,7 @@ inline ElementIterator<ElementType>& ElementIterator<ElementType>::traversePrevi
 {
     ASSERT(m_current);
     ASSERT(!m_assertions.domTreeHasMutated());
-    m_current = Traversal<ElementType>::previous(*m_current, m_root);
+    m_current = Traversal<ElementType>::previous(*m_current, m_root.get());
 #if ASSERT_ENABLED
     // Drop the assertion when the iterator reaches the end.
     if (!m_current)
@@ -92,7 +92,7 @@ inline ElementIterator<ElementType>& ElementIterator<ElementType>::traverseNextS
 {
     ASSERT(m_current);
     ASSERT(!m_assertions.domTreeHasMutated());
-    m_current = Traversal<ElementType>::nextSkippingChildren(*m_current, m_root);
+    m_current = Traversal<ElementType>::nextSkippingChildren(*m_current, m_root.get());
 #if ASSERT_ENABLED
     // Drop the assertion when the iterator reaches the end.
     if (!m_current)


### PR DESCRIPTION
#### 374c48e43da6f5388214d4b4edc48adbbab1eade
<pre>
Adopt more smart pointers in our DOM iterator classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=277344">https://bugs.webkit.org/show_bug.cgi?id=277344</a>

Reviewed by Ryosuke Niwa.

This tested as neutral on Speedometer.

* Source/WebCore/dom/ElementAndTextDescendantIterator.h:
(WebCore::ElementAndTextDescendantIterator::ElementAndTextDescendantIterator):
(WebCore::ElementAndTextDescendantIterator::operator-&gt;):
(WebCore::ElementAndTextDescendantIterator::operator-&gt; const):
* Source/WebCore/dom/ElementIterator.h:
(WebCore:: const):
(): Deleted.
* Source/WebCore/dom/ElementIteratorInlines.h:
(WebCore::ElementIterator&lt;ElementType&gt;::traverseNext):
(WebCore::ElementIterator&lt;ElementType&gt;::traversePrevious):
(WebCore::ElementIterator&lt;ElementType&gt;::traverseNextSkippingChildren):

Canonical link: <a href="https://commits.webkit.org/281635@main">https://commits.webkit.org/281635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7158badad1ce14176fb5f3116cb854bc9d7b24aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64373 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10993 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48931 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7649 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29763 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33772 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9601 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9902 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66105 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56291 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52342 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56460 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3642 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9100 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35613 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37786 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->