### PR TITLE
[WASM] Fix prefixed-opcode code origins for relaxed SIMD opcodes

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h
@@ -53,7 +53,7 @@ public:
     {
         ASSERT(static_cast<uint32_t>(offset) == offset);
         ASSERT(static_cast<OpType>(static_cast<uint8_t>(prefix)) == prefix);
-        ASSERT(static_cast<uint8_t>(opcode) == opcode);
+        ASSERT((opcode & (1 << 24) - 1) == opcode);
         packedData = (static_cast<uint64_t>(opcode) << 40) | (static_cast<uint64_t>(prefix) << 32) | offset;
     }
     OpcodeOrigin(B3::Origin origin)
@@ -62,10 +62,10 @@ public:
     }
 
     OpType opcode() const { return static_cast<OpType>(packedData >> 32 & 0xff); }
-    Ext1OpType ext1Opcode() const { return static_cast<Ext1OpType>(packedData >> 40 & 0xff); }
-    ExtSIMDOpType simdOpcode() const { return static_cast<ExtSIMDOpType>(packedData >> 40 & 0xff); }
-    ExtGCOpType gcOpcode() const { return static_cast<ExtGCOpType>(packedData >> 40 & 0xff); }
-    ExtAtomicOpType atomicOpcode() const { return static_cast<ExtAtomicOpType>(packedData >> 40 & 0xff); }
+    Ext1OpType ext1Opcode() const { return static_cast<Ext1OpType>(packedData >> 40); }
+    ExtSIMDOpType simdOpcode() const { return static_cast<ExtSIMDOpType>(packedData >> 40); }
+    ExtGCOpType gcOpcode() const { return static_cast<ExtGCOpType>(packedData >> 40); }
+    ExtAtomicOpType atomicOpcode() const { return static_cast<ExtAtomicOpType>(packedData >> 40); }
     size_t location() const { return static_cast<uint32_t>(packedData); }
 
 private:


### PR DESCRIPTION
#### 7da9729a2e2a44dd001f07f1acd000dda7a24e5f
<pre>
[WASM] Fix prefixed-opcode code origins for relaxed SIMD opcodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=277446">https://bugs.webkit.org/show_bug.cgi?id=277446</a>
<a href="https://rdar.apple.com/problem/132927699">rdar://problem/132927699</a>

Reviewed by Keith Miller and Yijia Huang.

Removes the assertion that the prefixed opcode in an OpcodeOrigin
fits in 8 bits. This is violated by the relaxed SIMD proposal, which
currently reserves up to 0x12F. Instead, this patch just lets the
opcode use all of the upper 24 bits of the origin.

* Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h:
(JSC::Wasm::OpcodeOrigin::OpcodeOrigin):
(JSC::Wasm::OpcodeOrigin::ext1Opcode const):
(JSC::Wasm::OpcodeOrigin::simdOpcode const):
(JSC::Wasm::OpcodeOrigin::gcOpcode const):
(JSC::Wasm::OpcodeOrigin::atomicOpcode const):

Canonical link: <a href="https://commits.webkit.org/281681@main">https://commits.webkit.org/281681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5c627b425702d8ce199699e755499762fddae62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64557 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11173 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11448 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49044 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7765 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29872 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9750 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10086 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/53726 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66286 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59873 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56409 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56585 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13512 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3791 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81628 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35790 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14199 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36872 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37965 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36617 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->