### PR TITLE
Replace a series of EnabledIf by EnabledBy in PlatformXRSystem.messages.in

### DIFF
--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -50,6 +50,11 @@ PlatformXRSystem::~PlatformXRSystem()
     m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::PlatformXRSystem::messageReceiverName(), m_page.webPageIDInMainFrameProcess());
 }
 
+const SharedPreferencesForWebProcess& PlatformXRSystem::sharedPreferencesForWebProcess() const
+{
+    return *m_page.legacyMainFrameProcess().sharedPreferencesForWebProcess();
+}
+
 void PlatformXRSystem::invalidate()
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -52,6 +52,7 @@ namespace WebKit {
 class PlatformXRCoordinator;
 class WebPageProxy;
 
+struct SharedPreferencesForWebProcess;
 struct XRDeviceInfo;
 
 class PlatformXRSystem : public IPC::MessageReceiver, public PlatformXRCoordinatorSessionEventClient {
@@ -59,6 +60,8 @@ class PlatformXRSystem : public IPC::MessageReceiver, public PlatformXRCoordinat
 public:
     PlatformXRSystem(WebPageProxy&);
     virtual ~PlatformXRSystem();
+
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcess() const;
 
     using PlatformXRCoordinatorSessionEventClient::weakPtrFactory;
     using PlatformXRCoordinatorSessionEventClient::WeakValueType;

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
@@ -25,14 +25,15 @@
  
 #if ENABLE(WEBXR)
 
+[EnabledBy=WebXREnabled]
 messages -> PlatformXRSystem NotRefCounted {
-    [EnabledIf='webXREnabled()'] EnumerateImmersiveXRDevices() -> (Vector<WebKit::XRDeviceInfo> devicesInfos)
-    [EnabledIf='webXREnabled()'] RequestPermissionOnSessionFeatures(WebCore::SecurityOriginData origin, PlatformXR::SessionMode mode, Vector<PlatformXR::SessionFeature> granted, Vector<PlatformXR::SessionFeature> consentRequired, Vector<PlatformXR::SessionFeature> consentOptional, Vector<PlatformXR::SessionFeature> requiredFeaturesRequested, Vector<PlatformXR::SessionFeature> optionalFeaturesRequested) -> (std::optional<Vector<PlatformXR::SessionFeature>> userGranted)
-    [EnabledIf='webXREnabled()'] InitializeTrackingAndRendering()
-    [EnabledIf='webXREnabled()'] ShutDownTrackingAndRendering()
-    [EnabledIf='webXREnabled()'] RequestFrame() -> (struct PlatformXR::FrameData frameData)
-    [EnabledIf='webXREnabled()'] SubmitFrame()
-    [EnabledIf='webXREnabled()'] DidCompleteShutdownTriggeredBySystem()
+    EnumerateImmersiveXRDevices() -> (Vector<WebKit::XRDeviceInfo> devicesInfos)
+    RequestPermissionOnSessionFeatures(WebCore::SecurityOriginData origin, PlatformXR::SessionMode mode, Vector<PlatformXR::SessionFeature> granted, Vector<PlatformXR::SessionFeature> consentRequired, Vector<PlatformXR::SessionFeature> consentOptional, Vector<PlatformXR::SessionFeature> requiredFeaturesRequested, Vector<PlatformXR::SessionFeature> optionalFeaturesRequested) -> (std::optional<Vector<PlatformXR::SessionFeature>> userGranted)
+    InitializeTrackingAndRendering()
+    ShutDownTrackingAndRendering()
+    RequestFrame() -> (struct PlatformXR::FrameData frameData)
+    SubmitFrame()
+    DidCompleteShutdownTriggeredBySystem()
 }
 
 #endif


### PR DESCRIPTION
#### 0265072d25519bbafe453dda39d945bb16901ba5
<pre>
Replace a series of EnabledIf by EnabledBy in PlatformXRSystem.messages.in
<a href="https://bugs.webkit.org/show_bug.cgi?id=277386">https://bugs.webkit.org/show_bug.cgi?id=277386</a>

Reviewed by Chris Dumez.

Cleanup.

* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::sharedPreferencesForWebProcess const):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in:

Canonical link: <a href="https://commits.webkit.org/281628@main">https://commits.webkit.org/281628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8aa18865854b12e0166b308b78928b4a399bda7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64414 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11028 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11259 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/48951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7672 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37116 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/52408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33812 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9943 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66145 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4429 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56482 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3675 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9093 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->