### PR TITLE
Implement MediaSession setCameraActive, setMicrophoneActive and setScreenshareActive

### DIFF
--- a/LayoutTests/http/wpt/mediasession/setCaptureState-audio-category-expected.txt
+++ b/LayoutTests/http/wpt/mediasession/setCaptureState-audio-category-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Use MediaSession to play recorded audio with MediaPlayback category
+

--- a/LayoutTests/http/wpt/mediasession/setCaptureState-audio-category.html
+++ b/LayoutTests/http/wpt/mediasession/setCaptureState-audio-category.html
@@ -1,0 +1,84 @@
+<html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<video id=video autoplay playsinline controls></video>
+<script>
+function validateInternalAudioCategory(expectedCategory)
+{
+    if (!window.internals)
+        return;
+    assert_equals(internals.audioSessionCategory(), expectedCategory);
+}
+
+async function waitForInternalAudioCategory(expectedCategory)
+{
+    let counter = 0;
+    while (++counter < 50) {
+        if (internals.audioSessionCategory() !== expectedCategory)
+           await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    assert_equals(internals.audioSessionCategory(), expectedCategory, "waitForInternalAudioCategory");
+}
+
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const track = stream.getTracks()[0];
+
+    const recorder = new MediaRecorder(stream);
+    recorder.start();
+    let blobs = [];
+    let resolveCallback;
+    let promise = new Promise((resolve, reject) => {
+        resolveCallback = resolve;
+        setTimeout(() => reject("blob promise rejected"), 5000);
+    });
+    recorder.ondataavailable = e => {
+       if (e.data.size)
+           blobs.push(e.data);
+       if (blobs.length > 1)
+           resolveCallback();
+    }
+    const timer = setInterval(() => recorder.requestData(), 200);
+    await Promise.all([
+        promise,
+        new Promise(resolve => setTimeout(resolve, 1000)),
+    ]);
+    clearInterval(timer);
+
+    validateInternalAudioCategory("PlayAndRecord");
+
+    assert_greater_than(blobs.length, 0);
+
+    const blob = new Blob(blobs, { type: blobs[blobs.length - 1].type });
+    video.srcObject = blob;
+    await video.play();
+
+    validateInternalAudioCategory("PlayAndRecord");
+
+    video.pause();
+
+    await navigator.mediaSession.setMicrophoneActive(false);
+    await new Promise(resolve => track.onmute = resolve);
+
+    validateInternalAudioCategory("None");
+
+    await video.play();
+    await waitForInternalAudioCategory("MediaPlayback");
+
+    video.pause();
+
+    if (!window.internals)
+        return;
+
+    internals.withUserGesture(() => {
+        promise = navigator.mediaSession.setMicrophoneActive(true);
+    });
+    await promise;
+    await new Promise(resolve => track.onunmute = resolve);
+    validateInternalAudioCategory("PlayAndRecord");
+}, "Use MediaSession to play recorded audio with MediaPlayback category");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/mediasession/setCaptureState-expected.txt
+++ b/LayoutTests/http/wpt/mediasession/setCaptureState-expected.txt
@@ -1,0 +1,7 @@
+
+PASS MediaSession setCameraActive, setMicrophoneActive and setScreenshareActive are no ops if document is not capturing anything
+PASS MediaSession setCameraActive, setMicrophoneActive and setScreenshareActive are no ops if trying to deactivate while capture is already muted
+PASS togglecamera and mute/unmute events order
+PASS togglemicrophone and mute/unmute events order
+PASS togglescreenshare and mute/unmute events order
+

