### PR TITLE
[WPE][cross-toolchain-helper] Update target layers references (chromium 124->126) and enable default plugins for cog

### DIFF
--- a/Tools/yocto/meta-openembedded_and_meta-webkit.patch
+++ b/Tools/yocto/meta-openembedded_and_meta-webkit.patch
@@ -1,16 +1,3 @@
-diff --git a/sources/meta-openembedded/meta-python/recipes-devtools/python/python3-twisted_24.3.0.bb b/sources/meta-openembedded/meta-python/recipes-devtools/python/python3-twisted_24.3.0.bb
-index e5223cc..1454b62 100644
---- a/sources/meta-openembedded/meta-python/recipes-devtools/python/python3-twisted_24.3.0.bb
-+++ b/sources/meta-openembedded/meta-python/recipes-devtools/python/python3-twisted_24.3.0.bb
-@@ -15,7 +15,7 @@ do_install:append() {
-     find ${D} \( -name "*.bat" -o -name "*.c" -o -name "*.h" \) -exec rm -f {} \;
- }
- 
--PACKAGES += "\
-+PACKAGES =+ "\
-     ${PN}-zsh \
-     ${PN}-test \
-     ${PN}-protocols \
 diff --git a/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata/netdata.service b/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata/netdata.service
 index f4911f3..b13abad 100644
 --- a/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata/netdata.service

--- a/Tools/yocto/riscv/manifest.xml
+++ b/Tools/yocto/riscv/manifest.xml
@@ -8,9 +8,9 @@
 
   <!-- Yocto version: scarthgap -->
 
-  <project remote="yocto"  revision="f7def85be9f99dcb4ba488bead201f670304379b" name="poky" path="sources/poky"/>
-  <project remote="github" revision="4a7bb77f7ebe0ac8be5bab5103d8bd993e17e18d" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="yocto"  revision="6879650b927c96a2464224cdc2bed8245511cbf1" name="poky" path="sources/poky"/>
+  <project remote="github" revision="80e01188fa822d87d301ee71973c462d7a865493" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
   <project remote="github" revision="d330dfe4011a873d379cdf6228fa1f243cf5a6db" name="riscv/meta-riscv" path="sources/meta-riscv"/>
-  <project remote="github" revision="d5d6eb779e1c86832dd8f645c3a8471d0d15ff3d" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
+  <project remote="github" revision="ec00a77f921f2443280f70bb9ca8eef9fe4bc679" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
 
 </manifest>

--- a/Tools/yocto/rpi/manifest.xml
+++ b/Tools/yocto/rpi/manifest.xml
@@ -8,11 +8,11 @@
 
   <!-- Yocto version: scarthgap -->
 
-  <project remote="yocto"  revision="f7def85be9f99dcb4ba488bead201f670304379b" name="poky" path="sources/poky"/>
-  <project remote="github" revision="4a7bb77f7ebe0ac8be5bab5103d8bd993e17e18d" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="yocto"  revision="6879650b927c96a2464224cdc2bed8245511cbf1" name="poky" path="sources/poky"/>
+  <project remote="github" revision="80e01188fa822d87d301ee71973c462d7a865493" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
   <project remote="yocto"  revision="1918a27419dcd5e79954c0dc0edddcde91057a7e" name="meta-raspberrypi" path="sources/meta-raspberrypi"/>
-  <project remote="github" revision="d5d6eb779e1c86832dd8f645c3a8471d0d15ff3d" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
-  <project remote="github" revision="e7dceb1c92caf7f21ef1d7b49c85328c30cffd90" name="kraj/meta-clang.git" path="sources/meta-clang"/>
-  <project remote="github" revision="40ef1d0799124a36b22df11a7562868c0edb23b1" name="OSSystems/meta-browser.git" path="sources/meta-browser"/>
+  <project remote="github" revision="ec00a77f921f2443280f70bb9ca8eef9fe4bc679" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
+  <project remote="github" revision="df21b1563910c80d7e2964971b7c5b79b5186922" name="kraj/meta-clang.git" path="sources/meta-clang"/>
+  <project remote="github" revision="83cb90c618e24af9bc40fb25baab2a0acd47a560" name="OSSystems/meta-browser.git" path="sources/meta-browser"/>
 
 </manifest>

--- a/Tools/yocto/targets.conf
+++ b/Tools/yocto/targets.conf
@@ -39,7 +39,7 @@ conf_local_path = rpi/local-rpi3-32bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi3-32bits-userland]
 repo_manifest_path = rpi/manifest.xml
@@ -49,7 +49,7 @@ image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
 # WTR and MiniBrowser require wpbackend-fdo, with wpbackend-rdk we can only build cog
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DENABLE_MINIBROWSER=OFF -DENABLE_API_TESTS=OFF -DENABLE_LAYOUT_TESTS=OFF -DWPE_COG_PLATFORMS=none -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DENABLE_MINIBROWSER=OFF -DENABLE_API_TESTS=OFF -DENABLE_LAYOUT_TESTS=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi4-32bits-mesa]
 repo_manifest_path = rpi/manifest.xml
@@ -58,7 +58,7 @@ conf_local_path = rpi/local-rpi4-32bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 # ARM 64-bits targets (AArch64)
 
@@ -69,7 +69,7 @@ conf_local_path = rpi/local-rpi3-64bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi4-64bits-mesa]
 repo_manifest_path = rpi/manifest.xml
@@ -78,7 +78,7 @@ conf_local_path = rpi/local-rpi4-64bits-mesa.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [qemu-riscv64]
 repo_manifest_path = riscv/manifest.xml
@@ -87,4 +87,4 @@ conf_local_path = riscv/local-qemu-riscv64.conf
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 patch_file_path = meta-openembedded_and_meta-webkit.patch
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"


### PR DESCRIPTION
#### e89434de872e7aa88c2d2119df0e30b1b8004d9e
<pre>
[WPE][cross-toolchain-helper] Update target layers references (chromium 124-&gt;126) and enable default plugins for cog
<a href="https://bugs.webkit.org/show_bug.cgi?id=277375">https://bugs.webkit.org/show_bug.cgi?id=277375</a>

Reviewed by Nikolas Zimmermann.

cross-toolchain-helper:
- Updates all the layers for the targets to the last version available
  for the Yocto version Scarthgap
- The Chromium version gets updated to 126.0.6478.126 from 124.0.6367.207
- GTK4 support is now built into the image and there is also libx11 support
  to build cog with all the platform plugins, so use the defaults.

* Tools/yocto/meta-openembedded_and_meta-webkit.patch:
* Tools/yocto/riscv/manifest.xml:
* Tools/yocto/rpi/manifest.xml:
* Tools/yocto/targets.conf:

Canonical link: <a href="https://commits.webkit.org/282040@main">https://commits.webkit.org/282040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/220e727b072276b17d24efc059b4af59400d9a3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64380 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10992 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48932 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7645 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29764 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33786 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9603 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9909 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55672 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9897 "Found 1 new test failure: imported/w3c/web-platform-tests/resource-timing/status-codes-create-entry.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66111 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9718 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56299 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4409 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52346 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56456 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3648 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9316 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35620 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37793 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->