### PR TITLE
[masonry] Fix intrinsic sizing with fixed-size and auto

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-007-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-007-expected.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+  <meta charset="utf-8">
+  <title>CSS Grid Test: Masonry layout column sizing - intrinsic</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <style>
+
+@import "support/masonry-intrinsic-sizing-visual.css";
+
+grid {
+  display: inline-grid;
+  gap: 1px 2px;
+  border: 1px solid;
+  padding: 0 1px 0 2px;
+  vertical-align: top;
+}
+
+.mix grid {
+  grid-template-columns: 1ch auto;
+}
+
+.mix2 grid {
+  grid-template-columns: 1ch auto 1ch;
+}
+</style>
+
+<body>
+
+<section class="mix">
+<grid title="Auto Last Track">
+  <item style="width:5ch; grid-column: span 2;">1</item>
+</grid>
+</section>
+
+<section class="mix2">
+<grid title="Auto Middle Track">
+    <item style="width:5ch; grid-column: span 3;">1</item>
+</grid>
+</section>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-007-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-007-ref.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+  <meta charset="utf-8">
+  <title>CSS Grid Test: Masonry layout column sizing - intrinsic</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <style>
+
+@import "support/masonry-intrinsic-sizing-visual.css";
+
+grid {
+  display: inline-grid;
+  gap: 1px 2px;
+  border: 1px solid;
+  padding: 0 1px 0 2px;
+  vertical-align: top;
+}
+
+.mix grid {
+  grid-template-columns: 1ch auto;
+}
+
+.mix2 grid {
+  grid-template-columns: 1ch auto 1ch;
+}
+</style>
+
+<body>
+
+<section class="mix">
+<grid title="Auto Last Track">
+  <item style="width:5ch; grid-column: span 2;">1</item>
+</grid>
+</section>
+
+<section class="mix2">
+<grid title="Auto Middle Track">
+    <item style="width:5ch; grid-column: span 3;">1</item>
+</grid>
+</section>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-007.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+  <meta charset="utf-8">
+  <title>CSS Grid Test: Masonry layout column sizing - intrinsic</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#track-sizing">
+  <link rel="match" href="masonry-intrinsic-sizing-cols-007-ref.html">
+  <style>
+
+@import "support/masonry-intrinsic-sizing-visual.css";
+
+grid {
+  display: inline-grid;
+  gap: 1px 2px;
+  grid-template-rows: masonry;
+  border: 1px solid;
+  padding: 0 1px 0 2px;
+  vertical-align: top;
+}
+
+.mix grid {
+  grid-template-columns: 1ch auto;
+}
+
+.mix2 grid {
+  grid-template-columns: 1ch auto 1ch;
+}
+</style>
+
+<body>
+
+<section class="mix">
+<grid title="Auto Last Track">
+  <item style="width:5ch; grid-column: span 2;">1</item>
+</grid>
+</section>
+
+<section class="mix2">
+<grid title="Auto Middle Track">
+    <item style="width:5ch; grid-column: span 3;">1</item>
+</grid>
+</section>

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1437,7 +1437,7 @@ bool GridTrackSizingAlgorithm::shouldExcludeGridItemForMasonryTrackSizing(const 
         shouldExcludeGridItemForMasonryTrackSizing = false;
 
     // If the item is going past the end of track do not consider it for inclusion.
-    if (itemSpan.integerSpan() + trackIndex > tracks(m_direction).size())
+    if (itemSpan.integerSpan() + itemSpan.startLine() > tracks(m_direction).size())
         shouldExcludeGridItemForMasonryTrackSizing = true;
 
     return shouldExcludeGridItemForMasonryTrackSizing;
@@ -1495,7 +1495,14 @@ void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrackMasonry(GridTrack
         isNewEntry = true;
 
         // Correct the span as the grid item is coming from another track.
-        span = GridSpan::translatedDefiniteGridSpan(trackIndex, trackIndex + span.integerSpan());
+        auto shift = 0u;
+        auto gridItemEndIndex = span.integerSpan() + trackIndex;
+        if (span.integerSpan() > 1 && (gridItemEndIndex > tracks(m_direction).size())) {
+            shift = gridItemEndIndex - tracks(m_direction).size();
+            shift = (shift > trackIndex) ? 0 : shift;
+        }
+
+        span = GridSpan::translatedDefiniteGridSpan(trackIndex - shift, trackIndex + span.integerSpan() - shift);
 
         if (shouldExcludeGridItemForMasonryTrackSizing(*gridItem, trackIndex, span))
             return;


### PR DESCRIPTION
#### a829f44a065e3bab573c8356f6e64e0f75895f37
<pre>
[masonry] Fix intrinsic sizing with fixed-size and auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=277382">https://bugs.webkit.org/show_bug.cgi?id=277382</a>
<a href="https://rdar.apple.com/problem/132849745">rdar://problem/132849745</a>

Reviewed by Sammy Gill.

We were not calculating auto sizes when there is a span and it
went outside of the track sizing range. This is due to masonry
trying to place all the indefinite items in each track, and since the span would
be outside the track range it would be skipped.

The solution is to try to shift the item&apos;s start and end to fit within the track.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-007-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-007-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/intrinsic-sizing/masonry-intrinsic-sizing-cols-007.html: Added.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::shouldExcludeGridItemForMasonryTrackSizing const):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:

Canonical link: <a href="https://commits.webkit.org/281677@main">https://commits.webkit.org/281677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eeb23ea3ce47aac0761202e48806abc9285f25c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49022 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7745 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29850 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33913 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9740 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10060 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55777 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66260 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4544 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56390 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56563 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13508 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3770 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35764 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36846 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36591 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->