### PR TITLE
[CSS] StyleColor should be 8 bytes.

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2658,6 +2658,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/backgrounds/StyleBorderRadius.h
 
+    style/values/color/ExtendedStyleColor.h
     style/values/color/StyleColor.h
     style/values/color/StyleColorOptions.h
     style/values/color/StyleCurrentColor.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3137,6 +3137,7 @@ style/UserAgentStyle.cpp
 style/values/backgrounds/StyleBorderRadius.cpp
 style/values/backgrounds/StyleBoxShadow.cpp
 style/values/color-adjust/StyleColorScheme.cpp
+style/values/color/ExtendedStyleColor.cpp
 style/values/color/StyleColor.cpp
 style/values/color/StyleColorLayers.cpp
 style/values/color/StyleColorMix.cpp

--- a/Source/WebCore/platform/graphics/Color.cpp
+++ b/Source/WebCore/platform/graphics/Color.cpp
@@ -28,7 +28,6 @@
 
 #include "ColorLuminance.h"
 #include "ColorSerialization.h"
-#include <cmath>
 #include <wtf/Assertions.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
@@ -43,12 +42,28 @@ static constexpr auto darkenedWhite = SRGBA<uint8_t> { 171, 171, 171 };
 Color::Color(const Color& other)
     : m_colorAndFlags(other.m_colorAndFlags)
 {
-    if (isOutOfLine())
+    ASSERT(!other.isExtendedStyleColor());
+
+    if (UNLIKELY(isOutOfLine()))
         asOutOfLine().ref();
+
+}
+
+Style::ExtendedStyleColor& Color::decodedOutOfLineExtendedStyleColor(uint64_t value)
+{
+    return *static_cast<Style::ExtendedStyleColor*>(decodedOutOfLinePointer(value));
+}
+
+const Style::ExtendedStyleColor& Color::asExtendedStyleColor() const
+{
+    ASSERT(isExtendedStyleColor());
+    return decodedOutOfLineExtendedStyleColor(m_colorAndFlags);
 }
 
 Color::Color(Color&& other)
 {
+    ASSERT(!other.isExtendedStyleColor());
+
     *this = WTFMove(other);
 }
 