--- a/LayoutTests/http/wpt/mediasession/setCaptureState.html
+++ b/LayoutTests/http/wpt/mediasession/setCaptureState.html
@@ -1,0 +1,184 @@
+<html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+function waitForMuteEvent(track)
+{
+    assert_false(track.muted);
+    return new Promise((resolve, reject) => {
+        setTimeout(() => reject("waitForMuteEvent failed"), 5000);
+        track.onmute = resolve;
+    });
+}
+
+function waitForUnmuteEvent(track)
+{
+    assert_true(track.muted);
+    return new Promise((resolve, reject) => {
+        setTimeout(() => reject("waitForUnmuteEvent failed"), 5000);
+        track.onunmute = resolve;
+    });
+}
+
+function waitForAction(action)
+{
+    return new Promise((resolve, reject) => {
+        setTimeout(() => reject("promiseAction timed out"), 5000);
+        navigator.mediaSession.setActionHandler(action, details => {
+            resolve(details.isActivating);
+        });
+    });
+}
+
+function waitForNoAction(action)
+{
+    return new Promise((resolve, reject) => {
+        setTimeout(() => resolve(true), 50);
+        navigator.mediaSession.setActionHandler(action, details => {
+            reject(details.isActivating);
+        });
+    });
+}
+
+async function testTrackMuteUnmute(test, track, action, stateCallback, muteCallback)
+{
+    if (!window.internals)
+        return;
+
+    await stateCallback(false);
+    await Promise.all([
+        waitForMuteEvent(track),
+        waitForNoAction(action)
+    ]);
+
+    let promise;
+    internals.withUserGesture(() => {
+        promise = stateCallback(true);
+    });
+    await promise;
+    await Promise.all([
+        waitForUnmuteEvent(track),
+        waitForNoAction(action)
+    ]);
+
+    await muteCallback(true);
+    await waitForAction(action);
+    await waitForMuteEvent(track);
+
+    internals.withUserGesture(() => {
+        promise = stateCallback(true);
+    });
+    await promise_rejects_dom(test, "NotAllowedError", promise);
+
+    await muteCallback(false);
+    await waitForAction(action);
+    await waitForUnmuteEvent(track);
+
+    await stateCallback(false);
+    await Promise.all([
+        waitForMuteEvent(track),
+        waitForNoAction(action)
+    ]);
+
+    internals.withUserGesture(() => {
+        promise = stateCallback(true);
+    });
+    await promise;
+    await Promise.all([
+        waitForUnmuteEvent(track),
+        waitForNoAction(action)
+    ]);
+}
+
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    stream.getTracks()[0].stop();
+    stream.getTracks()[1].stop();
+
+    await navigator.mediaSession.setCameraActive(false);
+    await navigator.mediaSession.setMicrophoneActive(false);
+    await navigator.mediaSession.setScreenshareActive(false);
+
+    if (!window.internals)
+        return;
+
+    await promise_rejects_dom(test, "InvalidStateError", navigator.mediaSession.setCameraActive(true));
+    await promise_rejects_dom(test, "InvalidStateError", navigator.mediaSession.setMicrophoneActive(true));
+    await promise_rejects_dom(test, "InvalidStateError", navigator.mediaSession.setScreenshareActive(true));
+
+    let promise1, promise2, promise3;
+    internals.withUserGesture(() => {
+        promise1 = navigator.mediaSession.setCameraActive(true);
+        promise2 = navigator.mediaSession.setMicrophoneActive(true);
+        promise3 = navigator.mediaSession.setScreenshareActive(true);
+    });
+    return Promise.all([promise1, promise2, promise3]);
+}, "MediaSession setCameraActive, setMicrophoneActive and setScreenshareActive are no ops if document is not capturing anything");
+
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+
+    if (!window.internals)
+        return;
+
+    window.testRunner.setCaptureState(false, false, false);
+
+    await Promise.all([
+       new Promise(resolve => stream.getAudioTracks()[0].onmute = resolve),
+       new Promise(resolve => stream.getVideoTracks()[0].onmute = resolve),
+    ]);
+
+    await navigator.mediaSession.setCameraActive(false);
+    await navigator.mediaSession.setMicrophoneActive(false);
+    await navigator.mediaSession.setScreenshareActive(false);
+
+    await new Promise((resolve, reject) => {
+        stream.getAudioTracks()[0].onmute = () => reject("audio track mute");
+        stream.getAudioTracks()[0].onunmute = () => reject("audio track unmute");
+        stream.getVideoTracks()[0].onmute = () => reject("video track mute");
+        stream.getVideoTracks()[0].onunmute = () => reject("video track unmute");
+        setTimeout(resolve, 100);
+    });
+
+    stream.getTracks()[0].stop();
+    stream.getTracks()[1].stop();
+}, "MediaSession setCameraActive, setMicrophoneActive and setScreenshareActive are no ops if trying to deactivate while capture is already muted");
+
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    const track = stream.getTracks()[0];
+
+    await testTrackMuteUnmute(test, track, "togglecamera", (state) => navigator.mediaSession.setCameraActive(state), mute => window.testRunner.setCaptureState(!mute, true, true));
+
+    track.stop();
+}, "togglecamera and mute/unmute events order");
+
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const track = stream.getTracks()[0];
+
+    await testTrackMuteUnmute(test, track, "togglemicrophone", (state) => navigator.mediaSession.setMicrophoneActive(state), mute => window.testRunner.setCaptureState(true, !mute, true));
+
+    track.stop();
+}, "togglemicrophone and mute/unmute events order");
+
+promise_test(async (test) => {
+    if (!window.internals)
+        return;
+
+    let promise;
+    internals.withUserGesture(() => {
+        promise = navigator.mediaDevices.getDisplayMedia({ video: true });
+    });
+    const stream = await promise;
+    const track = stream.getTracks()[0];
+
+    await testTrackMuteUnmute(test, track, "togglescreenshare", (state) => navigator.mediaSession.setScreenshareActive(state), mute => window.testRunner.setCaptureState(true, true, !mute));
+
+    track.stop();
+}, "togglescreenshare and mute/unmute events order");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/mediasession.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/mediasession.idl
@@ -1,7 +1,7 @@
 // GENERATED CONTENT - DO NOT EDIT
 // Content was automatically extracted by Reffy into webref
 // (https://github.com/w3c/webref)
