### PR TITLE
Click simulation should be able to target clickable elements with matching accessibility labels

### DIFF
--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -52,7 +52,7 @@ WEBCORE_EXPORT String plainTextReplacingNoBreakSpace(const SimpleRange&, TextIte
 // Find within the document, based on the text from the text iterator.
 WEBCORE_EXPORT SimpleRange findPlainText(const SimpleRange&, const String&, FindOptions);
 WEBCORE_EXPORT SimpleRange findClosestPlainText(const SimpleRange&, const String&, FindOptions, uint64_t targetCharacterOffset);
-bool containsPlainText(const String& document, const String&, FindOptions); // Lets us use the search algorithm on a string.
+WEBCORE_EXPORT bool containsPlainText(const String& document, const String&, FindOptions); // Lets us use the search algorithm on a string.
 WEBCORE_EXPORT String foldQuoteMarks(const String&);
 
 // FIXME: Move this somewhere else in the editing directory. It doesn't belong in the header with TextIterator.

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -140,7 +140,7 @@ public:
     bool isPresentingAttachedView() const;
 
     bool isSteppable() const; // stepUp()/stepDown() for user-interaction.
-    bool isTextButton() const;
+    WEBCORE_EXPORT bool isTextButton() const;
     bool isRadioButton() const;
     WEBCORE_EXPORT bool isTextField() const final;
     WEBCORE_EXPORT bool isSearchField() const;
@@ -164,7 +164,7 @@ public:
     WEBCORE_EXPORT bool isFileUpload() const;
     bool isImageButton() const;
     WEBCORE_EXPORT bool isNumberField() const;
-    bool isSubmitButton() const final;
+    WEBCORE_EXPORT bool isSubmitButton() const final;
     WEBCORE_EXPORT bool isTelephoneField() const;
     WEBCORE_EXPORT bool isURLField() const;
     WEBCORE_EXPORT bool isDateField() const;
@@ -212,7 +212,7 @@ public:
     String localizeValue(const String&) const;
 
     // The value which is drawn by a renderer.
-    String visibleValue() const;
+    WEBCORE_EXPORT String visibleValue() const;
 
     String valueWithDefault() const;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SimulateClickOverText.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SimulateClickOverText.mm
@@ -58,17 +58,26 @@ TEST(SimulateClickOverText, ClickTargets)
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     [webView synchronouslyLoadTestPageNamed:@"click-targets"];
 
-    [webView simulateClickOverText:@"Bugzilla"];
-    [webView simulateClickOverText:@"Sign up"];
-    [webView simulateClickOverText:@"First name"];
+    EXPECT_TRUE([webView simulateClickOverText:@"Bugzilla"]);
+    EXPECT_TRUE([webView simulateClickOverText:@"Sign up"]);
+    EXPECT_TRUE([webView simulateClickOverText:@"First name"]);
+    EXPECT_TRUE([webView simulateClickOverText:@"Log in"]);
+    EXPECT_TRUE([webView simulateClickOverText:@"More info"]);
+    EXPECT_TRUE([webView simulateClickOverText:@"Close"]);
 
     RetainPtr expectedEvents = @[ @"mousedown", @"mouseup", @"click" ];
     EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('a.top').events"]]);
     EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('button.top').events"]]);
-    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('input.top').events"]]);
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('input[type=text].top').events"]]);
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('input[type=submit].top').events"]]);
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('input[type=button].top').events"]]);
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('div.close.top').events"]]);
     EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('a.bottom').events"]);
     EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('button.bottom').events"]);
     EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('input.bottom').events"]);
+    EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('input[type=submit].bottom').events"]);
+    EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('input[type=button].bottom').events"]);
+    EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('div.close.bottom').events"]);
 }
 
 TEST(SimulateClickOverText, ClickTargetsAfterScrolling)
@@ -78,17 +87,26 @@ TEST(SimulateClickOverText, ClickTargetsAfterScrolling)
     [webView stringByEvaluatingJavaScript:@"scrollBy(0, 5000)"];
     [webView waitForNextPresentationUpdate];
 
-    [webView simulateClickOverText:@"Bugzilla"];
-    [webView simulateClickOverText:@"Sign up"];
-    [webView simulateClickOverText:@"First name"];
+    EXPECT_TRUE([webView simulateClickOverText:@"Bugzilla"]);
+    EXPECT_TRUE([webView simulateClickOverText:@"Sign up"]);
+    EXPECT_TRUE([webView simulateClickOverText:@"First name"]);
+    EXPECT_TRUE([webView simulateClickOverText:@"Log in"]);
+    EXPECT_TRUE([webView simulateClickOverText:@"More info"]);
+    EXPECT_TRUE([webView simulateClickOverText:@"Close"]);
 
     RetainPtr expectedEvents = @[ @"mousedown", @"mouseup", @"click" ];
     EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('a.top').events"]);
     EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('button.top').events"]);
     EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('input.top').events"]);
