### PR TITLE
text-autospace: Parse ideograph-alpha, ideograph-numeric and normal

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-autospace-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-autospace-computed-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Property text-autospace value 'normal' assert_true: 'normal' is a supported value for text-autospace. expected true got false
+PASS Property text-autospace value 'normal'
 PASS Property text-autospace value 'no-autospace'
 PASS Property text-autospace value 'auto'
-FAIL Property text-autospace value 'ideograph-alpha' assert_true: 'ideograph-alpha' is a supported value for text-autospace. expected true got false
-FAIL Property text-autospace value 'ideograph-numeric' assert_true: 'ideograph-numeric' is a supported value for text-autospace. expected true got false
+PASS Property text-autospace value 'ideograph-alpha'
+PASS Property text-autospace value 'ideograph-numeric'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-autospace-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-autospace-valid-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL e.style['text-autospace'] = "normal" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['text-autospace'] = "normal" should set the property value
 PASS e.style['text-autospace'] = "no-autospace" should set the property value
 PASS e.style['text-autospace'] = "auto" should set the property value
-FAIL e.style['text-autospace'] = "ideograph-alpha" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['text-autospace'] = "ideograph-numeric" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['text-autospace'] = "ideograph-alpha ideograph-numeric" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['text-autospace'] = "ideograph-alpha" should set the property value
+PASS e.style['text-autospace'] = "ideograph-numeric" should set the property value
+PASS e.style['text-autospace'] = "ideograph-alpha ideograph-numeric" should set the property value
 FAIL e.style['text-autospace'] = "punctuation" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['text-autospace'] = "punctuation normal" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['text-autospace'] = "punctuation ideograph-alpha" should set the property value assert_not_equals: property should be set got disallowed value ""

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -249,7 +249,7 @@ PASS text-anchor: "end" onto "middle"
 PASS text-anchor: "middle" onto "end"
 PASS text-autospace (type: discrete) has testAccumulation function
 PASS text-autospace: "no-autospace" onto "normal"
-FAIL text-autospace: "normal" onto "no-autospace" assert_equals: The value should be normal at 0ms expected "normal" but got "no-autospace"
+PASS text-autospace: "normal" onto "no-autospace"
 PASS text-box-edge (type: discrete) has testAccumulation function
 PASS text-box-edge: "text" onto "leading"
 PASS text-box-edge: "leading" onto "text"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -249,7 +249,7 @@ PASS text-anchor: "end" onto "middle"
 PASS text-anchor: "middle" onto "end"
 PASS text-autospace (type: discrete) has testAddition function
 PASS text-autospace: "no-autospace" onto "normal"
-FAIL text-autospace: "normal" onto "no-autospace" assert_equals: The value should be normal at 0ms expected "normal" but got "no-autospace"
+PASS text-autospace: "normal" onto "no-autospace"
 PASS text-box-edge (type: discrete) has testAddition function
 PASS text-box-edge: "text" onto "leading"
 PASS text-box-edge: "leading" onto "text"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -305,9 +305,9 @@ PASS text-anchor uses discrete animation when animating between "middle" and "en
 PASS text-anchor uses discrete animation when animating between "middle" and "end" with effect easing
 PASS text-anchor uses discrete animation when animating between "middle" and "end" with keyframe easing
 PASS text-autospace (type: discrete) has testInterpolation function
-FAIL text-autospace uses discrete animation when animating between "normal" and "no-autospace" with linear easing assert_equals: The value should be normal at 0ms expected "normal" but got "no-autospace"
-FAIL text-autospace uses discrete animation when animating between "normal" and "no-autospace" with effect easing assert_equals: The value should be normal at 0ms expected "normal" but got "no-autospace"
-FAIL text-autospace uses discrete animation when animating between "normal" and "no-autospace" with keyframe easing assert_equals: The value should be normal at 0ms expected "normal" but got "no-autospace"
+PASS text-autospace uses discrete animation when animating between "normal" and "no-autospace" with linear easing
+PASS text-autospace uses discrete animation when animating between "normal" and "no-autospace" with effect easing
+PASS text-autospace uses discrete animation when animating between "normal" and "no-autospace" with keyframe easing
 PASS text-box-edge (type: discrete) has testInterpolation function
 PASS text-box-edge uses discrete animation when animating between "leading" and "text" with linear easing
 PASS text-box-edge uses discrete animation when animating between "leading" and "text" with effect easing

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -246,7 +246,7 @@ PASS text-anchor: "end" onto "middle"
 PASS text-anchor: "middle" onto "end"
 PASS text-autospace (type: discrete) has testAccumulation function
 PASS text-autospace: "no-autospace" onto "normal"
