### PR TITLE
'ended' is true while a seek to the duration is still pending, and the end-of-media 'timeupdate' fires after 'ended'

### DIFF
--- a/LayoutTests/http/tests/media/video-end-of-media-event-order-expected.txt
+++ b/LayoutTests/http/tests/media/video-end-of-media-event-order-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Reaching the end of the media resource by playing fires timeupdate, pause, then ended
+PASS Reaching the end of the media resource by seeking to the duration fires timeupdate, pause, then ended
+PASS ended is false while a seek to the duration is still pending
+

--- a/LayoutTests/http/tests/media/video-end-of-media-event-order.html
+++ b/LayoutTests/http/tests/media/video-end-of-media-event-order.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Event order when the current playback position reaches the end of the media resource</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/media.html#reaching-the-end-of-the-media-resource">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/media.html#dom-media-seek">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+// "When the current playback position reaches the end of the media resource when the
+// direction of playback is forwards" the user agent must, in this order:
+//   3. Queue a task to fire an event named timeupdate,
+//   4. ... set paused to true and fire an event named pause,
+//   5. Queue a task to fire an event named ended.
+// The end can be reached either by ordinary playback or by seeking to the duration; the
+// seek algorithm sets the current playback position in step 11, which "can immediately
+// trigger other conditions, such as the rules regarding when playback reaches the end of
+// the media resource".
+
+const LOGGED_EVENTS = ["seeking", "seeked", "timeupdate", "pause", "ended"];
+
+function setupVideo(t) {
+    const video = document.createElement("video");
+    video.muted = true;
+    video.preload = "auto";
+    document.body.appendChild(video);
+    t.add_cleanup(() => {
+        video.pause();
+        video.removeAttribute("src");
+        video.remove();
+    });
+
+    const log = [];
+    for (const type of LOGGED_EVENTS)
+        video.addEventListener(type, () => log.push(type));
+
+    return { video, log };
+}
+
+function waitForEvent(video, type) {
+    return new Promise(resolve => video.addEventListener(type, resolve, { once: true }));
+}
+
+// The number of periodic 'timeupdate' events is not observable behaviour, but their
+// position relative to 'seeked', 'pause' and 'ended' is; collapse runs of one event type
+// down to a single entry before comparing sequences.
+function collapseRuns(log) {
+    return log.filter((type, index) => type !== log[index - 1]);
+}
+
+async function playFromLoadedData(video) {
+    video.src = "resources/test.mp4";
+    // Deliberately not awaiting the play() promise: a seek issued while playback is still
+    // getting under way is what makes the seek completion and the end of the media resource
+    // be handled in the same turn.
+    video.play().catch(() => { });
+    await waitForEvent(video, "loadeddata");
+    assert_false(video.paused, "video is playing");
+    assert_less_than(video.currentTime, video.duration, "playback position is before the end");
+}
+
+promise_test(async t => {
+    const { video, log } = setupVideo(t);
+    await playFromLoadedData(video);
+
+    // Play out the last fraction of a second rather than the whole resource.
+    video.currentTime = Math.max(0, video.duration - 0.3);
+    await waitForEvent(video, "ended");
+
+    assert_true(video.ended, "ended is true");
+    assert_true(video.paused, "paused is true");
+    assert_array_equals(collapseRuns(log).slice(-3), ["timeupdate", "pause", "ended"],
+        `'timeupdate', 'pause' then 'ended' must end the sequence, got: ${log.join(" ")}`);
+}, "Reaching the end of the media resource by playing fires timeupdate, pause, then ended");
+
+promise_test(async t => {
+    const { video, log } = setupVideo(t);
+    await playFromLoadedData(video);
+
+    video.currentTime = video.duration;
+    await waitForEvent(video, "ended");
+
+    // The end-of-media 'timeupdate' (step 3 of reaching the end of the media resource) is
+    // distinct from the seek algorithm's own 'timeupdate' (step 16), and both precede
+    // 'pause': the seek completes, and only then is the end of the resource reached.
+    const seekedIndex = log.indexOf("seeked");
+    const pauseIndex = log.indexOf("pause");
+    assert_not_equals(seekedIndex, -1, `'seeked' must fire, got: ${log.join(" ")}`);
+    assert_not_equals(pauseIndex, -1, `'pause' must fire, got: ${log.join(" ")}`);
+    assert_true(log.slice(seekedIndex + 1, pauseIndex).includes("timeupdate"),
+        `a 'timeupdate' must fire between 'seeked' and 'pause', got: ${log.join(" ")}`);
+
+    assert_array_equals(collapseRuns(log.slice(log.indexOf("seeking"))),
+        ["seeking", "timeupdate", "seeked", "timeupdate", "pause", "ended"],
+        `unexpected event sequence: ${log.join(" ")}`);
+}, "Reaching the end of the media resource by seeking to the duration fires timeupdate, pause, then ended");
+
+promise_test(async t => {
+    const { video } = setupVideo(t);
+    await playFromLoadedData(video);
+
+    video.currentTime = video.duration;
+
+    // Setting currentTime updates the official playback position synchronously, but the
+    // current playback position is only set in step 11 of the seek algorithm, which runs
+    // after the script continues. Ended playback is defined in terms of the current
+    // playback position, so it cannot have become true yet.
+    assert_true(video.seeking, "seeking is true");
+    assert_equals(video.currentTime, video.duration, "currentTime is the official playback position");
+    assert_false(video.ended, "ended is false while the seek to the duration is pending");
+
+    await waitForEvent(video, "seeked");
+}, "ended is false while a seek to the duration is still pending");
+</script>

