### PR TITLE
Rename PageLoadState's titleFromSafeBrowsingWarning to titleFromBrowsingWarning

### DIFF
--- a/Source/WebKit/UIProcess/PageLoadState.cpp
+++ b/Source/WebKit/UIProcess/PageLoadState.cpp
@@ -96,7 +96,7 @@ void PageLoadState::commitChanges()
     bool canGoBackChanged = m_committedState.canGoBack != m_uncommittedState.canGoBack;
     bool canGoForwardChanged = m_committedState.canGoForward != m_uncommittedState.canGoForward;
     bool titleChanged = m_committedState.title != m_uncommittedState.title
-        || m_committedState.titleFromSafeBrowsingWarning != m_uncommittedState.titleFromSafeBrowsingWarning;
+        || m_committedState.titleFromBrowsingWarning != m_uncommittedState.titleFromBrowsingWarning;
     bool isLoadingChanged = isLoading(m_committedState) != isLoading(m_uncommittedState);
     bool activeURLChanged = activeURL(m_committedState) != activeURL(m_uncommittedState);
     bool hasOnlySecureContentChanged = hasOnlySecureContent(m_committedState) != hasOnlySecureContent(m_uncommittedState);
@@ -174,7 +174,7 @@ void PageLoadState::reset(const Transaction::Token& token)
     m_lastUnreachableURL = String();
 
     m_uncommittedState.title = String();
-    m_uncommittedState.titleFromSafeBrowsingWarning = { };
+    m_uncommittedState.titleFromBrowsingWarning = { };
 
     m_uncommittedState.estimatedProgress = 0;
     m_uncommittedState.networkRequestsInProgress = false;
@@ -347,7 +347,7 @@ void PageLoadState::didCommitLoad(const Transaction::Token& token, const WebCore
     m_uncommittedState.origin = origin;
 
     m_uncommittedState.title = String();
-    m_uncommittedState.titleFromSafeBrowsingWarning = { };
+    m_uncommittedState.titleFromBrowsingWarning = { };
 }
 
 void PageLoadState::didFinishLoad(const Transaction::Token& token)
@@ -392,8 +392,8 @@ void PageLoadState::setUnreachableURL(const Transaction::Token& token, const Str
 
 const String& PageLoadState::title() const
 {
-    if (!m_committedState.titleFromSafeBrowsingWarning.isNull())
-        return m_committedState.titleFromSafeBrowsingWarning;
+    if (!m_committedState.titleFromBrowsingWarning.isNull())
+        return m_committedState.titleFromBrowsingWarning;
 
     return m_committedState.title;
 }
@@ -404,10 +404,10 @@ void PageLoadState::setTitle(const Transaction::Token& token, const String& titl
     m_uncommittedState.title = title;
 }
 
-void PageLoadState::setTitleFromSafeBrowsingWarning(const Transaction::Token& token, const String& title)
+void PageLoadState::setTitleFromBrowsingWarning(const Transaction::Token& token, const String& title)
 {
     ASSERT_UNUSED(token, &token.m_pageLoadState == this);
-    m_uncommittedState.titleFromSafeBrowsingWarning = title;
+    m_uncommittedState.titleFromBrowsingWarning = title;
 }
 
 bool PageLoadState::canGoBack() const

--- a/Source/WebKit/UIProcess/PageLoadState.h
+++ b/Source/WebKit/UIProcess/PageLoadState.h
@@ -187,7 +187,7 @@ public:
 
     const String& title() const;
     void setTitle(const Transaction::Token&, const String&);
-    void setTitleFromSafeBrowsingWarning(const Transaction::Token&, const String&);
+    void setTitleFromBrowsingWarning(const Transaction::Token&, const String&);
 
     bool canGoBack() const;
     void setCanGoBack(const Transaction::Token&, bool);
@@ -232,7 +232,7 @@ private:
         String unreachableURL;
 
         String title;
-        String titleFromSafeBrowsingWarning;
+        String titleFromBrowsingWarning;
 
         URL resourceDirectoryURL;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7232,12 +7232,12 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
             }
 
             auto transaction = internals().pageLoadState.transaction();
-            internals().pageLoadState.setTitleFromSafeBrowsingWarning(transaction, safeBrowsingWarning->title());
+            internals().pageLoadState.setTitleFromBrowsingWarning(transaction, safeBrowsingWarning->title());
 
             protectedPageClient->showSafeBrowsingWarning(*safeBrowsingWarning, [this, protectedThis = WTFMove(protectedThis), completionHandler = WTFMove(completionHandlerWrapper), policyAction, protectedPageClient] (auto&& result) mutable {
 
                 auto transaction = internals().pageLoadState.transaction();
-                internals().pageLoadState.setTitleFromSafeBrowsingWarning(transaction, { });
+                internals().pageLoadState.setTitleFromBrowsingWarning(transaction, { });
 
                 switchOn(result, [&] (const URL& url) {
                     completionHandler(PolicyAction::Ignore);


### PR DESCRIPTION
#### 8d191d02e3404cc45fe5e64fb76d340f9d25fd55
<pre>
Rename PageLoadState&apos;s titleFromSafeBrowsingWarning to titleFromBrowsingWarning
<a href="https://bugs.webkit.org/show_bug.cgi?id=277502">https://bugs.webkit.org/show_bug.cgi?id=277502</a>
<a href="https://rdar.apple.com/133007671">rdar://133007671</a>

Reviewed by Ryosuke Niwa.

Similar to 281715@main. This change renames usage of SafeBrowsingWarning in
PageLoadState to use a more generic name.

No behavioral changes.

* Source/WebKit/UIProcess/PageLoadState.cpp:
(WebKit::PageLoadState::commitChanges):
(WebKit::PageLoadState::reset):
(WebKit::PageLoadState::didCommitLoad):
(WebKit::PageLoadState::title const):
(WebKit::PageLoadState::setTitleFromBrowsingWarning):
(WebKit::PageLoadState::setTitleFromSafeBrowsingWarning): Deleted.
* Source/WebKit/UIProcess/PageLoadState.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForNavigationAction):

Canonical link: <a href="https://commits.webkit.org/281729@main">https://commits.webkit.org/281729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8cc6152a7d78d80b17e1342d8ad89d66688cdf3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64731 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11347 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11622 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/7884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52676 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/29998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34086 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10260 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66460 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4744 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56533 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52644 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3936 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9145 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37046 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38139 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->