### PR TITLE
Unreviewed, reverting 281408@main (6d24d35f975f)

### DIFF
--- a/Source/WebCore/SmartPointerExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SmartPointerExpectations/UncountedCallArgsCheckerExpectations
@@ -1823,6 +1823,8 @@ rendering/RenderFrame.cpp
 rendering/RenderFrameSet.cpp
 rendering/RenderHTMLCanvas.cpp
 rendering/RenderImage.cpp
+rendering/RenderImageResourceStyleImage.cpp
+rendering/RenderImageResourceStyleImage.h
 rendering/RenderInline.cpp
 rendering/RenderLayer.cpp
 rendering/RenderLayerBacking.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2712,6 +2712,7 @@ rendering/RenderHighlight.cpp
 rendering/RenderIFrame.cpp
 rendering/RenderImage.cpp
 rendering/RenderImageResource.cpp
+rendering/RenderImageResourceStyleImage.cpp
 rendering/RenderInline.cpp
 rendering/RenderLayer.cpp
 rendering/RenderLayerBacking.cpp

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -50,15 +50,6 @@ CSSImageValue::CSSImageValue(ResolvedURL&& location, LoadedFromOpaqueSource load
 {
 }
 
-CSSImageValue::CSSImageValue(CachedImage& cachedImage)
-    : CSSValue(ImageClass)
-    , m_location(makeResolvedURL(cachedImage.url()))
-    , m_initiatorType(cachedImage.initiatorType())
-    , m_loadedFromOpaqueSource(cachedImage.options().loadedFromOpaqueSource)
-    , m_cachedImage(cachedImage)
-{
-}
-
 Ref<CSSImageValue> CSSImageValue::create()
 {
     return adoptRef(*new CSSImageValue);
@@ -72,11 +63,6 @@ Ref<CSSImageValue> CSSImageValue::create(ResolvedURL location, LoadedFromOpaqueS
 Ref<CSSImageValue> CSSImageValue::create(URL imageURL, LoadedFromOpaqueSource loadedFromOpaqueSource, AtomString initiatorType)
 {
     return create(makeResolvedURL(WTFMove(imageURL)), loadedFromOpaqueSource, WTFMove(initiatorType));
-}
-
-Ref<CSSImageValue> CSSImageValue::create(CachedImage& cachedImage)
-{
-    return adoptRef(*new CSSImageValue(cachedImage));
 }
 
 CSSImageValue::~CSSImageValue() = default;

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -45,7 +45,6 @@ public:
     static Ref<CSSImageValue> create();
     static Ref<CSSImageValue> create(ResolvedURL, LoadedFromOpaqueSource, AtomString = { });
     static Ref<CSSImageValue> create(URL, LoadedFromOpaqueSource, AtomString = { });
-    static Ref<CSSImageValue> create(CachedImage&);
     ~CSSImageValue();
 
     bool isPending() const;
@@ -84,14 +83,13 @@ public:
     }
 
 private:
-    explicit CSSImageValue();
-    explicit CSSImageValue(ResolvedURL&&, LoadedFromOpaqueSource, AtomString&&);
-    explicit CSSImageValue(CachedImage&);
+    CSSImageValue();
+    CSSImageValue(ResolvedURL&&, LoadedFromOpaqueSource, AtomString&&);
 
     ResolvedURL m_location;
+    std::optional<CachedResourceHandle<CachedImage>> m_cachedImage;
     AtomString m_initiatorType;
     LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
-    std::optional<CachedResourceHandle<CachedImage>> m_cachedImage;
     RefPtr<CSSImageValue> m_unresolvedValue;
     bool m_isInvalid { false };
     String m_replacementURLString;

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -44,7 +44,7 @@ struct ResolvedURL {
     bool isLocalURL() const;
 };
 
-inline ResolvedURL makeResolvedURL(URL resolvedURL)
+inline ResolvedURL makeResolvedURL(URL&& resolvedURL)
 {
     auto string = resolvedURL.string();
     return { WTFMove(string), WTFMove(resolvedURL) };

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -63,6 +63,7 @@
 #include "RenderFragmentedFlow.h"
 #include "RenderGrid.h"
 #include "RenderImage.h"
+#include "RenderImageResourceStyleImage.h"
 #include "RenderInline.h"
 #include "RenderIterator.h"
 #include "RenderLayer.h"

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -57,7 +57,7 @@
 #include "RenderChildIterator.h"
 #include "RenderElementInlines.h"
 #include "RenderFragmentedFlow.h"
-#include "RenderImageResource.h"
+#include "RenderImageResourceStyleImage.h"
 #include "RenderLayoutState.h"
 #include "RenderStyleSetters.h"
 #include "RenderTheme.h"
@@ -151,7 +151,7 @@ using namespace HTMLNames;
 
 RenderImage::RenderImage(Type type, Element& element, RenderStyle&& style, OptionSet<ReplacedFlag> flags, StyleImage* styleImage, const float imageDevicePixelRatio)
     : RenderReplaced(type, element, WTFMove(style), IntSize(), flags | ReplacedFlag::IsImage)
-    , m_imageResource(makeUnique<RenderImageResource>(styleImage))
+    , m_imageResource(styleImage ? makeUnique<RenderImageResourceStyleImage>(*styleImage) : makeUnique<RenderImageResource>())
     , m_hasImageOverlay([&] {
         auto* htmlElement = dynamicDowncast<HTMLElement>(element);
         return htmlElement && ImageOverlay::hasOverlay(*htmlElement);
@@ -172,7 +172,7 @@ RenderImage::RenderImage(Type type, Element& element, RenderStyle&& style, Style
 
 RenderImage::RenderImage(Type type, Document& document, RenderStyle&& style, StyleImage* styleImage)
     : RenderReplaced(type, document, WTFMove(style), IntSize(), ReplacedFlag::IsImage)
-    , m_imageResource(makeUnique<RenderImageResource>(styleImage))
+    , m_imageResource(styleImage ? makeUnique<RenderImageResourceStyleImage>(*styleImage) : makeUnique<RenderImageResource>())
 {
 }
 

--- a/Source/WebCore/rendering/RenderImageResourceStyleImage.cpp
+++ b/Source/WebCore/rendering/RenderImageResourceStyleImage.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 1999 Lars Knoll <knoll@kde.org>
+ * Copyright (C) 1999 Antti Koivisto <koivisto@kde.org>
+ * Copyright (C) 2000 Dirk Mueller <mueller@kde.org>
+ * Copyright (C) 2006 Allan Sandfeld Jensen <kde@carewolf.com>
+ * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
+ * Copyright (C) 2003-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2010 Patrick Gansterer <paroga@paroga.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "config.h"
+#include "RenderImageResourceStyleImage.h"
+
+#include "CachedImage.h"
+#include "RenderElement.h"
+#include "RenderStyleInlines.h"
+#include "StyleCachedImage.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(RenderImageResourceStyleImage);
+
+RenderImageResourceStyleImage::RenderImageResourceStyleImage(StyleImage& styleImage)
+    : m_styleImage(styleImage)
+{
+}
+
+void RenderImageResourceStyleImage::initialize(RenderElement& renderer)
+{
+    RenderImageResource::initialize(renderer, m_styleImage->hasCachedImage() ? m_styleImage.get().cachedImage() : nullptr);
+    m_styleImage->addClient(renderer);
+}
+
+void RenderImageResourceStyleImage::shutdown()
+{
+    RenderImageResource::shutdown();
+    if (auto renderer = this->renderer())
+        m_styleImage->removeClient(*renderer);
+}
+
+RefPtr<Image> RenderImageResourceStyleImage::image(const IntSize& size) const
+{
+    // Generated content may trigger calls to image() while we're still pending, don't assert but gracefully exit.
+    if (m_styleImage->isPending())
+        return &Image::nullImage();
+    if (auto image = m_styleImage->image(renderer(), size))
+        return image;
+    return &Image::nullImage();
+}
+
+void RenderImageResourceStyleImage::setContainerContext(const IntSize& size, const URL&)
+{
+    if (auto renderer = this->renderer())
+        m_styleImage->setContainerContextForRenderer(*renderer, size, renderer->style().usedZoom());
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderImageResourceStyleImage.h
+++ b/Source/WebCore/rendering/RenderImageResourceStyleImage.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 1999 Lars Knoll <knoll@kde.org>
+ * Copyright (C) 1999 Antti Koivisto <koivisto@kde.org>
+ * Copyright (C) 2006 Allan Sandfeld Jensen <kde@carewolf.com>
+ * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
+ * Copyright (C) 2004, 2005, 2006, 2007, 2009, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010 Patrick Gansterer <paroga@paroga.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#pragma once
+
+#include "RenderImageResource.h"
+#include "StyleImage.h"
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+class RenderElement;
+
+class RenderImageResourceStyleImage final : public RenderImageResource {
+    WTF_MAKE_ISO_ALLOCATED(RenderImageResourceStyleImage);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderImageResourceStyleImage);
+public:
+    explicit RenderImageResourceStyleImage(StyleImage&);
+
+private:
+    void initialize(RenderElement&) final;
+    void shutdown() final;
+
+    RefPtr<Image> image(const IntSize& = { }) const final;
+    bool errorOccurred() const final { return m_styleImage->errorOccurred(); }
+
+    void setContainerContext(const IntSize&, const URL&) final;
+
+    bool imageHasRelativeWidth() const final { return m_styleImage->imageHasRelativeWidth(); }
+    bool imageHasRelativeHeight() const final { return m_styleImage->imageHasRelativeHeight(); }
+
+    WrappedImagePtr imagePtr() const final { return m_styleImage->data(); }
+    LayoutSize imageSize(float multiplier, CachedImage::SizeType) const final { return LayoutSize(m_styleImage->imageSize(renderer(), multiplier)); }
+
+    Ref<StyleImage> m_styleImage;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.h
@@ -30,7 +30,7 @@
 #if ENABLE(MATHML)
 
 #include "MathMLScriptsElement.h"
-#include "RenderMathMLRow.h"
+#include "RenderMathMLBlock.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/style/ContentData.cpp
+++ b/Source/WebCore/rendering/style/ContentData.cpp
@@ -24,6 +24,8 @@
 
 #include "RenderCounter.h"
 #include "RenderImage.h"
+#include "RenderImageResource.h"
+#include "RenderImageResourceStyleImage.h"
 #include "RenderQuote.h"
 #include "RenderStyle.h"
 #include "RenderTextFragment.h"

--- a/Source/WebCore/rendering/style/StyleCachedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCachedImage.cpp
@@ -43,11 +43,6 @@ Ref<StyleCachedImage> StyleCachedImage::create(Ref<CSSImageValue> cssValue, floa
     return adoptRef(*new StyleCachedImage(WTFMove(cssValue), scaleFactor));
 }
 
-Ref<StyleCachedImage> StyleCachedImage::create(CachedImage& cachedImage, float scaleFactor)
-{
-    return adoptRef(*new StyleCachedImage(cachedImage, scaleFactor));
-}
-
 Ref<StyleCachedImage> StyleCachedImage::copyOverridingScaleFactor(StyleCachedImage& other, float scaleFactor)
 {
     if (other.m_scaleFactor == scaleFactor)
@@ -63,11 +58,6 @@ StyleCachedImage::StyleCachedImage(Ref<CSSImageValue>&& cssValue, float scaleFac
     m_cachedImage = m_cssValue->cachedImage();
     if (m_cachedImage)
         m_isPending = false;
-}
-
-StyleCachedImage::StyleCachedImage(CachedImage& cachedImage, float scaleFactor)
-    : StyleCachedImage { CSSImageValue::create(cachedImage), scaleFactor }
-{
 }
 
 StyleCachedImage::~StyleCachedImage() = default;
@@ -235,13 +225,13 @@ bool StyleCachedImage::errorOccurred() const
     return m_cachedImage->errorOccurred();
 }
 
-FloatSize StyleCachedImage::imageSize(const RenderElement* renderer, float multiplier, CachedImage::SizeType sizeType) const
+FloatSize StyleCachedImage::imageSize(const RenderElement* renderer, float multiplier) const
 {
     if (isRenderSVGResource(renderer))
         return m_containerSize;
     if (!m_cachedImage)
         return { };
-    return m_cachedImage->imageSizeForRenderer(renderer, multiplier, sizeType) / m_scaleFactor;
+    return m_cachedImage->imageSizeForRenderer(renderer, multiplier) / m_scaleFactor;
 }
 
 bool StyleCachedImage::imageHasRelativeWidth() const
@@ -282,12 +272,12 @@ bool StyleCachedImage::usesImageContainerSize() const
     return m_cachedImage->usesImageContainerSize();
 }
 
-void StyleCachedImage::setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom, const URL& url)
+void StyleCachedImage::setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom)
 {
     m_containerSize = containerSize;
     if (!m_cachedImage)
         return;
-    m_cachedImage->setContainerContextForClient(renderer, LayoutSize(containerSize), containerZoom, !url.isNull() ? url : imageURL());
+    m_cachedImage->setContainerContextForClient(renderer, LayoutSize(containerSize), containerZoom, imageURL());
 }
 
 void StyleCachedImage::addClient(RenderElement& renderer)

--- a/Source/WebCore/rendering/style/StyleCachedImage.h
+++ b/Source/WebCore/rendering/style/StyleCachedImage.h
@@ -41,7 +41,6 @@ class StyleCachedImage final : public StyleImage {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<StyleCachedImage> create(Ref<CSSImageValue>, float scaleFactor = 1);
-    static Ref<StyleCachedImage> create(CachedImage&, float scaleFactor = 1);
     static Ref<StyleCachedImage> copyOverridingScaleFactor(StyleCachedImage&, float scaleFactor);
     virtual ~StyleCachedImage();
 
@@ -59,12 +58,12 @@ public:
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
     bool isLoaded(const RenderElement*) const final;
     bool errorOccurred() const final;
-    FloatSize imageSize(const RenderElement*, float multiplier, CachedImage::SizeType = CachedImage::UsedSize) const final;
+    FloatSize imageSize(const RenderElement*, float multiplier) const final;
     bool imageHasRelativeWidth() const final;
     bool imageHasRelativeHeight() const final;
     void computeIntrinsicDimensions(const RenderElement*, Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio) final;
     bool usesImageContainerSize() const final;
-    void setContainerContextForRenderer(const RenderElement&, const FloatSize&, float, const URL& = URL()) final;
+    void setContainerContextForRenderer(const RenderElement&, const FloatSize&, float) final;
     void addClient(RenderElement&) final;
     void removeClient(RenderElement&) final;
     bool hasClient(RenderElement&) const final;
@@ -80,7 +79,6 @@ public:
 
 private:
     StyleCachedImage(Ref<CSSImageValue>&&, float);
-    StyleCachedImage(CachedImage&, float);
 
     LegacyRenderSVGResourceContainer* uncheckedRenderSVGResource(TreeScope&, const AtomString& fragment) const;
     LegacyRenderSVGResourceContainer* uncheckedRenderSVGResource(const RenderElement*) const;

--- a/Source/WebCore/rendering/style/StyleCursorImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCursorImage.cpp
@@ -133,11 +133,11 @@ void StyleCursorImage::cursorElementChanged(SVGCursorElement& cursorElement)
     // FIXME: Why doesn't this funtion check for a change to the href of the cursor element? Why would we dynamically track changes to x/y but not href?
 }
 
-void StyleCursorImage::setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom, const URL& url)
+void StyleCursorImage::setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom)
 {
     if (!hasCachedImage())
         return;
-    cachedImage()->setContainerContextForClient(renderer, LayoutSize(containerSize), containerZoom, url);
+    cachedImage()->setContainerContextForClient(renderer, LayoutSize(containerSize), containerZoom, m_originalURL);
 }
 
 bool StyleCursorImage::usesDataProtocol() const

--- a/Source/WebCore/rendering/style/StyleCursorImage.h
+++ b/Source/WebCore/rendering/style/StyleCursorImage.h
@@ -54,7 +54,7 @@ public:
 private:
     explicit StyleCursorImage(Ref<StyleImage>&&, const std::optional<IntPoint>& hotSpot, const URL&, LoadedFromOpaqueSource);
 
-    void setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom, const URL& = URL()) final;
+    void setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom) final;
     Ref<CSSValue> computedStyleValue(const RenderStyle&) const final;
     ImageWithScale selectBestFitImage(const Document&) final;
 

