### PR TITLE
Rename WKSafeBrowsingWarning to WKWarningView

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -118,12 +118,12 @@ class ViewGestureController;
 
 @class WKContentView;
 @class WKPasswordView;
-@class WKSafeBrowsingWarning;
 @class WKScrollView;
 @class WKTextExtractionItem;
 @class WKTextExtractionRequest;
 @class WKWebViewContentProviderRegistry;
 @class _WKFrameHandle;
+@class _WKWarningView;
 
 #if ENABLE(WRITING_TOOLS)
 @class WTTextSuggestion;
@@ -236,7 +236,7 @@ struct PerWebProcessState {
     WeakObjCPtr<id <_WKInputDelegate>> _inputDelegate;
     WeakObjCPtr<id <_WKAppHighlightDelegate>> _appHighlightDelegate;
 
-    RetainPtr<WKSafeBrowsingWarning> _safeBrowsingWarning;
+    RetainPtr<_WKWarningView> _warningView;
 
     std::optional<BOOL> _resolutionForShareSheetImmediateCompletionForTesting;
 
@@ -433,8 +433,11 @@ struct PerWebProcessState {
 
 - (void)_recalculateViewportSizesWithMinimumViewportInset:(CocoaEdgeInsets)minimumViewportInset maximumViewportInset:(CocoaEdgeInsets)maximumViewportInset throwOnInvalidInput:(BOOL)throwOnInvalidInput;
 
+- (void)_showWarningView:(const WebKit::SafeBrowsingWarning&)warning completionHandler:(CompletionHandler<void(std::variant<WebKit::ContinueUnsafeLoad, URL>&&)>&&)completionHandler;
 - (void)_showSafeBrowsingWarning:(const WebKit::SafeBrowsingWarning&)warning completionHandler:(CompletionHandler<void(std::variant<WebKit::ContinueUnsafeLoad, URL>&&)>&&)completionHandler;
+- (void)_clearWarningView;
 - (void)_clearSafeBrowsingWarning;
+- (void)_clearWarningViewIfForMainFrameNavigation;
 - (void)_clearSafeBrowsingWarningIfForMainFrameNavigation;
 
 - (std::optional<BOOL>)_resolutionForShareSheetImmediateCompletionForTesting;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -48,7 +48,6 @@
 #import "WKDataDetectorTypesInternal.h"
 #import "WKPasswordView.h"
 #import "WKProcessPoolPrivate.h"
-#import "WKSafeBrowsingWarning.h"
 #import "WKScrollView.h"
 #import "WKTextAnimationType.h"
 #import "WKUIDelegatePrivate.h"
@@ -64,6 +63,7 @@
 #import "WebPreferences.h"
 #import "WebProcessPool.h"
 #import "_WKActivatedElementInfoInternal.h"
+#import "_WKWarningView.h"
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/GraphicsContextCG.h>
 #import <WebCore/IOSurfacePool.h>
@@ -177,7 +177,7 @@ static WebCore::IntDegrees deviceOrientationForUIInterfaceOrientation(UIInterfac
 
 - (void)layoutSubviews
 {
-    [_safeBrowsingWarning setFrame:self.bounds];
+    [_warningView setFrame:self.bounds];
     [super layoutSubviews];
     [self _frameOrBoundsMayHaveChanged];
 }
@@ -721,7 +721,7 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
     return _obscuredInsetEdgesAffectedBySafeArea;
 }
 
-- (UIEdgeInsets)_computedObscuredInsetForSafeBrowsingWarning
+- (UIEdgeInsets)_computedObscuredInsetForWarningView
 {
     if (_haveSetObscuredInsets)
         return _obscuredInsets;
@@ -2586,7 +2586,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     [super safeAreaInsetsDidChange];
 
     [self _scheduleVisibleContentRectUpdate];
-    [_safeBrowsingWarning setContentInset:[self _computedObscuredInsetForSafeBrowsingWarning]];
+    [_warningView setContentInset:[self _computedObscuredInsetForWarningView]];
 }
 #endif
 
@@ -3894,7 +3894,7 @@ static bool isLockdownModeWarningNeeded()
     _obscuredInsets = obscuredInsets;
 
     [self _scheduleVisibleContentRectUpdate];
-    [_safeBrowsingWarning setContentInset:[self _computedObscuredInsetForSafeBrowsingWarning]];
+    [_warningView setContentInset:[self _computedObscuredInsetForWarningView]];
 }
 
 - (UIRectEdge)_obscuredInsetEdgesAffectedBySafeArea
@@ -4035,7 +4035,7 @@ static bool isLockdownModeWarningNeeded()
 
 - (UIView *)_safeBrowsingWarning
 {
-    return _safeBrowsingWarning.get();
+    return _warningView.get();
 }
 
 - (CGPoint)_convertPointFromContentsToView:(CGPoint)point

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -29,7 +29,6 @@
 #if PLATFORM(MAC)
 
 #import "AppKitSPI.h"
-#import "WKSafeBrowsingWarning.h"
 #import "WKTextAnimationType.h"
 #import "WKTextFinderClient.h"
 #import "WKWebViewConfigurationPrivate.h"
@@ -41,6 +40,7 @@
 #import "WebViewImpl.h"
 #import "_WKFrameHandleInternal.h"
 #import "_WKHitTestResultInternal.h"
+#import "_WKWarningView.h"
 #import <pal/spi/mac/NSTextFinderSPI.h>
 #import <pal/spi/mac/NSTextInputContextSPI.h>
 #import <pal/spi/mac/NSViewSPI.h>
@@ -171,7 +171,7 @@ std::optional<WebCore::ScrollbarOverlayStyle> toCoreScrollbarStyle(_WKOverlayScr
     BOOL didCreateWindowSnapshotReadinessHandler = [self _holdWindowResizeSnapshotIfNeeded];
 
     [super setFrameSize:size];
-    [_safeBrowsingWarning setFrame:self.bounds];
+    [_warningView setFrame:self.bounds];
     if (_impl)
         _impl->setFrameSize(NSSizeToCGSize(size));
 
@@ -1374,7 +1374,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSView *)_safeBrowsingWarning
 {
-    return _impl->safeBrowsingWarning();
+    return _impl->warningView();
 }
 
 - (_WKRectEdge)_pinnedState

--- a/Source/WebKit/UIProcess/Cocoa/_WKWarningView.h
+++ b/Source/WebKit/UIProcess/Cocoa/_WKWarningView.h
@@ -42,7 +42,7 @@ class SafeBrowsingWarning;
 enum class ContinueUnsafeLoad : bool;
 }
 
