### PR TITLE
Short-lived processes are not terminated properly

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
@@ -57,6 +57,7 @@ public:
 #if USE(LEGACY_EXTENSIONKIT_SPI)
     ExtensionProcess(_SEExtensionProcess *);
 #endif
+    ~ExtensionProcess();
 
     void invalidate() const;
     OSObjectPtr<xpc_connection_t> makeLibXPCConnection() const;
@@ -65,6 +66,7 @@ public:
 
 private:
     ExtensionProcessVariant m_process;
+    bool m_didInvalidate { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
@@ -60,8 +60,17 @@ ExtensionProcess::ExtensionProcess(_SEExtensionProcess *process)
 }
 #endif
 
+ExtensionProcess::~ExtensionProcess()
+{
+    invalidate();
+}
+
 void ExtensionProcess::invalidate() const
 {
+    if (m_didInvalidate)
+        return;
+
+    m_didInvalidate = true;
     WTF::switchOn(m_process, [&] (auto& process) {
         [process invalidate];
     });


### PR DESCRIPTION
#### 4fe9bc865e57486b51f95ceb0ab2956dd9fc0122
<pre>
Short-lived processes are not terminated properly
<a href="https://bugs.webkit.org/show_bug.cgi?id=277087">https://bugs.webkit.org/show_bug.cgi?id=277087</a>
<a href="https://rdar.apple.com/132505461">rdar://132505461</a>

Reviewed by NOBODY (OOPS!).

When using BrowserEngineKit, we need to ensure that -invalidate is called on the extension process
object for the extension process to actually die. If we just allow drop the last reference to the
extension process without invalidating it, then it just becomes a detached process that we no longer
have any control over and which lives indefinitely.

This can happen because there are some paths in ProcessLauncherCocoa (where
ProcessLauncher::terminateProcess is called very shortly after ProcessLauncher::launchProcess) where
we drop the last reference to the extension process without calling -invalidate on the process
first.

Since we don&apos;t want to allow these types of detached processes, fix this by always calling
-invalidate in the destructor of our ExtensionProcess wrapper object.

* Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h:
* Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm:
(WebKit::ExtensionProcess::~ExtensionProcess):
(WebKit::ExtensionProcess::invalidate const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fe9bc865e57486b51f95ceb0ab2956dd9fc0122

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60386 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39737 "Hash 4fe9bc86 for PR 31472 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64305 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10917 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47409 "Hash 4fe9bc86 for PR 31472 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48898 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7603 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62417 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/47409 "Hash 4fe9bc86 for PR 31472 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29728 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/47409 "Hash 4fe9bc86 for PR 31472 does not build (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9834 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/47409 "Hash 4fe9bc86 for PR 31472 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9828 "Found 1 new test failure: imported/w3c/web-platform-tests/resource-timing/status-codes-create-entry.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66037 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4319 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56242 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56413 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3597 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35547 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36629 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36373 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->