### PR TITLE
[Cocoa] Remove some dead code after 266523@main (277499)

### DIFF
--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,10 +50,6 @@ public:
     ContentFilterUnblockHandler unblockHandler() const override;
 #endif
     
-#if PLATFORM(IOS) || PLATFORM(VISION)
-    WEBCORE_EXPORT static void setHasConsumedSandboxExtension(bool);
-#endif
-
 private:
     static bool enabled();
 
@@ -62,16 +58,6 @@ private:
 
     RetainPtr<WebFilterEvaluator> m_webFilterEvaluator;
     RetainPtr<NSData> m_replacementData;
-
-#if PLATFORM(IOS) || PLATFORM(VISION)
-    enum class SandboxExtensionState : uint8_t {
-        Consumed,
-        NotConsumed,
-        NotSet
-    };
-
-    WEBCORE_EXPORT static SandboxExtensionState m_sandboxExtensionState;
-#endif
 };
     
 } // namespace WebCore

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,28 +41,9 @@ SOFT_LINK_CLASS_OPTIONAL(WebContentAnalysis, WebFilterEvaluator);
 
 namespace WebCore {
 
-#if PLATFORM(IOS) || PLATFORM(VISION)
-ParentalControlsContentFilter::SandboxExtensionState ParentalControlsContentFilter::m_sandboxExtensionState = SandboxExtensionState::NotSet;
-#endif
-
 bool ParentalControlsContentFilter::enabled()
 {
-#if PLATFORM(IOS) || PLATFORM(VISION)
-    bool enabled = false;
-    switch (m_sandboxExtensionState) {
-    case SandboxExtensionState::Consumed:
-        enabled = true;
-        break;
-    case SandboxExtensionState::NotConsumed:
-        enabled = false;
-        break;
-    case SandboxExtensionState::NotSet:
-        enabled = [getWebFilterEvaluatorClass() isManagedSession];
-        break;
-    }
-#else
     bool enabled = [getWebFilterEvaluatorClass() isManagedSession];
-#endif
     LOG(ContentFiltering, "ParentalControlsContentFilter is %s.\n", enabled ? "enabled" : "not enabled");
     return enabled;
 }
@@ -146,16 +127,6 @@ void ParentalControlsContentFilter::updateFilterState()
         LOG(ContentFiltering, "ParentalControlsContentFilter stopped buffering with state %d and replacement data length %zu.\n", m_state, [m_replacementData length]);
 #endif
 }
-
-#if PLATFORM(IOS) || PLATFORM(VISION)
-void ParentalControlsContentFilter::setHasConsumedSandboxExtension(bool hasConsumedSandboxExtension)
-{
-    if (m_sandboxExtensionState == SandboxExtensionState::Consumed)
-        return;
-
-    m_sandboxExtensionState = (hasConsumedSandboxExtension ? SandboxExtensionState::Consumed : SandboxExtensionState::NotConsumed);
-}
-#endif
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 3cb28627b6969195c36d775b7f666f4569d5a575
<pre>
[Cocoa] Remove some dead code after 266523@main (277499)
<a href="https://bugs.webkit.org/show_bug.cgi?id=277499">https://bugs.webkit.org/show_bug.cgi?id=277499</a>
&lt;<a href="https://rdar.apple.com/133005426">rdar://133005426</a>&gt;

Reviewed by Alex Christensen and Andy Estes.

Network filtering code was simplified in Bug 259737, but left a no-longer needed
sandbox consumption method. We should remove this dead code.

* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm:
(WebCore::ParentalControlsContentFilter::enabled): Remove unneeded logic checking for
Sandbox extensions that are never vended or consumed.
(WebCore::ParentalControlsContentFilter::setHasConsumedSandboxExtension): Deleted.

Canonical link: <a href="https://commits.webkit.org/281738@main">https://commits.webkit.org/281738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad7a6154ba3602265b0e3876c6f0cf6386b7cbe7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11343 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11618 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49164 "Found 1 new test failure: imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-id.https.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7878 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29995 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34084 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10256 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66456 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10027 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56530 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56711 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3933 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9152 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35960 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37042 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->