-OBJC_CLASS WKSafeBrowsingTextView;
+OBJC_CLASS _WKWarningViewTextView;
 
 #if PLATFORM(MAC)
 using ViewType = NSView;
@@ -52,26 +52,26 @@ using ViewType = UIView;
 using RectType = CGRect;
 #endif
 
-@interface WKSafeBrowsingBox : ViewType {
+@interface _WKWarningViewBox : ViewType {
 @package
 #if PLATFORM(MAC)
     RetainPtr<WebCore::CocoaColor> _backgroundColor;
 #endif
 }
-- (void)setSafeBrowsingBackgroundColor:(WebCore::CocoaColor *)color;
+- (void)setWarningViewBackgroundColor:(WebCore::CocoaColor *)color;
 @end
 
 #if PLATFORM(MAC)
-@interface WKSafeBrowsingWarning : WKSafeBrowsingBox<NSTextViewDelegate, NSAccessibilityGroup>
+@interface _WKWarningView : _WKWarningViewBox<NSTextViewDelegate, NSAccessibilityGroup>
 #else
-@interface WKSafeBrowsingWarning : UIScrollView<UITextViewDelegate>
+@interface _WKWarningView : UIScrollView<UITextViewDelegate>
 #endif
 {
 @package
     CompletionHandler<void(std::variant<WebKit::ContinueUnsafeLoad, URL>&&)> _completionHandler;
     RefPtr<const WebKit::SafeBrowsingWarning> _warning;
-    WeakObjCPtr<WKSafeBrowsingTextView> _details;
-    WeakObjCPtr<WKSafeBrowsingBox> _box;
+    WeakObjCPtr<_WKWarningViewTextView> _details;
+    WeakObjCPtr<_WKWarningViewBox> _box;
 #if PLATFORM(WATCHOS)
     WeakObjCPtr<UIResponder> _previousFirstResponder;
 #endif

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -550,24 +550,24 @@ void PageClientImpl::showSafeBrowsingWarning(const SafeBrowsingWarning& warning,
 {
     if (!m_impl)
         return completionHandler(ContinueUnsafeLoad::Yes);
-    m_impl->showSafeBrowsingWarning(warning, WTFMove(completionHandler));
+    m_impl->showWarningView(warning, WTFMove(completionHandler));
 }
 
 bool PageClientImpl::hasSafeBrowsingWarning() const
 {
     if (!m_impl)
         return false;
-    return !!m_impl->safeBrowsingWarning();
+    return !!m_impl->warningView();
 }
 
 void PageClientImpl::clearSafeBrowsingWarning()
 {
-    m_impl->clearSafeBrowsingWarning();
+    m_impl->clearWarningView();
 }
 
 void PageClientImpl::clearSafeBrowsingWarningIfForMainFrameNavigation()
 {
-    m_impl->clearSafeBrowsingWarningIfForMainFrameNavigation();
+    m_impl->clearWarningViewIfForMainFrameNavigation();
 }
 
 void PageClientImpl::setTextIndicator(Ref<TextIndicator> textIndicator, WebCore::TextIndicatorLifetime lifetime)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -71,7 +71,7 @@ OBJC_CLASS WKImageAnalysisOverlayViewDelegate;
 OBJC_CLASS WKImmediateActionController;
 OBJC_CLASS WKMouseTrackingObserver;
 OBJC_CLASS WKRevealItemPresenter;
-OBJC_CLASS WKSafeBrowsingWarning;
+OBJC_CLASS _WKWarningView;
 OBJC_CLASS WKShareSheet;
 OBJC_CLASS WKTextAnimationManager;
 OBJC_CLASS WKViewLayoutStrategy;
@@ -281,9 +281,9 @@ public:
     void setViewScale(CGFloat);
     CGFloat viewScale() const;
 
-    void showSafeBrowsingWarning(const SafeBrowsingWarning&, CompletionHandler<void(std::variant<ContinueUnsafeLoad, URL>&&)>&&);
-    void clearSafeBrowsingWarning();
-    void clearSafeBrowsingWarningIfForMainFrameNavigation();
+    void showWarningView(const SafeBrowsingWarning&, CompletionHandler<void(std::variant<ContinueUnsafeLoad, URL>&&)>&&);
+    void clearWarningView();
+    void clearWarningViewIfForMainFrameNavigation();
 
     WKLayoutMode layoutMode() const;
     void setLayoutMode(WKLayoutMode);
@@ -541,7 +541,7 @@ public:
     void insertTextPlaceholderWithSize(CGSize, void(^completionHandler)(NSTextPlaceholder *));
     void removeTextPlaceholder(NSTextPlaceholder *, bool willInsertText, void(^completionHandler)());
 
-    WKSafeBrowsingWarning *safeBrowsingWarning() { return m_safeBrowsingWarning.get(); }
+    _WKWarningView *warningView() { return m_warningView.get(); }
 
     ViewGestureController* gestureController() { return m_gestureController.get(); }
     ViewGestureController& ensureGestureController();
@@ -974,7 +974,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     bool m_isHandlingAcceptedCandidate { false };
     bool m_editableElementIsFocused { false };
     bool m_isTextInsertionReplacingSoftSpace { false };
-    RetainPtr<WKSafeBrowsingWarning> m_safeBrowsingWarning;
+    RetainPtr<_WKWarningView> m_warningView;
     
 #if ENABLE(DRAG_SUPPORT)
     NSInteger m_initialNumberOfValidItemsForDrop { 0 };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1541,8 +1541,8 @@
 		5C9A9113228F69CD005C5B17 /* XPCServiceMain.mm in Sources */ = {isa = PBXBuildFile; fileRef = BC82839616B47EC400A278FE /* XPCServiceMain.mm */; };
 		5C9E0F992A577EDD00FC2664 /* WebKitPlatformGeneratedSerializers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C9E0F972A577EC400FC2664 /* WebKitPlatformGeneratedSerializers.mm */; };
 		5C9E56831DF7F1B300C9EE33 /* WKWebsitePolicies.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C9E56811DF7F05500C9EE33 /* WKWebsitePolicies.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5CA26D81217ABD5B00F97A35 /* WKSafeBrowsingWarning.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA26D80217ABBB600F97A35 /* WKSafeBrowsingWarning.h */; };
-		5CA26D83217AD1B800F97A35 /* WKSafeBrowsingWarning.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CA26D7F217ABBB600F97A35 /* WKSafeBrowsingWarning.mm */; };
+		5CA26D81217ABD5B00F97A35 /* _WKWarningView.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA26D80217ABBB600F97A35 /* _WKWarningView.h */; };
+		5CA26D83217AD1B800F97A35 /* _WKWarningView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CA26D7F217ABBB600F97A35 /* _WKWarningView.mm */; };
 		5CA9854A210BEB640057EB6B /* SafeBrowsingWarning.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA98549210BEB5A0057EB6B /* SafeBrowsingWarning.h */; };
 		5CAAA85029BFBE99003340AE /* TCCSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44C51843266BE8C3006DD522 /* TCCSoftLink.mm */; };
 		5CAB7DE128B80FE1002282A6 /* GeneratedSerializers.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CAB7DDF28B80FE1002282A6 /* GeneratedSerializers.h */; };