-FAIL text-autospace: "normal" onto "no-autospace" assert_equals: The value should be normal at 0ms expected "normal" but got "no-autospace"
+PASS text-autospace: "normal" onto "no-autospace"
 PASS text-box-edge (type: discrete) has testAccumulation function
 PASS text-box-edge: "text" onto "leading"
 PASS text-box-edge: "leading" onto "text"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -246,7 +246,7 @@ PASS text-anchor: "end" onto "middle"
 PASS text-anchor: "middle" onto "end"
 PASS text-autospace (type: discrete) has testAddition function
 PASS text-autospace: "no-autospace" onto "normal"
-FAIL text-autospace: "normal" onto "no-autospace" assert_equals: The value should be normal at 0ms expected "normal" but got "no-autospace"
+PASS text-autospace: "normal" onto "no-autospace"
 PASS text-box-edge (type: discrete) has testAddition function
 PASS text-box-edge: "text" onto "leading"
 PASS text-box-edge: "leading" onto "text"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -301,9 +301,9 @@ PASS text-anchor uses discrete animation when animating between "middle" and "en
 PASS text-anchor uses discrete animation when animating between "middle" and "end" with effect easing
 PASS text-anchor uses discrete animation when animating between "middle" and "end" with keyframe easing
 PASS text-autospace (type: discrete) has testInterpolation function
-FAIL text-autospace uses discrete animation when animating between "normal" and "no-autospace" with linear easing assert_equals: The value should be normal at 0ms expected "normal" but got "no-autospace"
-FAIL text-autospace uses discrete animation when animating between "normal" and "no-autospace" with effect easing assert_equals: The value should be normal at 0ms expected "normal" but got "no-autospace"
-FAIL text-autospace uses discrete animation when animating between "normal" and "no-autospace" with keyframe easing assert_equals: The value should be normal at 0ms expected "normal" but got "no-autospace"
+PASS text-autospace uses discrete animation when animating between "normal" and "no-autospace" with linear easing
+PASS text-autospace uses discrete animation when animating between "normal" and "no-autospace" with effect easing
+PASS text-autospace uses discrete animation when animating between "normal" and "no-autospace" with keyframe easing
 PASS text-box-edge (type: discrete) has testInterpolation function
 PASS text-box-edge uses discrete animation when animating between "leading" and "text" with linear easing
 PASS text-box-edge uses discrete animation when animating between "leading" and "text" with effect easing

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1294,6 +1294,20 @@ CSSStyleQueriesEnabled:
     WebCore:
       default: true
 
+CSSTextAutospaceEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS text-autospace property"
+  humanReadableDescription: "Enable the property text-autospace, defined in CSS Text 4"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSTextBoxTrimEnabled:
   type: bool
   status: preview

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1193,10 +1193,13 @@
             "inherited": true,
             "values": [
                 "auto",
-                "no-autospace"
+                "normal",
+                "no-autospace",
+                "ideograph-alpha",
+                "ideograph-numeric"
             ],
             "codegen-properties": {
-                "settings-flag": "cssTextSpacingEnabled",
+                "settings-flag": "cssTextAutospaceEnabled",
                 "font-property": true,
                 "high-priority": true,
                 "sink-priority": true,

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1761,7 +1761,10 @@ false
 // text-spacing-trim
 space-all
 // text-autospace
+// normal
 no-autospace
+ideograph-alpha
+ideograph-numeric
 
 // scrollbar-gutter
 // auto

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -387,14 +387,24 @@ static Ref<CSSPrimitiveValue> textSpacingTrimFromStyle(const RenderStyle& style)
     return CSSPrimitiveValue::create(CSSValueSpaceAll);
 }
 
