### PR TITLE
Fix failures in relative-color-out-of-gamut-expected due to rgbToHwb algorithm

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-mix-out-of-gamut-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-mix-out-of-gamut-expected.txt
@@ -9,15 +9,9 @@ PASS Property color value 'color-mix(in hsl, oklab(0 0.365 -0.16) 100%, rgb(0, 0
 PASS Property color value 'color-mix(in hsl, oklch(1 0.399 336.3) 100%, rgb(0, 0, 0) 0%)'
 PASS Property color value 'color-mix(in hsl, oklch(0 0.399 336.3) 100%, rgb(0, 0, 0) 0%)'
 PASS Property color value 'color-mix(in hwb, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)'
-FAIL Property color value 'color-mix(in hwb, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
-Actual:   color(srgb 0.587758 1.593503 0.775713)
-Expected: color(srgb 1.59343 0.58802 1.40564).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59343 +/- 0.01, expected 1.59343 but got 0.587758
+PASS Property color value 'color-mix(in hwb, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)'
 PASS Property color value 'color-mix(in hwb, lab(0 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)'
-FAIL Property color value 'color-mix(in hwb, lch(100 116 334) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
-Actual:   color(srgb 0.588021 1.593364 0.776217)
-Expected: color(srgb 1.59328 0.588284 1.40527).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.01, expected 1.59328 but got 0.588021
+PASS Property color value 'color-mix(in hwb, lch(100 116 334) 100%, rgb(0, 0, 0) 0%)'
 PASS Property color value 'color-mix(in hwb, lch(0 116 334) 100%, rgb(0, 0, 0) 0%)'
 PASS Property color value 'color-mix(in hwb, oklab(1 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)'
 PASS Property color value 'color-mix(in hwb, oklab(0 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)'

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/relative-color-out-of-gamut-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/relative-color-out-of-gamut-expected.txt
@@ -18,15 +18,9 @@ PASS Property color value 'hsl(from oklab(0 0.365 -0.16) h s l)'
 PASS Property color value 'hsl(from oklch(1 0.399 336.3) h s l)'
 PASS Property color value 'hsl(from oklch(0 0.399 336.3) h s l)'
 PASS Property color value 'hwb(from color(display-p3 0 1 0) h w b / alpha)'
-FAIL Property color value 'hwb(from lab(100 104.3 -50.9) h w b)' Colors do not match.
-Actual:   color(srgb 0.587758 1.593503 0.775713)
-Expected: color(srgb 1.59343 0.58802 1.40564).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59343 +/- 0.01, expected 1.59343 but got 0.587758
+PASS Property color value 'hwb(from lab(100 104.3 -50.9) h w b)'
 PASS Property color value 'hwb(from lab(0 104.3 -50.9) h w b)'
-FAIL Property color value 'hwb(from lch(100 116 334) h w b)' Colors do not match.
-Actual:   color(srgb 0.588021 1.593364 0.776217)
-Expected: color(srgb 1.59328 0.58828 1.40527).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.01, expected 1.59328 but got 0.588021
+PASS Property color value 'hwb(from lch(100 116 334) h w b)'
 PASS Property color value 'hwb(from lch(0 116 334) h w b)'
 PASS Property color value 'hwb(from oklab(1 0.365 -0.16) h w b)'
 PASS Property color value 'hwb(from oklab(0 0.365 -0.16) h w b)'

--- a/Source/WebCore/platform/graphics/ColorConversion.cpp
+++ b/Source/WebCore/platform/graphics/ColorConversion.cpp
@@ -145,16 +145,8 @@ HWBA<float> ColorConversion<HWBA<float>, ExtendedSRGBA<float>>::convert(const Ex
 
     float hue = std::numeric_limits<float>::quiet_NaN();
 
-    // Compute `hue` as done in conversion to HSLA.
+    // Compute `hue` as done in conversion to HSLA, but don't adjust for negative saturation, in order to respect out-of-gamut colors.
     if (d != 0.0f) {
-        float lightness = (min + max) / 2.0f;
-
-        float saturation;
-        if (lightness == 0.0f || lightness == 1.0f)
-            saturation = 0.0f;
-        else
-            saturation = (max - lightness) / std::min(lightness, 1.0f - lightness);
-
         if (max == red)
             hue = ((green - blue) / d) + (green < blue ? 6.0f : 0.0f);
         else if (max == green)
@@ -163,9 +155,6 @@ HWBA<float> ColorConversion<HWBA<float>, ExtendedSRGBA<float>>::convert(const Ex
             hue = ((red - green) / d) + 4.0f;
 
         hue *= 60.0f;
-
-        if (saturation < 0.0f)
-            hue += 180.0f;
 
         if (hue >= 360.0f)
             hue -= 360.0f;


### PR DESCRIPTION
#### d26cb4ae7f44f61334632273de133bd18023b67d
<pre>
Fix failures in relative-color-out-of-gamut-expected due to rgbToHwb algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=277538">https://bugs.webkit.org/show_bug.cgi?id=277538</a>
<a href="https://rdar.apple.com/133045692">rdar://133045692</a>

Reviewed by Tim Nguyen.

The suggested rgbToHwb algorithm at <a href="https://drafts.csswg.org/css-color-4/#rgb-to-hwb">https://drafts.csswg.org/css-color-4/#rgb-to-hwb</a>
used to use rgbToHsl to compute the hue, discarding the saturation and lightness.
But rgbToHsl special-cases negative saturations (possible with out-of-gamut colors),
and flips the hue in that case, resulting in incorrect out-of-gamut HWB values.
This was fixed in <a href="https://github.com/w3c/csswg-drafts/pull/10718">https://github.com/w3c/csswg-drafts/pull/10718</a>

This patch here replicates <a href="https://github.com/w3c/csswg-drafts/pull/10718">https://github.com/w3c/csswg-drafts/pull/10718</a> in the
equivalent WebKit function, it fixes failures in
relative-color-out-of-gamut-expected.html, but also in
color-mix-out-of-gamut-expected.html.

* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-mix-out-of-gamut-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/relative-color-out-of-gamut-expected.txt:
* Source/WebCore/platform/graphics/ColorConversion.cpp:
(WebCore::ExtendedSRGBA&lt;float&gt;&gt;::convert):

Canonical link: <a href="https://commits.webkit.org/282101@main">https://commits.webkit.org/282101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6a1b271f5006ea5a93652ede059d1810957d37c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65858 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12399 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49856 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8584 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30687 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34911 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10806 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11330 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67562 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10839 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57228 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57470 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13798 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4753 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37008 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38092 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39188 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37837 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->