@@ -6233,8 +6233,8 @@
 		5C9E56811DF7F05500C9EE33 /* WKWebsitePolicies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKWebsitePolicies.h; sourceTree = "<group>"; };
 		5C9EF2E721F058F9003BDC56 /* NetworkStorageSessionProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkStorageSessionProvider.h; sourceTree = "<group>"; };
 		5CA133EE28F61C4100541DAE /* WebPushDaemonConnectionConfiguration.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebPushDaemonConnectionConfiguration.serialization.in; sourceTree = "<group>"; };
-		5CA26D7F217ABBB600F97A35 /* WKSafeBrowsingWarning.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKSafeBrowsingWarning.mm; sourceTree = "<group>"; };
-		5CA26D80217ABBB600F97A35 /* WKSafeBrowsingWarning.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKSafeBrowsingWarning.h; sourceTree = "<group>"; };
+		5CA26D7F217ABBB600F97A35 /* _WKWarningView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWarningView.mm; sourceTree = "<group>"; };
+		5CA26D80217ABBB600F97A35 /* _WKWarningView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWarningView.h; sourceTree = "<group>"; };
 		5CA2F7472350E15400BE5194 /* NetworkSchemeRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkSchemeRegistry.h; sourceTree = "<group>"; };
 		5CA5A2CA29CBBA1B000F1046 /* WebContentExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = WebContentExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CA6A48B28F6621800F92B6E /* WTFArgumentCoders.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WTFArgumentCoders.serialization.in; sourceTree = "<group>"; };
@@ -9483,6 +9483,8 @@
 			children = (
 				CDF1B90C266F395E0007EC10 /* GroupActivities */,
 				57FD316B22B3367E008D0E8B /* SOAuthorization */,
