### PR TITLE
REGRESSION(281024@main) LLInt return locations need to be added to JITOperationList

### DIFF
--- a/Source/JavaScriptCore/assembler/JITOperationList.cpp
+++ b/Source/JavaScriptCore/assembler/JITOperationList.cpp
@@ -181,11 +181,7 @@ static LLIntOperations llintOperations()
             LLINT_OP(wasm_catch_all)
             LLINT_OP(llint_generic_return_point)
 
-            LLINT_RETURN_LOCATION(op_get_by_id)
-            LLINT_RETURN_LOCATION(op_get_length)
-            LLINT_RETURN_LOCATION(op_get_by_val)
-            LLINT_RETURN_LOCATION(op_put_by_id)
-            LLINT_RETURN_LOCATION(op_put_by_val)
+            FOR_EACH_LLINT_OPCODE_WITH_RETURN(LLINT_RETURN_LOCATION)
 
             JSC_JS_GATE_OPCODES(LLINT_RETURN_LOCATION)
             JSC_WASM_GATE_OPCODES(LLINT_RETURN_LOCATION)

--- a/Source/JavaScriptCore/llint/LLIntOpcode.h
+++ b/Source/JavaScriptCore/llint/LLIntOpcode.h
@@ -51,3 +51,26 @@
 #define FOR_EACH_LLINT_OPCODE_EXTENSION(macro) \
     FOR_EACH_BYTECODE_HELPER_ID(macro) \
     FOR_EACH_LLINT_NATIVE_HELPER(macro)
+
+
+#define FOR_EACH_LLINT_OPCODE_WITH_RETURN(macro) \
+    macro(op_call) \
+    macro(op_call_ignore_result) \
+    macro(op_iterator_open) \
+    macro(op_iterator_next) \
+    macro(op_construct) \
+    macro(op_call_varargs) \
+    macro(op_construct_varargs) \
+    macro(op_get_by_id) \
+    macro(op_get_by_id_direct) \
+    macro(op_get_length) \
+    macro(op_get_by_val) \
+    macro(op_put_by_id) \
+    macro(op_put_by_val) \
+    macro(op_put_by_val_direct) \
+    macro(op_in_by_id) \
+    macro(op_in_by_val) \
+    macro(op_enumerator_get_by_val) \
+    macro(op_enumerator_put_by_val) \
+    macro(op_enumerator_in_by_val) \
+

--- a/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -791,25 +791,7 @@ MacroAssemblerCodeRef<JSEntryPtrTag> returnLocationThunk(OpcodeID opcodeID, Opco
     }
 
     switch (opcodeID) {
-    LLINT_RETURN_LOCATION(op_call)
-    LLINT_RETURN_LOCATION(op_call_ignore_result)
-    LLINT_RETURN_LOCATION(op_iterator_open)
-    LLINT_RETURN_LOCATION(op_iterator_next)
-    LLINT_RETURN_LOCATION(op_construct)
-    LLINT_RETURN_LOCATION(op_call_varargs)
-    LLINT_RETURN_LOCATION(op_construct_varargs)
-    LLINT_RETURN_LOCATION(op_get_by_id)
-    LLINT_RETURN_LOCATION(op_get_by_id_direct)
-    LLINT_RETURN_LOCATION(op_get_length)
-    LLINT_RETURN_LOCATION(op_get_by_val)
-    LLINT_RETURN_LOCATION(op_put_by_id)
-    LLINT_RETURN_LOCATION(op_put_by_val)
-    LLINT_RETURN_LOCATION(op_put_by_val_direct)
-    LLINT_RETURN_LOCATION(op_in_by_id)
-    LLINT_RETURN_LOCATION(op_in_by_val)
-    LLINT_RETURN_LOCATION(op_enumerator_get_by_val)
-    LLINT_RETURN_LOCATION(op_enumerator_put_by_val)
-    LLINT_RETURN_LOCATION(op_enumerator_in_by_val)
+    FOR_EACH_LLINT_OPCODE_WITH_RETURN(LLINT_RETURN_LOCATION)
     default:
         RELEASE_ASSERT_NOT_REACHED();
         return { };


### PR DESCRIPTION
#### bf6e09860923b5dbb3392137c6a2932b4285e01e
<pre>
REGRESSION(281024@main) LLInt return locations need to be added to JITOperationList
<a href="https://bugs.webkit.org/show_bug.cgi?id=277462">https://bugs.webkit.org/show_bug.cgi?id=277462</a>
<a href="https://rdar.apple.com/132951616">rdar://132951616</a>

Reviewed by Alexey Shvayka.

Move the list of LLInt opcodes that need returns to a macro so they get automagically populated
into JITOperationList.

* Source/JavaScriptCore/assembler/JITOperationList.cpp:
(JSC::llintOperations):
* Source/JavaScriptCore/llint/LLIntOpcode.h:
* Source/JavaScriptCore/llint/LLIntThunks.cpp:
(JSC::LLInt::returnLocationThunk):

Canonical link: <a href="https://commits.webkit.org/281685@main">https://commits.webkit.org/281685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a0768118acc137bd0b962aed5f0c26dabfba123

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60688 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64619 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11235 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11510 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/7796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29902 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33984 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/9803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10148 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/53788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66348 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/59935 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4632 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/9938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52545 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13520 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3834 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/81690 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14217 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->