### PR TITLE
Make sure IPCData correctly encodes / decodes a null RetainPtr

### DIFF
--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -165,6 +165,11 @@ inline std::span<const uint8_t> span(CFDataRef data)
     return { static_cast<const uint8_t*>(CFDataGetBytePtr(data)), Checked<size_t>(CFDataGetLength(data)) };
 }
 
+inline RetainPtr<CFDataRef> toCFData(std::span<const uint8_t> span)
+{
+    return adoptCF(CFDataCreate(kCFAllocatorDefault, span.data(), span.size()));
+}
+
 inline Vector<uint8_t> makeVector(CFDataRef data)
 {
     return span(data);
@@ -189,5 +194,6 @@ inline std::optional<float> makeVectorElement(const float*, CFNumberRef cfNumber
 using WTF::createCFArray;
 using WTF::makeVector;
 using WTF::span;
+using WTF::toCFData;
 
 #endif // USE(CF)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCData.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCData.h
@@ -29,6 +29,7 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/cf/VectorCF.h>
 #include <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WebKit {
@@ -48,8 +49,8 @@ public:
     {
     }
 
-    CoreIPCData(std::span<const uint8_t> data)
-        : m_cfData(adoptCF(CFDataCreate(kCFAllocatorDefault, data.data(), data.size())))
+    CoreIPCData(std::optional<std::span<const uint8_t>> data)
+        : m_cfData(data ? toCFData(*data) : nullptr)
     {
     }
 
@@ -58,9 +59,11 @@ public:
         return m_cfData;
     }
 
-    std::span<const uint8_t> dataReference() const
+    std::optional<std::span<const uint8_t>> dataReference() const
     {
-        return { CFDataGetBytePtr(m_cfData.get()), static_cast<size_t>(CFDataGetLength(m_cfData.get())) };
+        if (!m_cfData)
+            return std::nullopt;
+        return span(m_cfData.get());
     }
 
     RetainPtr<id> toID() const

--- a/Source/WebKit/Shared/Cocoa/CoreIPCData.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCData.serialization.in
@@ -25,7 +25,7 @@
 webkit_platform_headers: "CoreIPCData.h"
 
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCData {
-    std::span<const uint8_t> dataReference();
+    std::optional<std::span<const uint8_t>> dataReference();
 }
 
 #endif // USE(CF)


### PR DESCRIPTION
#### 2a510c1db4df61eb95f42fdc5e74f3fe1f447e99
<pre>
Make sure IPCData correctly encodes / decodes a null RetainPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=277369">https://bugs.webkit.org/show_bug.cgi?id=277369</a>
<a href="https://rdar.apple.com/132787264">rdar://132787264</a>

Reviewed by Ryosuke Niwa.

We now serialize over IPC a `std::optional&lt;std::span&lt;const uint8_t&gt;&gt;` instead of
a `std::span&lt;const uint8_t&gt;`. This allows us to distinguish a null
`RetainPtr&lt;CFDataRef&gt;` and a pointer to a `CFDataRef` that is empty.

* Source/WTF/wtf/cf/VectorCF.h:
(WTF::toCFData):
* Source/WebKit/Shared/Cocoa/CoreIPCData.h:
(WebKit::CoreIPCData::CoreIPCData):
(WebKit::CoreIPCData::dataReference const):
* Source/WebKit/Shared/Cocoa/CoreIPCData.serialization.in:

Canonical link: <a href="https://commits.webkit.org/281615@main">https://commits.webkit.org/281615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5ab340c84f62cf91f65119c58cf9523dc9f01b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64346 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10958 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11191 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48905 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7624 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52348 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29746 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9575 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9875 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/53523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66078 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59670 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4360 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9699 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56272 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56441 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3626 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81428 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9084 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35589 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14145 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->