### PR TITLE
[GTK] Add support for explicit sync

### DIFF
--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -257,6 +257,7 @@ UIProcess/glib/DisplayLinkGLib.cpp
 UIProcess/glib/DisplayVBlankMonitor.cpp
 UIProcess/glib/DisplayVBlankMonitorDRM.cpp
 UIProcess/glib/DisplayVBlankMonitorTimer.cpp
+UIProcess/glib/FenceMonitor.cpp
 UIProcess/glib/ScreenManager.cpp
 UIProcess/glib/WebPageProxyGLib.cpp
 UIProcess/glib/WebProcessPoolGLib.cpp

--- a/Source/WebKit/UIProcess/glib/FenceMonitor.cpp
+++ b/Source/WebKit/UIProcess/glib/FenceMonitor.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FenceMonitor.h"
+
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+#include <glib-unix.h>
+
+#if PLATFORM(GTK)
+#include <gtk/gtk.h>
+#endif
+
+namespace WebKit {
+
+FenceMonitor::FenceMonitor(Function<void()>&& callback)
+    : m_callback(WTFMove(callback))
+{
+}
+
+FenceMonitor::~FenceMonitor()
+{
+    if (m_source)
+        g_source_destroy(m_source.get());
+}
+
+struct FenceSource {
+    static GSourceFuncs sourceFuncs;
+
+    ~FenceSource()
+    {
+        if (tag)
+            g_source_remove_unix_fd(&base, tag);
+    }
+
+    GSource base;
+    UnixFileDescriptor fd;
+    gpointer tag { nullptr };
+};
+
+GSourceFuncs FenceSource::sourceFuncs = {
+    nullptr, // prepare
+    nullptr, // check
+    // dispatch
+    [](GSource* base, GSourceFunc callback, gpointer userData) -> gboolean
+    {
+        auto& source = *reinterpret_cast<FenceSource*>(base);
+        g_source_remove_unix_fd(&source.base, source.tag);
+        source.tag = nullptr;
+        source.fd = { };
+
+        callback(userData);
+        return G_SOURCE_CONTINUE;
+    },
+    // finalize
+    [](GSource* base) {
+        auto* source = reinterpret_cast<FenceSource*>(base);
+        source->~FenceSource();
+    },
+    nullptr, // closure_callback
+    nullptr, // closure_marshall
+};
+
+void FenceMonitor::ensureSource()
+{
+    if (LIKELY(m_source))
+        return;
+
+    m_source = adoptGRef(g_source_new(&FenceSource::sourceFuncs, sizeof(FenceSource)));
+    g_source_set_name(m_source.get(), "[WebKit] Fence monitor");
+#if PLATFORM(GTK)
+    g_source_set_priority(m_source.get(), GDK_PRIORITY_REDRAW - 1);
+#endif
+    g_source_set_callback(m_source.get(), [](gpointer userData) -> gboolean {
+        auto& monitor = *static_cast<FenceMonitor*>(userData);
+        monitor.m_callback();
+        return G_SOURCE_CONTINUE;
+    }, this, nullptr);
+    g_source_attach(m_source.get(), g_main_context_get_thread_default());
+}
+
+static bool isFileDescriptorReadable(int fd)
+{
+    GPollFD pollFD = { fd, G_IO_IN, 0 };
+    if (!g_poll(&pollFD, 1, 0))
+        return FALSE;
+
+    return pollFD.revents & (G_IO_IN | G_IO_NVAL);
+}
+
+void FenceMonitor::addFileDescriptor(UnixFileDescriptor&& fd)
+{
+    if (!fd || isFileDescriptorReadable(fd.value())) {
+        m_callback();
+        return;
+    }
+
+    ensureSource();
+    auto& source = *reinterpret_cast<FenceSource*>(m_source.get());
+    if (source.tag)
+        g_source_remove_unix_fd(&source.base, source.tag);
+    source.tag = g_source_add_unix_fd(&source.base, fd.value(), G_IO_IN);
+    source.fd = WTFMove(fd);
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))

--- a/Source/WebKit/UIProcess/glib/FenceMonitor.h
+++ b/Source/WebKit/UIProcess/glib/FenceMonitor.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+
+#include <wtf/Function.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/unix/UnixFileDescriptor.h>
+
+namespace WebKit {
+
+class FenceMonitor {
+    WTF_MAKE_NONCOPYABLE(FenceMonitor);
+public:
+    explicit FenceMonitor(Function<void()>&&);
+    ~FenceMonitor();
+
+    void addFileDescriptor(WTF::UnixFileDescriptor&&);
+
+private:
+    void ensureSource();
+
+    Function<void()> m_callback;
+    GRefPtr<GSource> m_source;
+};
+
+} // namespace WebKit
+
+#endif // PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -27,6 +27,7 @@
 
 #include "AcceleratedBackingStore.h"
 #include "DMABufRendererBufferFormat.h"
+#include "FenceMonitor.h"
 #include "MessageReceiver.h"
 #include "RendererBufferFormat.h"
 #include <WebCore/IntSize.h>
@@ -238,6 +239,7 @@ private:
         RefPtr<Buffer> m_buffer;
     };
 
+    FenceMonitor m_fenceMonitor;
     GRefPtr<GdkGLContext> m_gdkGLContext;
     bool m_glContextInitialized { false };
     uint64_t m_surfaceID { 0 };

--- a/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
@@ -153,8 +153,7 @@ void WebPageProxy::callAfterNextPresentationUpdate(CompletionHandler<void()>&& c
 
 bool WebPageProxy::useExplicitSync() const
 {
-    // FIXME: implement explicit sync.
-    return false;
+    return true;
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 1e569695d21e775da81a79111300975afe81b5f4
<pre>
[GTK] Add support for explicit sync
<a href="https://bugs.webkit.org/show_bug.cgi?id=277485">https://bugs.webkit.org/show_bug.cgi?id=277485</a>

Reviewed by Alejandro G. Castro.

In case of GTK we can&apos;t pass the fence to GTK to wait for it, but we can
just wait for it ourselves by polling the sync file. This way we avoid
the client wait in the web process on every rendered frame.

* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/UIProcess/glib/FenceMonitor.cpp: Added.
(WebKit::FenceMonitor::FenceMonitor):
(WebKit::FenceMonitor::~FenceMonitor):
(WebKit::FenceSource::~FenceSource):
(WebKit::FenceMonitor::ensureSource):
(WebKit::isFileDescriptorReadable):
(WebKit::FenceMonitor::addFileDescriptor):
* Source/WebKit/UIProcess/glib/FenceMonitor.h: Added.
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::AcceleratedBackingStoreDMABuf):
(WebKit::AcceleratedBackingStoreDMABuf::frame):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp:
(WebKit::WebPageProxy::useExplicitSync const):

Canonical link: <a href="https://commits.webkit.org/281744@main">https://commits.webkit.org/281744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93a77811fa43a7d5711b0c1069cd814cb6e8ff44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60749 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64680 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11296 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49124 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7838 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29956 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34041 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10209 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55879 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66409 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56492 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56674 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3892 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9159 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35913 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36995 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38088 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36740 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->