+				5CA26D80217ABBB600F97A35 /* _WKWarningView.h */,
+				5CA26D7F217ABBB600F97A35 /* _WKWarningView.mm */,
 				99C81D551C20DFBE005C4C82 /* AutomationClient.h */,
 				99C81D561C20DFBE005C4C82 /* AutomationClient.mm */,
 				990D28B71C6539A000986977 /* AutomationSessionClient.h */,
@@ -9571,8 +9573,6 @@
 				E1AEA22E14687BDB00804569 /* WKFullKeyboardAccessWatcher.mm */,
 				1AD01BCB1905D54900C9C45F /* WKReloadFrameErrorRecoveryAttempter.h */,
 				1AD01BCA1905D54900C9C45F /* WKReloadFrameErrorRecoveryAttempter.mm */,
-				5CA26D80217ABBB600F97A35 /* WKSafeBrowsingWarning.h */,
-				5CA26D7F217ABBB600F97A35 /* WKSafeBrowsingWarning.mm */,
 				1DE0D095211CC21300439B5F /* WKShareSheet.h */,
 				1DBBB061211CC3CB00502ECC /* WKShareSheet.mm */,
 				7A78FF2E224191750096483E /* WKStorageAccessAlert.h */,
@@ -16021,6 +16021,7 @@
 				5790A66925679E000077C5A7 /* _WKUserVerificationRequirement.h in Headers */,
 				1A81B38118BD66AD0007FDAC /* _WKVisitedLinkStore.h in Headers */,
 				1A81B38518BD673A0007FDAC /* _WKVisitedLinkStoreInternal.h in Headers */,
