### PR TITLE
Add CSS parser support for the @view-transition rule and the navigation descriptor.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7529,6 +7529,7 @@ imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-vie
 
 # View transitions Level 2 - cross document transitions.
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-cssom.html [ Pass ]
 
 # View transitions Level 2 - types.
 imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-match-early-mutation.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-cssom-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL CSSViewTransitionRule is correctly parsed and accessible via CSSOM. The string did not match the expected pattern.
-FAIL `navigation: auto` is correctly parsed. The string did not match the expected pattern.
-FAIL `navigation: none` is correctly parsed. The string did not match the expected pattern.
+FAIL CSSViewTransitionRule is correctly parsed and accessible via CSSOM. assert_equals: expected "" but got "none"
+PASS `navigation: auto` is correctly parsed.
+PASS `navigation: none` is correctly parsed.
 PASS @view-transition fails parsing with a preamble
-FAIL Invalid `navigation` value fails to parse. The string did not match the expected pattern.
-FAIL `navigation` with !important flag should fail to parse. The string did not match the expected pattern.
-FAIL `navigation` descriptor cannot be set. The string did not match the expected pattern.
+PASS Invalid `navigation` value fails to parse.
+PASS `navigation` with !important flag should fail to parse.
+PASS `navigation` descriptor cannot be set.
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1834,6 +1834,20 @@ CoreMathMLEnabled:
     WebCore:
       default: false
 
+CrossDocumentViewTransitionsEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "Cross document view-transitions"
+  humanReadableDescription: "Enable support for view-transitions cross-document"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CrossOriginEmbedderPolicyEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -941,6 +941,7 @@ set(WebCore_NON_SVG_IDL_FILES
     css/CSSStyleSheet.idl
     css/CSSSupportsRule.idl
     css/CSSUnknownRule.idl
+    css/CSSViewTransitionRule.idl
     css/DocumentOrShadowRoot+CSSOM.idl
     css/DOMCSSCustomPropertyDescriptor.idl
     css/DOMCSSNamespace+CSSNumericFactory.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1231,6 +1231,7 @@ $(PROJECT_DIR)/css/CSSStyleSheet.idl
 $(PROJECT_DIR)/css/CSSSupportsRule.idl
 $(PROJECT_DIR)/css/CSSUnknownRule.idl
 $(PROJECT_DIR)/css/CSSValueKeywords.in
+$(PROJECT_DIR)/css/CSSViewTransitionRule.idl
 $(PROJECT_DIR)/css/DOMCSSCustomPropertyDescriptor.idl
 $(PROJECT_DIR)/css/DOMCSSNamespace+CSSNumericFactory.idl
 $(PROJECT_DIR)/css/DOMCSSNamespace+CSSPainting.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -507,6 +507,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSUnknownRule.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSUnknownRule.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSUnparsedValue.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSUnparsedValue.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSViewTransitionRule.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSViewTransitionRule.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCacheQueryOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCacheQueryOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCanvasCaptureMediaStreamTrack.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -952,6 +952,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/css/CSSStyleSheet.idl \
     $(WebCore)/css/CSSSupportsRule.idl \
     $(WebCore)/css/CSSUnknownRule.idl \
+    $(WebCore)/css/CSSViewTransitionRule.idl \
     $(WebCore)/css/DocumentOrShadowRoot+CSSOM.idl \
     $(WebCore)/css/DOMCSSCustomPropertyDescriptor.idl \
     $(WebCore)/css/DOMCSSNamespace.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -924,6 +924,7 @@ css/CSSValuePool.cpp
 css/CSSVariableData.cpp
 css/CSSVariableReferenceValue.cpp
 css/CSSViewValue.cpp
+css/CSSViewTransitionRule.cpp
 css/ComputedStyleExtractor.cpp
 css/DOMCSSNamespace.cpp
 css/DOMCSSPaintWorklet.cpp
@@ -3397,6 +3398,7 @@ JSCSSSupportsRule.cpp
 JSCSSTransition.cpp
 JSCSSTransitionEvent.cpp
 JSCSSUnknownRule.cpp
+JSCSSViewTransitionRule.cpp
 JSCOEPInheritenceViolationReportBody.cpp
 JSCORPViolationReportBody.cpp
 JSCacheQueryOptions.cpp

--- a/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
@@ -44,6 +44,7 @@
 #include "CSSStartingStyleRule.h"
 #include "CSSStyleRule.h"
 #include "CSSSupportsRule.h"
+#include "CSSViewTransitionRule.h"
 #include "JSCSSContainerRule.h"
 #include "JSCSSCounterStyleRule.h"
 #include "JSCSSFontFaceRule.h"
@@ -62,6 +63,7 @@
 #include "JSCSSStartingStyleRule.h"
 #include "JSCSSStyleRule.h"
 #include "JSCSSSupportsRule.h"
+#include "JSCSSViewTransitionRule.h"
 #include "JSNode.h"
 #include "JSStyleSheetCustom.h"
 #include "WebCoreOpaqueRootInlines.h"
@@ -119,6 +121,8 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<C
         return createWrapper<CSSScopeRule>(globalObject, WTFMove(rule));
     case StyleRuleType::StartingStyle:
         return createWrapper<CSSStartingStyleRule>(globalObject, WTFMove(rule));
+    case StyleRuleType::ViewTransition:
+        return createWrapper<CSSViewTransitionRule>(globalObject, WTFMove(rule));
     case StyleRuleType::Unknown:
     case StyleRuleType::Charset:
     case StyleRuleType::Margin:

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -168,6 +168,7 @@ namespace WebCore {
     macro(CSSUnitValue) \
     macro(CSSUnparsedValue) \
     macro(CSSVariableReferenceValue) \
+    macro(CSSViewTransitionRule) \
     macro(CommandEvent) \
     macro(CookieChangeEvent) \
     macro(CookieStore) \

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9924,6 +9924,23 @@
                 }
             }
         },