--- a/LayoutTests/http/tests/media/video-seek-to-duration-expected.txt
+++ b/LayoutTests/http/tests/media/video-seek-to-duration-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Test event dispatches and attribute changes for seek to duration. assert_equals: expected false but got true
+

--- a/LayoutTests/http/tests/media/video-seek-to-duration-expected.txt
+++ b/LayoutTests/http/tests/media/video-seek-to-duration-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Test event dispatches and attribute changes for seek to duration.
+

--- a/LayoutTests/http/tests/media/video-seek-to-duration.html
+++ b/LayoutTests/http/tests/media/video-seek-to-duration.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<title>Test event dispatches and attribute changes for seek to duration.</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<video></video>
+<script>
+async_test(function(t) {
+    var video = document.querySelector("video");
+
+    var watcher = new EventWatcher(t, video, ["durationchange", "loadedmetadata",
+        "loadeddata", "seeking", "timeupdate", "seeked", "pause", "ended"]);
+
+    watcher.wait_for(["durationchange", "loadedmetadata", "loadeddata"]).then(t.step_func(function() {
+        // Seek to the duration of the media.
+        assert_less_than(video.currentTime, video.duration);
+        assert_false(video.ended)
+        assert_false(video.paused);
+        //Starting seek to duration by setting video.currentTime to video.duration.
+        video.currentTime = video.duration;
+        testCommonAttributes({'seeking': true, 'ended': false});
+        return watcher.wait_for("seeking");
+    })).then(t.step_func(function() {
+        testCommonAttributes({'seeking': true, 'ended': false});
+        assert_false(video.paused);
+        return watcher.wait_for("timeupdate");
+    })).then(t.step_func(function() {
+        // Exactly when 'video.ended' will become true may vary between the
+        // start of the seek until the pause for ended.
+        testCommonAttributes({'seeking': false});
+        return watcher.wait_for("seeked");
+    })).then(t.step_func(function() {
+        testCommonAttributes({'seeking': false});
+        return watcher.wait_for("timeupdate");
+    })).then(t.step_func(function() {
+        testCommonAttributes({'seeking': false});
+        return watcher.wait_for("pause");
+    })).then(t.step_func(function() {
+        assert_true(video.paused, "should be paused after seeking");
+        testCommonAttributes({'seeking': false, 'ended': true});
+        return watcher.wait_for("ended");
+    })).then(t.step_func_done(function() {
+        testCommonAttributes({'seeking': false, 'ended': true});
+        assert_true(video.paused, "should be paused upon ended");
+    }));
+
+    function testCommonAttributes(testExpectations) {
+        assert_equals(video.seeking, testExpectations.seeking);
+        if ('ended' in testExpectations)
+            assert_equals(video.ended, testExpectations.ended);
+        assert_equals(video.currentTime, video.duration);
+    }
+
+    video.src = "resources/test.mp4";;
+    video.play();
+});
+</script>

