### PR TITLE
[JSC] `Intl.DurationFormat` should format seconds with `roundingMode` is `trunc`

### DIFF
--- a/JSTests/stress/intl-durationformat-format-to-parts.js
+++ b/JSTests/stress/intl-durationformat-format-to-parts.js
@@ -61,7 +61,7 @@ if (Intl.DurationFormat) {
     {
         var fmt = new Intl.DurationFormat('en-US', { style: 'digital', fractionalDigits: 9, millseconds: 'numeric' });
         shouldBeOneOf(JSON.stringify(fmt.formatToParts({ hours: 7, minutes: 8, seconds: 9, milliseconds: 123, microseconds: 456, nanoseconds: 789 })), [
-            `[{"type":"integer","value":"7","unit":"hour"},{"type":"literal","value":":"},{"type":"integer","value":"08","unit":"minute"},{"type":"literal","value":":"},{"type":"integer","value":"09","unit":"second"},{"type":"decimal","value":".","unit":"second"},{"type":"fraction","value":"123456789","unit":"second"}]`,
+            `[{"type":"integer","value":"7","unit":"hour"},{"type":"literal","value":":"},{"type":"integer","value":"08","unit":"minute"},{"type":"literal","value":":"},{"type":"integer","value":"09","unit":"second"},{"type":"decimal","value":".","unit":"second"},{"type":"fraction","value":"123456788","unit":"second"}]`
         ]);
     }
 }

--- a/JSTests/stress/intl-durationformat-roundingMode.js
+++ b/JSTests/stress/intl-durationformat-roundingMode.js
@@ -1,0 +1,38 @@
+function sameValue(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+// Should format seconds, milliseconds or microseconds with `roundingMode` is `trunc`
+const durations = [
+  {
+    fractionalDigits: 0,
+    expected: "1",
+    duration: {
+      seconds: 1,
+      milliseconds: 500,
+    },
+  },
+  {
+    fractionalDigits: 3,
+    expected: "0.001",
+    duration: {
+      milliseconds: 1,
+      microseconds: 500,
+    }
+  },
+  {
+    fractionalDigits: 6,
+    expected: "0.000001",
+    duration: {
+      microseconds: 1,
+      nanoseconds: 500
+    }
+  }
+];
+
+for (const { fractionalDigits, expected, duration } of durations) {
+    const df = new Intl.DurationFormat("en", { seconds: "numeric", fractionalDigits });
+    const result = df.format(duration);
+    sameValue(result, expected);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1102,9 +1102,9 @@ test/intl402/DateTimeFormat/timezone-not-canonicalized.js:
 test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js:
   default: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000.000000002», «0:00:10,000,000.000000001») to be true'
   strict mode: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000.000000002», «0:00:10,000,000.000000001») to be true'
-test/intl402/DurationFormat/prototype/format/rounding-mode-trunc-for-seconds.js:
-  default: 'Test262Error: Intl.DurationFormat should format seconds, milliseconds and microseconds with `roundingMode: "trunc"` Expected SameValue(«2», «1») to be true'
-  strict mode: 'Test262Error: Intl.DurationFormat should format seconds, milliseconds and microseconds with `roundingMode: "trunc"` Expected SameValue(«2», «1») to be true'
+test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-digital-en.js:
+  default: 'Test262Error: value for entry 6 Expected SameValue(«123456788», «123456789») to be true'
+  strict mode: 'Test262Error: value for entry 6 Expected SameValue(«123456788», «123456789») to be true'
 test/intl402/Locale/extensions-grandfathered.js:
   default: 'Test262Error: Expected SameValue(«fr-Cyrl-FR-gaulish-u-nu-latn», «fr-Cyrl-FR-u-nu-latn») to be true'
   strict mode: 'Test262Error: Expected SameValue(«fr-Cyrl-FR-gaulish-u-nu-latn», «fr-Cyrl-FR-u-nu-latn») to be true'

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -359,13 +359,13 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
         double value = duration[unit];
 
         StringBuilder skeletonBuilder;
-        skeletonBuilder.append("rounding-mode-half-up"_s);
 
         switch (unit) {
         // 3.j. If unit is "seconds", "milliseconds", or "microseconds", then
         case TemporalUnit::Second:
         case TemporalUnit::Millisecond:
         case TemporalUnit::Microsecond: {
+            skeletonBuilder.append("rounding-mode-down"_s);
             IntlDurationFormat::UnitStyle nextStyle = IntlDurationFormat::UnitStyle::Long;
             if (unit == TemporalUnit::Second)
                 nextStyle = durationFormat->units()[static_cast<unsigned>(TemporalUnit::Millisecond)].style();
@@ -398,8 +398,10 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
             }
             break;
         }
-        default:
+        default: {
+            skeletonBuilder.append("rounding-mode-half-up"_s);
             break;
+        }
         }
 
         auto style = unitData.style();


### PR DESCRIPTION
#### 55784d54785e187216c433d10b4e0c504a722e98
<pre>
[JSC] `Intl.DurationFormat` should format seconds with `roundingMode` is `trunc`
<a href="https://bugs.webkit.org/show_bug.cgi?id=275745">https://bugs.webkit.org/show_bug.cgi?id=275745</a>

Reviewed by Yusuke Suzuki.

According to the specifications [1][2], `Intl.DurationFormat` should use `trunc` as the
`roundingMode` when formatting seconds, milliseconds, or microseconds.

However, the current JSC is formatting with the default `roundingMode` of `Intl.NumberFormat`,
which is `halfExpand` (in practice, it uses the corresponding ICU rounding mode[3][4]
`rounding-mode-half-up`).

This patch changes the formatting of seconds, milliseconds, or microseconds to use the ICU rounding
mode `rounding-mode-down`, which corresponds to `trunc` as the `roundingMode`.

[1]: <a href="https://tc39.es/proposal-intl-duration-format/#sec-partitiondurationformatpattern">https://tc39.es/proposal-intl-duration-format/#sec-partitiondurationformatpattern</a>
[2]: <a href="https://tc39.es/proposal-intl-duration-format/#sec-formatnumericseconds">https://tc39.es/proposal-intl-duration-format/#sec-formatnumericseconds</a>
[3]: <a href="https://github.com/unicode-org/icu/blob/main/docs/userguide/format_parse/numbers/rounding-modes.md">https://github.com/unicode-org/icu/blob/main/docs/userguide/format_parse/numbers/rounding-modes.md</a>
[4]: <a href="https://github.com/unicode-org/icu/blob/main/docs/userguide/format_parse/numbers/skeletons.md#rounding-mode">https://github.com/unicode-org/icu/blob/main/docs/userguide/format_parse/numbers/skeletons.md#rounding-mode</a>

* JSTests/stress/intl-durationformat-format-to-parts.js:
(Intl.DurationFormat.shouldBeOneOf):
* JSTests/stress/intl-durationformat-roundingMode.js: Added.
(sameValue):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::collectElements):

Canonical link: <a href="https://commits.webkit.org/281955@main">https://commits.webkit.org/281955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac6d35371f2711f94d16c5241e13054d1ed922f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14166 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12124 "Build is in progress. Recent messages:") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12397 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/65553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/12124 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53333 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/65553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10565 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11055 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/54676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10864 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/67282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60822 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5522 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/67282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5548 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53288 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/67282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4541 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82585 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9265 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14433 "Found 1 new JSC stress test failure: stress/sampling-profiler-display-name.js.dfg-eager-no-cjit-validate (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/37820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->