+				5CA26D81217ABD5B00F97A35 /* _WKWarningView.h in Headers */,
 				579F1BF623C80DB600C7D4B4 /* _WKWebAuthenticationAssertionResponse.h in Headers */,
 				579F1BF923C80EC600C7D4B4 /* _WKWebAuthenticationAssertionResponseInternal.h in Headers */,
 				574728D123456E98001700AF /* _WKWebAuthenticationPanel.h in Headers */,
@@ -17483,7 +17484,6 @@
 				3336763B130C99DC006C9DE2 /* WKResourceCacheManager.h in Headers */,
 				BC8A501511765F5600757573 /* WKRetainPtr.h in Headers */,
 				F4974E76265ECBBC00B49B8C /* WKRevealItemPresenter.h in Headers */,
-				5CA26D81217ABD5B00F97A35 /* WKSafeBrowsingWarning.h in Headers */,
 				1A7E377918E4A4FE003D0FFF /* WKScriptMessage.h in Headers */,
 				1A7E377518E4A33A003D0FFF /* WKScriptMessageHandler.h in Headers */,
 				5109099723DACBF2003B1E4C /* WKScriptMessageHandlerWithReply.h in Headers */,
@@ -19410,6 +19410,7 @@
 				49FBEFFD239B011D00BD032F /* _WKResourceLoadStatisticsFirstParty.mm in Sources */,
 				49FBEFFF239B012F00BD032F /* _WKResourceLoadStatisticsThirdParty.mm in Sources */,
 				99E7189A21F79D9E0055E975 /* _WKTouchEventGenerator.mm in Sources */,
+				5CA26D83217AD1B800F97A35 /* _WKWarningView.mm in Sources */,
 				1C627479288B2F7400CED3A2 /* _WKWebExtension.mm in Sources */,
 				1CF0C9482AC37FAD00EC82F2 /* _WKWebExtensionAction.mm in Sources */,
 				1C974FDF2AFABD03009DE8FC /* _WKWebExtensionCommand.mm in Sources */,
@@ -19957,7 +19958,6 @@
 				5CE9120D2293C219005BEC78 /* WKMain.mm in Sources */,
 				DF84CEE4249AA24D009096F6 /* WKPDFHUDView.mm in Sources */,
 				E31869C42B1A7C2400571519 /* WKProcessExtension.mm in Sources */,
-				5CA26D83217AD1B800F97A35 /* WKSafeBrowsingWarning.mm in Sources */,
 				1DB01944211CF005009FB3E8 /* WKShareSheet.mm in Sources */,
 				7A78FF332241919B0096483E /* WKStorageAccessAlert.mm in Sources */,
 				C14D306924B79BE000480387 /* XPCEndpoint.mm in Sources */,