--- a/LayoutTests/http/tests/media/video-seek-to-duration.html
+++ b/LayoutTests/http/tests/media/video-seek-to-duration.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<title>Test event dispatches and attribute changes for seek to duration.</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<video></video>
+<script>
+async_test(function(t) {
+    var video = document.querySelector("video");
+
+    var watcher = new EventWatcher(t, video, ["durationchange", "loadedmetadata",
+        "loadeddata", "seeking", "timeupdate", "seeked", "pause", "ended"]);
+
+    watcher.wait_for(["durationchange", "loadedmetadata", "loadeddata"]).then(t.step_func(function() {
+        // Seek to the duration of the media.
+        assert_less_than(video.currentTime, video.duration);
+        assert_false(video.ended)
+        assert_false(video.paused);
+        //Starting seek to duration by setting video.currentTime to video.duration.
+        video.currentTime = video.duration;
+        testCommonAttributes({'seeking': true, 'ended': false});
+        return watcher.wait_for("seeking");
+    })).then(t.step_func(function() {
+        testCommonAttributes({'seeking': true, 'ended': false});
+        assert_false(video.paused);
+        return watcher.wait_for("timeupdate");
+    })).then(t.step_func(function() {
+        // Exactly when 'video.ended' will become true may vary between the
+        // start of the seek until the pause for ended.
+        testCommonAttributes({'seeking': false});
+        return watcher.wait_for("seeked");
+    })).then(t.step_func(function() {
+        testCommonAttributes({'seeking': false});
+        return watcher.wait_for("timeupdate");
+    })).then(t.step_func(function() {
+        testCommonAttributes({'seeking': false});
+        return watcher.wait_for("pause");
+    })).then(t.step_func(function() {
+        assert_true(video.paused, "should be paused after seeking");
+        testCommonAttributes({'seeking': false, 'ended': true});
+        return watcher.wait_for("ended");
+    })).then(t.step_func_done(function() {
+        testCommonAttributes({'seeking': false, 'ended': true});
+        assert_true(video.paused, "should be paused upon ended");
+    }));
+
+    function testCommonAttributes(testExpectations) {
+        assert_equals(video.seeking, testExpectations.seeking);
+        if ('ended' in testExpectations)
+            assert_equals(video.ended, testExpectations.ended);
+        assert_equals(video.currentTime, video.duration);
+    }
+
+    // Muted so that the test is also runnable in browsers that gate unmuted playback on a
+    // user gesture.
+    video.muted = true;
+    video.src = "resources/test.mp4";
+    video.play();
+});
+</script>

--- a/LayoutTests/http/tests/media/video-seek-to-middle-expected.txt
+++ b/LayoutTests/http/tests/media/video-seek-to-middle-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Test event dispatches and attribute changes for seek to middle.
+

--- a/LayoutTests/http/tests/media/video-seek-to-middle.html
+++ b/LayoutTests/http/tests/media/video-seek-to-middle.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<title>Test event dispatches and attribute changes for seek to middle.</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<video></video>
+<script>
+async_test(function(t) {
+    var video = document.querySelector("video");
+
+    video.onended = t.unreached_func();
+
+    var watcher = new EventWatcher(t, video, ["durationchange", "loadedmetadata", "loadeddata", "seeking", "timeupdate", "seeked"]);
+
+    watcher.wait_for(["durationchange", "loadedmetadata", "loadeddata"]).then(t.step_func(function() {
+        assert_less_than(video.currentTime, video.duration);
+        assert_false(video.ended);
+        assert_false(video.seeking);
+        assert_false(video.paused);
+        // Starting seek to middle by setting video.currentTime to half the duration.
+        video.currentTime = video.duration / 2;
+        testCommonAttributes(true);
+        assert_less_than(video.currentTime, video.duration);
+        assert_greater_than(video.currentTime, 0);
+        return watcher.wait_for("seeking");
+    })).then(t.step_func(function() {
+        testCommonAttributes(true);
+        return watcher.wait_for("timeupdate");
+    })).then(t.step_func(function() {
+        testCommonAttributes(false);
+        return watcher.wait_for("seeked");
+    })).then(t.step_func_done(function() {
+        testCommonAttributes(false);
+    }));
+
+    function testCommonAttributes(seekingExpected) {
+        assert_equals(video.seeking, seekingExpected);
+        assert_false(video.ended);
+        const tolerance = 0.0001;
+        if (seekingExpected) {
+            assert_approx_equals(video.currentTime, video.duration / 2, tolerance);
+        } else {
+            // If seek has completed, the currentTime may have advanced slightly
+            // beyond the initial seek point since the video is not paused.
+            assert_greater_than_equal(
+                video.currentTime, video.duration / 2 - tolerance);
+        }
+        assert_false(video.paused);
+    }
+
+    video.src = "resources/test.mp4";
+    video.play();
+});
+</script>

