### PR TITLE
Remove unnecessary IDBStorageConnectionToClient::didGetResult

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp
@@ -52,27 +52,6 @@ WebCore::IDBServer::IDBConnectionToClient& IDBStorageConnectionToClient::connect
     return m_connectionToClient;
 }
 
-template<class MessageType> void IDBStorageConnectionToClient::didGetResult(const WebCore::IDBResultData& resultData)
-{
-    if (resultData.type() == WebCore::IDBResultType::Error) {
-        IPC::Connection::send(m_connection, MessageType(resultData), 0);
-        return;
-    }
-
-    if (resultData.type() == WebCore::IDBResultType::GetAllRecordsSuccess && resultData.getAllResult().type() == WebCore::IndexedDB::GetAllType::Keys) {
-        IPC::Connection::send(m_connection, MessageType(resultData), 0);
-        return;
-    }
-
-    auto blobFilePaths = resultData.type() == WebCore::IDBResultType::GetAllRecordsSuccess ? resultData.getAllResult().allBlobFilePaths() : resultData.getResult().value().blobFilePaths();
-    if (blobFilePaths.isEmpty()) {
-        IPC::Connection::send(m_connection, MessageType(resultData), 0);
-        return;
-    }
-
-    IPC::Connection::send(m_connection, MessageType(resultData), 0);
-}
-
 void IDBStorageConnectionToClient::didDeleteDatabase(const WebCore::IDBResultData& resultData)
 {
     IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidDeleteDatabase(resultData), 0);
@@ -140,12 +119,12 @@ void IDBStorageConnectionToClient::didPutOrAdd(const WebCore::IDBResultData& res
 
 void IDBStorageConnectionToClient::didGetRecord(const WebCore::IDBResultData& resultData)
 {
-    didGetResult<Messages::WebIDBConnectionToServer::DidGetRecord>(resultData);
+    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidGetRecord(resultData), 0);
 }
 
 void IDBStorageConnectionToClient::didGetAllRecords(const WebCore::IDBResultData& resultData)
 {
-    didGetResult<Messages::WebIDBConnectionToServer::DidGetAllRecords>(resultData);
+    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidGetAllRecords(resultData), 0);
 }
 
 void IDBStorageConnectionToClient::didGetCount(const WebCore::IDBResultData& resultData)
@@ -160,12 +139,12 @@ void IDBStorageConnectionToClient::didDeleteRecord(const WebCore::IDBResultData&
 
 void IDBStorageConnectionToClient::didOpenCursor(const WebCore::IDBResultData& resultData)
 {
-    didGetResult<Messages::WebIDBConnectionToServer::DidOpenCursor>(resultData);
+    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidOpenCursor(resultData), 0);
 }
 
 void IDBStorageConnectionToClient::didIterateCursor(const WebCore::IDBResultData& resultData)
 {
-    didGetResult<Messages::WebIDBConnectionToServer::DidIterateCursor>(resultData);
+    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidIterateCursor(resultData), 0);
 }
 
 void IDBStorageConnectionToClient::didGetAllDatabaseNamesAndVersions(const WebCore::IDBResourceIdentifier& requestIdentifier, Vector<WebCore::IDBDatabaseNameAndVersion>&& databases)

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
@@ -42,8 +42,6 @@ public:
     WebCore::IDBServer::IDBConnectionToClient& connectionToClient();
 
 private:
-    template<class MessageType> void didGetResult(const WebCore::IDBResultData&);
-
     // IDBConnectionToClientDelegate
     void didDeleteDatabase(const WebCore::IDBResultData&) final;
     void didOpenDatabase(const WebCore::IDBResultData&) final;


### PR DESCRIPTION
#### d162212f64cced017d69cbf0924d4061fe34f2aa
<pre>
Remove unnecessary IDBStorageConnectionToClient::didGetResult
<a href="https://bugs.webkit.org/show_bug.cgi?id=277490">https://bugs.webkit.org/show_bug.cgi?id=277490</a>
<a href="https://rdar.apple.com/132993806">rdar://132993806</a>

Reviewed by Chris Dumez.

In IDBStorageConnectionToClient::didGetResult, all branches would lead to the same result, so it can be simplied as
one-liner.

* Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp:
(WebKit::IDBStorageConnectionToClient::didGetRecord):
(WebKit::IDBStorageConnectionToClient::didGetAllRecords):
(WebKit::IDBStorageConnectionToClient::didOpenCursor):
(WebKit::IDBStorageConnectionToClient::didIterateCursor):
(WebKit::IDBStorageConnectionToClient::didGetResult): Deleted.
* Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h:

Canonical link: <a href="https://commits.webkit.org/281746@main">https://commits.webkit.org/281746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a66410218237cc46c53e6627c5e2db36304b6957

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64699 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11315 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49141 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7854 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29973 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34059 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10228 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66428 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56510 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56692 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13578 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3909 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35932 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37014 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->