### PR TITLE
[web-animations] hanging-punctuation should support discrete animation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
@@ -350,6 +350,9 @@ PASS grid-template: "". . a b" ". . a b"" onto "none"
 PASS grid-template-areas (type: discrete) has testAccumulation function
 PASS grid-template-areas: "none" onto "". . a b" ". . a b""
 PASS grid-template-areas: "". . a b" ". . a b"" onto "none"
+PASS hanging-punctuation (type: discrete) has testAccumulation function
+PASS hanging-punctuation: "first last" onto "none"
+PASS hanging-punctuation: "none" onto "first last"
 PASS hyphens (type: discrete) has testAccumulation function
 PASS hyphens: "none" onto "manual"
 PASS hyphens: "manual" onto "none"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
@@ -350,6 +350,9 @@ PASS grid-template: "". . a b" ". . a b"" onto "none"
 PASS grid-template-areas (type: discrete) has testAddition function
 PASS grid-template-areas: "none" onto "". . a b" ". . a b""
 PASS grid-template-areas: "". . a b" ". . a b"" onto "none"
+PASS hanging-punctuation (type: discrete) has testAddition function
+PASS hanging-punctuation: "first last" onto "none"
+PASS hanging-punctuation: "none" onto "first last"
 PASS hyphens (type: discrete) has testAddition function
 PASS hyphens: "none" onto "manual"
 PASS hyphens: "manual" onto "none"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
@@ -435,6 +435,10 @@ PASS grid-template-areas (type: discrete) has testInterpolation function
 PASS grid-template-areas uses discrete animation when animating between "". . a b" ". . a b"" and "none" with linear easing
 PASS grid-template-areas uses discrete animation when animating between "". . a b" ". . a b"" and "none" with effect easing
 PASS grid-template-areas uses discrete animation when animating between "". . a b" ". . a b"" and "none" with keyframe easing
+PASS hanging-punctuation (type: discrete) has testInterpolation function
+PASS hanging-punctuation uses discrete animation when animating between "none" and "first last" with linear easing
+PASS hanging-punctuation uses discrete animation when animating between "none" and "first last" with effect easing
+PASS hanging-punctuation uses discrete animation when animating between "none" and "first last" with keyframe easing
 PASS hyphens (type: discrete) has testInterpolation function
 PASS hyphens uses discrete animation when animating between "manual" and "none" with linear easing
 PASS hyphens uses discrete animation when animating between "manual" and "none" with effect easing

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -752,6 +752,12 @@ const gCSSProperties1 = {
     types: [
     ]
   },
+  'hanging-punctuation': {
+    // https://drafts.csswg.org/css-text/#hanging-punctuation-property
+    types: [
+      { type: 'discrete', options: [ [ 'none', 'first last'] ] }
+    ]
+  },
   'hyphens': {
     // https://drafts.csswg.org/css-text-3/#propdef-hyphens
     types: [

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3948,6 +3948,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<const GridPosition&>(CSSPropertyGridColumnStart, &RenderStyle::gridItemColumnStart, &RenderStyle::setGridItemColumnStart),
         new DiscretePropertyWrapper<const GridPosition&>(CSSPropertyGridRowEnd, &RenderStyle::gridItemRowEnd, &RenderStyle::setGridItemRowEnd),
         new DiscretePropertyWrapper<const GridPosition&>(CSSPropertyGridRowStart, &RenderStyle::gridItemRowStart, &RenderStyle::setGridItemRowStart),
+        new DiscretePropertyWrapper<OptionSet<HangingPunctuation>>(CSSPropertyHangingPunctuation, &RenderStyle::hangingPunctuation, &RenderStyle::setHangingPunctuation),
         new DiscretePropertyWrapper<Hyphens>(CSSPropertyHyphens, &RenderStyle::hyphens, &RenderStyle::setHyphens),
         new DiscretePropertyWrapper<const AtomString&>(CSSPropertyHyphenateCharacter, &RenderStyle::hyphenationString, &RenderStyle::setHyphenationString),
         new DiscretePropertyWrapper<ImageOrientation>(CSSPropertyImageOrientation, &RenderStyle::imageOrientation, &RenderStyle::setImageOrientation),
@@ -4175,7 +4176,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyBorderInlineStyle: // logical shorthand
         case CSSPropertyBorderInlineWidth: // logical shorthand
         case CSSPropertyBorderStyle:
-        case CSSPropertyHangingPunctuation:
         case CSSPropertyInlineSize:
         case CSSPropertyInputSecurity:
         case CSSPropertyInset:

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2040,6 +2040,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyOverflowWrap);
         if (first.lineBreak != second.lineBreak)
             changingProperties.m_properties.set(CSSPropertyLineBreak);
+        if (first.hangingPunctuation != second.hangingPunctuation)
+            changingProperties.m_properties.set(CSSPropertyHangingPunctuation);
         if (first.hyphens != second.hyphens)
             changingProperties.m_properties.set(CSSPropertyHyphens);
         if (first.textEmphasisPosition != second.textEmphasisPosition)
@@ -2124,7 +2126,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // textZoom
         // lineSnap
         // lineAlign
-        // hangingPunctuation
         // cursorData
         // textEmphasisCustomMark
     };


### PR DESCRIPTION
#### 5e10aa6357793db2a91c8aa9d5c186aa3eb17dd9
<pre>
[web-animations] hanging-punctuation should support discrete animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=241174">https://bugs.webkit.org/show_bug.cgi?id=241174</a>
<a href="https://rdar.apple.com/94614108">rdar://94614108</a>

Reviewed by Simon Fraser.

As per:
<a href="https://drafts.csswg.org/css-text/#hanging-punctuation-property">https://drafts.csswg.org/css-text/#hanging-punctuation-property</a>

* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):

Canonical link: <a href="https://commits.webkit.org/281616@main">https://commits.webkit.org/281616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b85470ba5377753f442cd0a334ca66e700ef135b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64379 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10991 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11220 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7644 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37091 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/52373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9604 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9908 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66110 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4389 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52347 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13440 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3646 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->