### PR TITLE
[GTK][WPE] Add more WPE related trace points to better understand the graphics pipeline

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -149,6 +149,7 @@ enum TracePointCode {
     SyntheticMomentumEnd,
     SyntheticMomentumEvent,
     RemoteLayerTreeScheduleRenderingUpdate,
+    DisplayLinkUpdate,
 
     UIProcessRange = 14000,
     CommitLayerTreeStart,
@@ -167,6 +168,18 @@ enum TracePointCode {
     GPUProcessRange = 16000,
     WakeUpAndApplyDisplayListStart,
     WakeUpAndApplyDisplayListEnd,
+
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    GTKWPEPortRange = 20000,
+
+    WaitForCompositionCompletionStart,
+    WaitForCompositionCompletionEnd,
+    FrameCompositionStart,
+    FrameCompositionEnd,
+    LayerFlushStart,
+    LayerFlushEnd,
+#endif
+
 };
 
 #ifdef __cplusplus

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -135,6 +135,9 @@ public:
         case WebHTMLViewPaintStart:
         case BackingStoreFlushStart:
         case BuildTransactionStart:
+        case WaitForCompositionCompletionStart:
+        case FrameCompositionStart:
+        case LayerFlushStart:
         case SyncMessageStart:
         case SyncTouchEventStart:
         case InitializeWebProcessStart:
@@ -189,6 +192,9 @@ public:
         case WebXRSessionFrameCallbacksEnd:
         case WebHTMLViewPaintEnd:
         case BackingStoreFlushEnd:
+        case WaitForCompositionCompletionEnd:
+        case FrameCompositionEnd:
+        case LayerFlushEnd:
         case BuildTransactionEnd:
         case SyncMessageEnd:
         case SyncTouchEventEnd:
@@ -217,6 +223,7 @@ public:
         case ScrollingTreeDisplayDidRefresh:
         case SyntheticMomentumEvent:
         case RemoteLayerTreeScheduleRenderingUpdate:
+        case DisplayLinkUpdate:
             instantMark(tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
             break;
 
@@ -227,6 +234,7 @@ public:
         case WebKit2Range:
         case UIProcessRange:
         case GPUProcessRange:
+        case GTKWPEPortRange:
             break;
         }
     }
@@ -399,6 +407,8 @@ private:
             return "SyntheticMomentumEvent"_s;
         case RemoteLayerTreeScheduleRenderingUpdate:
             return "RemoteLayerTreeScheduleRenderingUpdate"_s;
+        case DisplayLinkUpdate:
+            return "DisplayLinkUpdate"_s;
 
         case CommitLayerTreeStart:
         case CommitLayerTreeEnd:
@@ -423,6 +433,16 @@ private:
         case WakeUpAndApplyDisplayListEnd:
             return "WakeUpAndApplyDisplayList"_s;
 
+        case WaitForCompositionCompletionStart:
+        case WaitForCompositionCompletionEnd:
+            return "WaitForCompositionCompletion"_s;
+        case FrameCompositionStart:
+        case FrameCompositionEnd:
+            return "FrameComposition"_s;
+        case LayerFlushStart:
+        case LayerFlushEnd:
+            return "LayerFlush"_s;
+
         case WTFRange:
         case JavaScriptRange:
         case WebCoreRange:
@@ -430,6 +450,7 @@ private:
         case WebKit2Range:
         case UIProcessRange:
         case GPUProcessRange:
+        case GTKWPEPortRange:
             return nullptr;
         }
 

--- a/Source/WebKit/Resources/Signposts/SystemTracePoints.plist
+++ b/Source/WebKit/Resources/Signposts/SystemTracePoints.plist
@@ -773,6 +773,21 @@
              </dict>
              <dict>
                  <key>Name</key>
+                 <string>DisplayLink update</string>
+                 <key>Type</key>
+                 <string>Impulse</string>
+                 <key>Component</key>
+                 <string>47</string>
+                 <key>Code</key>
+                 <string>12029</string>
+                 <key>ArgNames</key>
+                 <dict>
+                     <key>Arg1</key>
+                     <string>DisplayLink update entry point</string>
+                 </dict>
+             </dict>
+             <dict>
+                 <key>Name</key>
                  <string>Commit RemoteLayerTree transaction</string>
                  <key>Type</key>
                  <string>Interval</string>

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -32,6 +32,7 @@
 #include <WebCore/PlatformDisplay.h>
 #include <WebCore/TransformationMatrix.h>
 #include <wtf/SetForScope.h>
