### PR TITLE
[cocoa] Begin adding https navigation failure browsing warning

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1501,6 +1501,9 @@
 /* prompt string in authentication panel */
 "The user name or password you entered for this area on %@ was incorrect. Make sure you’re entering them correctly, and then try again." = "The user name or password you entered for this area on %@ was incorrect. Make sure you’re entering them correctly, and then try again.";
 
+/* Not Secure Connection warning page title */
+"This Connection Is Not Secure" = "This Connection Is Not Secure";
+
 /* WKErrorDuplicateCredential description */
 "This credential is already present" = "This credential is already present";
 
@@ -1512,6 +1515,9 @@
 
 /* text that appears at the start of nearly-obsolete web pages in the form of a 'searchable index' */
 "This is a searchable index. Enter search keywords: " = "This is a searchable index. Enter search keywords: ";
+
+/* Not Secure Connection warning text */
+"This website does not support connecting securely. The information you see and enter on this website, including credit cards, phone numbers, and passwords, can be read and altered by other people." = "This website does not support connecting securely. The information you see and enter on this website, including credit cards, phone numbers, and passwords, can be read and altered by other people.";
 
 /* Malware warning */
 "This website may attempt to install dangerous software, which could harm your computer or steal your personal or financial information, like passwords, photos, or credit cards." = "This website may attempt to install dangerous software, which could harm your computer or steal your personal or financial information, like passwords, photos, or credit cards.";

