### PR TITLE
Additional Web Extensions API changes based on feedback.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -82,14 +82,14 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @param appExtensionBundle The bundle to use for the new web extension.
  @param completionHandler A block to be called with an initialized web extension, or \c nil if the object could not be initialized due to an error.
  */
-+ (void)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle completionHandler:(void (^)(_WKWebExtension * _Nullable extension, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);
++ (void)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle completionHandler:(void (^)(_WKWebExtension * WK_NULLABLE_RESULT extension, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);
 
 /*!
  @abstract Returns a web extension initialized with a specified resource base URL.
  @param resourceBaseURL The directory URL to use for the new web extension.
  @param completionHandler A block to be called with an initialized web extension, or \c nil if the object could not be initialized due to an error.
  */
-+ (void)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL completionHandler:(void (^)(_WKWebExtension * _Nullable extension, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);
++ (void)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL completionHandler:(void (^)(_WKWebExtension * WK_NULLABLE_RESULT extension, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);
 
 /*!
  @abstract The active errors for the extension.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
@@ -42,7 +42,7 @@
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 /*!
- @abstract Constants used by @link WKWebExtensionController @/link to indicate tab changes.
+ @abstract Constants used by @link WKWebExtensionController @/link and @link WKWebExtensionContext @/link to indicate tab changes.
  @constant WKWebExtensionTabChangedPropertiesNone  Indicates nothing changed.
  @constant WKWebExtensionTabChangedPropertiesAudible  Indicates the audible state changed.
  @constant WKWebExtensionTabChangedPropertiesLoading  Indicates the loading state changed.
@@ -65,7 +65,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebExtensionTabChangedProperties) {
     _WKWebExtensionTabChangedPropertiesTitle      = 1 << 7,
     _WKWebExtensionTabChangedPropertiesURL        = 1 << 8,
     _WKWebExtensionTabChangedPropertiesZoomFactor = 1 << 9,
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+} NS_SWIFT_NAME(_WKWebExtension.TabChangedProperties) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*! @abstract A class conforming to the `WKWebExtensionTab` protocol represents a tab to web extensions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_SWIFT_UI_ACTOR
@@ -111,18 +111,18 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
 - (void)setParentTab:(nullable id <_WKWebExtensionTab>)parentTab forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
- @abstract Called when the main web view for the tab is needed.
+ @abstract Called when the web view for the tab is needed.
  @param context The context in which the web extension is running.
- @return The main web view for the tab.
+ @return The web view for the tab.
  @discussion Defaults to `nil` if not implemented.
  */
-- (nullable WKWebView *)mainWebViewForWebExtensionContext:(_WKWebExtensionContext *)context;
+- (nullable WKWebView *)webViewForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
  @abstract Called when the title of the tab is needed.
  @param context The context in which the web extension is running.
  @return The title of the tab.
- @discussion Defaults to `title` for the main web view if not implemented.
+ @discussion Defaults to `title` of the tab's web view if not implemented.
  */
 - (nullable NSString *)titleForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -210,7 +210,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @abstract Called when the size of the tab is needed.
  @param context The context in which the web extension is running.
  @return The size of the tab.
- @discussion Defaults to size of the main web view if not implemented.
+ @discussion Defaults to size of the tab's web view if not implemented.
  */
 - (CGSize)sizeForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -218,7 +218,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @abstract Called when the zoom factor of the tab is needed.
  @param context The context in which the web extension is running.
  @return The zoom factor of the tab.
- @discussion Defaults to `pageZoom` for the main web view if not implemented.
+ @discussion Defaults to `pageZoom` of the tab's web view if not implemented.
  @seealso setZoomFactor:forWebExtensionContext:completionHandler:
  */
 - (double)zoomFactorForWebExtensionContext:(_WKWebExtensionContext *)context;
@@ -229,7 +229,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
- @discussion Sets `pageZoom` for the main web view if not implemented.
+ @discussion Sets `pageZoom` of the tab's web view if not implemented.
  @seealso zoomFactorForWebExtensionContext:
  */
 - (void)setZoomFactor:(double)zoomFactor forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
@@ -238,7 +238,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @abstract Called when the URL of the tab is needed.
  @param context The context in which the web extension is running.
  @return The URL of the tab.
- @discussion Defaults to `URL` for the main web view if not implemented.
+ @discussion Defaults to `URL` of the tab's web view if not implemented.
  */
 - (nullable NSURL *)urlForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -255,7 +255,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @abstract Called to check if the tab has finished loading.
  @param context The context in which the web extension is running.
  @return `YES` if the tab has finished loading, `NO` otherwise.
- @discussion Defaults to `isLoading` for the main web view if not implemented.
+ @discussion Defaults to `isLoading` of the tab's web view if not implemented.
  */
 - (BOOL)isLoadingCompleteForWebExtensionContext:(_WKWebExtensionContext *)context;
 
@@ -274,7 +274,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param configuration An object that specifies how the snapshot is configured.
  @param completionHandler A block that must be called upon completion. The block takes two arguments:
  the captured image of the webpage (or \c nil if capturing failed) and an error, which should be provided if any errors occurred.
- @discussion Defaults to capturing the visible area for the main web view if not implemented.
+ @discussion Defaults to capturing the visible area of the tab's web view if not implemented.
  */
 #if TARGET_OS_IPHONE
 - (void)takeSnapshotWithConfiguration:(WKSnapshotConfiguration *)configuration forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(UIImage * WK_NULLABLE_RESULT visibleWebpageImage, NSError * _Nullable error))completionHandler;
@@ -289,7 +289,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
  @discussion If the tab is already loading a page, calling this method should stop the current page from loading and start
- loading the new URL. Loads the URL in the main web view via `loadRequest:` if not implemented.
+ loading the new URL. Loads the URL in the tab's web view via `loadRequest:` if not implemented.
  */
 - (void)loadURL:(NSURL *)url forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
@@ -299,7 +299,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
- @discussion Reloads the main web view via `reload` or `reloadFromOrigin` if not implemented.
+ @discussion Reloads the tab's web view via `reload` or `reloadFromOrigin` if not implemented.
  */
 - (void)reloadFromOrigin:(BOOL)fromOrigin forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
@@ -308,7 +308,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
- @discussion Navigates to the previous page in the main web view via `goBack` if not implemented.
+ @discussion Navigates to the previous page in the tab's web view via `goBack` if not implemented.
  */
 - (void)goBackForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
@@ -317,7 +317,7 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_S
  @param context The context in which the web extension is running.
  @param completionHandler A block that must be called upon completion. It takes a single error argument,
  which should be provided if any errors occurred.
- @discussion Navigates to the next page in the main web view via `goForward` if not implemented.
+ @discussion Navigates to the next page in the tab's web view via `goForward` if not implemented.
  */
 - (void)goForwardForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
@@ -40,7 +40,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 typedef NS_ENUM(NSInteger, _WKWebExtensionWindowType) {
     _WKWebExtensionWindowTypeNormal,
     _WKWebExtensionWindowTypePopup,
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+} NS_SWIFT_NAME(_WKWebExtension.WindowType) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*!
  @abstract Constants used by @link WKWebExtensionWindow @/link to indicate possible states of a window.
@@ -54,7 +54,7 @@ typedef NS_ENUM(NSInteger, _WKWebExtensionWindowState) {
     _WKWebExtensionWindowStateMinimized,
     _WKWebExtensionWindowStateMaximized,
     _WKWebExtensionWindowStateFullscreen,
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+} NS_SWIFT_NAME(_WKWebExtension.WindowState) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*! @abstract A class conforming to the `WKWebExtensionWindow` protocol represents a window to web extensions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK_SWIFT_UI_ACTOR

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
@@ -227,7 +227,7 @@ void WebExtensionContext::cookiesGetAllCookieStores(CompletionHandler<void(Expec
     stores.set(defaultSessionID, Vector<WebExtensionTabIdentifier> { });
 
     for (Ref tab : openTabs()) {
-        if (WKWebView *webView = tab->mainWebView()) {
+        if (WKWebView *webView = tab->webView()) {
             auto sessionID = webView.configuration.websiteDataStore->_websiteDataStore.get()->sessionID();
 
             auto& tabsVector = stores.ensure(sessionID, [] {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -76,7 +76,7 @@ void WebExtensionContext::scriptingExecuteScript(const WebExtensionScriptInjecti
             return;
         }
 
-        auto *webView = tab->mainWebView();
+        auto *webView = tab->webView();
         if (!webView) {
             completionHandler(toWebExtensionError(apiName, nil, @"could not execute script on this tab"));
             return;
@@ -107,7 +107,7 @@ void WebExtensionContext::scriptingInsertCSS(const WebExtensionScriptInjectionPa
             return;
         }
 
-        auto *webView = tab->mainWebView();
+        auto *webView = tab->webView();
         if (!webView) {
             completionHandler(toWebExtensionError(apiName, nil, @"could not inject stylesheet on this tab"));
             return;
@@ -138,7 +138,7 @@ void WebExtensionContext::scriptingRemoveCSS(const WebExtensionScriptInjectionPa
         return;
     }
 
-    auto *webView = tab->mainWebView();
+    auto *webView = tab->webView();
     if (!webView) {
         completionHandler(toWebExtensionError(apiName, nil, @"could not remove stylesheet from this tab"));
         return;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -578,7 +578,7 @@ void WebExtensionContext::tabsExecuteScript(WebPageProxyIdentifier webPageProxyI
             return;
         }
 
-        auto *webView = tab->mainWebView();
+        auto *webView = tab->webView();
         if (!webView) {
             completionHandler(toWebExtensionError(apiName, nil, @"could not execute script in tab"));
             return;
@@ -619,7 +619,7 @@ void WebExtensionContext::tabsInsertCSS(WebPageProxyIdentifier webPageProxyIdent
             return;
         }
 
-        auto *webView = tab->mainWebView();
+        auto *webView = tab->webView();
         if (!webView) {
             completionHandler(toWebExtensionError(apiName, nil, @"could not inject stylesheet on this tab"));
             return;
@@ -645,7 +645,7 @@ void WebExtensionContext::tabsRemoveCSS(WebPageProxyIdentifier webPageProxyIdent
         return;
     }
 
-    auto *webView = tab->mainWebView();
+    auto *webView = tab->webView();
     if (!webView) {
         completionHandler(toWebExtensionError(apiName, nil, @"could not remove stylesheet on this tab"));
         return;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
@@ -91,7 +91,7 @@ void WebExtensionContext::webNavigationGetFrame(WebExtensionTabIdentifier tabIde
         return;
     }
 
-    auto *webView = tab->mainWebView();
+    auto *webView = tab->webView();
     if (!webView) {
         completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nil, @"tab not found"));
         return;
@@ -119,7 +119,7 @@ void WebExtensionContext::webNavigationGetAllFrames(WebExtensionTabIdentifier ta
         return;
     }
 
-    auto *webView = tab->mainWebView();
+    auto *webView = tab->webView();
     if (!webView) {
         completionHandler(toWebExtensionError(@"webNavigation.getAllFrames()", nil, @"tab not found"));
         return;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1929,7 +1929,7 @@ RefPtr<WebExtensionTab> WebExtensionContext::getCurrentTab(WebPageProxyIdentifie
 
     // Search open tabs for the page.
     for (Ref tab : openTabs()) {
-        if (WKWebView *webView = tab->mainWebView()) {
+        if (WKWebView *webView = tab->webView()) {
             if (webView._page->identifier() != webPageProxyIdentifier)
                 continue;
 
@@ -3549,7 +3549,7 @@ void WebExtensionContext::reportWebViewConfigurationErrorIfNeeded(const WebExten
     // Access the method(s) below to trigger time-of-use logging with this stack trace
     // so it is easy to catch errors where they are actionable by the app.
 
-    tab.mainWebView();
+    tab.webView();
 }
 #endif
 
@@ -3629,7 +3629,7 @@ WebExtensionContext::InspectorTabVector WebExtensionContext::openInspectors(Func
     InspectorTabVector result;
 
     for (Ref tab : openTabs()) {
-        if (WKWebView *webView = tab->mainWebView()) {
+        if (WKWebView *webView = tab->webView()) {
             auto *webInspector = webView._inspector;
             if (!webInspector)
                 continue;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -131,7 +131,7 @@ public:
     RefPtr<WebExtensionTab> parentTab() const;
     void setParentTab(RefPtr<WebExtensionTab>, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
-    WKWebView *mainWebView() const;
+    WKWebView *webView() const;
 
     String title() const;
 
@@ -218,7 +218,7 @@ private:
     bool m_respondsToIndex : 1 { false };
     bool m_respondsToParentTab : 1 { false };
     bool m_respondsToSetParentTab : 1 { false };
-    bool m_respondsToMainWebView : 1 { false };
+    bool m_respondsToWebView : 1 { false };
     bool m_respondsToTitle : 1 { false };
     bool m_respondsToIsPinned : 1 { false };
     bool m_respondsToSetPinned : 1 { false };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -1203,13 +1203,13 @@ TEST(WKWebExtensionAPIAction, ClearTabSpecificActionPropertiesOnNavigation)
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:localhostRequest.URL];
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:addressRequest.URL];
 
-    [manager.get().defaultTab.mainWebView loadRequest:localhostRequest];
+    [manager.get().defaultTab.webView loadRequest:localhostRequest];
 
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:addressRequest];
+    [manager.get().defaultTab.webView loadRequest:addressRequest];
 
     [manager run];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICookies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICookies.mm
@@ -263,7 +263,7 @@ TEST(WKWebExtensionAPICookies, GetAllIncognito)
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
     auto *privateWindow = [manager openNewWindowUsingPrivateBrowsing:YES];
-    auto *cookieStore = privateWindow.activeTab.mainWebView.configuration.websiteDataStore.httpCookieStore;
+    auto *cookieStore = privateWindow.activeTab.webView.configuration.websiteDataStore.httpCookieStore;
 
     auto *cookie1 = [NSHTTPCookie cookieWithProperties:@{
         NSHTTPCookieName: @"testCookie1",
@@ -339,7 +339,7 @@ TEST(WKWebExtensionAPICookies, GetAllIncognitoWithPrivateAccess)
     manager.get().context.hasAccessInPrivateBrowsing = YES;
 
     auto *privateWindow = [manager openNewWindowUsingPrivateBrowsing:YES];
-    auto *cookieStore = privateWindow.activeTab.mainWebView.configuration.websiteDataStore.httpCookieStore;
+    auto *cookieStore = privateWindow.activeTab.webView.configuration.websiteDataStore.httpCookieStore;
 
     auto *cookie1 = [NSHTTPCookie cookieWithProperties:@{
         NSHTTPCookieName: @"testCookie1",

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -74,7 +74,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadTest)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    auto webView = manager.get().defaultTab.mainWebView;
+    auto webView = manager.get().defaultTab.webView;
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool receivedActionNotification { false };
@@ -133,7 +133,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadInPrivateBrowsingTest)
 
     auto privateWindow = [manager openNewWindowUsingPrivateBrowsing:YES];
     auto privateTab = privateWindow.tabs.firstObject;
-    auto webView = privateTab.mainWebView;
+    auto webView = privateTab.webView;
 
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
@@ -305,7 +305,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, UpdateEnabledRulesetsPerformsCompil
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    auto webView = manager.get().defaultTab.mainWebView;
+    auto webView = manager.get().defaultTab.webView;
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool receivedActionNotification { false };
@@ -410,7 +410,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, SetExtensionActionOptions)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
     auto *defaultTab = manager.get().defaultTab;
-    auto *webView = defaultTab.mainWebView;
+    auto *webView = defaultTab.webView;
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool receivedActionNotification { false };
@@ -491,7 +491,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, GetMatchedRules)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -533,7 +533,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, SessionRules)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
     EXPECT_TRUE(manager.get().context.hasContentModificationRules);
 
-    auto webView = manager.get().defaultTab.mainWebView;
+    auto webView = manager.get().defaultTab.webView;
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool receivedActionNotification { false };
@@ -602,7 +602,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    auto webView = manager.get().defaultTab.mainWebView;
+    auto webView = manager.get().defaultTab.webView;
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block bool receivedActionNotification { false };
@@ -691,7 +691,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, DISABLED_RedirectRule)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -770,7 +770,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermis
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -846,7 +846,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostPermission)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -925,7 +925,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRule)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -1005,7 +1005,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostAccessP
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -1082,7 +1082,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostPermiss
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm
@@ -80,8 +80,8 @@ TEST(WKWebExtensionAPIDevTools, Basics)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
-    [manager.get().defaultTab.mainWebView._inspector show];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
 
     [manager loadAndRun];
 }
@@ -139,15 +139,15 @@ TEST(WKWebExtensionAPIDevTools, CreatePanel)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
-    [manager.get().defaultTab.mainWebView._inspector show];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
 
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Panel Created");
 
     NSString *extensionIdentifier = [NSString stringWithFormat:@"WebExtensionTab-%@-1", manager.get().context.uniqueIdentifier];
-    [manager.get().defaultTab.mainWebView._inspector showExtensionTabWithIdentifier:extensionIdentifier completionHandler:^(NSError *error) {
+    [manager.get().defaultTab.webView._inspector showExtensionTabWithIdentifier:extensionIdentifier completionHandler:^(NSError *error) {
         EXPECT_NULL(error);
     }];
 
@@ -155,7 +155,7 @@ TEST(WKWebExtensionAPIDevTools, CreatePanel)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Panel Loaded");
 
-    [manager.get().defaultTab.mainWebView._inspector showResources];
+    [manager.get().defaultTab.webView._inspector showResources];
 
     [manager run];
 
@@ -207,8 +207,8 @@ TEST(WKWebExtensionAPIDevTools, InspectedWindowEval)
 
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:server.requestWithLocalhost().URL];
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
-    [manager.get().defaultTab.mainWebView._inspector show];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
 
     [manager loadAndRun];
 }
@@ -234,8 +234,8 @@ TEST(WKWebExtensionAPIDevTools, InspectedWindowReload)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
-    [manager.get().defaultTab.mainWebView._inspector show];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
 
     [manager loadAndRun];
 
@@ -269,8 +269,8 @@ TEST(WKWebExtensionAPIDevTools, InspectedWindowReloadIgnoringCache)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
-    [manager.get().defaultTab.mainWebView._inspector show];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
 
     [manager loadAndRun];
 
@@ -308,15 +308,15 @@ TEST(WKWebExtensionAPIDevTools, NetworkNavigatedEvent)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
-    [manager.get().defaultTab.mainWebView._inspector show];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
 
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Next Page");
 
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:server.request().URL];
-    [manager.get().defaultTab.mainWebView loadRequest:server.request()];
+    [manager.get().defaultTab.webView loadRequest:server.request()];
 
     [manager run];
 }
@@ -352,17 +352,17 @@ TEST(WKWebExtensionAPIDevTools, PanelsThemeName)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    auto *mainWebView = manager.get().defaultTab.mainWebView;
+    auto *webView = manager.get().defaultTab.webView;
 
-    [mainWebView loadRequest:server.requestWithLocalhost()];
-    [mainWebView._inspector show];
+    [webView loadRequest:server.requestWithLocalhost()];
+    [webView._inspector show];
 
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Change Theme");
 
     // Force dark mode on the inspector to tigger the theme change.
-    mainWebView._inspector.extensionHostWebView.appearance = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
+    webView._inspector.extensionHostWebView.appearance = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
 
     [manager run];
 }
@@ -396,8 +396,8 @@ TEST(WKWebExtensionAPIDevTools, MessagePassingToBackground)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
-    [manager.get().defaultTab.mainWebView._inspector show];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
 
     [manager loadAndRun];
 }
@@ -443,15 +443,15 @@ TEST(WKWebExtensionAPIDevTools, MessagePassingFromPanelToBackground)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
-    [manager.get().defaultTab.mainWebView._inspector show];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
 
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Panel Created");
 
     NSString *extensionIdentifier = [NSString stringWithFormat:@"WebExtensionTab-%@-1", manager.get().context.uniqueIdentifier];
-    [manager.get().defaultTab.mainWebView._inspector showExtensionTabWithIdentifier:extensionIdentifier completionHandler:^(NSError *error) {
+    [manager.get().defaultTab.webView._inspector showExtensionTabWithIdentifier:extensionIdentifier completionHandler:^(NSError *error) {
         EXPECT_NULL(error);
     }];
 
@@ -497,15 +497,15 @@ TEST(WKWebExtensionAPIDevTools, MessagePassingFromPanelToDevToolsBackground)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
-    [manager.get().defaultTab.mainWebView._inspector show];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
 
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Panel Created");
 
     NSString *extensionIdentifier = [NSString stringWithFormat:@"WebExtensionTab-%@-1", manager.get().context.uniqueIdentifier];
-    [manager.get().defaultTab.mainWebView._inspector showExtensionTabWithIdentifier:extensionIdentifier completionHandler:^(NSError *error) {
+    [manager.get().defaultTab.webView._inspector showExtensionTabWithIdentifier:extensionIdentifier completionHandler:^(NSError *error) {
         EXPECT_NULL(error);
     }];
 
@@ -547,8 +547,8 @@ TEST(WKWebExtensionAPIDevTools, PortMessagePassingToBackground)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
-    [manager.get().defaultTab.mainWebView._inspector show];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
 
     [manager loadAndRun];
 }
@@ -599,15 +599,15 @@ TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToBackground)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
-    [manager.get().defaultTab.mainWebView._inspector show];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
 
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Panel Created");
 
     NSString *extensionIdentifier = [NSString stringWithFormat:@"WebExtensionTab-%@-1", manager.get().context.uniqueIdentifier];
-    [manager.get().defaultTab.mainWebView._inspector showExtensionTabWithIdentifier:extensionIdentifier completionHandler:^(NSError *error) {
+    [manager.get().defaultTab.webView._inspector showExtensionTabWithIdentifier:extensionIdentifier completionHandler:^(NSError *error) {
         EXPECT_NULL(error);
     }];
 
@@ -659,15 +659,15 @@ TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToDevToolsBackground)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
-    [manager.get().defaultTab.mainWebView._inspector show];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView._inspector show];
 
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Panel Created");
 
     NSString *extensionIdentifier = [NSString stringWithFormat:@"WebExtensionTab-%@-1", manager.get().context.uniqueIdentifier];
-    [manager.get().defaultTab.mainWebView._inspector showExtensionTabWithIdentifier:extensionIdentifier completionHandler:^(NSError *error) {
+    [manager.get().defaultTab.webView._inspector showExtensionTabWithIdentifier:extensionIdentifier completionHandler:^(NSError *error) {
         EXPECT_NULL(error);
     }];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
@@ -356,7 +356,7 @@ TEST(WKWebExtensionAPIExtension, GetViewsForMultipleTabs)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:extensionManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
 
     [manager loadAndRun];
 }
@@ -439,7 +439,7 @@ TEST(WKWebExtensionAPIExtension, InIncognitoContext)
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
     manager.get().context.hasAccessInPrivateBrowsing = YES;
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 
@@ -450,7 +450,7 @@ TEST(WKWebExtensionAPIExtension, InIncognitoContext)
     auto *privateWindow = [manager openNewWindowUsingPrivateBrowsing:YES];
     auto *privateTab = privateWindow.tabs.firstObject;
 
-    [privateTab.mainWebView loadRequest:urlRequest];
+    [privateTab.webView loadRequest:urlRequest];
 
     [manager run];
 
@@ -480,7 +480,7 @@ TEST(WKWebExtensionAPIExtension, InIncognitoContextWithoutPrivateAccess)
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 
@@ -491,7 +491,7 @@ TEST(WKWebExtensionAPIExtension, InIncognitoContextWithoutPrivateAccess)
     auto *privateWindow = [manager openNewWindowUsingPrivateBrowsing:YES];
     auto *privateTab = privateWindow.tabs.firstObject;
 
-    [privateTab.mainWebView loadRequest:urlRequest];
+    [privateTab.webView loadRequest:urlRequest];
 
     // The content script should not run in the private tab, so timeout after waiting for 3 seconds.
     [manager runForTimeInterval:3];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
@@ -232,7 +232,7 @@ TEST(WKWebExtensionAPIMenus, ActionMenus)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
     [manager runForTimeInterval:1];
 
     auto *action = [manager.get().context actionForTab:manager.get().defaultTab];
@@ -307,7 +307,7 @@ TEST(WKWebExtensionAPIMenus, ActionMenusWithActiveTab)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<title>Test</title>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
     [manager runForTimeInterval:1];
 
     auto *action = [manager.get().context actionForTab:manager.get().defaultTab];
@@ -556,7 +556,7 @@ TEST(WKWebExtensionAPIMenus, TabMenus)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Menus Created");
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
     [manager runForTimeInterval:1];
 
     auto *menuItems = [manager.get().context menuItemsForTab:manager.get().defaultTab];
@@ -1129,7 +1129,7 @@ TEST(WKWebExtensionAPIMenus, MacContextMenuItems)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
-    manager.get().defaultTab.mainWebView = webView.get();
+    manager.get().defaultTab.webView = webView.get();
 
     [webView synchronouslyLoadRequest:urlRequest];
     [webView waitForNextPresentationUpdate];
@@ -1212,7 +1212,7 @@ TEST(WKWebExtensionAPIMenus, MacActiveTabContextMenuItems)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
-    manager.get().defaultTab.mainWebView = webView.get();
+    manager.get().defaultTab.webView = webView.get();
 
     [webView synchronouslyLoadRequest:server.requestWithLocalhost()];
     [webView waitForNextPresentationUpdate];
@@ -1311,7 +1311,7 @@ TEST(WKWebExtensionAPIMenus, MacURLPatternContextMenuItems)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
-    manager.get().defaultTab.mainWebView = webView.get();
+    manager.get().defaultTab.webView = webView.get();
 
     [webView synchronouslyLoadRequest:urlRequest];
     [webView waitForNextPresentationUpdate];
@@ -1395,7 +1395,7 @@ TEST(WKWebExtensionAPIMenus, MacSelectionContextMenuItems)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
-    manager.get().defaultTab.mainWebView = webView.get();
+    manager.get().defaultTab.webView = webView.get();
 
     [webView synchronouslyLoadRequest:urlRequest];
     [webView waitForNextPresentationUpdate];
@@ -1480,7 +1480,7 @@ TEST(WKWebExtensionAPIMenus, MacLinkContextMenuItems)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
-    manager.get().defaultTab.mainWebView = webView.get();
+    manager.get().defaultTab.webView = webView.get();
 
     [webView synchronouslyLoadRequest:urlRequest];
     [webView waitForNextPresentationUpdate];
@@ -1564,7 +1564,7 @@ TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
-    manager.get().defaultTab.mainWebView = webView.get();
+    manager.get().defaultTab.webView = webView.get();
 
     [webView synchronouslyLoadRequest:urlRequest];
     [webView waitForNextPresentationUpdate];
@@ -1648,7 +1648,7 @@ TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
-    manager.get().defaultTab.mainWebView = webView.get();
+    manager.get().defaultTab.webView = webView.get();
 
     [webView synchronouslyLoadRequest:urlRequest];
     [webView waitForNextPresentationUpdate];
@@ -1732,7 +1732,7 @@ TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
-    manager.get().defaultTab.mainWebView = webView.get();
+    manager.get().defaultTab.webView = webView.get();
 
     [webView synchronouslyLoadRequest:urlRequest];
     [webView waitForNextPresentationUpdate];
@@ -1812,7 +1812,7 @@ TEST(WKWebExtensionAPIMenus, MacEditableContextMenuItems)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
-    manager.get().defaultTab.mainWebView = webView.get();
+    manager.get().defaultTab.webView = webView.get();
 
     [webView synchronouslyLoadRequest:urlRequest];
     [webView waitForNextPresentationUpdate];
@@ -1896,7 +1896,7 @@ TEST(WKWebExtensionAPIMenus, MacFrameContextMenuItems)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     webView.get().UIDelegate = delegate.get();
 
-    manager.get().defaultTab.mainWebView = webView.get();
+    manager.get().defaultTab.webView = webView.get();
 
     [webView synchronouslyLoadRequest:urlRequest];
     [webView waitForNextPresentationUpdate];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -380,7 +380,7 @@ TEST(WKWebExtensionAPIRuntime, GetFrameId)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -450,7 +450,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScript)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -508,7 +508,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncReply)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -564,7 +564,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithPromiseReply)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -622,7 +622,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncPromiseReply
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -678,7 +678,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithNoReply)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -749,7 +749,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromSubframe)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequestMain];
+    [manager.get().defaultTab.webView loadRequest:urlRequestMain];
 
     [manager run];
 }
@@ -834,7 +834,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageWithTabFrameAndAsyncReply)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -881,7 +881,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageWithNaNValue)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
 
     [manager run];
 }
@@ -934,7 +934,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScript)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -1013,7 +1013,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromSubframe)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequestMain];
+    [manager.get().defaultTab.webView loadRequest:urlRequestMain];
 
     [manager run];
 }
@@ -1086,7 +1086,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScriptWithMultipleListeners)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -1135,7 +1135,7 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScript)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -1194,7 +1194,7 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScriptWithMultipleListen
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -1602,7 +1602,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPage)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -1647,7 +1647,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPageWithWrongIdentifier)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -1704,7 +1704,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPage)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -1803,10 +1803,10 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithTabFrameAndAsyncReply)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tabs");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     auto *secondTab = [manager.get().defaultWindow openNewTab];
-    [secondTab.mainWebView loadRequest:server.requestWithLocalhost("/second-tab.html"_s)];
+    [secondTab.webView loadRequest:server.requestWithLocalhost("/second-tab.html"_s)];
 
     [manager run];
 }
