### PR TITLE
Notify WKNavigationDelegate when GPU process crashed too frequently

### DIFF
--- a/Source/WebKit/Shared/ProcessTerminationReason.cpp
+++ b/Source/WebKit/Shared/ProcessTerminationReason.cpp
@@ -52,6 +52,10 @@ ASCIILiteral processTerminationReasonToString(ProcessTerminationReason reason)
         return "RequestedByNetworkProcess"_s;
     case ProcessTerminationReason::RequestedByGPUProcess:
         return "RequestedByGPUProcess"_s;
+    case ProcessTerminationReason::GPUProcessCrashedTooManyTimes:
+        return "GPUProcessCrashedTooManyTimes"_s;
+    case ProcessTerminationReason::ModelProcessCrashedTooManyTimes:
+        return "ModelProcessCrashedTooManyTimes"_s;
     }
 
     return ""_s;

--- a/Source/WebKit/Shared/ProcessTerminationReason.h
+++ b/Source/WebKit/Shared/ProcessTerminationReason.h
@@ -40,7 +40,9 @@ enum class ProcessTerminationReason : uint8_t {
     ExceededProcessCountLimit,
     NavigationSwap,
     RequestedByNetworkProcess,
-    RequestedByGPUProcess
+    RequestedByGPUProcess,
+    GPUProcessCrashedTooManyTimes,
+    ModelProcessCrashedTooManyTimes,
 };
 
 ASCIILiteral processTerminationReasonToString(ProcessTerminationReason);

--- a/Source/WebKit/UIProcess/API/C/WKAPICast.h
+++ b/Source/WebKit/UIProcess/API/C/WKAPICast.h
@@ -250,6 +250,8 @@ inline WKProcessTerminationReason toAPI(ProcessTerminationReason reason)
     case ProcessTerminationReason::RequestedByNetworkProcess:
     case ProcessTerminationReason::RequestedByGPUProcess:
     case ProcessTerminationReason::Crash:
+    case ProcessTerminationReason::GPUProcessCrashedTooManyTimes:
+    case ProcessTerminationReason::ModelProcessCrashedTooManyTimes:
         return kWKProcessTerminationReasonCrash;
     }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegatePrivate.h
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSInteger, _WKProcessTerminationReason) {
     _WKProcessTerminationReasonExceededCPULimit,
     _WKProcessTerminationReasonRequestedByClient,
     _WKProcessTerminationReasonCrash,
+    _WKProcessTerminationReasonExceededSharedProcessCrashLimit WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA)),
 } WK_API_AVAILABLE(macos(10.14), ios(12.0));
 
 typedef NS_ENUM(NSInteger, _WKSOAuthorizationLoadPolicy) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -615,7 +615,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (void)_terminateAllWebContentProcesses
 {
-    _processPool->terminateAllWebContentProcesses();
+    _processPool->terminateAllWebContentProcesses(WebKit::ProcessTerminationReason::RequestedByClient);
 }
 
 - (WKNotificationManagerRef)_notificationManagerForTesting

--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationClient.cpp
@@ -131,6 +131,8 @@ private:
         case ProcessTerminationReason::ExceededProcessCountLimit:
         case ProcessTerminationReason::IdleExit:
         case ProcessTerminationReason::Unresponsive:
+        case ProcessTerminationReason::GPUProcessCrashedTooManyTimes:
+        case ProcessTerminationReason::ModelProcessCrashedTooManyTimes:
             break;
         }
         return false;

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -1205,6 +1205,9 @@ static _WKProcessTerminationReason wkProcessTerminationReason(ProcessTermination
     case ProcessTerminationReason::RequestedByGPUProcess:
     case ProcessTerminationReason::Crash:
         return _WKProcessTerminationReasonCrash;
+    case ProcessTerminationReason::GPUProcessCrashedTooManyTimes:
+    case ProcessTerminationReason::ModelProcessCrashedTooManyTimes:
+        return _WKProcessTerminationReasonExceededSharedProcessCrashLimit;
     }
     ASSERT_NOT_REACHED();
     return _WKProcessTerminationReasonCrash;

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -527,6 +527,8 @@ void GPUProcessProxy::gpuProcessExited(ProcessTerminationReason reason)
     case ProcessTerminationReason::NavigationSwap:
     case ProcessTerminationReason::RequestedByNetworkProcess:
     case ProcessTerminationReason::RequestedByGPUProcess:
+    case ProcessTerminationReason::GPUProcessCrashedTooManyTimes:
+    case ProcessTerminationReason::ModelProcessCrashedTooManyTimes:
         ASSERT_NOT_REACHED();
         break;
     }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9949,6 +9949,8 @@ static bool shouldReloadAfterProcessTermination(ProcessTerminationReason reason)
     case ProcessTerminationReason::NavigationSwap:
     case ProcessTerminationReason::IdleExit:
     case ProcessTerminationReason::RequestedByClient:
+    case ProcessTerminationReason::GPUProcessCrashedTooManyTimes:
+    case ProcessTerminationReason::ModelProcessCrashedTooManyTimes:
         break;
     }
     return false;

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -318,7 +318,7 @@ public:
     };
     static Statistics& statistics();    
 
-    void terminateAllWebContentProcesses();
+    void terminateAllWebContentProcesses(ProcessTerminationReason);
     void sendNetworkProcessPrepareToSuspendForTesting(CompletionHandler<void()>&&);
     void sendNetworkProcessWillSuspendImminentlyForTesting();
     void sendNetworkProcessDidResume();

--- a/Tools/TestWebKitAPI/Tests/WebKit/NetworkProcessCrashWithPendingConnection.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/NetworkProcessCrashWithPendingConnection.mm
@@ -114,7 +114,7 @@ TEST(WebKit, NetworkProcessCrashWithPendingConnection)
         loadedOrCrashed = true;
         loaded = true;
     }];
-    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *) {
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
         loadedOrCrashed = true;
         webProcessCrashed = true;
     }];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
@@ -165,7 +165,8 @@ TEST(GPUProcess, WebProcessTerminationAfterTooManyGPUProcessCrashes)
     kill(gpuProcessPID, 9);
 
     // The WebView's WebProcess should get killed this time.
-    [webView _test_waitForWebContentProcessDidTerminate];
+    auto crashReason = [webView _test_waitForWebContentProcessDidTerminate];
+    EXPECT_EQ(crashReason, _WKProcessTerminationReasonExceededSharedProcessCrashLimit);
 
     EXPECT_EQ(0, [webView _webProcessIdentifier]);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
@@ -197,7 +197,7 @@ TEST(WebKit, LoadHTMLStringWithInvalidBaseURL)
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     __block bool didCrash = false;
-    navigationDelegate.get().webContentProcessDidTerminate = ^(WKWebView *view) {
+    navigationDelegate.get().webContentProcessDidTerminate = ^(WKWebView *view, _WKProcessTerminationReason) {
         didCrash = true;
     };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm
@@ -105,7 +105,7 @@ TEST(WebKit, LoadInvalidURLRequestNonASCII)
 {
     __block bool done = false;
     auto delegate = adoptNS([TestNavigationDelegate new]);
-    delegate.get().webContentProcessDidTerminate = ^(WKWebView *) {
+    delegate.get().webContentProcessDidTerminate = ^(WKWebView *, _WKProcessTerminationReason) {
         ASSERT_NOT_REACHED();
     };
     delegate.get().didFailProvisionalNavigation = ^(WKWebView *, WKNavigation *, NSError *error) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessPreWarming.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessPreWarming.mm
@@ -163,7 +163,7 @@ TEST(WebKit, TryUsingPrewarmedProcessThatJustCrashed)
     configuration.get().processPool = pool.get();
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
-    delegate.get().webContentProcessDidTerminate = ^(WKWebView *view) {
+    delegate.get().webContentProcessDidTerminate = ^(WKWebView *view, _WKProcessTerminationReason) {
         [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:loadableURL]]];
     };
     [webView setNavigationDelegate:delegate.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -3859,7 +3859,7 @@ TEST(ProcessSwap, UseWebProcessCacheAfterTermination)
     EXPECT_EQ(2U, [processPool _webProcessCountIgnoringPrewarmed]);
 
     __block bool webProcessTerminated = false;
-    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *) {
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
         webProcessTerminated = true;
     }];
 
@@ -5502,7 +5502,7 @@ TEST(ProcessSwap, ReloadRelatedWebViewAfterCrash)
     auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView1Configuration.get()]);
     auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
     __block bool didCrash = false;
