### PR TITLE
Deploy more smart pointers in HTMLInputElement.cpp.

### DIFF
--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -175,65 +175,70 @@ Vector<FileChooserFileInfo> HTMLInputElement::filesFromFileInputFormControlState
     return files;
 }
 
+RefPtr<InputType> HTMLInputElement::protectedInputType() const
+{
+    return m_inputType;
+}
+
 HTMLElement* HTMLInputElement::containerElement() const
 {
-    return m_inputType->containerElement();
+    return protectedInputType()->containerElement();
 }
 
 RefPtr<TextControlInnerTextElement> HTMLInputElement::innerTextElement() const
 {
-    return m_inputType->innerTextElement();
+    return protectedInputType()->innerTextElement();
 }
 
 RefPtr<TextControlInnerTextElement> HTMLInputElement::innerTextElementCreatingShadowSubtreeIfNeeded()
 {
-    return m_inputType->innerTextElementCreatingShadowSubtreeIfNeeded();
+    return protectedInputType()->innerTextElementCreatingShadowSubtreeIfNeeded();
 }
 
 HTMLElement* HTMLInputElement::innerBlockElement() const
 {
-    return m_inputType->innerBlockElement();
+    return protectedInputType()->innerBlockElement();
 }
 
 HTMLElement* HTMLInputElement::innerSpinButtonElement() const
 {
-    return m_inputType->innerSpinButtonElement();
+    return protectedInputType()->innerSpinButtonElement();
 }
 
 HTMLElement* HTMLInputElement::autoFillButtonElement() const
 {
-    return m_inputType->autoFillButtonElement();
+    return protectedInputType()->autoFillButtonElement();
 }
 
 HTMLElement* HTMLInputElement::resultsButtonElement() const
 {
-    return m_inputType->resultsButtonElement();
+    return protectedInputType()->resultsButtonElement();
 }
 
 HTMLElement* HTMLInputElement::cancelButtonElement() const
 {
-    return m_inputType->cancelButtonElement();
+    return protectedInputType()->cancelButtonElement();
 }
 
 HTMLElement* HTMLInputElement::sliderThumbElement() const
 {
-    return m_inputType->sliderThumbElement();
+    return protectedInputType()->sliderThumbElement();
 }
 
 HTMLElement* HTMLInputElement::sliderTrackElement() const
 {
-    return m_inputType->sliderTrackElement();
+    return protectedInputType()->sliderTrackElement();
 }
 
 HTMLElement* HTMLInputElement::placeholderElement() const
 {
-    return m_inputType->placeholderElement();
+    return protectedInputType()->placeholderElement();
 }
 
 #if ENABLE(DATALIST_ELEMENT)
 HTMLElement* HTMLInputElement::dataListButtonElement() const
 {
-    return m_inputType->dataListButtonElement();
+    return protectedInputType()->dataListButtonElement();
 }
 #endif
 
@@ -246,7 +251,7 @@ bool HTMLInputElement::shouldAutocomplete() const
 
 bool HTMLInputElement::isValidValue(const String& value) const
 {
-    if (!m_inputType->isValidValue(value))
+    if (!protectedInputType()->isValidValue(value))
         return false;
 
     return !tooShort(value, IgnoreDirtyFlag) && !tooLong(value, IgnoreDirtyFlag);
@@ -264,22 +269,22 @@ bool HTMLInputElement::tooLong() const
 
 bool HTMLInputElement::typeMismatch() const
 {
-    return m_inputType->typeMismatch();
+    return protectedInputType()->typeMismatch();
 }
 
 bool HTMLInputElement::valueMissing() const
 {
-    return m_inputType->valueMissing(value());
+    return protectedInputType()->valueMissing(value());
 }
 
 bool HTMLInputElement::hasBadInput() const
 {
-    return m_inputType->hasBadInput();
+    return protectedInputType()->hasBadInput();
 }
 
 bool HTMLInputElement::patternMismatch() const
 {
-    return m_inputType->patternMismatch(value());
+    return protectedInputType()->patternMismatch(value());
 }
 
 bool HTMLInputElement::tooShort(StringView value, NeedsToCheckDirtyFlag check) const
@@ -321,12 +326,12 @@ bool HTMLInputElement::tooLong(StringView value, NeedsToCheckDirtyFlag check) co
 
 bool HTMLInputElement::rangeUnderflow() const
 {
-    return m_inputType->rangeUnderflow(value());
+    return protectedInputType()->rangeUnderflow(value());
 }
 
 bool HTMLInputElement::rangeOverflow() const
 {
-    return m_inputType->rangeOverflow(value());
+    return protectedInputType()->rangeOverflow(value());
 }
 
 String HTMLInputElement::validationMessage() const
@@ -337,45 +342,45 @@ String HTMLInputElement::validationMessage() const
     if (customError())
         return customValidationMessage();
 
-    return m_inputType->validationMessage();
+    return protectedInputType()->validationMessage();
 }
 
 double HTMLInputElement::minimum() const
 {
-    return m_inputType->minimum();
+    return protectedInputType()->minimum();
 }
 
 double HTMLInputElement::maximum() const
 {
-    return m_inputType->maximum();
+    return protectedInputType()->maximum();
 }
 
 bool HTMLInputElement::stepMismatch() const
 {
-    return m_inputType->stepMismatch(value());
+    return protectedInputType()->stepMismatch(value());
 }
 
 bool HTMLInputElement::computeValidity() const
 {
     String value = this->value();
-    bool someError = m_inputType->isInvalid(value) || tooShort(value, CheckDirtyFlag) || tooLong(value, CheckDirtyFlag) || customError();
+    bool someError = protectedInputType()->isInvalid(value) || tooShort(value, CheckDirtyFlag) || tooLong(value, CheckDirtyFlag) || customError();
     return !someError;
 }
 
 bool HTMLInputElement::getAllowedValueStep(Decimal* step) const
 {
-    return m_inputType->getAllowedValueStep(step);
+    return protectedInputType()->getAllowedValueStep(step);
 }
 
 StepRange HTMLInputElement::createStepRange(AnyStepHandling anyStepHandling) const
 {
-    return m_inputType->createStepRange(anyStepHandling);
+    return protectedInputType()->createStepRange(anyStepHandling);
 }
 
 #if ENABLE(DATALIST_ELEMENT)
 std::optional<Decimal> HTMLInputElement::findClosestTickMarkValue(const Decimal& value)
 {
-    return m_inputType->findClosestTickMarkValue(value);
+    return protectedInputType()->findClosestTickMarkValue(value);
 }
 
 std::optional<double> HTMLInputElement::listOptionValueAsDouble(const HTMLOptionElement& optionElement)