@@ -1849,7 +1849,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithWrongIdentifier)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
@@ -210,7 +210,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScript)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -255,7 +255,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptJSONTypes)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -331,7 +331,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptWithFrameIds)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -435,7 +435,7 @@ TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSS)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -511,7 +511,7 @@ TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSSWithFrameIds)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -552,7 +552,7 @@ TEST(WKWebExtensionAPIScripting, CSSUserOrigin)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -593,7 +593,7 @@ TEST(WKWebExtensionAPIScripting, CSSAuthorOrigin)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -641,7 +641,7 @@ TEST(WKWebExtensionAPIScripting, World)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -718,7 +718,7 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScripts)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -773,7 +773,7 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScriptsWithCSSUserOrigin)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -828,7 +828,7 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScriptsWithCSSAuthorOrigin)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -917,7 +917,7 @@ TEST(WKWebExtensionAPIScripting, UpdateContentScripts)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -989,7 +989,7 @@ TEST(WKWebExtensionAPIScripting, GetContentScripts)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -1064,7 +1064,7 @@ TEST(WKWebExtensionAPIScripting, UnregisterContentScripts)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -1132,7 +1132,7 @@ TEST(WKWebExtensionAPIScripting, RegisteredScriptIsInjectedAfterContextReloads)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -1177,7 +1177,7 @@ TEST(WKWebExtensionAPIScripting, MainWorld)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -1221,7 +1221,7 @@ TEST(WKWebExtensionAPIScripting, IsolatedWorld)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
@@ -143,7 +143,7 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedContexts)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -185,7 +185,7 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedAndUntrustedContexts)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -439,7 +439,7 @@ TEST(WKWebExtensionAPIStorage, StorageFromSubframe)
 
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequestSubframe.URL];
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequestMain];
+    [manager.get().defaultTab.webView loadRequest:urlRequestMain];
 
     [manager loadAndRun];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -573,7 +573,7 @@ TEST(WKWebExtensionAPITabs, GetCurrentFromOptionsPage)
     EXPECT_NOT_NULL(defaultTab);
 
     [defaultTab changeWebViewIfNeededForURL:optionsPageURL forExtensionContext:manager.get().context];