--- a/Source/WebCore/rendering/style/StyleGeneratedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGeneratedImage.cpp
@@ -100,7 +100,7 @@ void StyleGeneratedImage::evictCachedGeneratedImage(FloatSize size)
     m_images.remove(size);
 }
 
-FloatSize StyleGeneratedImage::imageSize(const RenderElement* renderer, float multiplier, CachedImage::SizeType) const
+FloatSize StyleGeneratedImage::imageSize(const RenderElement* renderer, float multiplier) const
 {
     if (!m_fixedSize)
         return m_containerSize;

--- a/Source/WebCore/rendering/style/StyleGeneratedImage.h
+++ b/Source/WebCore/rendering/style/StyleGeneratedImage.h
@@ -50,12 +50,12 @@ protected:
 
     WrappedImagePtr data() const final { return this; }
 
-    FloatSize imageSize(const RenderElement*, float multiplier, CachedImage::SizeType = CachedImage::UsedSize) const final;
+    FloatSize imageSize(const RenderElement*, float multiplier) const final;
     void computeIntrinsicDimensions(const RenderElement*, Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio) final;
     bool imageHasRelativeWidth() const final { return !m_fixedSize; }
     bool imageHasRelativeHeight() const final { return !m_fixedSize; }
     bool usesImageContainerSize() const final { return !m_fixedSize; }
-    void setContainerContextForRenderer(const RenderElement&, const FloatSize& containerSize, float, const URL& = URL()) final { m_containerSize = containerSize; }
+    void setContainerContextForRenderer(const RenderElement&, const FloatSize& containerSize, float) final { m_containerSize = containerSize; }
     bool imageHasNaturalDimensions() const final { return !usesImageContainerSize(); }
     
     void addClient(RenderElement&) final;

--- a/Source/WebCore/rendering/style/StyleImage.h
+++ b/Source/WebCore/rendering/style/StyleImage.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include "CSSValue.h"
-#include "CachedImage.h"
 #include "FloatSize.h"
 #include "Image.h"
 #include <wtf/RefCounted.h>
@@ -72,7 +71,7 @@ public:
     virtual bool hasClient(RenderElement&) const = 0;
 
     // Size / scale.
-    virtual FloatSize imageSize(const RenderElement*, float multiplier, CachedImage::SizeType = CachedImage::UsedSize) const = 0;
+    virtual FloatSize imageSize(const RenderElement*, float multiplier) const = 0;
     virtual bool usesImageContainerSize() const = 0;
     virtual void computeIntrinsicDimensions(const RenderElement*, Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio) = 0;
     virtual bool imageHasRelativeWidth() const = 0;
@@ -88,7 +87,7 @@ public:
 
     // Rendering.
     virtual bool canRender(const RenderElement*, float /*multiplier*/) const { return true; }
-    virtual void setContainerContextForRenderer(const RenderElement&, const FloatSize&, float, const URL& = URL()) = 0;
+    virtual void setContainerContextForRenderer(const RenderElement&, const FloatSize&, float) = 0;
     virtual bool knownToBeOpaque(const RenderElement&) const = 0;
 
     // Derived type.

--- a/Source/WebCore/rendering/style/StyleMultiImage.cpp
+++ b/Source/WebCore/rendering/style/StyleMultiImage.cpp
@@ -120,11 +120,11 @@ bool StyleMultiImage::errorOccurred() const
     return m_selectedImage && m_selectedImage->errorOccurred();
 }
 
