### PR TITLE
More smart pointer adoption in DOM methods

### DIFF
--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -68,8 +68,7 @@ Ref<AbortSignal> AbortSignal::timeout(ScriptExecutionContext& context, uint64_t 
         if (!globalObject)
             return;
 
-        auto& vm = globalObject->vm();
-        Locker locker { vm.apiLock() };
+        Locker locker { globalObject->vm().apiLock() };
         signal->signalAbort(toJS(globalObject, globalObject, DOMException::create(ExceptionCode::TimeoutError)));
     };
     DOMTimer::install(context, WTFMove(action), Seconds::fromMilliseconds(milliseconds), DOMTimer::Type::SingleShot);

--- a/Source/WebCore/dom/ActiveDOMObject.cpp
+++ b/Source/WebCore/dom/ActiveDOMObject.cpp
@@ -140,7 +140,7 @@ bool ActiveDOMObject::isAllowedToRunScript() const
 
 void ActiveDOMObject::queueTaskInEventLoop(TaskSource source, Function<void ()>&& function)
 {
-    auto* context = scriptExecutionContext();
+    RefPtrAllowingPartiallyDestroyed<ScriptExecutionContext> context = scriptExecutionContext();
     if (!context)
         return;
     context->eventLoop().queueTask(source, WTFMove(function));

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -163,7 +163,7 @@ void CustomElementRegistry::upgrade(Node& root)
     if (!containerNode)
         return;
 
-    auto* element = dynamicDowncast<Element>(*containerNode);
+    RefPtr element = dynamicDowncast<Element>(*containerNode);
     if (element && element->isCustomElementUpgradeCandidate())
         CustomElementReactionQueue::tryToUpgradeElement(*element);
 


### PR DESCRIPTION
#### 4937bf611b791737e78de26473eb7accf5b35dfa
<pre>
More smart pointer adoption in DOM methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=277550">https://bugs.webkit.org/show_bug.cgi?id=277550</a>

Reviewed by Ryosuke Niwa and Chris Dumez.

Address more clang-analyzer-alpha.webkit.UncountedLocalVarsChecker warnings.

* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::timeout):
* Source/WebCore/dom/ActiveDOMObject.cpp:
(WebCore::ActiveDOMObject::queueTaskInEventLoop):
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::upgrade):

Canonical link: <a href="https://commits.webkit.org/281830@main">https://commits.webkit.org/281830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf3ad25db7007405cc60ffb6f4bd1348ae6d7079

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11708 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49449 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8150 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30279 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10211 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10620 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56191 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10506 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/text/reftests/text-font-face-load-image.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66840 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56820 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57014 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13635 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4226 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36324 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37407 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->