### PR TITLE
REGRESSION(278195@main): A bitmap image may get the size of a subsampled frame

### DIFF
--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
@@ -57,12 +57,12 @@ MetadataType BitmapImageDescriptor::imageMetadata(MetadataType& cachedValue, con
 }
 
 template<typename MetadataType>
-MetadataType BitmapImageDescriptor::primaryImageFrameMetadata(MetadataType& cachedValue, CachedFlag cachedFlag, MetadataType (ImageFrame::*functor)() const) const
+MetadataType BitmapImageDescriptor::primaryImageFrameMetadata(MetadataType& cachedValue, CachedFlag cachedFlag, MetadataType (ImageFrame::*functor)() const, const std::optional<SubsamplingLevel>& subsamplingLevel) const
 {
     if (m_cachedFlags.contains(cachedFlag))
         return cachedValue;
 
-    auto& frame = const_cast<BitmapImageSource&>(m_source).primaryImageFrame();
+    auto& frame = const_cast<BitmapImageSource&>(m_source).primaryImageFrame(subsamplingLevel);
 
     // Don't cache any unavailable frame metadata. Just return the default metadata.
     if (!frame.hasMetadata())
@@ -117,7 +117,7 @@ IntSize BitmapImageDescriptor::sourceSize(ImageOrientation orientation) const
         size = decoder->size();
     else
 #endif
-        size = primaryImageFrameMetadata(m_size, CachedFlag::Size, &ImageFrame::size);
+        size = primaryImageFrameMetadata(m_size, CachedFlag::Size, &ImageFrame::size, SubsamplingLevel::Default);
 
     if (orientation == ImageOrientation::Orientation::FromImage)
         orientation = this->orientation();
@@ -127,7 +127,7 @@ IntSize BitmapImageDescriptor::sourceSize(ImageOrientation orientation) const
 
 std::optional<IntSize> BitmapImageDescriptor::densityCorrectedSize() const
 {
-    return primaryImageFrameMetadata(m_densityCorrectedSize, CachedFlag::DensityCorrectedSize, &ImageFrame::densityCorrectedSize);
+    return primaryImageFrameMetadata(m_densityCorrectedSize, CachedFlag::DensityCorrectedSize, &ImageFrame::densityCorrectedSize, SubsamplingLevel::Default);
 }
 
 ImageOrientation BitmapImageDescriptor::orientation() const

--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
@@ -93,7 +93,7 @@ private:
     MetadataType imageMetadata(MetadataType& cachedValue, const MetadataType& defaultValue, CachedFlag, MetadataType (ImageDecoder::*functor)() const) const;
 
     template<typename MetadataType>
-    MetadataType primaryImageFrameMetadata(MetadataType& cachedValue, CachedFlag, MetadataType (ImageFrame::*functor)() const) const;
+    MetadataType primaryImageFrameMetadata(MetadataType& cachedValue, CachedFlag, MetadataType (ImageFrame::*functor)() const, const std::optional<SubsamplingLevel>& = std::nullopt) const;
 
     template<typename MetadataType>
     MetadataType primaryNativeImageMetadata(MetadataType& cachedValue, const MetadataType& defaultValue, CachedFlag, MetadataType (NativeImage::*functor)() const) const;

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -65,7 +65,7 @@ public:
     unsigned primaryFrameIndex() const final { return m_descriptor.primaryFrameIndex(); }
 
     const Vector<ImageFrame>& frames() const { return m_frames; }
-    const ImageFrame& primaryImageFrame() final { return frameAtIndexCacheIfNeeded(primaryFrameIndex()); }
+    const ImageFrame& primaryImageFrame(const std::optional<SubsamplingLevel>& subsamplingLevel = std::nullopt) final { return frameAtIndexCacheIfNeeded(primaryFrameIndex(), subsamplingLevel); }
 
     // NativeImage
     DecodingStatus requestNativeImageAtIndexIfNeeded(unsigned index, SubsamplingLevel, ImageAnimatingState, const DecodingOptions&);
@@ -130,7 +130,7 @@ private:
 
     const ImageFrame& frameAtIndex(unsigned index) const;
     const ImageFrame& frameAtIndexCacheIfNeeded(unsigned index, const std::optional<SubsamplingLevel>& = std::nullopt);
-    const ImageFrame& currentImageFrame() final { return frameAtIndexCacheIfNeeded(currentFrameIndex()); }
+    const ImageFrame& currentImageFrame(const std::optional<SubsamplingLevel>& subsamplingLevel = std::nullopt) final { return frameAtIndexCacheIfNeeded(currentFrameIndex(), subsamplingLevel); }
 
     // NativeImage
     DecodingStatus requestNativeImageAtIndex(unsigned index, SubsamplingLevel, ImageAnimatingState, const DecodingOptions&);

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -58,8 +58,8 @@ public:
     // ImageFrame
     virtual unsigned currentFrameIndex() const { return primaryFrameIndex(); }
 
-    virtual const ImageFrame& primaryImageFrame() = 0;
-    virtual const ImageFrame& currentImageFrame() { return primaryImageFrame(); }
+    virtual const ImageFrame& primaryImageFrame(const std::optional<SubsamplingLevel>& = std::nullopt) = 0;
+    virtual const ImageFrame& currentImageFrame(const std::optional<SubsamplingLevel>& subsamplingLevel = std::nullopt) { return primaryImageFrame(subsamplingLevel); }
 
     // NativeImage
     virtual RefPtr<NativeImage> primaryNativeImage() = 0;

--- a/Source/WebCore/platform/graphics/NativeImageSource.h
+++ b/Source/WebCore/platform/graphics/NativeImageSource.h
@@ -40,7 +40,7 @@ private:
     DestinationColorSpace colorSpace() const final { return m_frame.nativeImage()->colorSpace(); }
     std::optional<Color> singlePixelSolidColor() const final { return m_frame.nativeImage()->singlePixelSolidColor(); }
 
-    const ImageFrame& primaryImageFrame() final { return m_frame; }
+    const ImageFrame& primaryImageFrame(const std::optional<SubsamplingLevel>& = std::nullopt) final { return m_frame; }
 
     RefPtr<NativeImage> primaryNativeImage() final { return m_frame.nativeImage(); }
 


### PR DESCRIPTION
#### 2f897eb8b8385adf9e4d3b9b975f71ba4b700f26
<pre>
REGRESSION(278195@main): A bitmap image may get the size of a subsampled frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=277495">https://bugs.webkit.org/show_bug.cgi?id=277495</a>
<a href="https://rdar.apple.com/129703072">rdar://129703072</a>

Reviewed by Simon Fraser.

To get the size of an image, the default frame has to be queried from ImageDecoder.
A subsampled frame should not be used to get the size of an image.

* Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp:
(WebCore::BitmapImageDescriptor::primaryImageFrameMetadata const):
(WebCore::BitmapImageDescriptor::sourceSize const):
(WebCore::BitmapImageDescriptor::densityCorrectedSize const):
* Source/WebCore/platform/graphics/BitmapImageDescriptor.h:
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::currentImageFrame):
* Source/WebCore/platform/graphics/NativeImageSource.h:

Canonical link: <a href="https://commits.webkit.org/281731@main">https://commits.webkit.org/281731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a17694d8f5db22abd55091241ea6357337ddf4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64722 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11338 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49159 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7870 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52667 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34081 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9904 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10251 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55919 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66451 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56527 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56708 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3931 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9146 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35955 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37037 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38130 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->