### PR TITLE
Adopt async eventSender mouse functions in animations/, compositing/, css3/, pointerevents/

### DIFF
--- a/LayoutTests/accessibility/file-upload-button-stringvalue.html
+++ b/LayoutTests/accessibility/file-upload-button-stringvalue.html
@@ -8,13 +8,17 @@
 <p>This tests the value of stringValue for a single file- and multiple files-&lt;input type=&quot;file&quot;&gt; control.</p>
 <pre id="console"></pre>
 <script>
-if (window.testRunner && window.accessibilityController) {
-    testRunner.dumpAsText();
-    runTest();
-} else
-    log("This test must be run with DumpRenderTree and an implemented AccessibilityController.");
+onload = async () => {
+    if (window.testRunner && window.accessibilityController) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+        await runTest();
+        testRunner.notifyDone();
+    } else
+        log("This test must be run with DumpRenderTree and an implemented AccessibilityController.");
+}
 
-function runTest()
+async function runTest()
 {
     var elementIds = ["singleFileUpload", "multipleFileUpload"];
     var form = document.getElementById("form");
@@ -29,7 +33,7 @@ function runTest()
     log(""); // Add an empty line; make the expected results pretty.
     log("Drag and drop a single file:");
     for (var i = 0; i < elementIds.length; ++i) {
-        dragAndDropFauxFilesOnElement(["file1.txt"], elementIds[i]);
+        await dragAndDropFauxFilesOnElement(["file1.txt"], elementIds[i]);
         logAccessibilityStringValueForElement(elementIds[i]);
     }
 
@@ -37,7 +41,7 @@ function runTest()
     log(""); // Add an empty line; make the expected results pretty.
     log("Drag and drop two files:");
     for (var i = 0; i < elementIds.length; ++i) {
-        dragAndDropFauxFilesOnElement(["file1.txt", "file2.txt"], elementIds[i]);
+        await dragAndDropFauxFilesOnElement(["file1.txt", "file2.txt"], elementIds[i]);
         logAccessibilityStringValueForElement(elementIds[i]);
     }
 }
@@ -52,14 +56,14 @@ function logAccessibilityStringValueForElement(elementId)
     log('accessibilityController.accessibleElementById("' + elementId + '").stringValue: ' + accessibilityController.accessibleElementById(elementId).stringValue);
 }
 
-function dragAndDropFauxFilesOnElement(files, elementId)
+async function dragAndDropFauxFilesOnElement(files, elementId)
 {
     if (!window.eventSender || !eventSender.beginDragWithFiles)
         return;
     var element = document.getElementById(elementId);
     eventSender.beginDragWithFiles(files);
-    eventSender.mouseMoveTo(element.offsetLeft, element.offsetTop);
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(element.offsetLeft, element.offsetTop);
+    await eventSender.asyncMouseUp();
 }
 </script>
 </body>

--- a/LayoutTests/animations/restart-after-scroll-nested.html
+++ b/LayoutTests/animations/restart-after-scroll-nested.html
@@ -9,17 +9,17 @@ function sawIteration(event) {
     }
 }
 
