### PR TITLE
[WPE] WPE Platform: add explicit sync support on DRM platform

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp
@@ -169,7 +169,8 @@ std::unique_ptr<Plane> Plane::create(int fd, Type type, drmModePlane* plane, boo
         drmPropertyForName(fd, properties.get(), "SRC_Y"),
         drmPropertyForName(fd, properties.get(), "SRC_W"),
         drmPropertyForName(fd, properties.get(), "SRC_H"),
-        drmPropertyForName(fd, properties.get(), "FB_DAMAGE_CLIPS")
+        drmPropertyForName(fd, properties.get(), "FB_DAMAGE_CLIPS"),
+        drmPropertyForName(fd, properties.get(), "IN_FENCE_FD")
     };
     return makeUnique<Plane>(plane, WTFMove(formats), WTFMove(props));
 }

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h
@@ -29,6 +29,7 @@
 #include <optional>
 #include <wtf/FastMalloc.h>
 #include <wtf/Vector.h>
+#include <wtf/unix/UnixFileDescriptor.h>
 #include <xf86drmMode.h>
 
 namespace WPE {
@@ -122,6 +123,7 @@ public:
         Property srcW { 0, 0 };
         Property srcH { 0, 0 };
         Property fbDamageClips { 0, 0 };
+        Property inFenceFD { 0, 0 };
     };
 
     struct Format {
@@ -156,10 +158,13 @@ public:
 
     struct gbm_bo* bufferObject() const { return m_bufferObject; }
     uint32_t frameBufferID() const { return m_frameBufferID; }
+    void setFenceFD(WTF::UnixFileDescriptor&& fenceFD) { m_fenceFD = WTFMove(fenceFD); }
+    const WTF::UnixFileDescriptor& fenceFD() const { return m_fenceFD; }
 
 private:
     struct gbm_bo* m_bufferObject { nullptr };
     uint32_t m_frameBufferID { 0 };
+    mutable WTF::UnixFileDescriptor m_fenceFD;
 };
 
 } // namespace DRM

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
@@ -355,6 +355,11 @@ static const char* wpeDisplayDRMGetDRMRenderNode(WPEDisplay* display)
     return priv->drmDevice.data();
 }
 
+static gboolean wpeDisplayDRMUseExplicitSync(WPEDisplay* display)
+{
+    return WPE_DISPLAY_DRM(display)->priv->atomicSupported;
+}
+
 static void wpe_display_drm_class_init(WPEDisplayDRMClass* displayDRMClass)
 {
     GObjectClass* objectClass = G_OBJECT_CLASS(displayDRMClass);
@@ -368,6 +373,7 @@ static void wpe_display_drm_class_init(WPEDisplayDRMClass* displayDRMClass)
     displayClass->get_monitor = wpeDisplayDRMGetMonitor;
     displayClass->get_drm_device = wpeDisplayDRMGetDRMDevice;
     displayClass->get_drm_render_node = wpeDisplayDRMGetDRMRenderNode;
+    displayClass->use_explicit_sync = wpeDisplayDRMUseExplicitSync;
 }
 
 const WPE::DRM::Connector& wpeDisplayDRMGetConnector(WPEDisplayDRM* display)


### PR DESCRIPTION
#### a97267cb75b72d39e47bbc5460a8d958f767fe37
<pre>
[WPE] WPE Platform: add explicit sync support on DRM platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=277541">https://bugs.webkit.org/show_bug.cgi?id=277541</a>

Reviewed by Alejandro G. Castro.

We can enable explicit sync when using atomic requests and simply pass
the fence ID as a property of the primary plane.

* Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.cpp:
(WPE::DRM::Plane::create):
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRM.h:
(WPE::DRM::Buffer::setFenceFD):
(WPE::DRM::Buffer::fenceFD const):
* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp:
(wpeDisplayDRMUseExplicitSync):
(wpe_display_drm_class_init):
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp:
(primaryPlaneProperties):
(wpeViewDRMRenderBuffer):

Canonical link: <a href="https://commits.webkit.org/281880@main">https://commits.webkit.org/281880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f052d3f8effa6d2ebd83fd7dd84fbc63581b9753

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65310 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/11909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12184 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/49562 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/11909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/64121 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/37852 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/53144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30404 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34513 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10822 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/10672 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67042 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5307 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/10449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/56935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53109 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/57148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/4379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9222 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/36525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37608 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/38702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/37352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->