-FloatSize StyleMultiImage::imageSize(const RenderElement* renderer, float multiplier, CachedImage::SizeType sizeType) const
+FloatSize StyleMultiImage::imageSize(const RenderElement* renderer, float multiplier) const
 {
     if (!m_selectedImage)
         return { };
-    return m_selectedImage->imageSize(renderer, multiplier, sizeType);
+    return m_selectedImage->imageSize(renderer, multiplier);
 }
 
 bool StyleMultiImage::imageHasRelativeWidth() const
@@ -149,11 +149,11 @@ bool StyleMultiImage::usesImageContainerSize() const
     return m_selectedImage && m_selectedImage->usesImageContainerSize();
 }
 
-void StyleMultiImage::setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom, const URL& url)
+void StyleMultiImage::setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom)
 {
     if (!m_selectedImage)
         return;
-    m_selectedImage->setContainerContextForRenderer(renderer, containerSize, containerZoom, url);
+    m_selectedImage->setContainerContextForRenderer(renderer, containerSize, containerZoom);
 }
 
 void StyleMultiImage::addClient(RenderElement& renderer)

--- a/Source/WebCore/rendering/style/StyleMultiImage.h
+++ b/Source/WebCore/rendering/style/StyleMultiImage.h
@@ -63,12 +63,12 @@ private:
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
     bool isLoaded(const RenderElement*) const final;
     bool errorOccurred() const final;