-function startScroll() {
+async function startScroll() {
     if (window.eventSender) {
-        eventSender.mouseMoveTo(200, 200);
-        eventSender.mouseDown();
-        eventSender.mouseMoveTo(200, 300);
+        await eventSender.asyncMouseMoveTo(200, 200);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseMoveTo(200, 300);
         setTimeout(endScroll, 100);
     }
 }
 
-function endScroll() {
-    eventSender.mouseUp();
+async function endScroll() {
+    await eventSender.asyncMouseUp();
     hasScrolled = true;
 }
 

--- a/LayoutTests/animations/restart-after-scroll.html
+++ b/LayoutTests/animations/restart-after-scroll.html
@@ -30,17 +30,17 @@ function sawIteration(event) {
     }
 }
 
-function startScroll() {
+async function startScroll() {
     if (window.eventSender) {
-        eventSender.mouseMoveTo(200, 200);
-        eventSender.mouseDown();
-        eventSender.mouseMoveTo(200, 300);
+        await eventSender.asyncMouseMoveTo(200, 200);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseMoveTo(200, 300);
         setTimeout(endScroll, 100);
     }
 }
 
-function endScroll() {
-    eventSender.mouseUp();
+async function endScroll() {
+    await eventSender.asyncMouseUp();
     hasScrolled = true;
 }
 

--- a/LayoutTests/compositing/iframes/crash-mouse-event.html
+++ b/LayoutTests/compositing/iframes/crash-mouse-event.html
@@ -3,10 +3,10 @@
         testRunner.dumpAsText(false);
         testRunner.waitUntilDone();
     }
-    function testDone()
+    async function testDone()
     {
         if (window.eventSender) {
-            eventSender.mouseDown();
+            await eventSender.asyncMouseDown();
         }
         if (window.testRunner) {
             testRunner.notifyDone();

--- a/LayoutTests/compositing/iframes/layout-on-compositing-change.html
+++ b/LayoutTests/compositing/iframes/layout-on-compositing-change.html
@@ -49,12 +49,12 @@
     }
 
     // Called from subframe.
-    function testDone()
+    async function testDone()
     {
         if (window.eventSender) {
-            eventSender.mouseMoveTo(82, 52);
-            eventSender.mouseDown();
-            eventSender.mouseUp();
+            await eventSender.asyncMouseMoveTo(82, 52);
+            await eventSender.asyncMouseDown();
+            await eventSender.asyncMouseUp();
         }
 
         if (window.testRunner)

--- a/LayoutTests/compositing/iframes/leave-compositing-iframe.html
+++ b/LayoutTests/compositing/iframes/leave-compositing-iframe.html
@@ -29,7 +29,7 @@
     }
 
     // Called from subframe.
-    function testDone()
+    async function testDone()
     {
       document.getElementById('parent-iframe').contentDocument.body.offsetWidth; // work around bug 41999.
       if (window.testRunner)

--- a/LayoutTests/compositing/iframes/resources/leave-compositing-subframe-click.html
+++ b/LayoutTests/compositing/iframes/resources/leave-compositing-subframe-click.html
@@ -22,9 +22,9 @@
   <script type="text/javascript">
     function doTest()
     {
-      window.setTimeout(function() {
+      window.setTimeout(async function() {
         document.getElementById('target').className = 'box';
-        parent.testDone();
+        await parent.testDone();
       }, 50);
     }
     window.addEventListener('load', doTest, false);

--- a/LayoutTests/compositing/no-compositing-when-full-screen-is-present.html
+++ b/LayoutTests/compositing/no-compositing-when-full-screen-is-present.html
@@ -42,11 +42,14 @@ host.addEventListener('webkitfullscreenchange', finalizeTest);
 let button = document.querySelector('button');
 button.onclick = goFullscreen;
 
-if (window.eventSender) {
-    jsTestIsAsync = true;
-    eventSender.mouseMoveTo(button.offsetLeft + 5, button.offsetTop + 5);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+jsTestIsAsync = true;
+
+onload = async () => {
+    if (window.eventSender) {
+        await eventSender.asyncMouseMoveTo(button.offsetLeft + 5, button.offsetTop + 5);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+    }
 }
 
 </script>

--- a/LayoutTests/css3/scroll-snap/scroll-padding-overflow-paging.html
+++ b/LayoutTests/css3/scroll-snap/scroll-padding-overflow-paging.html
@@ -16,10 +16,10 @@
         <script>
         window.jsTestIsAsync = true;
 
-        function clickOnElement(targetElement) {
+        async function clickOnElement(targetElement) {
             var clientRect = targetElement.getBoundingClientRect();
-            eventSender.mouseMoveTo(clientRect.x + 5, clientRect.y + 5);
-            eventSender.mouseDown();
+            await eventSender.asyncMouseMoveTo(clientRect.x + 5, clientRect.y + 5);
+            await eventSender.asyncMouseDown();
         }
 
         async function runTests()
@@ -27,7 +27,7 @@
             try {
                 var container = document.getElementById("container");
 
-                clickOnElement(container);
+                await clickOnElement(container);
                 await UIHelper.keyDown("pageDown");
                 await UIHelper.waitForTargetScrollAnimationToSettle(container);
 

--- a/LayoutTests/css3/scroll-snap/scroll-snap-click-scrollbar-gutter.html
+++ b/LayoutTests/css3/scroll-snap/scroll-snap-click-scrollbar-gutter.html
@@ -73,17 +73,17 @@
                 return;
             }
             try {
-                eventSender.mouseMoveTo(175, 190);
-                eventSender.mouseDown();
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(175, 190);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseUp();
 
                 let horizontalContainer = document.getElementById("horizontal-container");
                 await UIHelper.waitForTargetScrollAnimationToSettle(horizontalContainer);
                 expectTrue(horizontalContainer.scrollLeft == 1000, "clicking the horizontal scrollbar gutter snapped");
 
-                eventSender.mouseMoveTo(190, 370);
-                eventSender.mouseDown();
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(190, 370);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseUp();
                 let verticalContainer = document.getElementById("vertical-container");
                 await UIHelper.waitForTargetScrollAnimationToSettle(verticalContainer);
                 expectTrue(verticalContainer.scrollTop == 1000, "dragging the vertical scrollbar thumb snapped");

--- a/LayoutTests/css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-relayouts.html
+++ b/LayoutTests/css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-relayouts.html
@@ -71,34 +71,34 @@
                 return;
             }
             try {
-                eventSender.mouseMoveTo(20, 190);
-                eventSender.mouseDown();
+                await eventSender.asyncMouseMoveTo(20, 190);
+                await eventSender.asyncMouseDown();
 
                 // Pause and move to trigger relayouts.
-                eventSender.mouseMoveTo(40, 190);
+                await eventSender.asyncMouseMoveTo(40, 190);
                 await UIHelper.delayFor(1);
-                eventSender.mouseMoveTo(50, 190);
+                await eventSender.asyncMouseMoveTo(50, 190);
                 await UIHelper.delayFor(1);
 
-                eventSender.mouseMoveTo(80, 190);
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(80, 190);
+                await eventSender.asyncMouseUp();
 
                 await UIHelper.waitForTargetScrollAnimationToSettle(horizontalContainer);
                 expectTrue(horizontalContainer.scrollLeft == 250, "dragging the horizontal scrollbar thumb snapped");
                 expectTrue(sawZero === false, "relayouts should not have snapped back");
 
                 sawZero = false;
-                eventSender.mouseMoveTo(190, 220);
-                eventSender.mouseDown();
+                await eventSender.asyncMouseMoveTo(190, 220);
+                await eventSender.asyncMouseDown();
 
                 // Pause and move to trigger relayouts.
-                eventSender.mouseMoveTo(190, 250);
+                await eventSender.asyncMouseMoveTo(190, 250);
                 await UIHelper.delayFor(1);
-                eventSender.mouseMoveTo(190, 255);
+                await eventSender.asyncMouseMoveTo(190, 255);
                 await UIHelper.delayFor(1);
 
-                eventSender.mouseMoveTo(190, 270);
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(190, 270);
+                await eventSender.asyncMouseUp();
                 await UIHelper.waitForTargetScrollAnimationToSettle(verticalContainer);
                 expectTrue(verticalContainer.scrollTop == 180, "dragging the vertical scrollbar thumb snapped");
                 expectTrue(sawZero === false, "relayouts should not have snapped back");

--- a/LayoutTests/css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-sticky.html
+++ b/LayoutTests/css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-sticky.html
@@ -70,12 +70,12 @@
                 return;
             }
             try {
-                eventSender.mouseMoveTo(20, 190);
-                eventSender.mouseDown();
-                eventSender.mouseMoveTo(100, 190);
+                await eventSender.asyncMouseMoveTo(20, 190);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseMoveTo(100, 190);
 
                 await UIHelper.ensurePresentationUpdate();
-                eventSender.mouseUp();
+                await eventSender.asyncMouseUp();
 
                 let horizontalContainer = document.getElementById("horizontal-container");
                 await UIHelper.waitForTargetScrollAnimationToSettle(horizontalContainer);

--- a/LayoutTests/css3/scroll-snap/scroll-snap-drag-scrollbar-thumb.html
+++ b/LayoutTests/css3/scroll-snap/scroll-snap-drag-scrollbar-thumb.html
@@ -58,19 +58,19 @@
                 return;
             }
             try {
-                eventSender.mouseMoveTo(20, 190);
-                eventSender.mouseDown();
-                eventSender.mouseMoveTo(80, 190);
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(20, 190);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseMoveTo(80, 190);
+                await eventSender.asyncMouseUp();
 
                 let horizontalContainer = document.getElementById("horizontal-container");
                 await UIHelper.waitForTargetScrollAnimationToSettle(horizontalContainer);
                 expectTrue(horizontalContainer.scrollLeft == 250, "dragging the horizontal scrollbar thumb snapped");
 
-                eventSender.mouseMoveTo(190, 220);
-                eventSender.mouseDown();
-                eventSender.mouseMoveTo(190, 270);
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(190, 220);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseMoveTo(190, 270);
+                await eventSender.asyncMouseUp();
                 let verticalContainer = document.getElementById("vertical-container");
                 await UIHelper.waitForTargetScrollAnimationToSettle(verticalContainer);
                 expectTrue(verticalContainer.scrollTop == 180, "dragging the vertical scrollbar thumb snapped");

--- a/LayoutTests/css3/scroll-snap/scroll-snap-wheel-event.html
+++ b/LayoutTests/css3/scroll-snap/scroll-snap-wheel-event.html
@@ -33,20 +33,20 @@
                 return;
             }
             try {
-                eventSender.mouseMoveTo(20, 190);
-                eventSender.mouseDown();
-                eventSender.mouseMoveTo(80, 190);
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(20, 190);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseMoveTo(80, 190);
+                await eventSender.asyncMouseUp();
 
                 await UIHelper.statelessMouseWheelScrollAt(80, 190, -1, 0);
 
                 let horizontalContainer = document.getElementById("horizontal-container");
                 expectTrue(horizontalContainer.scrollLeft == 200, "horizontal mouse wheel event snapped");
 
-                eventSender.mouseMoveTo(190, 220);
-                eventSender.mouseDown();
-                eventSender.mouseMoveTo(190, 270);
-                eventSender.mouseUp();
+                await eventSender.asyncMouseMoveTo(190, 220);
+                await eventSender.asyncMouseDown();
+                await eventSender.asyncMouseMoveTo(190, 270);
+                await eventSender.asyncMouseUp();
 
                 await UIHelper.statelessMouseWheelScrollAt(190, 270, 0, -1);
 

--- a/LayoutTests/css3/viewport-percentage-lengths/vh-resize.html
+++ b/LayoutTests/css3/viewport-percentage-lengths/vh-resize.html
@@ -2,20 +2,22 @@
 <html>
 <head>
 <script>
-function init() {
+async function init() {
       if (!window.testRunner)
           return;
+      testRunner.waitUntilDone();
       // Move the resizer 400 pixels down.
-      eventSender.mouseMoveTo(100, 400);
-      eventSender.mouseDown();
-      eventSender.mouseMoveTo(100, 200);
-      eventSender.mouseUp();
+      await eventSender.asyncMouseMoveTo(100, 400);
+      await eventSender.asyncMouseDown();
+      await eventSender.asyncMouseMoveTo(100, 200);
+      await eventSender.asyncMouseUp();
 
       // Also test when frame height is increased.
-      eventSender.mouseMoveTo(100, 200);
-      eventSender.mouseDown();
-      eventSender.mouseMoveTo(100, 300);
-      eventSender.mouseUp();
+      await eventSender.asyncMouseMoveTo(100, 200);
+      await eventSender.asyncMouseDown();
+      await eventSender.asyncMouseMoveTo(100, 300);
+      await eventSender.asyncMouseUp();
+      testRunner.notifyDone();
 }
 window.onload = init;
 </script>

--- a/LayoutTests/pointerevents/mouse/compatibility-mouse-events-prevention-mouse-pressed.html
+++ b/LayoutTests/pointerevents/mouse/compatibility-mouse-events-prevention-mouse-pressed.html
@@ -11,23 +11,23 @@
 
 'use strict';
 
-function runMouseSequence()
+async function runMouseSequence()
 {
-    eventSender.mouseDown();
-    eventSender.mouseMoveTo(25, 25);
-    eventSender.mouseMoveTo(75, 75);
-    eventSender.mouseUp();
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseMoveTo(25, 25);
+    await eventSender.asyncMouseMoveTo(75, 75);
+    await eventSender.asyncMouseUp();
 }
 
-target_test({ x: "50px", y: "50px", width: "100px", height: "100px" }, (target, test) => {
+target_test({ x: "50px", y: "50px", width: "100px", height: "100px" }, async (target, test) => {
     const eventTracker = new EventTracker(target, ["mousedown", "mouseover", "mouseenter", "mousemove", "mouseout", "mouseleave", "mouseup"]);
 
     // First, move the mouse over the element to start in that state.
-    eventSender.mouseMoveTo(75, 75);
+    await eventSender.asyncMouseMoveTo(75, 75);
     eventTracker.clear();
     
     // Then, press the mouse, don't call preventDefault() while handling "pointerdown", move the mouse out, then back over and finally release.
-    runMouseSequence();
+    await runMouseSequence();
 
     eventTracker.assertMatchesEvents([
         {"type": "mousedown" },
@@ -43,7 +43,7 @@ target_test({ x: "50px", y: "50px", width: "100px", height: "100px" }, (target, 
 
     // Then do the same thing but calling preventDefault() while handling "pointerdown".
     target.addEventListener("pointerdown", event => event.preventDefault());
-    runMouseSequence();
+    await runMouseSequence();
 
     eventTracker.assertMatchesEvents([
         {"type": "mouseout" },

--- a/LayoutTests/pointerevents/mouse/compatibility-mouse-events-prevention-mouse-released.html
+++ b/LayoutTests/pointerevents/mouse/compatibility-mouse-events-prevention-mouse-released.html
@@ -11,25 +11,25 @@
 
 'use strict';
 
-target_test((target, test) => {
+target_test(async (target, test) => {
     // First, let's make sure we call preventDefault() the first time we get a pointerdown event.
     target.addEventListener("pointerdown", event => event.preventDefault(), { once: true });
 
     // Press the mouse while over the element.
-    eventSender.mouseMoveTo(50, 50);
-    eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(50, 50);
+    await eventSender.asyncMouseDown();
 
     let obtainedMouseMove = false;
     target.addEventListener("mousemove", event => obtainedMouseMove = true, { once: true });
-    eventSender.mouseMoveTo(60, 60);
+    await eventSender.asyncMouseMoveTo(60, 60);
     assert_false(obtainedMouseMove, "The mousemove event is not fired after calling preventDefault() while handling the pointerdown event.");
 
     // Release the mouse.
-    eventSender.mouseUp();
+    await eventSender.asyncMouseUp();
 
     // Now, without the mouse pressed, move the pointer over the element again. This should not prevent the mousemove event anymore since
     // the mouse pointer is not pressed.
-    eventSender.mouseMoveTo(50, 50);
+    await eventSender.asyncMouseMoveTo(50, 50);
     assert_true(obtainedMouseMove, "The mousemove event is fired after releasing the mouse.");
 
     test.done();

--- a/LayoutTests/pointerevents/mouse/pointer-button-and-buttons.html
+++ b/LayoutTests/pointerevents/mouse/pointer-button-and-buttons.html
@@ -11,13 +11,13 @@
 
 'use strict';
 
-target_test((target, test) => {
+target_test(async (target, test) => {
     const eventTracker = new EventTracker(target, ["pointerdown", "pointerup"]);
 
     // Click without a move.
-    eventSender.mouseMoveTo(50, 50);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(50, 50);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
 
     eventTracker.assertMatchesEvents([
         { type : "pointerdown", x: 50, y: 50, button: 0, buttons: 1 },

--- a/LayoutTests/pointerevents/mouse/pointer-capture-element-removal.html
+++ b/LayoutTests/pointerevents/mouse/pointer-capture-element-removal.html
@@ -24,8 +24,7 @@
 
 'use strict';
 
-test(() => {
-
+promise_test(async () => {
     let numberOfPointerDownEvents = 0;
     document.body.addEventListener("pointerdown", event => {
         numberOfPointerDownEvents++;
@@ -41,15 +40,15 @@ test(() => {
     document.body.addEventListener("pointerup", event => event.target.remove(), { once: true });
 
     // Move the mouse pointer over both of the stacked targets.
-    eventSender.mouseMoveTo(50, 50);
+    await eventSender.asyncMouseMoveTo(50, 50);
 
     // Click once, this will set pointer capture on "first" and then remove it when the pointer is released.
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
 
     // Click a second time, this should target "second".
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
 
     assert_equals(numberOfPointerDownEvents, 2, "There were two pointerdown events dispatched.");
 }, `Testing that removing the capture element from the DOM doesn't prevent future pointer events to be dispatched.`);

--- a/LayoutTests/pointerevents/mouse/pointer-event-basic-properties.html
+++ b/LayoutTests/pointerevents/mouse/pointer-event-basic-properties.html
@@ -11,7 +11,7 @@
 
 'use strict';
 
-target_test((target, test) => {
+target_test(async (target, test) => {
     target.addEventListener("pointerdown", event => {
         assert_equals(event.pointerId, 1, "The pointer's identifier is 1.");
         assert_equals(event.pointerType, "mouse", "The pointer type is 'mouse'.");
@@ -20,8 +20,8 @@ target_test((target, test) => {
         test.done();
     });
 
-    eventSender.mouseMoveTo(50, 50);
-    eventSender.mouseDown();
+    await eventSender.asyncMouseMoveTo(50, 50);
+    await eventSender.asyncMouseDown();
 }, `Testing the basic properties of a pointer event triggered by a mouse.`);
 
 </script>

--- a/LayoutTests/pointerevents/mouse/pointerdown-prevent-default.html
+++ b/LayoutTests/pointerevents/mouse/pointerdown-prevent-default.html
@@ -11,19 +11,19 @@
 
 'use strict';
 
-target_test((target, test) => {
+target_test(async (target, test) => {
     const eventTracker = new EventTracker(target, ["pointerdown", "mousedown"]);
 
     // Press the mouse once without calling preventDefault().
-    eventSender.mouseMoveTo(50, 50);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(50, 50);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
 
     // Press it again and call preventDefault().
     target.addEventListener("pointerdown", event => event.preventDefault());
-    eventSender.mouseMoveTo(50, 50);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(50, 50);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseUp();
 
     eventTracker.assertMatchesEvents([
         { type: "pointerdown", x: 50, y: 50 },


### PR DESCRIPTION
#### ddb18619109aad0d66fbafa47bae91d84c151f72
<pre>
Adopt async eventSender mouse functions in animations/, compositing/, css3/, pointerevents/
<a href="https://rdar.apple.com/132968641">rdar://132968641</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=277477">https://bugs.webkit.org/show_bug.cgi?id=277477</a>

Reviewed by Alex Christensen.

This is needed so that the DOM does not change after using eventSender.mouse* functions with site
isolation enabled.

* LayoutTests/accessibility/file-upload-button-stringvalue.html:
* LayoutTests/animations/restart-after-scroll-nested.html:
* LayoutTests/animations/restart-after-scroll.html:
* LayoutTests/compositing/iframes/crash-mouse-event.html:
* LayoutTests/compositing/iframes/layout-on-compositing-change.html:
* LayoutTests/compositing/iframes/leave-compositing-iframe.html:
* LayoutTests/compositing/iframes/resources/leave-compositing-subframe-click.html:
* LayoutTests/compositing/no-compositing-when-full-screen-is-present.html:
* LayoutTests/css3/scroll-snap/scroll-padding-overflow-paging.html:
* LayoutTests/css3/scroll-snap/scroll-snap-click-scrollbar-gutter.html:
* LayoutTests/css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-relayouts.html:
* LayoutTests/css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-sticky.html:
* LayoutTests/css3/scroll-snap/scroll-snap-drag-scrollbar-thumb.html:
* LayoutTests/css3/scroll-snap/scroll-snap-wheel-event.html:
* LayoutTests/css3/viewport-percentage-lengths/vh-resize.html:
* LayoutTests/pointerevents/mouse/compatibility-mouse-events-prevention-mouse-pressed.html:
* LayoutTests/pointerevents/mouse/compatibility-mouse-events-prevention-mouse-released.html:
* LayoutTests/pointerevents/mouse/pointer-button-and-buttons.html:
* LayoutTests/pointerevents/mouse/pointer-capture-element-removal.html:
* LayoutTests/pointerevents/mouse/pointer-event-basic-properties.html:
* LayoutTests/pointerevents/mouse/pointerdown-prevent-default.html:

Canonical link: <a href="https://commits.webkit.org/281777@main">https://commits.webkit.org/281777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82d5471998357afe85eaa5b7f322a0049217b818

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11414 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49211 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7918 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62901 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37452 "Found 12 new test failures: editing/deleting/25322-1.html editing/deleting/smart-delete-002.html editing/deleting/smart-delete-paragraph-002.html editing/pasteboard/smart-paste-003-trailing-whitespace.html editing/pasteboard/smart-paste-004.html editing/pasteboard/smart-paste-in-text-control.html editing/pasteboard/smart-paste-paragraph-004.html editing/selection/clear-selection-crash.html editing/selection/doubleclick-whitespace-crash.html editing/selection/ios/change-selection-by-tapping.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30038 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9957 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10327 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55964 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66527 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56577 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56762 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3987 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9176 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36031 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37113 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38206 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->