### PR TITLE
[css-view-transitions-2] Implement pageswap and pagereveal events.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7531,8 +7531,19 @@ imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-vie
 imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-view-transition-image-pair.html [ ImageOnlyFailure ]
 
 # View transitions Level 2 - cross document transitions.
-imported/w3c/web-platform-tests/css/css-view-transitions/navigation [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-cssom.html [ Pass ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/at-rule-opt-in-auto-with-types-mutable.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/at-rule-opt-in-auto-with-types-no-cascade.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/at-rule-opt-in-auto-with-types.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-opt-in-none-in-old.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/chromium-paint-holding-timeout.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-cross-origin-redirect.sub.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-setup-transition.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-no-opt-in-on-old.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/prerender-removed-during-navigation.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe-cross-origin.sub.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe-with-startVT-on-main.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/transition-to-prerender.html [ Skip ]
 
 # View transitions Level 2 - types.
 imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-match-early-mutation.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-cascade-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-cascade-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View Transitions: @view-transition cascaldes correclty with layers. Test timed out
+FAIL View Transitions: @view-transition cascaldes correclty with layers. assert_not_equals: ViewTransition must be triggered. got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-cascade-external-stylesheet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-cascade-external-stylesheet-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View Transitions: @view-transition cascaldes correclty with layers in separate external stylesheets. Test timed out
+FAIL View Transitions: @view-transition cascaldes correclty with layers in separate external stylesheets. assert_not_equals: ViewTransition must be triggered. got disallowed value null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View Transitions: @view-transition nested in a @layer rule. Test timed out
+PASS View Transitions: @view-transition nested in a @layer rule.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-matching-media-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-matching-media-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View Transitions: @view-transition nested in a matching @media rule. Test timed out
+PASS View Transitions: @view-transition nested in a matching @media rule.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-non-matching-media-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-non-matching-media-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View Transitions: @view-transition nested in a non-matching @media rule. Test timed out
+PASS View Transitions: @view-transition nested in a non-matching @media rule.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-shadow-dom-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View Transitions: @view-transition not applied from shadow tree. Test timed out
+PASS View Transitions: @view-transition not applied from shadow tree.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-multiple-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-multiple-rules-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View Transitions: Multiple @view-transition, last one wins. Test timed out
+PASS View Transitions: Multiple @view-transition, last one wins.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-opt-in-change-with-script-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-opt-in-change-with-script-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View Transitions: @view-transition opt-in programmatically. Test timed out
+PASS View Transitions: @view-transition opt-in programmatically.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Inbound cross-document view-transition should be skipped if document is hidden Test timed out
+PASS Inbound cross-document view-transition should be skipped if document is hidden
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/mismatched-snapshot-containing-block-size-skips-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/mismatched-snapshot-containing-block-size-skips-expected.txt
@@ -1,5 +1,7 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Skipping view transition because viewport size changed.
+CONSOLE MESSAGE: TypeError: e.data.startsWith is not a function. (In 'e.data.startsWith('FAIL:')', 'e.data.startsWith' is undefined)
 
-FAIL
+PASS
 View transitions: mismatched snapshot containing block size skips transition.
- assert_implements: ViewTransition-on-navigation not implemented. undefined
+
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-microtask-sequence-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-microtask-sequence-expected.txt
@@ -1,8 +1,6 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT
+FAIL
   View transition promise reactions in incoming page should resolve before
   the rendering continues (rAF, style/layout etc)
- Test timed out
+ assert_array_equals: expected property 1 to be "updateCallbackDone" but got "ready" (expected array ["pagereveal", "updateCallbackDone", "ready", "rAF", "rAF-microtask", "finished"] got ["pagereveal", "ready", "updateCallbackDone", "rAF", "rAF-microtask", "finished"])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-no-view-transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-no-view-transition-expected.txt
@@ -1,8 +1,6 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT
+PASS
   View transitions: in navigation without transition, pagereveal event has
   null viewTransition
- Test timed out
+
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-no-view-transition-new-opt-out-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-no-view-transition-new-opt-out-expected.txt
@@ -1,8 +1,6 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT
+PASS
   View transitions: null event.viewTransition when new page removes opt-in
   before pagereveal
- Test timed out
+
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-updatecallbackdone-promise-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-updatecallbackdone-promise-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT
+PASS
   View transitions: Test pagereveal.updateCallbackDone promise is immediately resolved.
- Test timed out
+
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-with-view-transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-with-view-transition-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View transitions: pagereveal event provides viewTransition Test timed out
+PASS View transitions: pagereveal event provides viewTransition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-long-delay-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-long-delay-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View transitions: long delay in pageswap aborts the transition Test timed out
+FAIL View transitions: long delay in pageswap aborts the transition assert_equals: viewTransition must have been skipped. expected null but got object "[object ViewTransition]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View transitions: skipTransition() in pageswap aborts the transition Test timed out
+FAIL View transitions: skipTransition() in pageswap aborts the transition assert_equals: viewTransition must have been skipped. expected null but got object "[object ViewTransition]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https-expected.txt
@@ -1,6 +1,10 @@
-CONSOLE MESSAGE: SyntaxError: The string did not match the expected pattern.
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "https://localhost:9443/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-...
 
-Harness Error (TIMEOUT), message = null
+Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "https://localhost:9443/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https.html?popup", "traverse", "from", "pagehide"] length 6, got ["pagehide"] length 1
+
+TIMEOUT pageswap on traverse navigation from script Test timed out
+
+Harness Error (FAIL), message = Unhandled rejection: assert_array_equals: incorrect event order lengths differ, expected array ["pageswap", "transition", "https://localhost:9443/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https.html?popup", "traverse", "from", "pagehide"] length 6, got ["pagehide"] length 1
 
 TIMEOUT pageswap on traverse navigation from script Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/skip-outbound-vt-before-reveal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/skip-outbound-vt-before-reveal-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT when navigating away before revealing, never start a view transition Test timed out
+FAIL when navigating away before revealing, never start a view transition assert_equals: expected "did reveal new page without transition" but got "did reveal old page"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/at-rule-with-types-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/at-rule-with-types-parsing-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL types: none shoud result in [] assert_array_equals: value is null, expected array
-FAIL types: abc shoud result in ["abc"] assert_array_equals: value is null, expected array
-FAIL types: abc xyz shoud result in ["abc","xyz"] assert_array_equals: value is null, expected array
-FAIL types:    abc 	xyz  shoud result in ["abc","xyz"] assert_array_equals: value is null, expected array
-FAIL types: abc none shoud result in [] assert_array_equals: value is null, expected array
-FAIL types: abc -ua-something shoud result in [] assert_array_equals: value is null, expected array
-FAIL types: abc -ok-something shoud result in ["abc","-ok-something"] assert_array_equals: value is null, expected array
-FAIL types: abc abc shoud result in ["abc","abc"] assert_array_equals: value is null, expected array
-FAIL types: abc ABC shoud result in ["abc","ABC"] assert_array_equals: value is null, expected array
-FAIL types: 123 shoud result in [] assert_array_equals: value is null, expected array
-FAIL types: * shoud result in [] assert_array_equals: value is null, expected array
-FAIL types: *11 abc shoud result in [] assert_array_equals: value is null, expected array
+FAIL types: none shoud result in [] assert_array_equals: value is undefined, expected array
+FAIL types: abc shoud result in ["abc"] assert_array_equals: value is undefined, expected array
+FAIL types: abc xyz shoud result in ["abc","xyz"] assert_array_equals: value is undefined, expected array
+FAIL types:    abc 	xyz  shoud result in ["abc","xyz"] assert_array_equals: value is undefined, expected array
+FAIL types: abc none shoud result in [] assert_array_equals: value is undefined, expected array
+FAIL types: abc -ua-something shoud result in [] assert_array_equals: value is undefined, expected array
+FAIL types: abc -ok-something shoud result in ["abc","-ok-something"] assert_array_equals: value is undefined, expected array
+FAIL types: abc abc shoud result in ["abc","abc"] assert_array_equals: value is undefined, expected array
+FAIL types: abc ABC shoud result in ["abc","ABC"] assert_array_equals: value is undefined, expected array
+FAIL types: 123 shoud result in [] assert_array_equals: value is undefined, expected array
+FAIL types: * shoud result in [] assert_array_equals: value is undefined, expected array
+FAIL types: *11 abc shoud result in [] assert_array_equals: value is undefined, expected array
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/navigation-supersedes-types-same-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/navigation-supersedes-types-same-rule-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View transitions: types together with navigation:none doesn't apply Test timed out
+PASS View transitions: types together with navigation:none doesn't apply
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/navigation-supersedes-types-when-after-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/navigation-supersedes-types-when-after-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View transitions: types are superseded by navigation:none Test timed out
+PASS View transitions: types are superseded by navigation:none
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/types-in-pagereveal-and-pageswap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/types-in-pagereveal-and-pageswap-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT View transitions: types from rule are reflected in pagereveal and pageswap Test timed out
+FAIL View transitions: types from rule are reflected in pagereveal and pageswap promise_test: Unhandled rejection with value: object "TypeError: Spread syntax requires ...iterable not be null or undefined"
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4060,6 +4060,14 @@ imported/w3c/web-platform-tests/css/css-view-transitions/input-targets-root-whil
 imported/w3c/web-platform-tests/css/css-view-transitions/no-css-animation-while-render-blocked.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/no-raf-while-render-blocked.html [ ImageOnlyFailure ]
 
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-opt-in-auto.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/mismatched-snapshot-containing-block-size-skips.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-navigation.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-with-redirect.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-replace-navigation.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https.html [ Failure ]
+
 imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html [ ImageOnlyFailure ]
 
 # This test hits some infinite-loop condition inside Cairo

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1367,6 +1367,9 @@ fast/css/variables/env/ios [ Pass ]
 # Tests use resizable popups which are not a thing on iOS.
 imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition-before-ready.html [ Failure ]
 
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-from-click.html [ Failure ]
+
 # Needs special fuzziness on iOS.
 imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2429,6 +2429,7 @@ imported/w3c/web-platform-tests/fetch/metadata/generated/form-submission.sub.htm
 imported/w3c/web-platform-tests/fetch/metadata/generated/window-location.sub.html [ Skip ]
 
 [ Ventura ] imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition.html [ Failure ]
+[ Ventura ] imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html [ Failure ]
 
 webkit.org/b/273308 http/tests/media/media-source/mediasource-rvfc.html [ Timeout ]
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1126,6 +1126,8 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/NonDocumentTypeChildNode.idl
     dom/NonElementParentNode.idl
     dom/Observable.idl
+    dom/PageRevealEvent.idl
+    dom/PageSwapEvent.idl
     dom/PageTransitionEvent.idl
     dom/ParentNode.idl
     dom/PointerEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1460,6 +1460,8 @@ $(PROJECT_DIR)/dom/NodeList.idl
 $(PROJECT_DIR)/dom/NonDocumentTypeChildNode.idl
 $(PROJECT_DIR)/dom/NonElementParentNode.idl
 $(PROJECT_DIR)/dom/Observable.idl
+$(PROJECT_DIR)/dom/PageRevealEvent.idl
+$(PROJECT_DIR)/dom/PageSwapEvent.idl
 $(PROJECT_DIR)/dom/PageTransitionEvent.idl
 $(PROJECT_DIR)/dom/ParentNode.idl
 $(PROJECT_DIR)/dom/PointerEvent.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2105,6 +2105,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOverconstrainedError.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOverconstrainedError.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOverconstrainedErrorEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSOverconstrainedErrorEvent.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPageRevealEvent.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPageRevealEvent.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPageSwapEvent.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPageSwapEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPageTransitionEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPageTransitionEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPaintRenderingContext2D.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1153,6 +1153,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/NonDocumentTypeChildNode.idl \
     $(WebCore)/dom/NonElementParentNode.idl \
     $(WebCore)/dom/Observable.idl \
+    $(WebCore)/dom/PageRevealEvent.idl \
+    $(WebCore)/dom/PageSwapEvent.idl \
     $(WebCore)/dom/PageTransitionEvent.idl \
     $(WebCore)/dom/ParentNode.idl \
     $(WebCore)/dom/PointerEvent.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1218,6 +1218,8 @@ dom/NodeList.cpp
 dom/NodeRareData.cpp
 dom/NodeTraversal.cpp
 dom/Observable.cpp
+dom/PageRevealEvent.cpp
+dom/PageSwapEvent.cpp
 dom/PageTransitionEvent.cpp
 dom/PendingScript.cpp
 dom/PointerEvent.cpp
@@ -4082,6 +4084,8 @@ JSOscillatorType.cpp
 JSOverSampleType.cpp
 JSOverconstrainedError.cpp
 JSOverconstrainedErrorEvent.cpp
+JSPageRevealEvent.cpp
+JSPageSwapEvent.cpp
 JSPageTransitionEvent.cpp
 JSPaintRenderingContext2D.cpp
 JSPaintWorkletGlobalScope.cpp

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -277,6 +277,7 @@ struct IntersectionObserverData;
 struct OwnerPermissionsPolicyData;
 struct QuerySelectorAllResults;
 struct SecurityPolicyViolationEventInit;
+struct ViewTransitionParams;
 
 #if ENABLE(TOUCH_EVENTS)
 struct EventTrackingRegions;
@@ -948,6 +949,8 @@ public:
     void clearAutofocusCandidates();
     void flushAutofocusCandidates();
 
+    void reveal();
+
     void hoveredElementDidDetach(Element&);
     void elementInActiveChainDidDetach(Element&);
 
@@ -1375,6 +1378,8 @@ public:
     void queueTaskToDispatchEventOnWindow(TaskSource, Ref<Event>&&);
     void dispatchPageshowEvent(PageshowEventPersistence);
     void dispatchPagehideEvent(PageshowEventPersistence);
+    void dispatchPageswapEvent(bool canTriggerCrossDocumentViewTransition);
+    void transferViewTransitionParams(Document&);
     WEBCORE_EXPORT void enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventInit&&);
     void enqueueHashchangeEvent(const String& oldURL, const String& newURL);
     void dispatchPopstateEvent(RefPtr<SerializedScriptValue>&& stateObject);
