### PR TITLE
Add test case for floating object element

### DIFF
--- a/LayoutTests/fast/block/crash-when-style-and-renderer-invalidated-for-floating-object-element-expected.txt
+++ b/LayoutTests/fast/block/crash-when-style-and-renderer-invalidated-for-floating-object-element-expected.txt
@@ -1,0 +1,4 @@
+PASS if no crash or assert.
+
+
+

--- a/LayoutTests/fast/block/crash-when-style-and-renderer-invalidated-for-floating-object-element.html
+++ b/LayoutTests/fast/block/crash-when-style-and-renderer-invalidated-for-floating-object-element.html
@@ -1,0 +1,38 @@
+<!DOCTYPE>
+<style>
+  .vrl {
+      writing-mode: vertical-rl;
+  }
+  #wide {
+      display: inline-block;
+      width: 100000000vmin;
+  }
+  #outer.flow {
+      display: flow;
+  }
+  #inner:before {
+      content: "A";
+  }
+  object {
+      float: inline-end;
+  }
+</style>
+<p>PASS if no crash or assert.</p>
+<div id="container" class="vrl">
+  <span>
+    <span id="wide"></span>
+    <span id="outer" class="flow">
+      <span id="inner"></span>
+    </span>
+    <object></object>
+  </span>
+  <div id="div"></div>
+</div>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+  inner.append(div.cloneNode());
+  inner.scrollLeft;
+  outer.classList.remove("flow");
+  container.classList.remove("vrl");
+</script>


### PR DESCRIPTION
#### 7998bd43fa21c1e1f092f5d1222e4de3c47fea08
<pre>
Add test case for floating object element
<a href="https://bugs.webkit.org/show_bug.cgi?id=272687">https://bugs.webkit.org/show_bug.cgi?id=272687</a>
<a href="https://rdar.apple.com/132934874">rdar://132934874</a>

Reviewed by Alan Baradlay.

This is a reduced crash test for bug 272687 (and its duplicate bug
272296), which is fixed by the patch for bug 272488.

* LayoutTests/fast/block/crash-when-style-and-renderer-invalidated-for-floating-object-element-expected.txt: Added.
* LayoutTests/fast/block/crash-when-style-and-renderer-invalidated-for-floating-object-element.html: Added.

Originally-landed-as: 277198.3@webkit-2024.4-embargoed (547a9b1a997a). <a href="https://rdar.apple.com/132934874">rdar://132934874</a>
Canonical link: <a href="https://commits.webkit.org/281679@main">https://commits.webkit.org/281679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/358cfc618f7899f6b96ae0b46bbc8b59fd1d8095

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11188 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11463 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49049 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7770 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29877 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9756 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10101 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55803 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66301 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4585 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52500 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13509 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3802 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/37980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->