### PR TITLE
Implement `justify-self` on block-level elements

### DIFF
--- a/LayoutTests/fast/repaint/justify-items-legacy-change-expected.txt
+++ b/LayoutTests/fast/repaint/justify-items-legacy-change-expected.txt
@@ -1,11 +1,11 @@
 Tests invalidation on justify-items style change (legacy value). Passes if green bars are centerd inside their red container.
 
 (repaint rects
-  (rect 1 53 50 50)
-  (rect 0 52 52 100)
-  (rect 151 53 50 50)
-  (rect 150 52 52 100)
-  (rect 0 52 251 300)
-  (rect 0 52 300 400)
+  (rect 51 53 50 50)
+  (rect 50 52 52 100)
+  (rect 201 53 50 50)
+  (rect 200 52 52 100)
+  (rect 50 52 251 300)
+  (rect 0 52 301 400)
 )
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/self-alignment/block-justify-self-ltr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/self-alignment/block-justify-self-ltr-expected.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Self-Alignment: justify-self - block-level elements</title>
+<link rel="author" title="David Tran" href="mailto:davidtranhq+wpt@gmail.com">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#justify-block" />
+<meta name="assert" content="justify-self applies to block-level boxes">
+<style>
+.test {
+  width: 200px;
+  border: 2px solid;
+  padding: 0 5px;
+  margin: 0 2px;
+  break-inside: avoid;
+}
+
+.expected {
+  background-color: orange;
+  width: 50px;
+  direction: rtl;
+}
+
+.actual {
+  background-color: cyan;
+  width: 50px;
+  direction: rtl;
+}
+
+.test-suite {
+  columns: 2;
+  width: 570px;
+  height: 570px;
+}
+
+dt {
+  margin-top: 2px;
+  break-after: avoid;
+}
+
+html {
+  font: 10px/1 sans-serif;
+}
+
+.no-break {
+  break-inside: avoid-column;
+}
+
+</style>
+<div class="test-suite">
+  <dl>
+    <div class="no-break">
+      <dt>auto inherits from parent</dt>
+      <dd>
+        <div class="test" style="justify-items: center;">
+          <div class="expected" style="margin: auto">expected</div>
+          <div class="actual" style="margin: auto">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>normal acts as default layout</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretches if auto width and !auto margins</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: auto;">expected</div>
+          <div class="actual" style="width: auto;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretches auto width and !auto margin replaced elements</dt>
+      <dd>
+        <div class="test">
+          <img class="expected" src="../../../images/blue.png" alt="Placeholder Image" style="display: block; width: 200px; height: 10px;" />
+          <img class="actual" src="../../../images/blue.png" alt="Placeholder Image" style="display: block; width: 200px; height: 10px;" />
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch = flex-start if fixed width</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch = flex-start if auto margins</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: auto;">expected</div>
+          <div class="actual" style="width: auto;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch respects max-width</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 150px;">expected</div>
+          <div class="actual" style="width: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch respects min-width</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 230px;">expected</div>
+          <div class="actual" style="width: 230px">actual</div>
+        </div>
+      </dd>
+    </div>
+
+
+    <div class="no-break">
+      <dt>center</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin: auto;">expected</div>
+          <div class="actual" style="margin: auto;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>left</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-right: 150px;">expected</div>
+          <div class="actual" style="margin-right: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>right</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-left: 150px;">expected</div>
+          <div class="actual" style="margin-left: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-left: 150px;">expected</div>
+          <div class="actual" style="margin-left: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>flex-start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>flex-end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-left: 150px;">expected</div>
+          <div class="actual" style="margin-left: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>self-start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-left: 150px;">expected</div>
+          <div class="actual" style="margin-left: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>self-end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>normal (replaced box absolute is start)</dt>
+      <dd>
+        <div class="test" style="position: relative;">
+          <img src="../../../images/blue.png" alt="Placeholder Image" style="position: absolute; width: 50px; height: 10px;">
+          <div>dummy</div>
+          <img src="../../../images/blue.png" alt="Placeholder Image" style="position: absolute; width: 50px; height: 10px;">
+          <div>dummy</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>normal (absolute is stretch)</dt>
+      <dd>
+        <div class="test" style="position: relative;">
+          <div class="expected" style="position: absolute; width: auto; inset: auto 0 auto 0;">expected</div>
+          <div>dummy</div>
+          <div class="actual" style="position: absolute; width: auto; inset: auto 0 auto 0;">actual</div>
+          <div>dummy</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>safe end overflows to start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 225px">expected</div>
+          <div class="actual" style="width: 225px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>unsafe end overflows to end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 225px; margin-left: -25px">expected</div>
+          <div class="actual" style="width: 225px; margin-left: -25px">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>no effect on table cells</dt>
+      <dd>
+        <div class="test" style="display: table">
+          <div style="display: table-row">
+            <div class="expected" style="display: table-cell;">expected</div>
+          </div>
+          <div style="display: table-row">
+            <div class="actual" style="display: table-cell">actual</div>
+          </div>
+        </div>
+      </dd>
+    </div>
+  </dl>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/self-alignment/block-justify-self-ltr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/self-alignment/block-justify-self-ltr.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Self-Alignment: justify-self - block-level elements</title>
+<link rel="author" title="David Tran" href="mailto:davidtranhq+wpt@gmail.com">
+<link rel="match" href="block-justify-self-ltr-ref.html">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#justify-block" />
+<meta name="assert" content="justify-self applies to block-level boxes">
+<style>
+.test {
+  width: 200px;
+  border: 2px solid;
+  padding: 0 5px;
+  margin: 0 2px;
+  break-inside: avoid;
+}
+
+.expected {
+  background-color: orange;
+  width: 50px;
+  direction: rtl;
+}
+
+.actual {
+  background-color: cyan;
+  width: 50px;
+  direction: rtl;
+}
+
+.test-suite {
+  columns: 2;
+  width: 570px;
+  height: 570px;
+}
+
+dt {
+  margin-top: 2px;
+  break-after: avoid;
+}
+
+html {
+  font: 10px/1 sans-serif;
+}
+
+.no-break {
+  break-inside: avoid-column;
+}
+
+</style>
+<div class="test-suite">
+  <dl>
+    <div class="no-break">
+      <dt>auto inherits from parent</dt>
+      <dd>
+        <div class="test" style="justify-items: center;">
+          <div class="expected" style="margin: auto">expected</div>
+          <div class="actual" style="justify-self: auto;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>normal acts as default layout</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual" style="justify-self: normal">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretches if auto width and !auto margins</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: auto;">expected</div>
+          <div class="actual" style="justify-self: stretch; width: auto; margin: 0;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretches auto width and !auto margin replaced elements</dt>
+      <dd>
+        <div class="test">
+          <img class="expected" src="../../../images/blue.png" alt="Placeholder Image" style="display: block; width: 200px; height: 10px;" />
+          <img class="actual" src="../../../images/blue.png" alt="Placeholder Image" style="display: block; justify-self: stretch; height: 10px; width: auto; margin: 0;" />
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch = flex-start if fixed width</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual" style="justify-self: stretch; margin: 0;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch = flex-start if auto margins</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: auto;">expected</div>
+          <div class="actual" style="width: auto; justify-self: stretch;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch respects max-width</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 150px;">expected</div>
+          <div class="actual" style="justify-self: stretch; width:auto; max-width: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch respects min-width</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 230px;">expected</div>
+          <div class="actual" style="justify-self: stretch; width:auto; min-width: 230px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+
+    <div class="no-break">
+      <dt>center</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin: auto;">expected</div>
+          <div class="actual" style="justify-self: center;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>left</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-right: 150px;">expected</div>
+          <div class="actual" style="justify-self: left;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>right</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-left: 150px;">expected</div>
+          <div class="actual" style="justify-self: right;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual" style="justify-self: start;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-left: 150px;">expected</div>
+          <div class="actual" style="justify-self: end;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>flex-start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual" style="justify-self: flex-start;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>flex-end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-left: 150px;">expected</div>
+          <div class="actual" style="justify-self: flex-end;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>self-start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-left: 150px;">expected</div>
+          <div class="actual" style="justify-self: self-start;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>self-end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual" style="justify-self: self-end;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>normal (replaced box absolute is start)</dt>
+      <dd>
+        <div class="test" style="position: relative;">
+          <img src="../../../images/blue.png" alt="Placeholder Image" style="position: absolute; width: 50px; height: 10px;">
+          <div>dummy</div>
+          <img src="../../../images/blue.png" alt="Placeholder Image" style="position: absolute; justify-self: normal; width: 50px; height: 10px;">
+          <div>dummy</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>normal (absolute is stretch)</dt>
+      <dd>
+        <div class="test" style="position: relative;">
+          <div class="expected" style="position: absolute; width: auto; inset: auto 0 auto 0;">expected</div>
+          <div>dummy</div>
+          <div class="actual" style="position: absolute; width: auto; inset: auto 0 auto 0; justify-self: normal">actual</div>
+          <div>dummy</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>safe end overflows to start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 225px">expected</div>
+          <div class="actual" style="justify-self: safe end; width: 225px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>unsafe end overflows to end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 225px; margin-left: -25px">expected</div>
+          <div class="actual" style="width: 225px; justify-self: unsafe end">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>no effect on table cells</dt>
+      <dd>
+        <div class="test" style="display: table">
+          <div style="display: table-row">
+            <div class="expected" style="display: table-cell;">expected</div>
+          </div>
+          <div style="display: table-row">
+            <div class="actual" style="justify-self: center; display: table-cell">actual</div>
+          </div>
+        </div>
+      </dd>
+    </div>
+  </dl>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/self-alignment/block-justify-self-rtl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/self-alignment/block-justify-self-rtl-expected.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Self-Alignment: justify-self - block-level elements</title>
+<link rel="author" title="David Tran" href="mailto:davidtranhq+wpt@gmail.com">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#justify-block" />
+<meta name="assert" content="justify-self applies to block-level boxes">
+<style>
+.test {
+  width: 200px;
+  border: 2px solid;
+  padding: 0 5px;
+  margin: 0 2px;
+  break-inside: avoid;
+  direction: rtl;
+}
+
+.expected {
+  background-color: orange;
+  width: 50px;
+  direction: ltr;
+}
+
+.actual {
+  background-color: cyan;
+  width: 50px;
+  direction: ltr;
+}
+
+.test-suite {
+  columns: 2;
+  width: 570px;
+  height: 570px;
+}
+
+dt {
+  margin-top: 2px;
+  break-after: avoid;
+}
+
+html {
+  font: 10px/1 sans-serif;
+}
+
+.no-break {
+  break-inside: avoid-column;
+}
+
+</style>
+<div class="test-suite">
+  <dl>
+    <div class="no-break">
+      <dt>auto inherits from parent</dt>
+      <dd>
+        <div class="test" style="justify-items: center;">
+          <div class="expected" style="margin: auto">expected</div>
+          <div class="actual" style="margin: auto">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>normal acts as default layout</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretches if auto width and !auto margins</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: auto;">expected</div>
+          <div class="actual" style="width: auto;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretches auto width and !auto margin replaced elements</dt>
+      <dd>
+        <div class="test">
+          <img class="expected" src="../../../images/blue.png" alt="Placeholder Image" style="display: block; width: 200px; height: 10px;" />
+          <img class="actual" src="../../../images/blue.png" alt="Placeholder Image" style="display: block; width: 200px; height: 10px;" />
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch = flex-start if fixed width</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch = flex-start if auto margins</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: auto;">expected</div>
+          <div class="actual" style="width: auto;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch respects max-width</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 150px;">expected</div>
+          <div class="actual" style="width: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch respects min-width</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 230px;">expected</div>
+          <div class="actual" style="width: 230px">actual</div>
+        </div>
+      </dd>
+    </div>
+
+
+    <div class="no-break">
+      <dt>center</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin: auto;">expected</div>
+          <div class="actual" style="margin: auto;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>left</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-right: 150px;">expected</div>
+          <div class="actual" style="margin-right: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>right</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-left: 150px;">expected</div>
+          <div class="actual" style="margin-left: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-right: 150px;">expected</div>
+          <div class="actual" style="margin-right: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>flex-start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>flex-end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-right: 150px;">expected</div>
+          <div class="actual" style="margin-right: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>self-start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-right: 150px;">expected</div>
+          <div class="actual" style="margin-right: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>self-end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>normal (replaced box absolute is start)</dt>
+      <dd>
+        <div class="test" style="position: relative;">
+          <img src="../../../images/blue.png" alt="Placeholder Image" style="position: absolute; width: 50px; height: 10px;">
+          <div>dummy</div>
+          <img src="../../../images/blue.png" alt="Placeholder Image" style="position: absolute; width: 50px; height: 10px;">
+          <div>dummy</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>normal (absolute is stretch)</dt>
+      <dd>
+        <div class="test" style="position: relative;">
+          <div class="expected" style="position: absolute; width: auto; inset: auto 0 auto 0;">expected</div>
+          <div>dummy</div>
+          <div class="actual" style="position: absolute; width: auto; inset: auto 0 auto 0;">actual</div>
+          <div>dummy</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>safe end overflows to start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 225px">expected</div>
+          <div class="actual" style="width: 225px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>unsafe end overflows to end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 225px; margin-right: -25px">expected</div>
+          <div class="actual" style="width: 225px; margin-right: -25px">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>no effect on table cells</dt>
+      <dd>
+        <div class="test" style="display: table">
+          <div style="display: table-row">
+            <div class="expected" style="display: table-cell;">expected</div>
+          </div>
+          <div style="display: table-row">
+            <div class="actual" style="display: table-cell">actual</div>
+          </div>
+        </div>
+      </dd>
+    </div>
+  </dl>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/self-alignment/block-justify-self-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/self-alignment/block-justify-self-rtl.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Self-Alignment: justify-self - block-level elements</title>
+<link rel="author" title="David Tran" href="mailto:davidtranhq+wpt@gmail.com">
+<link rel="match" href="block-justify-self-rtl-ref.html">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#justify-block" />
+<meta name="assert" content="justify-self applies to block-level boxes">
+<style>
+.test {
+  width: 200px;
+  border: 2px solid;
+  padding: 0 5px;
+  margin: 0 2px;
+  break-inside: avoid;
+  direction: rtl;
+}
+
+.expected {
+  background-color: orange;
+  width: 50px;
+  direction: ltr;
+}
+
+.actual {
+  background-color: cyan;
+  width: 50px;
+  direction: ltr;
+}
+
+.test-suite {
+  columns: 2;
+  width: 570px;
+  height: 570px;
+}
+
+dt {
+  margin-top: 2px;
+  break-after: avoid;
+}
+
+html {
+  font: 10px/1 sans-serif;
+}
+
+.no-break {
+  break-inside: avoid-column;
+}
+
+</style>
+<div class="test-suite">
+  <dl>
+    <div class="no-break">
+      <dt>auto inherits from parent</dt>
+      <dd>
+        <div class="test" style="justify-items: center;">
+          <div class="expected" style="margin: auto">expected</div>
+          <div class="actual" style="justify-self: auto;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>normal acts as default layout</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual" style="justify-self: normal">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretches if auto width and !auto margins</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: auto;">expected</div>
+          <div class="actual" style="justify-self: stretch; width: auto; margin: 0;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretches auto width and !auto margin replaced elements</dt>
+      <dd>
+        <div class="test">
+          <img src="../../../images/blue.png" alt="Placeholder Image" style="display: block; width: 200px; height: 10px;" />
+          <img src="../../../images/blue.png" alt="Placeholder Image" style="display: block; justify-self: stretch; height: 10px; width: auto; margin: 0;" />
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch = flex-start if fixed width</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual" style="justify-self: stretch; margin: 0;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch = flex-start if auto margins</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: auto;">expected</div>
+          <div class="actual" style="width: auto; justify-self: stretch;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch respects max-width</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 150px;">expected</div>
+          <div class="actual" style="justify-self: stretch; width:auto; max-width: 150px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>stretch respects min-width</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 230px;">expected</div>
+          <div class="actual" style="justify-self: stretch; width:auto; min-width: 230px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+
+    <div class="no-break">
+      <dt>center</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin: auto;">expected</div>
+          <div class="actual" style="justify-self: center;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>left</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-right: 150px;">expected</div>
+          <div class="actual" style="justify-self: left;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>right</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-left: 150px;">expected</div>
+          <div class="actual" style="justify-self: right;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual" style="justify-self: start;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-right: 150px">expected</div>
+          <div class="actual" style="justify-self: end;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>flex-start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual" style="justify-self: flex-start;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>flex-end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-right: 150px">expected</div>
+          <div class="actual" style="justify-self: flex-end;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>self-start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="margin-right: 150px;">expected</div>
+          <div class="actual" style="justify-self: self-start;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>self-end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected">expected</div>
+          <div class="actual" style="justify-self: self-end;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>normal (replaced box absolute is start)</dt>
+      <dd>
+        <div class="test" style="position: relative;">
+          <img src="../../../images/blue.png" alt="Placeholder Image" style="position: absolute; width: 50px; height: 10px;">
+          <div>dummy</div>
+          <img src="../../../images/blue.png" alt="Placeholder Image" style="position: absolute; justify-self: normal; width: 50px; height: 10px;">
+          <div>dummy</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>normal (absolute is stretch)</dt>
+      <dd>
+        <div class="test" style="position: relative;">
+          <div class="expected" style="position: absolute; width: auto; inset: auto 0 auto 0;">expected</div>
+          <div>dummy</div>
+          <div class="actual" style="position: absolute; width: auto; inset: auto 0 auto 0; justify-self: normal">actual</div>
+          <div>dummy</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>safe end overflows to start</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 225px">expected</div>
+          <div class="actual" style="justify-self: safe end; width: 225px;">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>unsafe end overflows to end</dt>
+      <dd>
+        <div class="test">
+          <div class="expected" style="width: 225px; margin-right: -25px">expected</div>
+          <div class="actual" style="width: 225px; justify-self: unsafe end">actual</div>
+        </div>
+      </dd>
+    </div>
+
+    <div class="no-break">
+      <dt>no effect on table cells</dt>
+      <dd>
+        <div class="test" style="display: table">
+          <div style="display: table-row">
+            <div class="expected" style="display: table-cell;">expected</div>
+          </div>
+          <div style="display: table-row">
+            <div class="actual" style="justify-self: center; display: table-cell">actual</div>
+          </div>
+        </div>
+      </dd>
+    </div>
+  </dl>
+</div>

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -507,6 +507,7 @@ private:
     LayoutUnit getClearDelta(RenderBox& child, LayoutUnit yPos);
 
     void determineLogicalLeftPositionForChild(RenderBox& child, ApplyLayoutDeltaMode = DoNotApplyLayoutDelta);