-    [defaultTab.mainWebView loadRequest:[NSURLRequest requestWithURL:optionsPageURL]];
+    [defaultTab.webView loadRequest:[NSURLRequest requestWithURL:optionsPageURL]];
 
     [manager run];
 }
@@ -777,8 +777,8 @@ TEST(WKWebExtensionAPITabs, QueryWithAccessPrompt)
     auto *windowOne = manager.get().defaultWindow;
     [windowOne openNewTab];
 
-    [windowOne.tabs.firstObject.mainWebView loadRequest:server.requestWithLocalhost()];
-    [windowOne.tabs.lastObject.mainWebView loadRequest:server.request()];
+    [windowOne.tabs.firstObject.webView loadRequest:server.requestWithLocalhost()];
+    [windowOne.tabs.lastObject.webView loadRequest:server.request()];
 
     EXPECT_EQ(manager.get().windows.count, 1lu);
     EXPECT_EQ(windowOne.tabs.count, 2lu);
@@ -861,7 +861,7 @@ TEST(WKWebExtensionAPITabs, DetectLanguage)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     __block bool detectWebpageLocaleCalled = false;
 
@@ -1113,7 +1113,7 @@ TEST(WKWebExtensionAPITabs, UpdatedEventWithoutPrivateAccess)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
     auto *privateWindow = [manager openNewWindowUsingPrivateBrowsing:YES];