@@ -2373,6 +2378,8 @@ private:
 
     String m_cachedDOMCookies;
 
+    std::unique_ptr<ViewTransitionParams> m_inboundViewTransitionParams;
+
     Markable<WallTime> m_overrideLastModified;
 
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_associatedFormControls;
@@ -2628,6 +2635,8 @@ private:
 
     bool m_scheduledDeferredAXObjectCacheUpdate { false };
     bool m_wasRemovedLastRefCalled { false };
+
+    bool m_hasBeenRevealed { false };
 
     static bool hasEverCreatedAnAXObjectCache;
 

--- a/Source/WebCore/dom/EventInterfaces.in
+++ b/Source/WebCore/dom/EventInterfaces.in
@@ -40,6 +40,8 @@ MutationEvent
 MutationEvents interfaceName=MutationEvent
 NavigateEvent
 NavigationCurrentEntryChangeEvent
+PageRevealEvent
+PageSwapEvent
 PageTransitionEvent
 PopStateEvent
 ProgressEvent

--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -176,6 +176,8 @@
     "orientationchange": { },
     "pagehide": { },
     "pageshow": { },
+    "pagereveal": { },
+    "pageswap": { },
     "paste": { },
     "pause": { },
     "payerdetailchange": { },

--- a/Source/WebCore/dom/PageRevealEvent.cpp
+++ b/Source/WebCore/dom/PageRevealEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,34 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include "NavigationHistoryEntry.h"
-#include "ScriptWrappable.h"
+#include "config.h"
+#include "PageRevealEvent.h"
 
 namespace WebCore {
 
-class NavigationHistoryEntry;
-enum class NavigationNavigationType : uint8_t;
+WTF_MAKE_ISO_ALLOCATED_IMPL(PageRevealEvent);
 
-class NavigationActivation final : public RefCounted<NavigationActivation>, public ScriptWrappable {
-    WTF_MAKE_ISO_ALLOCATED(NavigationActivation);
-public:
-    static Ref<NavigationActivation> create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& entry, RefPtr<NavigationHistoryEntry>&& fromEntry)
-    {
-        return adoptRef(*new NavigationActivation(type, WTFMove(entry), WTFMove(fromEntry)));
-    }
+Ref<PageRevealEvent> PageRevealEvent::create(const AtomString& type, Init&& eventInitDict, IsTrusted isTrusted)
+{
+    return adoptRef(*new PageRevealEvent(type, WTFMove(eventInitDict), isTrusted));
+}
 
-    NavigationNavigationType navigationType() { return m_navigationType; };
-    NavigationHistoryEntry* from() const { return m_fromEntry.get(); };
-    const NavigationHistoryEntry& entry() const { return m_entry; };
+PageRevealEvent::PageRevealEvent(const AtomString& type, Init&& eventInitDict, IsTrusted isTrusted)
+    : Event(EventInterfaceType::PageRevealEvent, type, eventInitDict, isTrusted)
+    , m_viewTransition(WTFMove(eventInitDict.viewTransition))
+{ }
 
-private:
-    explicit NavigationActivation(NavigationNavigationType, Ref<NavigationHistoryEntry>&&, RefPtr<NavigationHistoryEntry>&& fromEntry);
-
-    NavigationNavigationType m_navigationType;
-    Ref<NavigationHistoryEntry> m_entry;
-    RefPtr<NavigationHistoryEntry> m_fromEntry;
-};
+PageRevealEvent::~PageRevealEvent() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PageRevealEvent.h
+++ b/Source/WebCore/dom/PageRevealEvent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,32 +25,27 @@
 
 #pragma once
 
