### PR TITLE
Make some of WebKitTestRunner's ResourceLoadStatistics functions properly async

### DIFF
--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-mixed-statistics.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-mixed-statistics.html
@@ -26,7 +26,7 @@
     }
 
     function runTestRunnerTest() {
-        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, function() {
+        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, async function() {
             if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
                 testFailed("Host did not get set as non-prevalent resource.");
 
@@ -36,7 +36,7 @@
 
             testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
 
-            testRunner.statisticsProcessStatisticsAndDataRecords();
+            await testRunner.statisticsProcessStatisticsAndDataRecords();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-sub-frame-under-top-frame-origins.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-sub-frame-under-top-frame-origins.html
@@ -26,7 +26,7 @@
     }
 
     function runTestRunnerTest() {
-        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, function() {
+        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, async function() {
             if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
                 testFailed("Host did not get set as non-prevalent resource.");
 
@@ -36,7 +36,7 @@
 
             testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
 
-            testRunner.statisticsProcessStatisticsAndDataRecords();
+            await testRunner.statisticsProcessStatisticsAndDataRecords();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-subresource-under-top-frame-origins.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-subresource-under-top-frame-origins.html
@@ -25,7 +25,7 @@
     }
 
     function runTestRunnerTest() {
-        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, function() {
+        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, async function() {
             if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
                 testFailed("Host did not get set as non-prevalent resource.");
 
@@ -34,7 +34,7 @@
 
             testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
 
-            testRunner.statisticsProcessStatisticsAndDataRecords();
+            await testRunner.statisticsProcessStatisticsAndDataRecords();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-subresource-unique-redirects-to.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-subresource-unique-redirects-to.html
@@ -25,7 +25,7 @@
     }
 
     function runTestRunnerTest() { 
-        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, function() {
+        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, async function() {
             if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
                 testFailed("Host did not get set as non-prevalent resource.");
 
@@ -34,7 +34,7 @@
 
             testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
 
-            testRunner.statisticsProcessStatisticsAndDataRecords();
+            await testRunner.statisticsProcessStatisticsAndDataRecords();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-mixed-statistics.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-mixed-statistics.html
@@ -28,8 +28,8 @@
         });
     }
 
-    function runTestRunnerTest() { 
-        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, function() {
+    async function runTestRunnerTest() {
+        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, async function() {
             if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
                 testFailed("Host did not get set as non-prevalent resource.");
 
@@ -45,7 +45,7 @@
 
             testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
 
-            testRunner.statisticsProcessStatisticsAndDataRecords();
+            await testRunner.statisticsProcessStatisticsAndDataRecords();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-sub-frame-under-top-frame-origins.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-sub-frame-under-top-frame-origins.html
@@ -29,7 +29,7 @@
     }
 
     function runTestRunnerTest() {
-        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, function() {
+        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, async function() {
             if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
                 testFailed("Host did not get set as non-prevalent resource.");
 
@@ -40,7 +40,7 @@
 
             testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
 
-            testRunner.statisticsProcessStatisticsAndDataRecords();
+            await testRunner.statisticsProcessStatisticsAndDataRecords();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-redirect-to-prevalent.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-redirect-to-prevalent.html
@@ -26,11 +26,11 @@
     }
 
     function runTest() {
-        testRunner.setStatisticsPrevalentResource(topFrameOrigin1, true, function() {
+        testRunner.setStatisticsPrevalentResource(topFrameOrigin1, true, async function() {
             testRunner.setStatisticsSubresourceUniqueRedirectTo(statisticsUrl, topFrameOrigin1);
 
             testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-            testRunner.statisticsProcessStatisticsAndDataRecords();
+            await testRunner.statisticsProcessStatisticsAndDataRecords();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-under-top-frame-origins.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-under-top-frame-origins.html
@@ -29,7 +29,7 @@
     }
 
     function runTestRunnerTest() { 
-        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, function() {
+        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, async function() {
             if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
                 testFailed("Host did not get set as non-prevalent resource.");
 
@@ -40,7 +40,7 @@
 
             testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
 
-            testRunner.statisticsProcessStatisticsAndDataRecords();
+            await testRunner.statisticsProcessStatisticsAndDataRecords();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-unique-redirects-to.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-unique-redirects-to.html
@@ -29,7 +29,7 @@
     }
 
     function runTestRunnerTest() { 
-        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, function() {
+        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, async function() {
             if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
                 testFailed("Host did not get set as non-prevalent resource.");
 
@@ -40,7 +40,7 @@
 
             testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
 
-            testRunner.statisticsProcessStatisticsAndDataRecords();
+            await testRunner.statisticsProcessStatisticsAndDataRecords();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-redirect-to-prevalent.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-redirect-to-prevalent.html
@@ -26,11 +26,11 @@
     }
 
     function runTest() {
-        testRunner.setStatisticsPrevalentResource(topFrameOrigin1, true, function() {
+        testRunner.setStatisticsPrevalentResource(topFrameOrigin1, true, async function() {
             testRunner.setStatisticsTopFrameUniqueRedirectTo(statisticsUrl, topFrameOrigin1);
 
             testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-            testRunner.statisticsProcessStatisticsAndDataRecords();
+            await testRunner.statisticsProcessStatisticsAndDataRecords();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-unique-redirects-to.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-unique-redirects-to.html
@@ -28,7 +28,7 @@
         setEnableFeature(false, finishJSTest);
     }
 
-    function runTest() {
+    async function runTest() {
         testRunner.setStatisticsTopFrameUniqueRedirectTo(statisticsUrl, topFrameOrigin1);
         testRunner.setStatisticsTopFrameUniqueRedirectTo(statisticsUrl, topFrameOrigin2);
         testRunner.setStatisticsTopFrameUniqueRedirectTo(statisticsUrl, topFrameOrigin3);
@@ -36,7 +36,7 @@
 
         testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
 
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     if (document.location.host === hostUnderTest && window.testRunner && window.internals) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-very-prevalent-based-on-mixed-statistics.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-very-prevalent-based-on-mixed-statistics.html
@@ -29,8 +29,8 @@
         setEnableFeature(false, finishJSTest);
     }
 
-    function runTestRunnerTest() { 
-        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, function() {
+    async function runTestRunnerTest() { 
+        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, async function() {
             if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
                 testFailed("Host started out as prevalent resource.");
 
@@ -51,7 +51,7 @@
             }
 
             testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-            testRunner.statisticsProcessStatisticsAndDataRecords();
+            await testRunner.statisticsProcessStatisticsAndDataRecords();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store-one-hour.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store-one-hour.html
@@ -35,7 +35,7 @@
         testRunner.statisticsClearInMemoryAndPersistentStoreModifiedSinceHours(1, completeTest);
     }
 
-    function runTestRunnerTest() {
+    async function runTestRunnerTest() {
         testRunner.setStatisticsPrevalentResource(statisticsUrl, false, function() {});
         if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
             testFailed("Host did not get set as non-prevalent resource.");
@@ -50,7 +50,7 @@
 
         testRunner.installStatisticsDidScanDataRecordsCallback(testStep2);
 
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     if (document.location.host === hostUnderTest && window.testRunner && window.internals) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store.html
@@ -36,7 +36,7 @@
     }
 
     function runTestRunnerTest() {
-        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, function() {
+        testRunner.setStatisticsPrevalentResource(statisticsUrl, false, async function() {
             if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
                 testFailed("Host did not get set as non-prevalent resource.");
 
@@ -50,7 +50,7 @@
 
             testRunner.installStatisticsDidScanDataRecordsCallback(testStep2);
 
-            testRunner.statisticsProcessStatisticsAndDataRecords();
+            await testRunner.statisticsProcessStatisticsAndDataRecords();
         });
     }
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/cookie-deletion-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/cookie-deletion-expected.txt
@@ -9,7 +9,7 @@ CONSOLE MESSAGE: step4. About to open an iFrame to test for third party cookie a
 CONSOLE MESSAGE: step5. About to open an iFrame to try to set a cookie as a third party (should fail)
 CONSOLE MESSAGE: step6. About to open an iFrame and fireDataModificationHandlerAndContinue
 CONSOLE MESSAGE: In fireDataModificationHandlerAndContinue
-CONSOLE MESSAGE: Calling statisticsProcessStatisticsAndDataRecords
+CONSOLE MESSAGE: Calling await statisticsProcessStatisticsAndDataRecords
 CONSOLE MESSAGE: In callback function for installStatisticsDidScanDataRecordsCallback
 CONSOLE MESSAGE: step7. About to open an iFrame and setAsNonPrevalentAndContinue
 CONSOLE MESSAGE: In setAsNonPrevalentAndContinue

--- a/LayoutTests/http/tests/resourceLoadStatistics/cookie-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/cookie-deletion.html
@@ -36,14 +36,14 @@
     }
 
 
-    function fireDataModificationHandlerAndContinue() {
+    async function fireDataModificationHandlerAndContinue() {
         console.log("In fireDataModificationHandlerAndContinue")
         testRunner.installStatisticsDidScanDataRecordsCallback(function() {
             console.log("In callback function for installStatisticsDidScanDataRecordsCallback")
             setTimeout(runTest, 500);
         });
-        console.log("Calling statisticsProcessStatisticsAndDataRecords")
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        console.log("Calling await statisticsProcessStatisticsAndDataRecords")
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function setAsNonPrevalentAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/delete-script-accessible-cookies.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/delete-script-accessible-cookies.html
@@ -57,9 +57,9 @@
         await fetch("/cookies/resources/setCookies.cgi", { headers: { "X-Set-Cookie": serverSideCookieName + "=1; path=/;" }, credentials: "same-origin" });
         document.cookie = clientSideCookieName + "=1";
         checkCookies(false);
-        testRunner.statisticsDeleteCookiesForHost("http://127.0.0.1", false);
+        await testRunner.statisticsDeleteCookiesForHost("http://127.0.0.1", false);
         checkCookies(true);
-        testRunner.statisticsDeleteCookiesForHost("http://127.0.0.1", true);
+        await testRunner.statisticsDeleteCookiesForHost("http://127.0.0.1", true);
         let cookiesLeft = internals.getCookies().length;
         if (cookiesLeft === 0)
             testPassed("After full deletion:               All cookies are gone.");

--- a/LayoutTests/http/tests/resourceLoadStatistics/enforce-samesite-strict-based-on-top-frame-unique-redirects-to.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/enforce-samesite-strict-based-on-top-frame-unique-redirects-to.html
@@ -42,7 +42,7 @@
         setEnableFeature(false, finishJSTest);
     }
 
-    function secondStep() {
+    async function secondStep() {
         let cookies = internals.getCookies();
         if (cookies.length !== 1) {
             testFailed("Should have exactly one cookie before test but found " + cookies.length + " cookies.");
@@ -60,10 +60,10 @@
 
         testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
 
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
-    function runTest() {
+    async function runTest() {
         document.cookie = "clientSideCookie=1";
 
         testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, true);
@@ -84,7 +84,7 @@
 
         testRunner.installStatisticsDidScanDataRecordsCallback(secondStep);
 
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     if (document.location.host === hostUnderTest && window.testRunner && window.internals) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion-database.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion-database.html
@@ -215,9 +215,9 @@
         });
     }
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion.html
@@ -215,9 +215,9 @@
         });
     }
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/managed-domains-exempt-from-website-data-deletion-database.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/managed-domains-exempt-from-website-data-deletion-database.html
@@ -215,9 +215,9 @@
         });
     }
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/managed-domains-exempt-from-website-data-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/managed-domains-exempt-from-website-data-deletion.html
@@ -215,9 +215,9 @@
         });
     }
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/grandfathering.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/grandfathering.html
@@ -25,11 +25,11 @@
         });
     }
 
-    function fireDataModificationHandlerAndContinue() {
+    async function fireDataModificationHandlerAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(function() {
             runTest();
         });
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function clearInMemoryAndPersistentStoreAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/many-inserts-only-insert-once.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/many-inserts-only-insert-once.html
@@ -48,10 +48,10 @@
         testRunner.setStatisticsSubresourceUniqueRedirectTo(url, topFrameUrl);
     }
 
-    function setUpStatisticsAndContinue() {
+    async function setUpStatisticsAndContinue() {
         insertManyTimes(subframeUrl);
         testRunner.installStatisticsDidScanDataRecordsCallback(checkClassificationAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function checkCountStatistics(result) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-prevalent-resource-with-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-prevalent-resource-with-user-interaction.html
@@ -30,7 +30,7 @@
                 if (!testRunner.isStatisticsPrevalentResource(otherPrevalentUrl))
                     testFailed("Other host did not get set as prevalent resource.");
 
-                testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, true, function() {
+                testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, true, async function() {
                     if (!testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
                         testFailed("Host did not get logged for user interaction.");
 
@@ -46,7 +46,7 @@
                     });
                     testRunner.setStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(false);
                     testRunner.setStatisticsMinimumTimeBetweenDataRecordsRemoval(0);
-                    testRunner.statisticsProcessStatisticsAndDataRecords();
+                    await testRunner.statisticsProcessStatisticsAndDataRecords();
                 });
             });
         });

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-prevalent-resource-without-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-prevalent-resource-without-user-interaction.html
@@ -30,7 +30,7 @@
                 if (!testRunner.isStatisticsPrevalentResource(otherPrevalentUrl))
                     testFailed("Other host did not get set as prevalent resource.");
 
-                testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, false, function() {
+                testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, false, async function() {
                     if (testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
                         testFailed("Host did not get cleared of user interaction.");
 
@@ -46,7 +46,7 @@
                     });
                     testRunner.setStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(false);
                     testRunner.setStatisticsMinimumTimeBetweenDataRecordsRemoval(0);
-                    testRunner.statisticsProcessStatisticsAndDataRecords();
+                    await testRunner.statisticsProcessStatisticsAndDataRecords();
                 });
             });
         });

--- a/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-not-removed-with-user-interaction-6-days-ago.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-not-removed-with-user-interaction-6-days-ago.html
@@ -214,9 +214,9 @@
         });
     }
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-removed-with-user-interaction-7-days-ago.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-removed-with-user-interaction-7-days-ago.html
@@ -214,9 +214,9 @@
         });
     }
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-website-data-removed.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-website-data-removed.html
@@ -214,9 +214,9 @@
         });
     }
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-handled-keydown.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-handled-keydown.html
@@ -18,7 +18,7 @@ onload = function() {
                 if (!testRunner.isStatisticsPrevalentResource(statisticsUrl))
                     testFailed("Host did not get set as prevalent resource.");
 
-                testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, false, function() {
+                testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, false, async function() {
                     if (testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
                         testFailed("Host did not get cleared of user interaction.");
 
@@ -41,7 +41,7 @@ onload = function() {
                     });
                     testRunner.setStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(false);
                     testRunner.setStatisticsMinimumTimeBetweenDataRecordsRemoval(0);
-                    testRunner.statisticsProcessStatisticsAndDataRecords();
+                    await testRunner.statisticsProcessStatisticsAndDataRecords();
 
                     debug("Simulate user typing letter 'a' into the field.");
                     testInput.focus();

--- a/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-unhandled-keydown.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-unhandled-keydown.html
@@ -18,7 +18,7 @@ onload = function() {
                 if (!testRunner.isStatisticsPrevalentResource(statisticsUrl))
                     testFailed("Host did not get set as prevalent resource.");
 
-                testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, false, function() {
+                testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, false, async function() {
                     if (testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
                         testFailed("Host did not get cleared of user interaction.");
 
@@ -36,7 +36,7 @@ onload = function() {
                     });
                     testRunner.setStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(false);
                     testRunner.setStatisticsMinimumTimeBetweenDataRecordsRemoval(0);
-                    testRunner.statisticsProcessStatisticsAndDataRecords();
+                    await testRunner.statisticsProcessStatisticsAndDataRecords();
 
                     debug("Simulate an unhandled user key press.");
                     if (window.eventSender)

--- a/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-with-user-interaction-timeout.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-with-user-interaction-timeout.html
@@ -10,6 +10,11 @@
 <script>
     const hostUnderTest = "127.0.0.1:8000";
     const statisticsUrl = "http://" + hostUnderTest + "/temp";
+    
+    async function processStatistics() {
+        await testRunner.statisticsProcessStatisticsAndDataRecords()
+    }
+    
     function runTestRunnerTest() {
         if (document.cookie !== "")
             testFailed("document.cookie not empty.");
@@ -40,7 +45,7 @@
                 testRunner.setStatisticsTimeToLiveUserInteraction(0);
 
                 // This is to ensure the timeout we're testing.
-                setTimeout("testRunner.statisticsProcessStatisticsAndDataRecords()", 1000);
+                setTimeout(processStatistics, 1000);
             });
         });
     }

--- a/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-with-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-with-user-interaction.html
@@ -32,7 +32,7 @@
                 if (!testRunner.isStatisticsPrevalentResource(otherPrevalentUrl))
                     testFailed("Other host did not get set as prevalent resource.");
 
-                testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, true, function() {
+                testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, true, async function() {
                     if (!testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
                         testFailed("Host did not get logged for user interaction.");
 
@@ -47,7 +47,7 @@
                     });
                     testRunner.setStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(false);
                     testRunner.setStatisticsMinimumTimeBetweenDataRecordsRemoval(0);
-                    testRunner.statisticsProcessStatisticsAndDataRecords();
+                    await testRunner.statisticsProcessStatisticsAndDataRecords();
                 });
             });
         });

