### PR TITLE
Sync `svg/crashtests` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -9374,6 +9374,7 @@
         "web-platform-tests/svg/coordinate-systems/support/viewBox-change-repaint-001-ref.html",
         "web-platform-tests/svg/coordinate-systems/support/viewBox-scaling-text-001-ref.html",
         "web-platform-tests/svg/coordinate-systems/support/views.svg",
+        "web-platform-tests/svg/crashtests/support/used.svg",
         "web-platform-tests/svg/geometry/reftests/circle-ref.svg",
         "web-platform-tests/svg/geometry/reftests/ellipse-ref.svg",
         "web-platform-tests/svg/geometry/reftests/percentage-ref.svg",

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1172059.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1172059.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<p>This test should not crash.</p>
+<svg><use href="support/used.svg#svg-text"></use></svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1205852.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1205852.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<body style="position: relative;">
+  <svg style="top: 0; left: 0; position:absolute;" width="10" height="10">
+    <rect id="target" width="5" height="10" />
+  </svg>
+  <div id="target2" style="position: absolute; width: 10px; height: 10px; top: 0; left: 0; background: lime;"></div>
+</body>
+<script>
+document.body.offsetTop;
+document.getElementById('target').setAttribute('width', '10');
+document.body.offsetTop;
+document.getElementById('target2').style.transform = 'translate(2px, 2px)'
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1207590.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1207590.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+body, svg {
+  position: absolute;
+}
+</style>
+<svg width="-1"></svg>
+<svg width="-5"></svg>
+<svg height="-1"></svg>
+<svg height="-5"></svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1238412.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1238412.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1238412">
+<div style="columns:2; column-fill:auto; height:60px;">
+  <svg viewBox="0 0 480 360">
+    <g>
+      <defs>
+        <path id="Red100" d="M 0 0 L 0 150 L 150 0 z"></path>
+        <filter id="xor" x="0" y="0" width="1" height="1">
+          <feImage href="#Red100" result="red"></feimage>
+        </filter>
+      </defs>
+      <g>
+        <rect x="0" y="0" width="150" height="150" filter="url(#xor)"></rect>
+      </g>
+    </g>
+  </svg>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1345806.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1345806.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1345806">
+<link rel="author" title="Philip Rogers" href="mailto:pdr@chromium.org">
+<svg>
+  <path pathLength='-0.0' d='M0 0 L 100 0 L 100 100 L 0 100Z' stroke-dasharray='58,119,146' stroke="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1371700.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1371700.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<p>This test should not crash.</p>
+<svg id="svgvar00001">
+  <clipPath>
+    <image xlink:href="#nothing" onerror="foo()"/>
+  </clippath>
+</svg>
+<svg>
+  <use xlink:href="#svgvar00001"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1474157.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1474157.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<svg>
+  <foreignObject id="target">
+    <div style="position: sticky; top: 0;"></div>
+  </foreignobject>
+</svg>
+<script>
+document.body.offsetTop;
+document.getElementById('target').style.overflow = 'visible';
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-333487749.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-333487749.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<body style="mask: url(#marker)">
+  <svg>
+    <marker id="marker">
+      <rect width="10" height="10" fill="yellow"/>
+    </marker>
+    <path d="M50,50h100" marker-start="url(#marker1)"/>
+  </svg>
+</body>
+<script>
+  document.documentElement.offsetTop;
+  document.documentElement.style.display = 'none';
+  document.documentElement.offsetTop;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1688293.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1688293.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script>
+  window.addEventListener('load', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    const clip = document.createElementNS('http://www.w3.org/2000/svg', 'clipPath')
+    const use = document.createElementNS('http://www.w3.org/2000/svg', 'use')
+    const style = document.createElementNS('http://www.w3.org/2000/svg', 'style')
+    document.documentElement.appendChild(svg)
+    svg.setAttribute('id', 'id_0')
+    clip.appendChild(use)
+    svg.appendChild(clip)
+    document.documentElement.appendChild(style)
+    style.textContent = `
+      @import url(dom--23104-J7UdNQ5SQ5Rv-.css);
+      @namespace url(http://www.w3.org/1999/xhtml);
+      @namespace svg url(http://www.w3.org/2000/svg);
+      * {
+        filter: url(#id_0);
+      }
+      svg|* {
+        transition: 352ms ! important;
+        y: 29%;
+      }`
+  })
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1703592.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1703592.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1703592">
+<style>
+* {
+  font-size: 1237818528.6247747em;
+}
+</style>
+<script>
+  window.addEventListener('load', async () => {
+    const svg_1 = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    const svg_2 = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    const anchor = document.createElementNS('http://www.w3.org/2000/svg', 'a')
+    svg_2.setAttribute('width', '14em')
+    anchor.appendChild(svg_2)
+    svg_1.appendChild(anchor)
+    document.documentElement.appendChild(svg_1)
+    const selection = window.getSelection()
+    selection.selectAllChildren(svg_1)
+  })
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1719483.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1719483.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+    * {
+        padding: 2880804336.4242716vmax 854269137% 347744005.57952744in 2487922492.561039pt;
+    }
+</style>
+<script>
+    const button = document.createElement("button")
+    const select = document.createElement("select")
+    const optgroup = document.createElement("optgroup")
+    const option = document.createElement("option")
+    button.setAttribute("id", "button_0")
+    optgroup.appendChild(option)
+    select.appendChild(optgroup)
+    button.appendChild(select)
+    document.documentElement.appendChild(button)
+    const canvas = document.createElement("canvas")
+    const context = canvas.getContext("2d", { "willReadFrequently": false, "alpha": true })
+    context.filter = "url(#button_0)"
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1723249.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1723249.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1723249">
+<style>
+#a {
+  mask-image: url(#c);
+}
+</style>
+<script>
+window.onload = () => {
+  c.innerHTML = b.outerHTML
+}
+</script>
+<pre id="a">x</pre>
+<svg id="b">
+<mask id="c" />
+<image requiredExtensions="x">

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1724237.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1724237.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel=help href="https://bugzilla.mozilla.org/show_bug.cgi?id=1724237">
+<svg>
+  <animateTransform id="id_0"></animatetransform>
+  <rect id="id_1"></rect>
+</svg>
+<script>
+  new IntersectionObserver((e1, e2) => {
+    e2.observe(document.getElementById("id_1"))
+  }).observe(document.getElementById("id_0"))
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1753105.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1753105.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg")
+    const text = document.createElementNS("http://www.w3.org/2000/svg", "text")
+    text.setAttribute("letter-spacing", "-37vw")
+    const node = document.createTextNode("\n\n\r7%Ù î¯•\0ó …§ð†ªã€€&**=ðŸ¯šð¯‚ï¸¡ó ”©Û¹â€Ùªv*/ð¯„ð–¹§åžçº¶*;{0ð–£”9ï¿¼Ì†ë¢»\r\n^æŽ¶ï¿ºð©¹º*|\r\nðŸ©‚Ù«ð‡½ë«»eçŠ®ã‡†á­²ð¡‡‚\u2028á¨²â¤\rv+ðŸ§Œ8ï¬¬\nð¯Žè›¥ó „ˆêº¡\nâ’ð±’Ù Û¹ð–¯¸0ó ¤™/á¾‚ð«ž¾99Â a&=ð‰‚Û¹ð¯©’ã‚™2ó ¥µ^0ê’‹ð—»ð…»\0X%+0*/é•³ã€€ÙªÈºXá©¿L2â¼¤ð›ªˆÂ­ðª¸ð›‰")
+    text.appendChild(node)
+    svg.appendChild(text)
+    document.documentElement.appendChild(svg)
+    const rect = document.documentElement.getBoundingClientRect()
+    node.convertRectFromNode(rect, svg, {})
+  })
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1883804.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1883804.html
@@ -1,0 +1,3 @@
+<svg>
+<set xlink:href="#)󠵵‏᭭%a8*=٫́壎
+<title class=" >

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/support/used.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/support/used.svg
@@ -1,0 +1,3 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <text id="svg-text" x="0" y="20" style="font-family: sans-serif">Text</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/support/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/support/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/support/used.svg

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/w3c-import.log
@@ -1,0 +1,31 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1172059.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1205852.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1207590.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1238412.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1345806.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1371700.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1474157.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-333487749.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1688293.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1703592.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1719483.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1723249.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1724237.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1753105.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1883804.html


### PR DESCRIPTION
#### d7424e7405afaa039e96904631736c098a17a63f
<pre>
Sync `svg/crashtests` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=277367">https://bugs.webkit.org/show_bug.cgi?id=277367</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/0a595a5048225b38c91ee9de0a39474c713897f9">https://github.com/web-platform-tests/wpt/commit/0a595a5048225b38c91ee9de0a39474c713897f9</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1172059.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1205852.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1207590.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1238412.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1345806.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1371700.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-1474157.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/chrome-bug-333487749.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1688293.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1703592.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1719483.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1723249.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1724237.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1753105.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1883804.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/support/used.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/support/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/281620@main">https://commits.webkit.org/281620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b422b8cc1db8fda73ad484c99d267eaa142dc7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64344 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10956 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48904 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7631 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29744 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33752 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9573 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9873 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55639 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66076 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4358 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56270 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4377 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56435 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13443 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3621 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35586 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->