-#include "NavigationHistoryEntry.h"
-#include "ScriptWrappable.h"
+#include "Event.h"
+#include "ViewTransition.h"
 
 namespace WebCore {
 
-class NavigationHistoryEntry;
-enum class NavigationNavigationType : uint8_t;
-
-class NavigationActivation final : public RefCounted<NavigationActivation>, public ScriptWrappable {
-    WTF_MAKE_ISO_ALLOCATED(NavigationActivation);
+class PageRevealEvent final : public Event {
+    WTF_MAKE_ISO_ALLOCATED(PageRevealEvent);
 public:
-    static Ref<NavigationActivation> create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& entry, RefPtr<NavigationHistoryEntry>&& fromEntry)
-    {
-        return adoptRef(*new NavigationActivation(type, WTFMove(entry), WTFMove(fromEntry)));
-    }
+    struct Init : EventInit {
+        RefPtr<ViewTransition> viewTransition;
+    };
 
-    NavigationNavigationType navigationType() { return m_navigationType; };
-    NavigationHistoryEntry* from() const { return m_fromEntry.get(); };
-    const NavigationHistoryEntry& entry() const { return m_entry; };
+    static Ref<PageRevealEvent> create(const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
+    ~PageRevealEvent();
+
+    const RefPtr<ViewTransition>& viewTransition() const { return m_viewTransition; }
 
 private:
-    explicit NavigationActivation(NavigationNavigationType, Ref<NavigationHistoryEntry>&&, RefPtr<NavigationHistoryEntry>&& fromEntry);
+    PageRevealEvent(const AtomString& type, Init&&, IsTrusted);
 
-    NavigationNavigationType m_navigationType;
-    Ref<NavigationHistoryEntry> m_entry;
-    RefPtr<NavigationHistoryEntry> m_fromEntry;
+    RefPtr<ViewTransition> m_viewTransition;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PageRevealEvent.idl
+++ b/Source/WebCore/dom/PageRevealEvent.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,34 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pagerevealevent-interface
 
-#include "NavigationHistoryEntry.h"
-#include "ScriptWrappable.h"
+[
+    Exposed=Window
+] interface PageRevealEvent : Event {
+    constructor([AtomString] DOMString type, optional PageRevealEventInit eventInitDict = {});
 
-namespace WebCore {
-
-class NavigationHistoryEntry;
-enum class NavigationNavigationType : uint8_t;
-
-class NavigationActivation final : public RefCounted<NavigationActivation>, public ScriptWrappable {
-    WTF_MAKE_ISO_ALLOCATED(NavigationActivation);
-public:
-    static Ref<NavigationActivation> create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& entry, RefPtr<NavigationHistoryEntry>&& fromEntry)
-    {
-        return adoptRef(*new NavigationActivation(type, WTFMove(entry), WTFMove(fromEntry)));
-    }
-
-    NavigationNavigationType navigationType() { return m_navigationType; };
-    NavigationHistoryEntry* from() const { return m_fromEntry.get(); };
-    const NavigationHistoryEntry& entry() const { return m_entry; };
-
-private:
-    explicit NavigationActivation(NavigationNavigationType, Ref<NavigationHistoryEntry>&&, RefPtr<NavigationHistoryEntry>&& fromEntry);
-
-    NavigationNavigationType m_navigationType;
-    Ref<NavigationHistoryEntry> m_entry;
-    RefPtr<NavigationHistoryEntry> m_fromEntry;
+    readonly attribute ViewTransition? viewTransition;
 };
 
-} // namespace WebCore
+dictionary PageRevealEventInit : EventInit {
+  ViewTransition? viewTransition = null;
+};

--- a/Source/WebCore/dom/PageSwapEvent.cpp
+++ b/Source/WebCore/dom/PageSwapEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,34 +23,24 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include "NavigationHistoryEntry.h"
-#include "ScriptWrappable.h"
+#include "config.h"
+#include "PageSwapEvent.h"
 
 namespace WebCore {
 
-class NavigationHistoryEntry;
-enum class NavigationNavigationType : uint8_t;
+WTF_MAKE_ISO_ALLOCATED_IMPL(PageSwapEvent);
 
-class NavigationActivation final : public RefCounted<NavigationActivation>, public ScriptWrappable {
-    WTF_MAKE_ISO_ALLOCATED(NavigationActivation);
-public:
-    static Ref<NavigationActivation> create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& entry, RefPtr<NavigationHistoryEntry>&& fromEntry)
-    {
-        return adoptRef(*new NavigationActivation(type, WTFMove(entry), WTFMove(fromEntry)));
-    }
+Ref<PageSwapEvent> PageSwapEvent::create(const AtomString& type, Init&& eventInitDict, IsTrusted isTrusted)
+{
+    return adoptRef(*new PageSwapEvent(type, WTFMove(eventInitDict), isTrusted));
+}
 
-    NavigationNavigationType navigationType() { return m_navigationType; };
-    NavigationHistoryEntry* from() const { return m_fromEntry.get(); };
-    const NavigationHistoryEntry& entry() const { return m_entry; };
+PageSwapEvent::PageSwapEvent(const AtomString& type, Init&& eventInitDict, IsTrusted isTrusted)
+    : Event(EventInterfaceType::PageSwapEvent, type, eventInitDict, isTrusted)
+    , m_activation(WTFMove(eventInitDict.activation))
+    , m_viewTransition(WTFMove(eventInitDict.viewTransition))
+{ }
 
-private:
-    explicit NavigationActivation(NavigationNavigationType, Ref<NavigationHistoryEntry>&&, RefPtr<NavigationHistoryEntry>&& fromEntry);
-
-    NavigationNavigationType m_navigationType;
-    Ref<NavigationHistoryEntry> m_entry;
-    RefPtr<NavigationHistoryEntry> m_fromEntry;
-};
+PageSwapEvent::~PageSwapEvent() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PageSwapEvent.h
+++ b/Source/WebCore/dom/PageSwapEvent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,32 +25,31 @@
 
 #pragma once
 
-#include "NavigationHistoryEntry.h"
-#include "ScriptWrappable.h"
+#include "Event.h"
+#include "NavigationActivation.h"
+#include "ViewTransition.h"
 
 namespace WebCore {
 
-class NavigationHistoryEntry;
-enum class NavigationNavigationType : uint8_t;
-
-class NavigationActivation final : public RefCounted<NavigationActivation>, public ScriptWrappable {
-    WTF_MAKE_ISO_ALLOCATED(NavigationActivation);
+class PageSwapEvent final : public Event {
+    WTF_MAKE_ISO_ALLOCATED(PageSwapEvent);
 public:
-    static Ref<NavigationActivation> create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& entry, RefPtr<NavigationHistoryEntry>&& fromEntry)
-    {
-        return adoptRef(*new NavigationActivation(type, WTFMove(entry), WTFMove(fromEntry)));
-    }
+    struct Init : EventInit {
+        RefPtr<NavigationActivation> activation;
+        RefPtr<ViewTransition> viewTransition;
+    };
 
-    NavigationNavigationType navigationType() { return m_navigationType; };
-    NavigationHistoryEntry* from() const { return m_fromEntry.get(); };
-    const NavigationHistoryEntry& entry() const { return m_entry; };
+    static Ref<PageSwapEvent> create(const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
+    ~PageSwapEvent();
+
+    const RefPtr<NavigationActivation>& activation() const { return m_activation; }
+    const RefPtr<ViewTransition>& viewTransition() const { return m_viewTransition; }
 
 private:
-    explicit NavigationActivation(NavigationNavigationType, Ref<NavigationHistoryEntry>&&, RefPtr<NavigationHistoryEntry>&& fromEntry);
+    PageSwapEvent(const AtomString& type, Init&&, IsTrusted);
 
-    NavigationNavigationType m_navigationType;
-    Ref<NavigationHistoryEntry> m_entry;
-    RefPtr<NavigationHistoryEntry> m_fromEntry;
+    RefPtr<NavigationActivation> m_activation;
+    RefPtr<ViewTransition> m_viewTransition;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PageSwapEvent.idl
+++ b/Source/WebCore/dom/PageSwapEvent.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,34 +23,18 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pageswapevent-interface
 
-#include "NavigationHistoryEntry.h"
-#include "ScriptWrappable.h"
-
-namespace WebCore {
-
-class NavigationHistoryEntry;
-enum class NavigationNavigationType : uint8_t;
-
-class NavigationActivation final : public RefCounted<NavigationActivation>, public ScriptWrappable {
-    WTF_MAKE_ISO_ALLOCATED(NavigationActivation);
-public:
-    static Ref<NavigationActivation> create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& entry, RefPtr<NavigationHistoryEntry>&& fromEntry)
-    {
-        return adoptRef(*new NavigationActivation(type, WTFMove(entry), WTFMove(fromEntry)));
-    }
-
-    NavigationNavigationType navigationType() { return m_navigationType; };
-    NavigationHistoryEntry* from() const { return m_fromEntry.get(); };
-    const NavigationHistoryEntry& entry() const { return m_entry; };
-
-private:
-    explicit NavigationActivation(NavigationNavigationType, Ref<NavigationHistoryEntry>&&, RefPtr<NavigationHistoryEntry>&& fromEntry);
-
-    NavigationNavigationType m_navigationType;
-    Ref<NavigationHistoryEntry> m_entry;
-    RefPtr<NavigationHistoryEntry> m_fromEntry;
+[
+    Exposed=Window
+] interface PageSwapEvent : Event {
+    constructor([AtomString] DOMString type, optional PageSwapEventInit eventInitDict = {});
+  
+    readonly attribute NavigationActivation? activation;
+    readonly attribute ViewTransition? viewTransition;
 };
 
-} // namespace WebCore
+dictionary PageSwapEventInit : EventInit {
+  NavigationActivation? activation = null;
+  ViewTransition? viewTransition = null;
+};

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -66,17 +66,50 @@ static std::pair<Ref<DOMPromise>, Ref<DeferredPromise>> createPromiseAndWrapper(
 ViewTransition::ViewTransition(Document& document, RefPtr<ViewTransitionUpdateCallback>&& updateCallback)
     : ActiveDOMObject(document)
     , m_updateCallback(WTFMove(updateCallback))
+    , m_shouldCallUpdateCallback(true)
     , m_ready(createPromiseAndWrapper(document))
     , m_updateCallbackDone(createPromiseAndWrapper(document))
     , m_finished(createPromiseAndWrapper(document))
 {
 }
 
+ViewTransition::ViewTransition(Document& document)
+    : ActiveDOMObject(document)
+    , m_ready(createPromiseAndWrapper(document))
+    , m_updateCallbackDone(createPromiseAndWrapper(document))
+    , m_finished(createPromiseAndWrapper(document))
+{
+}
+
+
 ViewTransition::~ViewTransition() = default;
 
-Ref<ViewTransition> ViewTransition::create(Document& document, RefPtr<ViewTransitionUpdateCallback>&& updateCallback)
+Ref<ViewTransition> ViewTransition::createSamePage(Document& document, RefPtr<ViewTransitionUpdateCallback>&& updateCallback)
 {
     Ref viewTransition = adoptRef(*new ViewTransition(document, WTFMove(updateCallback)));
+    viewTransition->suspendIfNeeded();
+    return viewTransition;
+}
+
+Ref<ViewTransition> ViewTransition::createInbound(Document& document, std::unique_ptr<ViewTransitionParams> params)
+{
+    Ref viewTransition = adoptRef(*new ViewTransition(document));
+    viewTransition->suspendIfNeeded();
+
+    viewTransition->m_namedElements.swap(params->namedElements);
+    viewTransition->m_initialLargeViewportSize = params->initialLargeViewportSize;
+    viewTransition->m_initialPageZoom = params->initialPageZoom;
+
+    document.setActiveViewTransition(viewTransition.ptr());
+
+    viewTransition->startInbound();
+
+    return viewTransition;
+}
+
+Ref<ViewTransition> ViewTransition::createOutbound(Document& document)
+{
+    Ref viewTransition = adoptRef(*new ViewTransition(document));
     viewTransition->suspendIfNeeded();
     return viewTransition;
 }
@@ -151,6 +184,20 @@ void ViewTransition::skipTransition()
         skipViewTransition(Exception { ExceptionCode::AbortError, "Skipping view transition because skipTransition() was called."_s });
 }
 
+void ViewTransition::startInbound()
+{
+    if (!document())
+        return;
+
+    ASSERT(m_phase < ViewTransitionPhase::UpdateCallbackCalled || m_phase == ViewTransitionPhase::Done);
+
+    if (m_phase != ViewTransitionPhase::Done)
+        m_phase = ViewTransitionPhase::UpdateCallbackCalled;
+
+    m_updateCallbackDone.second->resolve();
+    activateViewTransition();
+}
+
 // https://drafts.csswg.org/css-view-transitions/#call-dom-update-callback-algorithm
 void ViewTransition::callUpdateCallback()
 {
@@ -161,6 +208,12 @@ void ViewTransition::callUpdateCallback()
 
     Ref document = *this->document();
     RefPtr<DOMPromise> callbackPromise;
+    if (!m_shouldCallUpdateCallback) {
+        if (m_phase != ViewTransitionPhase::Done)
+            m_phase = ViewTransitionPhase::UpdateCallbackCalled;
+        return;
+    }
+
     if (!m_updateCallback) {
         auto promiseAndWrapper = createPromiseAndWrapper(document);
         promiseAndWrapper.second->resolve();
@@ -803,6 +856,16 @@ bool ViewTransition::documentElementIsCaptured() const
         return false;
 
     return renderer->capturedInViewTransition();
+}
+
+UniqueRef<ViewTransitionParams> ViewTransition::takeViewTransitionParams()
+{
+    auto params = makeUniqueRef<ViewTransitionParams>();
+    params->namedElements.swap(m_namedElements);
+    params->initialLargeViewportSize = m_initialLargeViewportSize;
+    params->initialPageZoom = m_initialPageZoom;
+
+    return params;
 }
 
 }

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -514,6 +514,8 @@ public:
 
     bool isInitialAboutBlank() const { return m_isInitialAboutBlank; }
 
+    bool navigationCanTriggerCrossDocumentViewTransition(Document& oldDocument);
+
 protected:
     WEBCORE_EXPORT DocumentLoader(const ResourceRequest&, const SubstituteData&);
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1925,6 +1925,10 @@ void Page::updateRendering()
         initialDocuments.append(document);
     });
 
+    runProcessingStep(RenderingUpdateStep::Reveal, [] (Document& document) {
+        document.reveal();
+    });
+
     runProcessingStep(RenderingUpdateStep::FlushAutofocusCandidates, [] (Document& document) {
         if (document.isTopDocument())
             document.flushAutofocusCandidates();
@@ -4451,6 +4455,7 @@ SpeechRecognitionConnection& Page::speechRecognitionConnection()
 WTF::TextStream& operator<<(WTF::TextStream& ts, RenderingUpdateStep step)
 {
     switch (step) {
+    case RenderingUpdateStep::Reveal: ts << "Reveal"; break;
     case RenderingUpdateStep::FlushAutofocusCandidates: ts << "FlushAutofocusCandidates"; break;
     case RenderingUpdateStep::Resize: ts << "Resize"; break;
     case RenderingUpdateStep::Scroll: ts << "Scroll"; break;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -245,35 +245,37 @@ enum class FinalizeRenderingUpdateFlags : uint8_t {
 };
 
 enum class RenderingUpdateStep : uint32_t {
-    Resize                          = 1 << 0,
-    Scroll                          = 1 << 1,
-    MediaQueryEvaluation            = 1 << 2,
-    Animations                      = 1 << 3,
-    Fullscreen                      = 1 << 4,
-    AnimationFrameCallbacks         = 1 << 5,
-    UpdateContentRelevancy          = 1 << 6,
-    PerformPendingViewTransitions   = 1 << 7,
-    IntersectionObservations        = 1 << 8,
-    ResizeObservations              = 1 << 9,
-    Images                          = 1 << 10,
-    WheelEventMonitorCallbacks      = 1 << 11,
-    CursorUpdate                    = 1 << 12,
-    EventRegionUpdate               = 1 << 13,
-    LayerFlush                      = 1 << 14,
+    Reveal                          = 1 << 0,
+    Resize                          = 1 << 1,
+    Scroll                          = 1 << 2,
+    MediaQueryEvaluation            = 1 << 3,
+    Animations                      = 1 << 4,
+    Fullscreen                      = 1 << 5,
+    AnimationFrameCallbacks         = 1 << 6,
+    UpdateContentRelevancy          = 1 << 7,
+    PerformPendingViewTransitions   = 1 << 8,
+    IntersectionObservations        = 1 << 9,
+    ResizeObservations              = 1 << 10,
+    Images                          = 1 << 11,
+    WheelEventMonitorCallbacks      = 1 << 12,
+    CursorUpdate                    = 1 << 13,
+    EventRegionUpdate               = 1 << 14,
+    LayerFlush                      = 1 << 15,
 #if ENABLE(ASYNC_SCROLLING)
-    ScrollingTreeUpdate             = 1 << 15,
+    ScrollingTreeUpdate             = 1 << 16,
 #endif
-    FlushAutofocusCandidates        = 1 << 16,
-    VideoFrameCallbacks             = 1 << 17,
-    PrepareCanvasesForDisplayOrFlush = 1 << 18,
-    CaretAnimation                  = 1 << 19,
-    FocusFixup                      = 1 << 20,
-    UpdateValidationMessagePositions= 1 << 21,
+    FlushAutofocusCandidates        = 1 << 17,
+    VideoFrameCallbacks             = 1 << 18,
+    PrepareCanvasesForDisplayOrFlush = 1 << 19,
+    CaretAnimation                  = 1 << 20,
+    FocusFixup                      = 1 << 21,
+    UpdateValidationMessagePositions= 1 << 22,
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    AccessibilityRegionUpdate       = 1 << 22,
+    AccessibilityRegionUpdate       = 1 << 23,
 #endif
-    RestoreScrollPositionAndViewState = 1 << 23,
-    AdjustVisibility                  = 1 << 24,
+    RestoreScrollPositionAndViewState = 1 << 24,
+    AdjustVisibility                  = 1 << 25,
+
 };
 
 enum class LinkDecorationFilteringTrigger : uint8_t {
@@ -284,6 +286,7 @@ enum class LinkDecorationFilteringTrigger : uint8_t {
 };
 
 constexpr OptionSet<RenderingUpdateStep> updateRenderingSteps = {
+    RenderingUpdateStep::Reveal,
     RenderingUpdateStep::FlushAutofocusCandidates,
     RenderingUpdateStep::Resize,
     RenderingUpdateStep::Scroll,


### PR DESCRIPTION
#### 9f76fdfc2789893b2ac005d7644d1e2a10622305
<pre>
[css-view-transitions-2] Implement pageswap and pagereveal events.
<a href="https://bugs.webkit.org/show_bug.cgi?id=277524">https://bugs.webkit.org/show_bug.cgi?id=277524</a>
&lt;<a href="https://rdar.apple.com/133025306">rdar://133025306</a>&gt;

Reviewed by Tim Nguyen.

Adds the basic IDLs for the pageswap and pagereveal events, plus the C++
implementations.

Adds code to fire these events (gated on the cross document view transitions
preference), and passes the view transition parameter in a partially correct
way.

This is the basic needed for the WPT test infrastructure to work, and as a
result, many new tests pass. There are still lots of FIXME&apos;s and bugs left
before the remaining tests pass.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-cascade-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-cascade-external-stylesheet-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-matching-media-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-non-matching-media-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-in-shadow-dom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-multiple-rules-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-opt-in-change-with-script-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/mismatched-snapshot-containing-block-size-skips-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-microtask-sequence-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-no-view-transition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-no-view-transition-new-opt-out-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-updatecallbackdone-promise-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pagereveal-with-view-transition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-long-delay-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-skip-transition-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-traverse-navigation-no-bfcache.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/skip-outbound-vt-before-reveal-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/at-rule-with-types-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/navigation-supersedes-types-same-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/navigation-supersedes-types-when-after-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/types-in-pagereveal-and-pageswap-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::reveal):
(WebCore::Document::transferViewTransitionParams):
(WebCore::Document::dispatchPageSwapEvent):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EventInterfaces.in:
* Source/WebCore/dom/EventNames.json:
* Source/WebCore/dom/PageRevealEvent.cpp: Copied from Source/WebCore/page/NavigationActivation.h.
(WebCore::PageRevealEvent::create):
(WebCore::PageRevealEvent::PageRevealEvent):
* Source/WebCore/dom/PageRevealEvent.h: Copied from Source/WebCore/page/NavigationActivation.h.
* Source/WebCore/dom/PageRevealEvent.idl: Added.
* Source/WebCore/dom/PageSwapEvent.cpp: Copied from Source/WebCore/page/NavigationActivation.h.
(WebCore::PageSwapEvent::create):
(WebCore::PageSwapEvent::PageSwapEvent):
* Source/WebCore/dom/PageSwapEvent.h: Copied from Source/WebCore/page/NavigationActivation.h.
* Source/WebCore/dom/PageSwapEvent.idl: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::ViewTransition):
(WebCore::ViewTransition::create):
(WebCore::ViewTransition::createInbound):
(WebCore::ViewTransition::startInbound):
(WebCore::ViewTransition::callUpdateCallback):
(WebCore::ViewTransition::activateViewTransition):
(WebCore::ViewTransition::takeViewTransitionParams):
* Source/WebCore/dom/ViewTransition.h:
(WebCore::OrderedNamedElementsMap::swap):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::navigationCanTriggerCrossDocumentViewTransition):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::clear):
(WebCore::FrameLoader::transitionToCommitted):
* Source/WebCore/page/NavigationActivation.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/282038@main">https://commits.webkit.org/282038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80f0b4b6225f894acead2fe30ac1a90e66dea968

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65809 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12375 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63949 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49831 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8569 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30663 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10783 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11306 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67538 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57211 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53501 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57447 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13756 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4732 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39164 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->