@@ -104,6 +119,9 @@ std::optional<ColorDataForIPC> Color::data() const
 
 Color& Color::operator=(const Color& other)
 {
+    ASSERT(!isExtendedStyleColor());
+    ASSERT(!other.isExtendedStyleColor());
+
     if (*this == other)
         return *this;
 
@@ -120,6 +138,9 @@ Color& Color::operator=(const Color& other)
 
 Color& Color::operator=(Color&& other)
 {
+    ASSERT(!isExtendedStyleColor());
+    ASSERT(!other.isExtendedStyleColor());
+
     if (*this == other)
         return *this;
 
@@ -129,6 +150,7 @@ Color& Color::operator=(Color&& other)
     m_colorAndFlags = other.m_colorAndFlags;
     other.m_colorAndFlags = invalidColorAndFlags;
 
+    // Moving the object doesn't change the ref count.
     return *this;
 }
 

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -55,6 +55,10 @@ typedef struct _GdkRGBA GdkRGBA;
 
 namespace WebCore {
 
+namespace Style {
+class ExtendedStyleColor;
+}
+
 struct OutOfLineColorDataForIPC {
     ColorSpace colorSpace;
     float c1;
@@ -105,7 +109,7 @@ public:
     WEBCORE_EXPORT Color& operator=(const Color&);
     WEBCORE_EXPORT Color& operator=(Color&&);
 
-    ~Color();
+    WEBCORE_EXPORT ~Color();
 
     bool isValid() const;
     bool isSemantic() const;
@@ -246,24 +250,32 @@ private:
         Semantic                        = static_cast<uint8_t>(Flags::Semantic),
         UseColorFunctionSerialization   = static_cast<uint8_t>(Flags::UseColorFunctionSerialization),
         Valid                           = 1 << 2,
-        OutOfLine                       = 1 << 3,
-        HashTableEmptyValue             = 1 << 4,
-        HashTableDeletedValue           = 1 << 5,
+        CurrentColor                    = 1 << 3, // This only has meaning for CSS.
+        ExtendedStyleColor              = 1 << 4, // This only has meaning for CSS.
+        OutOfLine                       = 1 << 5,
+        HashTableEmptyValue             = 1 << 6,
+        HashTableDeletedValue           = 1 << 7,
     };
     static OptionSet<FlagsIncludingPrivate> toFlagsIncludingPrivate(OptionSet<Flags> flags) { return OptionSet<FlagsIncludingPrivate>::fromRaw(flags.toRaw()); }
-
+public:
     OptionSet<FlagsIncludingPrivate> flags() const;
+    bool isCurrentColor() const;
     bool isOutOfLine() const;
+    bool isExtendedStyleColor() const;
     bool isInline() const;
 
+    void setCurrentColor();
     void setColor(SRGBA<uint8_t>, OptionSet<FlagsIncludingPrivate> = { });
     void setOutOfLineComponents(Ref<OutOfLineComponents>&&, ColorSpace, OptionSet<FlagsIncludingPrivate> = { });
+    void setExtendedStyleColor(Ref<Style::ExtendedStyleColor>&&);
 
     SRGBA<uint8_t> asInline() const;
     PackedColor::RGBA asPackedInline() const;
 
     const OutOfLineComponents& asOutOfLine() const;
     Ref<OutOfLineComponents> asOutOfLineRef() const;
+
+    WEBCORE_EXPORT const Style::ExtendedStyleColor& asExtendedStyleColor() const;
 
 #if CPU(ADDRESS64)
     static constexpr unsigned maxNumberOfBitsInPointer = 48;
@@ -282,12 +294,16 @@ private:
     static uint64_t encodedInlineColor(SRGBA<uint8_t>);
     static uint64_t encodedPackedInlineColor(PackedColor::RGBA);
     static uint64_t encodedOutOfLineComponents(Ref<OutOfLineComponents>&&);
+    static uint64_t encodedOutOfLineExtendedStyleColor(Ref<Style::ExtendedStyleColor>&&);
+    static uint64_t encodedOutOfLinePointer(void*);
 
     static OptionSet<FlagsIncludingPrivate> decodedFlags(uint64_t);
     static ColorSpace decodedColorSpace(uint64_t);
     static SRGBA<uint8_t> decodedInlineColor(uint64_t);
     static PackedColor::RGBA decodedPackedInlineColor(uint64_t);
     static OutOfLineComponents& decodedOutOfLineComponents(uint64_t);
+    static Style::ExtendedStyleColor& decodedOutOfLineExtendedStyleColor(uint64_t);
+    static void* decodedOutOfLinePointer(uint64_t);
 
     static constexpr uint64_t invalidColorAndFlags = 0;
     uint64_t m_colorAndFlags { invalidColorAndFlags };
@@ -297,6 +313,8 @@ inline void add(Hasher& hasher, const Color& color)
 {
     if (color.isOutOfLine())
         add(hasher, color.asOutOfLine().unresolvedComponents(), color.colorSpace(), color.flags());
+    else if (color.isExtendedStyleColor())
+        add(hasher, &color.asExtendedStyleColor(), color.flags());
     else
         add(hasher, color.asPackedInline().value, color.flags());
 }
@@ -317,8 +335,10 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Color&);
 
 inline bool operator==(const Color& a, const Color& b)
 {
-    if (a.isOutOfLine() || b.isOutOfLine())
+    if (UNLIKELY(a.isOutOfLine() || b.isOutOfLine()))
         return outOfLineComponentsEqual(a, b);
+    if (UNLIKELY(a.isExtendedStyleColor() || b.isExtendedStyleColor()))
+        ASSERT_NOT_REACHED();
     return a.m_colorAndFlags == b.m_colorAndFlags;
 }
 
@@ -404,8 +424,10 @@ inline bool Color::isHashTableEmptyValue() const
 
 inline Color::~Color()
 {
-    if (isOutOfLine())
+    if (UNLIKELY(isOutOfLine()))
         asOutOfLine().deref();
+    else if (UNLIKELY(isExtendedStyleColor()))
+        ASSERT_NOT_REACHED();
 }
 
 inline bool Color::isValid() const
@@ -416,6 +438,16 @@ inline bool Color::isValid() const
 inline bool Color::isSemantic() const
 {
     return flags().contains(FlagsIncludingPrivate::Semantic);
+}
+
+inline bool Color::isCurrentColor() const
+{
+    return flags().contains(FlagsIncludingPrivate::CurrentColor);
+}
+
+inline void Color::setCurrentColor()
+{
+    m_colorAndFlags = encodedFlags({ FlagsIncludingPrivate::Valid, FlagsIncludingPrivate::CurrentColor });
 }
 
 inline bool Color::usesColorFunctionSerialization() const
@@ -477,6 +509,11 @@ inline OptionSet<Color::FlagsIncludingPrivate> Color::flags() const
 inline bool Color::isOutOfLine() const
 {
     return flags().contains(FlagsIncludingPrivate::OutOfLine);
+}
+
+inline bool Color::isExtendedStyleColor() const
+{
+    return flags().contains(FlagsIncludingPrivate::ExtendedStyleColor);
 }
 
 inline bool Color::isInline() const
@@ -542,13 +579,23 @@ inline uint64_t Color::encodedPackedInlineColor(PackedColor::RGBA color)
     return color.value;
 }
 
