### PR TITLE
Use the WebKit subsystem in the OS Log instead of OS_LOG_DEFAULT

### DIFF
--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -124,10 +124,22 @@ void disableForwardingVPrintfStdErrToOSLog()
 
 extern "C" {
 
+#if PLATFORM(COCOA)
+static os_log_t webkitSubsystemForGenericOSLog()
+{
+    static dispatch_once_t once;
+    static os_log_t subsystem;
+    dispatch_once(&once, ^{
+        subsystem = os_log_create(LOG_CHANNEL_WEBKIT_SUBSYSTEM, "Generic");
+    });
+    return subsystem;
+}
+#endif
+
 static void logToStderr(const char* buffer)
 {
 #if PLATFORM(COCOA)
-    os_log(OS_LOG_DEFAULT, "%s", buffer);
+    os_log(webkitSubsystemForGenericOSLog(), "%s", buffer);
 #endif
     fputs(buffer, stderr);
 }
@@ -156,7 +168,7 @@ ALLOW_NONLITERAL_FORMAT_END
     if (!g_wtfConfig.disableForwardingVPrintfStdErrToOSLog) {
         va_list copyOfArgs;
         va_copy(copyOfArgs, args);
-        os_log_with_args(OS_LOG_DEFAULT, OS_LOG_TYPE_DEFAULT, format, copyOfArgs, __builtin_return_address(0));
+        os_log_with_args(webkitSubsystemForGenericOSLog(), OS_LOG_TYPE_DEFAULT, format, copyOfArgs, __builtin_return_address(0));
         va_end(copyOfArgs);
     }
 #endif


### PR DESCRIPTION
#### 9d1be6133e8fdc88f2ef40ef51a9def368f726da
<pre>
Use the WebKit subsystem in the OS Log instead of OS_LOG_DEFAULT
<a href="https://bugs.webkit.org/show_bug.cgi?id=277388">https://bugs.webkit.org/show_bug.cgi?id=277388</a>
<a href="https://rdar.apple.com/132856259">rdar://132856259</a>

Reviewed by Ben Nham.

Logging functions which output to both the OS Log (on Apple platforms)
and stderr use the Default logging subsystem. This logging would then be
missed by a simple log predicate which is using the com.apple.WebKit
subsystem. This change will cause functions such as WTFLogAlways or
WTFReportAssertionFailure use the com.apple.WebKit:Generic
subsystem:category pair as a logging ergonomics improvement.

* Source/WTF/wtf/Assertions.cpp:

Canonical link: <a href="https://commits.webkit.org/281650@main">https://commits.webkit.org/281650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4e88451ca7bb2043cf70aa5da6ead49510cc259

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64457 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11073 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48968 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7698 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29800 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33845 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9663 "Found 1 new test failure: imported/w3c/web-platform-tests/shadow-dom/focus/focus-shadowhost-display-none.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9986 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/53628 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66187 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59777 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56334 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56505 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13482 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3706 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81532 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35693 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14164 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37866 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->