-    FloatSize imageSize(const RenderElement*, float multiplier, CachedImage::SizeType = CachedImage::UsedSize) const final;
+    FloatSize imageSize(const RenderElement*, float multiplier) const final;
     bool imageHasRelativeWidth() const final;
     bool imageHasRelativeHeight() const final;
     void computeIntrinsicDimensions(const RenderElement*, Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio) final;
     bool usesImageContainerSize() const final;
-    void setContainerContextForRenderer(const RenderElement&, const FloatSize&, float, const URL& = URL());
+    void setContainerContextForRenderer(const RenderElement&, const FloatSize&, float);
     void addClient(RenderElement&) final;
     void removeClient(RenderElement&) final;
     bool hasClient(RenderElement&) const final;


### PR DESCRIPTION
#### 3975f750ae116b396609dc0c8b63ab50cb94b03b
<pre>
Unreviewed, reverting 281408@main (6d24d35f975f)
<a href="https://bugs.webkit.org/show_bug.cgi?id=277360">https://bugs.webkit.org/show_bug.cgi?id=277360</a>
<a href="https://rdar.apple.com/132644196">rdar://132644196</a>

accessibility/add-children-pseudo-element.html is consistently crashing.

Reverted change:

    Simplify RenderImageResource by always using a StyleImage, even for the &lt;img&gt; case
    <a href="https://bugs.webkit.org/show_bug.cgi?id=276904">https://bugs.webkit.org/show_bug.cgi?id=276904</a>
    281408@main (6d24d35f975f)

Canonical link: <a href="https://commits.webkit.org/281579@main">https://commits.webkit.org/281579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d377273ab5e86657429c85fb56881680959c853

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60401 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/39752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12959 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/10932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62531 "Failed to checkout and rebase branch from PR 31481") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/47424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/11165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/64320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/10932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62432 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/47424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/52328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/47424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/9554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/9849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/47424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/9842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/4334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/11165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/66052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/4353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/52303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9059 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->