### PR TITLE
[JSC] non-unified runtime/CachedBytecode.cpp can't compile after 279198@main

### DIFF
--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -543,7 +543,7 @@ private:
     }
 };
 
-constexpr ptrdiff_t CachedPtrOffsets::offsetOffset()
+ptrdiff_t CachedPtrOffsets::offsetOffset()
 {
     return OBJECT_OFFSETOF(CachedPtr<void>, m_offset);
 }
@@ -609,7 +609,7 @@ private:
     CachedPtr<T, Source> m_ptr;
 };
 
-constexpr ptrdiff_t CachedWriteBarrierOffsets::ptrOffset()
+ptrdiff_t CachedWriteBarrierOffsets::ptrOffset()
 {
     return OBJECT_OFFSETOF(CachedWriteBarrier<void>, m_ptr);
 }
@@ -1929,17 +1929,17 @@ private:
     CachedWriteBarrier<CachedFunctionCodeBlock, UnlinkedFunctionCodeBlock> m_unlinkedCodeBlockForConstruct;
 };
 
-constexpr ptrdiff_t CachedFunctionExecutableOffsets::codeBlockForCallOffset()
+ptrdiff_t CachedFunctionExecutableOffsets::codeBlockForCallOffset()
 {
     return OBJECT_OFFSETOF(CachedFunctionExecutable, m_unlinkedCodeBlockForCall);
 }
 
-constexpr ptrdiff_t CachedFunctionExecutableOffsets::codeBlockForConstructOffset()
+ptrdiff_t CachedFunctionExecutableOffsets::codeBlockForConstructOffset()
 {
     return OBJECT_OFFSETOF(CachedFunctionExecutable, m_unlinkedCodeBlockForConstruct);
 }
 
-constexpr ptrdiff_t CachedFunctionExecutableOffsets::metadataOffset()
+ptrdiff_t CachedFunctionExecutableOffsets::metadataOffset()
 {
     return OBJECT_OFFSETOF(CachedFunctionExecutable, m_mutableMetadata);
 }

--- a/Source/JavaScriptCore/runtime/CachedTypes.h
+++ b/Source/JavaScriptCore/runtime/CachedTypes.h
@@ -52,17 +52,17 @@ struct CachedFunctionExecutableMetadata {
 };
 
 struct CachedFunctionExecutableOffsets {
-    static constexpr ptrdiff_t codeBlockForCallOffset();
-    static constexpr ptrdiff_t codeBlockForConstructOffset();
-    static constexpr ptrdiff_t metadataOffset();
+    static ptrdiff_t codeBlockForCallOffset();
+    static ptrdiff_t codeBlockForConstructOffset();
+    static ptrdiff_t metadataOffset();
 };
 
 struct CachedWriteBarrierOffsets {
-    static constexpr ptrdiff_t ptrOffset();
+    static ptrdiff_t ptrOffset();
 };
 
 struct CachedPtrOffsets {
-    static constexpr ptrdiff_t offsetOffset();
+    static ptrdiff_t offsetOffset();
 };
 
 class VariableLengthObjectBase {


### PR DESCRIPTION
#### c773df72044f08bd567d94ecbd59a3b8f0f92a52
<pre>
[JSC] non-unified runtime/CachedBytecode.cpp can&apos;t compile after 279198@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=277376">https://bugs.webkit.org/show_bug.cgi?id=277376</a>

Reviewed by Keith Miller.

After <a href="https://commits.webkit.org/279198@main">https://commits.webkit.org/279198@main</a> changed some functions in
CachedTypes.h to be constexpr, non-unified CachedBytecode.cpp couldn&apos;t
compile because the inline function definitions are still only in
CachedTypes.cpp.

It&apos;s not easy to move the inline function definitions to CachedTypes.h
due to the dependencies. Reverted the CachedTypes.{cpp,h} parts of
279198@main. Removed constexpr of the functions.

* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedPtrOffsets::offsetOffset):
(JSC::CachedWriteBarrierOffsets::ptrOffset):
(JSC::CachedFunctionExecutableOffsets::codeBlockForCallOffset):
(JSC::CachedFunctionExecutableOffsets::codeBlockForConstructOffset):
(JSC::CachedFunctionExecutableOffsets::metadataOffset):
* Source/JavaScriptCore/runtime/CachedTypes.h:

Canonical link: <a href="https://commits.webkit.org/281670@main">https://commits.webkit.org/281670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2cc37e59f356b0b75a021faebad4b7677ef428a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64392 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11006 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48946 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7653 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29770 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9616 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9921 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/53572 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66123 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59714 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56302 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56476 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3661 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81471 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9112 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35632 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14150 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36714 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37805 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36459 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->