### PR TITLE
Make BaseAudioSharedUnit ref counted

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -41,11 +41,6 @@ namespace WebCore {
 class BaseAudioSharedUnit;
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::BaseAudioSharedUnit> : std::true_type { };
-}
-
 namespace WebCore {
 
 class AudioStreamDescription;
@@ -53,9 +48,8 @@ class CaptureDevice;
 class CoreAudioCaptureSource;
 class PlatformAudioData;
 
-class BaseAudioSharedUnit : public RealtimeMediaSourceCenterObserver {
+class BaseAudioSharedUnit : public RefCounted<BaseAudioSharedUnit>, public RealtimeMediaSourceCenterObserver {
 public:
-    BaseAudioSharedUnit();
     virtual ~BaseAudioSharedUnit();
 
     void startProducingData();
@@ -100,6 +94,8 @@ public:
     void handleNewCurrentMicrophoneDevice(CaptureDevice&&);
 
 protected:
+    BaseAudioSharedUnit();
+
     void forEachClient(const Function<void(CoreAudioCaptureSource&)>&) const;
     void captureFailed();
     void continueStartProducingData();

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -241,8 +241,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 CoreAudioSharedUnit& CoreAudioSharedUnit::unit()
 {
-    static NeverDestroyed<CoreAudioSharedUnit> singleton;
-    return singleton;
+    static NeverDestroyed<Ref<CoreAudioSharedUnit>> singleton(adoptRef(*new CoreAudioSharedUnit));
+    return singleton.get();
 }
 
 CoreAudioSharedUnit::CoreAudioSharedUnit()

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -86,7 +86,6 @@ public:
 
     WEBCORE_EXPORT static CoreAudioSharedUnit& unit();
     static BaseAudioSharedUnit& singleton()  { return unit(); }
-    CoreAudioSharedUnit();
     ~CoreAudioSharedUnit();
 
     using CreationCallback = Function<Expected<UniqueRef<InternalUnit>, OSStatus>(bool enableEchoCancellation)>;
@@ -117,6 +116,10 @@ public:
 #endif
 
 private:
+    CoreAudioSharedUnit();
+
+    friend class NeverDestroyed<CoreAudioSharedUnit>;
+
     static size_t preferredIOBufferSize();
 
     LongCapabilityRange sampleRateCapacities() const final { return m_sampleRateCapabilities; }


### PR DESCRIPTION
#### 2b823daac44ee321a5aad1a4aff1ef78ccb85306
<pre>
Make BaseAudioSharedUnit ref counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=277543">https://bugs.webkit.org/show_bug.cgi?id=277543</a>
<a href="https://rdar.apple.com/133053082">rdar://133053082</a>

Reviewed by Eric Carlson.

We move to ref counted so that we can protect weak BaseAudioSharedUnit when calling them.

* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::startProducingData):
(WebCore::BaseAudioSharedUnit::devicesChanged):
(WebCore::BaseAudioSharedUnit::resume):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::unit):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:

Canonical link: <a href="https://commits.webkit.org/282615@main">https://commits.webkit.org/282615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b43f89b8af309e81387a130585b6925be35fd516

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64827 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11443 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49237 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7942 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30063 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34164 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9986 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10356 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66556 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56602 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56789 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14090 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4014 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36060 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37142 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38235 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->