### PR TITLE
Make TestRunner.statisticsNotifyObserver return a promise

### DIFF
--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-redirect-collusion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-redirect-collusion.html
@@ -17,8 +17,8 @@
     const subresourceOrigin3 = "http://127.0.0.4:8000/temp";
     const subresourceOrigin4 = "http://127.0.0.5:8000/temp";
 
-    function runTest() {
-        testRunner.statisticsNotifyObserver();
+    async function runTest() {
+        await testRunner.statisticsNotifyObserver();
 
         testRunner.setStatisticsSubresourceUniqueRedirectFrom(statisticsUrl, subresourceOrigin1);
         testRunner.setStatisticsSubresourceUniqueRedirectFrom(subresourceOrigin1, subresourceOrigin2);

--- a/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-redirect-collusion.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-redirect-collusion.html
@@ -52,19 +52,22 @@
         });
     }
 
-    if (document.location.hash === "" && window.testRunner && window.internals) {
-        setEnableFeature(true, function() {
-            testRunner.setStatisticsPrevalentResource(statisticsUrl, false, function() {
-                if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
+    async function testMain() {
+        if (document.location.hash === "" && window.testRunner && window.internals) {
+            setEnableFeature(true, function() {
+                testRunner.setStatisticsPrevalentResource(statisticsUrl, false, function() {
+                    if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
                     testFailed("Host did not get set as non-prevalent resource.");
-
-                document.location.href = topFrameOrigin5 + "resourceLoadStatistics/resources/redirect.py?redirectTo=http://127.0.0.1:8000/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-redirect-collusion.html#continue";
+                    
+                    document.location.href = topFrameOrigin5 + "resourceLoadStatistics/resources/redirect.py?redirectTo=http://127.0.0.1:8000/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-redirect-collusion.html#continue";
+                });
             });
-        });
-    } else {
-        testRunner.statisticsNotifyObserver();
-        runTest();
-    }
+        } else {
+            await testRunner.statisticsNotifyObserver();
+            runTest();
+        }
+    };
+    testMain();
 </script>
 </body>
 </html>

--- a/LayoutTests/http/tests/resourceLoadStatistics/count-third-party-script-import-in-worker.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/count-third-party-script-import-in-worker.html
@@ -15,11 +15,11 @@
         });
     }
 
-    function receiveMessage(event) {
+    async function receiveMessage(event) {
         if (event.data.indexOf("PASS") === -1)
             testFailed(event.data.replace("FAIL ", ""));
 
-        testRunner.statisticsNotifyObserver();
+        await testRunner.statisticsNotifyObserver();
     }
 
     function runTest() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/count-third-party-script-loads.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/count-third-party-script-loads.html
@@ -18,7 +18,7 @@
         });
     }
 