+    void applyStretchAlignmentToChildIfNeeded(RenderBox& child);
     
     bool hitTestFloats(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset) override;
     bool hitTestInlineChildren(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;

--- a/Source/WebCore/rendering/style/StyleSelfAlignmentData.cpp
+++ b/Source/WebCore/rendering/style/StyleSelfAlignmentData.cpp
@@ -35,4 +35,65 @@ TextStream& operator<<(TextStream& ts, const StyleSelfAlignmentData& o)
     return ts << o.position() << " " << o.positionType() << " " << o.overflow();
 }
 
+bool StyleSelfAlignmentData::isStartward(TextDirection direction, TextDirection parentDirection) const
+{
+    switch (static_cast<ItemPosition>(m_position)) {
+    case ItemPosition::Normal:
+    case ItemPosition::Stretch:
+    case ItemPosition::Baseline:
+    case ItemPosition::Start:
+    case ItemPosition::FlexStart:
+        return true;
+    case ItemPosition::SelfStart:
+        return direction == parentDirection;
+    case ItemPosition::End:
+    case ItemPosition::FlexEnd:
+    case ItemPosition::LastBaseline:
+    case ItemPosition::Center:
+        return false;
+    case ItemPosition::SelfEnd:
+        return direction != parentDirection;
+    case ItemPosition::Left:
+        return parentDirection == TextDirection::LTR;
+    case ItemPosition::Right:
+        return parentDirection == TextDirection::RTL;
+    default:
+        ASSERT("Invalid ItemPosition");
+        return true;
+    };
 }
