### PR TITLE
Drop foreground and background NetworkProcess/GPUProcess token if WebProcess shuts down while in foreground or background state

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -692,6 +692,8 @@ void WebProcessProxy::shutDown()
     m_backgroundResponsivenessTimer.invalidate();
     m_audibleMediaActivity = std::nullopt;
     m_mediaStreamingActivity = std::nullopt;
+    m_foregroundToken = nullptr;
+    m_backgroundToken = nullptr;
 
     for (Ref page : mainPages())
         page->disconnectFramesFromPage();


### PR DESCRIPTION
#### 43da751ec19ac529302e5eb951494af5ccfb96b9
<pre>
Drop foreground and background NetworkProcess/GPUProcess token if WebProcess shuts down while in foreground or background state
<a href="https://bugs.webkit.org/show_bug.cgi?id=277520">https://bugs.webkit.org/show_bug.cgi?id=277520</a>
<a href="https://rdar.apple.com/132289273">rdar://132289273</a>

Reviewed by Per Arne Vollan and Chris Dumez.

We have logs showing that sometimes `WebProcessProxy::shutDown` runs while the `WebProcessProxy` is
in the foreground or background as opposed to suspended (i.e. while holding a non-null
`m_foregroundToken` or `m_backgroundToken`). If that `WebProcessProxy` object is never destructed,
then those token objects stay alive and cause NetworkProcess and GPUProcess to always think they
have an active WebContent process to service.  This then causes NetworkProcess and GPUProcess to
hold on to the e.g. `Networking for background view(s)` activity forever.

Fix this by dropping ownership of the foreground and background token in `WebProcessProxy::shutDown`.

* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shutDown):

Canonical link: <a href="https://commits.webkit.org/281758@main">https://commits.webkit.org/281758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c5b1c97f46ee9bcc6a66f2a425ef8b62bdce80f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64769 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11385 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49189 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7900 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62872 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37429 "Found 12 new test failures: editing/deleting/25322-1.html editing/deleting/smart-delete-002.html editing/deleting/smart-delete-paragraph-002.html editing/pasteboard/smart-paste-003-trailing-whitespace.html editing/pasteboard/smart-paste-004.html editing/pasteboard/smart-paste-in-text-control.html editing/pasteboard/smart-paste-paragraph-004.html editing/selection/clear-selection-crash.html editing/selection/doubleclick-whitespace-crash.html editing/selection/ios/change-selection-by-tapping.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30016 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34116 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10298 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66498 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4782 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56557 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56740 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13587 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3962 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36002 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37084 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->