-inline uint64_t Color::encodedOutOfLineComponents(Ref<OutOfLineComponents>&& outOfLineComponents)
+inline uint64_t Color::encodedOutOfLinePointer(void* pointer)
 {
 #if CPU(ADDRESS64)
-    return std::bit_cast<uint64_t>(&outOfLineComponents.leakRef());
+    return std::bit_cast<uint64_t>(pointer);
 #else
-    return std::bit_cast<uint32_t>(&outOfLineComponents.leakRef());
+    return std::bit_cast<uint32_t>(pointer);
 #endif
+}
+
+inline uint64_t Color::encodedOutOfLineComponents(Ref<OutOfLineComponents>&& outOfLineComponents)
+{
+    return encodedOutOfLinePointer(&outOfLineComponents.leakRef());
+}
+
+inline uint64_t Color::encodedOutOfLineExtendedStyleColor(Ref<Style::ExtendedStyleColor>&& styleColor)
+{
+    return encodedOutOfLinePointer(&styleColor.leakRef());
 }
 
 inline OptionSet<Color::FlagsIncludingPrivate> Color::decodedFlags(uint64_t value)
@@ -571,13 +618,18 @@ inline PackedColor::RGBA Color::decodedPackedInlineColor(uint64_t value)
     return PackedColor::RGBA { static_cast<uint32_t>(value & colorValueMask) };
 }
 
-inline Color::OutOfLineComponents& Color::decodedOutOfLineComponents(uint64_t value)
+inline void* Color::decodedOutOfLinePointer(uint64_t value)
 {
 #if CPU(ADDRESS64)
-    return *std::bit_cast<OutOfLineComponents*>(value & colorValueMask);
+    return std::bit_cast<void*>(value & colorValueMask);
 #else
-    return *std::bit_cast<OutOfLineComponents*>(static_cast<uint32_t>(value & colorValueMask));
+    return std::bit_cast<void*>(static_cast<uint32_t>(value & colorValueMask));
 #endif
+}
+
+inline Color::OutOfLineComponents& Color::decodedOutOfLineComponents(uint64_t value)
+{
+    return *static_cast<OutOfLineComponents*>(decodedOutOfLinePointer(value));
 }
 
 inline void Color::setColor(SRGBA<uint8_t> color, OptionSet<FlagsIncludingPrivate> flags)
@@ -592,6 +644,14 @@ inline void Color::setOutOfLineComponents(Ref<OutOfLineComponents>&& color, Colo
     flags.add({ FlagsIncludingPrivate::Valid, FlagsIncludingPrivate::OutOfLine });
     m_colorAndFlags = encodedOutOfLineComponents(WTFMove(color)) | encodedColorSpace(colorSpace) | encodedFlags(flags);
     ASSERT(isOutOfLine());
+}
+
+inline void Color::setExtendedStyleColor(Ref<Style::ExtendedStyleColor>&& color)
+{
+    OptionSet<FlagsIncludingPrivate> flags;
+    flags.add({ FlagsIncludingPrivate::Valid, FlagsIncludingPrivate::ExtendedStyleColor });
+    m_colorAndFlags = encodedOutOfLineExtendedStyleColor(WTFMove(color)) | encodedFlags(flags);
+    ASSERT(isExtendedStyleColor());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/style/values/color/ExtendedStyleColor.cpp
+++ b/Source/WebCore/style/values/color/ExtendedStyleColor.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ExtendedStyleColor.h"
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+namespace Style {
+
+ExtendedStyleColor::ExtendedStyleColor(ExtendedColorKind&& color)
+    : m_color { WTFMove(color) }
+{
+}
+
+WebCore::Color ExtendedStyleColor::resolveColor(const WebCore::Color& currentColor) const
+{
+    return WTF::switchOn(m_color,
+        [&](const auto& kind) {
+            return Style::resolveColor(kind, currentColor);
+        }
+    );
+}
+
+bool ExtendedStyleColor::containsCurrentColor() const
+{
+    return WTF::switchOn(m_color,
+        [&](const auto& kind) {
+            return Style::containsCurrentColor(kind);
+        }
+    );
+}
+
+String serializationForCSS(const ExtendedStyleColor& color)
+{
+    return WTF::switchOn(color.m_color,
+        [](const auto& kind) {
+            return serializationForCSS(kind);
+        }
+    );
+}
+
+void serializationForCSS(StringBuilder& builder, const ExtendedStyleColor& color)
+{
+    return WTF::switchOn(color.m_color,
+        [&](const auto& kind) {
+            serializationForCSS(builder, kind);
+        }
+    );
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& out, const ExtendedStyleColor& color)
+{
+    out << "ExtendedStyleColor[";
+    WTF::switchOn(color.m_color,
+        [&](const auto& kind) {
+            out << kind;
+        }
+    );
+    out << "]";
+    return out;
+}
+
+} // namespace Style
+
+} // namespace WebCore

