### PR TITLE
Implement Observable#drop

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-drop.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-drop.any-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL drop(): Observable should skip the first n values from the source observable, then pass through the rest of the values and completion source.drop is not a function. (In 'source.drop(2)', 'source.drop' is undefined)
-FAIL drop(): Observable passes through errors from source Observable source.drop is not a function. (In 'source.drop(2)', 'source.drop' is undefined)
-FAIL drop(): Observable passes through errors from source observable even before drop count is met source.drop is not a function. (In 'source.drop(2)', 'source.drop' is undefined)
-FAIL drop(): Observable passes through completions from source observable even before drop count is met source.drop is not a function. (In 'source.drop(2)', 'source.drop' is undefined)
-FAIL drop(): Unsubscribing from the Observable returned by drop() also unsubscribes from the source Observable source.drop is not a function. (In 'source.drop(2)', 'source.drop' is undefined)
-FAIL drop(): A drop amount of 0 simply mirrors the source Observable source.drop is not a function. (In 'source.drop(0)', 'source.drop' is undefined)
-FAIL drop(): Passing negative value wraps to maximum value  source.drop is not a function. (In 'source.drop(-1)', 'source.drop' is undefined)
+PASS drop(): Observable should skip the first n values from the source observable, then pass through the rest of the values and completion
+PASS drop(): Observable passes through errors from source Observable
+PASS drop(): Observable passes through errors from source observable even before drop count is met
+PASS drop(): Observable passes through completions from source observable even before drop count is met
+PASS drop(): Unsubscribing from the Observable returned by drop() also unsubscribes from the source Observable
+PASS drop(): A drop amount of 0 simply mirrors the source Observable
+PASS drop(): Passing negative value wraps to maximum value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-drop.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-drop.any.worker-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL drop(): Observable should skip the first n values from the source observable, then pass through the rest of the values and completion source.drop is not a function. (In 'source.drop(2)', 'source.drop' is undefined)
-FAIL drop(): Observable passes through errors from source Observable source.drop is not a function. (In 'source.drop(2)', 'source.drop' is undefined)
-FAIL drop(): Observable passes through errors from source observable even before drop count is met source.drop is not a function. (In 'source.drop(2)', 'source.drop' is undefined)
-FAIL drop(): Observable passes through completions from source observable even before drop count is met source.drop is not a function. (In 'source.drop(2)', 'source.drop' is undefined)
-FAIL drop(): Unsubscribing from the Observable returned by drop() also unsubscribes from the source Observable source.drop is not a function. (In 'source.drop(2)', 'source.drop' is undefined)
-FAIL drop(): A drop amount of 0 simply mirrors the source Observable source.drop is not a function. (In 'source.drop(0)', 'source.drop' is undefined)
-FAIL drop(): Passing negative value wraps to maximum value  source.drop is not a function. (In 'source.drop(-1)', 'source.drop' is undefined)
+PASS drop(): Observable should skip the first n values from the source observable, then pass through the rest of the values and completion
+PASS drop(): Observable passes through errors from source Observable
+PASS drop(): Observable passes through errors from source observable even before drop count is met
+PASS drop(): Observable passes through completions from source observable even before drop count is met
+PASS drop(): Unsubscribing from the Observable returned by drop() also unsubscribes from the source Observable
+PASS drop(): A drop amount of 0 simply mirrors the source Observable
+PASS drop(): Passing negative value wraps to maximum value
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1183,6 +1183,7 @@ dom/InternalObserverFromScript.cpp
 dom/InternalObserverFilter.cpp
 dom/InternalObserverMap.cpp
 dom/InternalObserverTake.cpp
+dom/InternalObserverDrop.cpp
 dom/KeyboardEvent.cpp
 dom/LiveNodeList.cpp
 dom/LoadableClassicScript.cpp

