### PR TITLE
[web-animations] alignment-baseline and buffered-rendering should support discrete animation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/animation/alignment-baseline-no-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/animation/alignment-baseline-no-interpolation-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial] to [central] at (-0.3) should be [initial] assert_equals: expected "baseline " but got "central "
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial] to [central] at (0) should be [initial] assert_equals: expected "baseline " but got "central "
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial] to [central] at (0.3) should be [initial] assert_equals: expected "baseline " but got "central "
+PASS CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial] to [central] at (-0.3) should be [initial]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial] to [central] at (0) should be [initial]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial] to [central] at (0.3) should be [initial]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial] to [central] at (0.5) should be [central]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial] to [central] at (0.6) should be [central]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial] to [central] at (1) should be [central]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial] to [central] at (1.5) should be [central]
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial] to [central] at (-0.3) should be [initial] assert_equals: expected "baseline " but got "central "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial] to [central] at (0) should be [initial] assert_equals: expected "baseline " but got "central "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial] to [central] at (0.3) should be [initial] assert_equals: expected "baseline " but got "central "
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial] to [central] at (-0.3) should be [initial]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial] to [central] at (0) should be [initial]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial] to [central] at (0.3) should be [initial]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial] to [central] at (0.5) should be [central]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial] to [central] at (0.6) should be [central]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial] to [central] at (1) should be [central]
@@ -30,15 +30,15 @@ PASS CSS Transitions with transition: all: property <alignment-baseline> from [i
 PASS CSS Animations: property <alignment-baseline> from [initial] to [central] at (-0.3) should be [initial]
 PASS CSS Animations: property <alignment-baseline> from [initial] to [central] at (0) should be [initial]
 PASS CSS Animations: property <alignment-baseline> from [initial] to [central] at (0.3) should be [initial]
-FAIL CSS Animations: property <alignment-baseline> from [initial] to [central] at (0.5) should be [central] assert_equals: expected "central " but got "baseline "
-FAIL CSS Animations: property <alignment-baseline> from [initial] to [central] at (0.6) should be [central] assert_equals: expected "central " but got "baseline "
-FAIL CSS Animations: property <alignment-baseline> from [initial] to [central] at (1) should be [central] assert_equals: expected "central " but got "baseline "
-FAIL CSS Animations: property <alignment-baseline> from [initial] to [central] at (1.5) should be [central] assert_equals: expected "central " but got "baseline "
+PASS CSS Animations: property <alignment-baseline> from [initial] to [central] at (0.5) should be [central]
+PASS CSS Animations: property <alignment-baseline> from [initial] to [central] at (0.6) should be [central]
+PASS CSS Animations: property <alignment-baseline> from [initial] to [central] at (1) should be [central]
+PASS CSS Animations: property <alignment-baseline> from [initial] to [central] at (1.5) should be [central]
 PASS Web Animations: property <alignment-baseline> from [initial] to [central] at (-0.3) should be [initial]
 PASS Web Animations: property <alignment-baseline> from [initial] to [central] at (0) should be [initial]
 PASS Web Animations: property <alignment-baseline> from [initial] to [central] at (0.3) should be [initial]
-FAIL Web Animations: property <alignment-baseline> from [initial] to [central] at (0.5) should be [central] assert_equals: expected "central " but got "baseline "
-FAIL Web Animations: property <alignment-baseline> from [initial] to [central] at (0.6) should be [central] assert_equals: expected "central " but got "baseline "
-FAIL Web Animations: property <alignment-baseline> from [initial] to [central] at (1) should be [central] assert_equals: expected "central " but got "baseline "
-FAIL Web Animations: property <alignment-baseline> from [initial] to [central] at (1.5) should be [central] assert_equals: expected "central " but got "baseline "
+PASS Web Animations: property <alignment-baseline> from [initial] to [central] at (0.5) should be [central]
+PASS Web Animations: property <alignment-baseline> from [initial] to [central] at (0.6) should be [central]
+PASS Web Animations: property <alignment-baseline> from [initial] to [central] at (1) should be [central]
+PASS Web Animations: property <alignment-baseline> from [initial] to [central] at (1.5) should be [central]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
@@ -1,5 +1,8 @@
 
 PASS Setup
+PASS alignment-baseline (type: discrete) has testAccumulation function
+PASS alignment-baseline: "middle" onto "baseline"
+PASS alignment-baseline: "baseline" onto "middle"
 PASS align-content (type: discrete) has testAccumulation function
 PASS align-content: "flex-end" onto "flex-start"
 PASS align-content: "flex-start" onto "flex-end"
@@ -115,6 +118,9 @@ PASS box-shadow: shadow
 PASS box-sizing (type: discrete) has testAccumulation function
 PASS box-sizing: "border-box" onto "content-box"
 PASS box-sizing: "content-box" onto "border-box"
+PASS buffered-rendering (type: discrete) has testAccumulation function
+PASS buffered-rendering: "dynamic" onto "auto"
+PASS buffered-rendering: "auto" onto "dynamic"
 PASS caption-side (type: discrete) has testAccumulation function
 PASS caption-side: "bottom" onto "top"
 PASS caption-side: "top" onto "bottom"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
@@ -1,5 +1,8 @@
 
 PASS Setup
+PASS alignment-baseline (type: discrete) has testAddition function
+PASS alignment-baseline: "middle" onto "baseline"
+PASS alignment-baseline: "baseline" onto "middle"
 PASS align-content (type: discrete) has testAddition function
 PASS align-content: "flex-end" onto "flex-start"
 PASS align-content: "flex-start" onto "flex-end"
@@ -115,6 +118,9 @@ PASS box-shadow: shadow
 PASS box-sizing (type: discrete) has testAddition function
 PASS box-sizing: "border-box" onto "content-box"
 PASS box-sizing: "content-box" onto "border-box"
+PASS buffered-rendering (type: discrete) has testAddition function
+PASS buffered-rendering: "dynamic" onto "auto"
+PASS buffered-rendering: "auto" onto "dynamic"
 PASS caption-side (type: discrete) has testAddition function
 PASS caption-side: "bottom" onto "top"
 PASS caption-side: "top" onto "bottom"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
@@ -1,5 +1,9 @@
 
 PASS Setup
+PASS alignment-baseline (type: discrete) has testInterpolation function
+PASS alignment-baseline uses discrete animation when animating between "baseline" and "middle" with linear easing
+PASS alignment-baseline uses discrete animation when animating between "baseline" and "middle" with effect easing
+PASS alignment-baseline uses discrete animation when animating between "baseline" and "middle" with keyframe easing
 PASS align-content (type: discrete) has testInterpolation function
 PASS align-content uses discrete animation when animating between "flex-start" and "flex-end" with linear easing
 PASS align-content uses discrete animation when animating between "flex-start" and "flex-end" with effect easing
@@ -141,6 +145,10 @@ PASS box-sizing (type: discrete) has testInterpolation function
 PASS box-sizing uses discrete animation when animating between "content-box" and "border-box" with linear easing
 PASS box-sizing uses discrete animation when animating between "content-box" and "border-box" with effect easing
 PASS box-sizing uses discrete animation when animating between "content-box" and "border-box" with keyframe easing
+PASS buffered-rendering (type: discrete) has testInterpolation function
+PASS buffered-rendering uses discrete animation when animating between "auto" and "dynamic" with linear easing
+PASS buffered-rendering uses discrete animation when animating between "auto" and "dynamic" with effect easing
+PASS buffered-rendering uses discrete animation when animating between "auto" and "dynamic" with keyframe easing
 PASS caption-side (type: discrete) has testInterpolation function
 PASS caption-side uses discrete animation when animating between "top" and "bottom" with linear easing
 PASS caption-side uses discrete animation when animating between "top" and "bottom" with effect easing

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -1,6 +1,12 @@
 'use strict';
 
 const gCSSProperties1 = {
+  'alignment-baseline': {
+    // https://drafts.csswg.org/css-inline/#propdef-alignment-baseline
+    types: [
+      { type: 'discrete', options: [ [ 'baseline', 'middle' ] ] }
+    ]
+  },
   'align-content': {
     // https://drafts.csswg.org/css-align/#propdef-align-content
     types: [
@@ -322,6 +328,12 @@ const gCSSProperties1 = {
     // https://drafts.csswg.org/css-ui-4/#box-sizing
     types: [
       { type: 'discrete', options: [ [ 'content-box', 'border-box' ] ] }
+    ]
+  },
+  'buffered-rendering': {
+    // https://www.w3.org/TR/SVGTiny12/painting.html#BufferedRenderingProperty
+    types: [
+      { type: 'discrete', options: [ [ 'auto', 'dynamic' ] ] }
     ]
   },
   'caption-side': {

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -4020,6 +4020,8 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscreteFontDescriptionTypedWrapper<Kerning>(CSSPropertyFontKerning, &FontCascadeDescription::kerning, &FontCascadeDescription::setKerning),
         new FontFeatureSettingsWrapper,
         new FontFamilyWrapper,
+        new DiscreteSVGPropertyWrapper<AlignmentBaseline>(CSSPropertyAlignmentBaseline, &SVGRenderStyle::alignmentBaseline, &SVGRenderStyle::setAlignmentBaseline),
+        new DiscreteSVGPropertyWrapper<BufferedRendering>(CSSPropertyBufferedRendering, &SVGRenderStyle::bufferedRendering, &SVGRenderStyle::setBufferedRendering),
         new DiscreteSVGPropertyWrapper<WindRule>(CSSPropertyClipRule, &SVGRenderStyle::clipRule, &SVGRenderStyle::setClipRule),
         new DiscreteSVGPropertyWrapper<ColorInterpolation>(CSSPropertyColorInterpolationFilters, &SVGRenderStyle::colorInterpolationFilters, &SVGRenderStyle::setColorInterpolationFilters),
         new DiscreteSVGPropertyWrapper<DominantBaseline>(CSSPropertyDominantBaseline, &SVGRenderStyle::dominantBaseline, &SVGRenderStyle::setDominantBaseline),
@@ -4164,7 +4166,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         // property should be animatable, make sure to file a bug.
 
         // To be fixed / untriaged:
-        case CSSPropertyAlignmentBaseline:
         case CSSPropertyBorderBlock: // logical shorthand
         case CSSPropertyBorderBlockColor: // logical shorthand
         case CSSPropertyBorderBlockStyle: // logical shorthand
@@ -4174,7 +4175,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyBorderInlineStyle: // logical shorthand
         case CSSPropertyBorderInlineWidth: // logical shorthand
         case CSSPropertyBorderStyle:
-        case CSSPropertyBufferedRendering:
         case CSSPropertyHangingPunctuation:
         case CSSPropertyInlineSize:
         case CSSPropertyInputSecurity:

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -336,18 +336,18 @@ void SVGRenderStyle::conservativelyCollectChangedAnimatableProperties(const SVGR
     };
 
     auto conservativelyCollectChangedAnimatablePropertiesViaNonInheritedFlags = [&](auto& first, auto& second) {
-        if (first.flagBits.dominantBaseline != second.flagBits.dominantBaseline)
-            changingProperties.m_properties.set(CSSPropertyDominantBaseline);
+        if (first.flagBits.alignmentBaseline != second.flagBits.alignmentBaseline)
+            changingProperties.m_properties.set(CSSPropertyAlignmentBaseline);
         if (first.flagBits.baselineShift != second.flagBits.baselineShift)
             changingProperties.m_properties.set(CSSPropertyBaselineShift);
-        if (first.flagBits.vectorEffect != second.flagBits.vectorEffect)
-            changingProperties.m_properties.set(CSSPropertyVectorEffect);
+        if (first.flagBits.bufferedRendering != second.flagBits.bufferedRendering)
+            changingProperties.m_properties.set(CSSPropertyBufferedRendering);
+        if (first.flagBits.dominantBaseline != second.flagBits.dominantBaseline)
+            changingProperties.m_properties.set(CSSPropertyDominantBaseline);
         if (first.flagBits.maskType != second.flagBits.maskType)
             changingProperties.m_properties.set(CSSPropertyMaskType);
-
-        // Non animated styles are followings.
-        // alignmentBaseline
-        // bufferedRendering
+        if (first.flagBits.vectorEffect != second.flagBits.vectorEffect)
+            changingProperties.m_properties.set(CSSPropertyVectorEffect);
     };
 
     if (m_fillData.ptr() != other.m_fillData.ptr())


### PR DESCRIPTION
#### 3c7c014a7d697c493d145a39c7e0f7fb897fcf4c
<pre>
[web-animations] alignment-baseline and buffered-rendering should support discrete animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=241172">https://bugs.webkit.org/show_bug.cgi?id=241172</a>
<a href="https://rdar.apple.com/94613679">rdar://94613679</a>

Reviewed by Matthieu Dubet.

As per:
<a href="https://drafts.csswg.org/css-inline/#alignment-baseline-property">https://drafts.csswg.org/css-inline/#alignment-baseline-property</a>
<a href="https://www.w3.org/TR/SVGTiny12/painting.html#BufferedRenderingProperty">https://www.w3.org/TR/SVGTiny12/painting.html#BufferedRenderingProperty</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/animation/alignment-baseline-no-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
(WebCore::SVGRenderStyle::conservativelyCollectChangedAnimatableProperties const):

Canonical link: <a href="https://commits.webkit.org/281602@main">https://commits.webkit.org/281602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4701a88115322e820876223aead00a0492e9e465

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12989 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/10962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11195 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/64350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/10962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37059 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/52349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33756 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/9576 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/9879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/9866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4364 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/66082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4383 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52327 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3629 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9075 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->