--- a/LayoutTests/http/tests/media/video-seek-to-middle.html
+++ b/LayoutTests/http/tests/media/video-seek-to-middle.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<title>Test event dispatches and attribute changes for seek to middle.</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<video></video>
+<script>
+async_test(function(t) {
+    var video = document.querySelector("video");
+
+    video.onended = t.unreached_func();
+
+    var watcher = new EventWatcher(t, video, ["durationchange", "loadedmetadata", "loadeddata", "seeking", "timeupdate", "seeked"]);
+
+    watcher.wait_for(["durationchange", "loadedmetadata", "loadeddata"]).then(t.step_func(function() {
+        assert_less_than(video.currentTime, video.duration);
+        assert_false(video.ended);
+        assert_false(video.seeking);
+        assert_false(video.paused);
+        // Starting seek to middle by setting video.currentTime to half the duration.
+        video.currentTime = video.duration / 2;
+        testCommonAttributes(true);
+        assert_less_than(video.currentTime, video.duration);
+        assert_greater_than(video.currentTime, 0);
+        return watcher.wait_for("seeking");
+    })).then(t.step_func(function() {
+        testCommonAttributes(true);
+        return watcher.wait_for("timeupdate");
+    })).then(t.step_func(function() {
+        testCommonAttributes(false);
+        return watcher.wait_for("seeked");
+    })).then(t.step_func_done(function() {
+        testCommonAttributes(false);
+    }));
+
+    function testCommonAttributes(seekingExpected) {
+        assert_equals(video.seeking, seekingExpected);
+        assert_false(video.ended);
+        const tolerance = 0.0001;
+        if (seekingExpected) {
+            assert_approx_equals(video.currentTime, video.duration / 2, tolerance);
+        } else {
+            // If seek has completed, the currentTime may have advanced slightly
+            // beyond the initial seek point since the video is not paused.
+            assert_greater_than_equal(
+                video.currentTime, video.duration / 2 - tolerance);
+        }
+        assert_false(video.paused);
+    }
+
+    // Muted so that the test is also runnable in browsers that gate unmuted playback on a
+    // user gesture.
+    video.muted = true;
+    video.src = "resources/test.mp4";
+    video.play();
+});
+</script>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6337,6 +6337,16 @@ void HTMLMediaElement::handlePlaybackPositionChanged()
 
             ALWAYS_LOG(LOGIDENTIFIER, "current time (", now, ") is greater then duration (", dur, ") or <= 0, pausing");
 