-    [delegate setWebContentProcessDidTerminate:^(WKWebView *view) {
+    [delegate setWebContentProcessDidTerminate:^(WKWebView *view, _WKProcessTerminationReason) {
         [view reload];
         didCrash = true;
     }];
@@ -6060,7 +6060,7 @@ TEST(ProcessSwap, TerminateProcessAfterProcessSwap)
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
     __block bool webProcessTerminated = false;
-    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *) {
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
         webProcessTerminated = true;
     }];
     [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {
@@ -6168,7 +6168,7 @@ TEST(ProcessSwap, CrashWithGestureController)
         auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
         [webView setNavigationDelegate:navigationDelegate.get()];
         __block bool webProcessTerminated = false;
-        [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *) {
+        [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
             webProcessTerminated = true;
         }];
         [navigationDelegate setDidFinishNavigation:^(WKWebView *, WKNavigation *) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
@@ -1428,7 +1428,7 @@ TEST(WKAttachmentTests, InvalidateAttachmentsAfterWebProcessTermination)
     __block bool webProcessTerminated = false;
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *) {
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
         webProcessTerminated = true;
     }];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm
@@ -407,7 +407,7 @@ TEST(WKNavigation, WebViewURLInProcessDidTerminate)
     [webView setNavigationDelegate:navigationDelegate.get()];
 
     __block bool done = false;
-    navigationDelegate.get().webContentProcessDidTerminate = ^(WKWebView *view) {
+    navigationDelegate.get().webContentProcessDidTerminate = ^(WKWebView *view, _WKProcessTerminationReason) {
         EXPECT_EQ(view, webView.get());
         EXPECT_WK_STREQ(view.URL.absoluteString, viewURL);
         done = true;
@@ -435,7 +435,7 @@ TEST(WKNavigation, WebProcessLimit)
         return webView;
     };
 
-    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *) {
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
         didCrash = true;
     }];
 
@@ -448,7 +448,7 @@ TEST(WKNavigation, WebProcessLimit)
 
     // We have now reached the WebProcess cap, let's try and launch a new one.
     __block unsigned crashCount = 0;
-    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView * view) {
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView * view, _WKProcessTerminationReason) {
         EXPECT_EQ(views[0], view);
         ++crashCount;
     }];
@@ -463,7 +463,7 @@ TEST(WKNavigation, WebProcessLimit)
     }
 
     crashCount = 0;
-    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView * view) {
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView * view, _WKProcessTerminationReason) {
         EXPECT_EQ(views[1], view);
         ++crashCount;
     }];
@@ -529,7 +529,7 @@ TEST(WKNavigation, MultipleProcessCrashesRelatedWebViews)
     // Kill both WebContent processes and make sure that both WebView's get notified of a single crash.
     __block unsigned webView1CrashCount = 0;
     __block unsigned webView2CrashCount = 0;
-    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView * view) {
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView * view, _WKProcessTerminationReason) {
         if (view == webView1)
             ++webView1CrashCount;
         else

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -2063,7 +2063,7 @@ TEST(WritingTools, NoCrashWhenWebProcessTerminates)
     __block bool webProcessTerminated = false;
     auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
-    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *) {
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
         webProcessTerminated = true;
     }];
 

--- a/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
@@ -124,7 +124,7 @@ TEST(ActionSheetTests, DISABLED_DismissingActionSheetShouldNotDismissPresentingV
     }];
 
     __block bool done = false;