+        "@view-transition": {
+            "navigation": {
+                "values": [
+                    "none",
+                    "auto"
+                ],
+                "codegen-properties": {
+                    "settings-flag": "crossDocumentViewTransitionsEnabled",
+                    "parser-grammar": "<<values>>",
+                    "parser-exported": true
+                },
+                 "specification": {
+                     "category": "css-view-transitions",
+                     "url": "https://www.w3.org/TR/css-view-transitions-2/#view-transition-navigation-descriptor"
+                 }
+             }
+        },
         "@property": {
             "syntax": {
                 "codegen-properties": {

--- a/Source/WebCore/css/CSSViewTransitionRule.cpp
+++ b/Source/WebCore/css/CSSViewTransitionRule.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSViewTransitionRule.h"
+
+#include "CSSPropertyParser.h"
+#include "CSSStyleSheet.h"
+#include "CSSTokenizer.h"
+#include "CSSValuePair.h"
+#include "MutableStyleProperties.h"
+#include "StyleProperties.h"
+#include "StylePropertiesInlines.h"
+#include <wtf/text/StringBuilder.h>
+
+namespace WebCore {
+
+static std::optional<ViewTransitionNavigation> toViewTransitionNavigationEnum(RefPtr<CSSValue> navigation)
+{
+    if (!navigation || !navigation->isPrimitiveValue())
+        return std::nullopt;
+
+    auto& primitiveNavigationValue = downcast<CSSPrimitiveValue>(*navigation);
+    ASSERT(primitiveNavigationValue.isValueID());
+
+    if (primitiveNavigationValue.valueID() == CSSValueAuto)
+        return ViewTransitionNavigation::Auto;
+    return ViewTransitionNavigation::None;
+}
+
+StyleRuleViewTransition::StyleRuleViewTransition(Ref<StyleProperties>&& properties)
+    : StyleRuleBase(StyleRuleType::ViewTransition)
+{
+    m_navigation = toViewTransitionNavigationEnum(properties->getPropertyCSSValue(CSSPropertyNavigation));
+}
+
+Ref<StyleRuleViewTransition> StyleRuleViewTransition::create(Ref<StyleProperties>&& properties)
+{
+    return adoptRef(*new StyleRuleViewTransition(WTFMove(properties)));
+}
+
+StyleRuleViewTransition::~StyleRuleViewTransition() = default;
+
+Ref<CSSViewTransitionRule> CSSViewTransitionRule::create(StyleRuleViewTransition& rule, CSSStyleSheet* sheet)
+{
+    return adoptRef(*new CSSViewTransitionRule(rule, sheet));
+}
+
+CSSViewTransitionRule::CSSViewTransitionRule(StyleRuleViewTransition& viewTransitionRule, CSSStyleSheet* parent)
+    : CSSRule(parent)
+    , m_viewTransitionRule(viewTransitionRule)
+{
+}
+
+CSSViewTransitionRule::~CSSViewTransitionRule() = default;
+
+String CSSViewTransitionRule::cssText() const
+{
+    StringBuilder builder;
+    builder.append("@view-transition { "_s);
+
+    if (m_viewTransitionRule->navigation()) {
+        builder.append("navigation: "_s);
+        if (*m_viewTransitionRule->navigation() == ViewTransitionNavigation::Auto)
+            builder.append("auto"_s);
+        else
+            builder.append("none"_s);
+        builder.append("; "_s);
+    }
+
+    builder.append('}');
+    return builder.toString();
+}
+
+void CSSViewTransitionRule::reattach(StyleRuleBase& rule)
+{
+    m_viewTransitionRule = downcast<StyleRuleViewTransition>(rule);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSViewTransitionRule.h
+++ b/Source/WebCore/css/CSSViewTransitionRule.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSRule.h"
+#include "StyleProperties.h"
+#include "StyleRule.h"
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+enum class ViewTransitionNavigation : bool {
+    Auto,
+    None,
+};
+
+class StyleRuleViewTransition final : public StyleRuleBase {
+public:
+    static Ref<StyleRuleViewTransition> create(Ref<StyleProperties>&&);
+    ~StyleRuleViewTransition();
+
+    Ref<StyleRuleViewTransition> copy() const { return adoptRef(*new StyleRuleViewTransition(*this)); }
+
+    std::optional<ViewTransitionNavigation> navigation() const { return m_navigation; }
+    ViewTransitionNavigation computedNavigation() const { return navigation().value_or(ViewTransitionNavigation::None); }
+
+private:
+    explicit StyleRuleViewTransition(Ref<StyleProperties>&&);
+    StyleRuleViewTransition(const StyleRuleViewTransition&) = default;
+
+    std::optional<ViewTransitionNavigation> m_navigation;
+};
+
+class CSSViewTransitionRule final : public CSSRule {
+public:
+    using ViewTransitionNavigation = WebCore::ViewTransitionNavigation;
+
+    static Ref<CSSViewTransitionRule> create(StyleRuleViewTransition&, CSSStyleSheet*);
+    virtual ~CSSViewTransitionRule();
+
+    String cssText() const final;
+    void reattach(StyleRuleBase&) final;
+    StyleRuleType styleRuleType() const final { return StyleRuleType::ViewTransition; }
+
+    ViewTransitionNavigation navigation() const { return m_viewTransitionRule->computedNavigation(); }
+
+private:
+    CSSViewTransitionRule(StyleRuleViewTransition&, CSSStyleSheet* parent);
+
+    Ref<StyleRuleViewTransition> m_viewTransitionRule;
+};
+
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_RULE(CSSViewTransitionRule, StyleRuleType::ViewTransition)
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleViewTransition)
+static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isViewTransitionRule(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/css/CSSViewTransitionRule.idl
+++ b/Source/WebCore/css/CSSViewTransitionRule.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://www.w3.org/TR/css-view-transitions-2/#view-transition-rule
+enum ViewTransitionNavigation { "auto", "none" };
+
+[
+    EnabledBySetting=CrossDocumentViewTransitionsEnabled,
+    Exposed=Window
+]
+interface CSSViewTransitionRule : CSSRule {
+  readonly attribute ViewTransitionNavigation navigation;
+};

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -4778,6 +4778,10 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertySizeAdjust:
         return nullptr;
 
+    // @view-transition descriptors.
+    case CSSPropertyNavigation:
+        return nullptr;
+
     // Unimplemented @font-palette-values properties
     case CSSPropertyBasePalette:
     case CSSPropertyOverrideColors:

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -41,6 +41,7 @@
 #include "CSSStartingStyleRule.h"
 #include "CSSStyleRule.h"
 #include "CSSSupportsRule.h"
+#include "CSSViewTransitionRule.h"
 #include "MediaList.h"
 #include "MutableStyleProperties.h"
 #include "StyleProperties.h"
@@ -124,6 +125,8 @@ template<typename Visitor> constexpr decltype(auto) StyleRuleBase::visitDerived(
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleScope>(*this));
     case StyleRuleType::StartingStyle:
         return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleStartingStyle>(*this));
+    case StyleRuleType::ViewTransition:
+        return std::invoke(std::forward<Visitor>(visitor), uncheckedDowncast<StyleRuleViewTransition>(*this));
     case StyleRuleType::Margin:
         break;
     case StyleRuleType::Unknown:
@@ -216,6 +219,9 @@ Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet* parentSheet, CSSRu
         },
         [&](StyleRuleStartingStyle& rule) -> Ref<CSSRule> {
             return CSSStartingStyleRule::create(rule, parentSheet);
+        },
+        [&](StyleRuleViewTransition& rule) -> Ref<CSSRule> {
+            return CSSViewTransitionRule::create(rule, parentSheet);
         },
         [](StyleRuleCharset&) -> Ref<CSSRule> {
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -78,6 +78,7 @@ public:
     bool isPropertyRule() const { return type() == StyleRuleType::Property; }
     bool isScopeRule() const { return type() == StyleRuleType::Scope; }
     bool isStartingStyleRule() const { return type() == StyleRuleType::StartingStyle; }
+    bool isViewTransitionRule() const { return type() == StyleRuleType::ViewTransition; }
 
     Ref<StyleRuleBase> copy() const;
 

--- a/Source/WebCore/css/StyleRuleType.h
+++ b/Source/WebCore/css/StyleRuleType.h
@@ -44,8 +44,9 @@ enum class StyleRuleType : uint8_t {
     CounterStyle = 11,
     Supports = 12,
     FontFeatureValues = 14,
-    // Numbers above 15 are not exposed to the web.
-    LayerBlock = 16,
+    // Numbers above 14 are not exposed to the web.
+    ViewTransition = 15,
+    LayerBlock,
     LayerStatement,
     Container,
     FontPaletteValues,
@@ -56,6 +57,6 @@ enum class StyleRuleType : uint8_t {
     StartingStyle,
 };
 
-static constexpr auto firstUnexposedStyleRuleType = StyleRuleType::LayerBlock;
+static constexpr auto firstUnexposedStyleRuleType = StyleRuleType::ViewTransition;
 
 } // namespace WebCore

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -566,6 +566,7 @@ bool StyleSheetContents::traverseSubresources(const Function<bool(const CachedRe
         case StyleRuleType::Property:
         case StyleRuleType::Scope:
         case StyleRuleType::StartingStyle:
+        case StyleRuleType::ViewTransition:
             return false;
         };
         ASSERT_NOT_REACHED();
@@ -638,6 +639,7 @@ bool StyleSheetContents::mayDependOnBaseURL() const
         case StyleRuleType::Property:
         case StyleRuleType::Scope:
         case StyleRuleType::StartingStyle:
+        case StyleRuleType::ViewTransition:
             return false;
         };
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/parser/CSSAtRuleID.cpp
+++ b/Source/WebCore/css/parser/CSSAtRuleID.cpp
@@ -60,6 +60,7 @@ CSSAtRuleID cssAtRuleID(StringView name)
         { "stylistic",             CSSAtRuleStylistic },
         { "supports",              CSSAtRuleSupports },
         { "swash",                 CSSAtRuleSwash },
+        { "view-transition",       CSSAtRuleViewTransition },
     };
     static constexpr SortedArrayMap cssAtRules { mappings };
     return cssAtRules.get(name, CSSAtRuleInvalid);

--- a/Source/WebCore/css/parser/CSSAtRuleID.h
+++ b/Source/WebCore/css/parser/CSSAtRuleID.h
@@ -44,6 +44,7 @@ enum CSSAtRuleID {
     CSSAtRuleNamespace,
     CSSAtRulePage,
     CSSAtRuleSupports,
+    CSSAtRuleViewTransition,
 
     CSSAtRuleWebkitKeyframes,
     CSSAtRuleCounterStyle,

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -63,6 +63,7 @@ class StyleRuleNamespace;
 class StyleRulePage;
 class StyleRuleSupports;
 class StyleRuleViewport;
+class StyleRuleViewTransition;
 class StyleSheetContents;
 class ImmutableStyleProperties;
 class Element;
@@ -88,6 +89,7 @@ public:
         KeyframeRules,
         CounterStyleRules,
         FontFeatureValuesRules,
+        ViewTransitionRules,
         NoRules, // For parsing at-rules inside declaration lists (without nesting support)
     };
 
@@ -160,6 +162,7 @@ private:
     RefPtr<StyleRuleProperty> consumePropertyRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleScope> consumeScopeRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleStartingStyle> consumeStartingStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
+    RefPtr<StyleRuleViewTransition> consumeViewTransitionRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
 
     RefPtr<StyleRuleKeyframe> consumeKeyframeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleBase> consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -220,6 +220,8 @@ bool CSSPropertyParser::parseValue(CSSPropertyID propertyID, bool important, con
         parseSuccess = parser.parseCounterStyleDescriptor(propertyID);
     else if (ruleType == StyleRuleType::Keyframe)
         parseSuccess = parser.parseKeyframeDescriptor(propertyID, important);
+    else if (ruleType == StyleRuleType::ViewTransition)
+        parseSuccess = parser.parseViewTransitionDescriptor(propertyID);
     else if (ruleType == StyleRuleType::Property)
         parseSuccess = parser.parsePropertyDescriptor(propertyID);
     else
@@ -541,6 +543,26 @@ bool CSSPropertyParser::parseCounterStyleDescriptor(CSSPropertyID property)
     addProperty(property, CSSPropertyInvalid, WTFMove(parsedValue), false);
     return true;
 }
+
+RefPtr<CSSValue> CSSPropertyParser::parseViewTransitionDescriptor(CSSPropertyID property, CSSParserTokenRange& range, const CSSParserContext& context)
+{
+    ASSERT(context.propertySettings.crossDocumentViewTransitionsEnabled);
+
+    return CSSPropertyParsing::parseViewTransitionDescriptor(range, property, context);
+}
+
+bool CSSPropertyParser::parseViewTransitionDescriptor(CSSPropertyID property)
+{
+    ASSERT(m_context.propertySettings.crossDocumentViewTransitionsEnabled);
+
+    RefPtr parsedValue = CSSPropertyParsing::parseViewTransitionDescriptor(m_range, property, m_context);
+    if (!parsedValue || !m_range.atEnd())
+        return false;
+
+    addProperty(property, CSSPropertyInvalid, WTFMove(parsedValue), false);
+    return true;
+}
+
 
 bool CSSPropertyParser::parseFontFaceDescriptor(CSSPropertyID property)
 {

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -56,6 +56,7 @@ public:
     static bool isValidCustomPropertyValueForSyntax(const CSSCustomPropertySyntax&, CSSParserTokenRange, const CSSParserContext&);
 
     static RefPtr<CSSValue> parseCounterStyleDescriptor(CSSPropertyID, CSSParserTokenRange&, const CSSParserContext&);
+    static RefPtr<CSSValue> parseViewTransitionDescriptor(CSSPropertyID, CSSParserTokenRange&, const CSSParserContext&);
 
 private:
     CSSPropertyParser(const CSSParserTokenRange&, const CSSParserContext&, Vector<CSSProperty, 256>*, bool consumeWhitespace = true);
@@ -86,6 +87,9 @@ private:
 
     // @property descriptors.
     bool parsePropertyDescriptor(CSSPropertyID);
+
+    // @view-transition descriptors.
+    bool parseViewTransitionDescriptor(CSSPropertyID);
 
     void addProperty(CSSPropertyID longhand, CSSPropertyID shorthand, RefPtr<CSSValue>&&, bool important, bool implicit = false);
     void addExpandedProperty(CSSPropertyID shorthand, RefPtr<CSSValue>&&, bool important, bool implicit = false);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -39,6 +39,7 @@
 #include "CSSPropertyNames.h"
 #include "CSSStyleDeclaration.h"
 #include "CSSStyleSheet.h"
+#include "CSSViewTransitionRule.h"
 #include "CachedCSSStyleSheet.h"
 #include "CachedFontLoadRequest.h"
 #include "CachedFrame.h"
@@ -8065,6 +8066,18 @@ void Document::dispatchPagehideEvent(PageshowEventPersistence persisted)
         return;
     m_lastPageStatus = PageStatus::Hidden;
     dispatchWindowEvent(PageTransitionEvent::create(eventNames().pagehideEvent, persisted == PageshowEventPersistence::Persisted), this);
+}
+
+// https://www.w3.org/TR/css-view-transitions-2/#vt-rule-algo
+bool Document::resolveViewTransitionRule()
+{
+    if (visibilityState() == VisibilityState::Hidden)
+        return false;
+
+    auto rule = styleScope().resolver().viewTransitionRule();
+    if (rule)
+        return rule->computedNavigation() == ViewTransitionNavigation::Auto;
+    return false;
 }
 
 void Document::enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventInit&& eventInit)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1384,6 +1384,8 @@ public:
     void enqueueHashchangeEvent(const String& oldURL, const String& newURL);
     void dispatchPopstateEvent(RefPtr<SerializedScriptValue>&& stateObject);
 
+    bool resolveViewTransitionRule();
+
     WEBCORE_EXPORT void addMediaCanStartListener(MediaCanStartListener&);
     WEBCORE_EXPORT void removeMediaCanStartListener(MediaCanStartListener&);
     MediaCanStartListener* takeAnyMediaCanStartListener();

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -118,6 +118,7 @@ static RuleFlatteningStrategy flatteningStrategyForStyleRuleType(StyleRuleType s
     case StyleRuleType::FontFeatureValuesBlock:
     case StyleRuleType::FontPaletteValues:
     case StyleRuleType::Property:
+    case StyleRuleType::ViewTransition:
         // These rule types do not contain rules that apply directly to an element (i.e. these rules should not appear
         // in the Styles details sidebar of the Elements tab in Web Inspector).
         return RuleFlatteningStrategy::Ignore;

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -33,6 +33,7 @@
 #include "CSSKeyframesRule.h"
 #include "CSSSelector.h"
 #include "CSSSelectorList.h"
+#include "CSSViewTransitionRule.h"
 #include "CommonAtomStrings.h"
 #include "DocumentInlines.h"
 #include "HTMLNames.h"
@@ -343,6 +344,16 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
 void RuleSet::addPageRule(StyleRulePage& rule)
 {
     m_pageRules.append(&rule);
+}
+
+void RuleSet::setViewTransitionRule(StyleRuleViewTransition& rule)
+{
+    m_viewTransitionRule = &rule;
+}
+
+RefPtr<StyleRuleViewTransition> RuleSet::viewTransitionRule() const
+{
+    return m_viewTransitionRule;
 }
 
 template<typename Function>

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class CSSSelector;
 class StyleSheetContents;
+class StyleRuleViewTransition;
 
 namespace MQ {
 class MediaQueryEvaluator;
@@ -78,6 +79,8 @@ public:
 
     void addRule(const StyleRule&, unsigned selectorIndex, unsigned selectorListIndex);
     void addPageRule(StyleRulePage&);
+    void setViewTransitionRule(StyleRuleViewTransition&);
+    RefPtr<StyleRuleViewTransition> viewTransitionRule() const;
 
     void addToRuleSet(const AtomString& key, AtomRuleMap&, const RuleData&);
     void shrinkToFit();
@@ -203,6 +206,7 @@ private:
     RuleDataVector m_rootElementRules;
     RuleDataVector m_universalRules;
     Vector<StyleRulePage*> m_pageRules;
+    RefPtr<StyleRuleViewTransition> m_viewTransitionRule;
     RuleFeatureSet m_features;
     Vector<DynamicMediaQueryRules> m_dynamicMediaQueryRules;
     HashMap<Vector<size_t>, Ref<const RuleSet>> m_mediaQueryInvalidationRuleSetCache;

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -219,6 +219,11 @@ void RuleSetBuilder::addChildRule(Ref<StyleRuleBase> rule)
             addChildRules(supportsRule->childRules());
         return;
     }
+    case StyleRuleType::ViewTransition:
+        if (m_ruleSet)
+            m_ruleSet->setViewTransitionRule(uncheckedDowncast<StyleRuleViewTransition>(rule));
+        return;
+
     case StyleRuleType::Import:
     case StyleRuleType::Margin:
     case StyleRuleType::Namespace:

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -42,6 +42,7 @@
 #include "CSSSelector.h"
 #include "CSSStyleRule.h"
 #include "CSSStyleSheet.h"
+#include "CSSViewTransitionRule.h"
 #include "CachedResourceLoader.h"
 #include "CompositeOperation.h"
 #include "Document.h"
@@ -813,6 +814,10 @@ static CSSSelectorList viewTransitionSelector(CSSSelector::PseudoElement element
     return CSSSelectorList(WTFMove(selectorList));
 }
 
+RefPtr<StyleRuleViewTransition> Resolver::viewTransitionRule() const
+{
+    return m_ruleSets.viewTransitionRule();
+}
 
 void Resolver::setViewTransitionStyles(CSSSelector::PseudoElement element, const AtomString& name, Ref<MutableStyleProperties> properties)
 {

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -145,6 +145,8 @@ public:
     void addKeyframeStyle(Ref<StyleRuleKeyframes>&&);
     Vector<Ref<StyleRuleKeyframe>> keyframeRulesForName(const AtomString&) const;
 
+    RefPtr<StyleRuleViewTransition> viewTransitionRule() const;
+
     bool usesFirstLineRules() const { return m_ruleSets.features().usesFirstLineRules; }
     bool usesFirstLetterRules() const { return m_ruleSets.features().usesFirstLetterRules; }
     

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -30,6 +30,7 @@
 #include "StyleScopeRuleSets.h"
 
 #include "CSSStyleSheet.h"
+#include "CSSViewTransitionRule.h"
 #include "CascadeLevel.h"
 #include "DocumentInlines.h"
 #include "ExtensionStyleSheets.h"
@@ -210,6 +211,17 @@ bool ScopeRuleSets::hasScopeRules() const
         return true;
 
     return false;
+}
+
+RefPtr<StyleRuleViewTransition> ScopeRuleSets::viewTransitionRule() const
+{
+    if (auto viewTransitionRule = m_authorStyle->viewTransitionRule())
+        return viewTransitionRule;
+    if (m_userStyle && m_userStyle->viewTransitionRule())
+        return m_userStyle->viewTransitionRule();
+    if (m_userAgentMediaQueryStyle && m_userAgentMediaQueryStyle->viewTransitionRule())
+        return m_userAgentMediaQueryStyle->viewTransitionRule();
+    return nullptr;
 }
 
 std::optional<DynamicMediaQueryEvaluationChanges> ScopeRuleSets::evaluateDynamicMediaQueryRules(const MQ::MediaQueryEvaluator& evaluator)

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -93,6 +93,8 @@ public:
     bool hasContainerQueries() const;
     bool hasScopeRules() const;
 
+    RefPtr<StyleRuleViewTransition> viewTransitionRule() const;
+
     std::optional<DynamicMediaQueryEvaluationChanges> evaluateDynamicMediaQueryRules(const MQ::MediaQueryEvaluator&);
 
     RuleFeatureSet& mutableFeatures();


### PR DESCRIPTION
#### add19a6245520b35080caa82faff3ed001ac0caf
<pre>
Add CSS parser support for the @view-transition rule and the navigation descriptor.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277461">https://bugs.webkit.org/show_bug.cgi?id=277461</a>
&lt;<a href="https://rdar.apple.com/132947828">rdar://132947828</a>&gt;

Reviewed by Tim Nguyen.

Adds support for parsing the @view-transition rule, and the navigation
descriptor.

Adds the CSSViewTransitionRule.idl CSSOM class, and implementation.

Adds a partial implemention of &apos;6.2. Resolving the @view-transition rule&apos;
(<a href="https://www.w3.org/TR/css-view-transitions-2/#vt-rule-algo)">https://www.w3.org/TR/css-view-transitions-2/#vt-rule-algo)</a>, which still needs
support for transition types.

All of this is gated behind a new experimental preference
CSSCrossDocumentViewTransitionsEnabled.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-cssom-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSCSSRuleCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSRule.idl:
* Source/WebCore/css/CSSViewTransitionRule.cpp: Added.
(WebCore::toViewTransitionNavigationEnum):
(WebCore::StyleRuleViewTransition::StyleRuleViewTransition):
(WebCore::StyleRuleViewTransition::create):
(WebCore::CSSViewTransitionRule::create):
(WebCore::CSSViewTransitionRule::CSSViewTransitionRule):
(WebCore::CSSViewTransitionRule::cssText const):
(WebCore::CSSViewTransitionRule::reattach):
* Source/WebCore/css/CSSViewTransitionRule.h: Added.
(isType):
* Source/WebCore/css/CSSViewTransitionRule.idl: Copied from Source/WebCore/css/StyleRuleType.h.
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::visitDerived):
(WebCore::StyleRuleBase::createCSSOMWrapper const):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::isViewTransitionRule const):
* Source/WebCore/css/StyleRuleType.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::traverseSubresources const):
(WebCore::StyleSheetContents::mayDependOnBaseURL const):
* Source/WebCore/css/parser/CSSAtRuleID.cpp:
(WebCore::cssAtRuleID):
* Source/WebCore/css/parser/CSSAtRuleID.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::computeNewAllowedRules):
(WebCore::CSSParserImpl::consumeAtRule):
(WebCore::CSSParserImpl::consumeViewTransitionRule):
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseValue):
(WebCore::CSSPropertyParser::parseViewTransitionDescriptor):
* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::dispatchPagehideEvent):
(WebCore::Document::resolveViewTransitionRule):
* Source/WebCore/dom/Document.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::flatteningStrategyForStyleRuleType):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::setViewTransitionRule):
(WebCore::Style::RuleSet::viewTransitionRule const):
* Source/WebCore/style/RuleSet.h:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::viewTransitionRule const):
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::viewTransitionRule const):
* Source/WebCore/style/StyleScopeRuleSets.h:

Canonical link: <a href="https://commits.webkit.org/281694@main">https://commits.webkit.org/281694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2703940df4ce18cf5ec74d145b01e2173de7b902

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64649 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11265 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11540 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49099 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7813 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29930 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9830 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10178 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/53818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66378 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59965 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4662 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9960 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52572 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13529 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3863 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81720 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14223 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36964 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->