-    function runTest() {
+    async function runTest() {
         switch (document.location.hash) {
             case "":
                 if (window.testRunner && window.internals) {
@@ -38,7 +38,7 @@
                 document.body.appendChild(scriptElement);
                 break;
             case "#step2":
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
                 break;
         }
     }

--- a/LayoutTests/http/tests/resourceLoadStatistics/do-not-capture-statistics-for-simple-top-navigations.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/do-not-capture-statistics-for-simple-top-navigations.html
@@ -21,7 +21,7 @@
         setEnableFeature(false, finishJSTest);
     }
 
-    function runTest() {
+    async function runTest() {
         switch (document.location.host) {
             case "127.0.0.1:8000":
                 setEnableFeature(true, function() {
@@ -31,9 +31,8 @@
                 });
                 break;
             case "localhost:8000":
-                testRunner.installStatisticsDidScanDataRecordsCallback(finishTest);
-                if (!testRunner.statisticsNotifyObserver())
-                    timerHandle = setTimeout(finishTest, 100);
+                await testRunner.statisticsNotifyObserver();
+                finishTest();
                 break;
             default:
                 testFailed("Unknown host: " + document.location.host);

--- a/LayoutTests/http/tests/resourceLoadStatistics/dont-count-third-party-image-as-third-party-script.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/dont-count-third-party-image-as-third-party-script.html
@@ -18,7 +18,7 @@
         });
     }
 
-    function runTest() {
+    async function runTest() {
         switch (document.location.hash) {
             case "":
                 if (window.testRunner && window.internals) {
@@ -38,7 +38,7 @@
                 document.body.appendChild(imgElement);
                 break;
             case "#step2":
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
                 break;
         }
     }

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
@@ -15,7 +15,7 @@
         var lastPageInRedirectChainLoaded = false;
         var statsChecked = false;
 
-        function receiveMessage(event) {
+        async function receiveMessage(event) {
             if (event.origin === "http://127.0.0.1:8000") {
                 if (event.data.indexOf("PASS") === -1)
                     testFailed(event.data.replace("FAIL ", ""));
@@ -26,7 +26,7 @@
             if (statsChecked)
                 finishTest();
             else
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
@@ -15,7 +15,7 @@
         var lastPageInRedirectChainLoaded = false;
         var statsChecked = false;
 
-        function receiveMessage(event) {
+        async function receiveMessage(event) {
             if (event.origin === "http://localhost:8000") {
                 if (event.data.indexOf("PASS") === -1)
                     testFailed(event.data.replace("FAIL ", ""));
@@ -26,7 +26,7 @@
             if (statsChecked)
                 finishTest();
             else
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
@@ -15,7 +15,7 @@
         var lastPageInRedirectChainLoaded = false;
         var statsChecked = false;
 
-        function receiveMessage(event) {
+        async function receiveMessage(event) {
             if (event.origin === "http://127.0.0.1:8000") {
                 if (event.data.indexOf("PASS") === -1)
                     testFailed(event.data.replace("FAIL ", ""));
@@ -26,7 +26,7 @@
             if (statsChecked)
                 finishTest();
             else
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
@@ -15,7 +15,7 @@
         var lastPageInRedirectChainLoaded = false;
         var statsChecked = false;
 
-        function receiveMessage(event) {
+        async function receiveMessage(event) {
             if (event.origin === "http://localhost:8000") {
                 if (event.data.indexOf("PASS") === -1)
                     testFailed(event.data.replace("FAIL ", ""));
@@ -26,7 +26,7 @@
             if (statsChecked)
                 finishTest();
             else
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
@@ -15,7 +15,7 @@
         var lastPageInRedirectChainLoaded = false;
         var statsChecked = false;
 
-        function receiveMessage(event) {
+        async function receiveMessage(event) {
             if (event.origin === "null") {
                 if (event.data.indexOf("PASS") === -1)
                     testFailed(event.data.replace("FAIL ", ""));
@@ -26,7 +26,7 @@
             if (statsChecked)
                 finishTest();
             else
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
@@ -15,7 +15,7 @@
         var lastPageInRedirectChainLoaded = false;
         var statsChecked = false;
 
-        function receiveMessage(event) {
+        async function receiveMessage(event) {
             if (event.origin === "null") {
                 if (event.data.indexOf("PASS") === -1)
                     testFailed(event.data.replace("FAIL ", ""));
@@ -26,7 +26,7 @@
             if (statsChecked)
                 finishTest();
             else
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/remove-website-data-for-origin-deletes-third-party-script-loads.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/remove-website-data-for-origin-deletes-third-party-script-loads.html
@@ -20,7 +20,7 @@
         });
     }
 
-    function runTest() {
+    async function runTest() {
         switch (document.location.hash) {
             case "":
                 if (window.testRunner && window.internals) {
@@ -40,7 +40,7 @@
                 document.body.appendChild(scriptElement);
                 break;
             case "#step2":
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
                 break;
         }
     }

--- a/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
@@ -21,7 +21,7 @@
         var lastPageInRedirectChainLoaded = false;
         var statsChecked = false;
 
-        function receiveMessage(event) {
+        async function receiveMessage(event) {
             if (event.origin === "null") {
                 if (event.data.indexOf("PASS") === -1)
                     testFailed(event.data.replace("FAIL ", ""));
@@ -32,7 +32,7 @@
             if (statsChecked)
                 finishTest();
             else
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
@@ -21,7 +21,7 @@
         var lastPageInRedirectChainLoaded = false;
         var statsChecked = false;
 
-        function receiveMessage(event) {
+        async function receiveMessage(event) {
             if (event.origin === "null") {
                 if (event.data.indexOf("PASS") === -1)
                     testFailed(event.data.replace("FAIL ", ""));
@@ -32,7 +32,7 @@
             if (statsChecked)
                 finishTest();
             else
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
@@ -21,7 +21,7 @@
         var lastPageInRedirectChainLoaded = false;
         var statsChecked = false;
 
-        function receiveMessage(event) {
+        async function receiveMessage(event) {
             if (event.origin === "null") {
                 if (event.data.indexOf("PASS") === -1)
                     testFailed(event.data.replace("FAIL ", ""));
@@ -32,7 +32,7 @@
             if (statsChecked)
                 finishTest();
             else
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
@@ -21,7 +21,7 @@
         var lastPageInRedirectChainLoaded = false;
         var statsChecked = false;
 
-        function receiveMessage(event) {
+        async function receiveMessage(event) {
             if (event.origin === "null") {
                 if (event.data.indexOf("PASS") === -1)
                     testFailed(event.data.replace("FAIL ", ""));
@@ -32,7 +32,7 @@
             if (statsChecked)
                 finishTest();
             else
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html
@@ -21,7 +21,7 @@
         var lastPageInRedirectChainLoaded = false;
         var statsChecked = false;
 
-        function receiveMessage(event) {
+        async function receiveMessage(event) {
             if (event.origin === "null") {
                 if (event.data.indexOf("PASS") === -1)
                     testFailed(event.data.replace("FAIL ", ""));
@@ -32,7 +32,7 @@
             if (statsChecked)
                 finishTest();
             else
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html
@@ -21,7 +21,7 @@
         var lastPageInRedirectChainLoaded = false;
         var statsChecked = false;
 
-        function receiveMessage(event) {
+        async function receiveMessage(event) {
             if (event.origin === "null") {
                 if (event.data.indexOf("PASS") === -1)
                     testFailed(event.data.replace("FAIL ", ""));
@@ -32,7 +32,7 @@
             if (statsChecked)
                 finishTest();
             else
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
         }
 
         function checkStats() {

--- a/LayoutTests/http/tests/webAPIStatistics/canvas-read-and-write-data-collection.html
+++ b/LayoutTests/http/tests/webAPIStatistics/canvas-read-and-write-data-collection.html
@@ -18,14 +18,14 @@
         });
     }
 
-    function runTestRunnerTest() {
+    async function runTestRunnerTest() {
         testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
     
         var canvas = document.createElement('canvas');
         var context = canvas.getContext('2d');
         context.fillText('suspicious invisible text', 2, 15);
         canvas.toDataURL();
-        testRunner.statisticsNotifyObserver();
+        await testRunner.statisticsNotifyObserver();
     }
 
     if (document.location.host === hostUnderTest && window.testRunner && window.internals) {

--- a/LayoutTests/http/tests/webAPIStatistics/font-load-data-collection.html
+++ b/LayoutTests/http/tests/webAPIStatistics/font-load-data-collection.html
@@ -30,8 +30,8 @@
         span.style.fontFamily = 'Andale, Fransiscan, notARealFont, serif';
         body.appendChild(span);
         // Adds a timeout to allow font loads to be recorded.
-        setTimeout(function() {
-            testRunner.statisticsNotifyObserver();
+        setTimeout(async function() {
+            await testRunner.statisticsNotifyObserver();
         }, 0);
     }
 

--- a/LayoutTests/http/tests/webAPIStatistics/navigator-functions-accessed-data-collection.html
+++ b/LayoutTests/http/tests/webAPIStatistics/navigator-functions-accessed-data-collection.html
@@ -18,7 +18,7 @@
         });
     }
 
-    function runTestRunnerTest() {
+    async function runTestRunnerTest() {
         testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
     
         var useragent = navigator.userAgent;
@@ -27,7 +27,7 @@
         var mimetypes = navigator.mimeTypes;
         var plugins = navigator.plugins;
         var appversion = navigator.appVersion;
-        testRunner.statisticsNotifyObserver();
+        await testRunner.statisticsNotifyObserver();
     }
 
     if (document.location.host === hostUnderTest && window.testRunner && window.internals) {

--- a/LayoutTests/http/tests/webAPIStatistics/screen-functions-accessed-data-collection.html
+++ b/LayoutTests/http/tests/webAPIStatistics/screen-functions-accessed-data-collection.html
@@ -18,7 +18,7 @@
         });
     }
 
-    function runTestRunnerTest() {
+    async function runTestRunnerTest() {
         testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
     
         var availTop = screen.availTop;
@@ -29,7 +29,7 @@
         var availLeft = screen.availLeft;
         var availHeight = screen.availHeight;
         var availWidth = screen.availWidth;
-        testRunner.statisticsNotifyObserver();
+        await testRunner.statisticsNotifyObserver();
     }
 
     if (document.location.host === hostUnderTest && window.testRunner && window.internals) {

--- a/LayoutTests/http/tests/websocket/connection-refusal-in-frame-resource-load-statistics.html
+++ b/LayoutTests/http/tests/websocket/connection-refusal-in-frame-resource-load-statistics.html
@@ -11,7 +11,7 @@
 
     const numberOfNotificationsExpected = 2;
     let numberOfNotificationsReceived = 0;
-    function completeTest() {
+    async function completeTest() {
         numberOfNotificationsReceived++;
         if (testRunner.isStatisticsRegisteredAsSubresourceUnder("http://localhost", "http://127.0.0.1")) {
             testPassed("localhost registered as subresource under 127.0.0.1.");
@@ -22,7 +22,7 @@
                 setEnableFeature(false, finishJSTest);
             } else {
                 testRunner.installStatisticsDidScanDataRecordsCallback(completeTest);
-                testRunner.statisticsNotifyObserver();
+                await testRunner.statisticsNotifyObserver();
             }
         }
     }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
@@ -211,15 +211,15 @@ void WKBundleClearResourceLoadStatistics(WKBundleRef)
     WebCore::ResourceLoadObserver::shared().clearState();
 }
 
-bool WKBundleResourceLoadStatisticsNotifyObserver(WKBundleRef)
+void WKBundleResourceLoadStatisticsNotifyObserver(WKBundleRef, void* context, NotifyObserverCallback callback)
 {
     if (!WebCore::ResourceLoadObserver::shared().hasStatistics())
-        return false;
+        return callback(context);
 
-    WebCore::ResourceLoadObserver::shared().updateCentralStatisticsStore([] { });
-    return true;
+    WebCore::ResourceLoadObserver::shared().updateCentralStatisticsStore([context, callback] {
+        callback(context);
+    });
 }
-
 
 void WKBundleExtendClassesForParameterCoder(WKBundleRef bundle, WKArrayRef classes)
 {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePrivate.h
@@ -69,12 +69,14 @@ WK_EXPORT bool WKBundleIsProcessingUserGesture(WKBundleRef bundle);
 
 WK_EXPORT void WKBundleSetTabKeyCyclesThroughElements(WKBundleRef bundle, WKBundlePageRef page, bool enabled);
 
-WK_EXPORT void WKBundleClearResourceLoadStatistics(WKBundleRef);
-WK_EXPORT bool WKBundleResourceLoadStatisticsNotifyObserver(WKBundleRef);
+WK_EXPORT void WKBundleClearResourceLoadStatistics(WKBundleRef bundle);
+
+typedef void (*NotifyObserverCallback)(void* functionContext);
+WK_EXPORT void WKBundleResourceLoadStatisticsNotifyObserver(WKBundleRef bundle, void* context, NotifyObserverCallback callback);
 
 WK_EXPORT void WKBundleExtendClassesForParameterCoder(WKBundleRef bundle, WKArrayRef classes);
 
-WK_EXPORT void WKBundleReleaseMemory(WKBundleRef);
+WK_EXPORT void WKBundleReleaseMemory(WKBundleRef bundle);
 
 #ifdef __cplusplus
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -340,7 +340,7 @@ interface TestRunner {
     undefined setStatisticsTopFrameUniqueRedirectFrom(DOMString hostName, DOMString hostNameRedirectedTo);
     undefined setStatisticsCrossSiteLoadWithLinkDecoration(DOMString fromHost, DOMString toHost, boolean wasFiltered);
     undefined setStatisticsTimeToLiveUserInteraction(double seconds);
-    boolean statisticsNotifyObserver();
+    Promise<undefined> statisticsNotifyObserver();
     Promise<undefined> statisticsProcessStatisticsAndDataRecords();
     undefined statisticsUpdateCookieBlocking(object completionHandler);
     undefined setStatisticsTimeAdvanceForTesting(double value);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -38,9 +38,10 @@
 #include <WebKit/WKBundlePrivate.h>
 #include <WebKit/WKRetainPtr.h>
 #include <WebKit/WebKit2_C.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/Vector.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
-#include <wtf/Vector.h>
 
 namespace WTR {
 
@@ -695,9 +696,11 @@ void InjectedBundle::setAllowsAnySSLCertificate(bool allowsAnySSLCertificate)
     WebCoreTestSupport::setAllowsAnySSLCertificate(allowsAnySSLCertificate);
 }
 
-bool InjectedBundle::statisticsNotifyObserver()
+void InjectedBundle::statisticsNotifyObserver(CompletionHandler<void()>&& completionHandler)
 {
-    return WKBundleResourceLoadStatisticsNotifyObserver(m_bundle.get());
+    return WKBundleResourceLoadStatisticsNotifyObserver(m_bundle.get(), completionHandler.leak(), [] (void* context) {
+        WTF::adopt(static_cast<CompletionHandler<void()>::Impl*>(context))();
+    });
 }
 
 WKRetainPtr<WKStringRef> InjectedBundle::lastAddedBackgroundFetchIdentifier() const

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -131,7 +131,7 @@ public:
 
     void setAllowsAnySSLCertificate(bool);
 
-    bool statisticsNotifyObserver();
+    void statisticsNotifyObserver(CompletionHandler<void()>&&);
 
     void textDidChangeInTextField();
     void textFieldDidBeginEditing();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1437,9 +1437,15 @@ void TestRunner::statisticsDidScanDataRecordsCallback()
     callTestRunnerCallback(StatisticsDidScanDataRecordsCallbackID);
 }
 
-bool TestRunner::statisticsNotifyObserver()
+void TestRunner::statisticsNotifyObserver(JSContextRef context, JSValueRef callback)
 {
-    return InjectedBundle::singleton().statisticsNotifyObserver();
+    auto globalContext = JSContextGetGlobalContext(context);
+    JSValueProtect(globalContext, callback);
+    InjectedBundle::singleton().statisticsNotifyObserver([callback, globalContext = JSRetainPtr { globalContext }] {
+        JSContextRef context = globalContext.get();
+        JSObjectCallAsFunction(context, JSValueToObject(context, callback, nullptr), JSContextGetGlobalObject(context), 0, nullptr, nullptr);
+        JSValueUnprotect(context, callback);
+    });
 }
 
 void TestRunner::statisticsProcessStatisticsAndDataRecords(JSContextRef context, JSValueRef completionHandler)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -415,7 +415,7 @@ public:
     void installStatisticsDidScanDataRecordsCallback(JSContextRef, JSValueRef callback);
     void statisticsDidModifyDataRecordsCallback();
     void statisticsDidScanDataRecordsCallback();
-    bool statisticsNotifyObserver();
+    void statisticsNotifyObserver(JSContextRef, JSValueRef completionHandler);
     void statisticsProcessStatisticsAndDataRecords(JSContextRef, JSValueRef completionHandler);
     void statisticsUpdateCookieBlocking(JSContextRef, JSValueRef completionHandler);
     void setStatisticsDebugMode(JSContextRef, bool value, JSValueRef completionHandler);


### PR DESCRIPTION
#### d3bda6d206461de6b69b51913eff60a49b07d827
<pre>
Make TestRunner.statisticsNotifyObserver return a promise
<a href="https://bugs.webkit.org/show_bug.cgi?id=277468">https://bugs.webkit.org/show_bug.cgi?id=277468</a>
<a href="https://rdar.apple.com/132957567">rdar://132957567</a>

Reviewed by Charlie Wolfe.

This is a step towards making it work better with site isolation.

* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-subresource-redirect-collusion.html:
* LayoutTests/http/tests/resourceLoadStatistics/classify-as-prevalent-based-on-top-frame-redirect-collusion.html:
* LayoutTests/http/tests/resourceLoadStatistics/count-third-party-script-import-in-worker.html:
* LayoutTests/http/tests/resourceLoadStatistics/count-third-party-script-loads.html:
* LayoutTests/http/tests/resourceLoadStatistics/do-not-capture-statistics-for-simple-top-navigations.html:
* LayoutTests/http/tests/resourceLoadStatistics/dont-count-third-party-image-as-third-party-script.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html:
* LayoutTests/http/tests/resourceLoadStatistics/non-sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html:
* LayoutTests/http/tests/resourceLoadStatistics/remove-website-data-for-origin-deletes-third-party-script-loads.html:
* LayoutTests/http/tests/resourceLoadStatistics/sandboxed-iframe-redirect-ip-to-localhost-to-ip.html:
* LayoutTests/http/tests/resourceLoadStatistics/sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html:
* LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html:
* LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-non-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html:
* LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-ip-to-localhost-to-ip.html:
* LayoutTests/http/tests/resourceLoadStatistics/sandboxed-nesting-iframe-with-sandboxed-iframe-redirect-localhost-to-ip-to-localhost.html:
* LayoutTests/http/tests/webAPIStatistics/canvas-read-and-write-data-collection.html:
* LayoutTests/http/tests/webAPIStatistics/font-load-data-collection.html:
* LayoutTests/http/tests/webAPIStatistics/navigator-functions-accessed-data-collection.html:
* LayoutTests/http/tests/webAPIStatistics/screen-functions-accessed-data-collection.html:
* LayoutTests/http/tests/websocket/connection-refusal-in-frame-resource-load-statistics.html:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp:
(WKBundleResourceLoadStatisticsNotifyObserver):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePrivate.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::statisticsNotifyObserver):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::statisticsNotifyObserver):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:

Canonical link: <a href="https://commits.webkit.org/281712@main">https://commits.webkit.org/281712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7830ac15023034b9ab81a6cac094a91dc9a4f3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64628 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11244 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11519 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49087 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7800 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52575 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29916 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33992 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9808 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10157 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66357 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9943 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56449 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56630 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3839 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9136 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35861 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36943 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->