### PR TITLE
View stability should be updated for Overlay Regions

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -382,6 +382,10 @@ struct PerWebProcessState {
 #if ENABLE(GAMEPAD)
     RetainPtr<id> _gamepadsRecentlyAccessedState;
 #endif
+
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    BOOL _isScrollingWithOverlayRegion;
+#endif
 }
 
 - (BOOL)_isValid;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2050,6 +2050,10 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     if (![self usesStandardContentView])
         return;
 
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    _isScrollingWithOverlayRegion = NO;
+#endif
+
     [self _scheduleVisibleContentRectUpdate];
     [_contentView didFinishScrolling];
 
@@ -2126,9 +2130,11 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     if (update._scrollDeviceCategory == _UIScrollDeviceCategoryOverlayScroll) {
+        _isScrollingWithOverlayRegion = YES;
         completion(isHandledByDefault);
         return;
     }
+    _isScrollingWithOverlayRegion = NO;
 #endif
 
 #if !USE(BROWSERENGINEKIT)
@@ -2604,6 +2610,11 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
         stabilityFlags.add(WebKit::ViewStabilityFlag::ScrollViewInteracting);
     if (scrollView.isDecelerating || scrollView._wk_isZoomAnimating || scrollView._wk_isScrollAnimating || scrollView.isZoomBouncing)
         stabilityFlags.add(WebKit::ViewStabilityFlag::ScrollViewAnimatedScrollOrZoom);
+
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    if (_isScrollingWithOverlayRegion)
+        stabilityFlags.add(WebKit::ViewStabilityFlag::ScrollViewAnimatedScrollOrZoom);
+#endif
 
     if (scrollView == _scrollView.get() && _isChangingObscuredInsetsInteractively)
         stabilityFlags.add(WebKit::ViewStabilityFlag::ChangingObscuredInsetsInteractively);


### PR DESCRIPTION
#### 90022b521582044d73a2d72d0606deb092108d39
<pre>
View stability should be updated for Overlay Regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=277415">https://bugs.webkit.org/show_bug.cgi?id=277415</a>
&lt;<a href="https://rdar.apple.com/125444317">rdar://125444317</a>&gt;

Reviewed by Wenson Hsieh and Simon Fraser.

Scroll updates with the overlay scroll device category should be treated
as animations when it comes to view stability.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
Introduce a new boolean for scrolling with overlay regions.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didFinishScrolling:]):
(-[WKWebView scrollView:handleScrollUpdate:completion:]):
Update the new state based on the scroll device category.
(-[WKWebView _viewStabilityState:]):
Flag the view stability state as animating when using overlay regions.

Canonical link: <a href="https://commits.webkit.org/281692@main">https://commits.webkit.org/281692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e682ac72a710b331c6e8d6da769b018af64fbbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64502 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11118 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48999 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7728 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29832 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33885 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10031 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55747 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66232 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56366 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56543 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13527 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3747 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35738 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36821 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->