### PR TITLE
[cocoa]

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1501,6 +1501,9 @@
 /* prompt string in authentication panel */
 "The user name or password you entered for this area on %@ was incorrect. Make sure you’re entering them correctly, and then try again." = "The user name or password you entered for this area on %@ was incorrect. Make sure you’re entering them correctly, and then try again.";
 
+/* Not Secure Connection warning page title */
+"This Connection Is Not Secure" = "This Connection Is Not Secure";
+
 /* WKErrorDuplicateCredential description */
 "This credential is already present" = "This credential is already present";
 
@@ -1512,6 +1515,9 @@
 
 /* text that appears at the start of nearly-obsolete web pages in the form of a 'searchable index' */
 "This is a searchable index. Enter search keywords: " = "This is a searchable index. Enter search keywords: ";
+
+/* Not Secure Connection warning text */
+"This website does not support connecting securely. The information you see and enter on this website, including credit cards, phone numbers, and passwords, can be read and altered by other people." = "This website does not support connecting securely. The information you see and enter on this website, including credit cards, phone numbers, and passwords, can be read and altered by other people.";
 
 /* Malware warning */
 "This website may attempt to install dangerous software, which could harm your computer or steal your personal or financial information, like passwords, photos, or credit cards." = "This website may attempt to install dangerous software, which could harm your computer or steal your personal or financial information, like passwords, photos, or credit cards.";

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3673,7 +3673,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 - (void)_showWarningViewWithURL:(NSURL *)url title:(NSString *)title warning:(NSString *)warning detailsWithLinks:(NSAttributedString *)details completionHandler:(void(^)(BOOL, NSURL *))completionHandler
 {
     THROW_IF_SUSPENDED;
-    auto safeBrowsingWarning = WebKit::BrowsingWarning::create(url, title, warning, details);
+    auto safeBrowsingWarning = WebKit::BrowsingWarning::create(url, title, warning, details, WebKit::BrowsingWarning::WarningType::SafeBrowsing);
     auto wrapper = [completionHandler = makeBlockPtr(completionHandler)] (std::variant<WebKit::ContinueUnsafeLoad, URL>&& variant) {
         switchOn(variant, [&] (WebKit::ContinueUnsafeLoad continueUnsafeLoad) {
             switch (continueUnsafeLoad) {

--- a/Source/WebKit/UIProcess/BrowsingWarning.h
+++ b/Source/WebKit/UIProcess/BrowsingWarning.h
@@ -38,17 +38,23 @@ namespace WebKit {
 
 class BrowsingWarning : public RefCounted<BrowsingWarning> {
 public:
+    enum class WarningType : uint8_t { SafeBrowsing, HTTPSNavigationFailure };
 
 #if HAVE(SAFE_BROWSING)
     static Ref<BrowsingWarning> create(const URL& url, bool forMainFrameNavigation, SSBServiceLookupResult *result)
     {
         return adoptRef(*new BrowsingWarning(url, forMainFrameNavigation, result));
     }
+
+    static Ref<BrowsingWarning> create(const URL& url, bool forMainFrameNavigation, WarningType type)
+    {
+        return adoptRef(*new BrowsingWarning(url, forMainFrameNavigation, type));
+    }
 #endif
 #if PLATFORM(COCOA)
-    static Ref<BrowsingWarning> create(URL&& url, String&& title, String&& warning, RetainPtr<NSAttributedString>&& details)
+    static Ref<BrowsingWarning> create(URL&& url, String&& title, String&& warning, RetainPtr<NSAttributedString>&& details, WarningType type)
     {
-        return adoptRef(*new BrowsingWarning(WTFMove(url), WTFMove(title), WTFMove(warning), WTFMove(details)));
+        return adoptRef(*new BrowsingWarning(WTFMove(url), WTFMove(title), WTFMove(warning), WTFMove(details), type));
     }
 #endif
 
@@ -59,6 +65,7 @@ public:
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> details() const { return m_details; }
 #endif
+    WarningType type() const { return m_type; };
 
     static NSURL *visitUnsafeWebsiteSentinel();
     static NSURL *confirmMalwareSentinel();
@@ -66,9 +73,10 @@ public:
 private:
 #if HAVE(SAFE_BROWSING)
     BrowsingWarning(const URL&, bool, SSBServiceLookupResult *);
+    BrowsingWarning(const URL&, bool, WarningType);
 #endif
 #if PLATFORM(COCOA)
-    BrowsingWarning(URL&&, String&&, String&&, RetainPtr<NSAttributedString>&&);
+    BrowsingWarning(URL&&, String&&, String&&, RetainPtr<NSAttributedString>&&, WarningType);
 #endif
 
     URL m_url;
@@ -78,6 +86,7 @@ private:
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> m_details;
 #endif
+    WarningType m_type;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm
@@ -260,6 +260,17 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
 #endif
 }
 
+static WarningItem backgroundColorForWarningType(const WebKit::BrowsingWarning& warning)
+{
+    switch (warning.type()) {
+    case WebKit::BrowsingWarning::WarningType::SafeBrowsing:
+    case WebKit::BrowsingWarning::WarningType::HTTPSNavigationFailure:
+        return WarningItem::SafeBrowsingBackground;
+    }
+    ASSERT_NOT_REACHED();
+    return WarningItem::SafeBrowsingBackground;
+}
+
 @implementation _WKWarningViewBox
 
 - (void)setWarningViewBackgroundColor:(WebCore::CocoaColor *)color
@@ -304,11 +315,12 @@ static RetainPtr<ViewType> makeLabel(NSAttributedString *attributedString)
         completionHandler(WTFMove(result));
     };
     _warning = &warning;
+    auto backgroundColor = backgroundColorForWarningType(warning);
 #if PLATFORM(MAC)
-    [self setWarningViewBackgroundColor:colorForItem(WarningItem::SafeBrowsingBackground, self)];
+    [self setWarningViewBackgroundColor:colorForItem(backgroundColor, self)];
     [self addContent];
 #else
-    [self setBackgroundColor:colorForItem(WarningItem::SafeBrowsingBackground, self)];
+    [self setBackgroundColor:colorForItem(backgroundColor, self)];
 #endif
 
 #if PLATFORM(WATCHOS)


### PR DESCRIPTION
#### 2cd5a8978824cbcea0e63787256225411ecd773c
<pre>
[cocoa] Add Continue button on warning view
<a href="https://bugs.webkit.org/show_bug.cgi?id=277529">https://bugs.webkit.org/show_bug.cgi?id=277529</a>
<a href="https://rdar.apple.com/133037364">rdar://133037364</a>

Reviewed by NOBODY (OOPS!).

Adds support for a &quot;Continue&quot; button in the same place as the &quot;Show Details&quot;
button.

* Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm:
(colorForItem):
(makeButton):
(-[_WKWarningView addContent]):
(-[_WKWarningView continueClicked]):
</pre>
----------------------------------------------------------------------
#### 5c9ad9e72945eee60ac326ec332d2c04cd37bd16
<pre>
[cocoa] Begin adding https navigation failure browsing warning
<a href="https://bugs.webkit.org/show_bug.cgi?id=277527">https://bugs.webkit.org/show_bug.cgi?id=277527</a>
<a href="https://rdar.apple.com/problem/133035983">rdar://problem/133035983</a>

Reviewed by NOBODY (OOPS!).

Add a new WarningType that will distinguish between the different supported
warnings. Currently the supported warnings are SafeBrowsing and
HTTPSNavigationFailure. HTTPSNavigationFailure is the warning associated with
the https-by-default/HTTPSOnly load failure.

The current HTTPSNavigationFailure warning uses the same buttons, color, and
image as the SafeBrowsing warning. These will be changed in subsequent patches.

The SafeBrowsing warning is covered by existing tests. The
HTTPSNavigationFailure warning will be covered by tests in a later patch.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _showWarningViewWithURL:title:warning:detailsWithLinks:completionHandler:]):
* Source/WebKit/UIProcess/BrowsingWarning.h:
(WebKit::BrowsingWarning::create):
(WebKit::BrowsingWarning::type const):
* Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm:
(WebKit::browsingWarningTitleText):
(WebKit::browsingWarningText):
(WebKit::browsingDetailsText):
(WebKit::BrowsingWarning::BrowsingWarning):
(WebKit::browsingTitleText): Deleted.
* Source/WebKit/UIProcess/Cocoa/_WKWarningView.mm:
(backgroundColorForWarningType):
(-[_WKWarningView initWithFrame:browsingWarning:completionHandler:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cd5a8978824cbcea0e63787256225411ecd773c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40224 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13441 "Hash 2cd5a897 for PR 31629 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64796 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11412 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49209 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7917 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37451 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/13441 "Hash 2cd5a897 for PR 31629 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30036 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34138 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/13441 "Hash 2cd5a897 for PR 31629 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55963 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/13441 "Hash 2cd5a897 for PR 31629 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56578 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4830 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/13441 "Hash 2cd5a897 for PR 31629 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56770 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3988 "Passed tests") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36029 "Hash 2cd5a897 for PR 31629 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37111 "Hash 2cd5a897 for PR 31629 does not build (failure)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->