--- a/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-without-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-without-user-interaction.html
@@ -34,7 +34,7 @@
             if (!testRunner.isStatisticsPrevalentResource(statisticsUrl))
                 testFailed("Host did not get set as prevalent resource.");
 
-            testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, false, function() {
+            testRunner.setStatisticsHasHadUserInteraction(statisticsUrl, false, async function() {
                 if (testRunner.isStatisticsHasHadUserInteraction(statisticsUrl))
                     testFailed("Host did not get cleared of user interaction.");
 
@@ -43,7 +43,7 @@
                 });
                 testRunner.setStatisticsShouldClassifyResourcesBeforeDataRecordsRemoval(false);
                 testRunner.setStatisticsMinimumTimeBetweenDataRecordsRemoval(0);
-                testRunner.statisticsProcessStatisticsAndDataRecords();
+                await testRunner.statisticsProcessStatisticsAndDataRecords();
             });
         });
     }

--- a/LayoutTests/http/tests/resourceLoadStatistics/prune-statistics.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/prune-statistics.html
@@ -141,7 +141,7 @@
         testRunner.setStatisticsPrevalentResource(fillerUrl, true, function() {
             testRunner.setStatisticsHasHadUserInteraction(fillerUrl, true, async function () {
                 await testRunner.setStatisticsLastSeen(fillerUrl, newestTimestamp);
-                testRunner.statisticsProcessStatisticsAndDataRecords();
+                await testRunner.statisticsProcessStatisticsAndDataRecords();
             });
         });
     }