-// Source: Media Session Standard (https://w3c.github.io/mediasession/)
+// Source: Media Session (https://w3c.github.io/mediasession/)
 
 [Exposed=Window]
 partial interface Navigator {
@@ -26,7 +26,11 @@ enum MediaSessionAction {
   "seekto",
   "togglemicrophone",
   "togglecamera",
-  "hangup"
+  "togglescreenshare",
+  "hangup",
+  "previousslide",
+  "nextslide",
+  "enterpictureinpicture"
 };
 
 callback MediaSessionActionHandler = undefined(MediaSessionActionDetails details);
@@ -41,9 +45,11 @@ interface MediaSession {
 
   undefined setPositionState(optional MediaPositionState state = {});
 
-  undefined setMicrophoneActive(boolean active);
+  Promise<undefined> setMicrophoneActive(boolean active);
 
-  undefined setCameraActive(boolean active);
+  Promise<undefined> setCameraActive(boolean active);
+
+  Promise<undefined> setScreenshareActive(boolean active);
 };
 
 [Exposed=Window]

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/idlharness.window-expected.txt
@@ -22,8 +22,9 @@ PASS MediaSession interface: attribute metadata
 PASS MediaSession interface: attribute playbackState
 PASS MediaSession interface: operation setActionHandler(MediaSessionAction, MediaSessionActionHandler?)
 PASS MediaSession interface: operation setPositionState(optional MediaPositionState)
-FAIL MediaSession interface: operation setMicrophoneActive(boolean) assert_own_property: interface prototype object missing non-static operation expected property "setMicrophoneActive" missing
-FAIL MediaSession interface: operation setCameraActive(boolean) assert_own_property: interface prototype object missing non-static operation expected property "setCameraActive" missing
+PASS MediaSession interface: operation setMicrophoneActive(boolean)
+PASS MediaSession interface: operation setCameraActive(boolean)
+PASS MediaSession interface: operation setScreenshareActive(boolean)
 PASS MediaSession must be primary interface of navigator.mediaSession
 PASS Stringification of navigator.mediaSession
 PASS MediaSession interface: navigator.mediaSession must inherit property "metadata" with the proper type
@@ -32,10 +33,12 @@ PASS MediaSession interface: navigator.mediaSession must inherit property "setAc
 PASS MediaSession interface: calling setActionHandler(MediaSessionAction, MediaSessionActionHandler?) on navigator.mediaSession with too few arguments must throw TypeError
 PASS MediaSession interface: navigator.mediaSession must inherit property "setPositionState(optional MediaPositionState)" with the proper type
 PASS MediaSession interface: calling setPositionState(optional MediaPositionState) on navigator.mediaSession with too few arguments must throw TypeError
-FAIL MediaSession interface: navigator.mediaSession must inherit property "setMicrophoneActive(boolean)" with the proper type assert_inherits: property "setMicrophoneActive" not found in prototype chain
-FAIL MediaSession interface: calling setMicrophoneActive(boolean) on navigator.mediaSession with too few arguments must throw TypeError assert_inherits: property "setMicrophoneActive" not found in prototype chain
-FAIL MediaSession interface: navigator.mediaSession must inherit property "setCameraActive(boolean)" with the proper type assert_inherits: property "setCameraActive" not found in prototype chain
-FAIL MediaSession interface: calling setCameraActive(boolean) on navigator.mediaSession with too few arguments must throw TypeError assert_inherits: property "setCameraActive" not found in prototype chain
+PASS MediaSession interface: navigator.mediaSession must inherit property "setMicrophoneActive(boolean)" with the proper type
+PASS MediaSession interface: calling setMicrophoneActive(boolean) on navigator.mediaSession with too few arguments must throw TypeError
+PASS MediaSession interface: navigator.mediaSession must inherit property "setCameraActive(boolean)" with the proper type
+PASS MediaSession interface: calling setCameraActive(boolean) on navigator.mediaSession with too few arguments must throw TypeError
+PASS MediaSession interface: navigator.mediaSession must inherit property "setScreenshareActive(boolean)" with the proper type
+PASS MediaSession interface: calling setScreenshareActive(boolean) on navigator.mediaSession with too few arguments must throw TypeError
 PASS MediaMetadata interface: existence and properties of interface object
 PASS MediaMetadata interface object length
 PASS MediaMetadata interface object name

--- a/LayoutTests/media/audio-session-category-expected.txt
+++ b/LayoutTests/media/audio-session-category-expected.txt
@@ -77,10 +77,7 @@ EXPECTED (internals.routeSharingPolicy() == 'Default') OK
 ** Check after MediaStream muting audio track.
 EXPECTED (internals.audioSessionCategory() == 'PlayAndRecord') OK
 
-** Check 500ms after MediaStream stopping capture.
-EXPECTED (internals.audioSessionCategory() == 'PlayAndRecord') OK
-
-** And check again after 3 seconds.
+** Check right after MediaStream stopping capture.
 EXPECTED (internals.audioSessionCategory() == 'None') OK
 END OF TEST
 

--- a/LayoutTests/media/audio-session-category.html
+++ b/LayoutTests/media/audio-session-category.html
@@ -121,14 +121,9 @@
             await sleepFor(500);
             testExpected('internals.audioSessionCategory()', 'PlayAndRecord');
 
-            consoleWrite('<br>** Check 500ms after MediaStream stopping capture.');
+            consoleWrite('<br>** Check right after MediaStream stopping capture.');
             audioTrack.stop();
-            await sleepFor(500);
-            testExpected('internals.audioSessionCategory()', 'PlayAndRecord');
-
-            await waitForCategory('None', 3, '<br>** And check again after 3 seconds.');
-            video.src = '';
-            video.load();
+            testExpected('internals.audioSessionCategory()', 'None');
         }
 
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2375,8 +2375,8 @@ webkit.org/b/151344 fast/mediastream/MediaStream-add-ended-tracks.html [ Skip ]
 # Flakes moved from wpe/TestExpectations -- if they're flaky in WPE they're very likely to be flaky in GTK
 http/tests/webrtc/muted-video-mediastream-invisible-autoplay.html [ Failure Timeout Pass ]
 