-    [privateWindow.activeTab.mainWebView loadRequest:server.requestWithLocalhost()];
+    [privateWindow.activeTab.webView loadRequest:server.requestWithLocalhost()];
 
     [manager run];
 }
@@ -1144,7 +1144,7 @@ TEST(WKWebExtensionAPITabs, UpdatedEventWithPrivateAccess)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
     auto *privateWindow = [manager openNewWindowUsingPrivateBrowsing:YES];
-    [privateWindow.activeTab.mainWebView loadRequest:server.requestWithLocalhost()];
+    [privateWindow.activeTab.webView loadRequest:server.requestWithLocalhost()];
 
     [manager run];
 }
@@ -1504,7 +1504,7 @@ TEST(WKWebExtensionAPITabs, SendMessage)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -1557,7 +1557,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncReply)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -1608,7 +1608,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithPromiseReply)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -1661,7 +1661,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncPromiseReply)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -1710,7 +1710,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithoutReply)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -1768,7 +1768,7 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundPageToFullPageExtensionCont
     EXPECT_NOT_NULL(defaultTab);
 
     [defaultTab changeWebViewIfNeededForURL:optionsPageURL forExtensionContext:manager.get().context];
-    [defaultTab.mainWebView loadRequest:[NSURLRequest requestWithURL:optionsPageURL]];
+    [defaultTab.webView loadRequest:[NSURLRequest requestWithURL:optionsPageURL]];
 
     [manager run];
 }