--- a/LayoutTests/http/tests/resourceLoadStatistics/standalone-web-application-exempt-from-website-data-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/standalone-web-application-exempt-from-website-data-deletion.html
@@ -216,9 +216,9 @@
         });
     }
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-long-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-long-deletion.html
@@ -247,9 +247,9 @@
     }
 
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function setStatisticsForDomain(callback) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-short-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-short-deletion.html
@@ -247,9 +247,9 @@
     }
 
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function setStatisticsForDomain(callback) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-before-short-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-before-short-deletion.html
@@ -247,9 +247,9 @@
     }
 
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function setStatisticsForDomain(callback) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration-js-cookie-checking.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration-js-cookie-checking.html
@@ -219,9 +219,9 @@
         });
     }
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-after-short-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-after-short-deletion.html
@@ -247,9 +247,9 @@
     }
 
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function setStatisticsForDomain(callback) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-before-short-deletion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-before-short-deletion.html
@@ -247,9 +247,9 @@
     }
 
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function setStatisticsForDomain(callback) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-without-link-decoration.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-without-link-decoration.html
@@ -247,9 +247,9 @@
     }
 
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function setPrevalentDomain(callback) {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-with-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-with-user-interaction.html
@@ -215,9 +215,9 @@
         });
     }
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction-js-cookie-checking.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction-js-cookie-checking.html
@@ -219,9 +219,9 @@
         });
     }
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction.html
@@ -234,9 +234,9 @@
         });
     }
 
