### PR TITLE
[GTK][Gamepad] Some buttons not mapped in Xbox Series S|X Controller

### DIFF
--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
@@ -74,8 +74,9 @@ public:
     const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }
     const Vector<SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
 
-    void absoluteAxisChanged(ManetteDevice*, StandardGamepadAxis, double value);
-    void buttonPressedOrReleased(ManetteDevice*, StandardGamepadButton, bool pressed);
+    void absoluteAxisChanged(StandardGamepadAxis, double value);
+    void buttonPressedOrReleased(StandardGamepadButton, bool pressed);
+    void buttonChanged(StandardGamepadButton, double value);
 
 private:
     GRefPtr<ManetteDevice> m_device;


### PR DESCRIPTION
#### f31eec05fce33f66ec9373f929d442670941f644
<pre>
[GTK][Gamepad] Some buttons not mapped in Xbox Series S|X Controller
<a href="https://bugs.webkit.org/show_bug.cgi?id=277544">https://bugs.webkit.org/show_bug.cgi?id=277544</a>

Reviewed by NOBODY (OOPS!).

In libmanette, the Xbox Series S|X Controller has the events for
- directional buttons mapped as &quot;hat axis&quot; events;
- left/right triggers mapped as ABS_Z/RZ

Handle these events so that the controller has all the buttons
now mapped and can be tested at <a href="https://hardwaretester.com/gamepad">https://hardwaretester.com/gamepad</a>

* Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp:
(WebCore::handleAlternativeAbsoluteAxis):
(WebCore::onAbsoluteAxisEvent):
(WebCore::onButtonPressEvent):
(WebCore::onButtonReleaseEvent):
(WebCore::hatAxisToStandardGamepadButton):
(WebCore::onHatAxisEvent):
(WebCore::ManetteGamepad::ManetteGamepad):
(WebCore::ManetteGamepad::buttonPressedOrReleased):
(WebCore::ManetteGamepad::buttonChanged):
(WebCore::ManetteGamepad::absoluteAxisChanged):
* Source/WebCore/platform/gamepad/manette/ManetteGamepad.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f31eec05fce33f66ec9373f929d442670941f644

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11444 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49238 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7941 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37479 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30064 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34165 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9985 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10357 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55991 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66557 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56603 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56791 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4013 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36061 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37143 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->