@@ -1842,7 +1842,7 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSubframe)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequestMain];
+    [manager.get().defaultTab.webView loadRequest:urlRequestMain];
 
     [manager run];
 }
@@ -1904,7 +1904,7 @@ TEST(WKWebExtensionAPITabs, Connect)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -1988,7 +1988,7 @@ TEST(WKWebExtensionAPITabs, ConnectToSubframe)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequestMain];
+    [manager.get().defaultTab.webView loadRequest:urlRequestMain];
 
     [manager run];
 }
@@ -2043,7 +2043,7 @@ TEST(WKWebExtensionAPITabs, PortDisconnect)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -2112,7 +2112,7 @@ TEST(WKWebExtensionAPITabs, ConnectWithMultipleListeners)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -2173,7 +2173,7 @@ TEST(WKWebExtensionAPITabs, PortDisconnectWithMultipleListeners)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -2227,7 +2227,7 @@ TEST(WKWebExtensionAPITabs, ExecuteScript)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -2267,7 +2267,7 @@ TEST(WKWebExtensionAPITabs, ExecuteScriptJSONTypes)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -2337,7 +2337,7 @@ TEST(WKWebExtensionAPITabs, InsertAndRemoveCSSInMainFrame)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -2391,7 +2391,7 @@ TEST(WKWebExtensionAPITabs, InsertAndRemoveCSSInAllFrames)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -2426,7 +2426,7 @@ TEST(WKWebExtensionAPITabs, CSSUserOrigin)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -2461,7 +2461,7 @@ TEST(WKWebExtensionAPITabs, CSSAuthorOrigin)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -2541,7 +2541,7 @@ TEST(WKWebExtensionAPITabs, ActiveTab)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Localhost");
 
