### PR TITLE
[Remote Inspection] Refactor ElementTargetingController to avoid a rare nullptr crash

### DIFF
--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -654,21 +654,35 @@ static HashSet<URL> collectMediaAndLinkURLs(const Element& element)
 }
 
 enum class IsNearbyTarget : bool { No, Yes };
-static TargetedElementInfo targetedElementInfo(Element& element, IsNearbyTarget isNearbyTarget, ElementSelectorCache& cache)
+static std::optional<TargetedElementInfo> targetedElementInfo(Element& element, IsNearbyTarget isNearbyTarget, ElementSelectorCache& cache)
 {
-    CheckedPtr renderer = element.renderer();
+    element.document().updateLayoutIgnorePendingStylesheets();
+
+    FloatRect boundsInClientCoordinates;
+    RectEdges<bool> offsetEdges;
+    PositionType positionType = PositionType::Static;
+    {
+        WeakPtr renderer = element.renderer();
+        if (!renderer)
+            return { };
+
+        offsetEdges = computeOffsetEdges(renderer->style());
+        positionType = renderer->style().position();
+        boundsInClientCoordinates = computeClientRect(*renderer);
+    }
+
     auto [renderedText, screenReaderText, hasLargeReplacedDescendant] = TextExtraction::extractRenderedText(element);
-    return {
+    return { {
         .elementIdentifier = element.identifier(),
         .documentIdentifier = element.document().identifier(),
-        .offsetEdges = computeOffsetEdges(renderer->style()),
+        .offsetEdges = offsetEdges,
         .renderedText = WTFMove(renderedText),
         .searchableText = searchableTextForTarget(element),
         .screenReaderText = WTFMove(screenReaderText),
         .selectors = selectorsForTarget(element, cache),
         .boundsInRootView = element.boundingBoxInRootViewCoordinates(),
-        .boundsInClientCoordinates = computeClientRect(*renderer),
-        .positionType = renderer->style().position(),
+        .boundsInClientCoordinates = WTFMove(boundsInClientCoordinates),
+        .positionType = positionType,
         .childFrameIdentifiers = collectChildFrameIdentifiers(element),
         .mediaAndLinkURLs = collectMediaAndLinkURLs(element),
         .isNearbyTarget = isNearbyTarget == IsNearbyTarget::Yes,
@@ -677,7 +691,7 @@ static TargetedElementInfo targetedElementInfo(Element& element, IsNearbyTarget 
         .isInVisibilityAdjustmentSubtree = element.isInVisibilityAdjustmentSubtree(),
         .hasLargeReplacedDescendant = hasLargeReplacedDescendant,
         .hasAudibleMedia = hasAudibleMedia(element)
-    };
+    } };
 }
 
 static const HTMLElement* findOnlyMainElement(const HTMLBodyElement& bodyElement)
@@ -1078,8 +1092,10 @@ Vector<TargetedElementInfo> ElementTargetingController::extractTargets(Vector<Re
     Vector<TargetedElementInfo> results;
     results.reserveInitialCapacity(targets.size());
     for (auto iterator = targets.rbegin(); iterator != targets.rend(); ++iterator) {
-        results.append(targetedElementInfo(*iterator, IsNearbyTarget::No, cache));
-        addOutOfFlowTargetClientRectIfNeeded(*iterator);
+        if (auto info = targetedElementInfo(*iterator, IsNearbyTarget::No, cache)) {
+            results.append(WTFMove(*info));
+            addOutOfFlowTargetClientRectIfNeeded(*iterator);
+        }
     }
 
     if (additionalRegionForNearbyElements.isEmpty())
@@ -1135,8 +1151,10 @@ Vector<TargetedElementInfo> ElementTargetingController::extractTargets(Vector<Re
     }();
 
     for (auto& element : nearbyTargets) {
-        results.append(targetedElementInfo(element, IsNearbyTarget::Yes, cache));
-        addOutOfFlowTargetClientRectIfNeeded(element);
+        if (auto info = targetedElementInfo(element, IsNearbyTarget::Yes, cache)) {
+            results.append(WTFMove(*info));
+            addOutOfFlowTargetClientRectIfNeeded(element);
+        }
     }
 
     return results;


### PR DESCRIPTION
#### d15c4b4addcad589c6dda36bc3bde03a78da1e10
<pre>
[Remote Inspection] Refactor ElementTargetingController to avoid a rare nullptr crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=277371">https://bugs.webkit.org/show_bug.cgi?id=277371</a>
<a href="https://rdar.apple.com/132831879">rdar://132831879</a>

Reviewed by Aditya Keerthi.

This is a speculative fix for a `nullptr` (or `CheckedPtr`) crash, due to the fact that `renderer`
is a `CheckedPtr` below:

```
    CheckedPtr renderer = element.renderer();

    …

    return {
        .elementIdentifier = element.identifier(),
        .documentIdentifier = element.document().identifier(),
        .offsetEdges = computeOffsetEdges(renderer-&gt;style()),               // &lt;--- A
        .renderedText = WTFMove(renderedText),
        .searchableText = searchableTextForTarget(element),                 // &lt;--- B
        .screenReaderText = WTFMove(screenReaderText),
        .selectors = selectorsForTarget(element, cache),
        .boundsInRootView = element.boundingBoxInRootViewCoordinates(),
        .boundsInClientCoordinates = computeClientRect(*renderer),          // &lt;--- C

        …
    };
```

Because we may update layout in (B) (and rebuild parts of the render tree in the process), it&apos;s
possible for the renderer to become null by the time we get to line (C). To address this, we make
the `renderer` a `WeakPtr` and limit its lifetime to only code that accesses information from
`RenderStyle` and geometry information, without updating layout.

No new test case, since it only seemed to reproduce once.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::targetedElementInfo):
(WebCore::ElementTargetingController::extractTargets):

Canonical link: <a href="https://commits.webkit.org/281613@main">https://commits.webkit.org/281613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e91b73c37ebb2665366f8df5ca6bf2657515c3a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64366 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10974 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62573 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11207 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/7641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52363 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33766 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9586 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9895 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66094 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4376 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52337 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3636 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9082 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->