-    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *) {
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
         dispatch_async(dispatch_get_main_queue(), ^{
             done = true;
         });

--- a/Tools/TestWebKitAPI/Tests/ios/ScrollViewInsetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ScrollViewInsetTests.mm
@@ -175,7 +175,7 @@ TEST(ScrollViewInsetTests, RestoreInitialContentOffsetAfterCrash)
     CGPoint initialContentOffset = [webView scrollView].contentOffset;
     __block CGPoint contentOffsetAfterCrash = CGPointZero;
     __block bool done = false;
-    [delegate setWebContentProcessDidTerminate:^(WKWebView *webView) {
+    [delegate setWebContentProcessDidTerminate:^(WKWebView *webView, _WKProcessTerminationReason) {
         contentOffsetAfterCrash = webView.scrollView.contentOffset;
         done = true;
     }];

--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
@@ -42,7 +42,7 @@
 @property (nonatomic, copy) void (^didFinishNavigation)(WKWebView *, WKNavigation *);
 @property (nonatomic, copy) void (^didSameDocumentNavigation)(WKWebView *, WKNavigation *);
 @property (nonatomic, copy) void (^renderingProgressDidChange)(WKWebView *, _WKRenderingProgressEvents);
-@property (nonatomic, copy) void (^webContentProcessDidTerminate)(WKWebView *);
+@property (nonatomic, copy) void (^webContentProcessDidTerminate)(WKWebView *, _WKProcessTerminationReason);
 @property (nonatomic, copy) void (^didReceiveAuthenticationChallenge)(WKWebView *, NSURLAuthenticationChallenge *, void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *));
 @property (nonatomic, copy) void (^contentRuleListPerformedAction)(WKWebView *, NSString *, _WKContentRuleListAction *, NSURL *);
 @property (nonatomic, copy) void (^didChangeLookalikeCharactersFromURL)(WKWebView *, NSURL *, NSURL *);
@@ -67,5 +67,5 @@
 - (void)_test_waitForDidFinishNavigationWithoutPresentationUpdate;
 - (void)_test_waitForDidFinishNavigationWhileIgnoringSSLErrors;
 - (void)_test_waitForDidFailProvisionalNavigation;
-- (void)_test_waitForWebContentProcessDidTerminate;
+- (_WKProcessTerminationReason)_test_waitForWebContentProcessDidTerminate;
 @end


### PR DESCRIPTION
#### 63c54304c7eab3891a8c2bb4c13a4d2d2dcd4db0
<pre>
Notify WKNavigationDelegate when GPU process crashed too frequently
<a href="https://bugs.webkit.org/show_bug.cgi?id=277531">https://bugs.webkit.org/show_bug.cgi?id=277531</a>

Reviewed by Wenson Hsieh.

Add _WKProcessTerminationReasonExceededSharedProcessCrashLimit as a process termination reason and use it when
GPU or model processes crashed too frequently and resulted in the termination of all web content processes.

* Source/WebKit/Shared/ProcessTerminationReason.cpp:
(WebKit::processTerminationReasonToString):
* Source/WebKit/Shared/ProcessTerminationReason.h:
* Source/WebKit/UIProcess/API/C/WKAPICast.h:
(WebKit::toAPI):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(-[WKProcessPool _terminateAllWebContentProcesses]):
* Source/WebKit/UIProcess/API/glib/WebKitNavigationClient.cpp:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::wkProcessTerminationReason):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::gpuProcessExited):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::shouldReloadAfterProcessTermination):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::shouldReportAuxiliaryProcessCrash):
(WebKit::WebProcessPool::gpuProcessExited):
(WebKit::WebProcessPool::modelProcessExited):
(WebKit::WebProcessPool::terminateAllWebContentProcesses):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Tools/TestWebKitAPI/Tests/WebKit/NetworkProcessCrashWithPendingConnection.mm:
(TestWebKitAPI::TEST(WebKit, NetworkProcessCrashWithPendingConnection)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm:
(TestWebKitAPI::TEST(GPUProcess, WebProcessTerminationAfterTooManyGPUProcessCrashes)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm:
(TEST(WebKit, LoadHTMLStringWithInvalidBaseURL)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm:
(TestWebKitAPI::TEST(WebKit, LoadInvalidURLRequestNonASCII)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessPreWarming.mm:
(TEST(WebKit, TryUsingPrewarmedProcessThatJustCrashed)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
((ProcessSwap, UseWebProcessCacheAfterTermination)):
((ProcessSwap, ReloadRelatedWebViewAfterCrash)):
((ProcessSwap, TerminateProcessAfterProcessSwap)):
((ProcessSwap, CrashWithGestureController)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm:
(TestWebKitAPI::TEST(WKAttachmentTests, InvalidateAttachmentsAfterWebProcessTermination)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm:
(TEST(WKNavigation, WebViewURLInProcessDidTerminate)):
(TEST(WKNavigation, WebProcessLimit)):
(TEST(WKNavigation, MultipleProcessCrashesRelatedWebViews)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, NoCrashWhenWebProcessTerminates)):
* Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm:
(TestWebKitAPI::TEST(ActionSheetTests, DISABLED_DismissingActionSheetShouldNotDismissPresentingViewController)):
* Tools/TestWebKitAPI/Tests/ios/ScrollViewInsetTests.mm:
(TestWebKitAPI::TEST(ScrollViewInsetTests, RestoreInitialContentOffsetAfterCrash)):
* Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm:
(-[TestNavigationDelegate _webView:webContentProcessDidTerminateWithReason:]):
(-[TestNavigationDelegate waitForWebContentProcessDidTerminate]):
(-[WKWebView _test_waitForWebContentProcessDidTerminate]):
(-[TestNavigationDelegate webViewWebContentProcessDidTerminate:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/281765@main">https://commits.webkit.org/281765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8aafa26e98940d3f14b43abe761f3e35b7e2804

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49225 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7929 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52750 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30051 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34153 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9973 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10342 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66542 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4826 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10094 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/URL-createObjectURL-null.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56591 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52713 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56777 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4000 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9168 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36046 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37128 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38221 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36873 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->