-    [manager.get().defaultTab.mainWebView loadRequest:localhostRequest];
+    [manager.get().defaultTab.webView loadRequest:localhostRequest];
 
     [manager run];
 
@@ -2571,13 +2571,13 @@ TEST(WKWebExtensionAPITabs, ActiveTab)
     EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL]);
     EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.URL]);
 
-    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost("/next.html"_s)];
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost("/next.html"_s)];
 
     [manager run];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load IP Address");
 
-    [manager.get().defaultTab.mainWebView loadRequest:addressRequest];
+    [manager.get().defaultTab.webView loadRequest:addressRequest];
 
     [manager run];
 
@@ -2626,7 +2626,7 @@ TEST(WKWebExtensionAPITabs, UserGestureWithoutActiveTab)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Localhost");
 
-    [manager.get().defaultTab.mainWebView loadRequest:localhostRequest];
+    [manager.get().defaultTab.webView loadRequest:localhostRequest];
 
     [manager run];
 
@@ -2681,7 +2681,7 @@ TEST(WKWebExtensionAPITabs, ActiveTabWithDeniedPermissions)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Localhost");
 
-    [manager.get().defaultTab.mainWebView loadRequest:localhostRequest];
+    [manager.get().defaultTab.webView loadRequest:localhostRequest];
 
     [manager run];
 
@@ -2732,7 +2732,7 @@ TEST(WKWebExtensionAPITabs, ActiveTabRemovedWithDeniedPermissions)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Localhost");
 
-    [manager.get().defaultTab.mainWebView loadRequest:localhostRequest];
+    [manager.get().defaultTab.webView loadRequest:localhostRequest];
 
     [manager run];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
@@ -94,7 +94,7 @@ TEST(WKWebExtensionAPIWebNavigation, EventFiringTest)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -129,7 +129,7 @@ TEST(WKWebExtensionAPIWebNavigation, AllowedFilterTest)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -166,7 +166,7 @@ TEST(WKWebExtensionAPIWebNavigation, DeniedFilterTest)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -214,7 +214,7 @@ TEST(WKWebExtensionAPIWebNavigation, AllEventsFiredTest)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -260,7 +260,7 @@ TEST(WKWebExtensionAPIWebNavigation, OnErrorOccurredProvisionalLoadEvent)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -348,7 +348,7 @@ TEST(WKWebExtensionAPIWebNavigation, OnErrorOccurredDuringLoadEvent)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -397,7 +397,7 @@ TEST(WKWebExtensionAPIWebNavigation, GetMainFrame)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -446,7 +446,7 @@ TEST(WKWebExtensionAPIWebNavigation, GetSubframe)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -505,7 +505,7 @@ TEST(WKWebExtensionAPIWebNavigation, GetAllFrames)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -558,7 +558,7 @@ TEST(WKWebExtensionAPIWebNavigation, ErrorOccurred)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -605,7 +605,7 @@ TEST(WKWebExtensionAPIWebNavigation, Errors)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm
@@ -96,7 +96,7 @@ TEST(WKWebExtensionAPIWebRequest, EventFiringTest)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -132,7 +132,7 @@ TEST(WKWebExtensionAPIWebRequest, AllowedFilterTest)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -170,7 +170,7 @@ TEST(WKWebExtensionAPIWebRequest, DeniedFilterTest)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -224,7 +224,7 @@ TEST(WKWebExtensionAPIWebRequest, AllEventsFiredTest)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -260,7 +260,7 @@ TEST(WKWebExtensionAPIWebRequest, ErrorOccurred)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
@@ -296,7 +296,7 @@ TEST(WKWebExtensionAPIWebRequest, RedirectOccurred)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");
 
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
@@ -156,7 +156,7 @@ TEST(WKWebExtensionAPIWindows, GetCurrentFromOptionsPage)
     EXPECT_NOT_NULL(defaultTab);
 
     [defaultTab changeWebViewIfNeededForURL:optionsPageURL forExtensionContext:manager.get().context];