### PR DESCRIPTION
#### fc46bbbaea29d6bc0c9d342e45c5e24fb3da0a63
<pre>
Rename WKSafeBrowsingWarning to WKWarningView
<a href="https://bugs.webkit.org/show_bug.cgi?id=277442">https://bugs.webkit.org/show_bug.cgi?id=277442</a>
<a href="https://rdar.apple.com/132924925">rdar://132924925</a>

Reviewed by Alex Christensen.

Rename WKSafeBrowsingWarning, and associated state, to a more generic name.
This will be useful in future changes.

No other behavioral changes.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _showWarningView:completionHandler:]):
(-[WKWebView _showSafeBrowsingWarning:completionHandler:]):
(-[WKWebView _clearWarningView]):
(-[WKWebView _clearSafeBrowsingWarning]):
(-[WKWebView _clearWarningViewIfForMainFrameNavigation]):
(-[WKWebView _clearSafeBrowsingWarningIfForMainFrameNavigation]):
(-[WKWebView _showWarningViewWithTitle:warning:details:completionHandler:]):
(-[WKWebView _showSafeBrowsingWarningWithTitle:warning:details:completionHandler:]):
(-[WKWebView _showWarningViewWithURL:title:warning:details:completionHandler:]):
(-[WKWebView _showSafeBrowsingWarningWithURL:title:warning:details:completionHandler:]):
(-[WKWebView _showWarningViewWithURL:title:warning:detailsWithLinks:completionHandler:]):
(-[WKWebView _showSafeBrowsingWarningWithURL:title:warning:detailsWithLinks:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView layoutSubviews]):
(-[WKWebView _computedObscuredInsetForWarningView]):
(-[WKWebView safeAreaInsetsDidChange]):
(-[WKWebView _setObscuredInsets:]):
(-[WKWebView _safeBrowsingWarning]):
(-[WKWebView _computedObscuredInsetForSafeBrowsingWarning]): Deleted.
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView setFrameSize:]):
(-[WKWebView _safeBrowsingWarning]):
* Source/WebKit/UIProcess/Cocoa/_WKWarningView.h: Renamed from Source/WebKit/UIProcess/Cocoa/WKSafeBrowsingWarning.h.
* Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm: Renamed from Source/WebKit/UIProcess/Cocoa/WKSafeBrowsingWarning.mm.
(colorForItem):
(-[WKSafeBrowsingExclamationPoint drawRect:]):
(makeButton):
(-[_WKWarningViewBox setWarningViewBackgroundColor:]):
(-[_WKWarningView initWithFrame:safeBrowsingWarning:completionHandler:]):
(-[_WKWarningView addContent]):
(-[_WKWarningView showDetailsClicked]):
(-[_WKWarningView clickedOnLink:]):
(-[_WKWarningViewTextView initWithAttributedString:forWarning:]):
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::showSafeBrowsingWarning):
(WebKit::PageClientImpl::hasSafeBrowsingWarning const):
(WebKit::PageClientImpl::clearSafeBrowsingWarning):
(WebKit::PageClientImpl::clearSafeBrowsingWarningIfForMainFrameNavigation):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::showWarningView):
(WebKit::WebViewImpl::clearWarningView):
(WebKit::WebViewImpl::clearWarningViewIfForMainFrameNavigation):
(WebKit::WebViewImpl::setFrameSize):
(WebKit::WebViewImpl::accessibilityAttributeValue):
(WebKit::WebViewImpl::nativeMouseEventHandlerInternal):
(WebKit::WebViewImpl::showSafeBrowsingWarning): Deleted.
(WebKit::WebViewImpl::clearSafeBrowsingWarning): Deleted.
(WebKit::WebViewImpl::clearSafeBrowsingWarningIfForMainFrameNavigation): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/281715@main">https://commits.webkit.org/281715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/618070e1907e2f17e6088c02f999a65727c1daf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60649 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11196 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49051 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7775 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29905 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33952 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10109 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66309 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56421 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56598 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3807 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9138 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35813 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36895 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37988 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->