### PR TITLE
DNS filtering not flagging expected domains

### DIFF
--- a/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
@@ -278,6 +278,9 @@ ResourceError::operator CFErrorRef() const
 
 bool ResourceError::blockedKnownTracker() const
 {
+    if (id blockedTrackerFailure = nsError().userInfo[@"_NSURLErrorBlockedTrackerFailureKey"])
+        return [blockedTrackerFailure boolValue];
+    // This loop can be removed when the CFNetwork loader is no longer in use
     for (NSError *underlyingError in nsError().underlyingErrors) {
         if ([underlyingError.userInfo[@"_NSURLErrorBlockedTrackerFailureKey"] boolValue])
             return true;
@@ -289,6 +292,13 @@ String ResourceError::blockedTrackerHostName() const
 {
     ASSERT(blockedKnownTracker());
 
+    if (id failingPath = nsError().userInfo[@"_NSURLErrorNWPathKey"]) {
+        auto failingEndpoint = adoptNS(nw_path_copy_effective_remote_endpoint(failingPath));
+        if (auto* hostName = nw_endpoint_get_known_tracker_name(failingEndpoint.get()))
+            return String::fromUTF8(hostName);
+        return { };
+    }
+    // This loop can be removed when the CFNetwork loader is no longer in use
     for (NSError *underlyingError in nsError().underlyingErrors) {
         if (id failingPath = underlyingError.userInfo[@"_NSURLErrorNWPathKey"]) {
             auto failingEndpoint = adoptNS(nw_path_copy_effective_remote_endpoint(failingPath));

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -897,10 +897,15 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
             newUserInfo[@"networkTaskMetricsPrivacyStance"] = privacyStanceToString(networkDataTask->networkLoadMetrics().privacyStance);
 #endif
 #if HAVE(NETWORK_RESOLUTION_FAILURE_REPORT) && defined(NW_CONNECTION_HAS_FAILED_RESOLUTION_REPORT)
-            for (NSError *underlyingError in error.underlyingErrors) {
-                if (auto report = extractResolutionReport(underlyingError)) {
-                    newUserInfo[@"networkResolutionReport"] = report;
-                    break;
+            if (auto report = extractResolutionReport(error))
+                newUserInfo[@"networkResolutionReport"] = report;
+            else {
+                // This can be removed when the CFNetwork loader is no longer in use
+                for (NSError *underlyingError in error.underlyingErrors) {
+                    if (auto report = extractResolutionReport(underlyingError)) {
+                        newUserInfo[@"networkResolutionReport"] = report;
+                        break;
+                    }
                 }
             }
 #endif


### PR DESCRIPTION
#### d89cd1cf5382b9cabd28727c09687304c49e70f0
<pre>
DNS filtering not flagging expected domains
<a href="https://bugs.webkit.org/show_bug.cgi?id=277515">https://bugs.webkit.org/show_bug.cgi?id=277515</a>
<a href="https://rdar.apple.com/132952350">rdar://132952350</a> (DNS filtering not flagging expected domains)

Reviewed by Alex Christensen.

The new network loader puts information in the top level user info dictionary instead of the underlying error&apos;s user info dictionary.

* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
(WebCore::ResourceError::blockedKnownTracker const):
(WebCore::ResourceError::blockedTrackerHostName const):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:task:didCompleteWithError:]):

Canonical link: <a href="https://commits.webkit.org/281735@main">https://commits.webkit.org/281735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/162a0fe478e16b2ba144675350a9f80ee727cb1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11369 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11644 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49178 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7892 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52695 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30005 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9921 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10282 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/55939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/10218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66482 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10045 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52662 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56730 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3951 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9150 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/35986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/37068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->