### PR TITLE
[UnifiedPDF] PDFPresentationController::updateForCurrentScrollability() should use the scrollability provided by callers

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -1306,9 +1306,14 @@ void PDFDiscretePresentationController::updateDebugBorders(bool showDebugBorders
         asyncRenderer->setShowDebugBorders(showDebugBorders);
 }
 
-void PDFDiscretePresentationController::updateForCurrentScrollability(OptionSet<TiledBackingScrollability>)
+void PDFDiscretePresentationController::updateForCurrentScrollability(OptionSet<TiledBackingScrollability> scrollability)
 {
+    if (m_visibleRowIndex >= m_rows.size())
+        return;
 
+    auto& visibleRow = m_rows[m_visibleRowIndex];
+    if (auto* tiledBacking = visibleRow.contentsLayer->tiledBacking())
+        tiledBacking->setScrollability(scrollability);
 }
 
 void PDFDiscretePresentationController::repaintForIncrementalLoad()

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -311,10 +311,10 @@ void PDFScrollingPresentationController::updateDebugBorders(bool showDebugBorder
         asyncRenderer->setShowDebugBorders(showDebugBorders);
 }
 
-void PDFScrollingPresentationController::updateForCurrentScrollability(OptionSet<TiledBackingScrollability>)
+void PDFScrollingPresentationController::updateForCurrentScrollability(OptionSet<TiledBackingScrollability> scrollability)
 {
     if (auto* tiledBacking = m_contentsLayer->tiledBacking())
-        tiledBacking->setScrollability(m_plugin->computeScrollability());
+        tiledBacking->setScrollability(scrollability);
 }
 
 void PDFScrollingPresentationController::setNeedsRepaintInDocumentRect(OptionSet<RepaintRequirement> repaintRequirements, const FloatRect& rectInDocumentCoordinates, std::optional<PDFLayoutRow> layoutRow)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -286,8 +286,6 @@ private:
     WebCore::DelegatedScrollingMode scrollingMode() const;
     bool isFullMainFramePlugin() const;
 
-    OptionSet<WebCore::TiledBackingScrollability> computeScrollability() const;
-
     void scrollbarStyleChanged(WebCore::ScrollbarStyle, bool forceUpdate) override;
     void updateScrollbars() override;
     void willAttachScrollingNode() final;
@@ -485,6 +483,8 @@ private:
 
     // Only use this if some other function has ensured that the correct page is visible.
     void scrollToPointInContentsSpace(WebCore::FloatPoint);
+
+    OptionSet<WebCore::TiledBackingScrollability> computeScrollability() const;
 
     // ScrollableArea
     bool requestScrollToPosition(const WebCore::ScrollPosition&, const WebCore::ScrollPositionChangeOptions& = WebCore::ScrollPositionChangeOptions::createProgrammatic()) override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1333,6 +1333,8 @@ void UnifiedPDFPlugin::didChangeVisibleRow()
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
     didInvalidateDataDetectorHighlightOverlayRects();
 #endif
+
+    m_presentationController->updateForCurrentScrollability(computeScrollability());
 }
 
 bool UnifiedPDFPlugin::updateOverflowControlsLayers(bool needsHorizontalScrollbarLayer, bool needsVerticalScrollbarLayer, bool needsScrollCornerLayer)


### PR DESCRIPTION
#### 7f5aad034fe5a856ca4209d2b2dfa26efa9e3ddf
<pre>
[UnifiedPDF] PDFPresentationController::updateForCurrentScrollability() should use the scrollability provided by callers
<a href="https://bugs.webkit.org/show_bug.cgi?id=277533">https://bugs.webkit.org/show_bug.cgi?id=277533</a>
<a href="https://rdar.apple.com/133042660">rdar://133042660</a>

Reviewed by Tim Horton.

Currently, the discrete controller does not observe the updated
scrollability at all, while the scrolling controller asks the plugin to
compute scrollability, which is a duplication of work.

This patch addresses both of these issues.

Finally, we make UnifiedPDFPlugin::computeScrollability() private, since
this should not be called by the presentation controller.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::updateForCurrentScrollability):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::updateForCurrentScrollability):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::didChangeVisibleRow):

Ensure that the presentation controller accounts for scrollability of
the newly visible row.

Canonical link: <a href="https://commits.webkit.org/281775@main">https://commits.webkit.org/281775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53274893431bd05771658dd9a5e0b23b54c00622

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64867 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11483 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11758 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49267 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7972 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62970 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/37509 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34192 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10396 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56018 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66598 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56636 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52753 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/56826 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4042 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9175 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37182 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38275 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/36927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->