-    function processWebsiteDataAndContinue() {
+    async function processWebsiteDataAndContinue() {
         testRunner.installStatisticsDidScanDataRecordsCallback(checkWebsiteDataAndContinue);
-        testRunner.statisticsProcessStatisticsAndDataRecords();
+        await testRunner.statisticsProcessStatisticsAndDataRecords();
     }
 
     function checkWebsiteDataAndContinue() {

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -341,7 +341,7 @@ interface TestRunner {
     undefined setStatisticsCrossSiteLoadWithLinkDecoration(DOMString fromHost, DOMString toHost, boolean wasFiltered);
     undefined setStatisticsTimeToLiveUserInteraction(double seconds);
     boolean statisticsNotifyObserver();
-    undefined statisticsProcessStatisticsAndDataRecords();
+    Promise<undefined> statisticsProcessStatisticsAndDataRecords();
     undefined statisticsUpdateCookieBlocking(object completionHandler);
     undefined setStatisticsTimeAdvanceForTesting(double value);
     undefined setStatisticsIsRunningTest(boolean value);
@@ -353,7 +353,7 @@ interface TestRunner {
     undefined statisticsClearInMemoryAndPersistentStore(object callback);
     undefined statisticsClearInMemoryAndPersistentStoreModifiedSinceHours(unsigned long hours, object callback);
     undefined statisticsClearThroughWebsiteDataRemoval(object callback);
-    undefined statisticsDeleteCookiesForHost(DOMString hostName, boolean includeHttpOnlyCookies);
+    Promise<undefined> statisticsDeleteCookiesForHost(DOMString hostName, boolean includeHttpOnlyCookies);
     boolean isStatisticsHasLocalStorage(DOMString hostName);
     undefined setStatisticsCacheMaxAgeCap(double seconds);
     undefined statisticsResetToConsistentState(object completionHandler);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1440,9 +1440,9 @@ bool TestRunner::statisticsNotifyObserver()
     return InjectedBundle::singleton().statisticsNotifyObserver();
 }
 
-void TestRunner::statisticsProcessStatisticsAndDataRecords()
+void TestRunner::statisticsProcessStatisticsAndDataRecords(JSContextRef context, JSValueRef completionHandler)
 {
-    postSynchronousMessage("StatisticsProcessStatisticsAndDataRecords");
+    postMessageWithAsyncReply(context, "StatisticsProcessStatisticsAndDataRecords", completionHandler);
 }
 
 void TestRunner::statisticsUpdateCookieBlocking(JSContextRef context, JSValueRef completionHandler)
@@ -1505,12 +1505,12 @@ void TestRunner::statisticsClearThroughWebsiteDataRemoval(JSContextRef context, 
     postMessageWithAsyncReply(context, "StatisticsClearThroughWebsiteDataRemoval", callback);
 }
 
-void TestRunner::statisticsDeleteCookiesForHost(JSStringRef hostName, bool includeHttpOnlyCookies)
+void TestRunner::statisticsDeleteCookiesForHost(JSContextRef context, JSStringRef hostName, bool includeHttpOnlyCookies, JSValueRef callback)
 {
-    postSynchronousMessage("StatisticsDeleteCookiesForHost", createWKDictionary({
+    postMessageWithAsyncReply(context, "StatisticsDeleteCookiesForHost", createWKDictionary({
         { "HostName", toWK(hostName) },
         { "IncludeHttpOnlyCookies", adoptWK(WKBooleanCreate(includeHttpOnlyCookies)) },
-    }));
+    }), callback);
 }
 
 bool TestRunner::isStatisticsHasLocalStorage(JSStringRef hostName)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -416,7 +416,7 @@ public:
     void statisticsDidModifyDataRecordsCallback();
     void statisticsDidScanDataRecordsCallback();
     bool statisticsNotifyObserver();
-    void statisticsProcessStatisticsAndDataRecords();
+    void statisticsProcessStatisticsAndDataRecords(JSContextRef, JSValueRef completionHandler);
     void statisticsUpdateCookieBlocking(JSContextRef, JSValueRef completionHandler);
     void setStatisticsDebugMode(JSContextRef, bool value, JSValueRef completionHandler);
     void setStatisticsPrevalentResourceForDebugMode(JSContextRef, JSStringRef hostName, JSValueRef completionHandler);
@@ -454,7 +454,7 @@ public:
     void statisticsClearInMemoryAndPersistentStore(JSContextRef, JSValueRef callback);
     void statisticsClearInMemoryAndPersistentStoreModifiedSinceHours(JSContextRef, unsigned hours, JSValueRef callback);
     void statisticsClearThroughWebsiteDataRemoval(JSContextRef, JSValueRef callback);
-    void statisticsDeleteCookiesForHost(JSStringRef hostName, bool includeHttpOnlyCookies);
+    void statisticsDeleteCookiesForHost(JSContextRef, JSStringRef hostName, bool includeHttpOnlyCookies, JSValueRef callback);
     bool isStatisticsHasLocalStorage(JSStringRef hostName);
     void setStatisticsCacheMaxAgeCap(double seconds);
     bool hasStatisticsIsolatedSession(JSStringRef hostName);

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -250,7 +250,7 @@ public:
     void platformSetStatisticsCrossSiteLoadWithLinkDecoration(WKStringRef fromHost, WKStringRef toHost, bool wasFiltered, void* context, SetStatisticsCrossSiteLoadWithLinkDecorationCallBack);
 #endif
     void setStatisticsTimeToLiveUserInteraction(double seconds);
-    void statisticsProcessStatisticsAndDataRecords();
+    void statisticsProcessStatisticsAndDataRecords(CompletionHandler<void(WKTypeRef)>&&);
     void statisticsUpdateCookieBlocking(CompletionHandler<void(WKTypeRef)>&&);
     void setStatisticsNotifyPagesWhenDataRecordsWereScanned(bool);
     void setStatisticsTimeAdvanceForTesting(double);
@@ -263,7 +263,7 @@ public:
     void statisticsClearInMemoryAndPersistentStore(CompletionHandler<void(WKTypeRef)>&&);
     void statisticsClearInMemoryAndPersistentStoreModifiedSinceHours(unsigned hours, CompletionHandler<void(WKTypeRef)>&&);
     void statisticsClearThroughWebsiteDataRemoval(CompletionHandler<void(WKTypeRef)>&&);
-    void statisticsDeleteCookiesForHost(WKStringRef host, bool includeHttpOnlyCookies);
+    void statisticsDeleteCookiesForHost(WKStringRef host, bool includeHttpOnlyCookies, CompletionHandler<void(WKTypeRef)>&&);
     bool isStatisticsHasLocalStorage(WKStringRef hostName);
     void setStatisticsCacheMaxAgeCap(double seconds);
     bool hasStatisticsIsolatedSession(WKStringRef hostName);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1115,11 +1115,6 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         TestController::singleton().setStatisticsTimeToLiveUserInteraction(doubleValue(messageBody));
         return nullptr;
     }
-    
-    if (WKStringIsEqualToUTF8CString(messageName, "StatisticsProcessStatisticsAndDataRecords")) {
-        TestController::singleton().statisticsProcessStatisticsAndDataRecords();
-        return nullptr;
-    }
 
     if (WKStringIsEqualToUTF8CString(messageName, "StatisticsNotifyPagesWhenDataRecordsWereScanned")) {
         TestController::singleton().setStatisticsNotifyPagesWhenDataRecordsWereScanned(booleanValue(messageBody));
@@ -1158,14 +1153,6 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
     
     if (WKStringIsEqualToUTF8CString(messageName, "SetPruneEntriesDownTo")) {
         TestController::singleton().setStatisticsPruneEntriesDownTo(uint64Value(messageBody));
-        return nullptr;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "StatisticsDeleteCookiesForHost")) {
-        auto messageBodyDictionary = dictionaryValue(messageBody);
-        auto hostName = stringValue(messageBodyDictionary, "HostName");
-        auto includeHttpOnlyCookies = booleanValue(messageBodyDictionary, "IncludeHttpOnlyCookies");
-        TestController::singleton().statisticsDeleteCookiesForHost(hostName, includeHttpOnlyCookies);
         return nullptr;
     }
 


### PR DESCRIPTION
#### b4558e60491710224dc1ad1337f3de2899b33a01
<pre>
Make some of WebKitTestRunner&apos;s ResourceLoadStatistics functions properly async
<a href="https://bugs.webkit.org/show_bug.cgi?id=277430">https://bugs.webkit.org/show_bug.cgi?id=277430</a>
<a href="https://rdar.apple.com/132911948">rdar://132911948</a>

Reviewed by Charlie Wolfe.

This is a step towards making them work with site isolation.  It was big enough
I decided to make it its own PR.

* LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-mixed-statistics.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-sub-frame-under-top-frame-origins.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-subresource-under-top-frame-origins.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-non-prevalent-based-on-subresource-unique-redirects-to.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-mixed-statistics.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-sub-frame-under-top-frame-origins.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-redirect-to-prevalent.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-under-top-frame-origins.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-unique-redirects-to.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-redirect-to-prevalent.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-unique-redirects-to.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-very-prevalent-based-on-mixed-statistics.html:
* LayoutTests/http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store-one-hour.html:
* LayoutTests/http/tests/resourceLoadStatistics/clear-in-memory-and-persistent-store.html:
* LayoutTests/http/tests/resourceLoadStatistics/cookie-deletion-expected.txt:
* LayoutTests/http/tests/resourceLoadStatistics/cookie-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/delete-script-accessible-cookies.html:
* LayoutTests/http/tests/resourceLoadStatistics/enforce-samesite-strict-based-on-top-frame-unique-redirects-to.html:
* LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion-database.html:
* LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/app-bound-domains-exempt-from-website-data-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/managed-domains-exempt-from-website-data-deletion-database.html:
* LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/managed-domains-exempt-from-website-data-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/grandfathering.html:
* LayoutTests/http/tests/resourceLoadStatistics/many-inserts-only-insert-once.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-prevalent-resource-with-user-interaction.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-prevalent-resource-without-user-interaction.html:
* LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-not-removed-with-user-interaction-6-days-ago.html:
* LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-but-cookies-removed-with-user-interaction-7-days-ago.html:
* LayoutTests/http/tests/resourceLoadStatistics/operating-dates-all-website-data-removed.html:
* LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-handled-keydown.html:
* LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-unhandled-keydown.html:
* LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-with-user-interaction-timeout.html:
* LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-with-user-interaction.html:
* LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-without-user-interaction.html:
* LayoutTests/http/tests/resourceLoadStatistics/prune-statistics.html:
* LayoutTests/http/tests/resourceLoadStatistics/standalone-web-application-exempt-from-website-data-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-long-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-short-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-before-short-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration-js-cookie-checking.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-after-short-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-before-short-deletion.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-without-link-decoration.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-with-user-interaction.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction-js-cookie-checking.html:
* LayoutTests/http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction.html:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::statisticsProcessStatisticsAndDataRecords):
(WTR::TestRunner::statisticsDeleteCookiesForHost):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveAsyncMessageFromInjectedBundle):
(WTR::TestController::statisticsProcessStatisticsAndDataRecords):
(WTR::TestController::statisticsDeleteCookiesForHost):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/281671@main">https://commits.webkit.org/281671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffb752be31c9d192dbc3a9037459087441aadb45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64518 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11134 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49024 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7742 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52488 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29852 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9717 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10047 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66244 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4531 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56381 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52462 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56554 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3763 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9113 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35750 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36833 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37926 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->