### PR TITLE
Regression: http/tests/media/media-element-frame-destroyed-crash.html flaky crashing due to nullptr in LocalFrameView::AutoPreventLayerAccess.

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1913,7 +1913,7 @@ FloatRect Element::boundingClientRect()
 {
     Ref document = this->document();
     document->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout , LayoutOptions::CanDeferUpdateLayerPositions }, this);
-    LocalFrameView::AutoPreventLayerAccess preventAccess(*document->view());
+    LocalFrameView::AutoPreventLayerAccess preventAccess(document->view());
     auto pair = boundingAbsoluteRectWithoutLayout();
     if (!pair)
         return { };

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -732,20 +732,22 @@ public:
 
 #if ASSERT_ENABLED
     struct AutoPreventLayerAccess {
-        AutoPreventLayerAccess(LocalFrameView& view)
+        AutoPreventLayerAccess(LocalFrameView* view)
             : frameView(view)
-            , oldPreventLayerAccess(view.layerAccessPrevented())
+            , oldPreventLayerAccess(view ? view->layerAccessPrevented() : false)
         {
-            view.setLayerAcessPrevented(true);
+            if (view)
+                view->setLayerAcessPrevented(true);
         }
 
         ~AutoPreventLayerAccess()
         {
-            frameView->setLayerAcessPrevented(oldPreventLayerAccess);
+            if (frameView)
+                frameView->setLayerAcessPrevented(oldPreventLayerAccess);
         }
 
     private:
-        CheckedPtr<LocalFrameView> frameView;
+        SingleThreadWeakPtr<LocalFrameView> frameView;
         bool oldPreventLayerAccess { false };
     };
 
@@ -753,7 +755,7 @@ public:
     bool layerAccessPrevented() const { return m_layerAccessPrevented; }
 #else
     struct AutoPreventLayerAccess {
-        AutoPreventLayerAccess(LocalFrameView&) { }
+        AutoPreventLayerAccess(LocalFrameView*) { }
     };
 #endif
 


### PR DESCRIPTION
#### 48fbff7a82dd99106aef77b050bb8813988430fb
<pre>
Regression: http/tests/media/media-element-frame-destroyed-crash.html flaky crashing due to nullptr in LocalFrameView::AutoPreventLayerAccess.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277505">https://bugs.webkit.org/show_bug.cgi?id=277505</a>
&lt;<a href="https://rdar.apple.com/132904989">rdar://132904989</a>&gt;

Reviewed by NOBODY (OOPS!).

Flushing layout can result in the view going away, we shouldn&apos;t unconditionally
dereference it.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::boundingClientRect):
* Source/WebCore/page/LocalFrameView.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48fbff7a82dd99106aef77b050bb8813988430fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64751 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11367 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49181 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7893 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62854 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37413 "Found 11 new test failures: editing/deleting/smart-delete-002.html editing/deleting/smart-delete-paragraph-002.html editing/pasteboard/smart-paste-003-trailing-whitespace.html editing/pasteboard/smart-paste-004.html editing/pasteboard/smart-paste-in-text-control.html editing/pasteboard/smart-paste-paragraph-004.html editing/selection/clear-selection-crash.html editing/selection/doubleclick-whitespace-crash.html editing/selection/ios/change-selection-by-tapping.html editing/selection/ios/select-text-with-long-press-actions-disabled.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30008 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34100 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9917 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10280 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55937 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66480 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4764 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10042 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56547 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56729 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/14432 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3950 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35984 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37066 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38159 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36811 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->