+#include <wtf/SystemTracing.h>
 
 #if USE(GLIB_EVENT_LOOP)
 #include <wtf/glib/RunLoopSourcePriority.h>
@@ -220,6 +221,8 @@ void ThreadedCompositor::forceRepaint()
 
 void ThreadedCompositor::renderLayerTree()
 {
+    TraceScope traceScope(FrameCompositionStart, FrameCompositionEnd);
+
     if (!m_scene || !m_scene->isActive())
         return;
 

--- a/Source/WebKit/UIProcess/DisplayLink.cpp
+++ b/Source/WebKit/UIProcess/DisplayLink.cpp
@@ -31,6 +31,7 @@
 #include "Logging.h"
 #include <WebCore/AnimationFrameRate.h>
 #include <wtf/RunLoop.h>
+#include <wtf/SystemTracing.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebKit {
@@ -182,6 +183,8 @@ void DisplayLink::notifyObserversDisplayDidRefresh()
     ASSERT(!RunLoop::isMain());
 
     Locker locker { m_clientsLock };
+
+    tracePoint(DisplayLinkUpdate);
 
     auto maxFramesPerSecond = [](const Vector<ObserverInfo>& observers) {
         std::optional<FramesPerSecond> observersMaxFramesPerSecond;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -46,6 +46,7 @@
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/NumberOfCores.h>
 #include <wtf/SetForScope.h>
+#include <wtf/SystemTracing.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 #if USE(CAIRO)
@@ -161,6 +162,7 @@ void CompositingCoordinator::sizeDidChange(const IntSize& newSize)
 
 bool CompositingCoordinator::flushPendingLayerChanges(OptionSet<FinalizeRenderingUpdateFlags> flags)
 {
+    TraceScope traceScope(BackingStoreFlushStart, BackingStoreFlushEnd);
     SetForScope protector(m_isFlushingLayerChanges, true);
 
     bool shouldSyncFrame = initializeRootCompositingLayerIfNeeded();

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -41,6 +41,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <wtf/SafeStrerror.h>
+#include <wtf/SystemTracing.h>
 
 #if USE(GBM)
 #include <WebCore/DRMDeviceManager.h>
@@ -635,6 +636,8 @@ void AcceleratedSurfaceDMABuf::willRenderFrame()
 
 void AcceleratedSurfaceDMABuf::didRenderFrame(WebCore::Region&& damage)
 {
+    TraceScope traceScope(WaitForCompositionCompletionStart, WaitForCompositionCompletionEnd);
+
     if (!m_target)
         return;
 


### PR DESCRIPTION
#### 57b47fb1d205b4dfd9ac47dd5e9aa506f2de7a32
<pre>
[GTK][WPE] Add more WPE related trace points to better understand the graphics pipeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=277412">https://bugs.webkit.org/show_bug.cgi?id=277412</a>

Reviewed by Miguel Gomez.

Add new WPE specific trace points that help us understand the graphics
pipeline, starting from DRM vblank signal (capture by sysprof) until
composition starts/ends for a frame.

Based on a patch from Alejandro G. Castro, refactored to avoid changing
any of the existing enum values - which would be problematic for the Apple
ports.

No new tests - doesn&apos;t affect non-glib ports.

* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WebKit/Resources/Signposts/SystemTracePoints.plist:
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::renderLayerTree):
* Source/WebKit/UIProcess/DisplayLink.cpp:
(WebKit::DisplayLink::notifyObserversDisplayDidRefresh):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::flushPendingLayerChanges):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):

Canonical link: <a href="https://commits.webkit.org/281852@main">https://commits.webkit.org/281852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0a01eea7e2f0a8c97a48aaf99e1f561ccc36225

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64665 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11281 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49107 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7822 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34026 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9845 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10194 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/53834 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55866 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66394 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59981 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9975 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56475 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56654 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13648 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3878 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81736 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35898 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14227 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36980 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->