--- a/Source/WebKit/UIProcess/BrowsingWarning.h
+++ b/Source/WebKit/UIProcess/BrowsingWarning.h
@@ -38,11 +38,20 @@ namespace WebKit {
 
 class BrowsingWarning : public RefCounted<BrowsingWarning> {
 public:
+    struct HTTPSNavigationFailureData { };
+
+    struct SafeBrowsingWarningData {
+#if PLATFORM(COCOA)
+        RetainPtr<SSBServiceLookupResult> result;
+#endif
+    };
+
+    using Data = std::variant<SafeBrowsingWarningData, HTTPSNavigationFailureData>;
 
 #if HAVE(SAFE_BROWSING)
-    static Ref<BrowsingWarning> create(const URL& url, bool forMainFrameNavigation, SSBServiceLookupResult *result)
+    static Ref<BrowsingWarning> create(const URL& url, bool forMainFrameNavigation, Data&& data)
     {
-        return adoptRef(*new BrowsingWarning(url, forMainFrameNavigation, result));
+        return adoptRef(*new BrowsingWarning(url, forMainFrameNavigation, WTFMove(data)));
     }
 #endif
 #if PLATFORM(COCOA)
@@ -65,7 +74,7 @@ public:
 
 private:
 #if HAVE(SAFE_BROWSING)
-    BrowsingWarning(const URL&, bool, SSBServiceLookupResult *);
+    BrowsingWarning(const URL&, bool, Data&&);
 #endif
 #if PLATFORM(COCOA)
     BrowsingWarning(URL&&, String&&, String&&, RetainPtr<NSAttributedString>&&);

--- a/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
@@ -30,6 +30,7 @@
 #import <WebCore/LocalizedStrings.h>
 #import <pal/spi/cocoa/NSAttributedStringSPI.h>
 #import <wtf/Language.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/text/MakeString.h>
 
 namespace WebKit {
@@ -106,7 +107,7 @@ static NSURL *malwareDetailsURL(const URL& url, SSBServiceLookupResult *result)
     return URL({ }, makeString(malwareDetailsBase(result), "&site="_s, url.host(), "&hl="_s, defaultLanguage()));
 }
 
-static NSString *browsingTitleText(SSBServiceLookupResult *result)
+static NSString *browsingWarningTitleText(SSBServiceLookupResult *result)
 {
     if (result.isPhishing)
         return WEB_UI_NSSTRING(@"Deceptive Website Warning", "Phishing warning title");
@@ -114,6 +115,15 @@ static NSString *browsingTitleText(SSBServiceLookupResult *result)
         return WEB_UI_NSSTRING(@"Malware Website Warning", "Malware warning title");
     ASSERT(result.isUnwantedSoftware);
     return WEB_UI_NSSTRING(@"Website With Harmful Software Warning", "Unwanted software warning title");
+}
+
+static NSString *browsingWarningTitleText(BrowsingWarning::Data data)
+{
+    return WTF::switchOn(data, [&] (BrowsingWarning::SafeBrowsingWarningData data) {
+        return browsingWarningTitleText(data.result.get());
+    }, [&] (BrowsingWarning::HTTPSNavigationFailureData) {
+        return WEB_UI_NSSTRING(@"This Connection Is Not Secure", "Not Secure Connection warning page title");
+    });
 }
 
 static NSString *browsingWarningText(SSBServiceLookupResult *result)
@@ -125,6 +135,15 @@ static NSString *browsingWarningText(SSBServiceLookupResult *result)
 
     ASSERT(result.isUnwantedSoftware);
     return WEB_UI_NSSTRING(@"This website may try to trick you into installing software that harms your browsing experience, like changing your settings without your permission or showing you unwanted ads. Once installed, it may be difficult to remove.", "Unwanted software warning");
+}
+
+static NSString *browsingWarningText(BrowsingWarning::Data data)
+{
+    return WTF::switchOn(data, [&] (BrowsingWarning::SafeBrowsingWarningData data) {
+        return browsingWarningText(data.result.get());
+    }, [&] (BrowsingWarning::HTTPSNavigationFailureData) {
+        return WEB_UI_NSSTRING(@"This website does not support connecting securely. The information you see and enter on this website, including credit cards, phone numbers, and passwords, can be read and altered by other people.", "Not Secure Connection warning text");
+    });
 }
 
 static NSMutableAttributedString *browsingDetailsText(const URL& url, SSBServiceLookupResult *result)
@@ -164,12 +183,19 @@ static NSMutableAttributedString *browsingDetailsText(const URL& url, SSBService
     return malwareOrUnwantedSoftwareDetails(WEB_UI_NSSTRING(@"Warnings are shown for websites where harmful software has been detected. You can check %the-status-of-site% on the %safeBrowsingProvider% diagnostic page.", "Unwanted software warning description"), @"%the-status-of-site%", false);
 }
 
-BrowsingWarning::BrowsingWarning(const URL& url, bool forMainFrameNavigation, SSBServiceLookupResult *result)
+static NSMutableAttributedString *browsingDetailsText(const URL& url, BrowsingWarning::Data data)
+{
+    if (auto* safeBrowsingData = std::get_if<BrowsingWarning::SafeBrowsingWarningData>(&data))
+        return browsingDetailsText(url, safeBrowsingData->result.get());
+    return nil;
+}
+
+BrowsingWarning::BrowsingWarning(const URL& url, bool forMainFrameNavigation, Data&& data)
     : m_url(url)
-    , m_title(browsingTitleText(result))
-    , m_warning(browsingWarningText(result))
+    , m_title(browsingWarningTitleText(data))
+    , m_warning(browsingWarningText(data))
     , m_forMainFrameNavigation(forMainFrameNavigation)
-    , m_details(browsingDetailsText(url, result))
+    , m_details(browsingDetailsText(url, data))
 {
 }
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -228,7 +228,7 @@ void WebPageProxy::beginSafeBrowsingCheck(const URL& url, bool forMainFrameNavig
 
             for (SSBServiceLookupResult *lookupResult in [result serviceLookupResults]) {
                 if (lookupResult.isPhishing || lookupResult.isMalware || lookupResult.isUnwantedSoftware) {
-                    listener->didReceiveSafeBrowsingResults(BrowsingWarning::create(url, forMainFrameNavigation, lookupResult));
+                    listener->didReceiveSafeBrowsingResults(BrowsingWarning::create(url, forMainFrameNavigation, BrowsingWarning::SafeBrowsingWarningData { lookupResult }));
                     return;
                 }
             }


### PR DESCRIPTION
#### 743aecc8bcfee0db00fd09778a5becc4cf46d53a
<pre>
[cocoa] Begin adding https navigation failure browsing warning
<a href="https://bugs.webkit.org/show_bug.cgi?id=277527">https://bugs.webkit.org/show_bug.cgi?id=277527</a>
<a href="https://rdar.apple.com/problem/133035983">rdar://problem/133035983</a>

Reviewed by Alex Christensen.

Add two new types that identify the desired warning. Currently the supported
warnings are for SafeBrowsing and HTTPSNavigationFailure.
HTTPSNavigationFailure is the warning associated with the
https-by-default/HTTPSOnly load failure.

The current HTTPSNavigationFailure warning uses the same buttons, color, and
image as the SafeBrowsing warning. These will be changed in subsequent patches.

The SafeBrowsing warning is covered by existing tests. The
HTTPSNavigationFailure warning will be covered by tests in a later patch.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _showWarningViewWithURL:title:warning:detailsWithLinks:completionHandler:]):
* Source/WebKit/UIProcess/BrowsingWarning.h:
(WebKit::BrowsingWarning::create):
(WebKit::BrowsingWarning::type const):
* Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm:
(WebKit::browsingWarningTitleText):
(WebKit::browsingWarningText):
(WebKit::browsingDetailsText):
(WebKit::BrowsingWarning::BrowsingWarning):
(WebKit::browsingTitleText): Deleted.
* Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm:
(backgroundColorForWarningType):
(-[_WKWarningView initWithFrame:browsingWarning:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/281773@main">https://commits.webkit.org/281773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b26a18a1f2f98983d9a6d8c082ade987d3855ea4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64870 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11485 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11760 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7975 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62972 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/37516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30094 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10017 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10398 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66600 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10141 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4904 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56825 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4044 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9174 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37184 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38277 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->