### PR TITLE
[JSC] Do not invoke macro-task unnecessarily for wasm instantiate

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -137,6 +137,11 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
     }
 #endif
     m_plan->setMode(mode);
+    if (Options::useWasmLLInt()) {
+        Ref plan { *m_plan };
+        if (plan->completeSyncIfPossible())
+            return;
+    }
 
     auto& worklist = Wasm::ensureWorklist();
     // Note, immediately after we enqueue the plan, there is a chance the above callback will be called.
@@ -206,6 +211,11 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
     }
 #endif
     m_plan->setMode(mode);
+    if (Options::useWasmIPInt()) {
+        Ref plan { *m_plan };
+        if (plan->completeSyncIfPossible())
+            return;
+    }
 
     auto& worklist = Wasm::ensureWorklist();
     // Note, immediately after we enqueue the plan, there is a chance the above callback will be called.
@@ -237,15 +247,18 @@ void CalleeGroup::compileAsync(VM& vm, AsyncCompilationCallback&& task)
         plan = m_plan;
     }
 
-    if (plan) {
+    bool isAsync = plan;
+    if (isAsync) {
         // We don't need to keep a RefPtr on the Plan because the worklist will keep
         // a RefPtr on the Plan until the plan finishes notifying all of its callbacks.
-        RefPtr<CalleeGroup> protectedThis = this;
-        plan->addCompletionTask(vm, createSharedTask<Plan::CallbackType>([this, task = WTFMove(task), protectedThis = WTFMove(protectedThis)] (Plan&) {
-            task->run(Ref { *this });
+        isAsync = plan->addCompletionTaskIfNecessary(vm, createSharedTask<Plan::CallbackType>([this, task, protectedThis = Ref { *this }, isAsync](Plan&) {
+            task->run(Ref { *this }, isAsync);
         }));
-    } else
-        task->run(Ref { *this });
+        if (isAsync)
+            return;
+    }
+
+    task->run(Ref { *this }, isAsync);
 }
 
 bool CalleeGroup::isSafeToRun(MemoryMode memoryMode)

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -53,7 +53,7 @@ struct UnlinkedWasmToWasmCall;
 class CalleeGroup final : public ThreadSafeRefCounted<CalleeGroup> {
 public:
     friend class CallsiteCollection;
-    typedef void CallbackType(Ref<CalleeGroup>&&);
+    typedef void CallbackType(Ref<CalleeGroup>&&, bool);
     using AsyncCompilationCallback = RefPtr<WTF::SharedTask<CallbackType>>;
     static Ref<CalleeGroup> createFromLLInt(VM&, MemoryMode, ModuleInformation&, RefPtr<LLIntCallees>);
     static Ref<CalleeGroup> createFromIPInt(VM&, MemoryMode, ModuleInformation&, RefPtr<IPIntCallees>);

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -253,6 +253,21 @@ void EntryPlan::complete()
     }
 }
 
+bool EntryPlan::completeSyncIfPossible()
+{
+    Locker locker { m_lock };
+    if (m_currentIndex >= m_numberOfFunctions) {
+        if (hasWork())
+            moveToState(State::Compiled);
+
+        if (!m_numberOfActiveThreads) {
+            complete();
+            return true;
+        }
+    }
+    return false;
+}
+
 void EntryPlan::generateStubsIfNecessary()
 {
     if (!std::exchange(m_areWasmToWasmStubsCompiled, true)) {

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.h
@@ -92,6 +92,8 @@ public:
 
     bool multiThreaded() const override { return m_state >= State::Prepared; }
 
+    bool completeSyncIfPossible();
+
 private:
     class ThreadCountHolder;
     friend class ThreadCountHolder;

--- a/Source/JavaScriptCore/wasm/WasmPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmPlan.cpp
@@ -62,13 +62,14 @@ void Plan::runCompletionTasks()
     m_completed.notifyAll();
 }
 
-void Plan::addCompletionTask(VM& vm, CompletionTask&& task)
+bool Plan::addCompletionTaskIfNecessary(VM& vm, CompletionTask&& task)
 {
     Locker locker { m_lock };
-    if (!isComplete())
+    if (!isComplete()) {
         m_completionTasks.append(std::make_pair(&vm, WTFMove(task)));
-    else
-        task->run(*this);
+        return true;
+    }
+    return false;
 }
 
 void Plan::waitForCompletion()

--- a/Source/JavaScriptCore/wasm/WasmPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmPlan.h
@@ -58,9 +58,9 @@ public:
     JS_EXPORT_PRIVATE Plan(VM&, CompletionTask&&);
     virtual JS_EXPORT_PRIVATE ~Plan();
 
-    // If you guarantee the ordering here, you can rely on FIFO of the
-    // completion tasks being called.
-    void addCompletionTask(VM&, CompletionTask&&);
+    // If you guarantee the ordering here, you can rely on FIFO of the completion tasks being called.
+    // Return false if the task plan is already completed.
+    bool addCompletionTaskIfNecessary(VM&, CompletionTask&&);
 
     void setMode(MemoryMode mode) { m_mode = mode; }
     ALWAYS_INLINE MemoryMode mode() const { return m_mode; }


### PR DESCRIPTION
#### 5bb9d4d5b23a5ab7aac6fbac9033a2ce09ab1a01
<pre>
[JSC] Do not invoke macro-task unnecessarily for wasm instantiate
<a href="https://bugs.webkit.org/show_bug.cgi?id=277345">https://bugs.webkit.org/show_bug.cgi?id=277345</a>
<a href="https://rdar.apple.com/problem/132831541">rdar://problem/132831541</a>

Reviewed by Yijia Huang.

WebAssembly.instantiate could do compile and instantiate. At that time, since wasm LLInt is doing similar thing for both,
when instantiating after compiling, we may already have well-established wasm module. We should skip resolving promise in
the next macro task in that case since we already asynchronously compiled the module and further asynchronous instantiation
is not necessary.

* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::CalleeGroup):
(JSC::Wasm::CalleeGroup::compileAsync):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmEntryPlan.cpp:
(JSC::Wasm::EntryPlan::completeSyncIfPossible):
* Source/JavaScriptCore/wasm/WasmEntryPlan.h:
* Source/JavaScriptCore/wasm/WasmPlan.cpp:
(JSC::Wasm::Plan::addCompletionTaskIfNecessary):
(JSC::Wasm::Plan::addCompletionTask): Deleted.
* Source/JavaScriptCore/wasm/WasmPlan.h:
* Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp:
(JSC::instantiate):
(JSC::compileAndInstantiate):
(JSC::JSWebAssembly::instantiateForStreaming):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/281608@main">https://commits.webkit.org/281608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9049ebbcc96afae5269340c768bb5e7f5bbb2c15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10943 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11176 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7617 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52340 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9566 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9860 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/53508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66063 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59655 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4345 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9682 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56428 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3618 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81413 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9079 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35573 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14143 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->