--- a/Source/WebCore/style/values/color/ExtendedStyleColor.h
+++ b/Source/WebCore/style/values/color/ExtendedStyleColor.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSColorDescriptors.h"
+#include "StyleColorLayers.h"
+#include "StyleColorMix.h"
+#include "StyleContrastColor.h"
+#include "StyleRelativeColor.h"
+
+namespace WebCore {
+
+namespace Style {
+
+using ExtendedColorKind = std::variant<
+    ColorMix,
+    ColorLayers,
+    ContrastColor,
+    RelativeColor<RGBFunctionModernRelative>,
+    RelativeColor<HSLFunctionModern>,
+    RelativeColor<HWBFunction>,
+    RelativeColor<LabFunction>,
+    RelativeColor<LCHFunction>,
+    RelativeColor<OKLabFunction>,
+    RelativeColor<OKLCHFunction>,
+    RelativeColor<ColorRGBFunction<ExtendedA98RGB<float>>>,
+    RelativeColor<ColorRGBFunction<ExtendedDisplayP3<float>>>,
+    RelativeColor<ColorRGBFunction<ExtendedProPhotoRGB<float>>>,
+    RelativeColor<ColorRGBFunction<ExtendedRec2020<float>>>,
+    RelativeColor<ColorRGBFunction<ExtendedSRGBA<float>>>,
+    RelativeColor<ColorRGBFunction<ExtendedLinearSRGBA<float>>>,
+    RelativeColor<ColorXYZFunction<XYZA<float, WhitePoint::D50>>>,
+    RelativeColor<ColorXYZFunction<XYZA<float, WhitePoint::D65>>>
+    >;
+
+class ExtendedStyleColor : public RefCounted<ExtendedStyleColor> {
+public:
+
+    template <typename T>
+    static Ref<ExtendedStyleColor> create(T&& t) { return adoptRef(*new ExtendedStyleColor(WTFMove(t))); }
+
+    bool containsCurrentColor() const;
+    WEBCORE_EXPORT WebCore::Color resolveColor(const WebCore::Color& currentColor) const;
+
+    bool operator==(const ExtendedStyleColor& other) const { return m_color == other.m_color; }
+
+    friend WEBCORE_EXPORT String serializationForCSS(const ExtendedStyleColor&);
+    friend void serializationForCSS(StringBuilder&, const ExtendedStyleColor&);
+    friend WTF::TextStream& operator<<(WTF::TextStream&, const ExtendedStyleColor&);
+
+private:
+    ExtendedStyleColor(ExtendedColorKind&&);
+    ExtendedColorKind m_color;
+};
+
+bool containsCurrentColor(const ExtendedStyleColor&);
+void serializationForCSS(StringBuilder&, const ExtendedStyleColor&);
+WEBCORE_EXPORT String serializationForCSS(const ExtendedStyleColor&);
+WTF::TextStream& operator<<(WTF::TextStream&, const ExtendedStyleColor&);
+
+} // namespace Style
+
+} // namespace WebCore

--- a/Source/WebCore/style/values/color/StyleRelativeColor.h
+++ b/Source/WebCore/style/values/color/StyleRelativeColor.h
@@ -32,6 +32,7 @@
 #include "Color.h"
 #include "ColorSerialization.h"
 #include "StyleColor.h"