+
+bool StyleSelfAlignmentData::isEndward(TextDirection direction, TextDirection parentDirection) const
+{
+    switch (static_cast<ItemPosition>(m_position)) {
+    case ItemPosition::Normal:
+    case ItemPosition::Stretch:
+    case ItemPosition::Baseline:
+    case ItemPosition::Start:
+    case ItemPosition::FlexStart:
+    case ItemPosition::Center:
+        return false;
+    case ItemPosition::SelfStart:
+        return direction != parentDirection;
+    case ItemPosition::End:
+    case ItemPosition::FlexEnd:
+    case ItemPosition::LastBaseline:
+        return true;
+    case ItemPosition::SelfEnd:
+        return direction == parentDirection;
+    case ItemPosition::Left:
+        return parentDirection == TextDirection::RTL;
+    case ItemPosition::Right:
+        return parentDirection == TextDirection::LTR;
+    default:
+        ASSERT("Invalid ItemPosition");
+        return false;
+    };
+}
+
+bool StyleSelfAlignmentData::isCentered() const
+{
+    return position() == ItemPosition::Center;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
+++ b/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
@@ -54,6 +54,9 @@ public:
     ItemPosition position() const { return static_cast<ItemPosition>(m_position); }
     ItemPositionType positionType() const { return static_cast<ItemPositionType>(m_positionType); }
     OverflowAlignment overflow() const { return static_cast<OverflowAlignment>(m_overflow); }
+    bool isStartward(TextDirection, TextDirection parentDirection) const;
+    bool isEndward(TextDirection, TextDirection parentDirection) const;
+    bool isCentered() const;
 
     friend bool operator==(const StyleSelfAlignmentData&, const StyleSelfAlignmentData&) = default;
 


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=277022

Reviewed by NOBODY (OOPS!).

Adds handling in `RenderBlockFlow::determineLogicalLeftPositionForChild`
for block-level self alignment. We also need to update the expected
result for the existing `justify-items-legacy-change` LayoutTest since
it did not expect block-level self-alignment.

* LayoutTests/css3/self-alignment/block-justify-self-ltr-expected.html
* LayoutTests/css3/self-alignment/block-justify-self-ltr.html
* LayoutTests/css3/self-alignment/block-justify-self-rtl-expected.html
* LayoutTests/css3/self-alignment/block-justify-self-rtl.html
* LayoutTests/fast/repaint/justify-items-legacy-change-expected.txt:
* Source/WebCore/rendering/RenderBlockFlow.cpp

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fb661e2e2638734169d801a721b08711f198a59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68705 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15288 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15567 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/52013 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10546 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55965 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32635 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37416 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13341 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14161 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/59343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70412 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13167 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/59339 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8661 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56051 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59520 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7127 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/795 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39859 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40936 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->