### PR TITLE
AX: When display:table is applied to tbody elements, VoiceOver cannot find any content in the table

### DIFF
--- a/LayoutTests/accessibility/tbody-with-display-table-expected.txt
+++ b/LayoutTests/accessibility/tbody-with-display-table-expected.txt
@@ -1,0 +1,85 @@
+This test ensures that a table with display:block components is accessible.
+
+PASS: table.rowCount === 4
+PASS: table.columnCount === 3
+PASS: table.cellForColumnAndRow(0, 0).domIdentifier === "r0c0"
+PASS: table.cellForColumnAndRow(1, 0).domIdentifier === "r0c1"
+PASS: table.cellForColumnAndRow(2, 0).domIdentifier === "r0c2"
+PASS: table.cellForColumnAndRow(0, 1).domIdentifier === "r1c0"
+PASS: table.cellForColumnAndRow(1, 1).domIdentifier === "r1c1"
+PASS: table.cellForColumnAndRow(2, 1).domIdentifier === "r1c2"
+PASS: table.cellForColumnAndRow(0, 2).domIdentifier === "r2c0"
+PASS: table.cellForColumnAndRow(1, 2).domIdentifier === "r2c1"
+PASS: table.cellForColumnAndRow(2, 2).domIdentifier === "r2c2"
+PASS: table.cellForColumnAndRow(0, 3).domIdentifier === "r3c0"
+PASS: table.cellForColumnAndRow(1, 3).domIdentifier === "r3c1"
+PASS: table.cellForColumnAndRow(2, 3).domIdentifier === "r3c2"
+
+Performing search traversal of body.
+
+{#table AXRole: AXTable} (parent: {#body AXRole: AXGroup})
+
+{#r0 AXRole: AXRow} (parent: {#table AXRole: AXTable})
+
+{#r0c0 AXRole: AXCell} (parent: {#r0 AXRole: AXRow})
+
+{AXRole: AXStaticText AXValue: Author} (parent: {#r0c0 AXRole: AXCell})
+
+{#r0c1 AXRole: AXCell} (parent: {#r0 AXRole: AXRow})
+
+{AXRole: AXStaticText AXValue: Title} (parent: {#r0c1 AXRole: AXCell})
+
+{#r0c2 AXRole: AXCell} (parent: {#r0 AXRole: AXRow})
+
+{AXRole: AXStaticText AXValue: Year} (parent: {#r0c2 AXRole: AXCell})
+
+{#r1 AXRole: AXRow} (parent: {#table AXRole: AXTable})
+
+{#r1c0 AXRole: AXCell} (parent: {#r1 AXRole: AXRow})
+
+{AXRole: AXStaticText AXValue: Stephen Hawking} (parent: {#r1c0 AXRole: AXCell})
+
+{#r1c1 AXRole: AXCell} (parent: {#r1 AXRole: AXRow})
+
+{AXRole: AXStaticText AXValue: A Brief History of Time} (parent: {#r1c1 AXRole: AXCell})
+
+{#r1c2 AXRole: AXCell} (parent: {#r1 AXRole: AXRow})
+
+{AXRole: AXStaticText AXValue: 1988} (parent: {#r1c2 AXRole: AXCell})
+
+{#r2 AXRole: AXRow} (parent: {#table AXRole: AXTable})
+
+{#r2c0 AXRole: AXCell} (parent: {#r2 AXRole: AXRow})
+
+{AXRole: AXStaticText AXValue: Carl Sagan} (parent: {#r2c0 AXRole: AXCell})
+
+{#r2c1 AXRole: AXCell} (parent: {#r2 AXRole: AXRow})
+
+{AXRole: AXStaticText AXValue: Cosmos} (parent: {#r2c1 AXRole: AXCell})
+
+{#r2c2 AXRole: AXCell} (parent: {#r2 AXRole: AXRow})
+
+{AXRole: AXStaticText AXValue: 1980} (parent: {#r2c2 AXRole: AXCell})
+
+{#r3 AXRole: AXRow} (parent: {#table AXRole: AXTable})
+
+{#r3c0 AXRole: AXCell} (parent: {#r3 AXRole: AXRow})
+
+{AXRole: AXStaticText AXValue: Will Gater} (parent: {#r3c0 AXRole: AXCell})
+
+{#r3c1 AXRole: AXCell} (parent: {#r3 AXRole: AXRow})
+
+{AXRole: AXStaticText AXValue: The Mysteries of the Universe} (parent: {#r3c1 AXRole: AXCell})
+
+{#r3c2 AXRole: AXCell} (parent: {#r3 AXRole: AXRow})
+
+{AXRole: AXStaticText AXValue: 2020} (parent: {#r3c2 AXRole: AXCell})
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is a table caption
+Author	Title	Year
+Stephen Hawking	A Brief History of Time	1988
+Carl Sagan	Cosmos	1980
+Will Gater	The Mysteries of the Universe	2020

--- a/LayoutTests/accessibility/tbody-with-display-table.html
+++ b/LayoutTests/accessibility/tbody-with-display-table.html
@@ -1,0 +1,83 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style>
+/* This is an extremely weird thing to do, but is markup from a real website. */
+tbody, thead { display: table; }
+</style>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body id="body" role="group">
+
+<table id="table">
+<caption>This is a table caption</caption>
+<thead>
+    <tr id="r0">
+        <th id="r0c0">Author</th>
+        <th id="r0c1">Title</th>
+        <th id="r0c2">Year</th>
+    </tr>
+</thead>
+<tbody>
+    <tr id="r1">
+        <td id="r1c0">Stephen Hawking</td>
+        <td id="r1c1">A Brief History of Time</td>
+        <td id="r1c2">1988</td>
+    </tr>
+    <tr id="r2">
+        <td id="r2c0">Carl Sagan</td>
+        <td id="r2c1">Cosmos</td>
+        <td id="r2c2">1980</td>
+    </tr>
+    <tr id="r3">
+        <td id="r3c0">Will Gater</td>
+        <td id="r3c1">The Mysteries of the Universe</td>
+        <td id="r3c2">2020</td>
+    </tr>
+</tbody>
+</table>
+
+<script>
+var output = "This test ensures that a table with display:block components is accessible.\n\n";
+
+if (window.accessibilityController) {
+    var table = accessibilityController.accessibleElementById("table");
+    output += expect("table.rowCount", "4");
+    output += expect("table.columnCount", "3");
+
+    for (let row = 0; row < 4; row++) {
+        for (let column = 0; column < 3; column++)
+            output += expect(`table.cellForColumnAndRow(${column}, ${row}).domIdentifier`, `"r${row}c${column}"`);
+    }
+
+    const platform = accessibilityController.platformName;
+    if (platform == "mac" || platform == "ios") {
+        output += `\nPerforming search traversal of body.\n`;
+        function elementDescription(axElement) {
+            if (!axElement)
+                return "null";
+
+            const role = axElement.role;
+            const id = axElement.domIdentifier;
+            let result = `${id ? `#${id} ` : ""}${role}`;
+            if (role.includes("StaticText"))
+                result += ` ${platform === "ios" ? axElement.description : axElement.stringValue}`;
+            return result;
+        }
+
+        const container = accessibilityController.accessibleElementById("body");
+        let searchResult = null;
+        while (true) {
+            searchResult = container.uiElementForSearchPredicate(searchResult, true, "AXAnyTypeSearchKey", "", false);
+            if (!searchResult)
+                break;
+            const parentOutput = platform === "ios" ? "" : ` (parent: {${elementDescription(searchResult.parentElement())}})`;
+            output += `\n{${elementDescription(searchResult)}}${parentOutput}\n`;
+        }
+    }
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/accessibility/tbody-with-display-table-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/tbody-with-display-table-expected.txt
@@ -1,0 +1,25 @@
+This test ensures that a table with display:block components is accessible.
+
+PASS: table.rowCount === 4
+PASS: table.columnCount === 3
+PASS: table.cellForColumnAndRow(0, 0).domIdentifier === "r0c0"
+PASS: table.cellForColumnAndRow(1, 0).domIdentifier === "r0c1"
+PASS: table.cellForColumnAndRow(2, 0).domIdentifier === "r0c2"
+PASS: table.cellForColumnAndRow(0, 1).domIdentifier === "r1c0"
+PASS: table.cellForColumnAndRow(1, 1).domIdentifier === "r1c1"
+PASS: table.cellForColumnAndRow(2, 1).domIdentifier === "r1c2"
+PASS: table.cellForColumnAndRow(0, 2).domIdentifier === "r2c0"
+PASS: table.cellForColumnAndRow(1, 2).domIdentifier === "r2c1"
+PASS: table.cellForColumnAndRow(2, 2).domIdentifier === "r2c2"
+PASS: table.cellForColumnAndRow(0, 3).domIdentifier === "r3c0"
+PASS: table.cellForColumnAndRow(1, 3).domIdentifier === "r3c1"
+PASS: table.cellForColumnAndRow(2, 3).domIdentifier === "r3c2"
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is a table caption
+Author	Title	Year
+Stephen Hawking	A Brief History of Time	1988
+Carl Sagan	Cosmos	1980
+Will Gater	The Mysteries of the Universe	2020

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -743,8 +743,11 @@ Ref<AccessibilityObject> AXObjectCache::createObjectFromRenderer(RenderObject& r
     if (auto* renderMenuList = dynamicDowncast<RenderMenuList>(renderer))
         return AccessibilityMenuList::create(*renderMenuList);
 
-    // standard tables
-    if ((is<RenderTable>(renderer) && !renderer.isAnonymous()) || isAccessibilityTable(node.get()))
+
+    // Some websites put display:table on tbody / thead / tfoot, resulting in a RenderTable being generated.
+    // We don't want to consider these tables (since they are typically wrapped by an actual <table> element),
+    // so only create an AccessibilityTable when !is<HTMLTableSectionElement>.
+    if ((is<RenderTable>(renderer) && !renderer.isAnonymous() && !is<HTMLTableSectionElement>(node.get())) || isAccessibilityTable(node.get()))
         return AccessibilityTable::create(renderer);
     if ((is<RenderTableRow>(renderer) && !renderer.isAnonymous()) || isAccessibilityTableRow(node.get()))
         return AccessibilityTableRow::create(renderer);

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -71,9 +71,8 @@ bool AccessibilityTableCell::computeAccessibilityIsIgnored() const
         return true;
 
     // Ignore anonymous table cells as long as they're not in a table (ie. when display:table is used).
-    auto* renderTableCell = dynamicDowncast<RenderTableCell>(renderer());
-    auto* renderTable = renderTableCell ? renderTableCell->table() : nullptr;
-    bool inTable = renderTable && renderTable->element() && (renderTable->element()->hasTagName(tableTag) || nodeHasTableRole(renderTable->element()));
+    WeakPtr parentTable = this->parentTable();
+    bool inTable = parentTable && parentTable->element() && (parentTable->element()->hasTagName(tableTag) || nodeHasTableRole(parentTable->element()));
     if (!element() && !inTable)
         return true;
 
@@ -92,9 +91,9 @@ AccessibilityTable* AccessibilityTableCell::parentTable() const
     // By using only get() implies that the AXTable must be created before AXTableCells. This should
     // always be the case when AT clients access a table.
     // https://bugs.webkit.org/show_bug.cgi?id=42652
-    RefPtr<AccessibilityObject> tableFromRenderTree;
+    RefPtr<AccessibilityTable> tableFromRenderTree;
     if (auto* renderTableCell = dynamicDowncast<RenderTableCell>(renderer()))
-        tableFromRenderTree = cache->get(renderTableCell->table());
+        tableFromRenderTree = dynamicDowncast<AccessibilityTable>(cache->get(renderTableCell->table()));
 
     if (!tableFromRenderTree) {
         if (node()) {
@@ -121,7 +120,7 @@ AccessibilityTable* AccessibilityTableCell::parentTable() const
         return nullptr;
     }
     
-    return dynamicDowncast<AccessibilityTable>(tableFromRenderTree.get());
+    return tableFromRenderTree.get();
 }
     
 bool AccessibilityTableCell::isExposedTableCell() const


### PR DESCRIPTION
#### b61776dc58608649c3f05a51c5c75338415a2ed6
<pre>
AX: When display:table is applied to tbody elements, VoiceOver cannot find any content in the table
<a href="https://bugs.webkit.org/show_bug.cgi?id=277354">https://bugs.webkit.org/show_bug.cgi?id=277354</a>
<a href="https://rdar.apple.com/132820485">rdar://132820485</a>

Reviewed by Chris Fleizach.

This is invalid markup and generally a really strange thing to do, but it renders fine visually, and
other browsers expose a valid accessibility tree, so we should too. This patch fixes this issue by
avoiding the creation of an AccessibilityTable for a RenderTable if the associated element is an
HTMLTableSectionElement, instead allowing the section element (e.g. tbody) to properly be considered a rowgroup.

* LayoutTests/accessibility/tbody-with-display-table-expected.txt: Added.
* LayoutTests/accessibility/tbody-with-display-table.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::createObjectFromRenderer):
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::computeAccessibilityIsIgnored const):
(WebCore::AccessibilityTableCell::parentTable const):

Canonical link: <a href="https://commits.webkit.org/281648@main">https://commits.webkit.org/281648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18b8fef7144f9c816c1d1d2ea0610893074b80ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64429 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11046 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48952 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7686 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52410 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29784 "Found 1 new API test failure: /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/languages (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33818 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9637 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9958 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66160 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56318 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56487 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13476 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3683 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35669 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36751 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37842 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36496 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->