@@ -390,17 +395,17 @@ std::optional<double> HTMLInputElement::listOptionValueAsDouble(const HTMLOption
 
 ExceptionOr<void> HTMLInputElement::stepUp(int n)
 {
-    return m_inputType->stepUp(n);
+    return protectedInputType()->stepUp(n);
 }
 
 ExceptionOr<void> HTMLInputElement::stepDown(int n)
 {
-    return m_inputType->stepUp(-n);
+    return protectedInputType()->stepUp(-n);
 }
 
 void HTMLInputElement::blur()
 {
-    m_inputType->blur();
+    protectedInputType()->blur();
 }
 
 void HTMLInputElement::defaultBlur()
@@ -410,7 +415,7 @@ void HTMLInputElement::defaultBlur()
 
 bool HTMLInputElement::hasCustomFocusLogic() const
 {
-    return m_inputType->hasCustomFocusLogic();
+    return protectedInputType()->hasCustomFocusLogic();
 }
 
 int HTMLInputElement::defaultTabIndex() const
@@ -420,17 +425,17 @@ int HTMLInputElement::defaultTabIndex() const
 
 bool HTMLInputElement::isKeyboardFocusable(KeyboardEvent* event) const
 {
-    return m_inputType->isKeyboardFocusable(event);
+    return protectedInputType()->isKeyboardFocusable(event);
 }
 
 bool HTMLInputElement::isMouseFocusable() const
 {
-    return m_inputType->isMouseFocusable();
+    return protectedInputType()->isMouseFocusable();
 }
 
 bool HTMLInputElement::isInteractiveContent() const
 {
-    return m_inputType->isInteractiveContent();
+    return protectedInputType()->isInteractiveContent();
 }
 
 bool HTMLInputElement::isTextFormControlFocusable() const
@@ -464,7 +469,7 @@ void HTMLInputElement::setDefaultSelectionAfterFocus(SelectionRestorationMode re
     ASSERT(isTextField());
     unsigned start = 0;
     auto direction = SelectionHasNoDirection;
-    auto* frame = document().frame();
+    RefPtr frame = document().frame();
     if (frame && frame->editor().behavior().shouldMoveSelectionToEndWhenFocusingTextInput()) {
         start = std::numeric_limits<unsigned>::max();
         direction = SelectionHasForwardDirection;
@@ -484,19 +489,19 @@ void HTMLInputElement::endEditing()
 
 bool HTMLInputElement::shouldUseInputMethod()
 {
-    return m_inputType->shouldUseInputMethod();
+    return protectedInputType()->shouldUseInputMethod();
 }
 
 void HTMLInputElement::handleFocusEvent(Node* oldFocusedNode, FocusDirection direction)
 {
-    m_inputType->handleFocusEvent(oldFocusedNode, direction);
+    protectedInputType()->handleFocusEvent(oldFocusedNode, direction);
 
     invalidateStyleOnFocusChangeIfNeeded();
 }
 
 void HTMLInputElement::handleBlurEvent()
 {
-    m_inputType->handleBlurEvent();
+    protectedInputType()->handleBlurEvent();
 
     invalidateStyleOnFocusChangeIfNeeded();
 }
@@ -513,7 +518,7 @@ void HTMLInputElement::resignStrongPasswordAppearance()
     setAutofilled(false);
     setAutofilledAndViewable(false);
     setAutofillButtonType(AutoFillButtonType::None);
-    if (auto* page = document().page())
+    if (RefPtr page = document().page())
         page->chrome().client().inputElementDidResignStrongPasswordAppearance(*this);
 }
 
@@ -524,44 +529,44 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
     m_hasType = true;
     if (!newType)
         return;
-    ASSERT(m_inputType->type() != newType->type());
+    ASSERT(protectedInputType()->type() != newType->type());
 
     Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClass::Default, Style::PseudoClassChangeInvalidation::AnyValue);
 
     removeFromRadioButtonGroup();
     resignStrongPasswordAppearance();
 
-    bool didSupportReadOnly = m_inputType->supportsReadOnly();
+    bool didSupportReadOnly = protectedInputType()->supportsReadOnly();
     bool willSupportReadOnly = newType->supportsReadOnly();
     std::optional<Style::PseudoClassChangeInvalidation> readWriteInvalidation;
 
-    bool didStoreValue = m_inputType->storesValueSeparateFromAttribute();
+    bool didStoreValue = protectedInputType()->storesValueSeparateFromAttribute();
     bool willStoreValue = newType->storesValueSeparateFromAttribute();
     bool neededSuspensionCallback = needsSuspensionCallback();
-    bool didRespectHeightAndWidth = m_inputType->shouldRespectHeightAndWidthAttributes();
-    bool wasSuccessfulSubmitButtonCandidate = m_inputType->canBeSuccessfulSubmitButton();
+    bool didRespectHeightAndWidth = protectedInputType()->shouldRespectHeightAndWidthAttributes();
+    bool wasSuccessfulSubmitButtonCandidate = protectedInputType()->canBeSuccessfulSubmitButton();
 
     if (didStoreValue && !willStoreValue) {
         if (auto dirtyValue = std::exchange(m_valueIfDirty, { }); !dirtyValue.isEmpty())
             setAttributeWithoutSynchronization(valueAttr, AtomString { WTFMove(dirtyValue) });
     }
 
-    m_inputType->removeShadowSubtree();
-    m_inputType->detachFromElement();
-    auto oldType = m_inputType->type();
+    protectedInputType()->removeShadowSubtree();
+    protectedInputType()->detachFromElement();
+    auto oldType = protectedInputType()->type();
 
-    bool didDirAutoUseValue = m_inputType->dirAutoUsesValue();
-    bool previouslySelectable = m_inputType->supportsSelectionAPI();
+    bool didDirAutoUseValue = protectedInputType()->dirAutoUsesValue();
+    bool previouslySelectable = protectedInputType()->supportsSelectionAPI();
 
     m_inputType = WTFMove(newType);
     if (!didStoreValue && willStoreValue)
         m_valueIfDirty = sanitizeValue(attributeWithoutSynchronization(valueAttr));
     else
         updateValueIfNeeded();
-    m_inputType->createShadowSubtreeIfNeeded();
+    protectedInputType()->createShadowSubtreeIfNeeded();
 
     // https://html.spec.whatwg.org/multipage/dom.html#auto-directionality
-    if (oldType == InputType::Type::Telephone || m_inputType->type() == InputType::Type::Telephone || (hasAutoTextDirectionState() && didDirAutoUseValue != m_inputType->dirAutoUsesValue()))
+    if (oldType == InputType::Type::Telephone || protectedInputType()->type() == InputType::Type::Telephone || (hasAutoTextDirectionState() && didDirAutoUseValue != protectedInputType()->dirAutoUsesValue()))
         updateEffectiveTextDirection();
 
     if (UNLIKELY(didSupportReadOnly != willSupportReadOnly && hasAttributeWithoutSynchronization(readonlyAttr))) {
@@ -572,7 +577,7 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
     updateWillValidateAndValidity();
 
     setFormControlValueMatchesRenderer(false);
-    m_inputType->updateInnerTextValue();
+    protectedInputType()->updateInnerTextValue();
 
     m_wasModifiedByUser = false;
 
@@ -581,7 +586,7 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
     else
         registerForSuspensionCallbackIfNeeded();
 
-    if (didRespectHeightAndWidth != m_inputType->shouldRespectHeightAndWidthAttributes()) {
+    if (didRespectHeightAndWidth != protectedInputType()->shouldRespectHeightAndWidthAttributes()) {
         ASSERT(elementData());
         // FIXME: We don't have the old attribute values so we pretend that we didn't have the old values.
         if (const Attribute* height = findAttributeByName(heightAttr))
@@ -592,14 +597,14 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
             attributeChanged(alignAttr, nullAtom(), align->value());
     }
 
-    if (auto* form = this->form(); form && wasSuccessfulSubmitButtonCandidate != m_inputType->canBeSuccessfulSubmitButton())
+    if (auto* form = this->form(); form && wasSuccessfulSubmitButtonCandidate != protectedInputType()->canBeSuccessfulSubmitButton())
         form->resetDefaultButton();
 
     runPostTypeUpdateTasks();
 
     // https://html.spec.whatwg.org/multipage/input.html#input-type-change
     // 8. Let nowSelectable be true if setRangeText() now applies to the element, and false otherwise.
-    bool nowSelectable = m_inputType->supportsSelectionAPI();
+    bool nowSelectable = protectedInputType()->supportsSelectionAPI();
     // 9. If previouslySelectable is false and nowSelectable is true, set the element's text entry cursor position to the beginning of the text control, and set its selection direction to "none".
     if (!previouslySelectable && nowSelectable) {
         TextFieldSelectionDirection direction = SelectionHasNoDirection;
@@ -637,7 +642,7 @@ inline void HTMLInputElement::runPostTypeUpdateTasks()
 #if ENABLE(TOUCH_EVENTS)
 inline void HTMLInputElement::updateTouchEventHandler()
 {
-    bool hasTouchEventHandler = m_inputType->hasTouchEventHandler();
+    bool hasTouchEventHandler = protectedInputType()->hasTouchEventHandler();
     if (hasTouchEventHandler != m_hasTouchEventHandler) {
         if (hasTouchEventHandler) {
 #if ENABLE(IOS_TOUCH_EVENTS)
@@ -659,7 +664,7 @@ inline void HTMLInputElement::updateTouchEventHandler()
 
 void HTMLInputElement::subtreeHasChanged()
 {
-    m_inputType->subtreeHasChanged();
+    protectedInputType()->subtreeHasChanged();
     // When typing in an input field, childrenChanged is not called, so we need to force the directionality check.
     if (selfOrPrecedingNodesAffectDirAuto())
         updateEffectiveTextDirection();
@@ -667,22 +672,22 @@ void HTMLInputElement::subtreeHasChanged()
 
 const AtomString& HTMLInputElement::formControlType() const
 {
-    return m_inputType->formControlType();
+    return protectedInputType()->formControlType();
 }
 
 bool HTMLInputElement::shouldSaveAndRestoreFormControlState() const
 {
-    return m_inputType->shouldSaveAndRestoreFormControlState();
+    return protectedInputType()->shouldSaveAndRestoreFormControlState();
 }
 
 FormControlState HTMLInputElement::saveFormControlState() const
 {
-    return m_inputType->saveFormControlState();
+    return protectedInputType()->saveFormControlState();
 }
 
 void HTMLInputElement::restoreFormControlState(const FormControlState& state)
 {
-    m_inputType->restoreFormControlState(state);
+    protectedInputType()->restoreFormControlState(state);
     m_stateRestored = true;
 }
 
@@ -700,7 +705,7 @@ bool HTMLInputElement::canHaveSelection() const
 
 bool HTMLInputElement::accessKeyAction(bool sendMouseEvents)
 {
-    return Ref { *m_inputType }->accessKeyAction(sendMouseEvents);
+    return protectedInputType()->accessKeyAction(sendMouseEvents);
 }
 
 bool HTMLInputElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
@@ -735,17 +740,17 @@ void HTMLInputElement::collectPresentationalHintsForAttribute(const QualifiedNam
         }
         break;
     case AttributeNames::alignAttr:
-        if (m_inputType->shouldRespectAlignAttribute())
+        if (protectedInputType()->shouldRespectAlignAttribute())
             applyAlignmentAttributeToStyle(value, style);
         break;
     case AttributeNames::widthAttr:
-        if (m_inputType->shouldRespectHeightAndWidthAttributes())
+        if (protectedInputType()->shouldRespectHeightAndWidthAttributes())
             addHTMLLengthToStyle(style, CSSPropertyWidth, value);
         if (isImageButton())
             applyAspectRatioFromWidthAndHeightAttributesToStyle(value, attributeWithoutSynchronization(heightAttr), style);
         break;
     case AttributeNames::heightAttr:
-        if (m_inputType->shouldRespectHeightAndWidthAttributes())
+        if (protectedInputType()->shouldRespectHeightAndWidthAttributes())
             addHTMLLengthToStyle(style, CSSPropertyHeight, value);
         if (isImageButton())
             applyAspectRatioFromWidthAndHeightAttributesToStyle(attributeWithoutSynchronization(widthAttr), value, style);
@@ -785,7 +790,6 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
         return;
 
     ASSERT(m_inputType);
-    Ref protectedInputType { *m_inputType };
 
     HTMLTextFormControlElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
@@ -889,9 +893,9 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
             auto hasSwitchAttribute = !newValue.isNull();
             m_hasSwitchAttribute = hasSwitchAttribute;
             if (isSwitch())
-                m_inputType->createShadowSubtreeIfNeeded();
+                protectedInputType()->createShadowSubtreeIfNeeded();
             else if (isCheckbox())
-                m_inputType->removeShadowSubtree();
+                protectedInputType()->removeShadowSubtree();
             if (renderer())
                 invalidateStyleAndRenderersForSubtree();
 #if ENABLE(TOUCH_EVENTS)
@@ -912,24 +916,24 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
         break;
     }
 
-    m_inputType->attributeChanged(name);
+    protectedInputType()->attributeChanged(name);
 }
 
 void HTMLInputElement::disabledStateChanged()
 {
     HTMLTextFormControlElement::disabledStateChanged();
-    m_inputType->disabledStateChanged();
+    protectedInputType()->disabledStateChanged();
 }
 
 void HTMLInputElement::readOnlyStateChanged()
 {
     HTMLTextFormControlElement::readOnlyStateChanged();
-    m_inputType->readOnlyStateChanged();
+    protectedInputType()->readOnlyStateChanged();
 }
 
 bool HTMLInputElement::supportsReadOnly() const
 {
-    return m_inputType->supportsReadOnly();
+    return protectedInputType()->supportsReadOnly();
 }
 
 void HTMLInputElement::finishParsingChildren()
@@ -946,12 +950,12 @@ void HTMLInputElement::finishParsingChildren()
 
 bool HTMLInputElement::rendererIsNeeded(const RenderStyle& style)
 {
-    return m_inputType->rendererIsNeeded() && HTMLTextFormControlElement::rendererIsNeeded(style);
+    return protectedInputType()->rendererIsNeeded() && HTMLTextFormControlElement::rendererIsNeeded(style);
 }
 
 RenderPtr<RenderElement> HTMLInputElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    return m_inputType->createInputRenderer(WTFMove(style));
+    return protectedInputType()->createInputRenderer(WTFMove(style));
 }
 
 bool HTMLInputElement::isReplaced(const RenderStyle&) const
@@ -969,7 +973,7 @@ void HTMLInputElement::didAttachRenderers()
 {
     HTMLTextFormControlElement::didAttachRenderers();
 
-    m_inputType->attach();
+    protectedInputType()->attach();
 
     if (document().focusedElement() == this) {
         document().eventLoop().queueTask(TaskSource::UserInteraction, [weakThis = WeakPtr { *this }]() {
@@ -984,7 +988,7 @@ void HTMLInputElement::didAttachRenderers()
 void HTMLInputElement::didDetachRenderers()
 {
     setFormControlValueMatchesRenderer(false);
-    m_inputType->detach();
+    protectedInputType()->detach();
 }
 
 String HTMLInputElement::altText() const
@@ -1007,15 +1011,15 @@ bool HTMLInputElement::isSuccessfulSubmitButton() const
 {
     // HTML spec says that buttons must have names to be considered successful.
     // However, other browsers do not impose this constraint. So we do not.
-    return m_inputType->canBeSuccessfulSubmitButton();
+    return protectedInputType()->canBeSuccessfulSubmitButton();
 }
 
 bool HTMLInputElement::matchesDefaultPseudoClass() const
 {
     ASSERT(m_inputType);
-    if (m_inputType->canBeSuccessfulSubmitButton())
+    if (protectedInputType()->canBeSuccessfulSubmitButton())
         return !isDisabledFormControl() && form() && form()->defaultButton() == this;
-    return m_inputType->isCheckable() && m_isDefaultChecked;
+    return protectedInputType()->isCheckable() && m_isDefaultChecked;
 }
 
 bool HTMLInputElement::isActivatedSubmit() const
@@ -1030,13 +1034,12 @@ void HTMLInputElement::setActivatedSubmit(bool flag)
 
 bool HTMLInputElement::appendFormData(DOMFormData& formData)
 {
-    Ref protectedInputType { *m_inputType };
-    return m_inputType->isFormDataAppendable() && m_inputType->appendFormData(formData);
+    return protectedInputType()->isFormDataAppendable() && protectedInputType()->appendFormData(formData);
 }
 
 void HTMLInputElement::reset()
 {
-    if (m_inputType->storesValueSeparateFromAttribute()) {
+    if (protectedInputType()->storesValueSeparateFromAttribute()) {
         setValue({ });
         updateValidity();
     }
@@ -1052,12 +1055,12 @@ void HTMLInputElement::reset()
 
 bool HTMLInputElement::isTextField() const
 {
-    return m_inputType->isTextField();
+    return protectedInputType()->isTextField();
 }
 
 bool HTMLInputElement::isTextType() const
 {
-    return m_inputType->isTextType();
+    return protectedInputType()->isTextType();
 }
 
 bool HTMLInputElement::supportsWritingSuggestions() const
@@ -1069,7 +1072,7 @@ bool HTMLInputElement::supportsWritingSuggestions() const
         InputType::Type::Email,
     };
 
-    return allowedTypes.contains(m_inputType->type());
+    return allowedTypes.contains(protectedInputType()->type());
 }
 
 void HTMLInputElement::setDefaultCheckedState(bool isDefaultChecked)
@@ -1078,7 +1081,7 @@ void HTMLInputElement::setDefaultCheckedState(bool isDefaultChecked)
         return;
 
     std::optional<Style::PseudoClassChangeInvalidation> defaultInvalidation;
-    if (m_inputType->isCheckable())
+    if (protectedInputType()->isCheckable())
         defaultInvalidation.emplace(*this, CSSSelector::PseudoClass::Default, isDefaultChecked);
     m_isDefaultChecked = isDefaultChecked;
 }
@@ -1089,7 +1092,7 @@ void HTMLInputElement::setChecked(bool isChecked, WasSetByJavaScript wasCheckedB
     if (checked() == isChecked)
         return;
 
-    m_inputType->willUpdateCheckedness(isChecked, wasCheckedByJavaScript);
+    protectedInputType()->willUpdateCheckedness(isChecked, wasCheckedByJavaScript);
 
     Style::PseudoClassChangeInvalidation checkedInvalidation(*this, CSSSelector::PseudoClass::Checked, isChecked);
 
@@ -1127,12 +1130,12 @@ void HTMLInputElement::setIndeterminate(bool newValue)
 
 bool HTMLInputElement::sizeShouldIncludeDecoration(int& preferredSize) const
 {
-    return m_inputType->sizeShouldIncludeDecoration(defaultSize, preferredSize);
+    return protectedInputType()->sizeShouldIncludeDecoration(defaultSize, preferredSize);
 }
 
 float HTMLInputElement::decorationWidth() const
 {
-    return m_inputType->decorationWidth();
+    return protectedInputType()->decorationWidth();
 }
 
 void HTMLInputElement::copyNonAttributePropertiesFromElement(const Element& source)
@@ -1150,8 +1153,8 @@ void HTMLInputElement::copyNonAttributePropertiesFromElement(const Element& sour
 
     updateValidity();
     setFormControlValueMatchesRenderer(false);
-    if (m_inputType->hasCreatedShadowSubtree())
-        m_inputType->updateInnerTextValue();
+    if (protectedInputType()->hasCreatedShadowSubtree())
+        protectedInputType()->updateInnerTextValue();
 }
 
 String HTMLInputElement::value() const
@@ -1169,7 +1172,7 @@ String HTMLInputElement::value() const
             return sanitizedValue;
     }
 
-    return m_inputType->fallbackValue();
+    return protectedInputType()->fallbackValue();
 }
 
 String HTMLInputElement::valueWithDefault() const
@@ -1177,7 +1180,7 @@ String HTMLInputElement::valueWithDefault() const
     if (auto value = this->value(); !value.isNull())
         return value;
 
-    return m_inputType->defaultValue();
+    return protectedInputType()->defaultValue();
 }
 
 ExceptionOr<void> HTMLInputElement::setValue(const String& value, TextFieldEventBehavior eventBehavior, TextControlSetValueSelection selection)
@@ -1192,7 +1195,7 @@ ExceptionOr<void> HTMLInputElement::setValue(const String& value, TextFieldEvent
 
     setLastChangeWasNotUserEdit();
     setFormControlValueMatchesRenderer(false);
-    m_inputType->setValue(WTFMove(sanitizedValue), valueChanged, eventBehavior, selection);
+    protectedInputType()->setValue(WTFMove(sanitizedValue), valueChanged, eventBehavior, selection);
     if (selfOrPrecedingNodesAffectDirAuto())
         updateEffectiveTextDirection();
 
@@ -1219,29 +1222,29 @@ void HTMLInputElement::setValueInternal(const String& sanitizedValue, TextFieldE
 
 WallTime HTMLInputElement::valueAsDate() const
 {
-    return m_inputType->valueAsDate();
+    return protectedInputType()->valueAsDate();
 }
 
 ExceptionOr<void> HTMLInputElement::setValueAsDate(WallTime value)
 {
-    return m_inputType->setValueAsDate(value);
+    return protectedInputType()->setValueAsDate(value);
 }
 
 WallTime HTMLInputElement::accessibilityValueAsDate() const
 {
-    return m_inputType->accessibilityValueAsDate();
+    return protectedInputType()->accessibilityValueAsDate();
 }
 
 double HTMLInputElement::valueAsNumber() const
 {
-    return m_inputType->valueAsDouble();
+    return protectedInputType()->valueAsDouble();
 }
 
 ExceptionOr<void> HTMLInputElement::setValueAsNumber(double newValue, TextFieldEventBehavior eventBehavior)
 {
     if (!std::isfinite(newValue))
         return Exception { ExceptionCode::NotSupportedError };
-    return m_inputType->setValueAsDouble(newValue, eventBehavior);
+    return protectedInputType()->setValueAsDouble(newValue, eventBehavior);
 }
 
 void HTMLInputElement::setValueFromRenderer(const String& value)
@@ -1253,7 +1256,7 @@ void HTMLInputElement::setValueFromRenderer(const String& value)
     // Input types that support the selection API do *not* sanitize their
     // user input in order to retain parity between what's in the model and
     // what's on the screen.
-    ASSERT(m_inputType->supportsSelectionAPI() || value == sanitizeValue(value) || sanitizeValue(value).isEmpty());
+    ASSERT(protectedInputType()->supportsSelectionAPI() || value == sanitizeValue(value) || sanitizeValue(value).isEmpty());
 
     // Workaround for bug where trailing \n is included in the result of textContent.
     // The assert macro above may also be simplified by removing the expression
@@ -1286,12 +1289,12 @@ void HTMLInputElement::setValueFromRenderer(const String& value)
 void HTMLInputElement::willDispatchEvent(Event& event, InputElementClickState& state)
 {
     auto& eventNames = WebCore::eventNames();
-    if (event.type() == eventNames.textInputEvent && m_inputType->shouldSubmitImplicitly(event))
+    if (event.type() == eventNames.textInputEvent && protectedInputType()->shouldSubmitImplicitly(event))
         event.stopPropagation();
     if (event.type() == eventNames.clickEvent) {
         auto* mouseEvent = dynamicDowncast<MouseEvent>(event);
         if (mouseEvent && mouseEvent->button() == MouseButton::Left) {
-            m_inputType->willDispatchClick(state);
+            protectedInputType()->willDispatchClick(state);
             state.stateful = true;
         }
     }
@@ -1299,7 +1302,7 @@ void HTMLInputElement::willDispatchEvent(Event& event, InputElementClickState& s
     if (event.type() == eventNames.auxclickEvent) {
         auto* mouseEvent = dynamicDowncast<MouseEvent>(event);
         if (mouseEvent && mouseEvent->button() != MouseButton::Left) {
-            m_inputType->willDispatchClick(state);
+            protectedInputType()->willDispatchClick(state);
             state.stateful = true;
         }
     }
@@ -1307,12 +1310,12 @@ void HTMLInputElement::willDispatchEvent(Event& event, InputElementClickState& s
 
 void HTMLInputElement::didDispatchClickEvent(Event& event, const InputElementClickState& state)
 {
-    m_inputType->didDispatchClick(event, state);
+    protectedInputType()->didDispatchClick(event, state);
 }
 
 void HTMLInputElement::didBlur()
 {
-    m_inputType->elementDidBlur();
+    protectedInputType()->elementDidBlur();
 }
 
 void HTMLInputElement::defaultEventHandler(Event& event)
@@ -1320,11 +1323,11 @@ void HTMLInputElement::defaultEventHandler(Event& event)
     if (auto* mouseEvent = dynamicDowncast<MouseEvent>(event); mouseEvent && mouseEvent->button() == MouseButton::Left) {
         auto eventType = mouseEvent->type();
         if (isAnyClick(*mouseEvent))
-            m_inputType->handleClickEvent(*mouseEvent);
+            protectedInputType()->handleClickEvent(*mouseEvent);
         else if (eventType == eventNames().mousedownEvent)
-            m_inputType->handleMouseDownEvent(*mouseEvent);
+            protectedInputType()->handleMouseDownEvent(*mouseEvent);
         else if (eventType == eventNames().mousemoveEvent)
-            m_inputType->handleMouseMoveEvent(*mouseEvent);
+            protectedInputType()->handleMouseMoveEvent(*mouseEvent);
 
         if (mouseEvent->defaultHandled())
             return;
@@ -1332,14 +1335,14 @@ void HTMLInputElement::defaultEventHandler(Event& event)
 
 #if ENABLE(TOUCH_EVENTS)
     if (auto* touchEvent = dynamicDowncast<TouchEvent>(event)) {
-        m_inputType->handleTouchEvent(*touchEvent);
+        protectedInputType()->handleTouchEvent(*touchEvent);
         if (event.defaultHandled())
             return;
     }
 #endif
 
     if (auto* keyboardEvent = dynamicDowncast<KeyboardEvent>(event); keyboardEvent && keyboardEvent->type() == eventNames().keydownEvent) {
-        auto shouldCallBaseEventHandler = m_inputType->handleKeydownEvent(*keyboardEvent);
+        auto shouldCallBaseEventHandler = protectedInputType()->handleKeydownEvent(*keyboardEvent);
         if (event.defaultHandled() || shouldCallBaseEventHandler == InputType::ShouldCallBaseEventHandler::No)
             return;
     }
@@ -1358,7 +1361,7 @@ void HTMLInputElement::defaultEventHandler(Event& event)
     // on the element, or presses enter while it is the active element. JavaScript code wishing to activate the element
     // must dispatch a DOMActivate event - a click event will not do the job.
     if (event.type() == eventNames().DOMActivateEvent) {
-        m_inputType->handleDOMActivateEvent(event);
+        protectedInputType()->handleDOMActivateEvent(event);
         if (commandForElement())
             handleCommand();
         else
@@ -1371,17 +1374,17 @@ void HTMLInputElement::defaultEventHandler(Event& event)
     // on key down blocks the proper sending of the key press event.
     if (auto* keyboardEvent = dynamicDowncast<KeyboardEvent>(event)) {
         if (keyboardEvent->type() == eventNames().keypressEvent) {
-            m_inputType->handleKeypressEvent(*keyboardEvent);
+            protectedInputType()->handleKeypressEvent(*keyboardEvent);
             if (keyboardEvent->defaultHandled())
                 return;
         } else if (keyboardEvent->type() == eventNames().keyupEvent) {
-            m_inputType->handleKeyupEvent(*keyboardEvent);
+            protectedInputType()->handleKeyupEvent(*keyboardEvent);
             if (keyboardEvent->defaultHandled())
                 return;
         }
     }
 
-    if (m_inputType->shouldSubmitImplicitly(event)) {
+    if (protectedInputType()->shouldSubmitImplicitly(event)) {
         if (isSearchField())
             addSearchResult();
         // Form submission finishes editing, just as loss of focus does.
@@ -1398,9 +1401,9 @@ void HTMLInputElement::defaultEventHandler(Event& event)
     }
 
     if (auto* beforeTextInsertedEvent = dynamicDowncast<BeforeTextInsertedEvent>(event); beforeTextInsertedEvent)
-        m_inputType->handleBeforeTextInsertedEvent(*beforeTextInsertedEvent);
+        protectedInputType()->handleBeforeTextInsertedEvent(*beforeTextInsertedEvent);
 
-    m_inputType->forwardEvent(event);
+    protectedInputType()->forwardEvent(event);
 
     if (!callBaseClassEarly && !event.defaultHandled())
         HTMLTextFormControlElement::defaultEventHandler(event);
@@ -1421,7 +1424,7 @@ bool HTMLInputElement::isURLAttribute(const Attribute& attribute) const
 
 ExceptionOr<void> HTMLInputElement::showPicker()
 {
-    auto* frame = document().frame();
+    RefPtr frame = document().frame();
     if (!frame)
         return { };
 
@@ -1430,17 +1433,17 @@ ExceptionOr<void> HTMLInputElement::showPicker()
 
     // In cross-origin iframes it should throw a "SecurityError" DOMException except on file and color. In same-origin iframes it should work fine.
     // https://github.com/whatwg/html/issues/6909#issuecomment-917138991
-    if (!m_inputType->allowsShowPickerAcrossFrames()) {
-        auto* localTopFrame = dynamicDowncast<LocalFrame>(frame->tree().top());
+    if (!protectedInputType()->allowsShowPickerAcrossFrames()) {
+        RefPtr localTopFrame = dynamicDowncast<LocalFrame>(frame->tree().top());
         if (!localTopFrame || !frame->document()->protectedSecurityOrigin()->isSameOriginAs(localTopFrame->document()->protectedSecurityOrigin()))
             return Exception { ExceptionCode::SecurityError, "Input showPicker() called from cross-origin iframe."_s };
     }
 
-    auto* window = frame->window();
+    RefPtr window = frame->window();
     if (!window || !window->hasTransientActivation())
         return Exception { ExceptionCode::NotAllowedError, "Input showPicker() requires a user gesture."_s };
 
-    m_inputType->showPicker();
+    protectedInputType()->showPicker();
     return { };
 }
 
@@ -1572,7 +1575,7 @@ void HTMLInputElement::setAutofillButtonType(AutoFillButtonType autoFillButtonTy
 
     m_lastAutoFillButtonType = m_autoFillButtonType;
     m_autoFillButtonType = enumToUnderlyingType(autoFillButtonType);
-    m_inputType->updateAutoFillButton();
+    protectedInputType()->updateAutoFillButton();
     updateInnerTextElementEditability();
     invalidateStyleForSubtree();
 
@@ -1648,18 +1651,18 @@ void HTMLInputElement::setFiles(RefPtr<FileList>&& files, WasSetByJavaScript was
 #if ENABLE(DRAG_SUPPORT)
 bool HTMLInputElement::receiveDroppedFiles(const DragData& dragData)
 {
-    return m_inputType->receiveDroppedFiles(dragData);
+    return protectedInputType()->receiveDroppedFiles(dragData);
 }
 #endif
 
 Icon* HTMLInputElement::icon() const
 {
-    return m_inputType->icon();
+    return protectedInputType()->icon();
 }
 
 String HTMLInputElement::displayString() const
 {
-    return m_inputType->displayString();
+    return protectedInputType()->displayString();
 }
 
 void HTMLInputElement::setCanReceiveDroppedFiles(bool canReceiveDroppedFiles)
@@ -1673,31 +1676,31 @@ void HTMLInputElement::setCanReceiveDroppedFiles(bool canReceiveDroppedFiles)
 
 String HTMLInputElement::visibleValue() const
 {
-    return m_inputType->visibleValue();
+    return protectedInputType()->visibleValue();
 }
 
 String HTMLInputElement::sanitizeValue(const String& proposedValue) const
 {
     if (proposedValue.isNull())
         return proposedValue;
-    return m_inputType->sanitizeValue(proposedValue);
+    return protectedInputType()->sanitizeValue(proposedValue);
 }
 
 String HTMLInputElement::localizeValue(const String& proposedValue) const
 {
     if (proposedValue.isNull())
         return proposedValue;
-    return m_inputType->localizeValue(proposedValue);
+    return protectedInputType()->localizeValue(proposedValue);
 }
 
 bool HTMLInputElement::isInRange() const
 {
-    return willValidate() && m_inputType->isInRange(value());
+    return willValidate() && protectedInputType()->isInRange(value());
 }
 
 bool HTMLInputElement::isOutOfRange() const
 {
-    return willValidate() && m_inputType->isOutOfRange(value());
+    return willValidate() && protectedInputType()->isOutOfRange(value());
 }
 
 bool HTMLInputElement::needsSuspensionCallback()
@@ -1705,7 +1708,7 @@ bool HTMLInputElement::needsSuspensionCallback()
     if (!m_inputType)
         return false;
 
-    if (m_inputType->shouldResetOnDocumentActivation())
+    if (protectedInputType()->shouldResetOnDocumentActivation())
         return true;
 
     // Sensitive input elements are marked with autocomplete=off, and we want to wipe them out
@@ -1713,7 +1716,7 @@ bool HTMLInputElement::needsSuspensionCallback()
     // the page is restored. Non-empty textual default values indicate that the field
     // is not really sensitive -- there's no default value for an account number --
     // and we would see unexpected results if we reset to something other than blank.
-    bool isSensitive = m_autocomplete == Off && !(m_inputType->isTextType() && !defaultValue().isEmpty());
+    bool isSensitive = m_autocomplete == Off && !(protectedInputType()->isTextType() && !defaultValue().isEmpty());
 
     return isSensitive;
 }
@@ -1732,7 +1735,7 @@ void HTMLInputElement::unregisterForSuspensionCallbackIfNeeded()
 
 bool HTMLInputElement::isRequiredFormControl() const
 {
-    return m_inputType->supportsRequired() && isRequired();
+    return protectedInputType()->supportsRequired() && isRequired();
 }
 
 bool HTMLInputElement::matchesReadWritePseudoClass() const
@@ -1742,7 +1745,7 @@ bool HTMLInputElement::matchesReadWritePseudoClass() const
 
 void HTMLInputElement::addSearchResult()
 {
-    m_inputType->addSearchResult();
+    protectedInputType()->addSearchResult();
 }
 
 void HTMLInputElement::resumeFromDocumentSuspension()
@@ -1763,7 +1766,7 @@ void HTMLInputElement::resumeFromDocumentSuspension()
 #if ENABLE(INPUT_TYPE_COLOR)
 void HTMLInputElement::prepareForDocumentSuspension()
 {
-    m_inputType->detach();
+    protectedInputType()->detach();
 }
 #endif // ENABLE(INPUT_TYPE_COLOR)
 
@@ -1787,7 +1790,7 @@ Node::InsertedIntoAncestorResult HTMLInputElement::insertedIntoAncestor(Insertio
 #endif
     if (isRadioButton())
         updateValidity();
-    if (insertionType.connectedToDocument && m_inputType->needsShadowSubtree() && !m_inputType->hasCreatedShadowSubtree() && !m_hasPendingUserAgentShadowTreeUpdate) {
+    if (insertionType.connectedToDocument && protectedInputType()->needsShadowSubtree() && !protectedInputType()->hasCreatedShadowSubtree() && !m_hasPendingUserAgentShadowTreeUpdate) {
         document().addElementWithPendingUserAgentShadowTreeUpdate(*this);
         m_hasPendingUserAgentShadowTreeUpdate = true;
     }
@@ -1803,7 +1806,7 @@ void HTMLInputElement::updateUserAgentShadowTree()
     ASSERT(m_hasPendingUserAgentShadowTreeUpdate);
     document().removeElementWithPendingUserAgentShadowTreeUpdate(*this);
     m_hasPendingUserAgentShadowTreeUpdate = false;
-    m_inputType->createShadowSubtreeIfNeeded();
+    protectedInputType()->createShadowSubtreeIfNeeded();
 }
 
 void HTMLInputElement::didFinishInsertingNode()
@@ -1867,7 +1870,7 @@ void HTMLInputElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 
 bool HTMLInputElement::computeWillValidate() const
 {
-    return m_inputType->supportsValidation() && HTMLTextFormControlElement::computeWillValidate();
+    return protectedInputType()->supportsValidation() && HTMLTextFormControlElement::computeWillValidate();
 }
 
 void HTMLInputElement::requiredStateChanged()
@@ -1875,7 +1878,7 @@ void HTMLInputElement::requiredStateChanged()
     HTMLTextFormControlElement::requiredStateChanged();
     if (auto* buttons = radioButtonGroups())
         buttons->requiredStateChanged(*this);
-    m_inputType->requiredStateChanged();
+    protectedInputType()->requiredStateChanged();
 }
 
 Color HTMLInputElement::valueAsColor() const
@@ -1915,7 +1918,7 @@ RefPtr<HTMLElement> HTMLInputElement::list() const
 
 RefPtr<HTMLDataListElement> HTMLInputElement::dataList() const
 {
-    if (!m_hasNonEmptyList || !m_inputType->shouldRespectListAttribute())
+    if (!m_hasNonEmptyList || !protectedInputType()->shouldRespectListAttribute())
         return nullptr;
 
     return dynamicDowncast<HTMLDataListElement>(treeScope().getElementById(attributeWithoutSynchronization(listAttr)));
@@ -1941,166 +1944,166 @@ void HTMLInputElement::dataListMayHaveChanged()
 
 bool HTMLInputElement::isFocusingWithDataListDropdown() const
 {
-    return m_inputType->isFocusingWithDataListDropdown();
+    return protectedInputType()->isFocusingWithDataListDropdown();
 }
 
 #endif // ENABLE(DATALIST_ELEMENT)
 
 bool HTMLInputElement::isPresentingAttachedView() const
 {
-    return m_inputType->isPresentingAttachedView();
+    return protectedInputType()->isPresentingAttachedView();
 }
 
 bool HTMLInputElement::isSteppable() const
 {
-    return m_inputType->isSteppable();
+    return protectedInputType()->isSteppable();
 }
 
 DateComponentsType HTMLInputElement::dateType() const
 {
-    return m_inputType->dateType();
+    return protectedInputType()->dateType();
 }
 
 bool HTMLInputElement::isTextButton() const
 {
-    return m_inputType->isTextButton();
+    return protectedInputType()->isTextButton();
 }
 
 bool HTMLInputElement::isRadioButton() const
 {
-    return m_inputType->isRadioButton();
+    return protectedInputType()->isRadioButton();
 }
 
 bool HTMLInputElement::isSearchField() const
 {
-    return m_inputType->isSearchField();
+    return protectedInputType()->isSearchField();
 }
 
 bool HTMLInputElement::isInputTypeHidden() const
 {
-    return m_inputType->isHiddenType();
+    return protectedInputType()->isHiddenType();
 }
 
 bool HTMLInputElement::isPasswordField() const
 {
-    return m_inputType->isPasswordField();
+    return protectedInputType()->isPasswordField();
 }
 
 bool HTMLInputElement::isCheckbox() const
 {
-    return m_inputType->isCheckbox();
+    return protectedInputType()->isCheckbox();
 }
 
 bool HTMLInputElement::isSwitch() const
 {
-    return m_inputType->isSwitch();
+    return protectedInputType()->isSwitch();
 }
 
 bool HTMLInputElement::isRangeControl() const
 {
-    return m_inputType->isRangeControl();
+    return protectedInputType()->isRangeControl();
 }
 
 #if ENABLE(INPUT_TYPE_COLOR)
 bool HTMLInputElement::isColorControl() const
 {
-    return m_inputType->isColorControl();
+    return protectedInputType()->isColorControl();
 }
 #endif
 
 bool HTMLInputElement::isText() const
 {
-    return m_inputType->isTextType();
+    return protectedInputType()->isTextType();
 }
 
 bool HTMLInputElement::isEmailField() const
 {
-    return m_inputType->isEmailField();
+    return protectedInputType()->isEmailField();
 }
 
 bool HTMLInputElement::isFileUpload() const
 {
-    return m_inputType->isFileUpload();
+    return protectedInputType()->isFileUpload();
 }
 
 bool HTMLInputElement::isImageButton() const
 {
-    return m_inputType->isImageButton();
+    return protectedInputType()->isImageButton();
 }
 
 bool HTMLInputElement::isNumberField() const
 {
-    return m_inputType->isNumberField();
+    return protectedInputType()->isNumberField();
 }
 
 bool HTMLInputElement::isSubmitButton() const
 {
-    return m_inputType->isSubmitButton();
+    return protectedInputType()->isSubmitButton();
 }
 
 bool HTMLInputElement::isTelephoneField() const
 {
-    return m_inputType->isTelephoneField();
+    return protectedInputType()->isTelephoneField();
 }
 
 bool HTMLInputElement::isURLField() const
 {
-    return m_inputType->isURLField();
+    return protectedInputType()->isURLField();
 }
 
 bool HTMLInputElement::isDateField() const
 {
-    return m_inputType->isDateField();
+    return protectedInputType()->isDateField();
 }
 
 bool HTMLInputElement::isDateTimeLocalField() const
 {
-    return m_inputType->isDateTimeLocalField();
+    return protectedInputType()->isDateTimeLocalField();
 }
 
 bool HTMLInputElement::isMonthField() const
 {
-    return m_inputType->isMonthField();
+    return protectedInputType()->isMonthField();
 }
 
 bool HTMLInputElement::isTimeField() const
 {
-    return m_inputType->isTimeField();
+    return protectedInputType()->isTimeField();
 }
 
 bool HTMLInputElement::isWeekField() const
 {
-    return m_inputType->isWeekField();
+    return protectedInputType()->isWeekField();
 }
 
 bool HTMLInputElement::isEnumeratable() const
 {
-    return m_inputType->isEnumeratable();
+    return protectedInputType()->isEnumeratable();
 }
 
 bool HTMLInputElement::isLabelable() const
 {
-    return m_inputType->isLabelable();
+    return protectedInputType()->isLabelable();
 }
 
 bool HTMLInputElement::matchesCheckedPseudoClass() const
 {
-    return checked() && m_inputType->isCheckable();
+    return checked() && protectedInputType()->isCheckable();
 }
 
 bool HTMLInputElement::supportsPlaceholder() const
 {
-    return m_inputType->supportsPlaceholder();
+    return protectedInputType()->supportsPlaceholder();
 }
 
 void HTMLInputElement::updatePlaceholderText()
 {
-    return m_inputType->updatePlaceholderText();
+    return protectedInputType()->updatePlaceholderText();
 }
 
 bool HTMLInputElement::isEmptyValue() const
 {
-    return m_inputType->isEmptyValue();
+    return protectedInputType()->isEmptyValue();
 }
 
 void HTMLInputElement::maxLengthAttributeChanged(const AtomString& newValue)
@@ -2133,12 +2136,12 @@ void HTMLInputElement::updateValueIfNeeded()
 
 String HTMLInputElement::defaultToolTip() const
 {
-    return m_inputType->defaultToolTip();
+    return protectedInputType()->defaultToolTip();
 }
 
 bool HTMLInputElement::matchesIndeterminatePseudoClass() const
 {
-    return m_inputType->matchesIndeterminatePseudoClass();
+    return protectedInputType()->matchesIndeterminatePseudoClass();
 }
 
 #if ENABLE(MEDIA_CAPTURE)
@@ -2219,12 +2222,12 @@ inline void HTMLInputElement::removeFromRadioButtonGroup()
 
 unsigned HTMLInputElement::height() const
 {
-    return m_inputType->height();
+    return protectedInputType()->height();
 }
 
 unsigned HTMLInputElement::width() const
 {
-    return m_inputType->width();
+    return protectedInputType()->width();
 }
 
 void HTMLInputElement::setHeight(unsigned height)
@@ -2255,7 +2258,7 @@ void ListAttributeTargetObserver::idTargetChanged()
 
 ExceptionOr<void> HTMLInputElement::setRangeText(StringView replacement, unsigned start, unsigned end, const String& selectionMode)
 {
-    if (!m_inputType->supportsSelectionAPI())
+    if (!protectedInputType()->supportsSelectionAPI())
         return Exception { ExceptionCode::InvalidStateError };
 
     return HTMLTextFormControlElement::setRangeText(replacement, start, end, selectionMode);
@@ -2279,7 +2282,7 @@ void HTMLInputElement::invalidateStyleOnFocusChangeIfNeeded()
 
 std::optional<unsigned> HTMLInputElement::selectionStartForBindings() const
 {
-    if (!canHaveSelection() || !m_inputType->supportsSelectionAPI())
+    if (!canHaveSelection() || !protectedInputType()->supportsSelectionAPI())
         return std::nullopt;
 
     return selectionStart();
@@ -2287,8 +2290,8 @@ std::optional<unsigned> HTMLInputElement::selectionStartForBindings() const
 
 ExceptionOr<void> HTMLInputElement::setSelectionStartForBindings(std::optional<unsigned> start)
 {
-    if (!canHaveSelection() || !m_inputType->supportsSelectionAPI())
-        return Exception { ExceptionCode::InvalidStateError, makeString("The input element's type ('"_s, m_inputType->formControlType(), "') does not support selection."_s) };
+    if (!canHaveSelection() || !protectedInputType()->supportsSelectionAPI())
+        return Exception { ExceptionCode::InvalidStateError, makeString("The input element's type ('"_s, protectedInputType()->formControlType(), "') does not support selection."_s) };
 
     setSelectionStart(start.value_or(0));
     return { };
@@ -2296,7 +2299,7 @@ ExceptionOr<void> HTMLInputElement::setSelectionStartForBindings(std::optional<u
 
 std::optional<unsigned> HTMLInputElement::selectionEndForBindings() const
 {
-    if (!canHaveSelection() || !m_inputType->supportsSelectionAPI())
+    if (!canHaveSelection() || !protectedInputType()->supportsSelectionAPI())
         return std::nullopt;
 
     return selectionEnd();
@@ -2304,8 +2307,8 @@ std::optional<unsigned> HTMLInputElement::selectionEndForBindings() const
 
 ExceptionOr<void> HTMLInputElement::setSelectionEndForBindings(std::optional<unsigned> end)
 {
-    if (!canHaveSelection() || !m_inputType->supportsSelectionAPI())
-        return Exception { ExceptionCode::InvalidStateError, makeString("The input element's type ('"_s, m_inputType->formControlType(), "') does not support selection."_s) };
+    if (!canHaveSelection() || !protectedInputType()->supportsSelectionAPI())
+        return Exception { ExceptionCode::InvalidStateError, makeString("The input element's type ('"_s, protectedInputType()->formControlType(), "') does not support selection."_s) };
 
     setSelectionEnd(end.value_or(0));
     return { };
@@ -2313,7 +2316,7 @@ ExceptionOr<void> HTMLInputElement::setSelectionEndForBindings(std::optional<uns
 
 ExceptionOr<String> HTMLInputElement::selectionDirectionForBindings() const
 {
-    if (!canHaveSelection() || !m_inputType->supportsSelectionAPI())
+    if (!canHaveSelection() || !protectedInputType()->supportsSelectionAPI())
         return String();
 
     return String { selectionDirection() };
@@ -2321,8 +2324,8 @@ ExceptionOr<String> HTMLInputElement::selectionDirectionForBindings() const
 
 ExceptionOr<void> HTMLInputElement::setSelectionDirectionForBindings(const String& direction)
 {
-    if (!canHaveSelection() || !m_inputType->supportsSelectionAPI())
-        return Exception { ExceptionCode::InvalidStateError, makeString("The input element's type ('"_s, m_inputType->formControlType(), "') does not support selection."_s) };
+    if (!canHaveSelection() || !protectedInputType()->supportsSelectionAPI())
+        return Exception { ExceptionCode::InvalidStateError, makeString("The input element's type ('"_s, protectedInputType()->formControlType(), "') does not support selection."_s) };
 
     setSelectionDirection(direction);
     return { };
@@ -2330,8 +2333,8 @@ ExceptionOr<void> HTMLInputElement::setSelectionDirectionForBindings(const Strin
 
 ExceptionOr<void> HTMLInputElement::setSelectionRangeForBindings(unsigned start, unsigned end, const String& direction)
 {
-    if (!canHaveSelection() || !m_inputType->supportsSelectionAPI())
-        return Exception { ExceptionCode::InvalidStateError, makeString("The input element's type ('"_s, m_inputType->formControlType(), "') does not support selection."_s) };
+    if (!canHaveSelection() || !protectedInputType()->supportsSelectionAPI())
+        return Exception { ExceptionCode::InvalidStateError, makeString("The input element's type ('"_s, protectedInputType()->formControlType(), "') does not support selection."_s) };
     
     setSelectionRange(start, end, direction, AXTextStateChangeIntent(), ForBindings::Yes);
     return { };
@@ -2393,12 +2396,12 @@ RenderStyle HTMLInputElement::createInnerTextStyle(const RenderStyle& style)
 
 void HTMLInputElement::capsLockStateMayHaveChanged()
 {
-    m_inputType->capsLockStateMayHaveChanged();
+    protectedInputType()->capsLockStateMayHaveChanged();
 }
 
 String HTMLInputElement::resultForDialogSubmit() const
 {
-    return m_inputType->resultForDialogSubmit();
+    return protectedInputType()->resultForDialogSubmit();
 }
 
 String HTMLInputElement::placeholder() const
@@ -2416,7 +2419,7 @@ String HTMLInputElement::placeholder() const
 
 bool HTMLInputElement::dirAutoUsesValue() const
 {
-    return m_inputType->dirAutoUsesValue();
+    return protectedInputType()->dirAutoUsesValue();
 }
 
 float HTMLInputElement::switchAnimationVisuallyOnProgress() const

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -365,6 +365,7 @@ public:
 
     void initializeInputTypeAfterParsingOrCloning();
 
+
 private:
     enum class CreationType : uint8_t { Normal, ByParser, ByCloning };
     HTMLInputElement(const QualifiedName&, Document&, HTMLFormElement*, CreationType);
@@ -481,6 +482,8 @@ private:
     void updateUserAgentShadowTree() final;
 
     bool dirAutoUsesValue() const final;
+
+    RefPtr<InputType> protectedInputType() const;
 
     AtomString m_name;
     String m_valueIfDirty;


### PR DESCRIPTION
#### 77dbd4aa69bee93345cbfb1f5d7772953936e274
<pre>
Deploy more smart pointers in HTMLInputElement.cpp.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277328.">https://bugs.webkit.org/show_bug.cgi?id=277328.</a>

Reviewed by NOBODY (OOPS!).

Deploy more smart pointers in HTMLInputElement.cpp.

* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::protectedInputType const):
(WebCore::HTMLInputElement::containerElement const):
(WebCore::HTMLInputElement::innerTextElement const):
(WebCore::HTMLInputElement::innerTextElementCreatingShadowSubtreeIfNeeded):
(WebCore::HTMLInputElement::innerBlockElement const):
(WebCore::HTMLInputElement::innerSpinButtonElement const):
(WebCore::HTMLInputElement::autoFillButtonElement const):
(WebCore::HTMLInputElement::resultsButtonElement const):
(WebCore::HTMLInputElement::cancelButtonElement const):
(WebCore::HTMLInputElement::sliderThumbElement const):
(WebCore::HTMLInputElement::sliderTrackElement const):
(WebCore::HTMLInputElement::placeholderElement const):
(WebCore::HTMLInputElement::dataListButtonElement const):
(WebCore::HTMLInputElement::isValidValue const):
(WebCore::HTMLInputElement::typeMismatch const):
(WebCore::HTMLInputElement::valueMissing const):
(WebCore::HTMLInputElement::hasBadInput const):
(WebCore::HTMLInputElement::patternMismatch const):
(WebCore::HTMLInputElement::rangeUnderflow const):
(WebCore::HTMLInputElement::rangeOverflow const):
(WebCore::HTMLInputElement::validationMessage const):
(WebCore::HTMLInputElement::minimum const):
(WebCore::HTMLInputElement::maximum const):
(WebCore::HTMLInputElement::stepMismatch const):
(WebCore::HTMLInputElement::computeValidity const):
(WebCore::HTMLInputElement::getAllowedValueStep const):
(WebCore::HTMLInputElement::createStepRange const):
(WebCore::HTMLInputElement::findClosestTickMarkValue):
(WebCore::HTMLInputElement::stepUp):
(WebCore::HTMLInputElement::stepDown):
(WebCore::HTMLInputElement::blur):
(WebCore::HTMLInputElement::hasCustomFocusLogic const):
(WebCore::HTMLInputElement::isKeyboardFocusable const):
(WebCore::HTMLInputElement::isMouseFocusable const):
(WebCore::HTMLInputElement::isInteractiveContent const):
(WebCore::HTMLInputElement::setDefaultSelectionAfterFocus):
(WebCore::HTMLInputElement::shouldUseInputMethod):
(WebCore::HTMLInputElement::handleFocusEvent):
(WebCore::HTMLInputElement::handleBlurEvent):
(WebCore::HTMLInputElement::resignStrongPasswordAppearance):
(WebCore::HTMLInputElement::updateType):
(WebCore::HTMLInputElement::updateTouchEventHandler):
(WebCore::HTMLInputElement::subtreeHasChanged):
(WebCore::HTMLInputElement::formControlType const):
(WebCore::HTMLInputElement::shouldSaveAndRestoreFormControlState const):
(WebCore::HTMLInputElement::saveFormControlState const):
(WebCore::HTMLInputElement::restoreFormControlState):
(WebCore::HTMLInputElement::accessKeyAction):
(WebCore::HTMLInputElement::collectPresentationalHintsForAttribute):
(WebCore::HTMLInputElement::attributeChanged):
(WebCore::HTMLInputElement::disabledStateChanged):
(WebCore::HTMLInputElement::readOnlyStateChanged):
(WebCore::HTMLInputElement::supportsReadOnly const):
(WebCore::HTMLInputElement::rendererIsNeeded):
(WebCore::HTMLInputElement::createElementRenderer):
(WebCore::HTMLInputElement::didAttachRenderers):
(WebCore::HTMLInputElement::didDetachRenderers):
(WebCore::HTMLInputElement::isSuccessfulSubmitButton const):
(WebCore::HTMLInputElement::matchesDefaultPseudoClass const):
(WebCore::HTMLInputElement::appendFormData):
(WebCore::HTMLInputElement::reset):
(WebCore::HTMLInputElement::isTextField const):
(WebCore::HTMLInputElement::isTextType const):
(WebCore::HTMLInputElement::supportsWritingSuggestions const):
(WebCore::HTMLInputElement::setDefaultCheckedState):
(WebCore::HTMLInputElement::setChecked):
(WebCore::HTMLInputElement::sizeShouldIncludeDecoration const):
(WebCore::HTMLInputElement::decorationWidth const):
(WebCore::HTMLInputElement::copyNonAttributePropertiesFromElement):
(WebCore::HTMLInputElement::value const):
(WebCore::HTMLInputElement::valueWithDefault const):
(WebCore::HTMLInputElement::setValue):
(WebCore::HTMLInputElement::valueAsDate const):
(WebCore::HTMLInputElement::setValueAsDate):
(WebCore::HTMLInputElement::accessibilityValueAsDate const):
(WebCore::HTMLInputElement::valueAsNumber const):
(WebCore::HTMLInputElement::setValueAsNumber):
(WebCore::HTMLInputElement::setValueFromRenderer):
(WebCore::HTMLInputElement::willDispatchEvent):
(WebCore::HTMLInputElement::didDispatchClickEvent):
(WebCore::HTMLInputElement::didBlur):
(WebCore::HTMLInputElement::defaultEventHandler):
(WebCore::HTMLInputElement::showPicker):
(WebCore::HTMLInputElement::setShowAutoFillButton):
(WebCore::HTMLInputElement::receiveDroppedFiles):
(WebCore::HTMLInputElement::icon const):
(WebCore::HTMLInputElement::displayString const):
(WebCore::HTMLInputElement::visibleValue const):
(WebCore::HTMLInputElement::sanitizeValue const):
(WebCore::HTMLInputElement::localizeValue const):
(WebCore::HTMLInputElement::isInRange const):
(WebCore::HTMLInputElement::isOutOfRange const):
(WebCore::HTMLInputElement::needsSuspensionCallback):
(WebCore::HTMLInputElement::isRequiredFormControl const):
(WebCore::HTMLInputElement::addSearchResult):
(WebCore::HTMLInputElement::prepareForDocumentSuspension):
(WebCore::HTMLInputElement::insertedIntoAncestor):
(WebCore::HTMLInputElement::updateUserAgentShadowTree):
(WebCore::HTMLInputElement::computeWillValidate const):
(WebCore::HTMLInputElement::requiredStateChanged):
(WebCore::HTMLInputElement::dataList const):
(WebCore::HTMLInputElement::isFocusingWithDataListDropdown const):
(WebCore::HTMLInputElement::isPresentingAttachedView const):
(WebCore::HTMLInputElement::isSteppable const):
(WebCore::HTMLInputElement::dateType const):
(WebCore::HTMLInputElement::isTextButton const):
(WebCore::HTMLInputElement::isRadioButton const):
(WebCore::HTMLInputElement::isSearchField const):
(WebCore::HTMLInputElement::isInputTypeHidden const):
(WebCore::HTMLInputElement::isPasswordField const):
(WebCore::HTMLInputElement::isCheckbox const):
(WebCore::HTMLInputElement::isSwitch const):
(WebCore::HTMLInputElement::isRangeControl const):
(WebCore::HTMLInputElement::isColorControl const):
(WebCore::HTMLInputElement::isText const):
(WebCore::HTMLInputElement::isEmailField const):
(WebCore::HTMLInputElement::isFileUpload const):
(WebCore::HTMLInputElement::isImageButton const):
(WebCore::HTMLInputElement::isNumberField const):
(WebCore::HTMLInputElement::isSubmitButton const):
(WebCore::HTMLInputElement::isTelephoneField const):
(WebCore::HTMLInputElement::isURLField const):
(WebCore::HTMLInputElement::isDateField const):
(WebCore::HTMLInputElement::isDateTimeLocalField const):
(WebCore::HTMLInputElement::isMonthField const):
(WebCore::HTMLInputElement::isTimeField const):
(WebCore::HTMLInputElement::isWeekField const):
(WebCore::HTMLInputElement::isEnumeratable const):
(WebCore::HTMLInputElement::isLabelable const):
(WebCore::HTMLInputElement::matchesCheckedPseudoClass const):
(WebCore::HTMLInputElement::supportsPlaceholder const):
(WebCore::HTMLInputElement::updatePlaceholderText):
(WebCore::HTMLInputElement::isEmptyValue const):
(WebCore::HTMLInputElement::defaultToolTip const):
(WebCore::HTMLInputElement::matchesIndeterminatePseudoClass const):
(WebCore::HTMLInputElement::height const):
(WebCore::HTMLInputElement::width const):
(WebCore::HTMLInputElement::setRangeText):
(WebCore::HTMLInputElement::selectionStartForBindings const):
(WebCore::HTMLInputElement::setSelectionStartForBindings):
(WebCore::HTMLInputElement::selectionEndForBindings const):
(WebCore::HTMLInputElement::setSelectionEndForBindings):
(WebCore::HTMLInputElement::selectionDirectionForBindings const):
(WebCore::HTMLInputElement::setSelectionDirectionForBindings):
(WebCore::HTMLInputElement::setSelectionRangeForBindings):
(WebCore::HTMLInputElement::capsLockStateMayHaveChanged):
(WebCore::HTMLInputElement::resultForDialogSubmit const):
(WebCore::HTMLInputElement::dirAutoUsesValue const):
* Source/WebCore/html/HTMLInputElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77dbd4aa69bee93345cbfb1f5d7772953936e274

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/59009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/33410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/84527 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/30984 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82120 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/68073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/7305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/62542 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20366 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83080 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/52608 "Found 1 new test failure: media/audioSession/getUserMedia.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/72870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/42851 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27023 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/29448 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/72984 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/27518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/85958 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5089 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/70814 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/7405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/68711 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70056 "Found 1 new API test failure: /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-empty-realm (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14056 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/12992 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7191 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/12722 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7036 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/10551 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/8841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->