-static Ref<CSSPrimitiveValue> textAutospaceFromStyle(const RenderStyle& style)
+static Ref<CSSValue> textAutospaceFromStyle(const RenderStyle& style)
 {
     // FIXME: add support for remaining values once spec is stable and we are parsing them.
     auto textAutospace = style.textAutospace();
     if (textAutospace.isAuto())
         return CSSPrimitiveValue::create(CSSValueAuto);
+    if (textAutospace.isNoAutospace())
+        return CSSPrimitiveValue::create(CSSValueNoAutospace);
+    if (textAutospace.isNormal())
+        return CSSPrimitiveValue::create(CSSValueNormal);
 
-    return CSSPrimitiveValue::create(CSSValueNoAutospace);
+    CSSValueListBuilder list;
+    if (textAutospace.hasIdeographAlpha())
+        list.append(CSSPrimitiveValue::create(CSSValueIdeographAlpha));
+    if (textAutospace.hasIdeographNumeric())
+        list.append(CSSPrimitiveValue::create(CSSValueIdeographNumeric));
+
+    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 static Ref<CSSPrimitiveValue> zoomAdjustedPixelValue(double value, const RenderStyle& style)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -267,7 +267,7 @@ struct ScrollbarColor;
 struct ViewTimelineInsets;
 
 struct TabSize;
-struct TextAutospace;
+class TextAutospace;
 struct TextBoxEdge;
 struct TextSpacingTrim;
 struct TransformOperationData;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -2029,10 +2029,30 @@ inline TextSpacingTrim BuilderConverter::convertTextSpacingTrim(BuilderState&, c
 inline TextAutospace BuilderConverter::convertTextAutospace(BuilderState&, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (primitiveValue->valueID() == CSSValueNoAutospace)
+            return { };
         if (primitiveValue->valueID() == CSSValueAuto)
-            return { .m_autoSpace = TextAutospace::TextAutospaceType::Auto };
+            return { TextAutospace::Type::Auto };
+        if (primitiveValue->valueID() == CSSValueNormal)
+            return { TextAutospace::Type::Normal };
     }
-    return { };
+
+    TextAutospace::Options options;
+    for (auto& item : downcast<CSSValueList>(value)) {
+        auto& value = downcast<CSSPrimitiveValue>(item);
+        switch (value.valueID()) {
+        case CSSValueIdeographAlpha:
+            options.add(TextAutospace::Type::IdeographAlpha);
+            break;
+        case CSSValueIdeographNumeric:
+            options.add(TextAutospace::Type::IdeographNumeric);
+            break;
+        default:
+            ASSERT_NOT_REACHED();
+            break;
+        }
+    }
+    return options;
 }
 
 inline std::optional<Length> BuilderConverter::convertBlockStepSize(BuilderState& builderState, const CSSValue& value)


### PR DESCRIPTION
#### 94f380ede47d26c550c3e09b4c01a719204f50c2
<pre>
text-autospace: Parse ideograph-alpha, ideograph-numeric and normal
<a href="https://bugs.webkit.org/show_bug.cgi?id=277390">https://bugs.webkit.org/show_bug.cgi?id=277390</a>
<a href="https://rdar.apple.com/problem/132860482">rdar://problem/132860482</a>

Reviewed by Tim Nguyen.

We are now parsing ideograph-alpha, ideograph-numeric and normal
as valid values of text-autospace according to specification [1].

We are also creating text-autospace&apos;s own feature flag.

[1]: <a href="https://drafts.csswg.org/css-text-4/#text-autospace-property">https://drafts.csswg.org/css-text-4/#text-autospace-property</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-autospace-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/text-autospace-valid-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::textAutospaceFromStyle):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeTextAutospace):
* Source/WebCore/platform/text/TextSpacing.h:
(WebCore::TextAutospace::TextAutospace):
(WebCore::TextAutospace::isAuto const):
(WebCore::TextAutospace::isNoAutospace const):
(WebCore::TextAutospace::isNormal const):
(WebCore::TextAutospace::hasIdeographAlpha const):
(WebCore::TextAutospace::hasIdeographNumeric const):
(WebCore::TextAutospace::options):
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertTextAutospace):

Canonical link: <a href="https://commits.webkit.org/281719@main">https://commits.webkit.org/281719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43783a1fb6a7075d00ee719a72f29bf32f483b5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64697 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11313 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49140 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7855 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37370 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/52648 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29972 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9874 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10226 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/53868 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55896 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66426 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60013 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10004 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56690 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13551 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3908 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81768 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35930 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14236 "Found 21 new JSC stress test failures: stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.default, stress/proxy-set.js.dfg-eager, stress/proxy-set.js.dfg-eager-no-cjit-validate, stress/proxy-set.js.eager-jettison-no-cjit, stress/proxy-set.js.mini-mode, stress/proxy-set.js.no-cjit-collect-continuously ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37012 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38105 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->