-# webrtcbin doesn't emit "outbound-rtp" stats until it's in connected state
-webrtc/audio-muted-stats.html [ Failure ]
+# Lack of AudioSession category
+http/wpt/mediasession/setCaptureState-audio-category.html [ Skip ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebRTC-related bugs

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -30,6 +30,7 @@
 #include "ActiveDOMObject.h"
 #include "ExceptionOr.h"
 #include "MediaPositionState.h"
+#include "MediaProducer.h"
 #include "MediaSessionAction.h"
 #include "MediaSessionActionHandler.h"
 #include "MediaSessionPlaybackState.h"
@@ -139,6 +140,12 @@ public:
 
     void updateNowPlayingInfo(NowPlayingInfo&);
 
+#if ENABLE(MEDIA_STREAM)
+    void setMicrophoneActive(bool isActive, DOMPromiseDeferred<void>&& promise) { updateCaptureState(isActive, WTFMove(promise), MediaProducerMediaCaptureKind::Microphone); }
+    void setCameraActive(bool isActive, DOMPromiseDeferred<void>&& promise) { updateCaptureState(isActive, WTFMove(promise), MediaProducerMediaCaptureKind::Camera); }
+    void setScreenshareActive(bool isActive, DOMPromiseDeferred<void>&& promise) { updateCaptureState(isActive, WTFMove(promise), MediaProducerMediaCaptureKind::Display); }
+#endif
+
 private:
     explicit MediaSession(Navigator&);
 
@@ -152,6 +159,10 @@ private:
     void notifyPlaybackStateObservers();
     void notifyActionHandlerObservers();
     void notifyReadyStateObservers();
+
+#if ENABLE(MEDIA_STREAM)
+    void updateCaptureState(bool, DOMPromiseDeferred<void>&&, MediaProducerMediaCaptureKind);
+#endif
 
     // ActiveDOMObject.
     void suspend(ReasonForSuspension) final;

--- a/Source/WebCore/Modules/mediasession/MediaSession.idl
+++ b/Source/WebCore/Modules/mediasession/MediaSession.idl
@@ -40,6 +40,10 @@
     Promise<undefined> callActionHandler(MediaSessionActionDetails actionDetails);
 
     undefined setPositionState(optional MediaPositionState? state = null);
+
+    [Conditional=MEDIA_STREAM, EnabledBySetting=MediaSessionCaptureToggleAPIEnabled] Promise<undefined> setMicrophoneActive(boolean active);
+    [Conditional=MEDIA_STREAM, EnabledBySetting=MediaSessionCaptureToggleAPIEnabled] Promise<undefined> setCameraActive(boolean active);
+    [Conditional=MEDIA_STREAM, EnabledBySetting=MediaSessionCaptureToggleAPIEnabled] Promise<undefined> setScreenshareActive(boolean active);
 };
 
 MediaSession includes MediaSessionCoordinatorMixin;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -252,6 +252,9 @@ void MediaStreamTrack::stopTrack(StopMode mode)
     m_private->endTrack();
     m_ended = true;
 
+    if (isAudio() && isCaptureTrack())
+        PlatformMediaSessionManager::sharedManager().audioCaptureSourceStateChanged();
+
     configureTrackRendering();
 }
 
@@ -529,6 +532,10 @@ void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
             return;
 
         m_muted = muted;
+
+        if (isAudio() && isCaptureTrack())
+            PlatformMediaSessionManager::sharedManager().audioCaptureSourceStateChanged();
+
         dispatchEvent(Event::create(muted ? eventNames().muteEvent : eventNames().unmuteEvent, Event::CanBubble::No, Event::IsCancelable::No));
     };
     if (m_shouldFireMuteEventImmediately)

--- a/Source/WebCore/Modules/mediastream/UserMediaClient.h
+++ b/Source/WebCore/Modules/mediastream/UserMediaClient.h
@@ -33,6 +33,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include "MediaProducer.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/ObjectIdentifier.h>
 
@@ -40,6 +41,7 @@ namespace WebCore {
 
 struct CaptureDeviceWithCapabilities;
 class Document;
+class Exception;
 class Page;
 class UserMediaRequest;
 
@@ -59,6 +61,8 @@ public:
     using DeviceChangeObserverToken = LegacyNullableObjectIdentifier<DeviceChangeObserverTokenType>;
     virtual DeviceChangeObserverToken addDeviceChangeObserver(Function<void()>&&) = 0;
     virtual void removeDeviceChangeObserver(DeviceChangeObserverToken) = 0;
+
+    virtual void updateCaptureState(bool isActive, MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<Exception>&&)>&&) = 0;
 
 protected:
     virtual ~UserMediaClient() = default;