-    [defaultTab.mainWebView loadRequest:[NSURLRequest requestWithURL:optionsPageURL]];
+    [defaultTab.webView loadRequest:[NSURLRequest requestWithURL:optionsPageURL]];
 
     [manager run];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
@@ -579,7 +579,7 @@ TEST(WKWebExtensionController, CSSUserOrigin)
     auto *urlRequest = server.requestWithLocalhost();
 
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -625,7 +625,7 @@ TEST(WKWebExtensionController, CSSAuthorOrigin)
     auto *urlRequest = server.requestWithLocalhost();
 
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -786,7 +786,7 @@ TEST(WKWebExtensionController, WebAccessibleResources)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }
@@ -856,7 +856,7 @@ TEST(WKWebExtensionController, WebAccessibleResourcesV2)
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager loadAndRun];
 }

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -75,7 +75,7 @@
 - (void)assignWindow:(TestWebExtensionWindow *)window;
 
 @property (nonatomic, weak) TestWebExtensionWindow *window;
-@property (nonatomic, strong) WKWebView *mainWebView;
+@property (nonatomic, strong) WKWebView *webView;
 
 - (void)changeWebViewIfNeededForURL:(NSURL *)url forExtensionContext:(_WKWebExtensionContext *)context;
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -129,7 +129,7 @@
 
         if (options.url) {
             [newTab changeWebViewIfNeededForURL:options.url forExtensionContext:context];
-            [newTab.mainWebView loadRequest:[NSURLRequest requestWithURL:options.url]];
+            [newTab.webView loadRequest:[NSURLRequest requestWithURL:options.url]];
         }
 
         newTab.parentTab = options.parentTab;
@@ -334,8 +334,8 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
         configuration.userContentController = userContentController(usingPrivateBrowsing);
         configuration.preferences._developerExtrasEnabled = YES;
 
-        _mainWebView = [[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration];
-        _mainWebView.navigationDelegate = self;
+        _webView = [[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration];
+        _webView.navigationDelegate = self;
 
         _extensionController = extensionController;
     }
@@ -375,7 +375,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 {
     BOOL usingPrivateBrowsing = _window.usingPrivateBrowsing;
 
-    if ([_mainWebView.URL.scheme isEqualToString:url.scheme])
+    if ([_webView.URL.scheme isEqualToString:url.scheme])
         return;
 
     WKWebViewConfiguration *configuration = [url.scheme hasPrefix:@"http"] ? [[WKWebViewConfiguration alloc] init] : context.webViewConfiguration;
@@ -383,8 +383,8 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     configuration.websiteDataStore = usingPrivateBrowsing ? WKWebsiteDataStore.nonPersistentDataStore : WKWebsiteDataStore.defaultDataStore;
     configuration.userContentController = userContentController(usingPrivateBrowsing);
 
-    _mainWebView = [[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration];
-    _mainWebView.navigationDelegate = self;
+    _webView = [[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration];
+    _webView.navigationDelegate = self;
 }
 
 - (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation
@@ -412,9 +412,9 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesLoading forTab:self];
 }
 
-- (WKWebView *)mainWebViewForWebExtensionContext:(_WKWebExtensionContext *)context
+- (WKWebView *)webViewForWebExtensionContext:(_WKWebExtensionContext *)context
 {
-    return _mainWebView;
+    return _webView;
 }
 
 - (BOOL)isReaderModeShowingForWebExtensionContext:(_WKWebExtensionContext *)context
@@ -452,9 +452,9 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
         if (self->_reload)
             self->_reload(fromOrigin);
         else if (fromOrigin)
-            [self->_mainWebView reloadFromOrigin];
+            [self->_webView reloadFromOrigin];
         else
-            [self->_mainWebView reload];
+            [self->_webView reload];
 
         completionHandler(nil);
     });
@@ -466,7 +466,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
         if (self->_goBack)
             self->_goBack();
         else
-            [self->_mainWebView goBack];
+            [self->_webView goBack];
 
         completionHandler(nil);
     });
@@ -478,7 +478,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
         if (self->_goForward)
             self->_goForward();
         else
-            [self->_mainWebView goForward];
+            [self->_webView goForward];
 
         completionHandler(nil);
     });