+            // Queue a task to fire a simple event named timeupdate at the media element.
+            // This is the first step of the "reached the end of the media resource" steps, so it
+            // must precede 'pause' and 'ended'. In the ordinary playback case mediaPlayerTimeChanged()
+            // has already scheduled this timeupdate for the same movie time, and the movie time filter
+            // in scheduleTimeupdateEvent() drops this one; when the end is reached by seeking to the
+            // duration, the seek callback calls us directly and this is the only site that queues it.
+            // (Reaching the earliest possible position while playing backwards queues a timeupdate and
+            // nothing else, which is also covered here.)
+            scheduleTimeupdateEvent(false);
+
             // If the media element does not have a current media controller, and the media element
             // has still ended playback and paused is false,
             if (!m_mediaController && !m_paused) {
@@ -6802,6 +6812,17 @@ bool HTMLMediaElement::endedPlayback() const
     // A media element is said to have ended playback when the element's
     // readyState attribute is HAVE_METADATA or greater,
     if (m_readyState < HAVE_METADATA)
+        return false;
+
+    // A seek that is still in flight has not moved the current playback position yet:
+    // currentMediaTime() reports the seek target while m_seeking is set, which is the official
+    // playback position (updated before the script continues), not the current playback
+    // position (set in 4.8.10.9 Seeking, step 11). Ended playback is defined in terms of the
+    // latter, and the element learns of it when the media engine reports the seek complete and
+    // finishSeek() runs the steps for reaching the end of the media resource. Reporting ended
+    // before that would make 'ended' true as soon as a seek to the duration was started, and
+    // would depend on how promptly the engine's reported time caught up with the target.
+    if (m_seeking)
         return false;
 
     // and the current playback position is the end of the media resource and the direction


### PR DESCRIPTION
#### 152382bdc89e32b30fb4687c904b5eebb7160484
<pre>
&apos;ended&apos; is true while a seek to the duration is still pending, and the end-of-media &apos;timeupdate&apos; fires after &apos;ended&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=119285">https://bugs.webkit.org/show_bug.cgi?id=119285</a>

Reviewed by NOBODY (OOPS!).

Seeking to the duration of a playing media element diverged from the HTML specification in
two ways, both observable from script:

1. &apos;ended&apos; became true while the seek was still in flight, as early as synchronously from
`video.currentTime = video.duration`, before the &apos;seeking&apos; event had been fired.
currentMediaTime() returns m_lastSeekTime while m_seeking is set, so endedPlayback()
compared the seek target, rather than the current playback position, against the duration.
The seek algorithm only sets the current playback position in step 11, and the currentTime
attribute &quot;returns the official playback position, not the current playback position, and
therefore gets updated before script execution, separate from this algorithm&quot;, whereas
ended playback is defined in terms of the current playback position. The element learns
that the position reached the end of the media resource when the media engine reports the
seek complete and finishSeek() runs, so report not-ended until then. Deriving it from the
engine&apos;s reported time instead is racy: with the GPU process, the remote player&apos;s estimated
time can reach the target while the seek is still in flight, which made the behaviour
depend on timing.

2. The end-of-media &apos;timeupdate&apos; was dispatched after &apos;pause&apos; and &apos;ended&apos; rather than
before them. handlePlaybackPositionChanged() relied on mediaPlayerTimeChanged() having
already scheduled it, which does not happen when the end of the media resource is reached
by seeking to the duration: the seek completion callback calls finishSeek() and
handlePlaybackPositionChanged() directly. Schedule it where the specification does, as the
first of the steps for reaching the end of the media resource. The movie time filter in
scheduleTimeupdateEvent() drops it as a duplicate on the ordinary playback path, so no
additional event is dispatched there. This also covers reaching the earliest possible
position while playing backwards, for which a &apos;timeupdate&apos; is the only event the
specification requires.

Specifications:
* <a href="https://html.spec.whatwg.org/#seeking">https://html.spec.whatwg.org/#seeking</a>
* <a href="https://html.spec.whatwg.org/multipage/media.html#media-resource">https://html.spec.whatwg.org/multipage/media.html#media-resource</a>
* <a href="https://html.spec.whatwg.org/multipage/media.html#ended-playback">https://html.spec.whatwg.org/multipage/media.html#ended-playback</a>

Chrome and Firefox both keep &apos;ended&apos; false while the seek is pending, and both dispatch a
&apos;timeupdate&apos; before &apos;pause&apos;. video-seek-to-duration.html, merged from Blink along with
video-seek-to-middle.html, now passes, so its expectation is updated accordingly:

Merge (Test only): <a href="https://chromium.googlesource.com/chromium/blink/+/36c0ea867becef18abb14681975018bb8cb69169">https://chromium.googlesource.com/chromium/blink/+/36c0ea867becef18abb14681975018bb8cb69169</a>

The new test asserts the event order for both ways of reaching the end of the media
resource, and passes in Chrome and Firefox as well. It collapses runs of &apos;timeupdate&apos;
instead of counting them, since the number of periodic timeupdates is not observable
behaviour: Firefox dispatches more of them than WebKit and Chrome do, which is why the
stricter Blink test fails there.

* LayoutTests/http/tests/media/video-end-of-media-event-order-expected.txt: Added.
* LayoutTests/http/tests/media/video-end-of-media-event-order.html: Added.
* LayoutTests/http/tests/media/video-seek-to-duration-expected.txt: Added.
* LayoutTests/http/tests/media/video-seek-to-duration.html: Added. Muted, so that the test
is also runnable in browsers that gate unmuted playback on a user gesture.
* LayoutTests/http/tests/media/video-seek-to-middle-expected.txt: Added.
* LayoutTests/http/tests/media/video-seek-to-middle.html: Added. Ditto.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::handlePlaybackPositionChanged):
(WebCore::HTMLMediaElement::endedPlayback const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/152382bdc89e32b30fb4687c904b5eebb7160484

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/55283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/197929 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/152273 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/atp/a1eb2ed0-b2dc-11f1-e105-f14d5cb12fbd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/189598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/62970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/61278 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146582 "Found 1 new test failure: media/media-source/media-managedmse-no-streaming-toggle-at-end.html (failure)") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/101297 "An unexpected error occured in step: Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/atp/a1eb2ed0-b2dc-11f1-0f40-76d8815adfc0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/50319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/167046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/127099 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/atp/a1eb2ed0-b2dc-11f1-3d22-c68eb4673837) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/49056 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46871 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/159322 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46678 "Found 1 new test failure: media/media-source/media-managedmse-no-streaming-toggle-at-end.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/9039 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/53961 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51465 "Found 1 new test failure: media/media-source/media-managedmse-no-streaming-toggle-at-end.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/199978 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/61153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/166594 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/156280 "Found 1 new test failure: media/media-source/media-managedmse-no-streaming-toggle-at-end.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/61874 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/43167 "Found 1 new test failure: media/media-source/media-managedmse-no-streaming-toggle-at-end.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155922 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/50225 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133994 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/131622 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/60244 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21662 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59656 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59839 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59812 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->