### PR TITLE
AX: lineTextMarkerRangeForTextMarker returns too much text for some blank lines

### DIFF
--- a/LayoutTests/accessibility/mac/line-text-marker-range-for-text-marker-expected.txt
+++ b/LayoutTests/accessibility/mac/line-text-marker-range-for-text-marker-expected.txt
@@ -1,6 +1,9 @@
 This tests that when there are <br> elements with contenteditable=false in a contenteditable text area, we can get the correct range for a line.
 
-PASS: rangeStr === "First line of text"
+PASS: rangeStr === 'First line of text'
+PASS: rangeStr === 'Second line of text'
+PASS: rangeStr === ''
+PASS: rangeStr === 'Fourth line of text'
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/mac/line-text-marker-range-for-text-marker.html
+++ b/LayoutTests/accessibility/mac/line-text-marker-range-for-text-marker.html
@@ -10,18 +10,26 @@
   First line of text
   <span contenteditable="false"><br></span>
   Second line of text
+  <p>
+    <br>
+  </p>
+  Fourth line of text
 </div>
 
 <script>
 let output = "This tests that when there are &lt;br&gt; elements with contenteditable=false in a contenteditable text area, we can get the correct range for a line.\n\n";
 
 if (window.accessibilityController) {
+  const expectedLines = ['First line of text', 'Second line of text', '', 'Fourth line of text'];
   const textControl = accessibilityController.accessibleElementById("textcontrol");
-  const fullRange = textControl.textMarkerRangeForElement(textControl.childAtIndex(0));
-  const marker = textControl.startTextMarkerForTextMarkerRange(fullRange);
-  const range = textControl.lineTextMarkerRangeForTextMarker(marker);
-  var rangeStr = (textControl.stringForTextMarkerRange(range) + "").trim();
-  output += expect("rangeStr", '"First line of text"');
+  for (let i = 0; i < textControl.childrenCount; i++) {
+    const child = textControl.childAtIndex(i);
+    const fullRange = textControl.textMarkerRangeForElement(child);
+    const marker = textControl.startTextMarkerForTextMarkerRange(fullRange);
+    const range = textControl.lineTextMarkerRangeForTextMarker(marker);
+    var rangeStr = (textControl.stringForTextMarkerRange(range) + "").trim();
+    output += expect("rangeStr", "'" + expectedLines[i] + "'");
+  }
   debug(output);
   document.getElementById("textcontrol").hidden = true;
 }


### PR DESCRIPTION
#### ca993564405e47a71e87c0ef6f2605fb0ec88911
<pre>
AX: lineTextMarkerRangeForTextMarker returns too much text for some blank lines
<a href="https://bugs.webkit.org/show_bug.cgi?id=277489">https://bugs.webkit.org/show_bug.cgi?id=277489</a>
<a href="https://rdar.apple.com/132989539">rdar://132989539</a>

Reviewed by Chris Fleizach.

In <a href="https://bugs.webkit.org/show_bug.cgi?id=275870">https://bugs.webkit.org/show_bug.cgi?id=275870</a> (AX:
lineTextMarkerRangeForTextMarker fails on first character of line in
Google Docs) we fixed an issue where lineTextMarkerRangeForTextMarker
failed to return a range at all.

This fix resulted in a regression where now it returns a range that&apos;s
too large, for some blank lines. One symptom was that when using
VoiceOver to arrow through editable text, landing on a blank line
would sometimes read the subsequent line rather than just &quot;newline&quot;.

* LayoutTests/accessibility/mac/line-text-marker-range-for-text-marker-expected.txt:
* LayoutTests/accessibility/mac/line-text-marker-range-for-text-marker.html:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::lineRangeForPosition const):

Canonical link: <a href="https://commits.webkit.org/281724@main">https://commits.webkit.org/281724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/395e6c11fb46ef590e5779c86c4c8b5df011bd32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64723 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11339 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11614 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7873 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52670 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9896 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10252 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66452 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10023 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56526 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56707 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13559 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3932 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37038 "Failed to checkout and rebase branch from PR 31601") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38131 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->