@@ -632,8 +632,8 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     auto *previousActiveTab = _activeTab;
 
     for (TestWebExtensionTab *tab in _tabs) {
-        [tab.mainWebView _close];
-        tab.mainWebView = nil;
+        [tab.webView _close];
+        tab.webView = nil;
 
         [_extensionController didCloseTab:tab windowIsClosing:NO];
 
@@ -688,7 +688,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
         auto *desiredWindow = dynamic_objc_cast<TestWebExtensionWindow>(options.window) ?: weakTab.window;
         auto *duplicatedTab = [desiredWindow openNewTabAtIndex:options.index];
 
-        [duplicatedTab.mainWebView loadRequest:[NSURLRequest requestWithURL:weakTab.mainWebView.URL]];
+        [duplicatedTab.webView loadRequest:[NSURLRequest requestWithURL:weakTab.webView.URL]];
 
         duplicatedTab.selected = options.selected;
 
@@ -714,8 +714,8 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)closeTab:(TestWebExtensionTab *)tab windowIsClosing:(BOOL)windowIsClosing
 {
-    [tab.mainWebView _close];
-    tab.mainWebView = nil;
+    [tab.webView _close];
+    tab.webView = nil;
 
     [_tabs removeObject:tab];
 
@@ -736,8 +736,8 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     ASSERT([_tabs containsObject:oldTab]);
     ASSERT(![_tabs containsObject:newTab]);
 
-    [oldTab.mainWebView _close];
-    oldTab.mainWebView = nil;
+    [oldTab.webView _close];
+    oldTab.webView = nil;
 
     if (_activeTab == oldTab)
         _activeTab = newTab;


### PR DESCRIPTION
#### 45e07b5428077bf94cff5940445ca7254e16268e
<pre>
Additional Web Extensions API changes based on feedback.
<a href="https://webkit.org/b/277374">https://webkit.org/b/277374</a>
<a href="https://rdar.apple.com/problem/132843735">rdar://problem/132843735</a>

Reviewed by Brian Weinstein.

Renamed the protocol method on `_WKWebExtensionTab` from `mainWebViewForWebExtensionContext:`
to just `webViewForWebExtensionContext:` since `webViewsForWebExtensionContext:` was removed.
Renamed all uses of `mainWebView` in extensions code to match.

Added `NS_SWIFT_NAME` to `_WKWebExtensionTabChangedProperties`, `_WKWebExtensionWindowType`,
and `_WKWebExtensionWindowState`.

Finally, use `WK_NULLABLE_RESULT` for `_WKWebExtension` async convenience methods for better
importation to Swift.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm:
(WebKit::WebExtensionContext::cookiesGetAllCookieStores):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingExecuteScript):
(WebKit::WebExtensionContext::scriptingInsertCSS):
(WebKit::WebExtensionContext::scriptingRemoveCSS):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsExecuteScript):
(WebKit::WebExtensionContext::tabsInsertCSS):
(WebKit::WebExtensionContext::tabsRemoveCSS):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm:
(WebKit::WebExtensionContext::webNavigationGetFrame):
(WebKit::WebExtensionContext::webNavigationGetAllFrames):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::getCurrentTab const):
(WebKit::WebExtensionContext::reportWebViewConfigurationErrorIfNeeded const):
(WebKit::WebExtensionContext::openInspectors const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::WebExtensionTab):
(WebKit::WebExtensionTab::webView const):
(WebKit::WebExtensionTab::title const):
(WebKit::WebExtensionTab::size const):
(WebKit::WebExtensionTab::zoomFactor const):
(WebKit::WebExtensionTab::setZoomFactor):
(WebKit::WebExtensionTab::url const):
(WebKit::WebExtensionTab::isLoadingComplete const):
(WebKit::WebExtensionTab::captureVisibleWebpage):
(WebKit::WebExtensionTab::loadURL):
(WebKit::WebExtensionTab::reload):
(WebKit::WebExtensionTab::goBack):
(WebKit::WebExtensionTab::goForward):
(WebKit::WebExtensionTab::processes const):
(WebKit::WebExtensionTab::mainWebView const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, ClearTabSpecificActionPropertiesOnNavigation)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICookies.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, GetAllIncognito)):
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, GetAllIncognitoWithPrivateAccess)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadTest)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadInPrivateBrowsingTest)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, UpdateEnabledRulesetsPerformsCompilation)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, SetExtensionActionOptions)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, GetMatchedRules)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, SessionRules)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, DISABLED_RedirectRule)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermission)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostPermission)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRule)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostAccessPermission)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostPermission)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, Basics)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, CreatePanel)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, InspectedWindowEval)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, InspectedWindowReload)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, InspectedWindowReloadIgnoringCache)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, NetworkNavigatedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, PanelsThemeName)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, MessagePassingToBackground)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, MessagePassingFromPanelToBackground)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, MessagePassingFromPanelToDevToolsBackground)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, PortMessagePassingToBackground)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToBackground)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToDevToolsBackground)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIExtension, GetViewsForMultipleTabs)):
(TestWebKitAPI::TEST(WKWebExtensionAPIExtension, InIncognitoContext)):
(TestWebKitAPI::TEST(WKWebExtensionAPIExtension, InIncognitoContextWithoutPrivateAccess)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, ActionMenus)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, ActionMenusWithActiveTab)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, TabMenus)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacContextMenuItems)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacActiveTabContextMenuItems)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacURLPatternContextMenuItems)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacSelectionContextMenuItems)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacLinkContextMenuItems)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacEditableContextMenuItems)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacFrameContextMenuItems)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, GetFrameId)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScript)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithPromiseReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncPromiseReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithNoReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromSubframe)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageWithTabFrameAndAsyncReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageWithNaNValue)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectFromContentScript)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectFromSubframe)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectFromContentScriptWithMultipleListeners)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScript)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScriptWithMultipleListeners)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectFromWebPage)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectFromWebPageWithWrongIdentifier)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPage)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithTabFrameAndAsyncReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithWrongIdentifier)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ExecuteScript)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ExecuteScriptJSONTypes)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ExecuteScriptWithFrameIds)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSS)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSSWithFrameIds)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, CSSUserOrigin)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, CSSAuthorOrigin)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, World)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, RegisterContentScripts)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, RegisterContentScriptsWithCSSUserOrigin)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, RegisterContentScriptsWithCSSAuthorOrigin)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, UpdateContentScripts)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, GetContentScripts)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, UnregisterContentScripts)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, RegisteredScriptIsInjectedAfterContextReloads)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, MainWorld)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, IsolatedWorld)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedContexts)):
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedAndUntrustedContexts)):
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, StorageFromSubframe)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, GetCurrentFromOptionsPage)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, QueryWithAccessPrompt)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, DetectLanguage)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, UpdatedEventWithoutPrivateAccess)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, UpdatedEventWithPrivateAccess)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessage)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageWithAsyncReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageWithPromiseReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageWithAsyncPromiseReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageWithoutReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundPageToFullPageExtensionContent)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSubframe)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, Connect)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, ConnectToSubframe)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, PortDisconnect)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, ConnectWithMultipleListeners)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, PortDisconnectWithMultipleListeners)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, ExecuteScript)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, ExecuteScriptJSONTypes)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, InsertAndRemoveCSSInMainFrame)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, InsertAndRemoveCSSInAllFrames)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, CSSUserOrigin)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, CSSAuthorOrigin)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, ActiveTab)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, UserGestureWithoutActiveTab)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, ActiveTabWithDeniedPermissions)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, ActiveTabRemovedWithDeniedPermissions)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, EventFiringTest)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, AllowedFilterTest)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, DeniedFilterTest)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, AllEventsFiredTest)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, OnErrorOccurredProvisionalLoadEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, OnErrorOccurredDuringLoadEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, GetMainFrame)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, GetSubframe)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, GetAllFrames)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, ErrorOccurred)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebNavigation, Errors)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, EventFiringTest)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, AllowedFilterTest)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, DeniedFilterTest)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, AllEventsFiredTest)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, ErrorOccurred)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, RedirectOccurred)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIWindows, GetCurrentFromOptionsPage)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm:
(TestWebKitAPI::TEST(WKWebExtensionController, CSSUserOrigin)):
(TestWebKitAPI::TEST(WKWebExtensionController, CSSAuthorOrigin)):
(TestWebKitAPI::TEST(WKWebExtensionController, WebAccessibleResources)):
(TestWebKitAPI::TEST(WKWebExtensionController, WebAccessibleResourcesV2)):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:]):
(-[TestWebExtensionTab initWithWindow:extensionController:]):
(-[TestWebExtensionTab changeWebViewIfNeededForURL:forExtensionContext:]):
(-[TestWebExtensionTab webViewForWebExtensionContext:]):
(-[TestWebExtensionTab reloadFromOrigin:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab goBackForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab goForwardForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionWindow setTabs:]):
(-[TestWebExtensionWindow openNewTabAtIndex:]):
(-[TestWebExtensionWindow closeTab:windowIsClosing:]):
(-[TestWebExtensionWindow replaceTab:withTab:]):
(-[TestWebExtensionTab mainWebViewForWebExtensionContext:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/281607@main">https://commits.webkit.org/281607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/181c95f73da331fcd3017ceb0b07efdff66c9d1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13011 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/10988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11217 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/64376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/10988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62484 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/37078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/52370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/64376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/33775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9593 "Failed to checkout and rebase branch from PR 31496") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/9905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9883 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4386 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/66107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52344 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/66107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3645 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9078 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->