### PR TITLE
_hasActiveNowPlayingSession incorrectly set to NO when a subframe navigation occurs

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -330,6 +330,8 @@ void PageClientImplCocoa::hasActiveNowPlayingSessionChanged(bool hasActiveNowPla
     if ([m_webView _hasActiveNowPlayingSession] == hasActiveNowPlayingSession)
         return;
 
+    RELEASE_LOG(ViewState, "%p PageClientImplCocoa::hasActiveNowPlayingSessionChanged %d", m_webView.get().get(), hasActiveNowPlayingSession);
+
     [m_webView willChangeValueForKey:@"_hasActiveNowPlayingSession"];
     [m_webView _setHasActiveNowPlayingSession:hasActiveNowPlayingSession];
     [m_webView didChangeValueForKey:@"_hasActiveNowPlayingSession"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/large-video-test-now-playing.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/large-video-test-now-playing.html
@@ -64,6 +64,15 @@
             });
         }
 
+        function loadSubframe() {
+            const frame = document.createElement("iframe");
+            frame.addEventListener("load", () => {
+                window.webkit.messageHandlers.testHandler.postMessage("subframeLoaded");
+            });
+            frame.src = "simple.html";
+            document.body.appendChild(frame);
+        }
+
     </script>
 </head>
 <body>


### PR DESCRIPTION
#### ec9c5dbe3501425a942c3e0c969802c2998be98e
<pre>
_hasActiveNowPlayingSession incorrectly set to NO when a subframe navigation occurs
<a href="https://bugs.webkit.org/show_bug.cgi?id=277404">https://bugs.webkit.org/show_bug.cgi?id=277404</a>
<a href="https://rdar.apple.com/131082146">rdar://131082146</a>

Reviewed by Jean-Yves Avenard.

WebPageProxy::didCommitLoadForFrame would set WKWebView&apos;s _hasActiveNowPlayingSession property to
NO when a load committed in *any* frame, even if that frame was not playing media. Furthermore, it
would be set to NO during a same-document navigation even if the navigation did not stop media
playback.

To correct these two mistakes, moved the call to PageClient::hasActiveNowPlayingSessionChanged from
WebPageProxy::didCommitLoadForFrame to WebPageProxy::didChangeMainDocument and ensured that it&apos;s
only called on the main frame.

Added API tests.

* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::hasActiveNowPlayingSessionChanged):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didChangeMainDocument):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingSession.mm:
(TEST(NowPlayingSession, NavigateToFragmentAfterHasSession)):
(TEST(NowPlayingSession, LoadSubframeAfterHasSession)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/large-video-test-now-playing.html:

Canonical link: <a href="https://commits.webkit.org/281664@main">https://commits.webkit.org/281664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f9e9b3a8b68d6e836058cb46299c51c716f7572

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11136 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11376 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7739 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52493 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33906 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/9722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10049 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66249 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4533 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9847 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56555 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13499 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3760 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35752 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37928 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->