### PR TITLE
REGRESSION (281109@main?): [ Guard-Malloc ] media/media-source/media-managedmse-video-with-poster.html is constantly crashing.

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
@@ -50,7 +50,7 @@ class PlaybackSessionModelMediaElement;
 
 class VideoPresentationModelVideoElement final : public VideoPresentationModel {
 public:
-    static RefPtr<VideoPresentationModelVideoElement> create()
+    static Ref<VideoPresentationModelVideoElement> create()
     {
         return adoptRef(*new VideoPresentationModelVideoElement());
     }

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -97,8 +97,8 @@ void VideoPresentationInterfaceLMK::setupFullscreen(UIView& videoView, const Web
 
 void VideoPresentationInterfaceLMK::finalizeSetup()
 {
-    RunLoop::main().dispatch([protectedThis = Ref { *this }, this] {
-        if (RefPtr model = videoPresentationModel())
+    RunLoop::main().dispatch([protectedThis = Ref { *this }] {
+        if (RefPtr model = protectedThis->videoPresentationModel())
             model->didSetupFullscreen();
     });
 }
@@ -120,7 +120,7 @@ void VideoPresentationInterfaceLMK::presentFullscreen(bool animated, Function<vo
 {
     playbackSessionInterface().startObservingNowPlayingMetadata();
     [linearMediaPlayer() enterFullscreenWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (BOOL success, NSError *error) {
-        if (auto* playbackSessionModel = playbackSessionInterface().playbackSessionModel()) {
+        if (auto* playbackSessionModel = this->playbackSessionModel()) {
             playbackSessionModel->setSpatialTrackingLabel(m_spatialTrackingLabel);
             playbackSessionModel->setSoundStageSize(WebCore::AudioSessionSoundStageSize::Large);
         }
@@ -132,7 +132,7 @@ void VideoPresentationInterfaceLMK::dismissFullscreen(bool animated, Function<vo
 {
     playbackSessionInterface().stopObservingNowPlayingMetadata();
     [linearMediaPlayer() exitFullscreenWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (BOOL success, NSError *error) {
-        if (auto* playbackSessionModel = playbackSessionInterface().playbackSessionModel()) {
+        if (auto* playbackSessionModel = this->playbackSessionModel()) {
             playbackSessionModel->setSpatialTrackingLabel(nullString());
             playbackSessionModel->setSoundStageSize(WebCore::AudioSessionSoundStageSize::Automatic);
         }

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -231,7 +231,7 @@ public:
     void invalidate();
 
     bool hasControlsManagerInterface() const { return !!m_controlsManagerContextId; }
-    WebCore::PlatformPlaybackSessionInterface* controlsManagerInterface();
+    RefPtr<WebCore::PlatformPlaybackSessionInterface> controlsManagerInterface();
     void requestControlledElementID();
 
     bool isPaused(PlaybackSessionContextIdentifier) const;
@@ -246,11 +246,11 @@ private:
     explicit PlaybackSessionManagerProxy(WebPageProxy&);
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
-    typedef std::tuple<RefPtr<PlaybackSessionModelContext>, RefPtr<WebCore::PlatformPlaybackSessionInterface>> ModelInterfaceTuple;
+    typedef std::tuple<Ref<PlaybackSessionModelContext>, Ref<WebCore::PlatformPlaybackSessionInterface>> ModelInterfaceTuple;
     ModelInterfaceTuple createModelAndInterface(PlaybackSessionContextIdentifier);
-    ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier);
-    PlaybackSessionModelContext& ensureModel(PlaybackSessionContextIdentifier);
-    WebCore::PlatformPlaybackSessionInterface& ensureInterface(PlaybackSessionContextIdentifier);
+    const ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier);
+    Ref<PlaybackSessionModelContext> ensureModel(PlaybackSessionContextIdentifier);
+    Ref<WebCore::PlatformPlaybackSessionInterface> ensureInterface(PlaybackSessionContextIdentifier);
     void addClientForContext(PlaybackSessionContextIdentifier);
     void removeClientForContext(PlaybackSessionContextIdentifier);
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -181,7 +181,7 @@ public:
 
     bool isPlayingVideoInEnhancedFullscreen() const;
 
-    WebCore::PlatformVideoPresentationInterface* controlsManagerInterface();
+    RefPtr<WebCore::PlatformVideoPresentationInterface> controlsManagerInterface();
     using VideoInPictureInPictureDidChangeObserver = WTF::Observer<void(bool)>;
     void addVideoInPictureInPictureDidChangeObserver(const VideoInPictureInPictureDidChangeObserver&);
 
@@ -190,7 +190,7 @@ public:
     void requestBitmapImageForCurrentTime(PlaybackSessionContextIdentifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
 
 #if PLATFORM(IOS_FAMILY)
-    WebCore::PlatformVideoPresentationInterface* returningToStandbyInterface() const;
+    RefPtr<WebCore::PlatformVideoPresentationInterface> returningToStandbyInterface() const;
     AVPlayerViewController *playerViewController(PlaybackSessionContextIdentifier) const;
     RetainPtr<WKVideoView> createViewWithID(PlaybackSessionContextIdentifier, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& nativeSize, float hostingScaleFactor);
 #endif
@@ -209,12 +209,12 @@ private:
     explicit VideoPresentationManagerProxy(WebPageProxy&, PlaybackSessionManagerProxy&);
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    typedef std::tuple<RefPtr<VideoPresentationModelContext>, RefPtr<WebCore::PlatformVideoPresentationInterface>> ModelInterfaceTuple;
+    typedef std::tuple<Ref<VideoPresentationModelContext>, Ref<WebCore::PlatformVideoPresentationInterface>> ModelInterfaceTuple;
     ModelInterfaceTuple createModelAndInterface(PlaybackSessionContextIdentifier);
-    ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier);
-    VideoPresentationModelContext& ensureModel(PlaybackSessionContextIdentifier);
-    WebCore::PlatformVideoPresentationInterface& ensureInterface(PlaybackSessionContextIdentifier);
-    WebCore::PlatformVideoPresentationInterface* findInterface(PlaybackSessionContextIdentifier) const;
+    const ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier);
+    Ref<VideoPresentationModelContext> ensureModel(PlaybackSessionContextIdentifier);
+    Ref<WebCore::PlatformVideoPresentationInterface> ensureInterface(PlaybackSessionContextIdentifier);
+    RefPtr<WebCore::PlatformVideoPresentationInterface> findInterface(PlaybackSessionContextIdentifier) const;
     void ensureClientForContext(PlaybackSessionContextIdentifier);
     void addClientForContext(PlaybackSessionContextIdentifier);
     void removeClientForContext(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -365,11 +365,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     ASSERT(_valid);
     auto page = [self._webView _page];
-    auto* videoPresentationManager = page ? page->videoPresentationManager() : nullptr;
-    auto* videoPresentationInterface = videoPresentationManager ? videoPresentationManager->controlsManagerInterface() : nullptr;
-    auto* playbackSessionInterface = videoPresentationInterface ? &videoPresentationInterface->playbackSessionInterface() : nullptr;
+    RefPtr videoPresentationManager = page ? page->videoPresentationManager() : nullptr;
+    RefPtr videoPresentationInterface = videoPresentationManager ? videoPresentationManager->controlsManagerInterface() : nullptr;
+    RefPtr playbackSessionInterface = videoPresentationInterface ? &videoPresentationInterface->playbackSessionInterface() : nullptr;
 
-    _playbackClient.setInterface(playbackSessionInterface);
+    _playbackClient.setInterface(playbackSessionInterface.get());
 
     WebCore::PlaybackSessionModel* playbackSessionModel = playbackSessionInterface ? playbackSessionInterface->playbackSessionModel() : nullptr;
     self.playing = playbackSessionModel ? playbackSessionModel->isPlaying() : NO;
@@ -854,15 +854,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!playbackSessionManager)
         return;
 
-    WebCore::PlatformPlaybackSessionInterface* playbackSessionInterface = playbackSessionManager->controlsManagerInterface();
+    RefPtr playbackSessionInterface = playbackSessionManager->controlsManagerInterface();
     if (!playbackSessionInterface)
         return;
 
-    WebCore::PlaybackSessionModel* playbackSessionModel = playbackSessionInterface->playbackSessionModel();
-    if (!playbackSessionModel)
-        return;
-
-    playbackSessionModel->togglePictureInPicture();
+    if (auto* playbackSessionModel = playbackSessionInterface->playbackSessionModel())
+        playbackSessionModel->togglePictureInPicture();
 }
 
 - (void)_touchDetected:(id)sender

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1195,11 +1195,11 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
                     });
                     videoPresentationManager->addVideoInPictureInPictureDidChangeObserver(*_pipObserver);
                 }
-                if (auto* videoPresentationInterface = videoPresentationManager ? videoPresentationManager->returningToStandbyInterface() : nullptr) {
+                if (RefPtr videoPresentationInterface = videoPresentationManager ? videoPresentationManager->returningToStandbyInterface() : nullptr) {
                     if (_returnToFullscreenFromPictureInPicture)
                         videoPresentationInterface->preparedToReturnToStandby();
                     else if (videoPresentationInterface->inPictureInPicture()) {
-                        if (auto model = videoPresentationInterface->videoPresentationModel()) {
+                        if (RefPtr model = videoPresentationInterface->videoPresentationModel()) {
                             _enterFullscreenNeedsExitPictureInPicture = YES;
                             model->requestFullscreenMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModeNone);
                         }
@@ -1397,7 +1397,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         manager->didExitFullScreen();
     }
 
-    auto* videoPresentationInterface = self._videoPresentationManager ? self._videoPresentationManager->controlsManagerInterface() : nullptr;
+    RefPtr videoPresentationInterface = self._videoPresentationManager ? self._videoPresentationManager->controlsManagerInterface() : nullptr;
     _shouldReturnToFullscreenFromPictureInPicture = videoPresentationInterface && videoPresentationInterface->inPictureInPicture();
 
     [_window setHidden:YES];
@@ -1487,7 +1487,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 - (void)didExitPictureInPicture
 {
     if (!_enterFullscreenNeedsExitPictureInPicture && _shouldReturnToFullscreenFromPictureInPicture) {
-        auto* videoPresentationInterface = self._videoPresentationManager ? self._videoPresentationManager->returningToStandbyInterface() : nullptr;
+        RefPtr videoPresentationInterface = self._videoPresentationManager ? self._videoPresentationManager->returningToStandbyInterface() : nullptr;
         if (videoPresentationInterface && videoPresentationInterface->returningToStandby()) {
             OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, "returning to standby");
             if (!_exitingFullScreen) {

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -132,11 +132,11 @@ private:
 
     explicit PlaybackSessionManager(WebPage&);
 
-    typedef std::tuple<RefPtr<WebCore::PlaybackSessionModelMediaElement>, RefPtr<PlaybackSessionInterfaceContext>> ModelInterfaceTuple;
+    typedef std::tuple<Ref<WebCore::PlaybackSessionModelMediaElement>, Ref<PlaybackSessionInterfaceContext>> ModelInterfaceTuple;
     ModelInterfaceTuple createModelAndInterface(PlaybackSessionContextIdentifier);
-    ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier);
-    WebCore::PlaybackSessionModelMediaElement& ensureModel(PlaybackSessionContextIdentifier);
-    PlaybackSessionInterfaceContext& ensureInterface(PlaybackSessionContextIdentifier);
+    const ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier);
+    Ref<WebCore::PlaybackSessionModelMediaElement> ensureModel(PlaybackSessionContextIdentifier);
+    Ref<PlaybackSessionInterfaceContext> ensureInterface(PlaybackSessionContextIdentifier);
     void removeContext(PlaybackSessionContextIdentifier);
     void addClientForContext(PlaybackSessionContextIdentifier);
     void removeClientForContext(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -168,11 +168,11 @@ protected:
 
     explicit VideoPresentationManager(WebPage&, PlaybackSessionManager&);
 
-    typedef std::tuple<RefPtr<WebCore::VideoPresentationModelVideoElement>, RefPtr<VideoPresentationInterfaceContext>> ModelInterfaceTuple;
+    typedef std::tuple<Ref<WebCore::VideoPresentationModelVideoElement>, Ref<VideoPresentationInterfaceContext>> ModelInterfaceTuple;
     ModelInterfaceTuple createModelAndInterface(PlaybackSessionContextIdentifier, bool createLayerHostingContext);
-    ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier, bool createLayerHostingContext = true);
-    WebCore::VideoPresentationModelVideoElement& ensureModel(PlaybackSessionContextIdentifier);
-    VideoPresentationInterfaceContext& ensureInterface(PlaybackSessionContextIdentifier);
+    const ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier, bool createLayerHostingContext = true);
+    Ref<WebCore::VideoPresentationModelVideoElement> ensureModel(PlaybackSessionContextIdentifier);
+    Ref<VideoPresentationInterfaceContext> ensureInterface(PlaybackSessionContextIdentifier);
     void removeContext(PlaybackSessionContextIdentifier);
     void addClientForContext(PlaybackSessionContextIdentifier);
     void removeClientForContext(PlaybackSessionContextIdentifier);


### PR DESCRIPTION
#### eb83b03a1b126f855603d1dc66332d493531b53f
<pre>
REGRESSION (281109@main?): [ Guard-Malloc ] media/media-source/media-managedmse-video-with-poster.html is constantly crashing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277395">https://bugs.webkit.org/show_bug.cgi?id=277395</a>
<a href="https://rdar.apple.com/132767136">rdar://132767136</a>

Reviewed by Youenn Fablet.

It was possible for the VideoPresentationInterfaceIOS to be removed from the
VideoPresentationManagerProxy&apos;s contexts HashMap. We adopt more smart pointers
adoption to get around the issue of the interface potentially being deleted
while exiting fullscreen.
We adopt the use of `Ref` in the HashMap for model/interface as they can never contained
null pointers. Which helps simplify the code in some instances and remove unnecessary tests.
Fly-by: Running some tests in debug mode triggered an assertion in `VideoPresentationManager::removeClientForContext`
We had handling for this case instead and exit early if the VideoPresentationManager had no client left.

Covered by existing tests.

* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::finalizeSetup):
(WebKit::VideoPresentationInterfaceLMK::presentFullscreen):
(WebKit::VideoPresentationInterfaceLMK::dismissFullscreen):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::createModelAndInterface):
(WebKit::PlaybackSessionManagerProxy::ensureModelAndInterface):
(WebKit::PlaybackSessionManagerProxy::ensureModel):
(WebKit::PlaybackSessionManagerProxy::ensureInterface):
(WebKit::PlaybackSessionManagerProxy::removeClientForContext):
(WebKit::PlaybackSessionManagerProxy::setUpPlaybackControlsManagerWithID):
(WebKit::PlaybackSessionManagerProxy::currentTimeChanged):
(WebKit::PlaybackSessionManagerProxy::bufferedTimeChanged):
(WebKit::PlaybackSessionManagerProxy::seekableRangesVectorChanged):
(WebKit::PlaybackSessionManagerProxy::canPlayFastReverseChanged):
(WebKit::PlaybackSessionManagerProxy::audioMediaSelectionOptionsChanged):
(WebKit::PlaybackSessionManagerProxy::legibleMediaSelectionOptionsChanged):
(WebKit::PlaybackSessionManagerProxy::audioMediaSelectionIndexChanged):
(WebKit::PlaybackSessionManagerProxy::legibleMediaSelectionIndexChanged):
(WebKit::PlaybackSessionManagerProxy::externalPlaybackPropertiesChanged):
(WebKit::PlaybackSessionManagerProxy::wirelessVideoPlaybackDisabledChanged):
(WebKit::PlaybackSessionManagerProxy::mutedChanged):
(WebKit::PlaybackSessionManagerProxy::volumeChanged):
(WebKit::PlaybackSessionManagerProxy::durationChanged):
(WebKit::PlaybackSessionManagerProxy::playbackStartedTimeChanged):
(WebKit::PlaybackSessionManagerProxy::rateChanged):
(WebKit::PlaybackSessionManagerProxy::pictureInPictureSupportedChanged):
(WebKit::PlaybackSessionManagerProxy::isInWindowFullscreenActiveChanged):
(WebKit::PlaybackSessionManagerProxy::supportsLinearMediaPlayerChanged):
(WebKit::PlaybackSessionManagerProxy::setVideoReceiverEndpoint):
(WebKit::PlaybackSessionManagerProxy::controlsManagerInterface):
(WebKit::PlaybackSessionManagerProxy::isPaused const):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::controlsManagerInterface):
(WebKit::VideoPresentationManagerProxy::createModelAndInterface):
(WebKit::VideoPresentationManagerProxy::ensureModelAndInterface):
(WebKit::VideoPresentationManagerProxy::ensureModel):
(WebKit::VideoPresentationManagerProxy::ensureInterface):
(WebKit::VideoPresentationManagerProxy::findInterface const):
(WebKit::VideoPresentationManagerProxy::forEachSession):
(WebKit::VideoPresentationManagerProxy::createLayerWithID):
(WebKit::VideoPresentationManagerProxy::createLayerHostViewWithID):
(WebKit::VideoPresentationManagerProxy::returningToStandbyInterface const):
(WebKit::VideoPresentationManagerProxy::createViewWithID):
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
(WebKit::VideoPresentationManagerProxy::setPlayerIdentifier):
(WebKit::VideoPresentationManagerProxy::setHasVideo):
(WebKit::VideoPresentationManagerProxy::setVideoDimensions):
(WebKit::VideoPresentationManagerProxy::exitFullscreen):
(WebKit::VideoPresentationManagerProxy::exitFullscreenWithoutAnimationToMode):
(WebKit::VideoPresentationManagerProxy::setVideoFullscreenMode):
(WebKit::VideoPresentationManagerProxy::clearVideoFullscreenMode):
(WebKit::VideoPresentationManagerProxy::setInlineRect):
(WebKit::VideoPresentationManagerProxy::setHasVideoContentLayer):
(WebKit::VideoPresentationManagerProxy::cleanupFullscreen):
(WebKit::VideoPresentationManagerProxy::preparedToReturnToInline):
(WebKit::VideoPresentationManagerProxy::preparedToExitFullscreen):
(WebKit::VideoPresentationManagerProxy::textTrackRepresentationUpdate):
(WebKit::VideoPresentationManagerProxy::textTrackRepresentationSetContentsScale):
(WebKit::VideoPresentationManagerProxy::textTrackRepresentationSetHidden):
(WebKit::VideoPresentationManagerProxy::returnVideoView):
(WebKit::VideoPresentationManagerProxy::didExitFullscreen):
(WebKit::VideoPresentationManagerProxy::didEnterFullscreen):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):
(WebKit::VideoPresentationManagerProxy::playerViewController const):
(WebKit::VideoPresentationManagerProxy::playableViewController const):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController videoControlsManagerDidChange]):
(-[WKFullScreenViewController _togglePiPAction:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:]):
(-[WKFullScreenWindowController _completedExitFullScreen]):
(-[WKFullScreenWindowController didExitPictureInPicture]):
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::~PlaybackSessionManager):
(WebKit::PlaybackSessionManager::ensureModelAndInterface):
(WebKit::PlaybackSessionManager::ensureModel):
(WebKit::PlaybackSessionManager::ensureInterface):
(WebKit::PlaybackSessionManager::removeContext):
(WebKit::PlaybackSessionManager::setUpPlaybackControlsManager):
(WebKit::PlaybackSessionManager::contextIdForMediaElement):
(WebKit::PlaybackSessionManager::play):
(WebKit::PlaybackSessionManager::pause):
(WebKit::PlaybackSessionManager::togglePlayState):
(WebKit::PlaybackSessionManager::beginScrubbing):
(WebKit::PlaybackSessionManager::endScrubbing):
(WebKit::PlaybackSessionManager::seekToTime):
(WebKit::PlaybackSessionManager::fastSeek):
(WebKit::PlaybackSessionManager::beginScanningForward):
(WebKit::PlaybackSessionManager::beginScanningBackward):
(WebKit::PlaybackSessionManager::endScanning):
(WebKit::PlaybackSessionManager::setDefaultPlaybackRate):
(WebKit::PlaybackSessionManager::setPlaybackRate):
(WebKit::PlaybackSessionManager::selectAudioMediaOption):
(WebKit::PlaybackSessionManager::handleControlledElementIDRequest):
(WebKit::PlaybackSessionManager::togglePictureInPicture):
(WebKit::PlaybackSessionManager::enterFullscreen):
(WebKit::PlaybackSessionManager::exitFullscreen):
(WebKit::PlaybackSessionManager::toggleInWindow):
(WebKit::PlaybackSessionManager::toggleMuted):
(WebKit::PlaybackSessionManager::setMuted):
(WebKit::PlaybackSessionManager::setVolume):
(WebKit::PlaybackSessionManager::setPlayingOnSecondScreen):
(WebKit::PlaybackSessionManager::sendRemoteCommand):
(WebKit::PlaybackSessionManager::setSoundStageSize):
(WebKit::PlaybackSessionManager::setSpatialTrackingLabel):
(WebKit::PlaybackSessionManager::forEachModel):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::~VideoPresentationManager):
(WebKit::VideoPresentationManager::ensureModelAndInterface):
(WebKit::VideoPresentationManager::ensureModel):
(WebKit::VideoPresentationManager::ensureInterface):
(WebKit::VideoPresentationManager::removeContext):
(WebKit::VideoPresentationManager::removeClientForContext):
(WebKit::VideoPresentationManager::enterVideoFullscreenForVideoElement):
(WebKit::VideoPresentationManager::exitVideoFullscreenForVideoElement):
(WebKit::VideoPresentationManager::exitVideoFullscreenToModeWithoutAnimation):
(WebKit::VideoPresentationManager::requestFullscreenMode):
(WebKit::VideoPresentationManager::returnVideoContentLayer):
(WebKit::VideoPresentationManager::failedToEnterFullscreen):
(WebKit::VideoPresentationManager::didExitFullscreen):
(WebKit::VideoPresentationManager::didCleanupFullscreen):
(WebKit::VideoPresentationManager::requestRouteSharingPolicyAndContextUID):
(WebKit::VideoPresentationManager::ensureUpdatedVideoDimensions):
(WebKit::VideoPresentationManager::setVideoFullscreenFrame):
(WebKit::VideoPresentationManager::setRequiresTextTrackRepresentation):
(WebKit::VideoPresentationManager::setTextTrackRepresentationBounds):

Canonical link: <a href="https://commits.webkit.org/281680@main">https://commits.webkit.org/281680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bd4a24090336e93289e31105f7ee4ad007fda64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64585 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/11201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11476 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/11201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52541 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9772 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10114 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66314 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4598 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4619 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52516 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13510 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3808 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->