### PR TITLE
[WPE] MiniBrowser script doesn't proxy Sysprof env vars

### DIFF
--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -154,6 +154,21 @@ class GLibPort(Port):
         env['LD_LIBRARY_PATH'] = self._prepend_to_env_value(self._build_path('lib'), env.get('LD_LIBRARY_PATH', ''))
         return env
 
+    def setup_sysprof_for_minibrowser(self):
+        pass_fds = ()
+        env = self.setup_environ_for_minibrowser()
+
+        if os.environ.get("SYSPROF_CONTROL_FD"):
+            try:
+                control_fd = int(os.environ.get("SYSPROF_CONTROL_FD"))
+                copy_fd = os.dup(control_fd)
+                pass_fds += (copy_fd, )
+                env["SYSPROF_CONTROL_FD"] = str(copy_fd)
+            except (ValueError):
+                pass
+
+        return env, pass_fds
+
     def _get_crash_log(self, name, pid, stdout, stderr, newer_than, target_host=None):
         return GDBCrashLogGenerator(self._executive, name, pid, newer_than,
                                     self._filesystem, self._path_to_driver, self.port_name, self.get_option('configuration')).generate_crash_log(stdout, stderr)

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -181,17 +181,7 @@ class GtkPort(GLibPort):
         if os.environ.get("WEBKIT_MINI_BROWSER_PREFIX"):
             command = shlex.split(os.environ["WEBKIT_MINI_BROWSER_PREFIX"]) + command
 
-        env = self.setup_environ_for_minibrowser()
-        pass_fds = ()
-        if os.environ.get("SYSPROF_CONTROL_FD"):
-            try:
-                control_fd = int(os.environ.get("SYSPROF_CONTROL_FD"))
-                copy_fd = os.dup(control_fd)
-                pass_fds += (copy_fd, )
-                env["SYSPROF_CONTROL_FD"] = str(copy_fd)
-
-            except (ValueError):
-                pass
+        env, pass_fds = self.setup_sysprof_for_minibrowser()
 
         if self._should_use_jhbuild():
             command = self._jhbuild_wrapper + command

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -131,7 +131,6 @@ class WPEPort(GLibPort):
         return env
 
     def run_minibrowser(self, args):
-        env = None
         miniBrowser = None
 
         if self.browser_name() == "cog":
@@ -155,6 +154,8 @@ class WPEPort(GLibPort):
         if os.environ.get("WEBKIT_MINI_BROWSER_PREFIX"):
             command = shlex.split(os.environ["WEBKIT_MINI_BROWSER_PREFIX"]) + command
 
+        env, pass_fds = self.setup_sysprof_for_minibrowser()
+
         if self._should_use_jhbuild():
             command = self._jhbuild_wrapper + command
-        return self._executive.run_command(command + args, cwd=self.webkit_base(), stdout=None, return_stderr=False, decode_output=False, env=self.setup_environ_for_minibrowser())
+        return self._executive.run_command(command + args, cwd=self.webkit_base(), stdout=None, return_stderr=False, decode_output=False, env=env, pass_fds=pass_fds)


### PR DESCRIPTION
#### 99e474353240cd26d2cd17951bdb2108bb98c04c
<pre>
[WPE] MiniBrowser script doesn&apos;t proxy Sysprof env vars
<a href="https://bugs.webkit.org/show_bug.cgi?id=277363">https://bugs.webkit.org/show_bug.cgi?id=277363</a>

Reviewed by Nikolas Zimmermann.

The MiniBrowser Python script proxies Sysprof env vars in the
GTK case, but a similar code in WPE is missing.

Move this code to the generic path (GLib) and use it in both
the GTK and WPE.

* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort.setup_sysprof_for_minibrowser):
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort.run_minibrowser):
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort.run_minibrowser):

Canonical link: <a href="https://commits.webkit.org/281652@main">https://commits.webkit.org/281652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7634bfef28388807fc46ccb469525460d7869b78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64402 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11016 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62609 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47511 "Hash 7634bfef for PR 31506 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48936 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7656 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62510 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/47511 "Hash 7634bfef for PR 31506 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29805 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/60004 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/47511 "Hash 7634bfef for PR 31506 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9625 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9931 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/47511 "Hash 7634bfef for PR 31506 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66133 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56304 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56466 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13483 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3664 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35642 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36724 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->