+    EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('input[type=submit].top').events"]);
+    EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('input[type=button].top').events"]);
+    EXPECT_NULL([webView objectByEvaluatingJavaScript:@"document.querySelector('div.close.top').events"]);
     EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('a.bottom').events"]]);
     EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('button.bottom').events"]]);
-    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('input.bottom').events"]]);
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('input[type=text].bottom').events"]]);
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('input[type=submit].bottom').events"]]);
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('input[type=button].bottom').events"]]);
+    EXPECT_TRUE([expectedEvents isEqualToArray:[webView objectByEvaluatingJavaScript:@"document.querySelector('div.close.bottom').events"]]);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/click-targets.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/click-targets.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
 <head>
 <style>
 body {
@@ -27,10 +28,23 @@ div.container {
 div.tall {
     height: 5000px;
 }
+
+.close {
+    width: 40px;
+    height: 40px;
+    box-sizing: border-box;
+    cursor: pointer;
+    border-radius: 20px;
+    background: black;
+    color: white;
+    font-size: 24px;
+    line-height: 36px;
+    text-align: center;
+}
 </style>
 <script>
 addEventListener("load", () => {
-    for (const element of [...document.querySelectorAll("a, button, input")]) {
+    for (const element of [...document.querySelectorAll("a, button, input, div.close")]) {
         for (const type of ["mousedown", "mouseup", "click"]) {
             element.addEventListener(type, event => {
                 const target = event.target;
@@ -49,10 +63,14 @@ addEventListener("load", () => {
     <div class="container"><a class="top" href="https://bugs.webkit.org">Bugzilla</a></div>
     <div class="container"><button class="top green button">Sign Up</button></div>
     <div class="container"><input class="top" type="text" placeholder="First name"></div>
+    <div class="container"><input class="top" type="submit" value="Log In">&nbsp;<input class="top" type="button" value="More Info"></div>
+    <div onclick="javascript:void()" aria-label="Close" class="top close">ｘ</div>
     <div class="tall"></div>
     <div class="container"><a class="bottom" href="https://bugs.webkit.org">Bugzilla</a></div>
     <div class="container"><button class="bottom green button">Sign Up</button></div>
     <div class="container"><input class="bottom" type="text" placeholder="First name"></div>
+    <div class="container"><input class="bottom" type="submit" value="Log In">&nbsp;<input class="bottom" type="button" value="More Info"></div>
+    <div onclick="javascript:void()" aria-label="Close" class="bottom close">ｘ</div>
     <div class="tall"></div>
 </body>
 </html>


### PR DESCRIPTION
#### b8175c8e661431d426d0ab8efe0459d8dd20c98b
<pre>
Click simulation should be able to target clickable elements with matching accessibility labels
<a href="https://bugs.webkit.org/show_bug.cgi?id=277423">https://bugs.webkit.org/show_bug.cgi?id=277423</a>
<a href="https://rdar.apple.com/132902431">rdar://132902431</a>

Reviewed by Abrar Rahman Protyasha.

When the target text passed to `simulateClickOverFirstMatchingTextInViewportWithUserInteraction`
does not match any visible text on the webpage, fall back to searching all hit-testable elements in
the viewport (using an area-based hit-test) for elements that have relevant accessibility labels
(`aria-label`) or semantically interesting DOM attributes (e.g. `value` for button inputs), which
match the target text.

* Source/WebCore/editing/TextIterator.h:
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::simulateClickOverFirstMatchingTextInViewportWithUserInteraction):

See above for more details. Also make a slight adjustment here to return `true` in the completion
handler, even if the event was not handled as a default action or prevented by the page. This is
because mouse or click events may still result in interesting changes on the page even if the event
is not prevented, so it&apos;s better to err on the side of not reporting an error if we do end up
dispatching synthetic events over a target element.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SimulateClickOverText.mm:
(TestWebKitAPI::TEST(SimulateClickOverText, ClickTargets)):
(TestWebKitAPI::TEST(SimulateClickOverText, ClickTargetsAfterScrolling)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/click-targets.html:

Augment these two API tests to cover more scenarios, where the click targets are:
• `input` of type `&quot;button&quot;`.
• `input` of type `&quot;submit&quot;`.
• `div` with click handler and accessibility label.

Canonical link: <a href="https://commits.webkit.org/281662@main">https://commits.webkit.org/281662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/951f5b458c213d73ef96a66a0224a3a56d026e07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64507 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11395 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7729 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29836 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9708 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10036 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66237 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4519 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56370 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4540 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56547 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3748 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9111 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35743 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->