--- a/Source/WebCore/dom/InternalObserverDrop.cpp
+++ b/Source/WebCore/dom/InternalObserverDrop.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InternalObserverDrop.h"
+
+#include "InternalObserver.h"
+#include "Observable.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include "Subscriber.h"
+#include "SubscriberCallback.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
+
+namespace WebCore {
+
+class InternalObserverDrop final : public InternalObserver {
+public:
+    static Ref<InternalObserverDrop> create(ScriptExecutionContext& context, Ref<Subscriber> subscriber, uint64_t amount)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverDrop(context, subscriber, amount));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+    class SubscriberCallbackDrop final : public SubscriberCallback {
+    public:
+        static Ref<SubscriberCallbackDrop> create(ScriptExecutionContext& context, Ref<Observable> source, uint64_t amount)
+        {
+            return adoptRef(*new InternalObserverDrop::SubscriberCallbackDrop(context, source, amount));
+        }
+
+        CallbackResult<void> handleEvent(Subscriber& subscriber) final
+        {
+            auto context = scriptExecutionContext();
+
+            if (!context) {
+                subscriber.complete();
+                return { };
+            }
+
+            SubscribeOptions options;
+            options.signal = &subscriber.signal();
+            m_sourceObservable->subscribeInternal(*context, InternalObserverDrop::create(*context, subscriber, m_amount), options);
+
+            return { };
+        }
+
+    private:
+        Ref<Observable> m_sourceObservable;
+        uint64_t m_amount;
+
+        SubscriberCallbackDrop(ScriptExecutionContext& context, Ref<Observable> source, uint64_t amount)
+            : SubscriberCallback(&context)
+            , m_sourceObservable(source)
+            , m_amount(amount)
+        { }
+
+        bool hasCallback() const final { return true; }
+    };
+
+private:
+    Ref<Subscriber> m_subscriber;
+    uint64_t m_amount;
+
+    void next(JSC::JSValue value) final
+    {
+        if (!m_amount) {
+            m_subscriber->next(value);
+            return;
+        }
+
+        m_amount -= 1;
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        m_subscriber->error(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+        m_subscriber->complete();
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    {
+        m_subscriber->visitAdditionalChildren(visitor);
+    }
+
+    void visitAdditionalChildren(JSC::SlotVisitor& visitor) const final
+    {
+        m_subscriber->visitAdditionalChildren(visitor);
+    }
+
+    InternalObserverDrop(ScriptExecutionContext& context, Ref<Subscriber> subscriber, uint64_t amount)
+        : InternalObserver(context)
+        , m_subscriber(subscriber)
+        , m_amount(amount)
+    { }
+
+};
+
+Ref<SubscriberCallback> createSubscriberCallbackDrop(ScriptExecutionContext& context, Ref<Observable> observable, uint64_t amount)
+{
+    return InternalObserverDrop::SubscriberCallbackDrop::create(context, observable, amount);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverDrop.h
+++ b/Source/WebCore/dom/InternalObserverDrop.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class Observable;
+class ScriptExecutionContext;
+class SubscriberCallback;
+
+Ref<SubscriberCallback> createSubscriberCallbackDrop(ScriptExecutionContext&, Ref<Observable>, uint64_t);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "Exception.h"
 #include "ExceptionCode.h"
+#include "InternalObserverDrop.h"
 #include "InternalObserverFilter.h"
 #include "InternalObserverFromScript.h"
 #include "InternalObserverMap.h"
@@ -111,6 +112,11 @@ Ref<Observable> Observable::filter(ScriptExecutionContext& context, PredicateCal
 Ref<Observable> Observable::take(ScriptExecutionContext& context, uint64_t amount)
 {
     return create(createSubscriberCallbackTake(context, *this, amount));
+}
+
+Ref<Observable> Observable::drop(ScriptExecutionContext& context, uint64_t amount)
+{
+    return create(createSubscriberCallbackDrop(context, *this, amount));
 }
 
 Observable::Observable(Ref<SubscriberCallback> callback)

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -60,6 +60,8 @@ public:
 
     Ref<Observable> take(ScriptExecutionContext&, uint64_t);
 
+    Ref<Observable> drop(ScriptExecutionContext&, uint64_t);
+
 private:
     Ref<SubscriberCallback> m_subscriberCallback;
 };

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -38,4 +38,6 @@ interface Observable {
   [CallWith=CurrentScriptExecutionContext] Observable filter(PredicateCallback predicate);
 
   [CallWith=CurrentScriptExecutionContext] Observable take(unsigned long long amount);
+
+  [CallWith=CurrentScriptExecutionContext] Observable drop(unsigned long long amount);
 };


### PR DESCRIPTION
#### f1556cc6daef8bf209e079fa87369c76767fbf01
<pre>
Implement Observable#drop
<a href="https://bugs.webkit.org/show_bug.cgi?id=277224">https://bugs.webkit.org/show_bug.cgi?id=277224</a>

Reviewed by Darin Adler.

This Pull Request implements the `drop` method for the `Observable`
class. This is required by the specification, for
[`#drop`](<a href="https://wicg.github.io/observable/#dom-observable-drop).">https://wicg.github.io/observable/#dom-observable-drop).</a> Also adds
the `InternalObserverDrop` and `SubscriberCallbackDrop` to support this.

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-drop.any-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-drop.any.worker-expected.txt: Rebaselined.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/InternalObserverDrop.cpp: Added.
(WebCore::createSubscriberCallbackDrop):
* Source/WebCore/dom/InternalObserverDrop.h: Added.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::drop):
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.idl:

Canonical link: <a href="https://commits.webkit.org/281734@main">https://commits.webkit.org/281734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50dd5c0c24495d5a26f0241cc53e69fdd692f693

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11264 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49094 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7811 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29925 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9829 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10177 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66377 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9959 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56462 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56641 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13565 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3860 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35881 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36963 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->