+#include "StyleColorResolutionState.h"
 #include "StyleResolvedColor.h"
 #include <wtf/text/TextStream.h>
 


### PR DESCRIPTION
#### 7a5867a265637924dbe79a69a404c53a4df52a85
<pre>
[CSS] StyleColor should be 8 bytes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=252384">https://bugs.webkit.org/show_bug.cgi?id=252384</a>
<a href="https://rdar.apple.com/105537363">rdar://105537363</a>

Reviewed by NOBODY (OOPS!).

For the rare complex cases (color-mix, relative color,..etc)
we use an out-of-line pointer to an ExtendedStyleColor.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/color/CSSUnresolvedAbsoluteColor.h:
(WebCore::createStyleColor):
* Source/WebCore/css/color/CSSUnresolvedColorHex.h:
(WebCore::createStyleColor):
* Source/WebCore/css/color/CSSUnresolvedColorMix.cpp:
(WebCore::createStyleColor):
* Source/WebCore/css/color/CSSUnresolvedColorMix.h:
* Source/WebCore/css/color/ExtendedStyleColor.cpp: Added.
(WebCore::ExtendedStyleColor::ExtendedStyleColor):
(WebCore::ExtendedStyleColor::resolveColor const):
(WebCore::serializationForCSS):
(WebCore::operator&lt;&lt;):
* Source/WebCore/css/color/ExtendedStyleColor.h: Added.
(WebCore::ExtendedStyleColor::create):
* Source/WebCore/css/color/StyleColor.cpp:
(WebCore::StyleColor::StyleColor):
(WebCore::StyleColor::currentColor):
(WebCore::StyleColor::resolveColor const):
(WebCore::StyleColor::containsCurrentColor const):
(WebCore::StyleColor::isCurrentColor const):
(WebCore::StyleColor::isExtendedStyleColor const):
(WebCore::StyleColor::store):
(WebCore::StyleColor::isAbsoluteColor const):
(WebCore::StyleColor::absoluteColor const):
(WebCore::StyleColor::extendedStyleColor const):
(WebCore::StyleColor::resolveAbsoluteComponents):
(WebCore::serializationForCSS):
(WebCore::operator&lt;&lt;):
(WebCore::StyleColor::operator=): Deleted.
(WebCore::StyleColor::operator== const): Deleted.
(WebCore::StyleColor::visit): Deleted.
(WebCore::StyleColor::copy): Deleted.
(WebCore::StyleColor::isColorMix const): Deleted.
(WebCore::StyleColor::isRelativeColor const): Deleted.
* Source/WebCore/css/color/StyleColor.h:
* Source/WebCore/platform/graphics/Color.cpp:
(WebCore::Color::~Color):
(WebCore::Color::Color):
(WebCore::Color::decodedOutOfLineExtendedStyleColor):
(WebCore::Color::asExtendedStyleColor const):
* Source/WebCore/platform/graphics/Color.h:
(WebCore::Color::operator bool const):
(WebCore::operator==):
(WebCore::Color::isCurrentColor const):
(WebCore::Color::setCurrentColor):
(WebCore::Color::isExtendedStyleColor const):
(WebCore::Color::encodedOutOfLinePointer):
(WebCore::Color::encodedOutOfLineComponents):
(WebCore::Color::encodedOutOfLineExtendedStyleColor):
(WebCore::Color::decodedOutOfLinePointer):
(WebCore::Color::decodedOutOfLineComponents):
(WebCore::Color::setExtendedStyleColor):
(WebCore::Color::~Color): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a5867a265637924dbe79a69a404c53a4df52a85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92354 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38231 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15172 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67576 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/animations/box-shadow-interpolation.html imported/w3c/web-platform-tests/css/css-transitions/animations/animate-with-color-mix.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25319 "Found 2 new test failures: css3/color/backgrounds-and-borders.html fast/canvas/webgl/match-page-color-space.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47926 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5416 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-relevancy-updates.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33568 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-backgrounds/animations/box-shadow-interpolation.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37347 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75829 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34432 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-backgrounds/animations/box-shadow-interpolation.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94239 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14657 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10752 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/animations/box-shadow-interpolation.html imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color.html imported/w3c/web-platform-tests/css/css-transitions/animations/change-duration-during-transition.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76404 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-backgrounds/animations/box-shadow-interpolation.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75631 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20007 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18429 "12 flakes 5 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7596 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14675 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19970 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14418 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17862 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16201 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->