### PR TITLE
Use capture delegate for setCameraActive and setMicrophone active

### DIFF
--- a/LayoutTests/http/wpt/mediasession/setCaptureState-permission-expected.txt
+++ b/LayoutTests/http/wpt/mediasession/setCaptureState-permission-expected.txt
@@ -1,0 +1,4 @@
+
+PASS setCameraActive after user muted
+PASS setMicrophoneActive after user muted
+

--- a/LayoutTests/http/wpt/mediasession/setCaptureState-permission.html
+++ b/LayoutTests/http/wpt/mediasession/setCaptureState-permission.html
@@ -1,0 +1,54 @@
+<html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    const track = stream.getTracks()[0];
+
+    testRunner.setCaptureState(false, true, true);
+    testRunner.setCameraPermission(false);
+
+    await new Promise(resolve => track.onmute = resolve);
+
+    let promise;
+    internals.withUserGesture(() => {
+        promise = navigator.mediaSession.setCameraActive(true);
+    });
+    await promise_rejects_dom(test, "NotAllowedError", promise);
+
+    testRunner.setCameraPermission(true);
+
+    internals.withUserGesture(() => {
+        promise = navigator.mediaSession.setCameraActive(true);
+    });
+    return promise;
+}, "setCameraActive after user muted");
+
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const track = stream.getTracks()[0];
+
+    testRunner.setCaptureState(true, false, true);
+    testRunner.setMicrophonePermission(false);
+
+    await new Promise(resolve => track.onmute = resolve);
+
+    let promise;
+    internals.withUserGesture(() => {
+        promise = navigator.mediaSession.setMicrophoneActive(true);
+    });
+    await promise_rejects_dom(test, "NotAllowedError", promise);
+
+    testRunner.setMicrophonePermission(true);
+
+    internals.withUserGesture(() => {
+        promise = navigator.mediaSession.setMicrophoneActive(true);
+    });
+    return promise;
+}, "setMicrophoneActive after user muted");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/mediasession/setCaptureState.html
+++ b/LayoutTests/http/wpt/mediasession/setCaptureState.html
@@ -66,10 +66,16 @@ async function testTrackMuteUnmute(test, track, action, stateCallback, muteCallb
     await waitForAction(action);
     await waitForMuteEvent(track);
 
+    testRunner.setCameraPermission(false);
+    testRunner.setMicrophonePermission(false);
+
     internals.withUserGesture(() => {
         promise = stateCallback(true);
     });
     await promise_rejects_dom(test, "NotAllowedError", promise);
+
+    testRunner.setCameraPermission(true);
+    testRunner.setMicrophonePermission(true);
 
     await muteCallback(false);
     await waitForAction(action);

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -518,7 +518,7 @@ void MediaSession::updateCaptureState(bool isActive, DOMPromiseDeferred<void>&& 
         return;
     }
 
-    controller->updateCaptureState(isActive, kind, [weakDocument = WeakPtr { document.get() }, promise = WTFMove(promise)] (auto&& exception) mutable {
+    controller->updateCaptureState(*document, isActive, kind, [weakDocument = WeakPtr { document.get() }, promise = WTFMove(promise)] (auto&& exception) mutable {
         RefPtr protectedDocument = weakDocument.get();
         if (!protectedDocument)
             return;

--- a/Source/WebCore/Modules/mediastream/UserMediaClient.h
+++ b/Source/WebCore/Modules/mediastream/UserMediaClient.h
@@ -62,7 +62,7 @@ public:
     virtual DeviceChangeObserverToken addDeviceChangeObserver(Function<void()>&&) = 0;
     virtual void removeDeviceChangeObserver(DeviceChangeObserverToken) = 0;
 
-    virtual void updateCaptureState(bool isActive, MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<Exception>&&)>&&) = 0;
+    virtual void updateCaptureState(const Document&, bool isActive, MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<Exception>&&)>&&) = 0;
 
 protected:
     virtual ~UserMediaClient() = default;

--- a/Source/WebCore/Modules/mediastream/UserMediaController.h
+++ b/Source/WebCore/Modules/mediastream/UserMediaController.h
@@ -53,7 +53,7 @@ public:
     UserMediaClient::DeviceChangeObserverToken addDeviceChangeObserver(Function<void()>&&);
     void removeDeviceChangeObserver(UserMediaClient::DeviceChangeObserverToken);
 
-    void updateCaptureState(bool isActive, MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<Exception>&&)>&&);
+    void updateCaptureState(const Document&, bool isActive, MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<Exception>&&)>&&);
 
     void logGetUserMediaDenial(Document&);
     void logGetDisplayMediaDenial(Document&);
@@ -92,9 +92,9 @@ inline void UserMediaController::removeDeviceChangeObserver(UserMediaClient::Dev
     m_client->removeDeviceChangeObserver(token);
 }
 
-inline void UserMediaController::updateCaptureState(bool isActive, MediaProducerMediaCaptureKind kind, CompletionHandler<void(std::optional<Exception>&&)>&& completionHandler)
+inline void UserMediaController::updateCaptureState(const Document& document, bool isActive, MediaProducerMediaCaptureKind kind, CompletionHandler<void(std::optional<Exception>&&)>&& completionHandler)
 {
-    m_client->updateCaptureState(isActive, kind, WTFMove(completionHandler));
+    m_client->updateCaptureState(document, isActive, kind, WTFMove(completionHandler));
 }
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2665,7 +2665,7 @@ private:
     void requestUserMediaPermissionForFrame(IPC::Connection&, WebCore::UserMediaRequestIdentifier, WebCore::FrameIdentifier, const WebCore::SecurityOriginData& userMediaDocumentOriginIdentifier, const WebCore::SecurityOriginData& topLevelDocumentOriginIdentifier, WebCore::MediaStreamRequest&&);
     void enumerateMediaDevicesForFrame(IPC::Connection&, WebCore::FrameIdentifier, const WebCore::SecurityOriginData& userMediaDocumentOriginData, const WebCore::SecurityOriginData& topLevelDocumentOriginData, CompletionHandler<void(const Vector<WebCore::CaptureDeviceWithCapabilities>&, WebCore::MediaDeviceHashSalts&&)>&&);
     void beginMonitoringCaptureDevices();
-    void validateCaptureStateUpdate(bool isActive, WebCore::MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
+    void validateCaptureStateUpdate(WebCore::UserMediaRequestIdentifier, WebCore::ClientOrigin&&, WebCore::FrameIdentifier, bool isActive, WebCore::MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -284,7 +284,7 @@ messages -> WebPageProxy {
     RequestUserMediaPermissionForFrame(WebCore::UserMediaRequestIdentifier userMediaID, WebCore::FrameIdentifier frameID, WebCore::SecurityOriginData userMediaDocumentOriginIdentifier, WebCore::SecurityOriginData topLevelDocumentOriginIdentifier, struct WebCore::MediaStreamRequest request)
     EnumerateMediaDevicesForFrame(WebCore::FrameIdentifier frameID, WebCore::SecurityOriginData userMediaDocumentOriginIdentifier, WebCore::SecurityOriginData topLevelDocumentOriginIdentifier) -> (Vector<WebCore::CaptureDeviceWithCapabilities> devices, struct WebCore::MediaDeviceHashSalts mediaDeviceIdentifierHashSalts)
     BeginMonitoringCaptureDevices()
-    ValidateCaptureStateUpdate(bool isActive, enum:uint8_t WebCore::MediaProducerMediaCaptureKind kind) -> (std::optional<WebCore::Exception> result)
+    ValidateCaptureStateUpdate(WebCore::UserMediaRequestIdentifier userMediaID, struct WebCore::ClientOrigin clientOrigin, WebCore::FrameIdentifier frameID, bool isActive, enum:uint8_t WebCore::MediaProducerMediaCaptureKind kind) -> (std::optional<WebCore::Exception> result)
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
@@ -197,9 +197,9 @@ void UserMediaPermissionRequestManager::removeDeviceChangeObserver(UserMediaClie
     ASSERT_UNUSED(wasRemoved, wasRemoved);
 }
 
-void UserMediaPermissionRequestManager::updateCaptureState(bool isActive, WebCore::MediaProducerMediaCaptureKind kind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
+void UserMediaPermissionRequestManager::updateCaptureState(const WebCore::Document& document, bool isActive, WebCore::MediaProducerMediaCaptureKind kind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
 {
-    m_page.updateCaptureState(isActive, kind, WTFMove(completionHandler));
+    m_page.updateCaptureState(document, isActive, kind, WTFMove(completionHandler));
 }
 
 void UserMediaPermissionRequestManager::captureDevicesChanged()

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
@@ -69,7 +69,7 @@ public:
 
     WebCore::UserMediaClient::DeviceChangeObserverToken addDeviceChangeObserver(WTF::Function<void()>&&);
     void removeDeviceChangeObserver(WebCore::UserMediaClient::DeviceChangeObserverToken);
-    void updateCaptureState(bool isActive, WebCore::MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
+    void updateCaptureState(const WebCore::Document&, bool isActive, WebCore::MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
 
     void captureDevicesChanged();
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp
@@ -68,9 +68,9 @@ void WebUserMediaClient::removeDeviceChangeObserver(DeviceChangeObserverToken to
     m_page.userMediaPermissionRequestManager().removeDeviceChangeObserver(token);
 }
 
-void WebUserMediaClient::updateCaptureState(bool isActive, WebCore::MediaProducerMediaCaptureKind kind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
+void WebUserMediaClient::updateCaptureState(const WebCore::Document& document, bool isActive, WebCore::MediaProducerMediaCaptureKind kind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
 {
-    m_page.userMediaPermissionRequestManager().updateCaptureState(isActive, kind, WTFMove(completionHandler));
+    m_page.userMediaPermissionRequestManager().updateCaptureState(document, isActive, kind, WTFMove(completionHandler));
 }
 
 } // namespace WebKit;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h
@@ -45,7 +45,7 @@ private:
 
     DeviceChangeObserverToken addDeviceChangeObserver(WTF::Function<void()>&&) final;
     void removeDeviceChangeObserver(DeviceChangeObserverToken) final;
-    void updateCaptureState(bool isActive, WebCore::MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&) final;
+    void updateCaptureState(const WebCore::Document&, bool isActive, WebCore::MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&) final;
 
     void initializeFactories();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -856,7 +856,7 @@ public:
 #if ENABLE(MEDIA_STREAM)
     UserMediaPermissionRequestManager& userMediaPermissionRequestManager() { return m_userMediaPermissionRequestManager; }
     void captureDevicesChanged();
-    void updateCaptureState(bool isActive, WebCore::MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
+    void updateCaptureState(const WebCore::Document&, bool isActive, WebCore::MediaProducerMediaCaptureKind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -895,7 +895,7 @@ void TestRunner::setCameraPermission(bool enabled)
 
 void TestRunner::setMicrophonePermission(bool enabled)
 {
-    InjectedBundle::singleton().setCameraPermission(enabled);
+    InjectedBundle::singleton().setMicrophonePermission(enabled);
 }
 
 void TestRunner::setUserMediaPermission(bool enabled)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -4168,9 +4168,7 @@ void TestController::triggerMockCaptureConfigurationChange(bool forMicrophone, b
 
 void TestController::setCaptureState(bool cameraState, bool microphoneState, bool displayState)
 {
-    WKPageSetMuted(m_mainWebView->page(), (cameraState ? kWKMediaCameraCaptureUnmuted : kWKMediaCameraCaptureMuted)
-                   | (microphoneState ? kWKMediaMicrophoneCaptureUnmuted : kWKMediaMicrophoneCaptureMuted)
-                   | (displayState ? kWKMediaScreenCaptureUnmuted : kWKMediaScreenCaptureMuted));
+    WKPageSetMuted(m_mainWebView->page(), (cameraState ? kWKMediaCameraCaptureUnmuted : kWKMediaCameraCaptureMuted) | (microphoneState ? kWKMediaMicrophoneCaptureUnmuted : kWKMediaMicrophoneCaptureMuted) | (displayState ? kWKMediaScreenCaptureUnmuted : kWKMediaScreenCaptureMuted));
 }
 
 struct InAppBrowserPrivacyCallbackContext {

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -892,7 +892,7 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         TestController::singleton().triggerMockCaptureConfigurationChange(forMicrophone, forDisplay);
         return nullptr;
     }
-    
+ 
     if (WKStringIsEqualToUTF8CString(messageName, "SetCaptureState")) {
         auto messageBodyDictionary = dictionaryValue(messageBody);
         bool camera = booleanValue(messageBodyDictionary, "camera");


### PR DESCRIPTION
#### f0d8b4a3a8bd1ffe48c7d52d005370ba42a0e272
<pre>
Use capture delegate for setCameraActive and setMicrophone active
<a href="https://bugs.webkit.org/show_bug.cgi?id=277494">https://bugs.webkit.org/show_bug.cgi?id=277494</a>
<a href="https://rdar.apple.com/problem/133041171">rdar://problem/133041171</a>

Reviewed by Eric Carlson.

In case the application (usually from a user decision) muted capture, WebKit is now asking whether the application is ok unmuting capture.
This allows to prompt the user as needed, reusing the same message as for starting capture.

* LayoutTests/http/wpt/mediasession/setCaptureState-permission-expected.txt: Added.
* LayoutTests/http/wpt/mediasession/setCaptureState-permission.html: Added.
* LayoutTests/http/wpt/mediasession/setCaptureState.html:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::updateCaptureState):
* Source/WebCore/Modules/mediastream/UserMediaClient.h:
* Source/WebCore/Modules/mediastream/UserMediaController.h:
(WebCore::UserMediaController::updateCaptureState):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::toUserMediaRequest):
(WebKit::WebPageProxy::updateCaptureState):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp:
(WebKit::UserMediaPermissionRequestManager::updateCaptureState):
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.cpp:
(WebKit::WebUserMediaClient::updateCaptureState):
* Source/WebKit/WebProcess/WebCoreSupport/WebUserMediaClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updateCaptureState):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setMicrophonePermission):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::setCaptureState):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Originally-landed-as: 0bf5b3bdea35. <a href="https://rdar.apple.com/problem/133041171">rdar://problem/133041171</a>
Canonical link: <a href="https://commits.webkit.org/282954@main">https://commits.webkit.org/282954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d68aaf1415251b4778200c7ec1e965ed7ba975c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/64775 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/68798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/66892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/51921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/15660 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10614 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/67841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40833 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/56048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32691 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37497 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/13417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14257 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/13753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70504 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/8720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/13251 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/8754 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/56126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14289 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7195 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39952 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/41030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/42211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/40772 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->