--- a/Source/WebCore/Modules/mediastream/UserMediaController.h
+++ b/Source/WebCore/Modules/mediastream/UserMediaController.h
@@ -34,6 +34,7 @@
 
 namespace WebCore {
 
+class Exception;
 class UserMediaRequest;
 
 class UserMediaController : public Supplement<Page> {
@@ -51,6 +52,8 @@ public:
 
     UserMediaClient::DeviceChangeObserverToken addDeviceChangeObserver(Function<void()>&&);
     void removeDeviceChangeObserver(UserMediaClient::DeviceChangeObserverToken);
+
+    void updateCaptureState(bool isActive, MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<Exception>&&)>&&);
 
     void logGetUserMediaDenial(Document&);
     void logGetDisplayMediaDenial(Document&);
@@ -87,6 +90,11 @@ inline UserMediaClient::DeviceChangeObserverToken UserMediaController::addDevice
 inline void UserMediaController::removeDeviceChangeObserver(UserMediaClient::DeviceChangeObserverToken token)
 {
     m_client->removeDeviceChangeObserver(token);
+}
+
+inline void UserMediaController::updateCaptureState(bool isActive, MediaProducerMediaCaptureKind kind, CompletionHandler<void(std::optional<Exception>&&)>&& completionHandler)
+{
+    m_client->updateCaptureState(isActive, kind, WTFMove(completionHandler));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5405,7 +5405,6 @@ void Document::pageMutedStateDidChange()
 static void updateCaptureSourceToPageMutedState(Document& document, Page& page, RealtimeMediaSource& source)
 {
     ASSERT(source.isCaptureSource());
-
     switch (source.deviceType()) {
     case CaptureDevice::DeviceType::Microphone:
 #if PLATFORM(IOS_FAMILY)
@@ -5418,8 +5417,10 @@ static void updateCaptureSourceToPageMutedState(Document& document, Page& page, 
         source.setMuted(page.mutedState().contains(MediaProducerMutedState::VideoCaptureIsMuted) || (document.hidden() && document.settings().interruptVideoOnPageVisibilityChangeEnabled()));
         break;
     case CaptureDevice::DeviceType::Screen:
-    case CaptureDevice::DeviceType::Window:
         source.setMuted(page.mutedState().contains(MediaProducerMutedState::ScreenCaptureIsMuted));
+        break;
+    case CaptureDevice::DeviceType::Window:
+        source.setMuted(page.mutedState().contains(MediaProducerMutedState::WindowCaptureIsMuted));
         break;
     case CaptureDevice::DeviceType::SystemAudio:
     case CaptureDevice::DeviceType::Speaker:

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -933,6 +933,9 @@ public:
     WEBCORE_EXPORT void setMuted(MediaProducerMutedStateFlags);
 
     WEBCORE_EXPORT void stopMediaCapture(MediaProducerMediaCaptureKind);
+#if ENABLE(MEDIA_STREAM)
+    WEBCORE_EXPORT void updateCaptureState(bool isActive, MediaProducerMediaCaptureKind);
+#endif
 
     MediaSessionGroupIdentifier mediaSessionGroupIdentifier() const;
     WEBCORE_EXPORT bool mediaPlaybackExists();

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -171,6 +171,7 @@ public:
 
     WEBCORE_EXPORT void addAudioCaptureSource(AudioCaptureSource&);
     WEBCORE_EXPORT void removeAudioCaptureSource(AudioCaptureSource&);
+    void audioCaptureSourceStateChanged() { updateSessionState(); }
     bool hasAudioCaptureSource(AudioCaptureSource& source) const { return m_audioCaptureSources.contains(source); }
 
     WEBCORE_EXPORT void processDidReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&);

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -119,6 +119,7 @@ void MediaSessionManagerCocoa::updateSessionState()
     int webAudioCount = 0;
     int audioMediaStreamTrackCount = 0;
     int captureCount = countActiveAudioCaptureSources();
+
     bool hasAudibleAudioOrVideoMediaType = false;
     bool hasAudibleVideoMediaType = false;
     bool isPlayingAudio = false;
@@ -203,7 +204,7 @@ void MediaSessionManagerCocoa::updateSessionState()
     else if (webAudioCount)
         category = AudioSession::CategoryType::AmbientSound;
 
-    if (category == AudioSession::CategoryType::None && m_previousCategory != AudioSession::CategoryType::None) {
+    if (category == AudioSession::CategoryType::None && m_previousCategory != AudioSession::CategoryType::None && m_previousCategory != AudioSession::CategoryType::PlayAndRecord) {
         if (!m_delayCategoryChangeTimer.isActive()) {
             m_delayCategoryChangeTimer.startOneShot(delayBeforeSettingCategoryNone);
             ALWAYS_LOG(LOGIDENTIFIER, "setting timer");

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -2811,8 +2811,20 @@ void WKPageSetMuted(WKPageRef pageRef, WKMediaMutedState mutedState)
         coreState.add(WebCore::MediaProducerMutedState::AudioIsMuted);
     if (mutedState & kWKMediaCaptureDevicesMuted)
         coreState.add(WebCore::MediaProducer::AudioAndVideoCaptureIsMuted);
+
     if (mutedState & kWKMediaScreenCaptureMuted)
         coreState.add(WebCore::MediaProducerMutedState::ScreenCaptureIsMuted);
+    if (mutedState & kWKMediaCameraCaptureMuted)
+        coreState.add(WebCore::MediaProducerMutedState::VideoCaptureIsMuted);
+    if (mutedState & kWKMediaMicrophoneCaptureMuted)
+        coreState.add(WebCore::MediaProducerMutedState::AudioCaptureIsMuted);
+
+    if (mutedState & kWKMediaScreenCaptureUnmuted)
+        coreState.remove(WebCore::MediaProducerMutedState::ScreenCaptureIsMuted);
+    if (mutedState & kWKMediaCameraCaptureUnmuted)
+        coreState.remove(WebCore::MediaProducerMutedState::VideoCaptureIsMuted);
+    if (mutedState & kWKMediaMicrophoneCaptureUnmuted)
+        coreState.remove(WebCore::MediaProducerMutedState::AudioCaptureIsMuted);
 
     toImpl(pageRef)->setMuted(coreState);
 }

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -127,7 +127,13 @@ enum {
     kWKMediaAudioMuted = 1 << 0,
     kWKMediaCaptureDevicesMuted = 1 << 1,
     kWKMediaScreenCaptureMuted = 1 << 2,
+    kWKMediaCameraCaptureMuted = 1 << 3,
+    kWKMediaMicrophoneCaptureMuted = 1 << 4,
+    kWKMediaScreenCaptureUnmuted = 1 << 5,
+    kWKMediaCameraCaptureUnmuted = 1 << 6,
+    kWKMediaMicrophoneCaptureUnmuted = 1 << 7,
 };
+
 typedef uint32_t WKMediaMutedState;
 WK_EXPORT void WKPageSetMuted(WKPageRef page, WKMediaMutedState muted);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -111,6 +111,7 @@ class Cursor;
 class DataSegment;
 class DestinationColorSpace;
 class DragData;
+class Exception;
 class FloatPoint;
 class FloatQuad;
 class FloatRect;
@@ -2647,10 +2648,11 @@ private:
 
 #if ENABLE(MEDIA_STREAM)
     UserMediaPermissionRequestManagerProxy& userMediaPermissionRequestManager();
-#endif
     void requestUserMediaPermissionForFrame(IPC::Connection&, WebCore::UserMediaRequestIdentifier, WebCore::FrameIdentifier, const WebCore::SecurityOriginData& userMediaDocumentOriginIdentifier, const WebCore::SecurityOriginData& topLevelDocumentOriginIdentifier, WebCore::MediaStreamRequest&&);
     void enumerateMediaDevicesForFrame(IPC::Connection&, WebCore::FrameIdentifier, const WebCore::SecurityOriginData& userMediaDocumentOriginData, const WebCore::SecurityOriginData& topLevelDocumentOriginData, CompletionHandler<void(const Vector<WebCore::CaptureDeviceWithCapabilities>&, WebCore::MediaDeviceHashSalts&&)>&&);
     void beginMonitoringCaptureDevices();
+    void validateCaptureStateUpdate(bool isActive, WebCore::MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
+#endif
 
 #if ENABLE(ENCRYPTED_MEDIA)
     MediaKeySystemPermissionRequestManagerProxy& mediaKeySystemPermissionRequestManager();

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -281,6 +281,7 @@ messages -> WebPageProxy {
     RequestUserMediaPermissionForFrame(WebCore::UserMediaRequestIdentifier userMediaID, WebCore::FrameIdentifier frameID, WebCore::SecurityOriginData userMediaDocumentOriginIdentifier, WebCore::SecurityOriginData topLevelDocumentOriginIdentifier, struct WebCore::MediaStreamRequest request)
     EnumerateMediaDevicesForFrame(WebCore::FrameIdentifier frameID, WebCore::SecurityOriginData userMediaDocumentOriginIdentifier, WebCore::SecurityOriginData topLevelDocumentOriginIdentifier) -> (Vector<WebCore::CaptureDeviceWithCapabilities> devices, struct WebCore::MediaDeviceHashSalts mediaDeviceIdentifierHashSalts)
     BeginMonitoringCaptureDevices()
+    ValidateCaptureStateUpdate(bool isActive, enum:uint8_t WebCore::MediaProducerMediaCaptureKind kind) -> (std::optional<WebCore::Exception> result)
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
@@ -197,6 +197,11 @@ void UserMediaPermissionRequestManager::removeDeviceChangeObserver(UserMediaClie
     ASSERT_UNUSED(wasRemoved, wasRemoved);
 }
 
+void UserMediaPermissionRequestManager::updateCaptureState(bool isActive, WebCore::MediaProducerMediaCaptureKind kind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
+{
+    m_page.updateCaptureState(isActive, kind, WTFMove(completionHandler));
+}
+
 void UserMediaPermissionRequestManager::captureDevicesChanged()
 {
     // When new media input and/or output devices are made available, or any available input and/or

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
@@ -69,6 +69,7 @@ public:
 
     WebCore::UserMediaClient::DeviceChangeObserverToken addDeviceChangeObserver(WTF::Function<void()>&&);
     void removeDeviceChangeObserver(WebCore::UserMediaClient::DeviceChangeObserverToken);
+    void updateCaptureState(bool isActive, WebCore::MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
 
     void captureDevicesChanged();
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp
@@ -68,6 +68,11 @@ void WebUserMediaClient::removeDeviceChangeObserver(DeviceChangeObserverToken to
     m_page.userMediaPermissionRequestManager().removeDeviceChangeObserver(token);
 }
 
+void WebUserMediaClient::updateCaptureState(bool isActive, WebCore::MediaProducerMediaCaptureKind kind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
+{
+    m_page.userMediaPermissionRequestManager().updateCaptureState(isActive, kind, WTFMove(completionHandler));
+}
+
 } // namespace WebKit;
 
 #endif // MEDIA_STREAM

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h
@@ -45,6 +45,7 @@ private:
 
     DeviceChangeObserverToken addDeviceChangeObserver(WTF::Function<void()>&&) final;
     void removeDeviceChangeObserver(DeviceChangeObserverToken) final;
+    void updateCaptureState(bool isActive, WebCore::MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&) final;
 
     void initializeFactories();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9953,6 +9953,22 @@ void WebPage::simulateClickOverFirstMatchingTextInViewportWithUserInteraction(co
     completion(true);
 }
 
+#if ENABLE(MEDIA_STREAM)
+void WebPage::updateCaptureState(bool isActive, WebCore::MediaProducerMediaCaptureKind kind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
+{
+    sendWithAsyncReply(Messages::WebPageProxy::ValidateCaptureStateUpdate(isActive, kind), [weakThis = WeakPtr { *this }, isActive, kind, completionHandler = WTFMove(completionHandler)] (auto&& error) mutable {
+        completionHandler(WTFMove(error));
+        if (error)
+            return;
+
+        RefPtr webPage = weakThis.get();
+        RefPtr page = webPage ? webPage->corePage() : nullptr;
+        if (page)
+            page->updateCaptureState(isActive, kind);
+    });
+}
+#endif
+
 } // namespace WebKit
 
 #undef WEBPAGE_RELEASE_LOG

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -855,6 +855,7 @@ public:
 #if ENABLE(MEDIA_STREAM)
     UserMediaPermissionRequestManager& userMediaPermissionRequestManager() { return m_userMediaPermissionRequestManager; }
     void captureDevicesChanged();
+    void updateCaptureState(bool isActive, WebCore::MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -412,6 +412,8 @@ interface TestRunner {
     undefined setMockCaptureDevicesInterrupted(boolean isCameraInterrupted, boolean isMicrophoneInterrupted);
     undefined triggerMockCaptureConfigurationChange(boolean forMicrophone, boolean forDisplay);
 
+    undefined setCaptureState(boolean cameraState, boolean microphoneState, boolean displayState);
+
     boolean hasAppBoundSession();
     undefined clearAppBoundSession();
     undefined setAppBoundDomains(object originsArray, object callback);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1702,6 +1702,15 @@ void TestRunner::triggerMockCaptureConfigurationChange(bool forMicrophone, bool 
     }));
 }
 
+void TestRunner::setCaptureState(bool cameraState, bool microphoneState, bool displayState)
+{
+    postSynchronousMessage("SetCaptureState", createWKDictionary({
+        { "camera", adoptWK(WKBooleanCreate(cameraState)) },
+        { "microphone", adoptWK(WKBooleanCreate(microphoneState)) },
+        { "display", adoptWK(WKBooleanCreate(displayState)) },
+    }));
+}
+
 #if ENABLE(GAMEPAD)
 
 void TestRunner::connectMockGamepad(unsigned index)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -507,6 +507,7 @@ public:
     bool isMockRealtimeMediaSourceCenterEnabled();
     void setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool isMicrophoneInterrupted);
     void triggerMockCaptureConfigurationChange(bool forMicrophone, bool forDisplay);
+    void setCaptureState(bool cameraState, bool microphoneState, bool displayState);
 
     bool hasAppBoundSession();
     void clearAppBoundSession();

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -4166,6 +4166,13 @@ void TestController::triggerMockCaptureConfigurationChange(bool forMicrophone, b
     WKPageTriggerMockCaptureConfigurationChange(m_mainWebView->page(), forMicrophone, forDisplay);
 }
 
+void TestController::setCaptureState(bool cameraState, bool microphoneState, bool displayState)
+{
+    WKPageSetMuted(m_mainWebView->page(), (cameraState ? kWKMediaCameraCaptureUnmuted : kWKMediaCameraCaptureMuted)
+                   | (microphoneState ? kWKMediaMicrophoneCaptureUnmuted : kWKMediaMicrophoneCaptureMuted)
+                   | (displayState ? kWKMediaScreenCaptureUnmuted : kWKMediaScreenCaptureMuted));
+}
+
 struct InAppBrowserPrivacyCallbackContext {
     explicit InAppBrowserPrivacyCallbackContext(TestController& controller)
         : testController(controller)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -343,6 +343,7 @@ public:
     bool isMockRealtimeMediaSourceCenterEnabled() const;
     void setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool isMicrophoneInterrupted);
     void triggerMockCaptureConfigurationChange(bool forMicrophone, bool forDisplay);
+    void setCaptureState(bool cameraState, bool microphoneState, bool displayState);
     bool hasAppBoundSession();
 
     void injectUserScript(WKStringRef);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -892,6 +892,15 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         TestController::singleton().triggerMockCaptureConfigurationChange(forMicrophone, forDisplay);
         return nullptr;
     }
+    
+    if (WKStringIsEqualToUTF8CString(messageName, "SetCaptureState")) {
+        auto messageBodyDictionary = dictionaryValue(messageBody);
+        bool camera = booleanValue(messageBodyDictionary, "camera");
+        bool microphone = booleanValue(messageBodyDictionary, "microphone");
+        bool display = booleanValue(messageBodyDictionary, "display");
+        TestController::singleton().setCaptureState(camera, microphone, display);
+        return nullptr;
+    }
 
     if (WKStringIsEqualToUTF8CString(messageName, "HasAppBoundSession"))
         return adoptWK(WKBooleanCreate(TestController::singleton().hasAppBoundSession()));


### PR DESCRIPTION
#### a9b4b55ed533b19f20f750a2a0c1aff15fb7f7df
<pre>
Implement MediaSession setCameraActive, setMicrophoneActive and setScreenshareActive
<a href="https://rdar.apple.com/132901228">rdar://132901228</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=277421">https://bugs.webkit.org/show_bug.cgi?id=277421</a>

Reviewed by Eric Carlson.

Implement these methods by sending IPC messages to UIProcess.
UIProcess will then always allow to mute capture.
But it will only allow to unmute capture if capture was previously muted by the web page and not the UIProcess directly.

We update the computation of the audio session category to synchronously exit of PlayAndRecord when all audio capture tracks are muted or ended.
This allows web applications to listen for mute events and know they can play audio with an audio session category that will be set to MediaPlayback instead of PlayAndRecord.
We update LayoutTests/media/audio-session-category.html accordingly.

* LayoutTests/http/wpt/mediasession/setCaptureState-audio-category-expected.txt: Added.
* LayoutTests/http/wpt/mediasession/setCaptureState-audio-category.html: Added.
* LayoutTests/http/wpt/mediasession/setCaptureState-expected.txt: Added.
* LayoutTests/http/wpt/mediasession/setCaptureState.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/interfaces/mediasession.idl:
* LayoutTests/imported/w3c/web-platform-tests/mediasession/idlharness.window-expected.txt:
* LayoutTests/media/audio-session-category-expected.txt:
* LayoutTests/media/audio-session-category.html:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::updateCaptureState):
* Source/WebCore/Modules/mediasession/MediaSession.h:
(WebCore::MediaSession::setMicrophoneActive):
(WebCore::MediaSession::setCameraActive):
(WebCore::MediaSession::setScreenshareActive):
* Source/WebCore/Modules/mediasession/MediaSession.idl:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::stopTrack):
(WebCore::MediaStreamTrack::trackMutedChanged):
* Source/WebCore/Modules/mediastream/UserMediaClient.h:
* Source/WebCore/Modules/mediastream/UserMediaController.h:
(WebCore::UserMediaController::updateCaptureState):
* Source/WebCore/dom/Document.cpp:
(WebCore::updateCaptureSourceToPageMutedState):
* Source/WebCore/page/Page.cpp:
(WebCore::toMediaProducerMutedStateFlags):
(WebCore::computeCaptureMutedState):
(WebCore::Page::updateCaptureState):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
(WebCore::PlatformMediaSessionManager::audioCaptureSourceStateChanged):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetMuted):
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestUserMediaPermissionForFrame):
(WebKit::WebPageProxy::enumerateMediaDevicesForFrame):
(WebKit::WebPageProxy::beginMonitoringCaptureDevices):
(WebKit::WebPageProxy::validateCaptureStateUpdate):
(WebKit::WebPageProxy::syncIfMockDevicesEnabledChanged):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::setCategory):
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp:
(WebKit::UserMediaPermissionRequestManager::updateCaptureState):
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp:
(WebKit::WebUserMediaClient::updateCaptureState):
* Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updateCaptureState):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setCaptureState):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::setCaptureState):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/282739@main">https://commits.webkit.org/282739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f474bdf0e6737d012af2c416812e37e4cd00b0f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64123 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68145 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14731 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15011 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51642 "Found 1 new test failure: webrtc/audio-muted-stats.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10176 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32261 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12875 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13605 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/13204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69844 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12732 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58961 "Found 1 new test failure: webrtc/audio-muted-stats.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/59118 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14166 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6689 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39300 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40379 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->