### PR TITLE
Introduce C SPI WKPageEvaluateJavaScriptInMainFrame to avoid using WKSerializedScriptValueRef

### DIFF
--- a/Source/WebKit/Shared/API/APIArray.cpp
+++ b/Source/WebKit/Shared/API/APIArray.cpp
@@ -40,6 +40,13 @@ Ref<Array> Array::create(Vector<RefPtr<Object>>&& elements)
     return adoptRef(*new Array(WTFMove(elements)));
 }
 
+Ref<Array> Array::createWithCapacity(size_t capacity)
+{
+    auto array = create(Vector<RefPtr<Object>>());
+    array->m_elements.reserveInitialCapacity(capacity);
+    return array;
+}
+
 Ref<Array> Array::createStringArray(const Vector<WTF::String>& strings)
 {
     auto elements = strings.map([](auto& string) -> RefPtr<Object> {

--- a/Source/WebKit/Shared/API/APIArray.h
+++ b/Source/WebKit/Shared/API/APIArray.h
@@ -50,6 +50,7 @@ private:
 
 public:
     static Ref<Array> create();
+    static Ref<Array> createWithCapacity(size_t);
     static Ref<Array> create(Vector<RefPtr<Object>>&&);
     static Ref<Array> createStringArray(const Vector<WTF::String>&);
     static Ref<Array> createStringArray(const std::span<const WTF::String>);

--- a/Source/WebKit/Shared/API/APIDictionary.cpp
+++ b/Source/WebKit/Shared/API/APIDictionary.cpp
@@ -36,6 +36,13 @@ Ref<Dictionary> Dictionary::create()
     return create({ });
 }
 
+Ref<Dictionary> Dictionary::createWithCapacity(size_t capacity)
+{
+    auto dictionary = create();
+    dictionary->m_map.reserveInitialCapacity(capacity);
+    return dictionary;
+}
+
 Ref<Dictionary> Dictionary::create(MapType&& map)
 {
     return adoptRef(*new Dictionary(WTFMove(map)));

--- a/Source/WebKit/Shared/API/APIDictionary.h
+++ b/Source/WebKit/Shared/API/APIDictionary.h
@@ -39,6 +39,7 @@ public:
     using MapType = HashMap<WTF::String, RefPtr<Object>>;
 
     static Ref<Dictionary> create();
+    static Ref<Dictionary> createWithCapacity(size_t);
     static Ref<Dictionary> create(MapType&&);
 
     virtual ~Dictionary();

--- a/Source/WebKit/Shared/API/APISerializedScriptValue.cpp
+++ b/Source/WebKit/Shared/API/APISerializedScriptValue.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "APISerializedScriptValue.h"
+
+#include "WKMutableArray.h"
+#include "WKMutableDictionary.h"
+#include "WKNumber.h"
+#include "WKString.h"
+#include <JavaScriptCore/JSRemoteInspector.h>
+#include <JavaScriptCore/JSRetainPtr.h>
+
+namespace API {
+
+static constexpr auto SharedJSContextWKMaxIdleTime = 10_s;
+
+class SharedJSContextWK {
+public:
+    SharedJSContextWK()
+        : m_timer(RunLoop::main(), this, &SharedJSContextWK::releaseContextIfNecessary)
+    {
+    }
+
+    JSRetainPtr<JSGlobalContextRef> ensureContext()
+    {
+        m_lastUseTime = MonotonicTime::now();
+        if (!m_context) {
+            bool inspectionPreviouslyFollowedInternalPolicies = JSRemoteInspectorGetInspectionFollowsInternalPolicies();
+            JSRemoteInspectorSetInspectionFollowsInternalPolicies(false);
+
+            // FIXME: rdar://100738357 Remote Web Inspector: Remove use of JSRemoteInspectorGetInspectionEnabledByDefault
+            // and JSRemoteInspectorSetInspectionEnabledByDefault once the default state is always false.
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+            bool previous = JSRemoteInspectorGetInspectionEnabledByDefault();
+            JSRemoteInspectorSetInspectionEnabledByDefault(false);
+            m_context = adopt(JSGlobalContextCreate(nullptr));
+            JSRemoteInspectorSetInspectionEnabledByDefault(previous);
+            ALLOW_DEPRECATED_DECLARATIONS_END
+
+            JSRemoteInspectorSetInspectionFollowsInternalPolicies(inspectionPreviouslyFollowedInternalPolicies);
+
+            m_timer.startOneShot(SharedJSContextWKMaxIdleTime);
+        }
+        return m_context;
+    }
+
+    void releaseContextIfNecessary()
+    {
+        auto idleTime = MonotonicTime::now() - m_lastUseTime;
+        if (idleTime < SharedJSContextWKMaxIdleTime) {
+            // We lazily restart the timer if needed every 10 seconds instead of doing so every time ensureContext()
+            // is called, for performance reasons.
+            m_timer.startOneShot(SharedJSContextWKMaxIdleTime - idleTime);
+            return;
+        }
+        m_context.clear();
+    }
+
+private:
+    JSRetainPtr<JSGlobalContextRef> m_context;
+    RunLoop::Timer m_timer;
+    MonotonicTime m_lastUseTime;
+};
+
+static SharedJSContextWK& sharedContext()
+{
+    static MainThreadNeverDestroyed<SharedJSContextWK> sharedContext;
+    return sharedContext.get();
+}
+
+static WKRetainPtr<WKTypeRef> valueToWKObject(JSContextRef context, JSValueRef value)
+{
+    auto jsToWKString = [] (JSStringRef input) {
+        size_t bufferSize = JSStringGetMaximumUTF8CStringSize(input);
+        Vector<char> buffer(bufferSize);
+        size_t utf8Length = JSStringGetUTF8CString(input, buffer.data(), bufferSize);
+        ASSERT(buffer[utf8Length] == '\0');
+        return adoptWK(WKStringCreateWithUTF8CStringWithLength(buffer.data(), utf8Length - 1));
+    };
+
+    if (!JSValueIsObject(context, value)) {
+        if (JSValueIsBoolean(context, value))
+            return adoptWK(WKBooleanCreate(JSValueToBoolean(context, value)));
+        if (JSValueIsNumber(context, value))
+            return adoptWK(WKDoubleCreate(JSValueToNumber(context, value, nullptr)));
+        if (JSValueIsString(context, value)) {
+            JSStringRef jsString = JSValueToStringCopy(context, value, nullptr);
+            WKRetainPtr result = jsToWKString(jsString);
+            JSStringRelease(jsString);
+            return result;
+        }
+        return nullptr;
+    }
+
+    JSObjectRef object = JSValueToObject(context, value, nullptr);
+
+    if (JSValueIsArray(context, value)) {
+        JSStringRef jsString = JSStringCreateWithUTF8CString("length");
+        JSValueRef lengthPropertyName = JSValueMakeString(context, jsString);
+        JSStringRelease(jsString);
+        JSValueRef lengthValue = JSObjectGetPropertyForKey(context, object, lengthPropertyName, nullptr);
+        double lengthDouble = JSValueToNumber(context, lengthValue, nullptr);
+        if (lengthDouble < 0 || lengthDouble > static_cast<double>(std::numeric_limits<size_t>::max()))
+            return nullptr;
+        size_t length = lengthDouble;
+        WKRetainPtr result = adoptWK(WKMutableArrayCreateWithCapacity(length));
+        for (size_t i = 0; i < length; ++i)
+            WKArrayAppendItem(result.get(), valueToWKObject(context, JSObjectGetPropertyAtIndex(context, object, i, nullptr)).get());
+        return result;
+    }
+
+    JSPropertyNameArrayRef names = JSObjectCopyPropertyNames(context, object);
+    size_t length = JSPropertyNameArrayGetCount(names);
+    auto result = adoptWK(WKMutableDictionaryCreateWithCapacity(length));
+    for (size_t i = 0; i < length; i++) {
+        JSStringRef jsKey = JSPropertyNameArrayGetNameAtIndex(names, i);
+        WKRetainPtr key = jsToWKString(jsKey);
+        WKRetainPtr value = valueToWKObject(context, JSObjectGetPropertyForKey(context, object, JSValueMakeString(context, jsKey), nullptr));
+        WKDictionarySetItem(result.get(), key.get(), value.get());
+    }
+    JSPropertyNameArrayRelease(names);
+
+    return result;
+}
+
+WKRetainPtr<WKTypeRef> SerializedScriptValue::deserializeWK(WebCore::SerializedScriptValue& serializedScriptValue)
+{
+    ASSERT(RunLoop::isMain());
+    JSRetainPtr context = sharedContext().ensureContext();
+    ASSERT(context);
+
+    JSValueRef value = serializedScriptValue.deserialize(context.get(), nullptr);
+    if (!value)
+        return nullptr;
+
+    return valueToWKObject(context.get(), value);
+}
+
+} // API

--- a/Source/WebKit/Shared/API/APISerializedScriptValue.h
+++ b/Source/WebKit/Shared/API/APISerializedScriptValue.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "APIObject.h"
-
+#include "WKRetainPtr.h"
 #include <WebCore/SerializedScriptValue.h>
 #include <wtf/RefPtr.h>
 
@@ -37,6 +37,8 @@ typedef struct _GVariant GVariant;
 typedef struct _JSCContext JSCContext;
 typedef struct _JSCValue JSCValue;
 #endif
+
+typedef const void* WKTypeRef;
 
 namespace API {
 
@@ -64,9 +66,11 @@ public:
     {
         return m_serializedScriptValue->deserialize(context, exception);
     }
-    
+
+    static WKRetainPtr<WKTypeRef> deserializeWK(WebCore::SerializedScriptValue&);
+
 #if PLATFORM(COCOA) && defined(__OBJC__)
-    static id deserialize(WebCore::SerializedScriptValue&, JSValueRef* exception);
+    static id deserialize(WebCore::SerializedScriptValue&);
     static RefPtr<SerializedScriptValue> createFromNSObject(id);
 #endif
 

--- a/Source/WebKit/Shared/API/c/WKMutableArray.cpp
+++ b/Source/WebKit/Shared/API/c/WKMutableArray.cpp
@@ -34,6 +34,11 @@ WKMutableArrayRef WKMutableArrayCreate()
     return const_cast<WKMutableArrayRef>(WebKit::toAPI(&API::Array::create().leakRef()));
 }
 
+WKMutableArrayRef WKMutableArrayCreateWithCapacity(size_t capacity)
+{
+    return const_cast<WKMutableArrayRef>(WebKit::toAPI(&API::Array::create().leakRef()));
+}
+
 void WKArrayAppendItem(WKMutableArrayRef arrayRef, WKTypeRef itemRef)
 {
     WebKit::toImpl(arrayRef)->elements().append(WebKit::toImpl(itemRef));

--- a/Source/WebKit/Shared/API/c/WKMutableArray.h
+++ b/Source/WebKit/Shared/API/c/WKMutableArray.h
@@ -38,6 +38,7 @@ extern "C" {
 #endif
 
 WK_EXPORT WKMutableArrayRef WKMutableArrayCreate(void);
+WK_EXPORT WKMutableArrayRef WKMutableArrayCreateWithCapacity(size_t capacity);
 
 WK_EXPORT void WKArrayAppendItem(WKMutableArrayRef array, WKTypeRef item);
 

--- a/Source/WebKit/Shared/API/c/WKMutableDictionary.cpp
+++ b/Source/WebKit/Shared/API/c/WKMutableDictionary.cpp
@@ -34,6 +34,11 @@ WKMutableDictionaryRef WKMutableDictionaryCreate()
     return const_cast<WKMutableDictionaryRef>(WebKit::toAPI(&API::Dictionary::create().leakRef()));
 }
 
+WKMutableDictionaryRef WKMutableDictionaryCreateWithCapacity(size_t capacity)
+{
+    return const_cast<WKMutableDictionaryRef>(WebKit::toAPI(&API::Dictionary::createWithCapacity(capacity).leakRef()));
+}
+
 bool WKDictionarySetItem(WKMutableDictionaryRef dictionaryRef, WKStringRef keyRef, WKTypeRef itemRef)
 {
     return WebKit::toImpl(dictionaryRef)->set(WebKit::toImpl(keyRef)->string(), WebKit::toImpl(itemRef));

--- a/Source/WebKit/Shared/API/c/WKMutableDictionary.h
+++ b/Source/WebKit/Shared/API/c/WKMutableDictionary.h
@@ -37,6 +37,7 @@ extern "C" {
 #endif
 
 WK_EXPORT WKMutableDictionaryRef WKMutableDictionaryCreate(void);
+WK_EXPORT WKMutableDictionaryRef WKMutableDictionaryCreateWithCapacity(size_t);
 
 WK_EXPORT bool WKDictionarySetItem(WKMutableDictionaryRef dictionary, WKStringRef key, WKTypeRef item);
 

--- a/Source/WebKit/Shared/API/c/WKString.cpp
+++ b/Source/WebKit/Shared/API/c/WKString.cpp
@@ -43,6 +43,11 @@ WKStringRef WKStringCreateWithUTF8CString(const char* string)
     return WebKit::toAPI(&API::String::create(WTF::String::fromUTF8(string)).leakRef());
 }
 
+WKStringRef WKStringCreateWithUTF8CStringWithLength(const char* string, size_t stringLength)
+{
+    return WebKit::toAPI(&API::String::create(WTF::String::fromUTF8({ string, stringLength })).leakRef());
+}
+
 bool WKStringIsEmpty(WKStringRef stringRef)
 {
     return WebKit::toImpl(stringRef)->stringView().isEmpty();

--- a/Source/WebKit/Shared/API/c/WKString.h
+++ b/Source/WebKit/Shared/API/c/WKString.h
@@ -47,6 +47,7 @@ extern "C" {
 WK_EXPORT WKTypeID WKStringGetTypeID(void);
 
 WK_EXPORT WKStringRef WKStringCreateWithUTF8CString(const char* string);
+WK_EXPORT WKStringRef WKStringCreateWithUTF8CStringWithLength(const char* string, size_t stringLength);
 
 WK_EXPORT bool WKStringIsEmpty(WKStringRef string);
 

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -270,6 +270,7 @@ Shared/API/APIData.cpp
 Shared/API/APIDictionary.cpp
 Shared/API/APIError.cpp
 Shared/API/APIObject.cpp
+Shared/API/APISerializedScriptValue.cpp
 Shared/API/APIURLRequest.cpp
 
 Shared/API/c/WKArray.cpp

--- a/Source/WebKit/UIProcess/API/C/WKPage.h
+++ b/Source/WebKit/UIProcess/API/C/WKPage.h
@@ -234,12 +234,8 @@ WK_EXPORT void WKPageSetPageNavigationClient(WKPageRef page, const WKPageNavigat
 
 WK_EXPORT void WKPageSetPageStateClient(WKPageRef page, WKPageStateClientBase* client);
 
-typedef void (*WKPageRunJavaScriptFunction)(WKSerializedScriptValueRef, WKErrorRef, void*);
-WK_EXPORT void WKPageRunJavaScriptInMainFrame(WKPageRef page, WKStringRef script, void* context, WKPageRunJavaScriptFunction function);
-#ifdef __BLOCKS__
-typedef void (^WKPageRunJavaScriptBlock)(WKSerializedScriptValueRef, WKErrorRef);
-WK_EXPORT void WKPageRunJavaScriptInMainFrame_b(WKPageRef page, WKStringRef script, WKPageRunJavaScriptBlock block);
-#endif
+typedef void (*WKPageEvaluateJavaScriptFunction)(WKTypeRef, WKErrorRef, void*);
+WK_EXPORT void WKPageEvaluateJavaScriptInMainFrame(WKPageRef page, WKStringRef script, void* context, WKPageEvaluateJavaScriptFunction function);
 
 typedef void (*WKPageGetSourceForFrameFunction)(WKStringRef, WKErrorRef, void*);
 WK_EXPORT void WKPageGetSourceForFrame(WKPageRef page, WKFrameRef frame, void* context, WKPageGetSourceForFrameFunction function);

--- a/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
@@ -93,13 +93,13 @@ static SharedJSContext& sharedContext()
     return sharedContext.get();
 }
 
-id SerializedScriptValue::deserialize(WebCore::SerializedScriptValue& serializedScriptValue, JSValueRef* exception)
+id SerializedScriptValue::deserialize(WebCore::SerializedScriptValue& serializedScriptValue)
 {
     ASSERT(RunLoop::isMain());
     RetainPtr context = sharedContext().ensureContext();
     JSRetainPtr globalContextRef = [context JSGlobalContextRef];
 
-    JSValueRef valueRef = serializedScriptValue.deserialize(globalContextRef.get(), exception);
+    JSValueRef valueRef = serializedScriptValue.deserialize(globalContextRef.get(), nullptr);
     if (!valueRef)
         return nil;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -152,7 +152,7 @@ public:
             if (!webView)
                 return;
             RetainPtr<WKFrameInfo> frameInfo = wrapper(API::FrameInfo::create(WTFMove(frameInfoData), &page));
-            id body = API::SerializedScriptValue::deserialize(serializedScriptValue, 0);
+            id body = API::SerializedScriptValue::deserialize(serializedScriptValue);
             auto message = adoptNS([[WKScriptMessage alloc] _initWithBody:body webView:webView.get() frameInfo:frameInfo.get() name:m_name.get() world:wrapper(world)]);
         
             [(id<WKScriptMessageHandler>)m_handler.get() userContentController:m_controller.get() didReceiveScriptMessage:message.get()];
@@ -181,7 +181,7 @@ public:
 
         @autoreleasepool {
             RetainPtr<WKFrameInfo> frameInfo = wrapper(API::FrameInfo::create(WTFMove(frameInfoData), &page));
-            id body = API::SerializedScriptValue::deserialize(serializedScriptValue, 0);
+            id body = API::SerializedScriptValue::deserialize(serializedScriptValue);
             auto message = adoptNS([[WKScriptMessage alloc] _initWithBody:body webView:webView.get() frameInfo:frameInfo.get() name:m_name.get() world:wrapper(world)]);
 
             [(id<WKScriptMessageHandlerWithReply>)m_handler.get() userContentController:m_controller.get() didReceiveScriptMessage:message.get() replyHandler:^(id result, NSString *errorMessage) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1208,7 +1208,7 @@ static WKMediaPlaybackState toWKMediaPlaybackState(WebKit::MediaPlaybackState me
             return;
         }
 
-        id body = API::SerializedScriptValue::deserialize(result.value()->internalRepresentation(), 0);
+        id body = API::SerializedScriptValue::deserialize(result.value()->internalRepresentation());
         rawHandler(body, nil);
     });
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
@@ -98,7 +98,7 @@
             return;
         }
 
-        id body = API::SerializedScriptValue::deserialize(valueOrException.value()->internalRepresentation(), 0);
+        id body = API::SerializedScriptValue::deserialize(valueOrException.value()->internalRepresentation());
         capturedBlock(nil, body);
     });
 }
@@ -117,7 +117,7 @@
             return;
         }
 
-        id body = API::SerializedScriptValue::deserialize(valueOrException.value()->internalRepresentation(), 0);
+        id body = API::SerializedScriptValue::deserialize(valueOrException.value()->internalRepresentation());
         capturedBlock(nil, body);
     });
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8329,6 +8329,7 @@
 		FA39AE662B23972A008F93CD /* CoreIPCAuditToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCAuditToken.h; sourceTree = "<group>"; };
 		FA39AE672B23972A008F93CD /* CoreIPCAuditToken.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCAuditToken.serialization.in; sourceTree = "<group>"; };
 		FA4368C62B811BA3001B993D /* CoreIPCNSURLCredential.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCNSURLCredential.serialization.in; sourceTree = "<group>"; };
+		FA4899BD2C5C56E800B04660 /* APISerializedScriptValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = APISerializedScriptValue.cpp; sourceTree = "<group>"; };
 		FA4FE2642B75EAFF0016E671 /* CoreIPCNull.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCNull.mm; sourceTree = "<group>"; };
 		FA651BA42AA3CBB500747576 /* NetworkTransportBidirectionalStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkTransportBidirectionalStream.h; sourceTree = "<group>"; };
 		FA651BA52AA3CBB500747576 /* NetworkTransportBidirectionalStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkTransportBidirectionalStream.cpp; sourceTree = "<group>"; };
@@ -15008,6 +15009,7 @@
 				1AC1336B18565C7A00F3EC05 /* APIPageHandle.h */,
 				7AE42B452954EDC200B20510 /* APIPageHandle.serialization.in */,
 				F634445512A885C8000612D8 /* APISecurityOrigin.h */,
+				FA4899BD2C5C56E800B04660 /* APISerializedScriptValue.cpp */,
 				A72D5D7F1236CBA800A88B15 /* APISerializedScriptValue.h */,
 				FA9AFA662B2250E600953DC5 /* APISerializedScriptValue.serialization.in */,
 				BCF04C8E11FF9F6E00F86A58 /* APIString.h */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
@@ -87,7 +87,7 @@ void WebExtensionAPIDevToolsInspectedWindow::eval(WebPage& page, NSString *expre
         }
 
         Ref serializedValue = API::SerializedScriptValue::createFromWireBytes(result.value().value());
-        id scriptResult = API::SerializedScriptValue::deserialize(serializedValue->internalRepresentation(), nullptr);
+        id scriptResult = API::SerializedScriptValue::deserialize(serializedValue->internalRepresentation());
 
         // If no error occurred, element 0 will contain the result of evaluating the expression, and element 1 will be undefined.
         callback->call(@[ scriptResult ?: undefinedValue, undefinedValue ]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/DidAssociateFormControls.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DidAssociateFormControls.cpp
@@ -37,10 +37,6 @@ static bool didReceiveAllMessages = false;
 static bool receivedMessageForAddingForm = false;
 static const uint64_t expectedNumberOfElements = 1;
 
-static void nullJavaScriptCallback(WKSerializedScriptValueRef, WKErrorRef, void*)
-{
-}
-
 static void didReceiveMessageFromInjectedBundle(WKContextRef, WKStringRef messageName, WKTypeRef messageBody, const void*)
 {
     EXPECT_WK_STREQ("DidReceiveDidAssociateFormControls", messageName);
@@ -56,7 +52,7 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef, WKStringRef messag
         receivedMessageForAddingForm = true;
 
         WKPageRef page = static_cast<WKPageRef>(WKDictionaryGetItemForKey(dictionary, Util::toWK("Page").get()));
-        WKPageRunJavaScriptInMainFrame(page, Util::toWK("addPasswordFieldToForm()").get(), 0, nullJavaScriptCallback);
+        WKPageEvaluateJavaScriptInMainFrame(page, Util::toWK("addPasswordFieldToForm()").get(), nullptr, nullptr);
 
         return;
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/EvaluateJavaScript.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/EvaluateJavaScript.cpp
@@ -37,10 +37,10 @@ namespace TestWebKitAPI {
 
 static bool testDone;
 
-static void didRunJavaScript(WKSerializedScriptValueRef resultSerializedScriptValue, WKErrorRef error, void* context)
+static void didRunJavaScript(WKTypeRef result, WKErrorRef error, void* context)
 {
     EXPECT_EQ(reinterpret_cast<void*>(0x1234578), context);
-    EXPECT_NULL(resultSerializedScriptValue);
+    EXPECT_NULL(result);
 
     // FIXME: We should also check the error, but right now it's always null.
     // Assert that it's null so we can revisit when this changes.
@@ -55,19 +55,14 @@ TEST(WebKit, EvaluateJavaScriptThatThrowsAnException)
     PlatformWebView webView(context.get());
 
     WKRetainPtr<WKStringRef> javaScriptString = adoptWK(WKStringCreateWithUTF8CString("throw 'Hello'"));
-    WKPageRunJavaScriptInMainFrame(webView.page(), javaScriptString.get(), reinterpret_cast<void*>(0x1234578), didRunJavaScript);
+    WKPageEvaluateJavaScriptInMainFrame(webView.page(), javaScriptString.get(), reinterpret_cast<void*>(0x1234578), didRunJavaScript);
 
     Util::run(&testDone);
 }
 
-static void didCreateBlob(WKSerializedScriptValueRef serializedScriptValue, WKErrorRef error, void* context)
+static void didCreateBlob(WKTypeRef result, WKErrorRef error, void* context)
 {
-    EXPECT_NOT_NULL(serializedScriptValue);
-    JSGlobalContextRef jsContext = JSGlobalContextCreate(0);
-    EXPECT_NOT_NULL(jsContext);
-    auto jsValue = WKSerializedScriptValueDeserialize(serializedScriptValue, jsContext, 0);
-    EXPECT_NOT_NULL(jsValue);
-
+    EXPECT_NULL(result);
     testDone = true;
 }
 
@@ -77,7 +72,7 @@ TEST(WebKit, EvaluateJavaScriptThatCreatesBlob)
     PlatformWebView webView(context.get());
 
     WKRetainPtr<WKStringRef> javaScriptString = adoptWK(WKStringCreateWithUTF8CString("new Blob(['this is a test blob'])"));
-    WKPageRunJavaScriptInMainFrame(webView.page(), javaScriptString.get(), 0, didCreateBlob);
+    WKPageEvaluateJavaScriptInMainFrame(webView.page(), javaScriptString.get(), 0, didCreateBlob);
 
     Util::run(&testDone);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/PageLoadDidChangeLocationWithinPageForFrame.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/PageLoadDidChangeLocationWithinPageForFrame.cpp
@@ -33,10 +33,6 @@
 
 namespace TestWebKitAPI {
 
-static void nullJavaScriptCallback(WKSerializedScriptValueRef, WKErrorRef error, void*)
-{
-}
-
 static bool didFinishLoad;
 static bool didPopStateWithinPage;
 static bool didChangeLocationWithinPage;
@@ -76,7 +72,7 @@ TEST(WebKit, PageLoadDidChangeLocationWithinPage)
 
     WKRetainPtr<WKURLRef> initialURL = adoptWK(WKFrameCopyURL(WKPageGetMainFrame(webView.page())));
 
-    WKPageRunJavaScriptInMainFrame(webView.page(), Util::toWK("clickLink()").get(), 0, nullJavaScriptCallback);
+    WKPageEvaluateJavaScriptInMainFrame(webView.page(), Util::toWK("clickLink()").get(), nullptr, nullptr);
     Util::run(&didChangeLocationWithinPage);
 
     WKRetainPtr<WKURLRef> urlAfterAnchorClick = adoptWK(WKFrameCopyURL(WKPageGetMainFrame(webView.page())));

--- a/Tools/TestWebKitAPI/Tests/WebKit/ReloadPageAfterCrash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ReloadPageAfterCrash.cpp
@@ -101,10 +101,6 @@ TEST(WebKit, ReloadPageAfterCrash)
 
 static bool calledCrashHandler = false;
 
-static void nullJavaScriptCallback(WKSerializedScriptValueRef, WKErrorRef, void*)
-{
-}
-
 static void didCrashCheckFrames(WKPageRef page, const void*)
 {
     // Test if first load actually worked.
@@ -140,7 +136,7 @@ TEST(WebKit, FocusedFrameAfterCrash)
     EXPECT_FALSE(!WKPageGetMainFrame(webView.page()));
 
     WKRetainPtr<WKStringRef> javaScriptString = adoptWK(WKStringCreateWithUTF8CString("frames[2].focus()"));
-    WKPageRunJavaScriptInMainFrame(webView.page(), javaScriptString.get(), 0, nullJavaScriptCallback);
+    WKPageEvaluateJavaScriptInMainFrame(webView.page(), javaScriptString.get(), nullptr, nullptr);
 
     while (!WKPageGetFocusedFrame(webView.page()))
         Util::spinRunLoop(10);

--- a/Tools/TestWebKitAPI/Tests/WebKit/SpacebarScrolling.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/SpacebarScrolling.cpp
@@ -53,15 +53,11 @@ static void didNotHandleKeyEventCallback(WKPageRef, WKNativeEventPtr event, cons
 }
 
 
-static void didRunJavascript(WKSerializedScriptValueRef serializedScriptValue, WKErrorRef error, void* context)
+static void didRunJavascript(WKTypeRef result, WKErrorRef error, void* context)
 {
-    JSGlobalContextRef scriptContext = JSGlobalContextCreate(0);
-    JSValueRef jsValue = WKSerializedScriptValueDeserialize(serializedScriptValue, scriptContext, 0);
-    isScrolled = JSValueToBoolean(scriptContext, jsValue);
-
+    EXPECT_EQ(WKGetTypeID(result), WKBooleanGetTypeID());
+    isScrolled = WKBooleanGetValue((WKBooleanRef)result);
     javascriptRun = true;
-
-    JSGlobalContextRelease(scriptContext);
 }
 
 TEST(WebKit, SpacebarScrolling)
@@ -118,7 +114,7 @@ TEST(WebKit, SpacebarScrolling)
 
     while (!isScrolled) {
         javascriptRun = false;
-        WKPageRunJavaScriptInMainFrame(webView.page(), Util::toWK("isDocumentScrolled()").get(), 0, didRunJavascript);
+        WKPageEvaluateJavaScriptInMainFrame(webView.page(), Util::toWK("isDocumentScrolled()").get(), nullptr, didRunJavascript);
         Util::run(&javascriptRun);
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/TextFieldDidBeginAndEndEditing.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/TextFieldDidBeginAndEndEditing.cpp
@@ -79,14 +79,10 @@ struct WebKit2TextFieldBeginAndEditEditingTest : public ::testing::Test {
         WKPageSetPageNavigationClient(page, &loaderClient.base);
     }
 
-    static void nullJavaScriptCallback(WKSerializedScriptValueRef, WKErrorRef, void*)
-    {
-    }
-
     void executeJavaScriptAndCheckDidReceiveMessage(const char* javaScriptCode, const char* expectedMessageName)
     {
         didReceiveMessage = false;
-        WKPageRunJavaScriptInMainFrame(webView->page(), Util::toWK(javaScriptCode).get(), 0, nullJavaScriptCallback);
+        WKPageEvaluateJavaScriptInMainFrame(webView->page(), Util::toWK(javaScriptCode).get(), nullptr, nullptr);
         Util::run(&didReceiveMessage);
         EXPECT_WK_STREQ(expectedMessageName, messageName);
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PictureInPictureDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PictureInPictureDelegate.mm
@@ -50,19 +50,13 @@ static bool hasVideoInPictureInPictureCalled;
 static bool onLoadCompleted = false;
 static bool fetchOnLoadedCompletedDone = false;
 
-static void onLoadedCompletedCallback(WKSerializedScriptValueRef serializedResultValue, WKErrorRef error, void*)
+static void onLoadedCompletedCallback(WKTypeRef result, WKErrorRef error, void*)
 {
     EXPECT_NULL(error);
-    
-    JSGlobalContextRef scriptContext = JSGlobalContextCreate(0);
-    
-    JSValueRef resultValue = WKSerializedScriptValueDeserialize(serializedResultValue, scriptContext, 0);
-    EXPECT_TRUE(JSValueIsBoolean(scriptContext, resultValue));
+    EXPECT_EQ(WKGetTypeID(result), WKBooleanGetTypeID());
     
     fetchOnLoadedCompletedDone = true;
-    onLoadCompleted = JSValueToBoolean(scriptContext, resultValue);
-    
-    JSGlobalContextRelease(scriptContext);
+    onLoadCompleted = WKBooleanGetValue((WKBooleanRef)result);
 }
 
 static void waitUntilOnLoadIsCompleted(WKPageRef page)
@@ -70,7 +64,7 @@ static void waitUntilOnLoadIsCompleted(WKPageRef page)
     onLoadCompleted = false;
     while (!onLoadCompleted) {
         fetchOnLoadedCompletedDone = false;
-        WKPageRunJavaScriptInMainFrame(page, TestWebKitAPI::Util::toWK("window.onloadcompleted !== undefined").get(), 0, onLoadedCompletedCallback);
+        WKPageEvaluateJavaScriptInMainFrame(page, TestWebKitAPI::Util::toWK("window.onloadcompleted !== undefined").get(), 0, onLoadedCompletedCallback);
         TestWebKitAPI::Util::run(&fetchOnLoadedCompletedDone);
     }
 }

--- a/Tools/WebKitTestRunner/WorkQueueManager.cpp
+++ b/Tools/WebKitTestRunner/WorkQueueManager.cpp
@@ -68,11 +68,6 @@ public:
     virtual Type invoke() const = 0;
 };
 
-// Required by WKPageRunJavaScriptInMainFrame().
-static void runJavaScriptFunction(WKSerializedScriptValueRef, WKErrorRef, void*)
-{
-}
-
 template <WorkQueueItem::Type type>
 class ScriptItem : public WorkQueueItem {
 public:
@@ -83,7 +78,7 @@ public:
 
     WorkQueueItem::Type invoke() const
     {
-        WKPageRunJavaScriptInMainFrame(mainPage(), m_script.get(), 0, runJavaScriptFunction);
+        WKPageEvaluateJavaScriptInMainFrame(mainPage(), m_script.get(), nullptr, nullptr);
         return type;
     }
 


### PR DESCRIPTION
#### 0b6bdc8b69f7b545c1c43217cf010f76eb6976bb
<pre>
Introduce C SPI WKPageEvaluateJavaScriptInMainFrame to avoid using WKSerializedScriptValueRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=277522">https://bugs.webkit.org/show_bug.cgi?id=277522</a>
<a href="https://rdar.apple.com/133024450">rdar://133024450</a>

Reviewed by Timothy Hatcher.

WKPageRunJavaScriptInMainFrame returns the result as a SerializedScriptValue, which you need a JS context to do anything with.
WKWebView.evaluateJavaScript returns the result as an NSNumber, NSString, NSDate, NSArray, NSDictionary, or NSNull.
This does the WKTypeRef equivalent to make the C SPI look more like the public ObjC API.
The next step is to stop using SerializedScriptValue and a temporary JS context just to send a result of one of these 5 types.

* Source/WebKit/Shared/API/APISerializedScriptValue.cpp: Copied from Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm.
(API::SharedJSContext::SharedJSContext):
(API::SharedJSContext::ensureContext):
(API::SharedJSContext::releaseContextIfNecessary):
(API::sharedContext):
(API::SerializedScriptValue::deserializeWK):
* Source/WebKit/Shared/API/APISerializedScriptValue.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageRunJavaScriptInMainFrame):
(WKPageEvaluateJavaScriptInMainFrame):
(callRunJavaScriptBlockAndRelease): Deleted.
(WKPageRunJavaScriptInMainFrame_b): Deleted.
* Source/WebKit/UIProcess/API/C/WKPage.h:
* Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm:
(API::SerializedScriptValue::deserialize):
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _evaluateJavaScript:asAsyncFunction:withSourceURL:withArguments:forceUserGesture:inFrame:inWorld:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm:
(-[_WKInspectorExtension evaluateScript:frameURL:contextSecurityOrigin:useContentScriptContext:completionHandler:]):
(-[_WKInspectorExtension evaluateScript:inTabWithIdentifier:completionHandler:]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
(WebKit::WebExtensionAPIDevToolsInspectedWindow::eval):

Canonical link: <a href="https://commits.webkit.org/281812@main">https://commits.webkit.org/281812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5556694e809600c5ad06082b10b9d405ccd21dd2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65006 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11618 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49366 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8073 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30196 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10134 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10530 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66736 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56735 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56928 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4157 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9187 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36234 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37317 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37061 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->